### PR TITLE
feat: Dark Factory Mode — v8.25.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v8.23.1 - Add missing /octo:claw and /octo:doctor command files. 31 personas, 44 commands, 48 skills. Run /octo:setup.",
-      "version": "8.23.1",
+      "description": "v8.25.0 - Dark Factory Mode: spec-in, software-out autonomous pipeline with holdout testing. 31 personas, 45 commands, 49 skills. Run /octo:setup.",
+      "version": "8.25.0",
       "author": {
         "name": "nyldn"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "8.23.1",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.23.1) Fix OpenClaw runtime API mismatch. 31 expert personas, 44 commands, 48 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
+  "version": "8.25.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.25.0) Dark Factory Mode — spec-in, software-out autonomous pipeline. 31 expert personas, 45 commands, 49 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
   "author": {
     "name": "nyldn"
   },
@@ -90,7 +90,8 @@
     "./.claude/skills/flow-spec.md",
     "./.claude/skills/flow-parallel.md",
     "./.claude/skills/skill-doctor.md",
-    "./.claude/skills/skill-claw.md"
+    "./.claude/skills/skill-claw.md",
+    "./.claude/skills/skill-factory.md"
   ],
   "commands": [
     "./.claude/commands/octo.md",
@@ -138,6 +139,7 @@
     "./.claude/commands/parallel.md",
     "./.claude/commands/sentinel.md",
     "./.claude/commands/claw.md",
-    "./.claude/commands/doctor.md"
+    "./.claude/commands/doctor.md",
+    "./.claude/commands/factory.md"
   ]
 }

--- a/.claude/commands/factory.md
+++ b/.claude/commands/factory.md
@@ -1,0 +1,105 @@
+---
+command: factory
+description: "Dark Factory Mode - Spec-in, software-out autonomous pipeline"
+aliases:
+  - dark-factory
+  - build-from-spec
+---
+
+# Factory - Dark Factory Mode (v8.25.0)
+
+## INSTRUCTIONS FOR CLAUDE
+
+When the user invokes this command (e.g., `/octo:factory --spec <path>`):
+
+### Step 1: Ask Clarifying Questions
+
+**CRITICAL: Before starting the factory pipeline, use the AskUserQuestion tool to gather context:**
+
+Ask 3 clarifying questions:
+1. Spec path — Where is the NLSpec file? (provide path, or paste inline)
+2. Satisfaction target — Accept spec default, or override? (Use spec default / Custom target 0.80-0.99)
+3. Cost confirmation — Factory mode runs ~20-30 agent calls (~$0.50-2.00). Proceed? (Yes / Yes with --ci for non-interactive / No)
+
+After receiving answers: validate spec path exists, set overrides, proceed.
+
+### Step 2: Check Provider Availability & Display Banner
+
+Check via bash:
+```bash
+codex_available=$(command -v codex &> /dev/null && echo "Available" || echo "Not installed")
+gemini_available=$(command -v gemini &> /dev/null && echo "Available" || echo "Not installed")
+```
+
+Display the factory banner:
+
+```
+CLAUDE OCTOPUS ACTIVATED - Dark Factory Mode
+Pipeline: Parse → Scenarios → Embrace → Holdout → Score → Report
+
+Providers:
+  Codex CLI - Scenario generation + holdout evaluation
+  Gemini CLI - Cross-provider diversity + blind review
+  Claude - Orchestration, synthesis, satisfaction scoring
+
+Spec: <spec-path>
+Estimated cost: $0.50-2.00 (~20-30 agent calls)
+```
+
+If both external providers are missing, warn but proceed (Claude-only mode is supported).
+
+### Step 3: Validate Spec
+
+Read the spec file and verify it contains:
+- Purpose or description section
+- At least one behavior or requirement
+- Ideally: actors, constraints, acceptance criteria
+
+If the spec is minimal, warn the user but proceed — factory mode works with thin specs (lower quality results).
+
+### Step 4: Execute Factory Pipeline
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate.sh factory --spec "<spec-path>"
+```
+
+With optional flags:
+- `--holdout-ratio 0.25` if user requested custom split
+- `--max-retries 2` if user wants more retry attempts
+- `--ci` if user confirmed non-interactive mode
+
+### Step 5: Present Results
+
+After factory completes, read the factory report:
+```bash
+cat .octo/factory/factory-*/factory-report.md
+```
+
+Present to the user:
+1. **Verdict** (PASS/WARN/FAIL) with the composite score
+2. **Score breakdown** across the 4 dimensions
+3. **Holdout results** — which blind scenarios passed/failed
+4. **Artifact locations** for deeper review
+5. **Next steps** — if WARN/FAIL, suggest reviewing holdout failures and re-running
+
+## 7-Phase Pipeline
+
+| Phase | What Happens |
+|-------|-------------|
+| 1. Parse Spec | Validate NLSpec, extract satisfaction target + complexity + behaviors |
+| 2. Generate Scenarios | Multi-provider scenario generation from spec |
+| 3. Split Holdout | 80/20 split ensuring holdout covers diverse behaviors |
+| 4. Embrace Workflow | Full 4-phase implementation (discover → define → develop → deliver) |
+| 5. Holdout Tests | Blind evaluation of withheld scenarios against implementation |
+| 6. Score Satisfaction | Weighted scoring: behavior(40%) + constraints(20%) + holdout(25%) + quality(15%) |
+| 7. Report | Markdown report + JSON session summary |
+
+## Key Properties
+
+- **Autonomy:** Runs embrace in fully autonomous mode (no phase-by-phase approval)
+- **Cost:** ~$0.50-2.00 per run depending on spec complexity and provider costs
+- **Retry:** On FAIL verdict, re-runs phases 3-4 with remediation context (up to max-retries)
+- **Verdict levels:** PASS (>= target), WARN (>= target - 0.05), FAIL (< target - 0.05)
+- **Artifacts:** `.octo/factory/<run-id>/` contains all intermediate files
+- **Not for:** Simple bug fixes, code review only, tasks without a clear specification
+- **Related commands:** `/octo:spec` (create NLSpec), `/octo:embrace` (manual 4-phase workflow)

--- a/.claude/skills/skill-factory.md
+++ b/.claude/skills/skill-factory.md
@@ -1,0 +1,155 @@
+---
+name: skill-factory
+aliases:
+  - factory
+  - dark-factory
+  - build-from-spec
+  - autonomous-build
+description: Dark Factory Mode — spec-in, software-out autonomous pipeline with holdout testing and satisfaction scoring
+execution_mode: enforced
+validation_gates:
+  - spec_file_validated
+  - orchestrate_sh_executed
+  - factory_report_exists
+---
+
+# STOP - SKILL ALREADY LOADED
+DO NOT call Skill() again. Execute directly.
+
+## EXECUTION CONTRACT (MANDATORY — 8-step sequence, CANNOT SKIP)
+
+### STEP 1: Clarifying Questions (MANDATORY)
+Ask via AskUserQuestion BEFORE any other action:
+1. Spec location — path to NLSpec file, or paste inline
+2. Satisfaction target override (Use spec default / Custom 0.80-0.99)
+3. Cost approval — ~$0.50-2.00 for ~20-30 agent calls (Approve / Approve --ci / Decline)
+
+If spec path provided inline with the command, use it but still ask remaining questions.
+If user says "skip", use defaults and proceed.
+DO NOT proceed to Step 2 until answered.
+
+### STEP 2: Display Visual Indicators (MANDATORY — BLOCKING)
+Check providers:
+```bash
+command -v codex &> /dev/null && codex_status="Available" || codex_status="Not installed"
+command -v gemini &> /dev/null && gemini_status="Available" || gemini_status="Not installed"
+```
+Display banner:
+```
+CLAUDE OCTOPUS ACTIVATED - Dark Factory Mode
+Pipeline: Parse → Scenarios → Embrace → Holdout → Score → Report
+
+Providers:
+  Codex CLI - <status> — Scenario generation + holdout evaluation
+  Gemini CLI - <status> — Cross-provider diversity
+  Claude - Orchestration + satisfaction scoring
+
+Spec: <path>
+Estimated: $0.50-2.00 / 15-45 min
+```
+
+Validation: BOTH external providers unavailable → continue with Claude-only (warn user about reduced diversity). At least one available → proceed normally.
+
+### STEP 3: Validate Spec File (MANDATORY — Validation Gate)
+```bash
+if [[ ! -f "<spec_path>" ]]; then
+    echo "ERROR: Spec file not found at <spec_path>"
+    exit 1
+fi
+# Check minimum content
+word_count=$(wc -w < "<spec_path>")
+if [[ $word_count -lt 20 ]]; then
+    echo "WARNING: Spec is very thin ($word_count words). Results may be limited."
+fi
+```
+If spec file missing → STOP, ask user for correct path.
+If spec is thin (< 50 words) → WARN but proceed.
+DO NOT proceed past this gate if file does not exist.
+
+### STEP 4: Read Prior State (OPTIONAL)
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" init_state 2>/dev/null || true
+"${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" set_current_workflow "factory" "factory" 2>/dev/null || true
+```
+Failure → continue without state, warn user.
+
+### STEP 5: Execute orchestrate.sh factory (MANDATORY — Bash Tool)
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate.sh factory --spec "<spec_path>"
+```
+
+With optional flags based on Step 1 answers:
+- `--holdout-ratio <value>` if custom ratio requested
+- `--max-retries <value>` if custom retry count
+- `--ci` if user approved non-interactive mode
+
+PROHIBITED from:
+- Running embrace directly (MUST use factory command which wraps it)
+- Simulating or faking holdout testing
+- Substituting direct Claude analysis for multi-provider scoring
+- Skipping the factory pipeline
+- Creating working/progress files in plugin directory
+
+### STEP 6: Verify Factory Report (MANDATORY — Validation Gate)
+```bash
+REPORT_FILE=$(find .octo/factory -name "factory-report.md" -mmin -60 2>/dev/null | sort -r | head -1)
+if [[ -z "$REPORT_FILE" ]]; then
+    echo "ERROR: Factory report not found"
+    exit 1
+fi
+cat "$REPORT_FILE"
+```
+If validation fails: report error, show logs from `~/.claude-octopus/logs/`, DO NOT proceed, DO NOT substitute.
+
+### STEP 7: Read Scores and Present Results (MANDATORY)
+```bash
+SCORES_FILE=$(find .octo/factory -name "satisfaction-scores.json" -mmin -60 2>/dev/null | sort -r | head -1)
+if [[ -n "$SCORES_FILE" ]]; then
+    cat "$SCORES_FILE"
+fi
+```
+
+Present to user:
+1. **Verdict** with emoji (PASS/WARN/FAIL)
+2. **Composite score** vs satisfaction target
+3. **Dimension breakdown** (behavior, constraints, holdout, quality)
+4. **Holdout highlights** — which blind scenarios passed/failed
+5. **Artifact directory** path for deep review
+
+### STEP 8: Update State & Next Steps (MANDATORY)
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" record_decision "factory" "Factory run completed: <verdict> (<score>/<target>)" 2>/dev/null || true
+```
+
+Present next-step suggestions based on verdict:
+- **PASS:** Implementation meets spec. Review artifacts, run manual testing, ship.
+- **WARN:** Close to target. Review holdout failures, consider targeted fixes.
+- **FAIL:** Below target. Review `holdout-results.md` for specific failures. Consider:
+  - Refining the NLSpec with `/octo:spec`
+  - Manual fixes + re-run with `--max-retries 2`
+  - Breaking spec into smaller, clearer pieces
+
+Include attribution footer:
+```
+Dark Factory Mode powered by Claude Octopus v8.25.0
+Pipeline: Spec → Scenarios → Embrace → Holdout → Score → Report
+Providers: Codex | Gemini | Claude
+```
+
+## Error Handling (by step)
+- Step 1 (Questions): If user declines all, proceed with defaults
+- Step 2 (Providers): Both external unavailable → Claude-only mode (warn)
+- Step 3 (Spec): File missing → STOP. Thin spec → WARN and proceed.
+- Step 4 (State): Failure → continue without state
+- Step 5 (orchestrate.sh): Show bash error, check logs — DO NOT substitute
+- Step 6 (Report): Missing → show logs, DO NOT proceed
+- Step 7 (Scores): Missing JSON → extract from report markdown
+- Step 8 (State): Failure → skip state update, still present results
+
+## Prohibited Actions
+- CANNOT skip orchestrate.sh factory execution
+- CANNOT simulate or fake the factory pipeline
+- CANNOT substitute direct Claude analysis for multi-provider scoring
+- CANNOT skip spec validation gate
+- CANNOT proceed past a failed validation gate
+- CANNOT create working/progress files in plugin directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [8.25.0] - 2026-02-25
+
+### Changed
+
+- **Dark Factory Mode** (closes #37): Spec-in, software-out autonomous pipeline with `/octo:factory` command. Wraps embrace workflow with scenario holdout testing (E19), satisfaction scoring (E21), and non-interactive execution (E22). 7 new functions: `parse_factory_spec`, `generate_factory_scenarios`, `split_holdout_scenarios`, `run_holdout_tests`, `score_satisfaction`, `generate_factory_report`, `factory_run`. Weighted 4-dimension scoring (behavior 40%, constraints 20%, holdout 25%, quality 15%) with PASS/WARN/FAIL verdicts. Retry on failure with remediation context. Artifacts stored at `.octo/factory/<run-id>/`.
+
+---
+
 ## [8.23.1] - 2026-02-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Every model has blind spots. Claude Octopus fills them by orchestrating Codex, G
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-8.23.1-blue" alt="Version 8.23.1">
+  <img src="https://img.shields.io/badge/Version-8.25.0-blue" alt="Version 8.25.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.34+-blueviolet" alt="Requires Claude Code v2.1.34+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -86,6 +86,7 @@ Here's the full set:
 | `/octo:brainstorm` | Creative thought partner session |
 | `/octo:claw` | OpenClaw instance admin — manage hosts across macOS, Ubuntu/Debian, Docker, OCI, Proxmox |
 | `/octo:doctor` | Environment diagnostics — 9 check categories with filtering and JSON output |
+| `/octo:factory` | Dark Factory Mode — spec-in, software-out autonomous pipeline with holdout testing |
 
 Don't remember the command name? Just describe what you need:
 

--- a/openclaw/src/tools/index.ts
+++ b/openclaw/src/tools/index.ts
@@ -37,6 +37,7 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "octopus-research", description: "Deep multi-AI parallel research with cost transparency and synthesis", type: "skill", file: "skill-deep-research.md" },
   { name: "skill-doc-delivery", description: "Convert markdown to DOCX, PPTX, XLSX office documents", type: "skill", file: "skill-doc-delivery.md" },
   { name: "skill-doctor", description: "Environment diagnostics — check providers, auth, config, hooks, scheduler, and more", type: "skill", file: "skill-doctor.md" },
+  { name: "skill-factory", description: "Dark Factory Mode — spec-in, software-out autonomous pipeline with holdout testing and satisfaction scoring", type: "skill", file: "skill-factory.md" },
   { name: "skill-finish-branch", description: "Post-implementation: verify tests, merge/PR/keep/discard", type: "skill", file: "skill-finish-branch.md" },
   { name: "skill-intent-contract", description: "Capture user goals and validate outputs against them", type: "skill", file: "skill-intent-contract.md" },
   { name: "skill-issues", description: "Track and manage project issues across sessions", type: "skill", file: "skill-issues.md" },
@@ -77,6 +78,7 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "doctor", description: "Environment diagnostics — check providers, auth, config, hooks, scheduler, and more", type: "command", file: "doctor.md" },
   { name: "embrace", description: "Full Double Diamond workflow - Research → Define → Develop → Deliver", type: "command", file: "embrace.md" },
   { name: "extract", description: "Design System & Product Reverse-Engineering - Extract tokens, components, architecture, and PRDs from codebases or live products", type: "command", file: "extract.md" },
+  { name: "factory", description: "Dark Factory Mode - Spec-in, software-out autonomous pipeline", type: "command", file: "factory.md" },
   { name: "grasp", description: "Definition phase - Requirements clarification and scope definition", type: "command", file: "grasp.md" },
   { name: "ink", description: "Delivery phase - Quality assurance, validation, and review", type: "command", file: "ink.md" },
   { name: "issues", description: "Track, inspect, and resolve cross-session Octopus issues", type: "command", file: "issues.md" },
@@ -111,4 +113,4 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "validate", description: "Run comprehensive multi-AI validation on code or project targets", type: "command", file: "validate.md" },
 ];
 
-export const REGISTRY_COUNT = 94;
+export const REGISTRY_COUNT = 96;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "8.23.1",
+  "version": "8.25.0",
   "description": "Claude Octopus - Multi-agent orchestration with persistent state management, codebase-aware discover, and STATE.md generation",
   "main": "orchestrate.sh",
   "scripts": {

--- a/tests/test-v8.0.0-opus-integration.sh
+++ b/tests/test-v8.0.0-opus-integration.sh
@@ -356,7 +356,7 @@ fi
 
 # 7.5: Correct skill file count
 skill_count=$(find "$SKILLS_DIR" -name "*.md" -type f | wc -l | tr -d ' ')
-assert_equals "48" "$skill_count" "7.5 Skill directory contains exactly 48 files"
+assert_equals "49" "$skill_count" "7.5 Skill directory contains exactly 49 files"
 
 echo ""
 

--- a/tests/test-v8.25.0-dark-factory.sh
+++ b/tests/test-v8.25.0-dark-factory.sh
@@ -1,0 +1,554 @@
+#!/usr/bin/env bash
+# Test v8.25.0 Dark Factory Mode (Issue #37)
+# Validates E19 (Scenario Holdout), E21 (Satisfaction Scoring), E22 (Factory Pipeline)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ORCHESTRATE_SH="$PROJECT_ROOT/scripts/orchestrate.sh"
+COMMAND_FILE="$PROJECT_ROOT/.claude/commands/factory.md"
+SKILL_FILE="$PROJECT_ROOT/.claude/skills/skill-factory.md"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TEST_COUNT=0
+PASS_COUNT=0
+FAIL_COUNT=0
+
+echo -e "${BLUE}Testing v8.25.0 Dark Factory Mode (Issue #37)${NC}"
+echo ""
+
+pass() {
+    PASS_COUNT=$((PASS_COUNT + 1))
+    TEST_COUNT=$((TEST_COUNT + 1))
+    echo -e "${GREEN}  PASS${NC}: $1"
+}
+
+fail() {
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    TEST_COUNT=$((TEST_COUNT + 1))
+    echo -e "${RED}  FAIL${NC}: $1"
+    if [[ -n "${2:-}" ]]; then echo -e "   ${YELLOW}$2${NC}"; fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test Suite 1: Function Registration
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo "Test Suite 1: Function Registration"
+echo "────────────────────────────────────────"
+
+# Test 1.1: parse_factory_spec exists
+if grep -q "^parse_factory_spec()" "$ORCHESTRATE_SH"; then
+    pass "parse_factory_spec() function exists"
+else
+    fail "parse_factory_spec() function NOT found"
+fi
+
+# Test 1.2: generate_factory_scenarios exists
+if grep -q "^generate_factory_scenarios()" "$ORCHESTRATE_SH"; then
+    pass "generate_factory_scenarios() function exists"
+else
+    fail "generate_factory_scenarios() function NOT found"
+fi
+
+# Test 1.3: split_holdout_scenarios exists
+if grep -q "^split_holdout_scenarios()" "$ORCHESTRATE_SH"; then
+    pass "split_holdout_scenarios() function exists"
+else
+    fail "split_holdout_scenarios() function NOT found"
+fi
+
+# Test 1.4: run_holdout_tests exists
+if grep -q "^run_holdout_tests()" "$ORCHESTRATE_SH"; then
+    pass "run_holdout_tests() function exists"
+else
+    fail "run_holdout_tests() function NOT found"
+fi
+
+# Test 1.5: score_satisfaction exists
+if grep -q "^score_satisfaction()" "$ORCHESTRATE_SH"; then
+    pass "score_satisfaction() function exists"
+else
+    fail "score_satisfaction() function NOT found"
+fi
+
+# Test 1.6: generate_factory_report exists
+if grep -q "^generate_factory_report()" "$ORCHESTRATE_SH"; then
+    pass "generate_factory_report() function exists"
+else
+    fail "generate_factory_report() function NOT found"
+fi
+
+# Test 1.7: factory_run exists
+if grep -q "^factory_run()" "$ORCHESTRATE_SH"; then
+    pass "factory_run() function exists"
+else
+    fail "factory_run() function NOT found"
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test Suite 2: Configuration Defaults
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo "Test Suite 2: Configuration Defaults"
+echo "────────────────────────────────────────"
+
+# Test 2.1: OCTOPUS_FACTORY_MODE default
+if grep -q 'OCTOPUS_FACTORY_MODE="${OCTOPUS_FACTORY_MODE:-false}"' "$ORCHESTRATE_SH"; then
+    pass "OCTOPUS_FACTORY_MODE defaults to false"
+else
+    fail "OCTOPUS_FACTORY_MODE default missing"
+fi
+
+# Test 2.2: OCTOPUS_FACTORY_HOLDOUT_RATIO default
+if grep -q 'OCTOPUS_FACTORY_HOLDOUT_RATIO="${OCTOPUS_FACTORY_HOLDOUT_RATIO:-0.20}"' "$ORCHESTRATE_SH"; then
+    pass "OCTOPUS_FACTORY_HOLDOUT_RATIO defaults to 0.20"
+else
+    fail "OCTOPUS_FACTORY_HOLDOUT_RATIO default missing"
+fi
+
+# Test 2.3: OCTOPUS_FACTORY_MAX_RETRIES default
+if grep -q 'OCTOPUS_FACTORY_MAX_RETRIES="${OCTOPUS_FACTORY_MAX_RETRIES:-1}"' "$ORCHESTRATE_SH"; then
+    pass "OCTOPUS_FACTORY_MAX_RETRIES defaults to 1"
+else
+    fail "OCTOPUS_FACTORY_MAX_RETRIES default missing"
+fi
+
+# Test 2.4: OCTOPUS_FACTORY_SATISFACTION_TARGET env var
+if grep -q 'OCTOPUS_FACTORY_SATISFACTION_TARGET' "$ORCHESTRATE_SH"; then
+    pass "OCTOPUS_FACTORY_SATISFACTION_TARGET env var supported"
+else
+    fail "OCTOPUS_FACTORY_SATISFACTION_TARGET env var missing"
+fi
+
+# Test 2.5: v8.25.0 version comment present
+if grep -q 'v8.25.0.*Dark Factory' "$ORCHESTRATE_SH"; then
+    pass "v8.25.0 version comment present"
+else
+    fail "v8.25.0 version comment missing"
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test Suite 3: Command File Validation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo "Test Suite 3: Command File Validation"
+echo "────────────────────────────────────────"
+
+# Test 3.1: Command file exists
+if [[ -f "$COMMAND_FILE" ]]; then
+    pass "factory.md command file exists"
+else
+    fail "factory.md command file NOT found"
+fi
+
+# Test 3.2: Frontmatter has command name
+if grep -q 'command: factory' "$COMMAND_FILE"; then
+    pass "Command frontmatter: command: factory"
+else
+    fail "Command frontmatter missing command name"
+fi
+
+# Test 3.3: Aliases include dark-factory
+if grep -q 'dark-factory' "$COMMAND_FILE"; then
+    pass "Command alias: dark-factory"
+else
+    fail "Command alias dark-factory missing"
+fi
+
+# Test 3.4: References orchestrate.sh factory
+if grep -q 'orchestrate.sh factory' "$COMMAND_FILE"; then
+    pass "Command references orchestrate.sh factory"
+else
+    fail "Command missing orchestrate.sh factory reference"
+fi
+
+# Test 3.5: Mentions --spec flag
+if grep -q '\-\-spec' "$COMMAND_FILE"; then
+    pass "Command documents --spec flag"
+else
+    fail "Command missing --spec flag documentation"
+fi
+
+# Test 3.6: Cost estimate mentioned
+if grep -q '\$0.50' "$COMMAND_FILE"; then
+    pass "Command includes cost estimate"
+else
+    fail "Command missing cost estimate"
+fi
+
+# Test 3.7: 7-phase pipeline documented
+if grep -q 'Holdout Tests' "$COMMAND_FILE" && grep -q 'Satisfaction' "$COMMAND_FILE"; then
+    pass "7-phase pipeline documented"
+else
+    fail "Pipeline documentation incomplete"
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test Suite 4: Skill File Validation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo "Test Suite 4: Skill File Validation"
+echo "────────────────────────────────────────"
+
+# Test 4.1: Skill file exists
+if [[ -f "$SKILL_FILE" ]]; then
+    pass "skill-factory.md skill file exists"
+else
+    fail "skill-factory.md skill file NOT found"
+fi
+
+# Test 4.2: Enforced execution mode
+if grep -q 'execution_mode: enforced' "$SKILL_FILE"; then
+    pass "Skill has execution_mode: enforced"
+else
+    fail "Skill missing enforced execution mode"
+fi
+
+# Test 4.3: Validation gates defined
+if grep -q 'factory_report_exists' "$SKILL_FILE"; then
+    pass "Validation gate: factory_report_exists"
+else
+    fail "Missing factory_report_exists validation gate"
+fi
+
+# Test 4.4: 8-step sequence
+if grep -q 'STEP 8' "$SKILL_FILE"; then
+    pass "Skill has 8-step execution contract"
+else
+    fail "Skill missing 8-step sequence"
+fi
+
+# Test 4.5: Prohibited actions section
+if grep -q 'CANNOT skip orchestrate.sh factory' "$SKILL_FILE"; then
+    pass "Prohibited actions documented"
+else
+    fail "Prohibited actions missing"
+fi
+
+# Test 4.6: References orchestrate.sh factory
+if grep -q 'orchestrate.sh factory' "$SKILL_FILE"; then
+    pass "Skill references orchestrate.sh factory"
+else
+    fail "Skill missing orchestrate.sh factory reference"
+fi
+
+# Test 4.7: Trigger aliases
+if grep -q 'build-from-spec' "$SKILL_FILE" && grep -q 'autonomous-build' "$SKILL_FILE"; then
+    pass "Skill trigger aliases present"
+else
+    fail "Skill trigger aliases missing"
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test Suite 5: Holdout Split Logic (Functional)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo "Test Suite 5: Holdout Split Logic"
+echo "────────────────────────────────────────"
+
+# Create temp directory and scenario file for functional testing
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+cat > "$TEMP_DIR/scenarios-all.md" << 'SCENARIOS'
+# Test Scenarios
+
+### Scenario 1: User login happy path
+**Behavior:** Authentication
+**Type:** happy-path
+**Given:** Valid credentials
+**When:** User submits login form
+**Then:** User is authenticated
+
+### Scenario 2: Invalid password
+**Behavior:** Authentication
+**Type:** error-handling
+**Given:** Valid username, wrong password
+**When:** User submits login form
+**Then:** Error message displayed
+
+### Scenario 3: Session timeout
+**Behavior:** Session management
+**Type:** edge-case
+**Given:** Authenticated user, idle for 30min
+**When:** User makes a request
+**Then:** Redirected to login
+
+### Scenario 4: Rate limiting
+**Behavior:** Security
+**Type:** non-functional
+**Given:** Same IP, 100 requests in 1 minute
+**When:** 101st request arrives
+**Then:** Request rejected with 429
+
+### Scenario 5: Password reset flow
+**Behavior:** Account recovery
+**Type:** happy-path
+**Given:** Registered email
+**When:** User requests password reset
+**Then:** Reset email sent
+
+### Scenario 6: OAuth integration
+**Behavior:** SSO
+**Type:** integration
+**Given:** Valid OAuth provider
+**When:** User clicks "Sign in with Google"
+**Then:** OAuth flow initiated
+
+### Scenario 7: Remember me checkbox
+**Behavior:** Session management
+**Type:** happy-path
+**Given:** User checks "remember me"
+**When:** Browser is closed and reopened
+**Then:** User remains authenticated
+
+### Scenario 8: SQL injection attempt
+**Behavior:** Security
+**Type:** edge-case
+**Given:** Malicious input in username field
+**When:** User submits login form
+**Then:** Input sanitized, no data leak
+
+### Scenario 9: Concurrent login detection
+**Behavior:** Security
+**Type:** edge-case
+**Given:** User logged in on device A
+**When:** Same user logs in on device B
+**Then:** Device A session invalidated
+
+### Scenario 10: Password complexity
+**Behavior:** Account management
+**Type:** happy-path
+**Given:** New password with weak criteria
+**When:** User submits password change
+**Then:** Validation error with requirements
+SCENARIOS
+
+# Test 5.1: Can source the split function (syntax check via grep of structure)
+if grep -q 'split_holdout_scenarios()' "$ORCHESTRATE_SH"; then
+    pass "split_holdout_scenarios() function found"
+else
+    fail "split_holdout_scenarios() function missing"
+fi
+
+# Test 5.2: Scenario file has 10 scenarios
+scenario_count=$(grep -c '### Scenario' "$TEMP_DIR/scenarios-all.md")
+if [[ $scenario_count -eq 10 ]]; then
+    pass "Test data: 10 scenarios created"
+else
+    fail "Test data: expected 10 scenarios, got $scenario_count"
+fi
+
+# Test 5.3: Function handles holdout ratio calculation
+# Verify the awk-based calculation pattern exists
+if grep -q 'holdout_count.*awk.*printf' "$ORCHESTRATE_SH"; then
+    pass "Holdout ratio calculation uses awk"
+else
+    fail "Holdout ratio calculation pattern missing"
+fi
+
+# Test 5.4: Function creates scenarios-visible.md and scenarios-holdout.md
+if grep -q 'scenarios-visible.md' "$ORCHESTRATE_SH" && grep -q 'scenarios-holdout.md' "$ORCHESTRATE_SH"; then
+    pass "Output files: scenarios-visible.md and scenarios-holdout.md"
+else
+    fail "Output file references missing"
+fi
+
+# Test 5.5: Minimum holdout count of 1
+if grep -q 'holdout_count -lt 1' "$ORCHESTRATE_SH"; then
+    pass "Minimum holdout count check present"
+else
+    fail "Minimum holdout count guard missing"
+fi
+
+# Test 5.6: Holdout index distribution (spread, not sequential)
+if grep -q 'step.*total.*holdout_count' "$ORCHESTRATE_SH"; then
+    pass "Holdout uses spread distribution (not sequential)"
+else
+    fail "Holdout distribution pattern missing"
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test Suite 6: CLI Integration
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo "Test Suite 6: CLI Integration"
+echo "────────────────────────────────────────"
+
+# Test 6.1: factory dispatch case exists
+if grep -q 'factory|dark-factory)' "$ORCHESTRATE_SH"; then
+    pass "CLI dispatch: factory|dark-factory case"
+else
+    fail "CLI dispatch case missing"
+fi
+
+# Test 6.2: --help flag handled
+help_output=$("$ORCHESTRATE_SH" factory --help 2>&1) || true
+if echo "$help_output" | grep -q 'Dark Factory Mode'; then
+    pass "factory --help displays usage"
+else
+    fail "factory --help output incorrect"
+fi
+
+# Test 6.3: Missing --spec shows error
+missing_output=$("$ORCHESTRATE_SH" factory 2>&1) || true
+if echo "$missing_output" | grep -q 'Missing --spec'; then
+    pass "Missing --spec shows error message"
+else
+    fail "Missing --spec error not displayed"
+fi
+
+# Test 6.4: --spec flag parsing
+if grep -q '\-\-spec)' "$ORCHESTRATE_SH" && grep -q 'factory_spec=' "$ORCHESTRATE_SH"; then
+    pass "--spec flag parsing implemented"
+else
+    fail "--spec flag parsing missing"
+fi
+
+# Test 6.5: --holdout-ratio flag parsing
+if grep -q '\-\-holdout-ratio)' "$ORCHESTRATE_SH" && grep -q 'factory_holdout=' "$ORCHESTRATE_SH"; then
+    pass "--holdout-ratio flag parsing implemented"
+else
+    fail "--holdout-ratio flag parsing missing"
+fi
+
+# Test 6.6: --max-retries flag parsing
+if grep -q '\-\-max-retries)' "$ORCHESTRATE_SH" && grep -q 'factory_retries=' "$ORCHESTRATE_SH"; then
+    pass "--max-retries flag parsing implemented"
+else
+    fail "--max-retries flag parsing missing"
+fi
+
+# Test 6.7: --ci flag parsing
+if grep -q '\-\-ci)' "$ORCHESTRATE_SH" && grep -q 'factory_ci=' "$ORCHESTRATE_SH"; then
+    pass "--ci flag parsing implemented"
+else
+    fail "--ci flag parsing missing"
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test Suite 7: Dry-Run Validation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo "Test Suite 7: Architecture Validation"
+echo "────────────────────────────────────────"
+
+# Test 7.1: Factory wraps embrace_full_workflow (not duplicate)
+if grep -q 'embrace_full_workflow.*embrace_prompt' "$ORCHESTRATE_SH"; then
+    pass "factory_run() wraps embrace_full_workflow()"
+else
+    fail "factory_run() does not wrap embrace_full_workflow()"
+fi
+
+# Test 7.2: Sets AUTONOMY_MODE=autonomous
+if grep -q 'AUTONOMY_MODE=autonomous' "$ORCHESTRATE_SH"; then
+    pass "Factory sets AUTONOMY_MODE=autonomous"
+else
+    fail "AUTONOMY_MODE=autonomous not set"
+fi
+
+# Test 7.3: Sets OCTOPUS_SKIP_PHASE_COST_PROMPT
+if grep -q 'OCTOPUS_SKIP_PHASE_COST_PROMPT=true' "$ORCHESTRATE_SH"; then
+    pass "Factory sets OCTOPUS_SKIP_PHASE_COST_PROMPT=true"
+else
+    fail "OCTOPUS_SKIP_PHASE_COST_PROMPT not set"
+fi
+
+# Test 7.4: Uses run_agent_sync for scenario generation
+if grep -A60 'generate_factory_scenarios()' "$ORCHESTRATE_SH" | grep -q 'run_agent_sync'; then
+    pass "Scenario generation uses run_agent_sync()"
+else
+    fail "Scenario generation does not use run_agent_sync()"
+fi
+
+# Test 7.5: Satisfaction scoring weights documented
+if grep -q '0\.40.*0\.20.*0\.25.*0\.15' "$ORCHESTRATE_SH"; then
+    pass "Satisfaction scoring weights: 40/20/25/15"
+else
+    fail "Satisfaction scoring weights missing or incorrect"
+fi
+
+# Test 7.6: Verdict levels (PASS, WARN, FAIL)
+if grep -q 'verdict="PASS"' "$ORCHESTRATE_SH" && grep -q 'verdict="WARN"' "$ORCHESTRATE_SH" && grep -q 'verdict="FAIL"' "$ORCHESTRATE_SH"; then
+    pass "Verdict levels: PASS, WARN, FAIL"
+else
+    fail "Verdict levels incomplete"
+fi
+
+# Test 7.7: Retry logic on FAIL
+if grep -q 'verdict.*FAIL.*retry_count.*max_retries' "$ORCHESTRATE_SH"; then
+    pass "Retry logic triggers on FAIL verdict"
+else
+    fail "Retry logic missing"
+fi
+
+# Test 7.8: Artifacts stored in .octo/factory/
+if grep -q '.octo/factory/' "$ORCHESTRATE_SH"; then
+    pass "Artifacts stored in .octo/factory/"
+else
+    fail "Artifact storage path missing"
+fi
+
+# Test 7.9: Session JSON written
+if grep -q 'session.json' "$ORCHESTRATE_SH"; then
+    pass "session.json metadata file created"
+else
+    fail "session.json creation missing"
+fi
+
+# Test 7.10: Satisfaction scores JSON written
+if grep -q 'satisfaction-scores.json' "$ORCHESTRATE_SH"; then
+    pass "satisfaction-scores.json written"
+else
+    fail "satisfaction-scores.json creation missing"
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Final Summary
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${BLUE}Test Summary${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "Total tests:  ${BLUE}${TEST_COUNT}${NC}"
+echo -e "Passed:       ${GREEN}${PASS_COUNT}${NC}"
+echo -e "Failed:       ${RED}${FAIL_COUNT}${NC}"
+echo ""
+
+if [[ $FAIL_COUNT -eq 0 ]]; then
+    echo -e "${GREEN}All v8.25.0 Dark Factory Mode tests passed!${NC}"
+    echo ""
+    echo -e "${BLUE}Summary:${NC}"
+    echo "  E19: Scenario Holdout Testing — split_holdout_scenarios()"
+    echo "  E21: Satisfaction Scoring — score_satisfaction() with 4-dimension weights"
+    echo "  E22: Dark Factory Pipeline — factory_run() wrapping embrace_full_workflow()"
+    echo "  7 new functions, CLI dispatch, command file, skill file"
+    echo "  Artifacts: .octo/factory/<run-id>/ (spec, scenarios, scores, report)"
+    echo ""
+    exit 0
+else
+    echo -e "${RED}Some tests failed${NC}"
+    exit 1
+fi

--- a/tests/test-version-consistency.sh
+++ b/tests/test-version-consistency.sh
@@ -153,7 +153,7 @@ echo ""
 echo "Test 7: Checking skill count in plugin.json..."
 if [[ -f "$PLUGIN_JSON" ]]; then
     SKILL_COUNT=$(grep -o '"\./\.claude/skills/[^"]*\.md"' "$PLUGIN_JSON" | wc -l | tr -d ' ')
-    EXPECTED_SKILLS=48
+    EXPECTED_SKILLS=49
 
     if [[ $SKILL_COUNT -eq $EXPECTED_SKILLS ]]; then
         pass "plugin.json has $SKILL_COUNT skills (expected: $EXPECTED_SKILLS)"


### PR DESCRIPTION
## Summary
- **Dark Factory Mode** (closes #37): Spec-in, software-out autonomous pipeline
- Implements E19 (Scenario Holdout Testing), E21 (Satisfaction Scoring), E22 (Non-Interactive Execution)
- 7 new functions in orchestrate.sh wrapping `embrace_full_workflow()` — zero modifications to embrace
- Pipeline: parse spec → generate scenarios → split holdout (20%) → embrace → holdout tests → score → report
- Weighted 4-dimension scoring: behavior (40%), constraints (20%), holdout (25%), quality (15%)
- PASS/WARN/FAIL verdicts with retry on failure using remediation context
- New `/octo:factory` command + `skill-factory.md` skill with enforced execution contract
- Artifacts at `.octo/factory/<run-id>/`
- Version bump to 8.25.0 across package.json, plugin.json, marketplace.json, README badge

## Files changed
| File | Change |
|------|--------|
| `scripts/orchestrate.sh` | +784 lines: 4 config constants, 7 functions, CLI dispatch |
| `.claude/commands/factory.md` | New: command file following embrace.md pattern |
| `.claude/skills/skill-factory.md` | New: enforced 8-step skill with validation gates |
| `tests/test-v8.25.0-dark-factory.sh` | New: 49 tests across 7 suites |
| `tests/test-version-consistency.sh` | Bump expected skill count 48→49 |
| `tests/test-v8.0.0-opus-integration.sh` | Bump expected skill count 48→49 |
| `.claude-plugin/plugin.json` | Version 8.25.0, register factory command + skill |
| `.claude-plugin/marketplace.json` | Version 8.25.0, update description |
| `package.json` | Version 8.25.0 |
| `CHANGELOG.md` | v8.25.0 entry |
| `README.md` | Version badge + factory command in table |

## Test plan
- [x] `bash tests/test-v8.25.0-dark-factory.sh` — 49/49 pass
- [x] `bash tests/test-v8.24.0-perplexity-integration.sh` — 35/35 pass (no regression)
- [x] `bash tests/test-version-consistency.sh` — 24/24 pass
- [x] `bash tests/test-v8.0.0-opus-integration.sh` — 40/40 pass
- [x] `orchestrate.sh factory --help` — shows usage
- [x] `orchestrate.sh factory` (no args) — shows missing --spec error
- [ ] Manual: `/octo:factory --spec spec.md` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Dark Factory Mode with /octo:factory command for autonomous spec-in → software-out runs, scenario generation, holdout testing, retry/remediation, and PASS/WARN/FAIL verdicts.
  * Non-interactive CI-friendly execution with configurable holdout ratio and retry limits; artifactized reports and scores.

* **Documentation**
  * Added detailed command, skill, and changelog entries describing Dark Factory workflow and scoring.

* **Tests**
  * New/updated test suites validating Dark Factory behavior and version/skill counts.

* **Chores**
  * Version bumped to 8.25.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->