### PR TITLE
fix: Codex agent 401 auth failure from literal quotes in env isolation (Issue #117)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v8.39.0 - GPT-5.4 models, Bash 3.2 macOS compatibility fix (Issue #108). 32 personas, 49 commands, 50 skills. Run /octo:setup.",
-      "version": "8.39.0",
+      "description": "v8.39.1 - Fix Codex 401 auth failure from literal quotes in env isolation (Issue #117). 32 personas, 49 commands, 50 skills. Run /octo:setup.",
+      "version": "8.39.1",
       "author": {
         "name": "nyldn"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "8.39.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.39.0) GPT-5.4 default, updated model pricing, OAuth/API-key availability notes. 32 expert personas, 49 commands, 50 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
+  "version": "8.39.1",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.39.1) Fix Codex 401 auth failure from literal quotes in env isolation (Issue #117). 32 expert personas, 49 commands, 50 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "8.39.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.39.0) GPT-5.4 default, updated model pricing. 32 expert personas, 49 commands, 50 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "8.39.1",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.39.1) Fix Codex 401 auth failure (Issue #117). 32 expert personas, 49 commands, 50 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [8.39.1] - 2026-03-07
+
+### Fixed
+
+- Codex agent 401 auth failure: `build_provider_env()` output contained escaped quotes that became literal characters after `read -ra`, corrupting `HOME` path and preventing Codex CLI from finding `~/.codex/auth.json` (Issue #117)
+- Added regression tests for literal quote detection in credential isolation
+
+---
+
 ## [8.39.0] - 2026-03-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Claude Code plugin that turns one model into three. Orchestrates Codex, Gemini
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-8.39.0-blue" alt="Version 8.39.0">
+  <img src="https://img.shields.io/badge/Version-8.39.1-blue" alt="Version 8.39.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.50+-blueviolet" alt="Requires Claude Code v2.1.50+">
   <img src="https://img.shields.io/badge/Factory_AI-Compatible-orange" alt="Factory AI Compatible">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "8.39.0",
+  "version": "8.39.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -1148,13 +1148,13 @@ build_provider_env() {
 
     case "$provider" in
         codex*)
-            echo "env -i PATH=\"$PATH\" HOME=\"$HOME\" OPENAI_API_KEY=\"${OPENAI_API_KEY:-}\" TMPDIR=\"${TMPDIR:-/tmp}\""
+            echo "env -i PATH=$PATH HOME=$HOME OPENAI_API_KEY=${OPENAI_API_KEY:-} TMPDIR=${TMPDIR:-/tmp}"
             ;;
         gemini*)
-            echo "env -i PATH=\"$PATH\" HOME=\"$HOME\" GEMINI_API_KEY=\"${GEMINI_API_KEY:-}\" GOOGLE_API_KEY=\"${GOOGLE_API_KEY:-}\" NODE_NO_WARNINGS=1 TMPDIR=\"${TMPDIR:-/tmp}\""
+            echo "env -i PATH=$PATH HOME=$HOME GEMINI_API_KEY=${GEMINI_API_KEY:-} GOOGLE_API_KEY=${GOOGLE_API_KEY:-} NODE_NO_WARNINGS=1 TMPDIR=${TMPDIR:-/tmp}"
             ;;
         perplexity*)
-            echo "env -i PATH=\"$PATH\" HOME=\"$HOME\" PERPLEXITY_API_KEY=\"${PERPLEXITY_API_KEY:-}\" TMPDIR=\"${TMPDIR:-/tmp}\""
+            echo "env -i PATH=$PATH HOME=$HOME PERPLEXITY_API_KEY=${PERPLEXITY_API_KEY:-} TMPDIR=${TMPDIR:-/tmp}"
             ;;
         *)
             # Claude and other providers: no isolation needed

--- a/tests/test-credential-isolation.sh
+++ b/tests/test-credential-isolation.sh
@@ -170,6 +170,34 @@ else
 fi
 
 # ─────────────────────────────────────────────────────────────────────
+# Suite 6: No literal quotes in env values (Issue #117)
+# read -ra treats escaped quotes as literal characters, corrupting
+# HOME/PATH and causing 401 auth failures in Codex CLI.
+# ─────────────────────────────────────────────────────────────────────
+suite "6. No Literal Quotes in build_provider_env() (Issue #117)"
+
+# 6.1 Codex env line must not contain escaped quotes around values
+if echo "$CODEX_ENV" | grep -q '\\\"'; then
+  fail "Codex env contains escaped quotes — causes literal quote chars after read -ra (Issue #117)"
+else
+  pass "Codex env free of escaped quotes"
+fi
+
+# 6.2 Gemini env line must not contain escaped quotes around values
+if echo "$GEMINI_ENV" | grep -q '\\\"'; then
+  fail "Gemini env contains escaped quotes — causes literal quote chars after read -ra (Issue #117)"
+else
+  pass "Gemini env free of escaped quotes"
+fi
+
+# 6.3 Perplexity env line must not contain escaped quotes around values
+if echo "$PERP_ENV" | grep -q '\\\"'; then
+  fail "Perplexity env contains escaped quotes — causes literal quote chars after read -ra (Issue #117)"
+else
+  pass "Perplexity env free of escaped quotes"
+fi
+
+# ─────────────────────────────────────────────────────────────────────
 # Summary
 # ─────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

- **Root cause**: `build_provider_env()` output contained escaped quotes (`\"`) that survived `read -ra` as literal characters, corrupting `HOME` path (e.g., `"/home/user"` instead of `/home/user`). This prevented Codex CLI from finding `~/.codex/auth.json`, causing persistent 401 Unauthorized errors.
- **Fix**: Removed escaped quotes from `env -i` assignments in all three provider branches (codex, gemini, perplexity). Values without spaces don't need quoting in `env KEY=VALUE` format after `read -ra` splitting.
- **Regression tests**: Added Suite 6 to `test-credential-isolation.sh` verifying no escaped quotes in `build_provider_env()` output.

Closes #117

## Test plan

- [x] All 73 test suites pass (including 19/19 credential isolation tests)
- [x] Pre-push hook passes (64/64)
- [ ] Manual verification: run `octo embrace` with ChatGPT OAuth auth (no `OPENAI_API_KEY`) and confirm Codex agents authenticate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Codex 401 authentication failure related to environment variable handling (Issue #117).

* **Tests**
  * Added regression tests for credential isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->