### PR TITLE
fix: update README badge alt text to v8.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Every model has blind spots. Claude Octopus fills them by orchestrating Codex, G
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-8.27.0-blue" alt="Version 8.26.0">
+  <img src="https://img.shields.io/badge/Version-8.27.0-blue" alt="Version 8.27.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.50+-blueviolet" alt="Requires Claude Code v2.1.50+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>


### PR DESCRIPTION
## Summary

- Fix stale alt text on version badge ("Version 8.26.0" → "Version 8.27.0")

## Test plan

- [x] Cosmetic-only change, no logic affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 8.27.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->