### PR TITLE
chore: release v8.49.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v8.49.0 - Relevance-aware synthesis, CC pre-prompt alignment, model catalog, usage reporting, test fixes. 32 personas, 38 commands, 50 skills. Run /octo:setup.",
-      "version": "8.49.0",
+      "description": "v8.49.1 - Fix /octo:setup command name mismatch (closes #17). 32 personas, 38 commands, 50 skills. Run /octo:setup.",
+      "version": "8.49.1",
       "author": {
         "name": "nyldn"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "8.49.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.49.0) Reaction engine \u2014 auto-responds to CI failures, review comments, stuck agents. 32 expert personas, 38 commands, 50 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
+  "version": "8.49.1",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.49.1) Reaction engine \u2014 auto-responds to CI failures, review comments, stuck agents. 32 expert personas, 38 commands, 50 skills. Commands '/octo:*'. Run /octo:setup for guided setup.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [8.49.1] - 2026-03-10
+
+### Changed
+
+- Fix /octo:setup command name mismatch (closes #17)
+
+---
+
 ## [8.49.0] - 2026-03-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Claude Code plugin that turns one model into three. Orchestrates Codex, Gemini
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-8.49.0-blue" alt="Version 8.49.0">
+  <img src="https://img.shields.io/badge/Version-8.49.1-blue" alt="Version 8.49.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.50+-blueviolet" alt="Requires Claude Code v2.1.50+">
   <img src="https://img.shields.io/badge/Factory_AI-Compatible-orange" alt="Factory AI Compatible">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "8.49.0",
+  "version": "8.49.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Release v8.49.1

Fix /octo:setup command name mismatch (closes #17)

---
🤖 Generated with release.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed /octo:setup command name mismatch issue.

* **Chores**
  * Version bumped to 8.49.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->