### PR TITLE
fix: coverage CI permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   smoke:
     name: Smoke Tests
@@ -139,6 +144,7 @@ jobs:
 
       - name: Comment coverage on PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` and `issues: write` permissions to test workflow so coverage report can comment on PRs
- Add `continue-on-error: true` to the PR comment step so a 403 doesn't fail the entire coverage job

## Test plan
- [x] 58/58 tests pass locally
- [ ] Coverage job no longer fails on PR comment step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated testing workflow with improved error tolerance for coverage checks, allowing the pipeline to continue processing despite minor coverage deviations.
  * Added workflow permissions for pull request and issue management during automated testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->