### PR TITLE
fix: Windows compat, model resolver routing, and test sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
 
 🔄 **Four-phase methodology, not just tools.** Every task moves through Discover → Define → Develop → Deliver, with quality gates between phases. Other orchestrators give you infrastructure. Octopus gives you the workflows.
 
-🐙 **32 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **47 commands** (slash commands you type), **50 skills** (reusable workflow modules). Say "audit my API" and the right expert activates. Don't know the command? The smart router figures it out.
+🐙 **32 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **48 commands** (slash commands you type), **51 skills** (reusable workflow modules). Say "audit my API" and the right expert activates. Don't know the command? The smart router figures it out.
 
 🐙 **Works with just Claude. Scales to eight.** Zero providers needed to start. Add them one at a time — each activates automatically when detected.
 
@@ -190,7 +190,7 @@ Specialized agents that activate automatically based on your request. When you s
 
 Categories: Software Engineering (11), Specialized Development (6), Documentation & Communication (5), Research & Strategy (3), Business & Compliance (3), Creative & Design (4).
 
-[Full persona reference](docs/AGENTS.md) | [All 50 skills](docs/COMMAND-REFERENCE.md)
+[Full persona reference](docs/AGENTS.md) | [All 51 skills](docs/COMMAND-REFERENCE.md)
 
 ### Built-in Reaction Engine
 

--- a/openclaw/src/tools/index.ts
+++ b/openclaw/src/tools/index.ts
@@ -53,6 +53,7 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "skill-parallel-agents", description: "Decompose large tasks across parallel agents — use for migrations, multi-file refactors, or batch work", type: "skill", file: "skill-parallel-agents.md" },
   { name: "skill-prd", description: "Write an AI-optimized PRD using multi-AI orchestration — use when scoping a new feature or product", type: "skill", file: "skill-prd.md" },
   { name: "skill-resume", description: "Pick up where you left off from a previous session — use after context resets, compaction, or new conversations", type: "skill", file: "skill-resume.md" },
+  { name: "skill-review-response", description: "How to handle code review feedback — verify before implementing, push back when wrong, never agree blindly", type: "skill", file: "skill-review-response.md" },
   { name: "skill-rollback", description: "Roll back to a previous checkpoint via git — use when a change went wrong and you need to revert", type: "skill", file: "skill-rollback.md" },
   { name: "skill-security-framing", description: "URL validation and content sanitization for untrusted sources — use when handling external input safely", type: "skill", file: "skill-security-framing.md" },
   { name: "skill-ship", description: "Package and finalize completed work for delivery — use when a feature is done and ready to ship", type: "skill", file: "skill-ship.md" },
@@ -61,7 +62,7 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "skill-task-management", description: "Manage tasks with Claude Code native tools — use to track TODOs, delegate work, and monitor progress", type: "skill", file: "skill-task-management-v2.md" },
   { name: "skill-tdd", description: "Build features with tests-before-code rigor — use for new features needing test coverage", type: "skill", file: "skill-tdd.md" },
   { name: "skill-thought-partner", description: "Brainstorm creatively with pattern spotting and paradox hunting — use for ideation and exploration", type: "skill", file: "skill-thought-partner.md" },
-  { name: "skill-verify", description: "Verify claims with actual evidence before declaring success — use to prevent false completion", type: "skill", file: "skill-verify.md" },
+  { name: "skill-verification-gate", description: "Evidence before claims — run verification commands before declaring work complete, fixed, or passing", type: "skill", file: "skill-verification-gate.md" },
   { name: "skill-visual-feedback", description: "Process screenshot-based UI/UX feedback to fix visual issues — use when users share screenshots of bugs", type: "skill", file: "skill-visual-feedback.md" },
   { name: "skill-writing-plans", description: "Create zero-context implementation plans with bite-sized tasks — use for multi-step feature planning", type: "skill", file: "skill-writing-plans.md" },
   { name: "sys-configure", description: "Configure Claude Octopus providers, models, and preferences — use for initial setup or provider changes", type: "skill", file: "sys-configure.md" },
@@ -78,6 +79,7 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "design-ui-ux", description: "Design UI/UX systems with style guides, palettes, typography, and component specs", type: "command", file: "design-ui-ux.md" },
   { name: "develop", description: "Development phase - Build solutions with multi-AI implementation and quality gates", type: "command", file: "develop.md" },
   { name: "dev", description: "Switch to Dev Work mode - optimized for software development", type: "command", file: "dev.md" },
+  { name: "discipline", description: "Toggle discipline mode — auto-invoke verification, brainstorming-before-coding, and review checks", type: "command", file: "discipline.md" },
   { name: "discover", description: "Discovery phase - Multi-AI research and exploration", type: "command", file: "discover.md" },
   { name: "docs", description: "Document delivery with export to PPTX, DOCX, PDF formats", type: "command", file: "docs.md" },
   { name: "doctor", description: "Environment diagnostics — check providers, auth, config, hooks, scheduler, and more", type: "command", file: "doctor.md" },
@@ -114,4 +116,4 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "unfreeze", description: "Remove freeze mode edit restriction", type: "command", file: "unfreeze.md" },
 ];
 
-export const REGISTRY_COUNT = 97;
+export const REGISTRY_COUNT = 99;

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -40,19 +40,19 @@ get_agent_command() {
     case "$agent_type" in
         codex|codex-standard|codex-max|codex-mini|codex-general)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --full-auto --model ${model} ${sandbox_flag} -"
+            echo "codex exec --skip-git-repo-check --full-auto --model ${model} ${sandbox_flag} -"
             ;;
         codex-spark)  # v8.9.0: Ultra-fast Spark model (1000+ tok/s)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --full-auto --model ${model} ${sandbox_flag} -"
+            echo "codex exec --skip-git-repo-check --full-auto --model ${model} ${sandbox_flag} -"
             ;;
         codex-reasoning)  # v8.9.0: Reasoning models (o3, o3)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --full-auto --model ${model} ${sandbox_flag} -"
+            echo "codex exec --skip-git-repo-check --full-auto --model ${model} ${sandbox_flag} -"
             ;;
         codex-large-context)  # v8.9.0: 1M context models (gpt-4.1)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --full-auto --model ${model} ${sandbox_flag} -"
+            echo "codex exec --skip-git-repo-check --full-auto --model ${model} ${sandbox_flag} -"
             ;;
         gemini|gemini-fast|gemini-image)
             model=$(get_agent_model "$agent_type" "$phase" "$role")

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -91,15 +91,25 @@ resolve_octopus_model() {
             fi
 
             # Handle recursive reference (e.g. "codex:spark")
+            # v9.17.1: Skip cross-provider routing — if route targets a different provider,
+            # don't apply its model to the current provider (fixes #235 item 3)
             if [[ -n "$routed" && "$routed" != "null" ]]; then
                 if [[ "$routed" == *:* ]]; then
                     local ref_provider="${routed%%:*}"
                     local ref_type="${routed#*:}"
-                    resolved_model=$(resolve_octopus_model "$ref_provider" "$ref_type" "" "")
+                    if [[ "$ref_provider" != "$provider" ]]; then
+                        # Route targets a different provider — skip for this resolution
+                        [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): SKIP (route $routed targets $ref_provider, resolving for $provider)" >&2
+                        routed=""
+                    else
+                        resolved_model=$(resolve_octopus_model "$ref_provider" "$ref_type" "" "")
+                    fi
                 else
                     resolved_model="$routed"
                 fi
-                [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): $resolved_model ← SELECTED (route: $routed)" >&2
+                if [[ -n "$routed" ]]; then
+                    [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): $resolved_model ← SELECTED (route: $routed)" >&2
+                fi
             else
                 [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): —" >&2
             fi

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -305,7 +305,7 @@ auto_detect_provider_config() {
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # Tier cache file location
-TIER_CACHE_FILE="${WORKSPACE_DIR}/.tier-cache"
+TIER_CACHE_FILE="${WORKSPACE_DIR:-$HOME/.claude-octopus}/.tier-cache"
 TIER_CACHE_TTL=86400  # 24 hours in seconds
 
 # Check if tier cache is valid for a provider (not expired)
@@ -849,7 +849,7 @@ show_provider_status() {
 # Fast parallel test that catches real provider failures before workflow starts
 # ═══════════════════════════════════════════════════════════════════════════════
 
-SMOKE_TEST_CACHE_FILE="${WORKSPACE_DIR}/.smoke-test-cache"
+SMOKE_TEST_CACHE_FILE="${WORKSPACE_DIR:-$HOME/.claude-octopus}/.smoke-test-cache"
 
 # Compute cache key from current model config (auto-invalidates on config change)
 smoke_test_cache_key() {

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -168,7 +168,14 @@ IMPORTANT: If you find yourself searching or grepping more than 3 times in a row
     while true; do
         exit_code=0
         # v9.2.2: All agents use stdin to avoid ARG_MAX "Argument list too long" on large diffs (Issue #173)
-        if printf '%s' "$enhanced_prompt" | run_with_timeout "$TIMEOUT" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then
+        # v9.17.1: Windows/MINGW fallback — pipe chain through tee loses stdout on Git Bash (fixes #235)
+        # Use file-based capture instead of pipe chain when on Windows
+        if [[ "${OCTOPUS_PLATFORM:-}" == MINGW* ]] || [[ "${OCTOPUS_PLATFORM:-}" == MSYS* ]]; then
+            printf '%s' "$enhanced_prompt" | run_with_timeout "$TIMEOUT" "${cmd_array[@]}" > "$raw_output" 2> "$temp_errors" || exit_code=$?
+            if [[ $exit_code -eq 0 ]]; then
+                cp "$raw_output" "$temp_output"
+            fi
+        elif printf '%s' "$enhanced_prompt" | run_with_timeout "$TIMEOUT" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then
             exit_code=0
         else
             exit_code=$?

--- a/skills/skill-scope-drift/SKILL.md
+++ b/skills/skill-scope-drift/SKILL.md
@@ -109,6 +109,13 @@ Sources checked: TODOS.md ✓ | PR description ✗ | Commit messages (N commits)
 - [One-line recommendation: "Clean — proceed to review" or "N items drifted, M requirements missing — review with awareness"]
 ```
 
+## MANDATORY COMPLIANCE — DO NOT SKIP
+
+**When this skill is invoked, you MUST execute the scope drift analysis pipeline. You are PROHIBITED from:**
+- Skipping the diff comparison and guessing whether drift occurred
+- Reporting "no drift" without actually checking available intent sources
+- Blocking or gating reviews based on drift results (this is informational only)
+
 ## Integration Points
 
 ### In `/octo:deliver` (flow-deliver)


### PR DESCRIPTION
Fixes #235 (Windows issues) and #236 (E2E test failures).

## Changes

**#235 — Windows/Git Bash compatibility:**
- Add `--skip-git-repo-check` to all `codex exec` commands in `dispatch.sh` — Codex CLI refuses to run in non-trusted dirs on Windows
- Add `${WORKSPACE_DIR:-$HOME/.claude-octopus}` fallback to `TIER_CACHE_FILE` and `SMOKE_TEST_CACHE_FILE` in `smoke.sh` — empty WORKSPACE_DIR resolved to `/.smoke-test-cache` (permission denied)
- Fix model resolver cross-provider routing contamination in `model-resolver.sh` — routing phases like `gemini:default` were being applied to Codex, causing it to try using model "gemini"
- Add Windows/MINGW pipe chain fallback in `workflows.sh` — `timeout | tee` loses stdout on Git Bash, switched to file-based capture

**#236 — Test failures:**
- Add MANDATORY COMPLIANCE enforcement block to `skill-scope-drift/SKILL.md`
- Update README counts: 48 commands, 51 skills (was 47/50)
- Sync OpenClaw registry: `skill-verify` → `skill-verification-gate`, add `discipline` command, update count to 99

## Test results

Previously failing tests now pass:
- `test-mandatory-compliance.sh`: 40/40 ✅
- `test-docs-sync.sh`: 128/128 ✅
- `test-openclaw-compat.sh`: 31/31 ✅

Remaining 16 failures are pre-existing (environment-dependent fleet diversity checks, hanging model config tests, legacy feature tests).