### PR TITLE
fix: align plugin.json name with marketplace registration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "octo",
+  "name": "claude-octopus",
   "version": "8.56.0",
   "description": "Multi-tentacled orchestrator using Double Diamond methodology. (v8.56.0) Agent ergonomics \u2014 readonly frontmatter, user-scope agents (~/.claude/agents/), /octo:resume. 32 expert personas, 39 commands, 50 skills. Commands use '/octo:*', including the '/octo:octo' smart router. Run /octo:setup for guided setup.",
   "author": {


### PR DESCRIPTION
## Description
plugin.json declares "name": "octo" but marketplace.json registers the plugin as "claude-octopus". The interactive /plugin UI reads from plugin.json, so uninstall and update operations fail with:

  Plugin "octo@nyldn-plugins" is not installed in user scope

while the CLI installed it as claude-octopus@nyldn-plugins.

Change plugin.json name from "octo" to "claude-octopus" to match.

## Type of Change
- [X] Bug fix

## Testing
How was this tested?

## Related Issues
Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin name for consistency and branding purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->