### PR TITLE
fix: remove non-existent npm package reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,10 +203,16 @@ Any MCP-compatible client can connect to the server.
 
 ### OpenClaw Extension
 
-Install in an OpenClaw instance:
+Install in an OpenClaw instance from git:
 
 ```bash
-npm install @claude-octopus/openclaw
+npm install github:nyldn/claude-octopus#main --prefix openclaw
+```
+
+Or clone and link locally:
+
+```bash
+cd openclaw && npm install && npm run build
 ```
 
 The extension registers as an OpenClaw plugin with configurable workflows, autonomy modes, and Claude Code path resolution.


### PR DESCRIPTION
## Summary
- The README referenced `npm install @claude-octopus/openclaw` which was never published to npm
- Replaced with git-based install instructions that actually work

## Test plan
- [x] 58/58 pre-push tests pass
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenClaw installation instructions with revised npm command for installing from git.
  * Added alternative local installation workflow for cloning and building locally.
  * Included additional build validation guidance in the OpenClaw Extension section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->