### PR TITLE
chore: release v8.23.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v8.22.6 - Fix OpenClaw runtime API mismatch. 31 personas, 44 commands, 48 skills. Run /octo:setup.",
-      "version": "8.22.6",
+      "description": "v8.23.0 - Add /octo:claw OpenClaw sysadmin command, /octo:doctor health diagnostics, and openclaw-admin standalone repo. 31 personas, 44 commands, 48 skills. Run /octo:setup.",
+      "version": "8.23.0",
       "author": {
         "name": "nyldn"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "8.22.6",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.22.6) Fix OpenClaw runtime API mismatch. 31 expert personas, 44 commands, 48 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
+  "version": "8.23.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.23.0) Fix OpenClaw runtime API mismatch. 31 expert personas, 44 commands, 48 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [8.23.0] - 2026-02-24
+
+### Changed
+
+- Add /octo:claw OpenClaw sysadmin command, /octo:doctor health diagnostics, and openclaw-admin standalone repo
+
+---
+
 ## [8.22.6] - 2026-02-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Every model has blind spots. Claude Octopus fills them by orchestrating Codex, G
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-8.22.6-blue" alt="Version 8.22.6">
+  <img src="https://img.shields.io/badge/Version-8.23.0-blue" alt="Version 8.23.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.34+-blueviolet" alt="Requires Claude Code v2.1.34+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "8.22.6",
+  "version": "8.23.0",
   "description": "Claude Octopus - Multi-agent orchestration with persistent state management, codebase-aware discover, and STATE.md generation",
   "main": "orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Release v8.23.0

Add /octo:claw OpenClaw sysadmin command, /octo:doctor health diagnostics, and openclaw-admin standalone repo

---
🤖 Generated with release.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added /octo:claw command for OpenClaw sysadmin operations.
  * Added /octo:doctor command for health diagnostics.
  * Introduced openclaw-admin as a standalone repository.

**Version:** 8.23.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->