### PR TITLE
fix: path traversal validation in loadCommands/loadSkills

### DIFF
--- a/openclaw/src/skill-loader.ts
+++ b/openclaw/src/skill-loader.ts
@@ -9,7 +9,7 @@
  */
 
 import { readFile, readdir } from "node:fs/promises";
-import { resolve } from "node:path";
+import { resolve, relative } from "node:path";
 
 export interface SkillMetadata {
   name: string;
@@ -87,6 +87,17 @@ function parseAliases(content: string): string[] {
 }
 
 /**
+ * Validate that a resolved file path stays within the expected directory.
+ * Prevents path traversal attacks via filenames containing ".." segments.
+ */
+function assertWithinDirectory(filePath: string, directory: string): void {
+  const rel = relative(directory, filePath);
+  if (rel.startsWith("..") || resolve(filePath) !== filePath) {
+    throw new Error(`Path traversal detected: ${filePath} escapes ${directory}`);
+  }
+}
+
+/**
  * Load all skill metadata from the Claude Octopus skills directory.
  */
 export async function loadSkills(pluginRoot: string): Promise<SkillMetadata[]> {
@@ -98,6 +109,7 @@ export async function loadSkills(pluginRoot: string): Promise<SkillMetadata[]> {
     if (!file.endsWith(".md")) continue;
 
     const filePath = resolve(skillsDir, file);
+    assertWithinDirectory(filePath, skillsDir);
     const content = await readFile(filePath, "utf-8");
     const frontmatter = parseFrontmatter(content);
 
@@ -133,6 +145,7 @@ export async function loadCommands(
     if (!file.endsWith(".md")) continue;
 
     const filePath = resolve(commandsDir, file);
+    assertWithinDirectory(filePath, commandsDir);
     const content = await readFile(filePath, "utf-8");
     const frontmatter = parseFrontmatter(content);
 


### PR DESCRIPTION
Adds path traversal validation to `loadCommands` and `loadSkills` in `skill-loader.ts`. Both functions now verify that resolved file paths from `readdir` don't escape their expected directory via `../` segments before reading file contents.

Closes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enhanced file loading security to prevent unauthorized path access through directory traversal attempts, improving protection against potential file system exploits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->