### PR TITLE
chore: release v8.54.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v8.53.0 - Agent ergonomics: readonly frontmatter, user-scope agents, /octo:resume. 32 personas, 39 commands, 50 skills. Run /octo:setup.",
-      "version": "8.53.0",
+      "description": "v8.54.0 - Multi-agentic /octo:research \u2014 parallel Agent dispatch replaces single Bash subprocess, user-configurable intensity, Claude in-conversation synthesis. 32 personas, 39 commands, 50 skills. Run /octo:setup.",
+      "version": "8.54.0",
       "author": {
         "name": "nyldn"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "8.53.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.53.0) Agent ergonomics \u2014 readonly frontmatter, user-scope agents (~/.claude/agents/), /octo:resume. 32 expert personas, 39 commands, 50 skills. Commands use '/octo:*', including the '/octo:octo' smart router. Run /octo:setup for guided setup.",
+  "version": "8.54.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.54.0) Agent ergonomics \u2014 readonly frontmatter, user-scope agents (~/.claude/agents/), /octo:resume. 32 expert personas, 39 commands, 50 skills. Commands use '/octo:*', including the '/octo:octo' smart router. Run /octo:setup for guided setup.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [8.54.0] - 2026-03-12
+
+### Changed
+
+- Multi-agentic /octo:research — parallel Agent dispatch replaces single Bash subprocess, user-configurable intensity, Claude in-conversation synthesis
+
+---
+
 ## [8.53.0] - 2026-03-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Claude Code plugin that turns one model into three. Orchestrates Codex, Gemini
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-8.53.0-blue" alt="Version 8.53.0">
+  <img src="https://img.shields.io/badge/Version-8.54.0-blue" alt="Version 8.54.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.50+-blueviolet" alt="Requires Claude Code v2.1.50+">
   <img src="https://img.shields.io/badge/Factory_AI-Compatible-orange" alt="Factory AI Compatible">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "8.53.0",
+  "version": "8.54.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Summary

- Version bump 8.53.0 → 8.54.0
- Multi-agentic `/octo:research` — parallel Agent dispatch replaces single Bash subprocess
- User-configurable research intensity (Quick/Standard/Deep)
- Claude in-conversation synthesis replaces Gemini synthesis that timed out
- Fixed pre-existing SIGPIPE flake in `test-knowledge-routing.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced multi-agentic /octo:research with parallel Agent dispatch system, replacing previous single subprocess model
  * Added user-configurable intensity settings for Agent dispatch operations
  * Integrated Claude in-conversation synthesis for enhanced result handling
  * Maintains support for 32 personas, 39 commands, and 50 skills

* **Chores**
  * Version updated to 8.54.0
  * Updated plugin metadata and documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->