### PR TITLE
feat: CC v2.1.72-v2.1.74 sync — 8 new flags, 94 total

### DIFF
--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -510,6 +510,14 @@ SUPPORTS_SUBAGENT_MODEL_FIX=false      # v8.52: Claude Code v2.1.73+ (model: opu
 SUPPORTS_SESSION_RESUME_HOOK_FIX=false # v8.52: Claude Code v2.1.73+ (SessionStart hooks fire once on --resume, not twice)
 SUPPORTS_BG_PROCESS_CLEANUP=false      # v8.52: Claude Code v2.1.73+ (background bash from subagents cleaned up on agent exit)
 SUPPORTS_SKILL_DEADLOCK_FIX=false      # v8.52: Claude Code v2.1.73+ (no deadlock with large .claude/skills/ during git pull)
+SUPPORTS_PARALLEL_TOOL_RESILIENCE=false # v8.56: Claude Code v2.1.72+ (failed Read/WebFetch/Glob no longer cancels sibling parallel tool calls)
+SUPPORTS_PLAN_WITH_ARGS=false          # v8.56: Claude Code v2.1.72+ (/plan accepts description argument e.g. /plan fix the auth bug)
+SUPPORTS_AUTO_MEMORY_DIR=false         # v8.56: Claude Code v2.1.74+ (autoMemoryDirectory setting for custom auto-memory storage path)
+SUPPORTS_FULL_MODEL_IDS=false          # v8.56: Claude Code v2.1.74+ (full model IDs e.g. claude-opus-4-6 work in agent model: frontmatter)
+SUPPORTS_SESSION_END_TIMEOUT=false     # v8.56: Claude Code v2.1.74+ (CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS configurable SessionEnd hook timeout)
+SUPPORTS_CONTEXT_SUGGESTIONS=false     # v8.56: Claude Code v2.1.74+ (/context command shows actionable optimization tips)
+SUPPORTS_PLUGIN_DIR_OVERRIDE=false     # v8.56: Claude Code v2.1.74+ (--plugin-dir local dev copies override installed marketplace plugins)
+SUPPORTS_MANAGED_POLICY_FIX=false      # v8.56: Claude Code v2.1.74+ (managed policy ask rules no longer bypassed by user allow/skill allowed-tools)
 SUPPORTS_CONTINUATION=false           # v8.30: Agent resume/continuation for iterative retries
 OCTOPUS_BACKEND="api"              # v8.16: Detected backend (api|bedrock|vertex|foundry)
 AGENT_TEAMS_ENABLED="${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}"
@@ -750,7 +758,7 @@ detect_claude_code_version() {
         SUPPORTS_FAST_BRIDGE_RECONNECT=true
     fi
 
-    # Check for v2.1.72+ features (ExitWorktree, Agent model override, effort redesign, cron disable env)
+    # Check for v2.1.72+ features (ExitWorktree, Agent model override, effort redesign, cron disable env, parallel tool resilience, plan args)
     if version_compare "$CLAUDE_CODE_VERSION" "2.1.72" ">="; then
         SUPPORTS_EXIT_WORKTREE=true
         SUPPORTS_AGENT_MODEL_OVERRIDE=true
@@ -760,6 +768,8 @@ detect_claude_code_version() {
         SUPPORTS_BASH_ALLOWLIST_V2=true
         SUPPORTS_CLEAR_PRESERVES_BG=true
         SUPPORTS_TEAM_MODEL_INHERIT_FIX=true
+        SUPPORTS_PARALLEL_TOOL_RESILIENCE=true
+        SUPPORTS_PLAN_WITH_ARGS=true
     fi
 
     # Check for v2.1.73+ features (modelOverrides, loop enterprise, subagent model fix, session resume hook fix, bg cleanup, skill deadlock fix)
@@ -770,6 +780,16 @@ detect_claude_code_version() {
         SUPPORTS_SESSION_RESUME_HOOK_FIX=true
         SUPPORTS_BG_PROCESS_CLEANUP=true
         SUPPORTS_SKILL_DEADLOCK_FIX=true
+    fi
+
+    # Check for v2.1.74+ features (autoMemoryDirectory, full model IDs in agents, SessionEnd timeout, /context, plugin-dir override, managed policy fix)
+    if version_compare "$CLAUDE_CODE_VERSION" "2.1.74" ">="; then
+        SUPPORTS_AUTO_MEMORY_DIR=true
+        SUPPORTS_FULL_MODEL_IDS=true
+        SUPPORTS_SESSION_END_TIMEOUT=true
+        SUPPORTS_CONTEXT_SUGGESTIONS=true
+        SUPPORTS_PLUGIN_DIR_OVERRIDE=true
+        SUPPORTS_MANAGED_POLICY_FIX=true
     fi
 
     log "INFO" "Claude Code v$CLAUDE_CODE_VERSION detected"
@@ -797,6 +817,9 @@ detect_claude_code_version() {
     log "INFO" "Clear Preserves BG: $SUPPORTS_CLEAR_PRESERVES_BG | Team Model Inherit Fix: $SUPPORTS_TEAM_MODEL_INHERIT_FIX"
     log "INFO" "Model Overrides: $SUPPORTS_MODEL_OVERRIDES | Loop Enterprise Fix: $SUPPORTS_LOOP_ENTERPRISE_FIX | Subagent Model Fix: $SUPPORTS_SUBAGENT_MODEL_FIX"
     log "INFO" "Session Resume Hook Fix: $SUPPORTS_SESSION_RESUME_HOOK_FIX | BG Process Cleanup: $SUPPORTS_BG_PROCESS_CLEANUP | Skill Deadlock Fix: $SUPPORTS_SKILL_DEADLOCK_FIX"
+    log "INFO" "Parallel Tool Resilience: $SUPPORTS_PARALLEL_TOOL_RESILIENCE | Plan With Args: $SUPPORTS_PLAN_WITH_ARGS"
+    log "INFO" "Auto Memory Dir: $SUPPORTS_AUTO_MEMORY_DIR | Full Model IDs: $SUPPORTS_FULL_MODEL_IDS | Session End Timeout: $SUPPORTS_SESSION_END_TIMEOUT"
+    log "INFO" "Context Suggestions: $SUPPORTS_CONTEXT_SUGGESTIONS | Plugin Dir Override: $SUPPORTS_PLUGIN_DIR_OVERRIDE | Managed Policy Fix: $SUPPORTS_MANAGED_POLICY_FIX"
 
     # v8.29.0: Context window control
     OCTOPUS_CONTEXT_WINDOW="${OCTOPUS_CONTEXT_WINDOW:-auto}"
@@ -12079,8 +12102,11 @@ ${skill_context}"
 
     # v8.52: Warn if spawning Claude agent on enterprise without subagent model fix (CC < v2.1.73)
     # Prior to v2.1.73, model: opus/sonnet/haiku in agent frontmatter was silently downgraded on Bedrock/Vertex/Foundry
+    # v8.56: CC v2.1.74+ also accepts full model IDs (claude-opus-4-6) in agent model: field
     if [[ "$agent_type" == "claude"* ]] && [[ "$OCTOPUS_BACKEND" != "api" ]] && [[ "$SUPPORTS_SUBAGENT_MODEL_FIX" != "true" ]]; then
         log "WARN" "Enterprise backend ($OCTOPUS_BACKEND) + CC < v2.1.73: agent model frontmatter may be silently downgraded. Upgrade to CC v2.1.73+ to fix."
+    elif [[ "$SUPPORTS_FULL_MODEL_IDS" == "true" ]]; then
+        log "DEBUG" "CC v2.1.74+: full model IDs (e.g. claude-opus-4-6) supported in agent frontmatter"
     fi
 
     log INFO "Spawning $agent_type agent (task: $task_id, role: ${role:-none})"
@@ -15612,6 +15638,26 @@ doctor_check_skills() {
             doctor_add "model-overrides-tip" "skills" "info" \
                 "CC v2.1.73 modelOverrides available for ${OCTOPUS_BACKEND} inference profiles" \
                 "Set modelOverrides in ~/.claude/settings.json to map model names to Bedrock ARNs/Vertex endpoints"
+        fi
+    fi
+
+    # v8.56: Surface /context command for context optimization tips
+    if [[ "$SUPPORTS_CONTEXT_SUGGESTIONS" == "true" ]]; then
+        doctor_add "context-suggestions" "skills" "info" \
+            "CC v2.1.74 /context command available for context window diagnostics" \
+            "Run /context in Claude Code to get actionable optimization tips for context-heavy sessions"
+    fi
+
+    # v8.56: Surface autoMemoryDirectory setting if CC v2.1.74+
+    if [[ "$SUPPORTS_AUTO_MEMORY_DIR" == "true" ]]; then
+        local settings_file="${HOME}/.claude/settings.json"
+        local has_memory_dir="false"
+        if [[ -f "$settings_file" ]] && command -v jq &>/dev/null; then
+            has_memory_dir=$(jq 'has("autoMemoryDirectory")' "$settings_file" 2>/dev/null || echo "false")
+        fi
+        if [[ "$has_memory_dir" == "true" ]]; then
+            doctor_add "auto-memory-dir" "skills" "pass" \
+                "CC autoMemoryDirectory configured (custom auto-memory path)" ""
         fi
     fi
 }

--- a/tests/test-version-check.sh
+++ b/tests/test-version-check.sh
@@ -101,7 +101,7 @@ fi
 
 # Test 5: Verify version check runs before provider detection
 test_start "Version check runs before provider detection"
-first_section=$(echo "$output" | head -30)
+first_section=$(echo "$output" | head -40)
 if echo "$first_section" | grep -q "Detecting Claude Code version"; then
     test_pass "Version check runs first"
 else

--- a/tests/unit/test-cc-v2174-sync.sh
+++ b/tests/unit/test-cc-v2174-sync.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Tests for CC v2.1.74 feature detection sync (+ 2 untracked v2.1.72 flags)
+# Validates: 8 new SUPPORTS_* flags, v2.1.74 detection block, wiring, doctor checks
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ORCH="$PROJECT_ROOT/scripts/orchestrate.sh"
+
+TEST_COUNT=0; PASS_COUNT=0; FAIL_COUNT=0
+pass() { TEST_COUNT=$((TEST_COUNT+1)); PASS_COUNT=$((PASS_COUNT+1)); echo "PASS: $1"; }
+fail() { TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1)); echo "FAIL: $1 — $2"; }
+
+# ── 1. Flag declarations exist ────────────────────────────────────────
+
+for flag in SUPPORTS_PARALLEL_TOOL_RESILIENCE SUPPORTS_PLAN_WITH_ARGS \
+            SUPPORTS_AUTO_MEMORY_DIR SUPPORTS_FULL_MODEL_IDS \
+            SUPPORTS_SESSION_END_TIMEOUT SUPPORTS_CONTEXT_SUGGESTIONS \
+            SUPPORTS_PLUGIN_DIR_OVERRIDE SUPPORTS_MANAGED_POLICY_FIX; do
+    if grep -c "${flag}=false" "$ORCH" >/dev/null 2>&1; then
+        pass "Declaration: $flag"
+    else
+        fail "Declaration: $flag" "missing ${flag}=false in orchestrate.sh"
+    fi
+done
+
+# ── 2. v2.1.72 detection block includes new flags ────────────────────
+
+v2172_block=$(grep -A20 'version_compare.*2\.1\.72' "$ORCH" | head -20)
+
+for flag in SUPPORTS_PARALLEL_TOOL_RESILIENCE SUPPORTS_PLAN_WITH_ARGS; do
+    if echo "$v2172_block" | grep -c "$flag=true" >/dev/null 2>&1; then
+        pass "v2.1.72 block sets: $flag"
+    else
+        fail "v2.1.72 block sets: $flag" "not found in v2.1.72 detection block"
+    fi
+done
+
+# ── 3. v2.1.74 detection block exists and sets all 6 flags ───────────
+
+if grep -c 'version_compare.*2\.1\.74' "$ORCH" >/dev/null 2>&1; then
+    pass "v2.1.74 detection block exists"
+else
+    fail "v2.1.74 detection block exists" "no version_compare for 2.1.74"
+fi
+
+v2174_block=$(grep -A15 'version_compare.*2\.1\.74' "$ORCH" | head -15)
+
+for flag in SUPPORTS_AUTO_MEMORY_DIR SUPPORTS_FULL_MODEL_IDS \
+            SUPPORTS_SESSION_END_TIMEOUT SUPPORTS_CONTEXT_SUGGESTIONS \
+            SUPPORTS_PLUGIN_DIR_OVERRIDE SUPPORTS_MANAGED_POLICY_FIX; do
+    if echo "$v2174_block" | grep -c "$flag=true" >/dev/null 2>&1; then
+        pass "v2.1.74 block sets: $flag"
+    else
+        fail "v2.1.74 block sets: $flag" "not found in v2.1.74 detection block"
+    fi
+done
+
+# ── 4. Logging lines for new flags ───────────────────────────────────
+
+for label in "Parallel Tool Resilience" "Plan With Args" "Auto Memory Dir" \
+             "Full Model IDs" "Session End Timeout" "Context Suggestions" \
+             "Plugin Dir Override" "Managed Policy Fix"; do
+    if grep -c "$label" "$ORCH" >/dev/null 2>&1; then
+        pass "Log line: $label"
+    else
+        fail "Log line: $label" "missing from logging output"
+    fi
+done
+
+# ── 5. Wiring: spawn_agent full model IDs ────────────────────────────
+
+if grep -c 'SUPPORTS_FULL_MODEL_IDS.*true' "$ORCH" >/dev/null 2>&1; then
+    # Should be wired in spawn_agent context (near SUPPORTS_SUBAGENT_MODEL_FIX)
+    spawn_context=$(grep -A5 'SUPPORTS_SUBAGENT_MODEL_FIX.*true' "$ORCH" | head -10)
+    if echo "$spawn_context" | grep -c 'SUPPORTS_FULL_MODEL_IDS' >/dev/null 2>&1; then
+        pass "Wired: SUPPORTS_FULL_MODEL_IDS in spawn_agent"
+    else
+        fail "Wired: SUPPORTS_FULL_MODEL_IDS in spawn_agent" "not found near SUBAGENT_MODEL_FIX check"
+    fi
+fi
+
+# ── 6. Wiring: doctor context suggestions ────────────────────────────
+
+if grep -c 'SUPPORTS_CONTEXT_SUGGESTIONS.*true.*doctor\|doctor.*context-suggestions' "$ORCH" >/dev/null 2>&1; then
+    pass "Wired: doctor context-suggestions check"
+else
+    # Try alternate pattern — doctor_add with context-suggestions
+    if grep -c 'doctor_add.*context-suggestions' "$ORCH" >/dev/null 2>&1; then
+        pass "Wired: doctor context-suggestions check"
+    else
+        fail "Wired: doctor context-suggestions check" "no doctor_add for context-suggestions"
+    fi
+fi
+
+# ── 7. Wiring: doctor autoMemoryDirectory ────────────────────────────
+
+if grep -c 'autoMemoryDirectory' "$ORCH" >/dev/null 2>&1; then
+    pass "Wired: doctor autoMemoryDirectory check"
+else
+    fail "Wired: doctor autoMemoryDirectory check" "no autoMemoryDirectory reference"
+fi
+
+# ── 8. Flag comments reference correct CC versions ───────────────────
+
+for flag_ver in "PARALLEL_TOOL_RESILIENCE.*v2.1.72" "PLAN_WITH_ARGS.*v2.1.72" \
+                "AUTO_MEMORY_DIR.*v2.1.74" "FULL_MODEL_IDS.*v2.1.74" \
+                "SESSION_END_TIMEOUT.*v2.1.74" "CONTEXT_SUGGESTIONS.*v2.1.74" \
+                "PLUGIN_DIR_OVERRIDE.*v2.1.74" "MANAGED_POLICY_FIX.*v2.1.74"; do
+    if grep -cE "$flag_ver" "$ORCH" >/dev/null 2>&1; then
+        pass "Version comment: $flag_ver"
+    else
+        fail "Version comment: $flag_ver" "missing or wrong version in comment"
+    fi
+done
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+echo ""
+echo "==============================================="
+echo "CC v2.1.74 sync tests: $PASS_COUNT/$TEST_COUNT passed"
+if [[ $FAIL_COUNT -gt 0 ]]; then
+    echo "$FAIL_COUNT FAILED"
+    exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
## Summary

- **8 new `SUPPORTS_*` flags** from CC v2.1.72 (2 untracked) + v2.1.74 (6 new)
- **3 wired integrations**: spawn_agent full model IDs, doctor `/context` tip, doctor `autoMemoryDirectory` check
- **94 total flags** across 30 `version_compare` blocks
- **Fixed** `test-version-check.sh` fragile `head -30` (→ `head -40`)

### New Flags

| Flag | CC Version | Description |
|------|-----------|-------------|
| `SUPPORTS_PARALLEL_TOOL_RESILIENCE` | v2.1.72 | Failed Read/WebFetch/Glob no longer cancels siblings |
| `SUPPORTS_PLAN_WITH_ARGS` | v2.1.72 | `/plan` accepts description argument |
| `SUPPORTS_AUTO_MEMORY_DIR` | v2.1.74 | `autoMemoryDirectory` setting |
| `SUPPORTS_FULL_MODEL_IDS` | v2.1.74 | Full model IDs in agent `model:` field |
| `SUPPORTS_SESSION_END_TIMEOUT` | v2.1.74 | Configurable SessionEnd hook timeout |
| `SUPPORTS_CONTEXT_SUGGESTIONS` | v2.1.74 | `/context` with actionable tips |
| `SUPPORTS_PLUGIN_DIR_OVERRIDE` | v2.1.74 | `--plugin-dir` overrides marketplace |
| `SUPPORTS_MANAGED_POLICY_FIX` | v2.1.74 | Managed policy `ask` rules fix |

## Test plan

- [x] `test-cc-v2174-sync.sh`: 36 tests — declarations, detection blocks, logging, wiring, version comments
- [x] `test-version-check.sh`: 10 tests (fixed fragile head -30)
- [x] Full suite: 85/85
- [x] Pre-push: 76/76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow execution now driven by configuration files with automatic state recovery
  * Workflows can pause and resume using checkpoint management
  * New diagnostic commands for system health validation
  * Enhanced progress tracking and error reporting
  * Expanded command-line options for workflow customization

* **Tests**
  * Added validation tests for feature detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->