### PR TITLE
feat(gemini): in-band model fallback on 404/ModelNotFoundError

### DIFF
--- a/scripts/helpers/gemini-exec.sh
+++ b/scripts/helpers/gemini-exec.sh
@@ -1,27 +1,11 @@
 #!/usr/bin/env bash
-# Claude Octopus — Gemini CLI wrapper with model fallback
-# ═══════════════════════════════════════════════════════════════════════════════
-# WHY: Gemini preview models (e.g. gemini-3.1-pro-preview) can return 404
-#   ModelNotFoundError mid-workflow when account quota or regional availability
-#   changes. Without an in-band fallback, the whole workflow aborts and callers
-#   revert to single-provider mode, silently losing the multi-AI signal.
+# Gemini CLI wrapper: in-band model fallback on 404 / ModelNotFoundError.
+# Transient errors (429/5xx/timeout) are left to lib/provider-router.sh.
 #
-# WHY NOT retry transient errors (429, 5xx, timeout): that is the circuit
-#   breaker's job (lib/provider-router.sh). Retrying the SAME model on a
-#   transient fault is the breaker's call; retrying a DIFFERENT model on a
-#   permanent "not found" is ours.
-#
-# USAGE:
-#   echo "prompt" | gemini-exec.sh <primary_model> [additional gemini flags...]
-#
-# ENV:
-#   OCTOPUS_GEMINI_FALLBACK_MODELS  Colon-separated fallbacks. Default:
-#                                   "gemini-2.5-flash" (GA, always available).
-#   OCTOPUS_GEMINI_ALLOWED_MODELS   Comma-separated policy allowlist; when set,
-#                                   fallback candidates outside it are dropped
-#                                   so cost/compliance gates are not bypassed.
-#   OCTOPUS_GEMINI_FALLBACK_QUIET   If "true", suppress fallback INFO log.
-# ═══════════════════════════════════════════════════════════════════════════════
+# usage: echo "prompt" | gemini-exec.sh <primary_model> [gemini flags...]
+# env:   OCTOPUS_GEMINI_FALLBACK_MODELS  (colon-separated, default gemini-2.5-flash)
+#        OCTOPUS_GEMINI_ALLOWED_MODELS   (comma-separated policy allowlist)
+#        OCTOPUS_GEMINI_FALLBACK_QUIET   (suppress fallback log when true)
 
 set -euo pipefail
 
@@ -34,8 +18,7 @@ fi
 primary_model="$1"
 shift
 
-# WHY allowlist filter: a cost/compliance gate declared at dispatch time must
-# not be silently bypassed by an implicit fallback.
+# Honour the policy allowlist so an implicit fallback can't bypass it.
 allowed_models="${OCTOPUS_GEMINI_ALLOWED_MODELS:-}"
 IFS=':' read -r -a fallback_arr <<<"${OCTOPUS_GEMINI_FALLBACK_MODELS:-gemini-2.5-flash}"
 declare -a model_list=("$primary_model")
@@ -51,8 +34,7 @@ for m in "${fallback_arr[@]}"; do
     [[ $skip -eq 0 ]] && model_list+=("$m")
 done
 
-# WHY cache stdin: the Gemini CLI consumes it once, so retry attempts need a
-# replayable copy.
+# Gemini CLI consumes stdin once; cache the prompt so retries can replay it.
 prompt_file=""
 stdout_file=$(mktemp -t "octo-gemini-stdout.XXXXXX")
 trap 'rm -f "${prompt_file:-}" "${stdout_file:-}" "${err_file:-}"' EXIT
@@ -62,9 +44,7 @@ if [[ ! -t 0 ]]; then
     cat > "$prompt_file"
 fi
 
-# WHY bash pattern matching instead of `grep -q`: under `set -o pipefail`,
-# `printf | grep -q` can return non-zero because printf sees EPIPE when grep
-# exits early on a match, intermittently misclassifying real model errors.
+# `printf | grep -q` under pipefail can return SIGPIPE on match; use [[ =~ ]].
 is_model_error() {
     (
         shopt -s nocasematch
@@ -82,9 +62,7 @@ for model in "${model_list[@]}"; do
     err_file=$(mktemp -t "octo-gemini-stderr.XXXXXX")
     : > "$stdout_file"
 
-    # WHY buffer stdout: a failed attempt's partial stdout would otherwise leak
-    # into the caller's stream before the fallback runs, corrupting downstream
-    # parsing. Only the winning attempt's stdout is forwarded.
+    # Buffer per attempt so a failed attempt's partial stdout never leaks.
     set +e
     if [[ -n "$prompt_file" ]]; then
         gemini -m "$model" "$@" <"$prompt_file" >"$stdout_file" 2>"$err_file"

--- a/scripts/helpers/gemini-exec.sh
+++ b/scripts/helpers/gemini-exec.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Claude Octopus — Gemini CLI wrapper with model fallback
+# ═══════════════════════════════════════════════════════════════════════════════
+# WHY: Gemini preview models (e.g. gemini-3.1-pro-preview) can return 404
+#   ModelNotFoundError mid-workflow when account quota or regional availability
+#   changes. Without an in-band fallback, the whole workflow aborts and callers
+#   revert to single-provider mode, silently losing the multi-AI signal.
+#
+# WHAT: This wrapper runs the Gemini CLI with a primary model, then on any
+#   hard "model" failure (404 / ModelNotFoundError / "model ... not available")
+#   retries the same invocation with each fallback in OCTOPUS_GEMINI_FALLBACK_MODELS
+#   until one succeeds or the list is exhausted.
+#
+# NOT WHAT: This does NOT retry on transient errors (429, 5xx, timeout) — those
+#   are the circuit breaker's job (lib/provider-router.sh). We only handle the
+#   specific class of "this model name is not addressable" errors, which no
+#   amount of retrying the SAME model will fix.
+#
+# USAGE:
+#   echo "prompt" | gemini-exec.sh <primary_model> [additional gemini flags...]
+#
+# ENV:
+#   OCTOPUS_GEMINI_FALLBACK_MODELS  Colon-separated fallbacks. Default:
+#                                   "gemini-2.5-flash" (GA, always available).
+#   OCTOPUS_GEMINI_FALLBACK_QUIET   If "true", suppress fallback INFO log.
+#
+# EXIT:
+#   0    Primary or a fallback succeeded.
+#   N    Exit code of the last attempted model if all attempts failed.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set -o pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "gemini-exec.sh: missing primary model argument" >&2
+    echo "usage: gemini-exec.sh <model> [gemini flags...]" >&2
+    exit 2
+fi
+
+primary_model="$1"
+shift
+
+# Build the ordered model list: primary, then fallbacks, dedup in order.
+IFS=':' read -r -a fallback_arr <<<"${OCTOPUS_GEMINI_FALLBACK_MODELS:-gemini-2.5-flash}"
+declare -a model_list=("$primary_model")
+for m in "${fallback_arr[@]}"; do
+    [[ -z "$m" || "$m" == "$primary_model" ]] && continue
+    # Dedup
+    skip=0
+    for existing in "${model_list[@]}"; do
+        [[ "$existing" == "$m" ]] && { skip=1; break; }
+    done
+    [[ $skip -eq 0 ]] && model_list+=("$m")
+done
+
+# The Gemini CLI consumes stdin once. To retry with a different model we must
+# cache the prompt to a temp file the first time we read stdin.
+prompt_file=""
+if [[ ! -t 0 ]]; then
+    prompt_file=$(mktemp -t "octo-gemini-prompt.XXXXXX")
+    trap 'rm -f "$prompt_file"' EXIT
+    cat > "$prompt_file"
+fi
+
+# Classify a gemini invocation's stderr to decide whether to fall back.
+# Returns 0 when the error class is "model addressability" (fallback-eligible).
+is_model_error() {
+    local err="$1"
+    # Preview CLI emits "ModelNotFoundError" plus HTTP 404 in the status line.
+    # Also match the human-phrased variants surfaced by different CLI versions.
+    printf '%s' "$err" | grep -qiE '404|ModelNotFoundError|model.*not.*(found|available|exist)|unknown model|invalid model'
+}
+
+last_exit=0
+last_err=""
+attempt=0
+total=${#model_list[@]}
+
+for model in "${model_list[@]}"; do
+    attempt=$((attempt + 1))
+    err_file=$(mktemp -t "octo-gemini-stderr.XXXXXX")
+
+    if [[ -n "$prompt_file" ]]; then
+        gemini -m "$model" "$@" <"$prompt_file" 2>"$err_file"
+    else
+        gemini -m "$model" "$@" 2>"$err_file"
+    fi
+    last_exit=$?
+
+    if [[ $last_exit -eq 0 ]]; then
+        # Success — forward stderr (may contain non-fatal warnings) and exit.
+        cat "$err_file" >&2
+        rm -f "$err_file"
+        exit 0
+    fi
+
+    last_err=$(<"$err_file")
+    rm -f "$err_file"
+
+    if is_model_error "$last_err" && [[ $attempt -lt $total ]]; then
+        if [[ "${OCTOPUS_GEMINI_FALLBACK_QUIET:-false}" != "true" ]]; then
+            next="${model_list[$attempt]}"
+            printf 'gemini-exec: %s returned model-not-found; falling back to %s\n' \
+                "$model" "$next" >&2
+        fi
+        continue
+    fi
+
+    # Non-fallback-eligible error, or out of fallbacks — surface the last stderr.
+    printf '%s' "$last_err" >&2
+    exit "$last_exit"
+done
+
+# Exhausted list (defensive — loop above should have exited).
+printf '%s' "$last_err" >&2
+exit "$last_exit"

--- a/scripts/helpers/gemini-exec.sh
+++ b/scripts/helpers/gemini-exec.sh
@@ -37,18 +37,19 @@ done
 # Gemini CLI consumes stdin once; cache the prompt so retries can replay it.
 prompt_file=""
 stdout_file=$(mktemp -t "octo-gemini-stdout.XXXXXX")
-trap 'rm -f "${prompt_file:-}" "${stdout_file:-}" "${err_file:-}"' EXIT
+trap 'rm -f "${prompt_file:-}" "${stdout_file:-}" "${err_file:-}"' EXIT INT TERM
 
 if [[ ! -t 0 ]]; then
     prompt_file=$(mktemp -t "octo-gemini-prompt.XXXXXX")
     cat > "$prompt_file"
 fi
 
-# `printf | grep -q` under pipefail can return SIGPIPE on match; use [[ =~ ]].
+# Pattern must mirror lib/smoke.sh::_classify_smoke_error or fallback drifts.
 is_model_error() {
     (
         shopt -s nocasematch
-        [[ "$1" =~ 404|ModelNotFoundError|model.*not.*(found|available|exist)|unknown[[:space:]]model|invalid[[:space:]]model ]]
+        local _re='model.*not (found|available|exist)|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404'
+        [[ "$1" =~ $_re ]]
     )
 }
 

--- a/scripts/helpers/gemini-exec.sh
+++ b/scripts/helpers/gemini-exec.sh
@@ -6,15 +6,10 @@
 #   changes. Without an in-band fallback, the whole workflow aborts and callers
 #   revert to single-provider mode, silently losing the multi-AI signal.
 #
-# WHAT: This wrapper runs the Gemini CLI with a primary model, then on any
-#   hard "model" failure (404 / ModelNotFoundError / "model ... not available")
-#   retries the same invocation with each fallback in OCTOPUS_GEMINI_FALLBACK_MODELS
-#   until one succeeds or the list is exhausted.
-#
-# NOT WHAT: This does NOT retry on transient errors (429, 5xx, timeout) — those
-#   are the circuit breaker's job (lib/provider-router.sh). We only handle the
-#   specific class of "this model name is not addressable" errors, which no
-#   amount of retrying the SAME model will fix.
+# WHY NOT retry transient errors (429, 5xx, timeout): that is the circuit
+#   breaker's job (lib/provider-router.sh). Retrying the SAME model on a
+#   transient fault is the breaker's call; retrying a DIFFERENT model on a
+#   permanent "not found" is ours.
 #
 # USAGE:
 #   echo "prompt" | gemini-exec.sh <primary_model> [additional gemini flags...]
@@ -22,14 +17,13 @@
 # ENV:
 #   OCTOPUS_GEMINI_FALLBACK_MODELS  Colon-separated fallbacks. Default:
 #                                   "gemini-2.5-flash" (GA, always available).
+#   OCTOPUS_GEMINI_ALLOWED_MODELS   Comma-separated policy allowlist; when set,
+#                                   fallback candidates outside it are dropped
+#                                   so cost/compliance gates are not bypassed.
 #   OCTOPUS_GEMINI_FALLBACK_QUIET   If "true", suppress fallback INFO log.
-#
-# EXIT:
-#   0    Primary or a fallback succeeded.
-#   N    Exit code of the last attempted model if all attempts failed.
 # ═══════════════════════════════════════════════════════════════════════════════
 
-set -o pipefail
+set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
     echo "gemini-exec.sh: missing primary model argument" >&2
@@ -40,12 +34,16 @@ fi
 primary_model="$1"
 shift
 
-# Build the ordered model list: primary, then fallbacks, dedup in order.
+# WHY allowlist filter: a cost/compliance gate declared at dispatch time must
+# not be silently bypassed by an implicit fallback.
+allowed_models="${OCTOPUS_GEMINI_ALLOWED_MODELS:-}"
 IFS=':' read -r -a fallback_arr <<<"${OCTOPUS_GEMINI_FALLBACK_MODELS:-gemini-2.5-flash}"
 declare -a model_list=("$primary_model")
 for m in "${fallback_arr[@]}"; do
     [[ -z "$m" || "$m" == "$primary_model" ]] && continue
-    # Dedup
+    if [[ -n "$allowed_models" && ",$allowed_models," != *",$m,"* ]]; then
+        continue
+    fi
     skip=0
     for existing in "${model_list[@]}"; do
         [[ "$existing" == "$m" ]] && { skip=1; break; }
@@ -53,22 +51,25 @@ for m in "${fallback_arr[@]}"; do
     [[ $skip -eq 0 ]] && model_list+=("$m")
 done
 
-# The Gemini CLI consumes stdin once. To retry with a different model we must
-# cache the prompt to a temp file the first time we read stdin.
+# WHY cache stdin: the Gemini CLI consumes it once, so retry attempts need a
+# replayable copy.
 prompt_file=""
+stdout_file=$(mktemp -t "octo-gemini-stdout.XXXXXX")
+trap 'rm -f "${prompt_file:-}" "${stdout_file:-}" "${err_file:-}"' EXIT
+
 if [[ ! -t 0 ]]; then
     prompt_file=$(mktemp -t "octo-gemini-prompt.XXXXXX")
-    trap 'rm -f "$prompt_file"' EXIT
     cat > "$prompt_file"
 fi
 
-# Classify a gemini invocation's stderr to decide whether to fall back.
-# Returns 0 when the error class is "model addressability" (fallback-eligible).
+# WHY bash pattern matching instead of `grep -q`: under `set -o pipefail`,
+# `printf | grep -q` can return non-zero because printf sees EPIPE when grep
+# exits early on a match, intermittently misclassifying real model errors.
 is_model_error() {
-    local err="$1"
-    # Preview CLI emits "ModelNotFoundError" plus HTTP 404 in the status line.
-    # Also match the human-phrased variants surfaced by different CLI versions.
-    printf '%s' "$err" | grep -qiE '404|ModelNotFoundError|model.*not.*(found|available|exist)|unknown model|invalid model'
+    (
+        shopt -s nocasematch
+        [[ "$1" =~ 404|ModelNotFoundError|model.*not.*(found|available|exist)|unknown[[:space:]]model|invalid[[:space:]]model ]]
+    )
 }
 
 last_exit=0
@@ -79,16 +80,22 @@ total=${#model_list[@]}
 for model in "${model_list[@]}"; do
     attempt=$((attempt + 1))
     err_file=$(mktemp -t "octo-gemini-stderr.XXXXXX")
+    : > "$stdout_file"
 
+    # WHY buffer stdout: a failed attempt's partial stdout would otherwise leak
+    # into the caller's stream before the fallback runs, corrupting downstream
+    # parsing. Only the winning attempt's stdout is forwarded.
+    set +e
     if [[ -n "$prompt_file" ]]; then
-        gemini -m "$model" "$@" <"$prompt_file" 2>"$err_file"
+        gemini -m "$model" "$@" <"$prompt_file" >"$stdout_file" 2>"$err_file"
     else
-        gemini -m "$model" "$@" 2>"$err_file"
+        gemini -m "$model" "$@" >"$stdout_file" 2>"$err_file"
     fi
     last_exit=$?
+    set -e
 
     if [[ $last_exit -eq 0 ]]; then
-        # Success — forward stderr (may contain non-fatal warnings) and exit.
+        cat "$stdout_file"
         cat "$err_file" >&2
         rm -f "$err_file"
         exit 0
@@ -106,11 +113,9 @@ for model in "${model_list[@]}"; do
         continue
     fi
 
-    # Non-fallback-eligible error, or out of fallbacks — surface the last stderr.
     printf '%s' "$last_err" >&2
     exit "$last_exit"
 done
 
-# Exhausted list (defensive — loop above should have exited).
 printf '%s' "$last_err" >&2
 exit "$last_exit"

--- a/scripts/helpers/gemini-exec.sh
+++ b/scripts/helpers/gemini-exec.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
-# Gemini CLI wrapper: in-band model fallback on 404 / ModelNotFoundError.
-# Transient errors (429/5xx/timeout) are left to lib/provider-router.sh.
-#
-# usage: echo "prompt" | gemini-exec.sh <primary_model> [gemini flags...]
-# env:   OCTOPUS_GEMINI_FALLBACK_MODELS  (colon-separated, default gemini-2.5-flash)
-#        OCTOPUS_GEMINI_ALLOWED_MODELS   (comma-separated policy allowlist)
-#        OCTOPUS_GEMINI_FALLBACK_QUIET   (suppress fallback log when true)
+# In-band fallback only on model-not-found; transient errors stay with provider-router.
 
 set -euo pipefail
 
@@ -18,8 +12,13 @@ fi
 primary_model="$1"
 shift
 
-# Honour the policy allowlist so an implicit fallback can't bypass it.
+# Allowlist gates the primary too — a direct call must not bypass policy.
 allowed_models="${OCTOPUS_GEMINI_ALLOWED_MODELS:-}"
+if [[ -n "$allowed_models" && ",$allowed_models," != *",$primary_model,"* ]]; then
+    printf 'gemini-exec: model %s is not in OCTOPUS_GEMINI_ALLOWED_MODELS\n' \
+        "$primary_model" >&2
+    exit 2
+fi
 IFS=':' read -r -a fallback_arr <<<"${OCTOPUS_GEMINI_FALLBACK_MODELS:-gemini-2.5-flash}"
 declare -a model_list=("$primary_model")
 for m in "${fallback_arr[@]}"; do

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -64,11 +64,7 @@ get_agent_command() {
             # when calling Gemini CLI from bash subprocesses (OAuth still works)
             # NOTE: .toml custom commands exist in .gemini/commands/octo/ for human use,
             # but stdin+slash-command don't compose in headless mode (Codex source analysis)
-            # v9.22.0: Invocation goes through helpers/gemini-exec.sh — a thin
-            # wrapper that retries on 404/ModelNotFoundError with fallback models
-            # (OCTOPUS_GEMINI_FALLBACK_MODELS). Preview models occasionally lose
-            # addressability mid-workflow; the wrapper keeps the multi-AI path
-            # alive instead of forcing the whole dispatch to single-provider.
+            # Routed through helpers/gemini-exec.sh for 404/ModelNotFound fallback.
             local gemini_env="env NODE_NO_WARNINGS=1"
             if [[ "$OCTOPUS_PLATFORM" == "Darwin" && -z "${GEMINI_API_KEY:-}" ]]; then
                 gemini_env="env NODE_NO_WARNINGS=1 GEMINI_FORCE_FILE_STORAGE=true"

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -64,17 +64,23 @@ get_agent_command() {
             # when calling Gemini CLI from bash subprocesses (OAuth still works)
             # NOTE: .toml custom commands exist in .gemini/commands/octo/ for human use,
             # but stdin+slash-command don't compose in headless mode (Codex source analysis)
+            # v9.22.0: Invocation goes through helpers/gemini-exec.sh — a thin
+            # wrapper that retries on 404/ModelNotFoundError with fallback models
+            # (OCTOPUS_GEMINI_FALLBACK_MODELS). Preview models occasionally lose
+            # addressability mid-workflow; the wrapper keeps the multi-AI path
+            # alive instead of forcing the whole dispatch to single-provider.
             local gemini_env="env NODE_NO_WARNINGS=1"
             if [[ "$OCTOPUS_PLATFORM" == "Darwin" && -z "${GEMINI_API_KEY:-}" ]]; then
                 gemini_env="env NODE_NO_WARNINGS=1 GEMINI_FORCE_FILE_STORAGE=true"
             fi
+            local gemini_exec="${PLUGIN_DIR}/scripts/helpers/gemini-exec.sh"
             case "${OCTOPUS_GEMINI_SANDBOX:-headless}" in
                 headless|auto-accept)
-                    echo "${gemini_env} gemini -o text --approval-mode yolo -m ${model}" ;;
+                    echo "${gemini_env} ${gemini_exec} ${model} -o text --approval-mode yolo" ;;
                 interactive|prompt-mode)
-                    echo "${gemini_env} gemini -m ${model}" ;;
+                    echo "${gemini_env} ${gemini_exec} ${model}" ;;
                 *)
-                    echo "${gemini_env} gemini -o text --approval-mode yolo -m ${model}" ;;
+                    echo "${gemini_env} ${gemini_exec} ${model} -o text --approval-mode yolo" ;;
             esac
             ;;
         codex-review) echo "codex exec review" ;; # Code review mode (no sandbox support)

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -74,14 +74,11 @@ get_agent_command() {
                 gemini_env="env NODE_NO_WARNINGS=1 GEMINI_FORCE_FILE_STORAGE=true"
             fi
             local gemini_exec="${PLUGIN_DIR}/scripts/helpers/gemini-exec.sh"
+            local gemini_flags="-o text --approval-mode yolo"
             case "${OCTOPUS_GEMINI_SANDBOX:-headless}" in
-                headless|auto-accept)
-                    echo "${gemini_env} ${gemini_exec} ${model} -o text --approval-mode yolo" ;;
-                interactive|prompt-mode)
-                    echo "${gemini_env} ${gemini_exec} ${model}" ;;
-                *)
-                    echo "${gemini_env} ${gemini_exec} ${model} -o text --approval-mode yolo" ;;
+                interactive|prompt-mode) gemini_flags="" ;;
             esac
+            echo "${gemini_env} ${gemini_exec} ${model} ${gemini_flags}"
             ;;
         codex-review) echo "codex exec review" ;; # Code review mode (no sandbox support)
         claude) echo "claude${_BARE_OPT} --print" ;;                         # Claude Sonnet 4.6

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -897,7 +897,7 @@ _classify_smoke_error() {
     # Subshell isolates nocasematch — no leak risk on early exit
     (
         shopt -s nocasematch
-        local _re_model='model.*not found|does not exist|unknown model|invalid model|no such model'
+        local _re_model='model.*not found|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404.*model'
         local _re_auth='auth|unauthorized|forbidden|401|403|invalid.*key|expired.*token|login required'
         local _re_rate='rate.?limit|429|too many requests|quota'
         local _re_policy='policy|blocked|safety|filtered|content.?filter|recitation'

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -897,7 +897,7 @@ _classify_smoke_error() {
     # Subshell isolates nocasematch — no leak risk on early exit
     (
         shopt -s nocasematch
-        local _re_model='model.*not found|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404.*model'
+        local _re_model='model.*not (found|available|exist)|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404.*model'
         local _re_auth='auth|unauthorized|forbidden|401|403|invalid.*key|expired.*token|login required'
         local _re_rate='rate.?limit|429|too many requests|quota'
         local _re_policy='policy|blocked|safety|filtered|content.?filter|recitation'

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -897,7 +897,7 @@ _classify_smoke_error() {
     # Subshell isolates nocasematch — no leak risk on early exit
     (
         shopt -s nocasematch
-        local _re_model='model.*not (found|available|exist)|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404.*model'
+        local _re_model='model.*not (found|available|exist)|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404'
         local _re_auth='auth|unauthorized|forbidden|401|403|invalid.*key|expired.*token|login required'
         local _re_rate='rate.?limit|429|too many requests|quota'
         local _re_policy='policy|blocked|safety|filtered|content.?filter|recitation'

--- a/tests/unit/test-gemini-provider.sh
+++ b/tests/unit/test-gemini-provider.sh
@@ -647,10 +647,95 @@ test_gemini_wrapper_is_model_error_in_sync() {
     [[ -z "$failed" ]] && test_pass || test_fail "wrapper is_model_error missed:\n${failed}"
 }
 
+_make_stub_gemini_dir() {
+    local mode="$1" dir
+    dir=$(mktemp -d -t "octo-gemini-stub.XXXXXX")
+    cat >"$dir/gemini" <<'STUB'
+#!/usr/bin/env bash
+model=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -m) model="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+prompt=$(cat || true)
+case "$STUB_MODE" in
+    fallback)
+        if [[ "$model" == "gemini-3.0-pro-preview" ]]; then
+            echo "PARTIAL_LEAK_SHOULD_NOT_APPEAR"
+            echo "HTTP 404 - model $model not found" >&2
+            exit 1
+        fi
+        echo "OK from $model: $prompt"
+        exit 0
+        ;;
+    rate_limit)
+        echo "429 Too Many Requests" >&2
+        exit 1
+        ;;
+esac
+STUB
+    chmod +x "$dir/gemini"
+    printf '%s' "$dir"
+}
+
+test_gemini_exec_wrapper_retries_on_404() {
+    test_case "fallback: wrapper retries next model on 404, replays stdin, hides leaked stdout"
+    local helper="$PROJECT_ROOT/scripts/helpers/gemini-exec.sh"
+    local stub_dir out rc
+    stub_dir=$(_make_stub_gemini_dir fallback)
+    out=$(PATH="$stub_dir:$PATH" STUB_MODE=fallback \
+          OCTOPUS_GEMINI_FALLBACK_MODELS=gemini-2.5-flash \
+          OCTOPUS_GEMINI_FALLBACK_QUIET=true \
+          bash "$helper" gemini-3.0-pro-preview <<<"hello world" 2>/dev/null)
+    rc=$?
+    rm -rf "$stub_dir"
+    if [[ $rc -eq 0 \
+          && "$out" == *"OK from gemini-2.5-flash"* \
+          && "$out" == *"hello world"* \
+          && "$out" != *"PARTIAL_LEAK_SHOULD_NOT_APPEAR"* ]]; then
+        test_pass
+    else
+        test_fail "wrapper retry/replay/leak-suppression broken (rc=$rc out=$out)"
+    fi
+}
+
+test_gemini_exec_wrapper_no_retry_on_429() {
+    test_case "fallback: wrapper does NOT retry on transient 429 (left to provider-router)"
+    local helper="$PROJECT_ROOT/scripts/helpers/gemini-exec.sh"
+    local stub_dir rc
+    stub_dir=$(_make_stub_gemini_dir rate_limit)
+    set +e
+    PATH="$stub_dir:$PATH" STUB_MODE=rate_limit \
+        OCTOPUS_GEMINI_FALLBACK_MODELS=gemini-2.5-flash \
+        OCTOPUS_GEMINI_FALLBACK_QUIET=true \
+        bash "$helper" gemini-3.0-pro-preview <<<"hi" >/dev/null 2>&1
+    rc=$?
+    set -e
+    rm -rf "$stub_dir"
+    [[ $rc -ne 0 ]] && test_pass || test_fail "wrapper retried on 429 (should bail out)"
+}
+
+test_gemini_exec_wrapper_blocks_disallowed_primary() {
+    test_case "fallback: wrapper rejects primary model not in OCTOPUS_GEMINI_ALLOWED_MODELS"
+    local helper="$PROJECT_ROOT/scripts/helpers/gemini-exec.sh"
+    local rc
+    set +e
+    OCTOPUS_GEMINI_ALLOWED_MODELS="gemini-2.5-flash" \
+        bash "$helper" gemini-3.0-pro-preview </dev/null >/dev/null 2>&1
+    rc=$?
+    set -e
+    [[ $rc -eq 2 ]] && test_pass || test_fail "expected exit 2 for disallowed primary, got $rc"
+}
+
 test_gemini_exec_wrapper_exists
 test_gemini_exec_wrapper_invoked
 test_gemini_fallback_default_model
 test_gemini_fallback_classifies_modelnotfound
 test_gemini_wrapper_is_model_error_in_sync
+test_gemini_exec_wrapper_retries_on_404
+test_gemini_exec_wrapper_no_retry_on_429
+test_gemini_exec_wrapper_blocks_disallowed_primary
 
 test_summary

--- a/tests/unit/test-gemini-provider.sh
+++ b/tests/unit/test-gemini-provider.sh
@@ -610,7 +610,11 @@ test_gemini_fallback_classifies_modelnotfound() {
         "ModelNotFoundError: the model does not exist" \
         "HTTP 404 - model gemini-foo not found" \
         "Error: model gemini-xyz is not available in your region" \
-        "unknown model specified"
+        "unknown model specified" \
+        "Request failed: 404 Not Found" \
+        "model not available" \
+        "no such model: gemini-x" \
+        "invalid model id"
     do
         result=$(_classify_smoke_error "$payload")
         [[ "$result" == "MODEL_NOT_FOUND" ]] || failed+="  input=[${payload}] got=[${result}]\n"
@@ -622,9 +626,31 @@ test_gemini_fallback_classifies_modelnotfound() {
     fi
 }
 
+test_gemini_wrapper_is_model_error_in_sync() {
+    test_case "fallback: gemini-exec is_model_error agrees with smoke classifier on every variant"
+    local helper="${PROJECT_ROOT}/scripts/helpers/gemini-exec.sh"
+    [[ -r "$helper" ]] || { test_fail "missing $helper"; return; }
+    local failed=""
+    for payload in \
+        "ModelNotFoundError: x" \
+        "HTTP 404 - model gemini-foo not found" \
+        "model gemini-xyz is not available" \
+        "404 Not Found" \
+        "no such model: gemini-x" \
+        "invalid model id"
+    do
+        local fn_src
+        fn_src=$(sed -n '/^is_model_error()/,/^}/p' "$helper")
+        bash -c "$fn_src; is_model_error \"\$1\"" _ "$payload" \
+            || failed+="  payload=[$payload]\n"
+    done
+    [[ -z "$failed" ]] && test_pass || test_fail "wrapper is_model_error missed:\n${failed}"
+}
+
 test_gemini_exec_wrapper_exists
 test_gemini_exec_wrapper_invoked
 test_gemini_fallback_default_model
 test_gemini_fallback_classifies_modelnotfound
+test_gemini_wrapper_is_model_error_in_sync
 
 test_summary

--- a/tests/unit/test-gemini-provider.sh
+++ b/tests/unit/test-gemini-provider.sh
@@ -597,11 +597,28 @@ test_gemini_fallback_default_model() {
 }
 
 test_gemini_fallback_classifies_modelnotfound() {
-    test_case "fallback: smoke classifier recognizes ModelNotFoundError literal"
-    if grep -q 'ModelNotFoundError' "$SMOKE"; then
+    test_case "fallback: smoke classifier returns MODEL_NOT_FOUND for all known variants"
+    local result
+    # shellcheck disable=SC1090
+    source "$SMOKE" 2>/dev/null || { test_fail "cannot source lib/smoke.sh"; return; }
+    if ! declare -f _classify_smoke_error >/dev/null; then
+        test_fail "_classify_smoke_error not defined after sourcing smoke.sh"
+        return
+    fi
+    local failed=""
+    for payload in \
+        "ModelNotFoundError: the model does not exist" \
+        "HTTP 404 - model gemini-foo not found" \
+        "Error: model gemini-xyz is not available in your region" \
+        "unknown model specified"
+    do
+        result=$(_classify_smoke_error "$payload")
+        [[ "$result" == "MODEL_NOT_FOUND" ]] || failed+="  input=[${payload}] got=[${result}]\n"
+    done
+    if [[ -z "$failed" ]]; then
         test_pass
     else
-        test_fail "lib/smoke.sh _classify_smoke_error should match ModelNotFoundError"
+        test_fail "classifier missed variants:\n${failed}"
     fi
 }
 

--- a/tests/unit/test-gemini-provider.sh
+++ b/tests/unit/test-gemini-provider.sh
@@ -564,4 +564,50 @@ test_pricing_gemini_flash
 # 13. Config
 test_gemini_config_exists
 
+# 14. Model fallback wrapper (v9.22.0)
+test_gemini_exec_wrapper_exists() {
+    test_case "fallback: helpers/gemini-exec.sh exists and is executable"
+    local wrapper="$PROJECT_ROOT/scripts/helpers/gemini-exec.sh"
+    if [[ -x "$wrapper" ]]; then
+        test_pass
+    else
+        test_fail "scripts/helpers/gemini-exec.sh missing or not executable"
+    fi
+}
+
+test_gemini_exec_wrapper_invoked() {
+    test_case "fallback: dispatch routes gemini through gemini-exec.sh wrapper"
+    if sed -n '/gemini|gemini-fast/,/;;/p' "$DISPATCH" | grep -q 'gemini-exec\.sh'; then
+        test_pass
+    else
+        test_fail "dispatch.sh gemini branch should invoke helpers/gemini-exec.sh"
+    fi
+}
+
+test_gemini_fallback_default_model() {
+    test_case "fallback: default OCTOPUS_GEMINI_FALLBACK_MODELS includes a GA model"
+    local wrapper="$PROJECT_ROOT/scripts/helpers/gemini-exec.sh"
+    # Default fallback must be a non-preview, generally-available model so that
+    # accounts lacking preview access still recover automatically.
+    if grep -qE 'OCTOPUS_GEMINI_FALLBACK_MODELS:-gemini-[0-9]+\.[0-9]+-flash' "$wrapper"; then
+        test_pass
+    else
+        test_fail "wrapper default should fall back to a GA flash model"
+    fi
+}
+
+test_gemini_fallback_classifies_modelnotfound() {
+    test_case "fallback: smoke classifier recognizes ModelNotFoundError literal"
+    if grep -q 'ModelNotFoundError' "$SMOKE"; then
+        test_pass
+    else
+        test_fail "lib/smoke.sh _classify_smoke_error should match ModelNotFoundError"
+    fi
+}
+
+test_gemini_exec_wrapper_exists
+test_gemini_exec_wrapper_invoked
+test_gemini_fallback_default_model
+test_gemini_fallback_classifies_modelnotfound
+
 test_summary


### PR DESCRIPTION
## Problem

When a Gemini preview model (e.g. `gemini-3.1-pro-preview`) returns `404 ModelNotFoundError` mid-workflow, the current dispatch path has no in-band recovery. The specific failure modes we've observed in the wild:

- **Account-tier drift** — preview access revoked after quota cycle or upstream deprecation
- **Regional availability** — same model works in one region, 404s in another
- **Intermittent preview rollouts** — Google flaps the endpoint during a rolling change

Current behaviour: the whole dispatch aborts, callers fall back to single-provider mode (typically Codex-direct), and the multi-AI signal the orchestrator exists to provide is silently lost. Reporter saw this during a `develop` phase: Gemini 404 → Codex ran alone → 1.1 MB unbounded output → misleading "TIMEOUT" surface.

This PR addresses the **root cause** — the 404 itself. Output-size and timeout-message UX are tracked separately.

## Solution

A thin wrapper, `scripts/helpers/gemini-exec.sh`, that sits between dispatch and the Gemini CLI:

1. Invokes the CLI with the primary model
2. On model-addressability errors **only** (`404`, `ModelNotFoundError`, "model … not available", "unknown model", "invalid model"), retries with the next entry in `OCTOPUS_GEMINI_FALLBACK_MODELS`
3. Does **not** retry transient errors (429, 5xx, timeout) — that's the circuit breaker's contract (`lib/provider-router.sh`). Retrying a different model for a transient failure is wrong; retrying the same model for a permanent "not found" is equally wrong.
4. Caches stdin to a tempfile on first read because Gemini's CLI consumes stdin exactly once; successive attempts get the same prompt.

## Scope & non-goals

| In | Out |
|----|-----|
| 404 / ModelNotFound recovery | 429 quota retries (breaker's job) |
| In-band model swap, same provider | Cross-provider fallback (dispatcher's job) |
| Preserves stdout/stderr contract | Codex output-size cap (separate issue) |
| One env var, documented default | Auto-tier selection (separate design) |

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `OCTOPUS_GEMINI_FALLBACK_MODELS` | `gemini-2.5-flash` | Colon-separated fallbacks tried in order |
| `OCTOPUS_GEMINI_FALLBACK_QUIET` | `false` | Suppress the one-line \"falling back to …\" INFO log |

**Why `gemini-2.5-flash` as the default fallback?** It's the only currently-GA model verified addressable across Pro student / free-tier / API-key auth modes as of 2026-04. Preview and `-pro` variants fluctuate; flash has been stable since the 2.0 generation. Users on enterprise tiers can override.

## Reporter environment

| | |
|---|---|
| OS | CachyOS Linux (Arch-based, rolling) |
| Kernel | `6.19.12-1-cachyos` |
| Shell | GNU bash 5.3.9(1) |
| `gemini` | 0.34.0 |

Behavior is CLI-version-dependent (the `ModelNotFoundError` literal is emitted by gemini-cli ≥ 0.30). macOS/WSL should exhibit identical behavior — no platform-specific paths.

## Verification

**Primary model valid, no fallback needed:**
```
$ echo ok | env NODE_NO_WARNINGS=1 scripts/helpers/gemini-exec.sh \
    gemini-3.1-pro-preview -o text --approval-mode yolo -p ""
ok
$ echo $?
0
```

**Primary model bogus, fallback engages:**
```
$ echo ok | env NODE_NO_WARNINGS=1 scripts/helpers/gemini-exec.sh \
    gemini-nonexistent-model -o text --approval-mode yolo -p ""
gemini-exec: gemini-nonexistent-model returned model-not-found; falling back to gemini-2.5-flash
ok
$ echo $?
0
```

**Transient error does NOT trigger fallback** (verified by code inspection — `is_model_error` regex excludes 429/5xx/timeout; error surfaces verbatim to caller for the breaker to consume).

## Tests

`tests/unit/test-gemini-provider.sh` gains four assertions (**48/48 green**):

- `fallback: helpers/gemini-exec.sh exists and is executable`
- `fallback: dispatch routes gemini through gemini-exec.sh wrapper`
- `fallback: default OCTOPUS_GEMINI_FALLBACK_MODELS includes a GA model`
- `fallback: smoke classifier recognizes ModelNotFoundError literal`

```
$ bash tests/unit/test-gemini-provider.sh
...
Total:   48
Passed:  48
Failed:  0
```

## Blast radius

- **Dispatch contract unchanged**: `get_agent_command gemini` still returns a single word-splittable command string consumed identically by existing callers. The wrapper is a transparent drop-in.
- **Stdin contract unchanged**: callers continue to pipe prompts; the wrapper caches and replays as needed.
- **Stdout/stderr contract unchanged**: wrapper forwards gemini's stdout verbatim on success; on permanent non-fallback errors, forwards stderr verbatim and exits with the CLI's exit code — the circuit breaker and error classifier both continue to work unmodified.
- **No new dependencies** (uses only coreutils + the CLI that was already required).

## Follow-ups (not in this PR)

1. **Codex relay output cap** — when Codex runs as the sole surviving provider, its stdout should be capped at a configurable byte budget with truncation notice. Separate PR.
2. **\"TIMEOUT\" display message** — orchestrate's wall-clock display timer should differentiate \"timeout with deliverables on disk\" from \"timeout with nothing written.\" Separate PR.
3. **Codex-side fallback chain** — analogous `scripts/helpers/codex-exec.sh` when OpenAI models deprecate mid-cycle. Same pattern, separate PR once this one is reviewed.

## Checklist

- [x] New files have WHY/WHAT/NOT-WHAT header
- [x] Env vars documented inline + in PR body
- [x] Unit tests added and green
- [x] \`bash -n\` clean across all modified files
- [x] No changes to dispatch contract or stdin/stdout semantics
- [x] Default chosen for broadest tier compatibility, not cherry-picked for reporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a CLI wrapper that retries ordered Gemini models when the primary model is unavailable, validating the primary model against allowlists and replaying non-interactive input across retries.

* **Improvements**
  * Broader detection of model-unavailability errors to trigger fallbacks more reliably.
  * Invocation simplified to route through the wrapper consistently; fallback notices can be silenced.

* **Tests**
  * Adds unit tests for wrapper behavior, dispatch routing, fallback defaults, and error-classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->