### PR TITLE
fix(version): read plugin version from manifest; validate git tag presence

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -56,3 +56,18 @@ octopus_complete() {
     echo -e "${green}✓ ${workflow} complete${nc}"
 }
 
+octopus_plugin_version() {
+    local root="${1:-${PLUGIN_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}}"
+    local manifest="$root/.claude-plugin/plugin.json"
+    if [[ ! -r "$manifest" ]]; then
+        echo "0.0.0-dev"
+        return
+    fi
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '.version // "0.0.0-dev"' "$manifest" 2>/dev/null || echo "0.0.0-dev"
+    else
+        sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest" \
+            | head -1 | grep . || echo "0.0.0-dev"
+    fi
+}
+

--- a/scripts/scheduler/octopus-scheduler.sh
+++ b/scripts/scheduler/octopus-scheduler.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Claude Octopus Scheduler - CLI Entry Point (v8.16.0)
+# Claude Octopus Scheduler - CLI Entry Point
 # Subcommands: dashboard, start, stop, status, add, list, remove, enable, disable, logs, emergency-stop
 #
 # Backend selection (set OCTOPUS_SCHEDULER_BACKEND=auto|daemon|coworkd):
@@ -10,10 +10,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 source "${SCRIPT_DIR}/store.sh"
 source "${SCRIPT_DIR}/cron.sh"
 source "${SCRIPT_DIR}/daemon.sh"
+source "${PLUGIN_DIR}/scripts/lib/common.sh"
 
 # --- Colors ---
 RED='\033[0;31m'
@@ -23,7 +25,7 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-VERSION="8.16.0"
+VERSION="$(octopus_plugin_version "$PLUGIN_DIR")"
 
 usage() {
     cat <<EOF

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -84,8 +84,8 @@ fi
 # Marketplace installers resolve by git ref; an un-tagged release silently
 # pins every consumer to main@HEAD.
 if git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    if git -C "$ROOT_DIR" rev-parse --verify --quiet "v$PLUGIN_VERSION" >/dev/null \
-       || git -C "$ROOT_DIR" rev-parse --verify --quiet "$PLUGIN_VERSION" >/dev/null; then
+    if git -C "$ROOT_DIR" show-ref --verify --quiet "refs/tags/v$PLUGIN_VERSION" \
+       || git -C "$ROOT_DIR" show-ref --verify --quiet "refs/tags/$PLUGIN_VERSION"; then
         echo -e "  ${GREEN}✓ git tag v$PLUGIN_VERSION exists${NC}"
     else
         echo -e "  ${YELLOW}WARNING: no git tag v$PLUGIN_VERSION — fresh installs pin to main@HEAD${NC}"

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -81,6 +81,18 @@ if [[ $errors -eq 0 ]] && [[ "$PLUGIN_VERSION" == "$MARKETPLACE_VERSION" ]] && [
     echo -e "  ${GREEN}✓ All versions synchronized: v$PLUGIN_VERSION${NC}"
 fi
 
+# Marketplace installers resolve by git ref; an un-tagged release silently
+# pins every consumer to main@HEAD.
+if git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if git -C "$ROOT_DIR" rev-parse --verify --quiet "v$PLUGIN_VERSION" >/dev/null \
+       || git -C "$ROOT_DIR" rev-parse --verify --quiet "$PLUGIN_VERSION" >/dev/null; then
+        echo -e "  ${GREEN}✓ git tag v$PLUGIN_VERSION exists${NC}"
+    else
+        echo -e "  ${YELLOW}WARNING: no git tag v$PLUGIN_VERSION — fresh installs pin to main@HEAD${NC}"
+        ((warnings++))
+    fi
+fi
+
 echo ""
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Three small, tightly-scoped fixes for version-drift hygiene.

| Change | Why |
|---|---|
| New `octopus_plugin_version` helper in `lib/common.sh` | Single source of truth is `.claude-plugin/plugin.json`. Runtime callers should not hold their own literal. |
| `scripts/scheduler/octopus-scheduler.sh` uses the helper | The literal was `VERSION=\"8.16.0\"` — seven major versions stale against the current `9.21.0` release, and it shipped that way. |
| `scripts/validate-release.sh` warns when no git tag matches | Marketplace installers resolve by git ref — an un-tagged release silently pins every consumer to `main@HEAD` and kills rollback. Preventative gate. |

## Non-goals / context

This was initially suspected as the cause of fresh installs shipping pre-fix code. It isn't — the `v9.21.0` tag does exist and points at the same commit as `main@HEAD`, which is where all the PR #263/#264/#265 bugs live. (I misread `git tag -l | tail` — it sorts alphabetically, so `v9.9.3` appeared last.) The install-freshness problem is solved by merging those three PRs, not by this one.

This PR still stands on its own merits: the stale scheduler version was genuinely wrong, and the git-tag gate is a cheap preventative against a real future hazard.

## Blast radius

- `octopus_plugin_version` is a new symbol, no callers broken.
- Scheduler banner now reads `v9.21.0` instead of `v8.16.0` — cosmetic to users, but accurate.
- Validator gate is warning-only (`((warnings++))`), does not block releases. Release-cutters will see the hint in the next run.

## Tests

- `bash -n` clean on all three files
- `bash scripts/validate-release.sh` output:
  ```
  ✓ All versions synchronized: v9.21.0
  ✓ git tag v9.21.0 exists
  ```
- Scheduler banner:
  ```
  $ bash scripts/scheduler/octopus-scheduler.sh
  🐙 Claude Octopus Scheduler v9.21.0
  ```

## Follow-ups (not in this PR)

- `scripts/lib/providers.sh:60` still hardcodes `CLAUDE_CODE_VERSION=\"2.1.69\"` as the Factory-host fallback. That's an *external* product's version, not ours, and it's a reasonable fallback when detection fails — but the value is stale (current CC is 2.1.105+). Separate judgment call for the maintainer; not touched here.
- `scripts/extract/core-extractor.sh:15: EXTRACTION_VERSION=\"1.0.0\"` is that tool's own schema version, unrelated to the plugin release. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled dynamic resolution of the plugin version from the project manifest so runtime tooling reflects the actual plugin release version.
  * Added a pre-release validation that checks for an existing version tag and reports a clear warning or confirmation to improve release readiness feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->