### PR TITLE
fix: use ${USERNAME} fallback for Windows compatibility

### DIFF
--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -5,7 +5,7 @@
 set -eo pipefail
 
 CONFIG_FILE="${HOME}/.claude-octopus/config/providers.json"
-CACHE_FILE="/tmp/octo-model-cache-${USER}-${CLAUDE_CODE_SESSION:-global}.json"
+CACHE_FILE="/tmp/octo-model-cache-${USER:-${USERNAME:-unknown}}-${CLAUDE_CODE_SESSION:-global}.json"
 
 # Known providers and phases for validation
 KNOWN_PROVIDERS="codex gemini claude perplexity openrouter"

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -33,7 +33,7 @@ resolve_octopus_model() {
     fi
 
     # Persistent File Cache (optional, for parallel execution speed)
-    local persistent_cache="/tmp/octo-model-cache-${USER}-${CLAUDE_CODE_SESSION:-global}.json"
+    local persistent_cache="/tmp/octo-model-cache-${USER:-${USERNAME:-unknown}}-${CLAUDE_CODE_SESSION:-global}.json"
     # v8.49.0: Invalidate cache if config file changed since cache was written
     if [[ -f "$persistent_cache" && -f "$config_file" && "$config_file" -nt "$persistent_cache" ]]; then
         rm -f "$persistent_cache"

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -174,7 +174,7 @@ EOF
         log "INFO" "Migration to v3.0 complete"
 
         # v8.49.0: Clear stale model cache after migration
-        rm -f "/tmp/octo-model-cache-${USER}-${CLAUDE_CODE_SESSION:-global}.json"
+        rm -f "/tmp/octo-model-cache-${USER:-${USERNAME:-unknown}}-${CLAUDE_CODE_SESSION:-global}.json"
     fi
 
     local changed=false
@@ -221,7 +221,7 @@ EOF
         echo "$content" > "$tmp_file" && mv "$tmp_file" "$config_file"
         log "INFO" "Updated ${config_file} with current model names"
         # v8.49.0: Clear model cache after stale name migration
-        rm -f "/tmp/octo-model-cache-${USER}-${CLAUDE_CODE_SESSION:-global}.json"
+        rm -f "/tmp/octo-model-cache-${USER:-${USERNAME:-unknown}}-${CLAUDE_CODE_SESSION:-global}.json"
     fi
 }
 
@@ -316,7 +316,7 @@ EOF
     fi
 
     # v8.49.0: Clear model resolution cache after config change
-    local persistent_cache="/tmp/octo-model-cache-${USER}-${CLAUDE_CODE_SESSION:-global}.json"
+    local persistent_cache="/tmp/octo-model-cache-${USER:-${USERNAME:-unknown}}-${CLAUDE_CODE_SESSION:-global}.json"
     rm -f "$persistent_cache"
 }
 
@@ -350,7 +350,7 @@ reset_provider_model() {
     fi
 
     # v8.49.0: Clear model resolution cache after config change
-    local persistent_cache="/tmp/octo-model-cache-${USER}-${CLAUDE_CODE_SESSION:-global}.json"
+    local persistent_cache="/tmp/octo-model-cache-${USER:-${USERNAME:-unknown}}-${CLAUDE_CODE_SESSION:-global}.json"
     rm -f "$persistent_cache"
 }
 


### PR DESCRIPTION
Closes #201

`$USER` is unset on Windows (Git Bash) — Windows uses `$USERNAME` instead. Under `set -u`, this crashes `orchestrate.sh` with `unbound variable`.

All 6 occurrences of `${USER}` in the model cache path now use `${USER:-${USERNAME:-unknown}}` to fall back to Windows `$USERNAME`, then to `unknown` if neither is set.

### Files changed
- `scripts/lib/model-resolver.sh` (1 occurrence)
- `scripts/lib/provider-routing.sh` (4 occurrences)
- `scripts/helpers/octo-model-config.sh` (1 occurrence)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache file path handling with better fallback logic to ensure reliable, consistent behavior across different system environments and shell configurations, even when standard environment variables are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->