### PR TITLE
fix: prevent embrace workflow silent exit (closes #241)

### DIFF
--- a/scripts/lib/semantic-cache.sh
+++ b/scripts/lib/semantic-cache.sh
@@ -194,7 +194,7 @@ cleanup_cache() {
         fi
     done
 
-    [[ $cleaned -gt 0 ]] && log "INFO" "Cleaned $cleaned expired cache entries"
+    [[ $cleaned -gt 0 ]] && log "INFO" "Cleaned $cleaned expired cache entries" || true
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -228,5 +228,5 @@ cleanup_old_results() {
     # Clean marker files
     find "$RESULTS_DIR" -name "*.marker" -mmin "+$retention_mins" -delete 2>/dev/null || true
 
-    [[ $cleaned -gt 0 ]] && log "INFO" "Cleaned $cleaned expired result files (retention: ${retention_hours}h)"
+    [[ $cleaned -gt 0 ]] && log "INFO" "Cleaned $cleaned expired result files (retention: ${retention_hours}h)" || true
 }

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -146,6 +146,10 @@ else
     WORKSPACE_DIR="${HOME}/.claude-octopus"
 fi
 
+# Re-derive SESSION_FILE now that WORKSPACE_DIR is known
+# (quality.sh sets it at source-time before WORKSPACE_DIR is defined)
+SESSION_FILE="${WORKSPACE_DIR}/session.json"
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # CLAUDE CODE INTEGRATION: Task Management (v7.16.0)
 # Capture Claude Code v2.1.16+ environment variables for enhanced progress tracking


### PR DESCRIPTION
## Summary

Fixes two bugs that combined to silently kill the embrace workflow immediately after the banner.

**Bug 1**: `cleanup_old_results()` and `cleanup_cache()` in `semantic-cache.sh` used bare `[[ cond ]] && cmd` patterns. When the condition was false (no files to clean — the common case), the expression returned exit code 1, which `set -e` caught and killed the script. Added `|| true` to both.

**Bug 2**: `SESSION_FILE` was derived from `WORKSPACE_DIR` in `quality.sh` at source-time (line 174), but `WORKSPACE_DIR` isn't defined until lines 140-147 of `orchestrate.sh`. This meant `SESSION_FILE` expanded to `/session.json`, hitting a read-only filesystem. Added a re-assignment after `WORKSPACE_DIR` is set.

## Test plan

- [x] `make test` — 79/80 passing (1 pre-existing failure in `test-loop-self-regulation.sh`, unrelated)
- [ ] Manual: run `orchestrate.sh embrace "test"` and verify all 4 phases execute

Closes #241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of cache cleanup operations
  * Enhanced session file path resolution with workspace directory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->