### PR TITLE
fix: quote default value in bash parameter expansion (closes #172)

### DIFF
--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -8181,7 +8181,7 @@ print_provider_report() {
 # Args: JSON profile string with fields:
 #   target, focus, provenance, autonomy, publish, debate
 review_run() {
-    local profile_json="${1:-{}}"
+    local profile_json="${1:-"{}"}"
 
     # Parse profile fields (with defaults)
     local target focus provenance autonomy publish debate
@@ -21930,7 +21930,7 @@ case "$COMMAND" in
             echo "Example: $(basename "$0") code-review '{\"target\":\"staged\",\"publish\":\"ask\"}'"
             exit 0
         fi
-        review_run "${1:-{}}"
+        review_run "${1:-"{}"}"
         ;;
     embrace)
         # Full 4-phase Double Diamond workflow


### PR DESCRIPTION
## What

`${1:-{}}` is parsed by bash as `${1:-{}` (default=`{`) plus a trailing literal `}`, which appends an extra closing brace to any JSON string passed as `$1`. This causes `jq` parse errors every time `code-review` is called with a profile argument.

## Fix

Quote the default value: `${1:-"{}"}`

Two occurrences fixed:
- `review_run()` function definition (line 8184)
- `review_run` call in the case dispatch (line 21933)

All 41 test suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSON default parameter handling in command dispatch to prevent syntax errors during workflow execution.

* **New Features**
  * Added YAML-based workflow runner support for specification-driven orchestrations.
  * Extended command dispatch with new orchestration commands.
  * Enhanced workflow lifecycle management with improved session recovery and progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->