### PR TITLE
feat: multi-agentic /octo:research — parallel Agent dispatch

### DIFF
--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -40,14 +40,13 @@ Ask 3 clarifying questions to ensure focused research:
 AskUserQuestion({
   questions: [
     {
-      question: "How deep should the research go?",
-      header: "Depth",
+      question: "How thorough should the research be?",
+      header: "Research Intensity",
       multiSelect: false,
       options: [
-        {label: "Quick overview (Recommended)", description: "1-2 min, surface-level scan"},
-        {label: "Moderate depth", description: "2-3 min, standard coverage"},
-        {label: "Comprehensive", description: "3-4 min, thorough analysis"},
-        {label: "Deep dive", description: "4-5 min, exhaustive research"}
+        {label: "Quick (1-2 min)", description: "2 agents — fast problem space scan"},
+        {label: "Standard (2-4 min)", description: "4-5 agents — balanced multi-perspective coverage (recommended)"},
+        {label: "Deep (3-6 min)", description: "6-7 agents — exhaustive analysis with web search"}
       ]
     },
     {
@@ -76,13 +75,20 @@ AskUserQuestion({
 })
 ```
 
+Map the intensity answer:
+- "Quick" → `quick`
+- "Standard" → `standard`
+- "Deep" → `deep`
+
 After receiving answers, incorporate them into the Skill invocation.
 
-### Step 2: Invoke Skill
+### Step 2: Invoke Skill with Intensity
 
 ```
-Skill(skill: "octo:discover", args: "<user's arguments>")
+Skill(skill: "octo:discover", args: "[intensity=quick|standard|deep] <user's arguments>")
 ```
+
+Example: `Skill(skill: "octo:discover", args: "[intensity=standard] OAuth authentication patterns")`
 
 ### Step 3: Post-Completion — Interactive Next Steps
 

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -15,10 +15,40 @@ description: Deep research with multi-source synthesis and comprehensive analysi
 
 When the user invokes this command (e.g., `/octo:research <arguments>`):
 
-**✓ CORRECT - Use the Skill tool:**
+### Step 1: Ask Research Intensity
+
+**CRITICAL: Before starting research, use the AskUserQuestion tool to select intensity:**
+
+```javascript
+AskUserQuestion({
+  questions: [
+    {
+      question: "How thorough should the research be?",
+      header: "Research Intensity",
+      multiSelect: false,
+      options: [
+        {label: "Quick (1-2 min)", description: "2 agents — fast problem space scan"},
+        {label: "Standard (2-4 min)", description: "4-5 agents — balanced multi-perspective coverage (recommended)"},
+        {label: "Deep (3-6 min)", description: "6-7 agents — exhaustive analysis with web search"}
+      ]
+    }
+  ]
+})
 ```
-Skill(skill: "octo:discover", args: "<user's arguments>")
+
+Map the answer to an intensity value:
+- "Quick" → `quick`
+- "Standard" → `standard`
+- "Deep" → `deep`
+
+### Step 2: Invoke Skill with Intensity
+
+**✓ CORRECT - Use the Skill tool with intensity prefix:**
 ```
+Skill(skill: "octo:discover", args: "[intensity=quick|standard|deep] <user's arguments>")
+```
+
+Example: `Skill(skill: "octo:discover", args: "[intensity=standard] OAuth 2.0 authentication patterns")`
 
 **✗ INCORRECT - Do NOT use Task tool:**
 ```

--- a/.claude/skills/flow-discover.md
+++ b/.claude/skills/flow-discover.md
@@ -213,92 +213,138 @@ fi
 
 ---
 
-### STEP 4: Execute orchestrate.sh probe (MANDATORY - Use Bash Tool)
+### STEP 3.5: Parse Intensity & Build Agent Fleet (MANDATORY)
 
-**You MUST execute this command via the Bash tool:**
+**Parse the `intensity` parameter from the skill args.** The args string may start with `[intensity=quick|standard|deep]`. If no intensity is specified, default to `"standard"` (backward compatible with `/octo:embrace` which doesn't pass intensity).
 
-```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate.sh probe "<user's research question>"
+**Agent fleets by intensity:**
+
+| Intensity | Count | Perspectives & Agent Types |
+|-----------|-------|----------------------------|
+| **Quick** | 2 | Codex: problem analysis, Gemini: ecosystem overview |
+| **Standard** | 4-5 | + Claude Sonnet: edge cases, Codex: feasibility, [Sonnet: codebase analysis if inside git repo] |
+| **Deep** | 6-7 | + Gemini: cross-synthesis, [Perplexity: web research if PERPLEXITY_API_KEY set] |
+
+**Build the perspective list as an array of objects, each with:**
+- `agent_type`: codex, gemini, claude-sonnet, or perplexity
+- `perspective`: the angle-specific prompt (same prompts as probe_discover() in orchestrate.sh)
+- `task_id`: `probe-<timestamp>-<index>`
+- `label`: human-readable name (e.g., "Problem Analysis", "Ecosystem Overview")
+
+**Perspective prompts (use the user's research question as `$PROMPT`):**
+
+1. **Problem Analysis** (Codex): `"Analyze the problem space: $PROMPT. Focus on understanding constraints, requirements, and user needs."`
+2. **Ecosystem Overview** (Gemini): `"Research existing solutions and patterns for: $PROMPT. What has been done before? What worked, what failed?"`
+3. **Edge Cases** (Claude Sonnet): `"Explore edge cases and potential challenges for: $PROMPT. What could go wrong? What's often overlooked?"`
+4. **Feasibility** (Codex): `"Investigate technical feasibility and dependencies for: $PROMPT. What are the prerequisites?"`
+5. **Codebase Analysis** (Claude Sonnet, only if inside git repo with source files): `"Analyze the LOCAL CODEBASE in the current directory for: $PROMPT. Run: find . -type f -name '*.ts' -o -name '*.py' -o -name '*.js' | head -30, then read key files. Report: tech stack, architecture patterns, file structure, coding conventions, and how they relate to the prompt. Focus on ACTUAL code, not hypotheticals."`
+6. **Cross-Synthesis** (Gemini): `"Synthesize cross-cutting concerns for: $PROMPT. What themes emerge across problem space, solutions, and feasibility?"`
+7. **Web Research** (Perplexity, only if PERPLEXITY_API_KEY set): `"Search the live web for the latest information about: $PROMPT. Find recent articles, documentation, blog posts, GitHub repos, and community discussions. Include source URLs and publication dates. Focus on information from the last 12 months that may not be in training data."`
+
+**DO NOT PROCEED TO STEP 4 until the fleet is built.**
+
+---
+
+### STEP 4: Launch Parallel Agent Subagents (MANDATORY - Use Agent Tool)
+
+**Launch each perspective as a background Agent subagent.** Each agent calls `orchestrate.sh probe-single` which handles persona application, credential isolation, and result file writing.
+
+**CRITICAL: You MUST use the Agent tool with `run_in_background: true` for each perspective.** Launch Gemini agents first (higher latency), then Codex, then Claude Sonnet, then Perplexity.
+
+For each perspective in the fleet, launch:
+
 ```
+Agent(
+  run_in_background: true,
+  description: "<label> (<agent_type>)",
+  prompt: "Run this command and return its COMPLETE stdout output, including the result file path on the last line:
+
+${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate.sh probe-single <agent_type> '<perspective_prompt>' <task_id> '<original_prompt>'
+
+After the command completes, read the result file path that was printed and return the full file contents."
+)
+```
+
+**Launch order:** All Gemini agents first, then all Codex agents, then Claude Sonnet, then Perplexity. Within each provider group, launch simultaneously (multiple Agent calls in a single message).
 
 **CRITICAL: You are PROHIBITED from:**
-- ❌ Researching directly without calling orchestrate.sh — single-model research misses perspectives that Codex (implementation depth) and Gemini (ecosystem breadth) bring; direct analysis cannot match multi-provider synthesis
+- ❌ Researching directly without calling orchestrate.sh probe-single — single-model research misses perspectives that Codex (implementation depth) and Gemini (ecosystem breadth) bring
+- ❌ Using a single `Bash(orchestrate.sh probe)` call — this causes the 120s Bash timeout that this refactor fixes
 - ❌ Using web search instead of orchestrate.sh
 - ❌ Claiming you're "simulating" the workflow
-- ❌ Proceeding to Step 4 without running this command
-
-**You MUST use the Bash tool to invoke orchestrate.sh.**
-
-#### What Users See During Execution (v7.16.0+)
-
-If running in Claude Code v2.1.16+, users will see **real-time progress indicators** in the task spinner:
-
-**Phase 1 - External Provider Execution (Parallel):**
-- 🔴 Researching technical patterns (Codex)...
-- 🟡 Exploring ecosystem and options (Gemini)...
-
-**Phase 2 - Synthesis (Sequential):**
-- 🔵 Synthesizing research findings...
-
-These spinner verb updates happen automatically - orchestrate.sh calls `update_task_progress()` before each agent execution. Users see exactly which provider is working and what it's doing.
-
-**If NOT running in Claude Code v2.1.16+:** Progress indicators are silently skipped, no errors shown.
 
 ---
 
-### STEP 5: Verify Execution (MANDATORY - Validation Gate)
+### STEP 5: Collect Results (MANDATORY - Wait for Background Agents)
 
-**After orchestrate.sh completes, verify it succeeded:**
+**Wait for all background agents to complete.** You will be automatically notified as each finishes.
+
+**Minimum 2 results required** (same threshold as synthesize_probe_results()). Graceful degradation rules:
+- 0 results → Report error, show logs, DO NOT proceed
+- 1 result → Warn user, proceed with reduced synthesis quality
+- 2+ results → Proceed normally
+- If some agents fail/timeout, proceed with successful results
+
+**For each completed agent, collect its output** (the result file contents returned by the agent).
+
+---
+
+### STEP 6: Synthesize In-Conversation (MANDATORY - Claude Synthesizes)
+
+**You (Claude) synthesize the collected results directly in conversation.** This replaces the previous Gemini synthesis call that frequently timed out.
+
+**Use this exact structure** (matching the format from `synthesize_probe_results()` in orchestrate.sh):
+
+1. **Key Findings** — Top 3-5 actionable insights, ranked by relevance to the original question
+2. **Patterns & Consensus** — Where multiple sources agree
+3. **Conflicts & Trade-offs** — Where sources disagree, with your reasoned resolution
+4. **Gaps** — What's still unknown and needs more research
+5. **Priority Matrix** — Rank findings by impact (High/Medium/Low) and effort (Low/Medium/High) in a table
+6. **Recommended Approach** — Specific next steps based on findings
+
+**Quality rules:**
+- Short but specific findings may be MORE valuable than lengthy general analysis
+- Minority opinions and dissenting views MUST be preserved — they often contain critical insights
+- Concrete examples (code, file paths, commands) outweigh abstract discussion
+- Attribute findings to their source provider (🔴 Codex, 🟡 Gemini, 🔵 Claude Sonnet, 🟣 Perplexity)
+
+**Write synthesis to file:**
 
 ```bash
-# Find the latest synthesis file (created within last 10 minutes)
-SYNTHESIS_FILE=$(find ~/.claude-octopus/results -name "probe-synthesis-*.md" -mmin -10 2>/dev/null | head -n1)
-
-if [[ -z "$SYNTHESIS_FILE" ]]; then
-  echo "❌ VALIDATION FAILED: No synthesis file found"
-  echo "orchestrate.sh did not execute properly"
-  exit 1
-fi
-
-echo "✅ VALIDATION PASSED: $SYNTHESIS_FILE"
-cat "$SYNTHESIS_FILE"
+SYNTHESIS_FILE="${HOME}/.claude-octopus/results/probe-synthesis-$(date +%s).md"
+mkdir -p "$(dirname "$SYNTHESIS_FILE")"
 ```
 
-**If validation fails:**
-1. Report error to user
-2. Show logs from `~/.claude-octopus/logs/`
-3. DO NOT proceed with presenting results
-4. DO NOT substitute with direct research — fallback to single-model analysis defeats the purpose of multi-provider synthesis and produces narrower findings
+Write the synthesis content to `$SYNTHESIS_FILE`. The file MUST exist for the validation gate.
 
 ---
 
-### STEP 6: Update State (MANDATORY - Post-Execution)
+### STEP 7: Verify, Update State & Present (Only After Steps 1-6 Complete)
 
-**After synthesis is verified, record findings in state:**
+**Verify synthesis file exists (probe-synthesis-*.md pattern):**
 
 ```bash
-# Extract key findings from synthesis for summary (keep it concise - 1-3 sentences)
+# Verify the synthesis file was written (matches probe-synthesis-*.md pattern)
+if [[ ! -f "$SYNTHESIS_FILE" ]]; then
+  echo "❌ VALIDATION FAILED: No synthesis file found"
+  exit 1
+fi
+echo "✅ VALIDATION PASSED: $SYNTHESIS_FILE"
+```
+
+**Update state:**
+
+```bash
 key_findings=$(head -50 "$SYNTHESIS_FILE" | grep -A 3 "## Key Findings\|## Summary" | tail -3 | tr '\n' ' ')
 
-# Update discover phase context
-"${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" update_context \
-  "discover" \
-  "$key_findings"
-
-# Update metrics
+"${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" update_context "discover" "$key_findings"
 "${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" update_metrics "phases_completed" "1"
 "${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" update_metrics "provider" "codex"
 "${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" update_metrics "provider" "gemini"
 "${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" update_metrics "provider" "claude"
 ```
 
-**DO NOT PROCEED TO STEP 7 until state updated.**
-
----
-
-### STEP 7: Present Results (Only After Steps 1-6 Complete)
-
-Read the synthesis file and format according to context:
+**Present results** formatted according to context (Dev vs Knowledge):
 
 **For Dev Context:**
 - Technical research summary
@@ -504,9 +550,12 @@ When this skill is invoked, follow the EXECUTION CONTRACT above exactly. The con
 
 1. **Blocking Step 1**: Detect work context (Dev vs Knowledge)
 2. **Blocking Step 2**: Check providers, display visual indicators
-3. **Blocking Step 3**: Execute orchestrate.sh probe via Bash tool
-4. **Blocking Step 4**: Verify synthesis file exists
-5. **Step 5**: Present formatted results
+3. **Blocking Step 3**: Read prior state
+4. **Blocking Step 3.5**: Parse intensity, build agent fleet
+5. **Blocking Step 4**: Launch parallel Agent subagents via orchestrate.sh probe-single
+6. **Blocking Step 5**: Collect results from background agents
+7. **Blocking Step 6**: Synthesize in-conversation (Claude synthesizes directly)
+8. **Step 7**: Verify, update state, present results
 
 Each step is **mandatory and blocking** - you cannot proceed to the next step until the current one completes successfully.
 
@@ -534,10 +583,12 @@ TaskUpdate({taskId: "...", status: "completed"})
 If any step fails:
 - **Step 1 (Context)**: Default to Dev Context if ambiguous
 - **Step 2 (Providers)**: If both unavailable, suggest `/octo:setup` and STOP
-- **Step 3 (orchestrate.sh)**: Show bash error, check logs, report to user
-- **Step 4 (Validation)**: If synthesis missing, show orchestrate.sh logs, DO NOT substitute with direct research
+- **Step 4 (Agent launch)**: If an agent fails, continue with remaining agents (graceful degradation)
+- **Step 5 (Collection)**: If fewer than 2 results, report error and let user decide
+- **Step 6 (Synthesis)**: If synthesis fails, present raw agent results without synthesis
+- **Step 7 (Validation)**: If synthesis file missing, report error
 
-Never fall back to direct research if orchestrate.sh execution fails. Report the failure and let the user decide how to proceed.
+DO NOT substitute with direct research if agent execution fails — fallback to single-model analysis defeats the purpose of multi-provider synthesis. Report the failure and let the user decide how to proceed.
 
 ### Context-Appropriate Presentation
 

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -16599,6 +16599,252 @@ run_yaml_workflow() {
     echo "${all_outputs[-1]:-}"
 }
 
+# v8.54.0: Single-agent probe for multi-agentic skill dispatch
+# Runs one probe perspective synchronously and writes result to RESULTS_DIR.
+# Called by Claude's Agent tool (one per perspective) instead of probe_discover().
+# WHY: probe_discover() runs 5-7 agents + synthesis inside a single Bash subprocess
+# that frequently exceeds the 120s Bash tool timeout. By exposing each agent as a
+# standalone command, the skill layer can launch them via Agent(run_in_background=true)
+# with no timeout constraint, and Claude synthesizes in-conversation.
+probe_single_agent() {
+    local agent_type="$1"
+    local perspective="$2"
+    local task_id="$3"
+    local original_prompt="${4:-}"
+
+    log "INFO" "probe_single_agent: agent=$agent_type task=$task_id"
+    log "DEBUG" "probe_single_agent: perspective=${perspective:0:100}..."
+
+    # Pre-flight validation
+    preflight_check || return 1
+
+    mkdir -p "$RESULTS_DIR" "$LOGS_DIR"
+
+    # Determine role and phase
+    local role="researcher"
+    local phase="probe"
+
+    # Determine role if routing rules override
+    local routed_role
+    routed_role=$(match_routing_rule "$(classify_task "$perspective" 2>/dev/null)" "$perspective" 2>/dev/null) || true
+    if [[ -n "$routed_role" ]]; then
+        role="$routed_role"
+    fi
+
+    # v8.53.0: Pre-compute curated_name for readonly frontmatter check
+    local curated_name_early=""
+    if [[ "$SUPPORTS_AGENT_TYPE_ROUTING" == "true" ]]; then
+        curated_name_early=$(select_curated_agent "$perspective" "$phase") || true
+    fi
+
+    # Apply persona to prompt
+    local enhanced_prompt
+    enhanced_prompt=$(apply_persona "$role" "$perspective" "false" "${curated_name_early:-}")
+
+    # v8.21.0: Persona pack override
+    if type get_persona_override &>/dev/null 2>&1 && [[ "${OCTOPUS_PERSONA_PACKS:-auto}" != "off" ]]; then
+        local persona_override_file
+        persona_override_file=$(get_persona_override "${curated_name_early:-$agent_type}" 2>/dev/null)
+        if [[ -n "$persona_override_file" && -f "$persona_override_file" ]]; then
+            local pack_persona
+            pack_persona=$(cat "$persona_override_file" 2>/dev/null)
+            if [[ -n "$pack_persona" ]]; then
+                enhanced_prompt="${pack_persona}
+
+---
+
+${enhanced_prompt}"
+            fi
+        fi
+    fi
+
+    # v8.10.0: Enforce context budget AFTER all injections
+    enhanced_prompt=$(enforce_context_budget "$enhanced_prompt")
+
+    # Resolve model and command
+    local model
+    model=$(get_agent_model "$agent_type" "$phase" "$role")
+
+    local cmd
+    if ! cmd=$(get_agent_command "$agent_type" "$phase" "$role"); then
+        log ERROR "Unknown agent type: $agent_type"
+        return 1
+    fi
+
+    if ! validate_agent_command "$cmd"; then
+        log ERROR "Invalid agent command: $cmd"
+        return 1
+    fi
+
+    # Record agent call
+    record_agent_call "$agent_type" "$model" "$enhanced_prompt" "$phase" "$role" "0"
+
+    # Track provider usage
+    local provider_name
+    case "$agent_type" in
+        codex*) provider_name="codex" ;;
+        gemini*) provider_name="gemini" ;;
+        claude*) provider_name="claude" ;;
+        perplexity*) provider_name="perplexity" ;;
+        *) provider_name="$agent_type" ;;
+    esac
+    update_metrics "provider" "$provider_name" 2>/dev/null || true
+
+    # Register in bridge ledger
+    bridge_register_task "$task_id" "$agent_type" "$phase" "$role" || true
+
+    local result_file="${RESULTS_DIR}/${agent_type}-${task_id}.md"
+
+    # Build command array with credential isolation
+    local -a cmd_array
+    local env_prefix
+    env_prefix=$(build_provider_env "$agent_type")
+    if [[ -n "$env_prefix" ]]; then
+        read -ra cmd_array <<< "$env_prefix $cmd"
+    else
+        read -ra cmd_array <<< "$cmd"
+    fi
+
+    local temp_output="${RESULTS_DIR}/.tmp-${task_id}.out"
+    local temp_errors="${RESULTS_DIR}/.tmp-${task_id}.err"
+    local raw_output="${RESULTS_DIR}/.raw-${task_id}.out"
+
+    # Write result file header
+    echo "# Agent: $agent_type" > "$result_file"
+    echo "# Task ID: $task_id" >> "$result_file"
+    echo "# Role: $role" >> "$result_file"
+    echo "# Phase: $phase" >> "$result_file"
+    echo "# Prompt: ${perspective:0:200}" >> "$result_file"
+    echo "# Started: $(date)" >> "$result_file"
+    echo "" >> "$result_file"
+    echo "## Output" >> "$result_file"
+    echo '```' >> "$result_file"
+
+    # Append gemini headless flag
+    if [[ "$agent_type" == gemini* ]]; then
+        cmd_array+=(-p "")
+    fi
+
+    # Auth-aware retry loop (same logic as spawn_agent legacy path)
+    local max_auth_retries=0
+    if [[ "$OCTOPUS_BACKEND" != "api" ]]; then
+        max_auth_retries="${OCTOPUS_AUTH_RETRIES:-2}"
+    fi
+    if [[ "$SUPPORTS_STABLE_AUTH" == "true" ]]; then
+        max_auth_retries=$((max_auth_retries > 1 ? 1 : max_auth_retries))
+    fi
+
+    local auth_attempt=0
+    local exit_code=0
+    local start_time_ms
+    start_time_ms=$(( $(date +%s) * 1000 ))
+
+    while true; do
+        exit_code=0
+        if [[ "$agent_type" == gemini* ]]; then
+            if printf '%s' "$enhanced_prompt" | run_with_timeout "$TIMEOUT" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then
+                exit_code=0
+            else
+                exit_code=$?
+            fi
+        else
+            if run_with_timeout "$TIMEOUT" "${cmd_array[@]}" "$enhanced_prompt" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then
+                exit_code=0
+            else
+                exit_code=$?
+            fi
+        fi
+
+        if [[ $exit_code -ne 0 ]] && [[ $auth_attempt -lt $max_auth_retries ]]; then
+            local stderr_content=""
+            [[ -s "$temp_errors" ]] && stderr_content=$(cat "$temp_errors")
+            if [[ "$stderr_content" == *"unauthorized"* ]] || \
+               [[ "$stderr_content" == *"401"* ]] || \
+               [[ "$stderr_content" == *"auth"* ]] || \
+               [[ "$stderr_content" == *"credential"* ]] || \
+               [[ "$stderr_content" == *"token expired"* ]] || \
+               [[ "$stderr_content" == *"refresh"* ]]; then
+                ((auth_attempt++)) || true
+                local backoff=$((auth_attempt * 5))
+                log "WARN" "Auth failure (attempt $auth_attempt/$max_auth_retries), retrying in ${backoff}s..."
+                sleep "$backoff"
+                > "$temp_output"; > "$temp_errors"; > "$raw_output"
+                continue
+            fi
+        fi
+        break
+    done
+
+    # Process output
+    if [[ $exit_code -eq 0 ]]; then
+        awk '
+            BEGIN { in_response = 0; header_done = 0; }
+            /^--------$/ { header_done = 1; next; }
+            !header_done { next; }
+            /^(codex|gemini|assistant)$/ { in_response = 1; next; }
+            /^thinking$/ { next; }
+            /^tokens used$/ { next; }
+            /^[0-9,]+$/ && in_response { next; }
+            in_response { print; }
+        ' "$temp_output" >> "$result_file"
+
+        # Trust marker for external CLI output
+        case "$agent_type" in codex*|gemini*|perplexity*)
+            if [[ "${OCTOPUS_SECURITY_V870:-true}" == "true" ]]; then
+                sed -i.bak '1s/^/<!-- trust=untrusted provider='"$agent_type"' -->\n/' "$result_file" 2>/dev/null || true
+                rm -f "${result_file}.bak"
+            fi ;; esac
+
+        echo '```' >> "$result_file"
+        echo "" >> "$result_file"
+        echo "## Status: SUCCESS" >> "$result_file"
+
+        local end_time_ms elapsed_ms
+        end_time_ms=$(( $(date +%s) * 1000 ))
+        elapsed_ms=$((end_time_ms - start_time_ms))
+        update_agent_status "$agent_type" "completed" "$elapsed_ms" 0.0
+        record_outcome "$agent_type" "$agent_type" "research" "$phase" "success" "$elapsed_ms" 2>/dev/null || true
+    elif [[ $exit_code -eq 124 ]] || [[ $exit_code -eq 143 ]]; then
+        # Timeout — preserve partial output
+        if [[ -s "$temp_output" ]]; then
+            awk '
+                BEGIN { in_response = 0; header_done = 0; }
+                /^--------$/ { header_done = 1; next; }
+                !header_done { next; }
+                /^(codex|gemini|assistant)$/ { in_response = 1; next; }
+                in_response { print; }
+            ' "$temp_output" >> "$result_file"
+        fi
+        echo '```' >> "$result_file"
+        echo "" >> "$result_file"
+        echo "## Status: TIMEOUT" >> "$result_file"
+        log "WARN" "Agent $agent_type timed out for task $task_id"
+    else
+        # Failure
+        if [[ -s "$temp_output" ]]; then
+            cat "$temp_output" >> "$result_file"
+        fi
+        echo '```' >> "$result_file"
+        echo "" >> "$result_file"
+        echo "## Status: FAILED (exit code: $exit_code)" >> "$result_file"
+        if [[ -s "$temp_errors" ]]; then
+            echo "" >> "$result_file"
+            echo "## Errors" >> "$result_file"
+            echo '```' >> "$result_file"
+            cat "$temp_errors" >> "$result_file"
+            echo '```' >> "$result_file"
+        fi
+        log "WARN" "Agent $agent_type failed for task $task_id (exit=$exit_code)"
+    fi
+
+    # Cleanup temp files
+    rm -f "$temp_output" "$temp_errors" "$raw_output"
+
+    log "INFO" "probe_single_agent complete: $result_file"
+    # Output the result file path for the caller
+    echo "$result_file"
+}
+
 # Phase 1: PROBE (Discover) - Parallel research with synthesis
 # Like an octopus probing with multiple tentacles simultaneously
 probe_discover() {
@@ -21159,6 +21405,15 @@ case "$COMMAND" in
             exit 1
         fi
         probe_discover "$*"
+        ;;
+    probe-single)
+        # v8.54.0: Single-agent probe for multi-agentic skill dispatch
+        # Called by Claude's Agent tool (one per perspective) instead of monolithic probe
+        if [[ $# -lt 3 ]]; then
+            echo "Usage: $(basename "$0") probe-single <agent_type> <perspective> <task_id> [original_prompt]"
+            exit 1
+        fi
+        probe_single_agent "$1" "$2" "$3" "${4:-}"
         ;;
     define|grasp)
         # Phase 2: Define - Consensus building

--- a/tests/test-enforcement-pattern.sh
+++ b/tests/test-enforcement-pattern.sh
@@ -201,9 +201,15 @@ for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "\${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate.sh" "$skill_file" && \
        grep -q "You MUST execute this command via the Bash tool" "$skill_file"; then
         ((skills_with_bash_call++))
+    elif [[ "$(basename "$skill_file")" == "flow-discover.md" ]] && \
+         grep -q "\${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate.sh" "$skill_file" && \
+         grep -q "You MUST use the Agent tool" "$skill_file"; then
+        # v8.54.0: flow-discover uses Agent tool for parallel probe-single dispatch
+        # instead of a single Bash(orchestrate.sh probe) call
+        ((skills_with_bash_call++))
     else
-        fail "$(basename "$skill_file") missing explicit Bash tool requirement" \
-             "Should require 'You MUST execute this command via the Bash tool'"
+        fail "$(basename "$skill_file") missing explicit tool requirement" \
+             "Should require Bash tool (or Agent tool for flow-discover) for orchestrate.sh"
     fi
 done
 if [[ $skills_with_bash_call -eq ${#ENFORCE_SKILLS[@]} ]]; then
@@ -235,9 +241,16 @@ for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "find.*results.*-name.*synthesis.*-mmin" "$skill_file" || \
        grep -q "find.*results.*-name.*validation.*-mmin" "$skill_file"; then
         ((skills_with_file_check++))
+    elif [[ "$(basename "$skill_file")" == "flow-discover.md" ]] && \
+         grep -q 'probe-synthesis-' "$skill_file" && \
+         grep -q 'VALIDATION FAILED\|VALIDATION PASSED' "$skill_file"; then
+        # v8.54.0: flow-discover uses Agent-based execution where Claude writes
+        # the synthesis file directly and holds the path — no find -mmin needed.
+        # Still requires VALIDATION FAILED/PASSED gate check.
+        ((skills_with_file_check++))
     else
         fail "$(basename "$skill_file") missing synthesis file check" \
-             "Should use 'find' with -mmin to verify recent synthesis files"
+             "Should verify synthesis files exist (find -mmin or direct file check)"
     fi
 done
 if [[ $skills_with_file_check -eq ${#ENFORCE_SKILLS[@]} ]]; then

--- a/tests/test-intent-questions.sh
+++ b/tests/test-intent-questions.sh
@@ -150,12 +150,12 @@ done
 echo ""
 echo "Test 8: Checking discover.md specific questions..."
 discover_path="$COMMANDS_DIR/discover.md"
-if grep -q "depth" "$discover_path" && \
+if (grep -qi "depth\|intensity" "$discover_path") && \
    grep -q "focus" "$discover_path" && \
    (grep -q "output" "$discover_path" || grep -q "format" "$discover_path"); then
-    pass "discover.md has appropriate question topics (depth, focus, output)"
+    pass "discover.md has appropriate question topics (intensity/depth, focus, output)"
 else
-    fail "discover.md missing expected question topics" "Should ask about depth, focus, and output format"
+    fail "discover.md missing expected question topics" "Should ask about intensity/depth, focus, and output format"
 fi
 
 # Test 9: Verify review.md has specific questions

--- a/tests/unit/test-knowledge-routing.sh
+++ b/tests/unit/test-knowledge-routing.sh
@@ -185,7 +185,8 @@ test_status_shows_mode() {
     local output=$("$PROJECT_ROOT/scripts/orchestrate.sh" status 2>&1)
 
     # Status output shows "Mode:" line with one of: Development, Knowledge, Auto-Detect
-    if echo "$output" | grep -qi "Mode:.*Development\|Mode:.*Knowledge\|Mode:.*Auto-Detect"; then
+    # Use grep -c instead of grep -q to avoid SIGPIPE with set -eo pipefail
+    if echo "$output" | grep -ci "Mode:.*Development\|Mode:.*Knowledge\|Mode:.*Auto-Detect" >/dev/null; then
         test_pass
     else
         test_fail "Status should show current mode"

--- a/tests/unit/test-probe-single.sh
+++ b/tests/unit/test-probe-single.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Tests for probe-single command: single-agent probe for multi-agentic skill dispatch (v8.54.0)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ORCHESTRATE="$PROJECT_ROOT/scripts/orchestrate.sh"
+
+TEST_COUNT=0; PASS_COUNT=0; FAIL_COUNT=0
+pass() { TEST_COUNT=$((TEST_COUNT+1)); PASS_COUNT=$((PASS_COUNT+1)); echo "PASS: $1"; }
+fail() { TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1)); echo "FAIL: $1 — $2"; }
+assert_contains() {
+  local output="$1" pattern="$2" label="$3"
+  echo "$output" | grep -qE "$pattern" && pass "$label" || fail "$label" "missing: $pattern"
+}
+
+# ── probe_single_agent function exists ────────────────────────────────────────
+
+assert_contains "$(grep -c 'probe_single_agent()' "$ORCHESTRATE" 2>/dev/null || echo 0)" \
+  "[1-9]" "probe_single_agent: function exists in orchestrate.sh"
+
+# ── probe-single dispatch case exists ─────────────────────────────────────────
+
+assert_contains "$(grep -c 'probe-single)' "$ORCHESTRATE" 2>/dev/null || echo 0)" \
+  "[1-9]" "probe-single: dispatch case exists in orchestrate.sh"
+
+# ── probe-single calls probe_single_agent ────────────────────────────────────
+
+assert_contains "$(grep -A10 'probe-single)' "$ORCHESTRATE" | head -15)" \
+  "probe_single_agent" "probe-single: dispatch calls probe_single_agent()"
+
+# ── probe_single_agent writes result files ───────────────────────────────────
+
+assert_contains "$(grep -A200 'probe_single_agent()' "$ORCHESTRATE" | head -220)" \
+  'RESULTS_DIR.*agent_type.*task_id.*\.md' "probe_single_agent: writes result file to RESULTS_DIR"
+
+# ── probe_single_agent calls apply_persona ───────────────────────────────────
+
+assert_contains "$(grep -A100 'probe_single_agent()' "$ORCHESTRATE" | head -120)" \
+  "apply_persona" "probe_single_agent: calls apply_persona()"
+
+# ── probe_single_agent calls enforce_context_budget ──────────────────────────
+
+assert_contains "$(grep -A100 'probe_single_agent()' "$ORCHESTRATE" | head -120)" \
+  "enforce_context_budget" "probe_single_agent: calls enforce_context_budget()"
+
+# ── probe_single_agent calls get_agent_command ───────────────────────────────
+
+assert_contains "$(grep -A120 'probe_single_agent()' "$ORCHESTRATE" | head -140)" \
+  "get_agent_command" "probe_single_agent: calls get_agent_command()"
+
+# ── probe_single_agent has auth retry logic ──────────────────────────────────
+
+assert_contains "$(grep -A200 'probe_single_agent()' "$ORCHESTRATE" | head -220)" \
+  "auth_attempt|max_auth_retries" "probe_single_agent: has auth retry logic"
+
+# ── probe_single_agent outputs result file path ──────────────────────────────
+
+assert_contains "$(grep -A250 'probe_single_agent()' "$ORCHESTRATE" | head -270)" \
+  'echo.*result_file' "probe_single_agent: outputs result file path on stdout"
+
+# ── probe_single_agent handles timeout status ────────────────────────────────
+
+assert_contains "$(grep -A250 'probe_single_agent()' "$ORCHESTRATE" | head -270)" \
+  "Status: TIMEOUT" "probe_single_agent: handles TIMEOUT status"
+
+# ── probe_single_agent handles failure status ────────────────────────────────
+
+assert_contains "$(grep -A250 'probe_single_agent()' "$ORCHESTRATE" | head -270)" \
+  "Status: FAILED" "probe_single_agent: handles FAILED status"
+
+# ── flow-discover.md references probe-single ─────────────────────────────────
+
+FLOW_DISCOVER="$PROJECT_ROOT/.claude/skills/flow-discover.md"
+assert_contains "$(grep -c 'probe-single' "$FLOW_DISCOVER" 2>/dev/null || echo 0)" \
+  "[1-9]" "flow-discover.md: references probe-single command"
+
+# ── flow-discover.md has intensity parsing ───────────────────────────────────
+
+assert_contains "$(grep -c 'intensity' "$FLOW_DISCOVER" 2>/dev/null || echo 0)" \
+  "[1-9]" "flow-discover.md: has intensity parsing"
+
+# ── flow-discover.md uses Agent tool (not single Bash probe) ─────────────────
+
+assert_contains "$(grep -c 'run_in_background.*true' "$FLOW_DISCOVER" 2>/dev/null || echo 0)" \
+  "[1-9]" "flow-discover.md: uses Agent(run_in_background=true)"
+
+# ── flow-discover.md preserves test markers ──────────────────────────────────
+
+assert_contains "$(cat "$FLOW_DISCOVER")" \
+  "execution_mode: enforced" "flow-discover.md: preserves execution_mode: enforced"
+
+assert_contains "$(cat "$FLOW_DISCOVER")" \
+  "orchestrate_sh_executed" "flow-discover.md: preserves orchestrate_sh_executed validation gate"
+
+assert_contains "$(cat "$FLOW_DISCOVER")" \
+  "synthesis_file_exists" "flow-discover.md: preserves synthesis_file_exists validation gate"
+
+assert_contains "$(cat "$FLOW_DISCOVER")" \
+  "probe-synthesis" "flow-discover.md: preserves probe-synthesis reference"
+
+assert_contains "$(cat "$FLOW_DISCOVER")" \
+  "Perplexity" "flow-discover.md: preserves Perplexity indicator"
+
+assert_contains "$(cat "$FLOW_DISCOVER")" \
+  "EXECUTION CONTRACT" "flow-discover.md: preserves EXECUTION CONTRACT header"
+
+# ── research.md has intensity AskUserQuestion ────────────────────────────────
+
+RESEARCH_CMD="$PROJECT_ROOT/.claude/commands/research.md"
+assert_contains "$(grep -c 'Research Intensity' "$RESEARCH_CMD" 2>/dev/null || echo 0)" \
+  "[1-9]" "research.md: has Research Intensity AskUserQuestion"
+
+assert_contains "$(grep -c 'intensity=' "$RESEARCH_CMD" 2>/dev/null || echo 0)" \
+  "[1-9]" "research.md: passes intensity in Skill args"
+
+# ── discover.md aligns intensity question ────────────────────────────────────
+
+DISCOVER_CMD="$PROJECT_ROOT/.claude/commands/discover.md"
+assert_contains "$(grep -c 'Research Intensity' "$DISCOVER_CMD" 2>/dev/null || echo 0)" \
+  "[1-9]" "discover.md: has Research Intensity header"
+
+assert_contains "$(grep -c 'intensity=' "$DISCOVER_CMD" 2>/dev/null || echo 0)" \
+  "[1-9]" "discover.md: passes intensity in Skill args"
+
+# ── backward compat: probe_discover still exists ─────────────────────────────
+
+assert_contains "$(grep -c 'probe_discover()' "$ORCHESTRATE" 2>/dev/null || echo 0)" \
+  "[1-9]" "probe_discover: original function still exists (backward compat)"
+
+# ── backward compat: discover|research|probe dispatch still exists ───────────
+
+assert_contains "$(grep -c 'discover|research|probe)' "$ORCHESTRATE" 2>/dev/null || echo 0)" \
+  "[1-9]" "discover|research|probe: original dispatch still exists (backward compat)"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "probe-single tests: $PASS_COUNT/$TEST_COUNT passed"
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  echo "$FAIL_COUNT FAILED"
+  exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
## Summary

- Refactors `/octo:research` and `/octo:discover` from a single `Bash(orchestrate.sh probe)` call (which frequently exceeded 120s Bash tool timeout) to parallel `Agent(run_in_background=true)` subagents, each calling `orchestrate.sh probe-single`
- Adds user-configurable research intensity (Quick/Standard/Deep) via AskUserQuestion
- Claude synthesizes in-conversation instead of Gemini synthesis that timed out
- Fixes pre-existing SIGPIPE flake in `test-knowledge-routing.sh`

## Test plan

- [x] 26 new tests in `test-probe-single.sh` (static analysis of function, dispatch, test markers)
- [x] 83/83 test suites pass (74/74 in pre-push hook)
- [x] Backward compat: `probe_discover()` untouched, `/octo:embrace` still uses original path
- [ ] Manual: `orchestrate.sh probe-single codex "test" test-1` produces result file
- [ ] Manual: `/octo:research <topic>` shows intensity question → parallel agents → synthesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added research intensity selection with three levels: Quick (1-2 min), Standard (2-4 min), and Deep (3-6 min).
  * Interactive workflow now prompts users to specify research thoroughness before execution.

* **Improvements**
  * Updated research command terminology for clarity and added explicit time expectations per intensity level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->