### PR TITLE
fix: OpenClaw register crash — enabledWorkflows undefined (closes #48)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v8.22.4 - Fix OpenClaw install, remove flaky coverage CI. 31 personas, 44 commands, 46 skills. Run /octo:setup.",
-      "version": "8.22.4",
+      "description": "v8.22.5 - Fix OpenClaw register crash, full OpenClaw compatibility. 31 personas, 44 commands, 46 skills. Run /octo:setup.",
+      "version": "8.22.5",
       "author": {
         "name": "nyldn"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "8.22.4",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.22.4) Fix OpenClaw install, remove flaky coverage CI. 31 expert personas, 44 commands, 46 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
+  "version": "8.22.5",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.22.5) Fix OpenClaw register crash, full OpenClaw compatibility. 31 expert personas, 44 commands, 46 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [8.22.5] - 2026-02-23
+
+### Fixed
+
+- **OpenClaw Register Crash**: Guard `api.getConfig()` with `?? {}` fallback — OpenClaw passes `undefined` config during initial registration, causing `TypeError: Cannot read properties of undefined (reading 'enabledWorkflows')` (closes #48).
+
+---
+
 ## [8.22.4] - 2026-02-23
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Every model has blind spots. Claude Octopus fills them by orchestrating Codex, G
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-8.22.4-blue" alt="Version 8.22.4">
+  <img src="https://img.shields.io/badge/Version-8.22.5-blue" alt="Version 8.22.5">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.34+-blueviolet" alt="Requires Claude Code v2.1.34+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/openclaw/dist/index.js
+++ b/openclaw/dist/index.js
@@ -171,7 +171,7 @@ const WORKFLOW_TOOLS = [
 ];
 // --- Extension Entry Point ---
 export default function register(api) {
-    const config = api.getConfig();
+    const config = api.getConfig() ?? {};
     const enabledWorkflows = config.enabledWorkflows ?? [
         "discover",
         "define",

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -224,7 +224,7 @@ const WORKFLOW_TOOLS: OpenClawTool[] = [
 // --- Extension Entry Point ---
 
 export default function register(api: OpenClawApi) {
-  const config = api.getConfig();
+  const config = api.getConfig() ?? {};
   const enabledWorkflows = (config.enabledWorkflows as string[]) ?? [
     "discover",
     "define",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "8.22.4",
+  "version": "8.22.5",
   "description": "Claude Octopus - Multi-agent orchestration with persistent state management, codebase-aware discover, and STATE.md generation",
   "main": "orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Summary
- Guard `api.getConfig()` with `?? {}` fallback in `openclaw/src/index.ts`
- OpenClaw passes `undefined` config during initial registration, causing `TypeError: Cannot read properties of undefined (reading 'enabledWorkflows')`
- Updated compiled `dist/index.js` to match
- Bump to v8.22.5

Fixes #48

## Test plan
- [x] 58/58 tests pass locally
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)