### PR TITLE
feat: add /octo:batch alias and strengthen parallel quality defaults

### DIFF
--- a/openclaw/src/tools/index.ts
+++ b/openclaw/src/tools/index.ts
@@ -20,7 +20,7 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "flow-deliver", description: "Multi-AI validation and review using Codex and Gemini CLIs (Double Diamond Deliver phase)", type: "skill", file: "flow-deliver.md" },
   { name: "flow-develop", description: "Multi-AI implementation using Codex and Gemini CLIs (Double Diamond Develop phase)", type: "skill", file: "flow-develop.md" },
   { name: "flow-discover", description: "Multi-AI research using Codex and Gemini CLIs (Double Diamond Discover phase)", type: "skill", file: "flow-discover.md" },
-  { name: "flow-parallel", description: "Parallel task decomposition", type: "skill", file: "flow-parallel.md" },
+  { name: "flow-parallel", description: "Decompose and execute large changes, migrations, or multi-issue fixes in parallel with quality gates", type: "skill", file: "flow-parallel.md" },
   { name: "flow-spec", description: "NLSpec authoring — structured specification from multi-AI research", type: "skill", file: "flow-spec.md" },
   { name: "octopus-security", description: "Adversarial red team security testing with blue/red team cycle", type: "skill", file: "skill-adversarial-security.md" },
   { name: "octopus-architecture", description: "System architecture and API design with multi-AI consensus", type: "skill", file: "skill-architecture.md" },


### PR DESCRIPTION
## Summary
- Add `batch` as alias for `flow-parallel` skill — `/octo:batch` now routes to Team of Teams workflow (no new command)
- Strengthen per-WP quality instructions: mandatory tests, linting, no type suppression or placeholder code
- Add quality spot-check in aggregation step (scans for `@ts-ignore`, `TODO`, test skips)
- Add batch-relevant examples: migrations, multi-issue fixes, parallel tool builds
- Rebuild OpenClaw registry to sync description change

## Context
Reddit thread in r/ClaudeCode showed users want `/batch`-style parallel execution with quality review. Octopus already has this via `/octo:parallel` — this PR improves discoverability (batch alias) and defaults (quality gates per work package).

## Test plan
- [x] All 63 pre-push tests pass
- [x] OpenClaw registry rebuild passes `--check`
- [x] Description under 120 chars, no banned words (opaque check passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced flow-parallel skill with expanded descriptions and clearer quality guidelines.
  * Improved work package instructions with mandatory quality requirements and checks.
  * Added new examples for batch-style migrations and parallel fixes.
  * Introduced quality spot-check mechanism for better oversight during reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->