### PR TITLE
Add FAQ entry for --verbose debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,9 @@ The workflow continues with available providers. You'll see the status in the vi
 **Why "octopus"?**
 🐙 *Fun fact: a real octopus has three hearts, blue blood, and 500 million neurons — two-thirds of which live in its eight arms.* Each arm can taste, touch, and act independently. Claude Octopus works the same way: each tentacle (command) operates autonomously with its own squeeze of logic, then ink flows back as the final deliverable. The crossfire review? That's the squeeze — adversarial pressure that untangles everything before it ships.
 
+**How do I debug when something goes wrong?**
+Run commands with the `--verbose` flag to get detailed debugging output. Logs are stored in `~/.claude-octopus/logs/` for inspection. You can also use `/octo:doctor` to run diagnostics and identify potential issues.
+
 ---
 
 ## Community


### PR DESCRIPTION
## Description
Added a FAQ entry explaining how to debug using the `--verbose` flag.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [ ] Code passes `bash -n scripts/orchestrate.sh`
- [ ] Shell scripts pass `bash -n` syntax check
- [ ] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync: `scripts/build-openclaw.sh --check`
- [ ] New skills/commands registered in `.claude-plugin/plugin.json`
- [ ] Version bump (if releasing): package.json + plugin.json + marketplace.json + README.md + CHANGELOG.md
- [x] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (for features/fixes)

## Testing
Not applicable. This is a documentation-only change.

## Related Issues
Closes #223 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ section with debugging guidance, including instructions for using the `--verbose` flag for detailed output, accessing log files, and running the `/octo:doctor` command for system diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->