### PR TITLE
chore: release v8.56.0 — CC v2.1.72-v2.1.74 sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v8.55.0 - Smart router v2.0 \u2014 priority-ordered routing to 17 workflows, decision tree confidence, debug test flake fix. 32 personas, 39 commands, 50 skills. Run /octo:setup.",
-      "version": "8.55.0",
+      "description": "v8.56.0 - CC v2.1.72-v2.1.74 feature sync \u2014 8 new flags (94 total, 30 version_compare blocks), smart router v2.0 already released in v8.55.0. 32 personas, 39 commands, 50 skills. Run /octo:setup.",
+      "version": "8.56.0",
       "author": {
         "name": "nyldn"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "8.55.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.55.0) Agent ergonomics \u2014 readonly frontmatter, user-scope agents (~/.claude/agents/), /octo:resume. 32 expert personas, 39 commands, 50 skills. Commands use '/octo:*', including the '/octo:octo' smart router. Run /octo:setup for guided setup.",
+  "version": "8.56.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.56.0) Agent ergonomics \u2014 readonly frontmatter, user-scope agents (~/.claude/agents/), /octo:resume. 32 expert personas, 39 commands, 50 skills. Commands use '/octo:*', including the '/octo:octo' smart router. Run /octo:setup for guided setup.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [8.56.0] - 2026-03-13
+
+### Changed
+
+- CC v2.1.72-v2.1.74 feature sync — 8 new flags (94 total, 30 version_compare blocks), smart router v2.0 already released in v8.55.0
+
+---
+
 ## [8.55.0] - 2026-03-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Claude Code plugin that turns one model into three. Orchestrates Codex, Gemini
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Version-8.55.0-blue" alt="Version 8.55.0">
+  <img src="https://img.shields.io/badge/Version-8.56.0-blue" alt="Version 8.56.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.50+-blueviolet" alt="Requires Claude Code v2.1.50+">
   <img src="https://img.shields.io/badge/Factory_AI-Compatible-orange" alt="Factory AI Compatible">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "8.55.0",
+  "version": "8.56.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
Version bump 8.55.0 → 8.56.0. 8 new flags, 94 total, 30 version_compare blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 8 new flags (94 total available).

* **Chores**
  * Version bumped to 8.56.0.
  * Updated metadata and documentation to reflect the latest release.
  * Synced feature updates from recent CC versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->