### PR TITLE
fix: eliminate command injection in claude-mem-bridge.sh

### DIFF
--- a/docs/RELEASE_AUTOMATION.md
+++ b/docs/RELEASE_AUTOMATION.md
@@ -48,7 +48,7 @@ The script performs 10 validation checks:
 
 | Check | What It Validates | Severity |
 |-------|------------------|----------|
-| 1. Plugin Names | `plugin.json` name = "octo", `marketplace.json` name = "claude-octopus" | 🔴 Critical |
+| 1. Plugin Names | `plugin.json` name = "octo", `marketplace.json` name = "octo" (must match) | 🔴 Critical |
 | 2. Version Sync | All manifests have same version | 🔴 Critical |
 | 3. Command Registration | All commands registered in plugin.json | 🔴 Critical |
 | 4. Command Frontmatter | No namespace prefix in command frontmatter | 🔴 Critical |

--- a/scripts/claude-mem-bridge.sh
+++ b/scripts/claude-mem-bridge.sh
@@ -24,7 +24,7 @@ claude_mem_search() {
     local limit="${2:-5}"
     local project="${3:-}"
 
-    local url="${CLAUDE_MEM_URL}/api/search?query=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$query'))" 2>/dev/null || echo "$query")&limit=${limit}"
+    local url="${CLAUDE_MEM_URL}/api/search?query=$(python3 -c "import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1]))" "$query" 2>/dev/null || printf '%s' "$query")&limit=${limit}"
     if [[ -n "$project" ]]; then
         url="${url}&project=${project}"
     fi
@@ -55,15 +55,8 @@ claude_mem_observe() {
     curl -sf --max-time "$CLAUDE_MEM_TIMEOUT" \
         -X POST "${CLAUDE_MEM_URL}/api/sessions/${session_id}/observations" \
         -H "Content-Type: application/json" \
-        -d "$(python3 -c "
-import json, sys
-print(json.dumps({
-    'type': '$obs_type',
-    'title': '$title',
-    'text': '$text',
-    'source': 'claude-octopus',
-    'concept': 'how-it-works'
-}))" 2>/dev/null)" >/dev/null 2>&1 &
+        -d "$(jq -n --arg type "$obs_type" --arg title "$title" --arg text "$text" \
+            '{type: $type, title: $title, text: $text, source: "claude-octopus", concept: "how-it-works"}')" >/dev/null 2>&1 &
 
     return 0
 }
@@ -84,21 +77,22 @@ claude_mem_context() {
     fi
 
     # Format results as brief context
-    python3 -c "
+    printf '%s' "$results" | python3 -c "
 import json, sys
 try:
-    data = json.loads('''$results''')
+    data = json.loads(sys.stdin.read())
     if not data or not isinstance(data, list):
         sys.exit(0)
+    limit = int(sys.argv[1]) if len(sys.argv) > 1 else 3
     print('## Recent claude-mem observations')
-    for item in data[:$limit]:
+    for item in data[:limit]:
         title = item.get('title', 'untitled')
         obs_type = item.get('type', '')
         created = item.get('created_at', '')[:10]
         print(f'- [{obs_type}] {title} ({created})')
 except:
     pass
-" 2>/dev/null || echo ""
+" "$limit" 2>/dev/null || echo ""
 }
 
 # Main dispatch


### PR DESCRIPTION
## Summary

3 command injection vulnerabilities in `scripts/claude-mem-bridge.sh` where shell variables were interpolated directly into Python string literals. A crafted input containing single quotes could execute arbitrary Python code.

### Fixes

| Function | Variable | Before | After |
|----------|----------|--------|-------|
| `claude_mem_search` | `$query` | Python `'$query'` | `sys.argv[1]` |
| `claude_mem_observe` | `$obs_type`, `$title`, `$text` | Python `'$var'` | `jq --arg` (no Python) |
| `claude_mem_context` | `$results`, `$limit` | Python `'''$results'''` | `stdin` + `sys.argv[1]` |

Also fixes stale `docs/RELEASE_AUTOMATION.md` marketplace name reference (still said `"claude-octopus"` after v9.0.1 rename).

## Test plan

- [x] 81/81 pre-push tests pass
- [x] No functional change — same behavior, safe data flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated validation requirements documentation to clarify marketplace configuration matching.

* **Maintenance**
  * Enhanced backend scripts for improved data processing and URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->