### PR TITLE
fix(#269): drop set -euo pipefail leak from sourced lib/memory.sh

### DIFF
--- a/scripts/lib/memory.sh
+++ b/scripts/lib/memory.sh
@@ -6,8 +6,6 @@
 #   OCTOPUS_MEMORY_BACKEND  "auto" (default) | comma-separated list
 #   OCTOPUS_MEMORY_SCOPE    override scope label (default: repo basename)
 
-set -euo pipefail
-
 _MEMORY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _MEMORY_PLUGIN_DIR="$(cd "${_MEMORY_LIB_DIR}/../.." && pwd)"
 _MEMORY_BRIDGE_DIR="${_MEMORY_PLUGIN_DIR}/scripts"


### PR DESCRIPTION
## Summary

Fixes #269 — every `orchestrate.sh` invocation on v9.22.0 silently aborts before the dispatch table loads.

## Root cause

`scripts/lib/memory.sh` (introduced in #267) sets `set -euo pipefail` at the top level of a *sourced* library. The `-u` option leaks into the parent shell. orchestrate.sh then sources `lib/session.sh`, which references `${WORKSPACE_DIR}` — a variable orchestrate.sh defines a few lines *after* `session.sh` is loaded. Under `-u`, the unbound-variable error fires, and because the source line is wrapped in `2>/dev/null || true`, it dies silently.

## Blast radius observed

- E2E smoke #269: **A15, B2, B7, B13, B17** all fail (orchestrate doesn't reach its dispatch table).
- Unit tests: **30+ suites cascade-fail** because they subprocess orchestrate.sh.
- Local repro on Arch: `bash scripts/orchestrate.sh detect-providers` → `rc=1`, no output.

## Fix

Remove `set -euo pipefail` from `lib/memory.sh`. orchestrate.sh already runs `set -eo pipefail` at line 1, so the library inherits the right mode without leaking `-u`.

**Sourced libs must never alter parent shell options** — this is a load-bearing invariant for the whole `lib/` decomposition.

## Test plan

- [x] `bash scripts/orchestrate.sh detect-providers` exits 0 with full output
- [x] `bash scripts/orchestrate.sh doctor` runs the full check (36 pass, 3 warnings)
- [x] `bash scripts/orchestrate.sh discover --dry-run "test"` orchestrates 6 agents and writes `~/.claude-octopus/progress.json`
- [x] `tests/run-all-tests.sh` — **100/137 → 129/137** with this PR alone (the remaining 8 are test-side bugs handled in the dependent PR)

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal shell script configuration for error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->