### PR TITLE
fix: enforce model resolution — prevent hardcoded stale model names

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -116,6 +116,19 @@
     },
     {
       "matcher": {
+        "tool": "Bash",
+        "pattern": "(codex|gemini|qwen|claude|ollama)\\s"
+      },
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/model-guard.sh",
+          "timeout": 5
+        }
+      ]
+    },
+    {
+      "matcher": {
         "tool": "Edit|Write"
       },
       "if": "env.OCTO_FREEZE_MODE == 'on'",

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -63,18 +63,27 @@ If using background Bash tasks: wait for ALL task completion notifications befor
 **Before ANY provider dispatch** (whether via orchestrate.sh or manual fallback), resolve the correct model:
 
 ```bash
-# Resolve the configured model for a provider:
-PLUGIN_DIR="$(find ~/.claude/plugins -name 'octo-dispatch.sh' -path '*/scripts/*' 2>/dev/null | head -1 | xargs dirname)"
-CODEX_MODEL=$("$PLUGIN_DIR/octo-dispatch.sh" --resolve codex)
-GEMINI_MODEL=$("$PLUGIN_DIR/octo-dispatch.sh" --resolve gemini)
-QWEN_MODEL=$("$PLUGIN_DIR/octo-dispatch.sh" --resolve qwen)
+# Find octo-dispatch.sh (prefer CLAUDE_PLUGIN_ROOT if available)
+if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
+    OCTO_DISPATCH="${CLAUDE_PLUGIN_ROOT}/scripts/octo-dispatch.sh"
+else
+    OCTO_DISPATCH="$(find ~/.claude/plugins -name 'octo-dispatch.sh' -path '*/scripts/*' -print 2>/dev/null | head -1)"
+fi
+if [[ ! -x "$OCTO_DISPATCH" ]]; then
+    echo "ERROR: octo-dispatch.sh not found. Is claude-octopus plugin installed?" >&2
+    exit 1
+fi
+CODEX_MODEL=$("$OCTO_DISPATCH" --resolve codex)
+GEMINI_MODEL=$("$OCTO_DISPATCH" --resolve gemini)
+QWEN_MODEL=$("$OCTO_DISPATCH" --resolve qwen)
 ```
 
 **If you must dispatch manually** (e.g., the review target is not a code diff), use `octo-dispatch.sh`:
+
 ```bash
-echo "your prompt" | "$PLUGIN_DIR/octo-dispatch.sh" codex
-echo "your prompt" | "$PLUGIN_DIR/octo-dispatch.sh" gemini
-echo "your prompt" | "$PLUGIN_DIR/octo-dispatch.sh" qwen
+echo "your prompt" | "$OCTO_DISPATCH" codex
+echo "your prompt" | "$OCTO_DISPATCH" gemini
+echo "your prompt" | "$OCTO_DISPATCH" qwen
 ```
 
 **PROHIBITED: typing ANY model name directly.** Always resolve via `octo-dispatch.sh --resolve <provider>`.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -45,6 +45,17 @@ Providers:
 
 **Multi-LLM orchestration is the purpose of this command.** If you execute using only Claude, you've violated the command's contract.
 
+### WAIT FOR ALL PROVIDERS — NON-NEGOTIABLE
+
+**You MUST wait for EVERY dispatched provider to complete before reading ANY results.**
+- ❌ Do NOT start synthesizing with 2/3 providers done while the third is still running
+- ❌ Do NOT read one provider's output "while waiting" for others
+- ❌ Do NOT produce partial analysis and then append the late provider's findings
+
+**Wait for all → Read all → Synthesize all.** The purpose of multi-provider review is triangulation. Partial results defeat the purpose.
+
+If using background Bash tasks: wait for ALL task completion notifications before reading any output files. If one provider is slow, wait — do not proceed without it.
+
 ### MODEL RESOLUTION — NON-NEGOTIABLE
 
 **You MUST NEVER hardcode model names when dispatching providers.** Models change frequently and your training data is stale.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -45,6 +45,34 @@ Providers:
 
 **Multi-LLM orchestration is the purpose of this command.** If you execute using only Claude, you've violated the command's contract.
 
+### MODEL RESOLUTION — NON-NEGOTIABLE
+
+**You MUST NEVER hardcode model names when dispatching providers.** Models change frequently and your training data is stale.
+
+**Before ANY provider dispatch** (whether via orchestrate.sh or manual fallback), resolve the correct model:
+
+```bash
+# Resolve the configured model for a provider:
+PLUGIN_DIR="$(find ~/.claude/plugins -name 'octo-dispatch.sh' -path '*/scripts/*' 2>/dev/null | head -1 | xargs dirname)"
+CODEX_MODEL=$("$PLUGIN_DIR/octo-dispatch.sh" --resolve codex)
+GEMINI_MODEL=$("$PLUGIN_DIR/octo-dispatch.sh" --resolve gemini)
+QWEN_MODEL=$("$PLUGIN_DIR/octo-dispatch.sh" --resolve qwen)
+```
+
+**If you must dispatch manually** (e.g., the review target is not a code diff), use `octo-dispatch.sh`:
+```bash
+echo "your prompt" | "$PLUGIN_DIR/octo-dispatch.sh" codex
+echo "your prompt" | "$PLUGIN_DIR/octo-dispatch.sh" gemini
+echo "your prompt" | "$PLUGIN_DIR/octo-dispatch.sh" qwen
+```
+
+**PROHIBITED model names** (these are ALWAYS wrong — never type them manually):
+- `o3`, `o3-mini`, `o4-mini`, `gpt-4o`, `gpt-4o-mini` — stale OpenAI names
+- `gemini-2.5-pro`, `gemini-2.0-flash` — stale Google names
+- Any model name from your training data that you "just know"
+
+The config at `~/.claude-octopus/config/providers.json` is the ONLY source of truth.
+
 ---
 
 ## Step 1: Ask Clarifying Questions / Context Acquisition

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -66,12 +66,9 @@ echo "your prompt" | "$PLUGIN_DIR/octo-dispatch.sh" gemini
 echo "your prompt" | "$PLUGIN_DIR/octo-dispatch.sh" qwen
 ```
 
-**PROHIBITED model names** (these are ALWAYS wrong — never type them manually):
-- `o3`, `o3-mini`, `o4-mini`, `gpt-4o`, `gpt-4o-mini` — stale OpenAI names
-- `gemini-2.5-pro`, `gemini-2.0-flash` — stale Google names
-- Any model name from your training data that you "just know"
-
-The config at `~/.claude-octopus/config/providers.json` is the ONLY source of truth.
+**PROHIBITED: typing ANY model name directly.** Always resolve via `octo-dispatch.sh --resolve <provider>`.
+The resolver uses a 7-tier precedence (env vars > session overrides > phase routing > config defaults > hardcoded fallbacks). `providers.json` is the primary config, but overrides may apply.
+Never guess a model name from your training data — the resolver handles all precedence logic.
 
 ---
 

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -78,10 +78,18 @@ get_agent_command() {
             esac
             ;;
         codex-review) echo "codex exec review" ;; # Code review mode (no sandbox support)
-        claude) echo "claude${_BARE_OPT} --print" ;;                         # Claude Sonnet 4.6
-        claude-sonnet) echo "claude${_BARE_OPT} --print --model sonnet" ;;        # Claude Sonnet explicit
-        claude-opus) echo "claude${_BARE_OPT} --print --model opus" ;;            # Claude Opus 4.6 (v8.0)
-        claude-opus-fast) echo "claude${_BARE_OPT} --print --model opus --fast" ;; # Claude Opus 4.6 Fast (v8.4: v2.1.36+)
+        claude|claude-sonnet)  # Claude Sonnet — resolve model from config
+            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            echo "claude${_BARE_OPT} --print --model ${model}"
+            ;;
+        claude-opus)  # Claude Opus 4.6 (v8.0)
+            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            echo "claude${_BARE_OPT} --print --model ${model}"
+            ;;
+        claude-opus-fast)  # Claude Opus 4.6 Fast (v8.4: v2.1.36+)
+            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            echo "claude${_BARE_OPT} --print --model ${model} --fast"
+            ;;
         openrouter) echo "openrouter_execute" ;;                 # OpenRouter API (v4.8)
         openrouter-glm5) echo "openrouter_execute_model z-ai/glm-5" ;;           # v8.11.0: GLM-5 via OpenRouter
         openrouter-kimi) echo "openrouter_execute_model moonshotai/kimi-k2.5" ;; # v8.11.0: Kimi K2.5 via OpenRouter
@@ -98,7 +106,13 @@ get_agent_command() {
             echo "ollama run $model"
             ;;
         qwen|qwen-research)  # v9.10.0: Qwen CLI — fork of Gemini CLI (free tier)
-            echo "env NODE_NO_WARNINGS=1 qwen -o text --approval-mode yolo"
+            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            # v9.20.3: QWEN_FORCE_FILE_STORAGE on macOS (same as Gemini — Qwen is a Gemini CLI fork)
+            local qwen_env="env NODE_NO_WARNINGS=1"
+            if [[ "$OCTOPUS_PLATFORM" == "Darwin" && -z "${QWEN_API_KEY:-}" ]]; then
+                qwen_env="env NODE_NO_WARNINGS=1 QWEN_FORCE_FILE_STORAGE=true"
+            fi
+            echo "${qwen_env} qwen -o text --approval-mode yolo -m ${model}"
             ;;
         opencode|opencode-fast|opencode-research)  # v9.11.0: OpenCode CLI — multi-provider router
             model=$(get_agent_model "$agent_type" "$phase" "$role")

--- a/scripts/model-guard.sh
+++ b/scripts/model-guard.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# model-guard — PreToolUse hook that blocks hardcoded model names in CLI calls
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# WHY: Claude frequently bypasses orchestrate.sh and dispatches providers
+# manually with hardcoded model names (e.g., `codex exec -m o3` instead of
+# reading providers.json). This hook intercepts Bash tool calls, detects
+# raw CLI invocations with model flags, and blocks them with the correct
+# model from the config.
+#
+# INSTALLATION:
+# Add to ~/.claude/settings.json (or project settings):
+#
+#   {
+#     "hooks": {
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [
+#             {
+#               "type": "command",
+#               "command": "/path/to/scripts/model-guard.sh"
+#             }
+#           ]
+#         }
+#       ]
+#     }
+#   }
+#
+# Or run: /octo:setup to configure automatically.
+#
+# HOW IT WORKS:
+# 1. Receives the Bash tool input as JSON on stdin
+# 2. Extracts the command string
+# 3. Checks if it matches known provider CLI patterns with model flags
+# 4. If a model is hardcoded, resolves the correct one from providers.json
+# 5. If they differ, blocks with an error message showing the correct model
+#
+# BYPASS: Set OCTOPUS_MODEL_GUARD=off to disable (e.g., for debugging)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set -euo pipefail
+
+# Skip if guard is disabled
+[[ "${OCTOPUS_MODEL_GUARD:-on}" == "off" ]] && exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${HOME}/.claude-octopus/config/providers.json"
+
+# Bail early if no config file (plugin not configured)
+[[ ! -f "$CONFIG_FILE" ]] && exit 0
+
+# Read tool input from stdin
+INPUT=$(cat)
+
+# Extract the command field from the JSON tool input
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[[ -z "$COMMAND" ]] && exit 0
+
+# ── Pattern matching ─────────────────────────────────────────────────────────
+
+check_model() {
+    local provider="$1"
+    local detected_model="$2"
+    local config_model
+
+    config_model=$(jq -r ".providers.${provider}.default // empty" "$CONFIG_FILE" 2>/dev/null)
+    [[ -z "$config_model" || "$config_model" == "null" ]] && return 0
+
+    if [[ "$detected_model" != "$config_model" ]]; then
+        # Output JSON to block the tool call
+        jq -n \
+            --arg provider "$provider" \
+            --arg wrong "$detected_model" \
+            --arg correct "$config_model" \
+            '{
+                "decision": "block",
+                "reason": ("MODEL GUARD: Wrong model for " + $provider + ". Got \"" + $wrong + "\", expected \"" + $correct + "\" (from providers.json). Use: octo-dispatch " + $provider + " OR fix the --model flag.")
+            }'
+        exit 0
+    fi
+}
+
+# Codex: codex exec ... --model <MODEL> ... or codex exec ... -m <MODEL> ...
+if echo "$COMMAND" | grep -qE 'codex\s+exec\b'; then
+    MODEL=$(echo "$COMMAND" | grep -oE '(-m|--model)\s+\S+' | head -1 | awk '{print $2}')
+    if [[ -n "$MODEL" ]]; then
+        check_model "codex" "$MODEL"
+    fi
+fi
+
+# Gemini: gemini ... -m <MODEL> ...
+if echo "$COMMAND" | grep -qE '\bgemini\b'; then
+    MODEL=$(echo "$COMMAND" | grep -oE '-m\s+\S+' | head -1 | awk '{print $2}')
+    if [[ -n "$MODEL" ]]; then
+        check_model "gemini" "$MODEL"
+    fi
+fi
+
+# Qwen: qwen ... -m <MODEL> ...
+if echo "$COMMAND" | grep -qE '\bqwen\b'; then
+    MODEL=$(echo "$COMMAND" | grep -oE '-m\s+\S+' | head -1 | awk '{print $2}')
+    if [[ -n "$MODEL" ]]; then
+        check_model "qwen" "$MODEL"
+    fi
+fi
+
+# If we get here, either no model flag was detected or it matched — allow
+exit 0

--- a/scripts/model-guard.sh
+++ b/scripts/model-guard.sh
@@ -81,9 +81,9 @@ check_model() {
         fi
     fi
 
-    # Fallback to config default if resolver unavailable
+    # Fallback to config default if resolver unavailable (mirrors model-resolver.sh tier 6)
     if [[ -z "$expected_model" || "$expected_model" == "null" ]]; then
-        expected_model=$(jq -r ".providers.${provider}.default // empty" "$CONFIG_FILE" 2>/dev/null) || true
+        expected_model=$(jq -r ".providers.${provider}.default // .providers.${provider}.model // empty" "$CONFIG_FILE" 2>/dev/null) || true
     fi
 
     [[ -z "$expected_model" || "$expected_model" == "null" ]] && return 0
@@ -136,24 +136,26 @@ if echo "$COMMAND" | grep -qE 'codex[[:space:]]+exec' 2>/dev/null; then
     fi
 fi
 
-# Gemini: gemini ... -m <MODEL> ... or ... --model <MODEL> ...
-if echo "$COMMAND" | grep -q 'gemini' 2>/dev/null; then
+# Gemini: gemini <flags> ... (require gemini as CLI invocation, not substring)
+# Pattern requires gemini followed by a space and a flag, avoiding false positives
+# on commands like: grep gemini logfile.txt, cat ~/.gemini/config
+if echo "$COMMAND" | grep -qE '(^|[;&|])([[:space:]]*)gemini[[:space:]]' 2>/dev/null; then
     MODEL=$(extract_model_flag "$COMMAND")
     if [[ -n "$MODEL" ]]; then
         check_model "gemini" "$MODEL"
     fi
 fi
 
-# Qwen: qwen ... -m <MODEL> ... or ... --model <MODEL> ...
-if echo "$COMMAND" | grep -q 'qwen' 2>/dev/null; then
+# Qwen: qwen <flags> ... (same CLI invocation pattern as gemini)
+if echo "$COMMAND" | grep -qE '(^|[;&|])([[:space:]]*)qwen[[:space:]]' 2>/dev/null; then
     MODEL=$(extract_model_flag "$COMMAND")
     if [[ -n "$MODEL" ]]; then
         check_model "qwen" "$MODEL"
     fi
 fi
 
-# Claude: claude ... --model <MODEL> ...
-if echo "$COMMAND" | grep -q 'claude.*--model' 2>/dev/null; then
+# Claude: claude <flags> --model <MODEL> (require CLI invocation + --model flag)
+if echo "$COMMAND" | grep -qE '(^|[;&|])([[:space:]]*)claude[[:space:]].*--model' 2>/dev/null; then
     MODEL=$(extract_model_flag "$COMMAND")
     if [[ -n "$MODEL" ]]; then
         check_model "claude" "$MODEL"

--- a/scripts/model-guard.sh
+++ b/scripts/model-guard.sh
@@ -82,27 +82,58 @@ check_model() {
     fi
 }
 
+# ── Extract model from flag patterns ─────────────────────────────────────────
+# Handles: --model <MODEL>, --model=<MODEL>, -m <MODEL>, -m=<MODEL>
+# Strips surrounding quotes from extracted model names
+extract_model_flag() {
+    local cmd="$1"
+    local model=""
+    # Try --model=VALUE or -m=VALUE first (equals form)
+    model=$(echo "$cmd" | grep -oE '(-m|--model)=[^ ]+' | head -1 | sed 's/^.*=//' | tr -d '"'"'")
+    if [[ -z "$model" ]]; then
+        # Try --model VALUE or -m VALUE (space form)
+        model=$(echo "$cmd" | grep -oE '(-m|--model)\s+[^ ]+' | head -1 | awk '{print $2}' | tr -d '"'"'")
+    fi
+    echo "$model"
+}
+
 # Codex: codex exec ... --model <MODEL> ... or codex exec ... -m <MODEL> ...
 if echo "$COMMAND" | grep -qE 'codex\s+exec\b'; then
-    MODEL=$(echo "$COMMAND" | grep -oE '(-m|--model)\s+\S+' | head -1 | awk '{print $2}')
+    MODEL=$(extract_model_flag "$COMMAND")
     if [[ -n "$MODEL" ]]; then
         check_model "codex" "$MODEL"
     fi
 fi
 
-# Gemini: gemini ... -m <MODEL> ...
+# Gemini: gemini ... -m <MODEL> ... or gemini ... --model <MODEL> ...
 if echo "$COMMAND" | grep -qE '\bgemini\b'; then
-    MODEL=$(echo "$COMMAND" | grep -oE '-m\s+\S+' | head -1 | awk '{print $2}')
+    MODEL=$(extract_model_flag "$COMMAND")
     if [[ -n "$MODEL" ]]; then
         check_model "gemini" "$MODEL"
     fi
 fi
 
-# Qwen: qwen ... -m <MODEL> ...
+# Qwen: qwen ... -m <MODEL> ... or qwen ... --model <MODEL> ...
 if echo "$COMMAND" | grep -qE '\bqwen\b'; then
-    MODEL=$(echo "$COMMAND" | grep -oE '-m\s+\S+' | head -1 | awk '{print $2}')
+    MODEL=$(extract_model_flag "$COMMAND")
     if [[ -n "$MODEL" ]]; then
         check_model "qwen" "$MODEL"
+    fi
+fi
+
+# Claude: claude ... --model <MODEL> ...
+if echo "$COMMAND" | grep -qE '\bclaude\b.*--model'; then
+    MODEL=$(extract_model_flag "$COMMAND")
+    if [[ -n "$MODEL" ]]; then
+        check_model "claude" "$MODEL"
+    fi
+fi
+
+# Ollama: ollama run <MODEL> ...
+if echo "$COMMAND" | grep -qE '\bollama\s+run\b'; then
+    MODEL=$(echo "$COMMAND" | grep -oE 'ollama\s+run\s+\S+' | head -1 | awk '{print $3}' | tr -d '"'"'")
+    if [[ -n "$MODEL" ]]; then
+        check_model "ollama" "$MODEL"
     fi
 fi
 

--- a/scripts/model-guard.sh
+++ b/scripts/model-guard.sh
@@ -34,46 +34,66 @@
 # 1. Receives the Bash tool input as JSON on stdin
 # 2. Extracts the command string
 # 3. Checks if it matches known provider CLI patterns with model flags
-# 4. If a model is hardcoded, resolves the correct one from providers.json
+# 4. If a model is hardcoded, resolves the correct one via resolve_octopus_model
+#    (same 7-tier precedence as orchestrate.sh)
 # 5. If they differ, blocks with an error message showing the correct model
 #
 # BYPASS: Set OCTOPUS_MODEL_GUARD=off to disable (e.g., for debugging)
 # ═══════════════════════════════════════════════════════════════════════════════
 
-set -euo pipefail
+# NOTE: Do NOT use set -e here — grep returns 1 on no-match, which would
+# abort the hook and block unrelated Bash commands.
+set -uo pipefail
 
 # Skip if guard is disabled
 [[ "${OCTOPUS_MODEL_GUARD:-on}" == "off" ]] && exit 0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="${HOME}/.claude-octopus/config/providers.json"
+RESOLVER="${SCRIPT_DIR}/lib/model-resolver.sh"
 
 # Bail early if no config file (plugin not configured)
 [[ ! -f "$CONFIG_FILE" ]] && exit 0
+
+# Require jq for JSON parsing
+command -v jq &>/dev/null || exit 0
 
 # Read tool input from stdin
 INPUT=$(cat)
 
 # Extract the command field from the JSON tool input
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || true
 [[ -z "$COMMAND" ]] && exit 0
 
-# ── Pattern matching ─────────────────────────────────────────────────────────
+# ── Model comparison ────────────────────────────────────────────────────────
 
 check_model() {
     local provider="$1"
     local detected_model="$2"
-    local config_model
+    local expected_model=""
 
-    config_model=$(jq -r ".providers.${provider}.default // empty" "$CONFIG_FILE" 2>/dev/null)
-    [[ -z "$config_model" || "$config_model" == "null" ]] && return 0
+    # Use the full resolver if available (same 7-tier precedence as dispatch)
+    if [[ -f "$RESOLVER" ]]; then
+        # shellcheck source=lib/model-resolver.sh
+        source "$RESOLVER" 2>/dev/null || true
+        if declare -f resolve_octopus_model &>/dev/null; then
+            expected_model=$(resolve_octopus_model "$provider" "$provider" "" "" 2>/dev/null) || true
+        fi
+    fi
 
-    if [[ "$detected_model" != "$config_model" ]]; then
+    # Fallback to config default if resolver unavailable
+    if [[ -z "$expected_model" || "$expected_model" == "null" ]]; then
+        expected_model=$(jq -r ".providers.${provider}.default // empty" "$CONFIG_FILE" 2>/dev/null) || true
+    fi
+
+    [[ -z "$expected_model" || "$expected_model" == "null" ]] && return 0
+
+    if [[ "$detected_model" != "$expected_model" ]]; then
         # Output JSON to block the tool call
         jq -n \
             --arg provider "$provider" \
             --arg wrong "$detected_model" \
-            --arg correct "$config_model" \
+            --arg correct "$expected_model" \
             '{
                 "decision": "block",
                 "reason": ("MODEL GUARD: Wrong model for " + $provider + ". Got \"" + $wrong + "\", expected \"" + $correct + "\" (from providers.json). Use: octo-dispatch " + $provider + " OR fix the --model flag.")
@@ -82,39 +102,50 @@ check_model() {
     fi
 }
 
-# ── Extract model from flag patterns ─────────────────────────────────────────
-# Handles: --model <MODEL>, --model=<MODEL>, -m <MODEL>, -m=<MODEL>
-# Strips surrounding quotes from extracted model names
+# ── Extract model from flag patterns ────────────────────────────────────────
+# Uses POSIX ERE only (no \s, \S, \b — those are PCRE and break on BSD grep).
+# Uses grep -e to prevent patterns starting with - from being parsed as flags.
 extract_model_flag() {
     local cmd="$1"
     local model=""
+
     # Try --model=VALUE or -m=VALUE first (equals form)
-    model=$(echo "$cmd" | grep -oE '(-m|--model)=[^ ]+' | head -1 | sed 's/^.*=//' | tr -d '"'"'")
+    model=$(echo "$cmd" | grep -oE -e '(--model|-m)=[^ ]+' 2>/dev/null | head -1 | sed 's/^.*=//' | tr -d "\"'") || true
     if [[ -z "$model" ]]; then
-        # Try --model VALUE or -m VALUE (space form)
-        model=$(echo "$cmd" | grep -oE '(-m|--model)\s+[^ ]+' | head -1 | awk '{print $2}' | tr -d '"'"'")
+        # Try --model VALUE (long flag, space-separated)
+        model=$(echo "$cmd" | grep -oE -e '--model[[:space:]]+[^ ]+' 2>/dev/null | head -1 | awk '{print $2}' | tr -d "\"'") || true
     fi
+    if [[ -z "$model" ]]; then
+        # Try -m VALUE (short flag, space-separated)
+        # Use sed to avoid grep interpreting -m as its own --max-count flag
+        model=$(echo "$cmd" | sed -n 's/.*[[:space:]]-m[[:space:]]\{1,\}\([^ ]*\).*/\1/p' | head -1 | tr -d "\"'") || true
+    fi
+
     echo "$model"
 }
 
-# Codex: codex exec ... --model <MODEL> ... or codex exec ... -m <MODEL> ...
-if echo "$COMMAND" | grep -qE 'codex\s+exec\b'; then
+# ── Provider detection ──────────────────────────────────────────────────────
+# Uses POSIX character classes and grep -e to avoid flag/pattern collisions.
+# All grep calls use || true to prevent exit-on-no-match under pipefail.
+
+# Codex: codex exec ... --model <MODEL> ... or ... -m <MODEL> ...
+if echo "$COMMAND" | grep -qE 'codex[[:space:]]+exec' 2>/dev/null; then
     MODEL=$(extract_model_flag "$COMMAND")
     if [[ -n "$MODEL" ]]; then
         check_model "codex" "$MODEL"
     fi
 fi
 
-# Gemini: gemini ... -m <MODEL> ... or gemini ... --model <MODEL> ...
-if echo "$COMMAND" | grep -qE '\bgemini\b'; then
+# Gemini: gemini ... -m <MODEL> ... or ... --model <MODEL> ...
+if echo "$COMMAND" | grep -q 'gemini' 2>/dev/null; then
     MODEL=$(extract_model_flag "$COMMAND")
     if [[ -n "$MODEL" ]]; then
         check_model "gemini" "$MODEL"
     fi
 fi
 
-# Qwen: qwen ... -m <MODEL> ... or qwen ... --model <MODEL> ...
-if echo "$COMMAND" | grep -qE '\bqwen\b'; then
+# Qwen: qwen ... -m <MODEL> ... or ... --model <MODEL> ...
+if echo "$COMMAND" | grep -q 'qwen' 2>/dev/null; then
     MODEL=$(extract_model_flag "$COMMAND")
     if [[ -n "$MODEL" ]]; then
         check_model "qwen" "$MODEL"
@@ -122,7 +153,7 @@ if echo "$COMMAND" | grep -qE '\bqwen\b'; then
 fi
 
 # Claude: claude ... --model <MODEL> ...
-if echo "$COMMAND" | grep -qE '\bclaude\b.*--model'; then
+if echo "$COMMAND" | grep -q 'claude.*--model' 2>/dev/null; then
     MODEL=$(extract_model_flag "$COMMAND")
     if [[ -n "$MODEL" ]]; then
         check_model "claude" "$MODEL"
@@ -130,8 +161,8 @@ if echo "$COMMAND" | grep -qE '\bclaude\b.*--model'; then
 fi
 
 # Ollama: ollama run <MODEL> ...
-if echo "$COMMAND" | grep -qE '\bollama\s+run\b'; then
-    MODEL=$(echo "$COMMAND" | grep -oE 'ollama\s+run\s+\S+' | head -1 | awk '{print $3}' | tr -d '"'"'")
+if echo "$COMMAND" | grep -qE 'ollama[[:space:]]+run' 2>/dev/null; then
+    MODEL=$(echo "$COMMAND" | sed -n 's/.*ollama[[:space:]]\{1,\}run[[:space:]]\{1,\}\([^ ]*\).*/\1/p' | head -1 | tr -d "\"'") || true
     if [[ -n "$MODEL" ]]; then
         check_model "ollama" "$MODEL"
     fi

--- a/scripts/octo-dispatch.sh
+++ b/scripts/octo-dispatch.sh
@@ -125,7 +125,7 @@ log INFO "Provider: $PROVIDER | Model: $MODEL"
 case "$PROVIDER" in
     codex)
         local_sandbox="${OCTOPUS_CODEX_SANDBOX:-workspace-write}"
-        echo "$PROMPT" | codex exec \
+        printf '%s\n' "$PROMPT" | codex exec \
             --skip-git-repo-check \
             --full-auto \
             --model "$MODEL" \
@@ -134,22 +134,23 @@ case "$PROVIDER" in
         ;;
     gemini)
         if [[ "$OCTOPUS_PLATFORM" == "Darwin" && -z "${GEMINI_API_KEY:-}" ]]; then
-            echo "$PROMPT" | env NODE_NO_WARNINGS=1 GEMINI_FORCE_FILE_STORAGE=true \
+            printf '%s\n' "$PROMPT" | env NODE_NO_WARNINGS=1 GEMINI_FORCE_FILE_STORAGE=true \
                 gemini -o text --approval-mode yolo -m "$MODEL"
         else
-            echo "$PROMPT" | env NODE_NO_WARNINGS=1 \
+            printf '%s\n' "$PROMPT" | env NODE_NO_WARNINGS=1 \
                 gemini -o text --approval-mode yolo -m "$MODEL"
         fi
         ;;
     qwen)
-        echo "$PROMPT" | env NODE_NO_WARNINGS=1 \
+        printf '%s\n' "$PROMPT" | env NODE_NO_WARNINGS=1 \
             qwen -o text --approval-mode yolo -m "$MODEL"
         ;;
     claude|claude-sonnet)
-        echo "$PROMPT" | claude --print --model sonnet
+        # Resolve model via providers.json — never hardcode "sonnet"/"opus"
+        printf '%s\n' "$PROMPT" | claude --print --model "$MODEL"
         ;;
     claude-opus)
-        echo "$PROMPT" | claude --print --model opus
+        printf '%s\n' "$PROMPT" | claude --print --model "$MODEL"
         ;;
     perplexity)
         # Perplexity uses API, not CLI — delegate to orchestrate.sh function
@@ -161,7 +162,7 @@ case "$PROVIDER" in
         exit 1
         ;;
     ollama)
-        echo "$PROMPT" | ollama run "$MODEL"
+        printf '%s\n' "$PROMPT" | ollama run "$MODEL"
         ;;
     *)
         log ERROR "Unknown provider: $PROVIDER"

--- a/scripts/octo-dispatch.sh
+++ b/scripts/octo-dispatch.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# octo-dispatch — Standalone provider dispatch with automatic model resolution
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# WHY: When Claude bypasses orchestrate.sh (ad-hoc review, custom analysis),
+# it manually constructs CLI commands and hardcodes wrong/stale model names.
+# This script provides a simple interface that ALWAYS reads providers.json.
+#
+# Usage:
+#   echo "your prompt" | octo-dispatch <provider> [--phase <phase>] [--role <role>]
+#   octo-dispatch <provider> "your prompt" [--phase <phase>] [--role <role>]
+#   octo-dispatch --resolve <provider>   # Just print the model, don't dispatch
+#
+# Examples:
+#   echo "Review this code for bugs" | octo-dispatch codex
+#   echo "Check for OWASP issues"    | octo-dispatch gemini
+#   echo "Analyze architecture"       | octo-dispatch qwen
+#   octo-dispatch --resolve codex     # prints: gpt-5.4-pro
+#   octo-dispatch --resolve gemini    # prints: gemini-3.1-pro-preview
+#
+# Model resolution uses the same 7-tier precedence as orchestrate.sh:
+#   Env Var > Session Override > Phase/Role Routing > Capability > Tier > Config Default > Hardcoded
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source model resolution (the single source of truth)
+source "${SCRIPT_DIR}/lib/model-resolver.sh"
+
+# Minimal logging (avoid sourcing all of orchestrate.sh)
+log() {
+    local level="$1"; shift
+    echo "[octo-dispatch] ${level}: $*" >&2
+}
+
+# ── Parse arguments ──────────────────────────────────────────────────────────
+
+RESOLVE_ONLY=false
+PROVIDER=""
+PHASE=""
+ROLE=""
+PROMPT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --resolve)
+            RESOLVE_ONLY=true
+            shift
+            ;;
+        --phase)
+            PHASE="${2:-}"
+            shift 2
+            ;;
+        --role)
+            ROLE="${2:-}"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: octo-dispatch <provider> [prompt] [--phase <phase>] [--role <role>]"
+            echo "       echo 'prompt' | octo-dispatch <provider>"
+            echo "       octo-dispatch --resolve <provider>"
+            echo ""
+            echo "Providers: codex, gemini, qwen, claude, openrouter, perplexity, ollama"
+            echo ""
+            echo "Resolves the correct model from ~/.claude-octopus/config/providers.json"
+            echo "and dispatches using the provider's CLI with proper flags."
+            exit 0
+            ;;
+        -*)
+            log ERROR "Unknown flag: $1"
+            exit 1
+            ;;
+        *)
+            if [[ -z "$PROVIDER" ]]; then
+                PROVIDER="$1"
+            else
+                PROMPT="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$PROVIDER" ]]; then
+    log ERROR "Provider required. Usage: octo-dispatch <provider> [prompt]"
+    exit 1
+fi
+
+# ── Resolve model ────────────────────────────────────────────────────────────
+
+MODEL=$(resolve_octopus_model "$PROVIDER" "$PROVIDER" "$PHASE" "$ROLE")
+
+if [[ -z "$MODEL" || "$MODEL" == "null" ]]; then
+    log ERROR "Could not resolve model for provider '$PROVIDER'"
+    exit 1
+fi
+
+if [[ "$RESOLVE_ONLY" == "true" ]]; then
+    echo "$MODEL"
+    exit 0
+fi
+
+# ── Read prompt from stdin if not provided as argument ───────────────────────
+
+if [[ -z "$PROMPT" ]]; then
+    if [[ -t 0 ]]; then
+        log ERROR "No prompt provided. Pass as argument or pipe via stdin."
+        exit 1
+    fi
+    PROMPT=$(cat)
+fi
+
+# ── Platform detection ───────────────────────────────────────────────────────
+
+OCTOPUS_PLATFORM="$(uname)"
+
+# ── Dispatch ─────────────────────────────────────────────────────────────────
+
+log INFO "Provider: $PROVIDER | Model: $MODEL"
+
+case "$PROVIDER" in
+    codex)
+        local_sandbox="${OCTOPUS_CODEX_SANDBOX:-workspace-write}"
+        echo "$PROMPT" | codex exec \
+            --skip-git-repo-check \
+            --full-auto \
+            --model "$MODEL" \
+            --sandbox "$local_sandbox" \
+            -
+        ;;
+    gemini)
+        if [[ "$OCTOPUS_PLATFORM" == "Darwin" && -z "${GEMINI_API_KEY:-}" ]]; then
+            echo "$PROMPT" | env NODE_NO_WARNINGS=1 GEMINI_FORCE_FILE_STORAGE=true \
+                gemini -o text --approval-mode yolo -m "$MODEL"
+        else
+            echo "$PROMPT" | env NODE_NO_WARNINGS=1 \
+                gemini -o text --approval-mode yolo -m "$MODEL"
+        fi
+        ;;
+    qwen)
+        echo "$PROMPT" | env NODE_NO_WARNINGS=1 \
+            qwen -o text --approval-mode yolo -m "$MODEL"
+        ;;
+    claude|claude-sonnet)
+        echo "$PROMPT" | claude --print --model sonnet
+        ;;
+    claude-opus)
+        echo "$PROMPT" | claude --print --model opus
+        ;;
+    perplexity)
+        # Perplexity uses API, not CLI — delegate to orchestrate.sh function
+        log ERROR "Perplexity dispatch requires orchestrate.sh (API-based). Use orchestrate.sh directly."
+        exit 1
+        ;;
+    openrouter)
+        log ERROR "OpenRouter dispatch requires orchestrate.sh (API-based). Use orchestrate.sh directly."
+        exit 1
+        ;;
+    ollama)
+        echo "$PROMPT" | ollama run "$MODEL"
+        ;;
+    *)
+        log ERROR "Unknown provider: $PROVIDER"
+        exit 1
+        ;;
+esac

--- a/scripts/octo-dispatch.sh
+++ b/scripts/octo-dispatch.sh
@@ -52,11 +52,19 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --phase)
-            PHASE="${2:-}"
+            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+                log ERROR "--phase requires a value"
+                exit 1
+            fi
+            PHASE="$2"
             shift 2
             ;;
         --role)
-            ROLE="${2:-}"
+            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+                log ERROR "--role requires a value"
+                exit 1
+            fi
+            ROLE="$2"
             shift 2
             ;;
         --help|-h)
@@ -142,8 +150,13 @@ case "$PROVIDER" in
         fi
         ;;
     qwen)
-        printf '%s\n' "$PROMPT" | env NODE_NO_WARNINGS=1 \
-            qwen -o text --approval-mode yolo -m "$MODEL"
+        if [[ "$OCTOPUS_PLATFORM" == "Darwin" && -z "${QWEN_API_KEY:-}" ]]; then
+            printf '%s\n' "$PROMPT" | env NODE_NO_WARNINGS=1 QWEN_FORCE_FILE_STORAGE=true \
+                qwen -o text --approval-mode yolo -m "$MODEL"
+        else
+            printf '%s\n' "$PROMPT" | env NODE_NO_WARNINGS=1 \
+                qwen -o text --approval-mode yolo -m "$MODEL"
+        fi
         ;;
     claude|claude-sonnet)
         # Resolve model via providers.json — never hardcode "sonnet"/"opus"


### PR DESCRIPTION
## Problem

Claude frequently bypasses `orchestrate.sh` for ad-hoc provider dispatch and hardcodes model names from its training data (e.g., `o3`, `gemini-2.5-pro`) instead of reading `providers.json`. This happens because:

1. The `/octo:review` command says to use `orchestrate.sh`, but when the review target isn't a standard code diff, Claude falls back to manual CLI dispatch
2. When constructing bash commands manually, Claude defaults to model names it "knows" from training data rather than checking the config
3. Memories and instructions don't reliably prevent this — they're passive context that gets deprioritized under cognitive load

Users who configure premium models via `/octo:model-config` or `providers.json` get silently downgraded to stale/cheaper models.

## Solution

Three-layer defense against model name drift:

### 1. `scripts/octo-dispatch.sh` — Standalone dispatch wrapper

Simple interface for ad-hoc provider dispatch that **always** reads `providers.json` via the same `resolve_octopus_model()` 7-tier precedence:

```bash
# Resolve model only (for inspection)
octo-dispatch.sh --resolve codex    # prints: gpt-5.4-pro
octo-dispatch.sh --resolve gemini   # prints: gemini-3.1-pro-preview

# Dispatch with correct model
echo "your prompt" | octo-dispatch.sh codex
echo "your prompt" | octo-dispatch.sh gemini --phase review
```

### 2. `scripts/model-guard.sh` — PreToolUse hook

Intercepts Bash tool calls containing provider CLI commands with model flags, validates against the full resolver, and **blocks execution** with the correct model if wrong.

Key implementation details (refined through multi-provider review):
- Uses POSIX ERE only (no `\s`, `\b` — compatible with BSD/macOS grep)
- Extracts `-m` flags via `sed` to avoid grep interpreting `-m` as `--max-count`
- Compares against `resolve_octopus_model()` output (not just config defaults), so env var overrides and phase routing are respected
- Does NOT use `set -e` to prevent grep no-match from aborting unrelated Bash calls
- Covers: codex, gemini, qwen, claude, ollama
- Handles: `--model VALUE`, `--model=VALUE`, `-m VALUE`, `-m=VALUE`, quoted values

### 3. Updated `/octo:review` command (`review.md`)

Added `MODEL RESOLUTION — NON-NEGOTIABLE` section directing Claude to always use `octo-dispatch.sh --resolve` before any dispatch, with correct description of the 7-tier resolver precedence.

## Multi-Provider Review

This PR was reviewed by three providers in parallel. All HIGH findings were addressed:

| Provider | Model | Key Findings (all fixed) |
|---|---|---|
| **Codex** | gpt-5.4-pro | `grep -oE '-m...'` parsed as grep flag (critical); PCRE on BSD; guard compared config default instead of full resolver |
| **Gemini** | gemini-3.1-pro-preview | Regex bypass via `--model=`; `echo "$PROMPT"` unsafe for flag-like content; quoted model names not stripped |
| **Qwen** | qwen3-coder | Hardcoded `--model sonnet`/`opus` in the anti-hardcoding script; missing claude/ollama coverage |

## Files changed

| File | Change |
|------|--------|
| `scripts/octo-dispatch.sh` | New: standalone model-resolving dispatch wrapper |
| `scripts/model-guard.sh` | New: PreToolUse hook for model validation |
| `.claude/commands/review.md` | Updated: added model resolution enforcement section |

## Test plan

- [ ] `bash octo-dispatch.sh --resolve codex` returns model from providers.json
- [ ] `bash octo-dispatch.sh --resolve gemini` returns model from providers.json
- [ ] `echo "test" | bash octo-dispatch.sh codex` dispatches with correct model
- [ ] `model-guard.sh` blocks `codex exec -m o3` when resolver says `gpt-5.4-pro`
- [ ] `model-guard.sh` allows `codex exec --model gpt-5.4-pro` when it matches
- [ ] `model-guard.sh` works on macOS (BSD grep) without errors
- [ ] `/octo:review` shows model resolution section in expanded command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a provider dispatch tool with automatic model resolution and a resolve-only mode.
  * Added a runtime model-guard that blocks tool calls using hardcoded/incorrect provider model flags.
* **Documentation**
  * Added mandatory execution guidance: wait for all provider tasks before consuming outputs and require model resolution via the dispatcher before dispatch.
* **Behavior**
  * Agent dispatch paths now use resolved models instead of hardcoded model names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->