### PR TITLE
fix: review pipeline — BSD sed, function timeout, false-negative output

### DIFF
--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -134,15 +134,23 @@ run_with_timeout() {
 
     local exit_code
 
-    # Use gtimeout (GNU) or timeout if available
-    if command -v gtimeout &>/dev/null; then
+    # v9.20.1: Detect if command is a shell function (e.g. perplexity_execute,
+    # openrouter_execute). External timeout/gtimeout can only exec binaries —
+    # shell functions require the in-process fallback path. (#255)
+    local _cmd_is_function=false
+    if [[ "$(type -t "$1" 2>/dev/null)" == "function" ]]; then
+        _cmd_is_function=true
+    fi
+
+    # Use gtimeout (GNU) or timeout if available AND command is an external binary
+    if [[ "$_cmd_is_function" == "false" ]] && command -v gtimeout &>/dev/null; then
         gtimeout "$timeout_secs" "$@"
         exit_code=$?
-    elif command -v timeout &>/dev/null; then
+    elif [[ "$_cmd_is_function" == "false" ]] && command -v timeout &>/dev/null; then
         timeout "$timeout_secs" "$@"
         exit_code=$?
     else
-        # Fallback with proper cleanup
+        # Fallback with proper cleanup (also used for shell functions)
         local cmd_pid monitor_pid
 
         "$@" &

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -336,8 +336,8 @@ ${agent_prompt_base}"
     for f in "${round1_files[@]}"; do
         [[ ! -f "$f" ]] && continue
         local agent_findings
-        # v9.3.1: Extract content from ## Output section (not the full markdown file)
-        agent_findings=$(sed -n '/^## Output$/,/^## /{/^## Output$/d;/^## /d;/^```$/d;/^```json$/d;/^```JSON$/d;p}' "$f" | \
+        # v9.20.1: Extract content from ## Output section (portable awk, fixes BSD sed #255)
+        agent_findings=$(awk '/^## Output$/{found=1;next} /^## /{if(found)exit} found && !/^```(json|JSON)?$/{print}' "$f" | \
             jq -r '.findings // []' 2>/dev/null || echo "[]")
         all_findings=$(printf '%s\n%s' "$all_findings" "$agent_findings" | \
             jq -s 'add' 2>/dev/null || echo "$all_findings")
@@ -352,6 +352,24 @@ ${agent_prompt_base}"
         fi
         ((idx++)) || true
     done
+
+    # v9.20.1: Detect total fleet failure — all providers crashed/timed out (#255)
+    local _r1_total=${#round1_files[@]}
+    local _r1_failed=0
+    for _rf in "${round1_files[@]}"; do
+        if [[ ! -f "$_rf" ]] || \
+           grep -qE '^## Status: (FAILED|TIMEOUT)' "$_rf" 2>/dev/null || \
+           [[ $(grep -c '^## Status:' "$_rf" 2>/dev/null || true) -eq 0 ]]; then
+            ((_r1_failed++)) || true
+        fi
+    done
+    if [[ $_r1_failed -ge $_r1_total ]] && [[ $_r1_total -gt 0 ]]; then
+        log ERROR "review_run: ALL Round 1 providers failed ($_r1_failed/$_r1_total). Review output is unreliable."
+        echo "{\"findings\":[],\"warning\":\"All $_r1_total review providers failed. No code was actually reviewed. Run /octo:doctor to diagnose provider issues.\"}" > "$findings_file"
+        render_terminal_report "$findings_file"
+        print_provider_report "$provider_status_file"
+        return 1
+    fi
 
     # ── ROUND 2: Verification ─────────────────────────────────────────────────
     log INFO "review_run: Round 2 — verification"
@@ -556,7 +574,17 @@ render_terminal_report() {
     echo ""
 
     if [[ "$finding_count" -eq 0 ]]; then
-        echo "No issues found."
+        # v9.20.1: Distinguish "clean review" from "all providers failed" (#255)
+        local warning_msg
+        warning_msg=$(jq -r '.warning // empty' "$findings_file" 2>/dev/null)
+        if [[ -n "$warning_msg" ]]; then
+            echo "⚠️  WARNING: $warning_msg"
+            echo ""
+            echo "This is NOT a clean review — zero providers returned results."
+            echo "Do not merge based on this output."
+        else
+            echo "No issues found."
+        fi
         return 0
     fi
 


### PR DESCRIPTION
Fixes #255 — three root causes for `/octo:review` end-to-end failure:

### 1. BSD sed incompatibility (the first domino)
The output extraction in Round 1 used GNU-only `sed` command grouping (`/addr1/,/addr2/{cmd1;cmd2;p}`) which fails on macOS BSD sed with `extra characters at the end of p command`. Replaced with portable `awk`.

### 2. Shell function timeout (Perplexity exit 127)
`run_with_timeout` always preferred `gtimeout`/`timeout` which can only exec external binaries. When the command is a bash function (`perplexity_execute`, `openrouter_execute`), these return exit 127. Now detects function commands and uses the in-process fallback.

### 3. False-negative output (the dangerous part)
When all Round 1 providers fail, the pipeline cascaded through Rounds 2/3 on empty data, then rendered "No issues found" — a false negative that could lead to merging unreviewed code. Now detects total fleet failure and exits early with a clear warning.

All three fixes are minimal and focused. No behavioral changes when providers are healthy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Round 1 total fleet failure detection with warning reporting

* **Bug Fixes**
  * Improved timeout handling for function execution
  * Enhanced output parsing for better portability
  * Updated warning messages for review results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->