### PR TITLE
fix(mcp-server): bump zod to 3.25.67 for MCP SDK 1.26 compatibility

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.26.0",
-    "zod": "3.24.1"
+    "zod": "3.25.67"
   },
   "devDependencies": {
     "typescript": "^5.7.0",


### PR DESCRIPTION
## Summary
- Bumps `zod` from `3.24.1` to `3.25.67` in `mcp-server/package.json`
- `@modelcontextprotocol/sdk` 1.26.0 requires `zod ^3.25` (imports `zod/v4` subpath)
- The pinned `3.24.1` causes `ERR_PACKAGE_PATH_NOT_EXPORTED` at startup, preventing the `octo-claw` MCP server from connecting

## Reproduction
```
$ node mcp-server/dist/index.js
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './v4' is not defined by "exports"
in zod/package.json imported from @modelcontextprotocol/sdk/dist/esm/types.js
```

## Test plan
- [x] `pnpm install` in `mcp-server/` succeeds without peer dependency warnings for zod
- [x] `node mcp-server/dist/index.js` starts without errors (stdio transport, hangs waiting for input)
- [x] Claude Code `/mcp` reconnects to `plugin:octo:octo-claw` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the runtime validation library to a newer version to keep dependencies current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->