### PR TITLE
fix: remove _comment key from plugin.json to fix installation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "⚠️ CRITICAL: Plugin name MUST be 'octo' for correct command prefixes (/octo:*). See PLUGIN_NAME_LOCK.md. Package name (claude-octopus) is different and in package.json.",
   "name": "octo",
   "version": "7.11.0",
   "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v7.11.0) Commands now '/octo:*'. Run /octo:setup for guided setup.",


### PR DESCRIPTION
## Problem

When installing the plugin via Claude Code's plugin system, installation fails with the following validation error:

```
Error: Failed to install: Plugin has an invalid manifest file at
/Users/admin/.claude/plugins/cache/temp_local_1769075694133_5vsn7q/.claude-plugin/plugin.json.
Validation errors: : Unrecognized key: "_comment"
```

Claude Code's plugin validation schema does not allow unrecognized keys in `plugin.json`. The `_comment` key was added in PR #8 as a safeguard to prevent accidental plugin name changes, but it breaks plugin installation.

## Solution

Remove the `_comment` key from `.claude-plugin/plugin.json`.

The safeguard intent is **not lost** - the documentation already exists in multiple places:
- `.claude-plugin/PLUGIN_NAME_LOCK.md` - Detailed explanation with historical context
- `PLUGIN_NAME_SAFEGUARDS.md` - Quick safeguards reference
- `SAFEGUARDS.md` - Comprehensive safeguards guide

Additionally, the automated tests in `tests/validate-plugin-name.sh` and the pre-commit hook continue to protect against accidental name changes.

## Testing

Tested locally with `claude --plugin-dir` flag:

```bash
claude --plugin-dir /path/to/claude-octopus --print "list the available /octo commands"
```

Result: Plugin loads successfully and all `/octo:*` commands are available.

## Checklist

- [x] Code passes syntax validation (`python3 -m json.tool plugin.json`)
- [x] Plugin installs successfully with fix
- [x] Safeguard documentation remains intact
- [x] Automated tests still protect plugin name
- [x] Commit message follows conventions