### PR TITLE
fix(doctor): resolve false positives in hook script validation

### DIFF
--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -504,9 +504,19 @@ doctor_check_hooks() {
         resolved_path="${resolved_path//\$\{CLAUDE_PLUGIN_ROOT\}/$PLUGIN_DIR}"
         resolved_path="${resolved_path//\$CLAUDE_PLUGIN_ROOT/$PLUGIN_DIR}"
 
-        # Handle paths with arguments (take only first word)
+        # Handle paths with arguments, env-var prefixes, and bash wrappers
         local script_path
-        script_path=$(echo "$resolved_path" | awk '{print $1}')
+        # Strip leading env-var assignments (KEY=value ...)
+        local cleaned="$resolved_path"
+        while [[ "$cleaned" =~ ^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+(.*) ]]; do
+            cleaned="${BASH_REMATCH[1]}"
+        done
+        # Strip leading 'bash ' wrapper
+        cleaned="${cleaned#bash }"
+        # Remove surrounding quotes
+        cleaned="${cleaned#\"}"
+        cleaned="${cleaned%\"}"
+        script_path=$(echo "$cleaned" | awk '{print $1}')
 
         if [[ ! -f "$script_path" ]]; then
             doctor_add "hook-script-$(basename "$script_path")" "hooks" "fail" \


### PR DESCRIPTION
## Description

### Context

While running `/octo:doctor` during a routine session health check, 5 hook script validation failures appeared in the `[hooks]` category — even though all 32 hook scripts exist on disk and are correctly executable. The doctor was reporting false positives, which undermines trust in the diagnostics output.

### Root cause

The hook validation logic in `scripts/lib/doctor.sh` (line 509) extracts the script path from each hook command using:

```bash
script_path=$(echo "$resolved_path" | awk '{print $1}')
```

This takes the **first whitespace-delimited token** as the file path. However, `hooks.json` contains two command patterns where the first token is NOT the script path:

**Pattern 1 — `bash`-wrapped commands** (2 occurrences):
```json
{ "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/strategy-rotation.sh\"" }
{ "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/done-criteria.sh\"" }
```
`awk '{print $1}'` extracts `bash` → file existence check fails → false positive.

**Pattern 2 — env-var prefixed commands** (3 occurrences):
```json
{ "command": "CLAUDE_HOOK_EVENT=SessionStart ${CLAUDE_PLUGIN_ROOT}/hooks/telemetry-posthog.sh" }
{ "command": "CLAUDE_HOOK_EVENT=SessionEnd ${CLAUDE_PLUGIN_ROOT}/hooks/telemetry-posthog.sh" }
{ "command": "CLAUDE_HOOK_EVENT=Stop ${CLAUDE_PLUGIN_ROOT}/hooks/telemetry-posthog.sh" }
```
`awk '{print $1}'` extracts the env-var assignment (e.g. `CLAUDE_HOOK_EVENT=SessionStart`) → file existence check fails → false positive.

### All 5 false positives

| Command in hooks.json | Token extracted (wrong) | Actual script |
|---|---|---|
| `bash "${...}/strategy-rotation.sh"` | `bash` | `hooks/strategy-rotation.sh` ✅ |
| `bash "${...}/done-criteria.sh"` | `bash` | `hooks/done-criteria.sh` ✅ |
| `CLAUDE_HOOK_EVENT=SessionStart ${...}/telemetry-posthog.sh` | `CLAUDE_HOOK_EVENT=SessionStart` | `hooks/telemetry-posthog.sh` ✅ |
| `CLAUDE_HOOK_EVENT=SessionEnd ${...}/telemetry-posthog.sh` | `CLAUDE_HOOK_EVENT=SessionEnd` | `hooks/telemetry-posthog.sh` ✅ |
| `CLAUDE_HOOK_EVENT=Stop ${...}/telemetry-posthog.sh` | `CLAUDE_HOOK_EVENT=Stop` | `hooks/telemetry-posthog.sh` ✅ |

### Fix

Before extracting the first token with `awk`, the parser now applies three normalization steps:

1. **Strips leading env-var assignments** (`KEY=value ...`) via a `while` loop with bash regex — handles one or more chained assignments
2. **Strips the leading `bash ` wrapper** prefix using parameter expansion
3. **Removes surrounding double quotes** from the remaining path

After normalization, `awk '{print $1}'` correctly extracts the actual script path.

### Before / After

```
# Before fix
Summary: 25 passed, 3 warning(s), 5 failure(s)

# After fix
Summary: 26 passed, 3 warning(s), 0 failure(s)
```

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/run-all.sh` — 127/129 pass (2 pre-existing failures on `main` in `test-model-config-simple.sh` and `test-phases-1-2-3.sh`, unrelated to this change)
- [ ] OpenClaw registry in sync — N/A (no registry changes)
- [ ] New skills/commands registered — N/A (no new skills/commands)
- [ ] Version bump — N/A (patch-level bug fix)
- [ ] Documentation updated — N/A (no user-facing doc changes needed)
- [ ] CHANGELOG.md updated — happy to add an entry if desired

## Testing

### Environment
- **OS**: macOS 26.3.1 (Darwin 25.3.0)
- **Shell**: zsh 5.9 / bash 3.2.57
- **Claude Code**: v2.1.85
- **Plugin version**: v9.14.0 (`005ef2a`)
- **jq**: 1.7.1

### Steps to reproduce (before fix)

```bash
# Run doctor — observe 5 false failures in [hooks] category
cd ~/.claude/plugins/marketplaces/nyldn-plugins/
bash scripts/orchestrate.sh doctor --verbose
# Output includes:
#   ✗ Hook script missing: bash
#   ✗ Hook script missing: CLAUDE_HOOK_EVENT=SessionStart
#   ✗ Hook script missing: CLAUDE_HOOK_EVENT=SessionEnd
#   ✗ Hook script missing: bash
#   ✗ Hook script missing: CLAUDE_HOOK_EVENT=Stop
```

### Verification (after fix)

```bash
# Syntax validation — all pass
bash -n scripts/orchestrate.sh
bash -n scripts/lib/doctor.sh
bash -n scripts/lib/*.sh

# Full test suite — 127/129 pass (same as main)
bash tests/run-all.sh

# Doctor re-run — 0 failures
bash scripts/orchestrate.sh doctor hooks
# Output: Summary: 26 passed, 3 warning(s)

# Independent verification — all 32 hook scripts exist on disk
for script in hooks/*.sh; do [ -f "$script" ] && echo "✅ $script"; done
```

## Related Issues
No existing issue — discovered during routine `/octo:doctor` session check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook command validation to correctly handle complex command formats, including those with environment variable assignments, bash wrappers, and quoted strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->