### PR TITLE
fix: add --full-auto flag to codex exec commands in dispatch.sh

### DIFF
--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -40,19 +40,19 @@ get_agent_command() {
     case "$agent_type" in
         codex|codex-standard|codex-max|codex-mini|codex-general)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --model ${model} ${sandbox_flag}"
+            echo "codex exec --full-auto --model ${model} ${sandbox_flag}"
             ;;
         codex-spark)  # v8.9.0: Ultra-fast Spark model (1000+ tok/s)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --model ${model} ${sandbox_flag}"
+            echo "codex exec --full-auto --model ${model} ${sandbox_flag}"
             ;;
         codex-reasoning)  # v8.9.0: Reasoning models (o3, o3)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --model ${model} ${sandbox_flag}"
+            echo "codex exec --full-auto --model ${model} ${sandbox_flag}"
             ;;
         codex-large-context)  # v8.9.0: 1M context models (gpt-4.1)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --model ${model} ${sandbox_flag}"
+            echo "codex exec --full-auto --model ${model} ${sandbox_flag}"
             ;;
         gemini|gemini-fast|gemini-image)
             model=$(get_agent_model "$agent_type" "$phase" "$role")


### PR DESCRIPTION
## Summary

- Add missing `--full-auto` flag to all four `codex exec` command variants in `get_agent_command()` (lines 43, 47, 51, 55)
- Without this flag, Codex waits for interactive approval in `exec` mode, causing empty output or hangs in all bash-orchestrated dispatches

Fixes #212

## Details

The skill-based path (SKILL.md templates) already includes `--full-auto`, but the bash orchestration path through `dispatch.sh` was never updated. This affects `grapple_debate`, `run_agent_sync`, `spawn_agent`, and any workflow routed through `get_agent_command()`.

The existing `${sandbox_flag}` (`--sandbox ...`) overrides the sandbox implied by `--full-auto`, so `OCTOPUS_CODEX_SANDBOX` configuration still works correctly.

## Test plan

- [ ] Run `/octo:debate` and verify Codex agents produce output instead of hanging
- [ ] Verify `run_agent_sync` completes with Codex provider
- [ ] Confirm `OCTOPUS_CODEX_SANDBOX` override still takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Codex agent command execution to include the `--full-auto` flag for enhanced automated processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->