### PR TITLE
fix: add explicit Skill tool instructions to all command files

### DIFF
--- a/.claude/commands/debate.md
+++ b/.claude/commands/debate.md
@@ -5,6 +5,24 @@ description: AI Debate Hub - Structured three-way debates between Claude, Gemini
 
 # Debate - AI Debate Hub
 
+## 🤖 INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:debate <arguments>`):
+
+**✓ CORRECT - Use the Skill tool:**
+```
+Skill(skill: "octo:debate", args: "<user's arguments>")
+```
+
+**✗ INCORRECT - Do NOT use Task tool:**
+```
+Task(subagent_type: "octo:debate", ...)  ❌ Wrong! This is a skill, not an agent type
+```
+
+**Why:** This command loads the `skill-debate` skill. Skills use the `Skill` tool, not `Task`.
+
+---
+
 **Auto-loads the `skill-debate` skill for structured multi-AI debates.**
 
 ## Quick Usage

--- a/.claude/commands/debug.md
+++ b/.claude/commands/debug.md
@@ -5,6 +5,24 @@ description: Systematic debugging with methodical problem investigation
 
 # Debug - Systematic Debugging Skill
 
+## 🤖 INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:debug <arguments>`):
+
+**✓ CORRECT - Use the Skill tool:**
+```
+Skill(skill: "octo:debug", args: "<user's arguments>")
+```
+
+**✗ INCORRECT - Do NOT use Task tool:**
+```
+Task(subagent_type: "octo:debug", ...)  ❌ Wrong! This is a skill, not an agent type
+```
+
+**Why:** This command loads the `skill-debug` skill. Skills use the `Skill` tool, not `Task`.
+
+---
+
 **Auto-loads the `skill-debug` skill for methodical bug investigation.**
 
 ## Quick Usage

--- a/.claude/commands/docs.md
+++ b/.claude/commands/docs.md
@@ -5,6 +5,24 @@ description: Document delivery with export to PPTX, DOCX, PDF formats
 
 # Docs - Document Delivery Skill
 
+## 🤖 INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:docs <arguments>`):
+
+**✓ CORRECT - Use the Skill tool:**
+```
+Skill(skill: "octo:docs", args: "<user's arguments>")
+```
+
+**✗ INCORRECT - Do NOT use Task tool:**
+```
+Task(subagent_type: "octo:docs", ...)  ❌ Wrong! This is a skill, not an agent type
+```
+
+**Why:** This command loads the `skill-doc-delivery` skill. Skills use the `Skill` tool, not `Task`.
+
+---
+
 **Auto-loads the `skill-doc-delivery` skill for document creation and export.**
 
 ## Quick Usage

--- a/.claude/commands/grasp.md
+++ b/.claude/commands/grasp.md
@@ -5,6 +5,24 @@ description: Definition phase - Requirements clarification and scope definition
 
 # Grasp - Definition Phase (Double Diamond)
 
+## 🤖 INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:grasp <arguments>`):
+
+**✓ CORRECT - Use the Skill tool:**
+```
+Skill(skill: "octo:grasp", args: "<user's arguments>")
+```
+
+**✗ INCORRECT - Do NOT use Task tool:**
+```
+Task(subagent_type: "octo:grasp", ...)  ❌ Wrong! This is a skill, not an agent type
+```
+
+**Why:** This command loads the `flow-grasp` skill. Skills use the `Skill` tool, not `Task`.
+
+---
+
 **Auto-loads the `flow-grasp` skill for the requirements/definition phase.**
 
 ## Quick Usage

--- a/.claude/commands/ink.md
+++ b/.claude/commands/ink.md
@@ -5,6 +5,24 @@ description: Delivery phase - Quality assurance, validation, and review
 
 # Ink - Delivery Phase (Double Diamond)
 
+## 🤖 INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:ink <arguments>`):
+
+**✓ CORRECT - Use the Skill tool:**
+```
+Skill(skill: "octo:ink", args: "<user's arguments>")
+```
+
+**✗ INCORRECT - Do NOT use Task tool:**
+```
+Task(subagent_type: "octo:ink", ...)  ❌ Wrong! This is a skill, not an agent type
+```
+
+**Why:** This command loads the `flow-ink` skill. Skills use the `Skill` tool, not `Task`.
+
+---
+
 **Auto-loads the `flow-ink` skill for the validation/delivery phase.**
 
 ## Quick Usage

--- a/.claude/commands/probe.md
+++ b/.claude/commands/probe.md
@@ -5,6 +5,24 @@ description: Research and discovery phase - Multi-AI research with broad explora
 
 # Probe - Discovery Phase (Double Diamond)
 
+## 🤖 INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:probe <arguments>`):
+
+**✓ CORRECT - Use the Skill tool:**
+```
+Skill(skill: "octo:probe", args: "<user's arguments>")
+```
+
+**✗ INCORRECT - Do NOT use Task tool:**
+```
+Task(subagent_type: "octo:probe", ...)  ❌ Wrong! This is a skill, not an agent type
+```
+
+**Why:** This command loads the `flow-probe` skill. Skills use the `Skill` tool, not `Task`.
+
+---
+
 **Auto-loads the `flow-probe` skill for the research/discovery phase.**
 
 ## Quick Usage

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -5,6 +5,24 @@ description: Deep research with multi-source synthesis and comprehensive analysi
 
 # Research - Deep Research Skill
 
+## 🤖 INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:research <arguments>`):
+
+**✓ CORRECT - Use the Skill tool:**
+```
+Skill(skill: "octo:research", args: "<user's arguments>")
+```
+
+**✗ INCORRECT - Do NOT use Task tool:**
+```
+Task(subagent_type: "octo:research", ...)  ❌ Wrong! This is a skill, not an agent type
+```
+
+**Why:** This command loads the `skill-deep-research` skill. Skills use the `Skill` tool, not `Task`.
+
+---
+
 **Auto-loads the `skill-deep-research` skill for comprehensive research tasks.**
 
 ## Quick Usage

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -5,6 +5,24 @@ description: Expert code review with comprehensive quality assessment and securi
 
 # Review - Code Quality Assessment
 
+## 🤖 INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:review <arguments>`):
+
+**✓ CORRECT - Use the Skill tool:**
+```
+Skill(skill: "octo:review", args: "<user's arguments>")
+```
+
+**✗ INCORRECT - Do NOT use Task tool:**
+```
+Task(subagent_type: "octo:review", ...)  ❌ Wrong! This is a skill, not an agent type
+```
+
+**Why:** This command loads the `skill-code-review` skill. Skills use the `Skill` tool, not `Task`.
+
+---
+
 **Auto-loads the `skill-code-review` skill for comprehensive code review.**
 
 ## Quick Usage

--- a/.claude/commands/security.md
+++ b/.claude/commands/security.md
@@ -5,6 +5,24 @@ description: Security audit with OWASP compliance and vulnerability detection
 
 # Security - Security Audit Skill
 
+## 🤖 INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:security <arguments>`):
+
+**✓ CORRECT - Use the Skill tool:**
+```
+Skill(skill: "octo:security", args: "<user's arguments>")
+```
+
+**✗ INCORRECT - Do NOT use Task tool:**
+```
+Task(subagent_type: "octo:security", ...)  ❌ Wrong! This is a skill, not an agent type
+```
+
+**Why:** This command loads the `skill-security-audit` skill. Skills use the `Skill` tool, not `Task`.
+
+---
+
 **Auto-loads the `skill-security-audit` skill for comprehensive security analysis.**
 
 ## Quick Usage

--- a/.claude/commands/tangle.md
+++ b/.claude/commands/tangle.md
@@ -5,6 +5,24 @@ description: Development phase - Multi-AI implementation with quality gates
 
 # Tangle - Development Phase (Double Diamond)
 
+## 🤖 INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:tangle <arguments>`):
+
+**✓ CORRECT - Use the Skill tool:**
+```
+Skill(skill: "octo:tangle", args: "<user's arguments>")
+```
+
+**✗ INCORRECT - Do NOT use Task tool:**
+```
+Task(subagent_type: "octo:tangle", ...)  ❌ Wrong! This is a skill, not an agent type
+```
+
+**Why:** This command loads the `flow-tangle` skill. Skills use the `Skill` tool, not `Task`.
+
+---
+
 **Auto-loads the `flow-tangle` skill for the development/implementation phase.**
 
 ## Quick Usage

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -5,6 +5,24 @@ description: Test-driven development with red-green-refactor discipline
 
 # TDD - Test-Driven Development Skill
 
+## 🤖 INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:tdd <arguments>`):
+
+**✓ CORRECT - Use the Skill tool:**
+```
+Skill(skill: "octo:tdd", args: "<user's arguments>")
+```
+
+**✗ INCORRECT - Do NOT use Task tool:**
+```
+Task(subagent_type: "octo:tdd", ...)  ❌ Wrong! This is a skill, not an agent type
+```
+
+**Why:** This command loads the `skill-tdd` skill. Skills use the `Skill` tool, not `Task`.
+
+---
+
 **Auto-loads the `skill-tdd` skill for test-first development.**
 
 ## Quick Usage


### PR DESCRIPTION
## Problem

Commands that auto-load skills (e.g., `/octo:debate`, `/octo:review`) were ambiguous about which tool Claude should use. When users invoked these commands, Claude would sometimes incorrectly attempt to use `Task(subagent_type: "octo:debate")` instead of `Skill(skill: "octo:debate")`, resulting in confusing "Agent type not found" errors.

### Example Error
```
User: /octo:debate Should we use Redis or PostgreSQL?
Result: Error: Agent type 'octo:debate' not found
```

## Solution

Added explicit **"🤖 INSTRUCTIONS FOR CLAUDE"** section to all 11 command files that auto-load skills. Each section clearly shows:

```markdown
## 🤖 INSTRUCTIONS FOR CLAUDE

When the user invokes this command (e.g., \`/octo:debate <arguments>\`):

**✓ CORRECT - Use the Skill tool:**
\`\`\`
Skill(skill: "octo:debate", args: "<user's arguments>")
\`\`\`

**✗ INCORRECT - Do NOT use Task tool:**
\`\`\`
Task(subagent_type: "octo:debate", ...)  ❌ Wrong! This is a skill, not an agent type
\`\`\`

**Why:** This command loads the \`skill-debate\` skill. Skills use the \`Skill\` tool, not \`Task\`.
```

## User Impact

✅ **Positive:**
- Users can now use `/octo:debate` and other skill commands without errors
- Fixes confusing "agent type not found" error messages
- Commands just work as documented

❌ **No negative impact:**
- No user-facing changes - same commands work the same way
- No new syntax to learn
- No workarounds needed

## Files Updated

All command files that auto-load skills (11 total):

- `.claude/commands/debate.md` → `skill-debate`
- `.claude/commands/debug.md` → `skill-debug`
- `.claude/commands/docs.md` → `skill-doc-delivery`
- `.claude/commands/grasp.md` → `flow-grasp`
- `.claude/commands/ink.md` → `flow-ink`
- `.claude/commands/probe.md` → `flow-probe`
- `.claude/commands/research.md` → `skill-deep-research`
- `.claude/commands/review.md` → `skill-code-review`
- `.claude/commands/security.md` → `skill-security-audit`
- `.claude/commands/tangle.md` → `flow-tangle`
- `.claude/commands/tdd.md` → `skill-tdd`

## Testing

Tested with `/octo:debate` command - now correctly invokes `Skill(skill: "octo:debate")` instead of attempting `Task(subagent_type: "octo:debate")`.

## Checklist

- [x] All 11 command files updated with explicit instructions
- [x] Instructions follow consistent format
- [x] Verified changes in sample command file (debate.md)
- [x] No breaking changes to user-facing functionality
- [x] Pre-commit hooks passed

🤖 Generated with Claude Code