### PR TITLE
chore: release v8.30.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v8.27.0 - Superpowers-Inspired Hardening: context compaction survival, description trap fixes, HARD-GATE enforcement, human-only flags, staged review pipeline. 31 personas, 46 commands, 50 skills. Run /octo:setup.",
-      "version": "8.27.0",
+      "description": "v8.30.0 - Agent continuation/resume for iterative tangle retries. 31 personas, 46 commands, 50 skills. Run /octo:setup.",
+      "version": "8.30.0",
       "author": {
         "name": "nyldn"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "8.27.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.27.0) Superpowers-Inspired Hardening — context compaction survival, description trap fixes, HARD-GATE enforcement tags, human-only skill flags, staged review pipeline. 31 expert personas, 46 commands, 50 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
+  "version": "8.30.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.30.0) Superpowers-Inspired Hardening \u2014 context compaction survival, description trap fixes, HARD-GATE enforcement tags, human-only skill flags, staged review pipeline. 31 expert personas, 46 commands, 50 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [8.30.0] - 2026-02-28
+
+### Changed
+
+- Agent continuation/resume for iterative tangle retries
+
+---
+
 ## [8.27.0] - 2026-02-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Every model has blind spots. Claude Octopus fills them by orchestrating Codex, G
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-8.27.0-blue" alt="Version 8.27.0">
+  <img src="https://img.shields.io/badge/Version-8.30.0-blue" alt="Version 8.30.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.50+-blueviolet" alt="Requires Claude Code v2.1.50+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "8.27.0",
+  "version": "8.30.0",
   "description": "Claude Octopus - Multi-agent orchestration with persistent state management, codebase-aware discover, and STATE.md generation",
   "main": "orchestrate.sh",
   "scripts": {

--- a/tests/test-v8.27.0-superpowers-hardening.sh
+++ b/tests/test-v8.27.0-superpowers-hardening.sh
@@ -211,32 +211,35 @@ fi
 # ─────────────────────────────────────────────────────────────────────
 suite "7. Version Consistency"
 
-# 7.1 package.json
-if grep -q '"8.27.0"' "$PLUGIN_DIR/package.json"; then
-  pass "package.json version is 8.27.0"
+# 7.1 package.json has valid semver >= 8.27.0
+PKG_VER=$(python3 -c "import json; print(json.load(open('$PLUGIN_DIR/package.json'))['version'])" 2>/dev/null || echo "")
+if [[ -n "$PKG_VER" ]] && python3 -c "exit(0 if tuple(int(x) for x in '$PKG_VER'.split('.')) >= (8,27,0) else 1)" 2>/dev/null; then
+  pass "package.json version >= 8.27.0 (is $PKG_VER)"
 else
-  fail "package.json version is not 8.27.0"
+  fail "package.json version not >= 8.27.0 (is $PKG_VER)"
 fi
 
-# 7.2 plugin.json
-if grep -q '"8.27.0"' "$PLUGIN_DIR/.claude-plugin/plugin.json"; then
-  pass "plugin.json version is 8.27.0"
+# 7.2 plugin.json has valid semver >= 8.27.0
+PLG_VER=$(python3 -c "import json; print(json.load(open('$PLUGIN_DIR/.claude-plugin/plugin.json'))['version'])" 2>/dev/null || echo "")
+if [[ -n "$PLG_VER" ]] && python3 -c "exit(0 if tuple(int(x) for x in '$PLG_VER'.split('.')) >= (8,27,0) else 1)" 2>/dev/null; then
+  pass "plugin.json version >= 8.27.0 (is $PLG_VER)"
 else
-  fail "plugin.json version is not 8.27.0"
+  fail "plugin.json version not >= 8.27.0 (is $PLG_VER)"
 fi
 
-# 7.3 marketplace.json
-if grep -q '"8.27.0"' "$PLUGIN_DIR/.claude-plugin/marketplace.json"; then
-  pass "marketplace.json version is 8.27.0"
+# 7.3 marketplace.json has valid semver >= 8.27.0
+MKT_VER=$(python3 -c "import json; [print(p['version']) for p in json.load(open('$PLUGIN_DIR/.claude-plugin/marketplace.json')).get('plugins',[]) if p.get('name')=='claude-octopus']" 2>/dev/null | head -1 || echo "")
+if [[ -n "$MKT_VER" ]] && python3 -c "exit(0 if tuple(int(x) for x in '$MKT_VER'.split('.')) >= (8,27,0) else 1)" 2>/dev/null; then
+  pass "marketplace.json version >= 8.27.0 (is $MKT_VER)"
 else
-  fail "marketplace.json version is not 8.27.0"
+  fail "marketplace.json version not >= 8.27.0 (is $MKT_VER)"
 fi
 
-# 7.4 README.md badge
-if grep -q 'Version-8.27.0' "$PLUGIN_DIR/README.md"; then
-  pass "README.md badge shows 8.27.0"
+# 7.4 README.md badge has valid version >= 8.27.0
+if grep -qE 'Version-[89][0-9]*\.[0-9]+\.[0-9]+-blue' "$PLUGIN_DIR/README.md"; then
+  pass "README.md badge shows valid version"
 else
-  fail "README.md badge does not show 8.27.0"
+  fail "README.md badge missing version badge"
 fi
 
 # 7.5 CHANGELOG.md has entry


### PR DESCRIPTION
## Release v8.30.0

Agent continuation/resume for iterative tangle retries

- `SUPPORTS_CONTINUATION` flag + `resume_agent()` function
- Bridge agent_id storage/lookup for transcript resume
- Tangle retry integration with cold-spawn fallback
- Fix version-hardcoded test in test-v8.27.0

---
🤖 Generated with release.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 8.30.0; updated version number across package configuration and plugin manifest files
  * Updated plugin description in marketplace configuration

* **Documentation**
  * Added changelog entry for v8.30.0 dated 2026-02-28
  * Updated version badge in README to reflect new release

* **Tests**
  * Enhanced test suite to support semantic version comparisons instead of exact-version checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->