### PR TITLE
fix: Skill tool references use actual skill names

### DIFF
--- a/.claude/commands/claw.md
+++ b/.claude/commands/claw.md
@@ -11,7 +11,7 @@ When the user invokes this command (e.g., `/octo:claw <arguments>`):
 
 **✓ CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:claw", args: "<user's arguments>")
+Skill(skill: "skill-claw", args: "<user's arguments>")
 ```
 
 **✗ INCORRECT - Do NOT use Task tool:**

--- a/.claude/commands/debug.md
+++ b/.claude/commands/debug.md
@@ -11,7 +11,7 @@ When the user invokes this command (e.g., `/octo:debug <arguments>`):
 
 **✓ CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:debug", args: "<user's arguments>")
+Skill(skill: "skill-debug", args: "<user's arguments>")
 ```
 
 **✗ INCORRECT - Do NOT use Task tool:**

--- a/.claude/commands/deck.md
+++ b/.claude/commands/deck.md
@@ -11,7 +11,7 @@ When the user invokes this command (e.g., `/octo:deck <arguments>`):
 
 **Use the Skill tool:**
 ```
-Skill(skill: "octo:deck", args: "<user's arguments>")
+Skill(skill: "skill-deck", args: "<user's arguments>")
 ```
 
 **Do NOT use Task tool** — this is a skill, not an agent type.

--- a/.claude/commands/define.md
+++ b/.claude/commands/define.md
@@ -20,7 +20,7 @@ When the user invokes this command (e.g., `/octo:define <arguments>`):
 
 **✓ CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:define", args: "<user's arguments>")
+Skill(skill: "flow-define", args: "<user's arguments>")
 ```
 
 **✗ INCORRECT - Do NOT use Task tool:**

--- a/.claude/commands/deliver.md
+++ b/.claude/commands/deliver.md
@@ -20,7 +20,7 @@ When the user invokes this command (e.g., `/octo:deliver <arguments>`):
 
 **✓ CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:deliver", args: "<user's arguments>")
+Skill(skill: "flow-deliver", args: "<user's arguments>")
 ```
 
 **✗ INCORRECT - Do NOT use Task tool:**

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -20,7 +20,7 @@ When the user invokes this command (e.g., `/octo:develop <arguments>`):
 
 **✓ CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:develop", args: "<user's arguments>")
+Skill(skill: "flow-develop", args: "<user's arguments>")
 ```
 
 **✗ INCORRECT - Do NOT use Task tool:**

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -20,7 +20,7 @@ When the user invokes this command (e.g., `/octo:discover <arguments>`):
 
 **✓ CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:discover", args: "<user's arguments>")
+Skill(skill: "flow-discover", args: "<user's arguments>")
 ```
 
 **✗ INCORRECT - Do NOT use Task tool:**
@@ -85,10 +85,10 @@ After receiving answers, incorporate them into the Skill invocation.
 ### Step 2: Invoke Skill with Intensity
 
 ```
-Skill(skill: "octo:discover", args: "[intensity=quick|standard|deep] <user's arguments>")
+Skill(skill: "flow-discover", args: "[intensity=quick|standard|deep] <user's arguments>")
 ```
 
-Example: `Skill(skill: "octo:discover", args: "[intensity=standard] OAuth authentication patterns")`
+Example: `Skill(skill: "flow-discover", args: "[intensity=standard] OAuth authentication patterns")`
 
 ### Step 3: Post-Completion — Interactive Next Steps
 

--- a/.claude/commands/docs.md
+++ b/.claude/commands/docs.md
@@ -11,7 +11,7 @@ When the user invokes this command (e.g., `/octo:docs <arguments>`):
 
 **✓ CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:docs", args: "<user's arguments>")
+Skill(skill: "skill-doc-delivery", args: "<user's arguments>")
 ```
 
 **✗ INCORRECT - Do NOT use Task tool:**

--- a/.claude/commands/doctor.md
+++ b/.claude/commands/doctor.md
@@ -11,7 +11,7 @@ When the user invokes this command (e.g., `/octo:doctor <arguments>`):
 
 **✓ CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:doctor", args: "<user's arguments>")
+Skill(skill: "skill-doctor", args: "<user's arguments>")
 ```
 
 **✗ INCORRECT - Do NOT use Task tool:**

--- a/.claude/commands/loop.md
+++ b/.claude/commands/loop.md
@@ -11,7 +11,7 @@ When the user invokes this command (e.g., `/octo:loop <arguments>`):
 
 **✓ CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:loop", args: "<user's arguments>")
+Skill(skill: "skill-iterative-loop", args: "<user's arguments>")
 ```
 
 **✗ INCORRECT - Do NOT use Task tool:**

--- a/.claude/commands/parallel.md
+++ b/.claude/commands/parallel.md
@@ -14,7 +14,7 @@ When the user invokes this command (e.g., `/octo:parallel <arguments>`):
 
 **CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:parallel", args: "<user's arguments>")
+Skill(skill: "flow-parallel", args: "<user's arguments>")
 ```
 
 **INCORRECT - Do NOT use Task tool:**

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -43,19 +43,21 @@ Map the answer to an intensity value:
 
 ### Step 2: Invoke Skill with Intensity
 
-**✓ CORRECT - Use the Skill tool with intensity prefix:**
+**✓ CORRECT - Use the Skill tool with the skill's registered name:**
 ```
-Skill(skill: "octo:discover", args: "[intensity=quick|standard|deep] <user's arguments>")
+Skill(skill: "flow-discover", args: "[intensity=quick|standard|deep] <user's arguments>")
 ```
 
-Example: `Skill(skill: "octo:discover", args: "[intensity=standard] OAuth 2.0 authentication patterns")`
+Example: `Skill(skill: "flow-discover", args: "[intensity=standard] OAuth 2.0 authentication patterns")`
 
-**✗ INCORRECT - Do NOT use Task tool:**
+**✗ INCORRECT - Do NOT use these names:**
 ```
+Skill(skill: "octo:discover", ...)   ❌ Wrong! "octo:discover" is the command name, not the skill name
+Skill(skill: "discover", ...)        ❌ Wrong! Use the full skill name "flow-discover"
 Task(subagent_type: "octo:discover", ...)  ❌ Wrong! This is a skill, not an agent type
 ```
 
-**Why:** This command loads the `flow-discover` skill for multi-AI research. Skills use the `Skill` tool, not `Task`.
+**Why:** The command is `/octo:discover` but the skill file is named `flow-discover`. Always use the skill's registered name with the Skill tool.
 
 ---
 

--- a/.claude/commands/security.md
+++ b/.claude/commands/security.md
@@ -78,7 +78,7 @@ AskUserQuestion({
 
 **✓ CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:security", args: "<user's arguments + context>")
+Skill(skill: "skill-security-framing", args: "<user's arguments + context>")
 ```
 
 **✗ INCORRECT - Do NOT use Task tool:**

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -14,7 +14,7 @@ When the user invokes this command (e.g., `/octo:spec <arguments>`):
 
 **CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:spec", args: "<user's arguments>")
+Skill(skill: "flow-spec", args: "<user's arguments>")
 ```
 
 **INCORRECT - Do NOT use Task tool:**

--- a/.claude/commands/staged-review.md
+++ b/.claude/commands/staged-review.md
@@ -48,7 +48,7 @@ If invoked with arguments (e.g., `/octo:staged-review src/auth/`), use that path
 
 **✓ CORRECT — Use the Skill tool:**
 ```
-Skill(skill: "octo:staged-review", args: "<scope>")
+Skill(skill: "skill-staged-review", args: "<scope>")
 ```
 
 **✗ INCORRECT — Do NOT use Task tool:**

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -63,7 +63,7 @@ AskUserQuestion({
 
 **✓ CORRECT - Use the Skill tool:**
 ```
-Skill(skill: "octo:tdd", args: "<user's arguments + context>")
+Skill(skill: "skill-tdd", args: "<user's arguments + context>")
 ```
 
 **✗ INCORRECT - Do NOT use Task tool:**


### PR DESCRIPTION
## Summary
All 16 command files were using `Skill(skill: "octo:X")` but the Skill tool resolves names from skill frontmatter (`name: flow-discover`), not command frontmatter (`command: discover`). This caused every `/octo:` command to fail with "Unknown skill" when trying to invoke its underlying skill.

Fixed all 16 command → skill name mappings.

## Test plan
- [x] 81/81 tests pass
- [x] No remaining `Skill(skill: "octo:` references (except router template in octo.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command documentation examples across multiple commands, including claw, debug, deck, define, deliver, develop, discover, docs, doctor, loop, parallel, research, security, spec, staged-review, and tdd. Command references now reflect current naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->