### PR TITLE
fix: strip CRLF from jq output in doctor hook check (closes #258)

### DIFF
--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -522,7 +522,7 @@ doctor_check_hooks() {
 
     # Extract all command paths from hooks.json and verify each exists
     local commands
-    commands=$(jq -r '.. | objects | select(.command?) | .command' "$hooks_json" 2>/dev/null || true)
+    commands=$(jq -r '.. | objects | select(.command?) | .command' "$hooks_json" 2>/dev/null | tr -d '\r' || true)
     if [[ -z "$commands" ]]; then
         return
     fi


### PR DESCRIPTION
On Windows/Git Bash, `jq.exe` outputs CRLF line endings. The `doctor_check_hooks()` function parses jq output to verify hook script paths exist, but the trailing `\r` prevents the quote-stripping logic from working, leaving a stale `"` in the path. This causes `-f` to fail and doctor reports a false "Hook script missing" error.

Fix: pipe jq output through `tr -d \"\\r\"` before the while-read loop. No impact on Unix (no `\r` to strip).

One-line change at `scripts/lib/doctor.sh:525`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Windows-style line endings could interfere with the doctor check script's command processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->