### PR TITLE
docs: add update instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ A Claude Code plugin that turns one model into three. Orchestrates Codex, Gemini
 
 [Full changelog](CHANGELOG.md)
 
+**To update:**
+```
+/plugin update octo
+```
+
+If that fails (older installs used a different name), do a clean reinstall:
+```
+/plugin uninstall claude-octopus
+/plugin install octo@nyldn-plugins
+```
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/image?repos=nyldn/claude-octopus&type=date&legend=top-left)](https://www.star-history.com/?repos=nyldn%2Fclaude-octopus&type=date&legend=top-left)


### PR DESCRIPTION
## Summary
- Added update command (`/plugin update octo`) below Recent Updates table
- Includes fallback for older installs that used the previous name

## Test plan
- [x] README only — 81/81 pre-push pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added plugin update guidance with instructions for standard updates and fallback clean reinstall steps, making it easier for users to keep the plugin current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->