### PR TITLE
fix(orchestrate): define PROGRESS_FILE missed in v9.7.x lib extraction

### DIFF
--- a/scripts/lib/memory.sh
+++ b/scripts/lib/memory.sh
@@ -6,8 +6,6 @@
 #   OCTOPUS_MEMORY_BACKEND  "auto" (default) | comma-separated list
 #   OCTOPUS_MEMORY_SCOPE    override scope label (default: repo basename)
 
-set -euo pipefail
-
 _MEMORY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _MEMORY_PLUGIN_DIR="$(cd "${_MEMORY_LIB_DIR}/../.." && pwd)"
 _MEMORY_BRIDGE_DIR="${_MEMORY_PLUGIN_DIR}/scripts"

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -150,6 +150,7 @@ fi
 # Re-derive SESSION_FILE now that WORKSPACE_DIR is known
 # (quality.sh sets it at source-time before WORKSPACE_DIR is defined)
 SESSION_FILE="${WORKSPACE_DIR}/session.json"
+PROGRESS_FILE="${WORKSPACE_DIR}/progress.json"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CLAUDE CODE INTEGRATION: Task Management (v7.16.0)


### PR DESCRIPTION
## Summary

`lib/session.sh` and `lib/agents.sh` both reference `$PROGRESS_FILE`, but no file in `scripts/` ever assigns it. The v9.7.x extraction that moved `init_progress_tracking` out of `orchestrate.sh` left the variable definition behind.

## Symptom

Without `-u`, the missing variable expands to an empty string. `init_progress_tracking()` then does:

```bash
cat > "${PROGRESS_FILE}.tmp.$$" << EOF   # writes ./.tmp.NNNN  (cwd-relative!)
mv  "${PROGRESS_FILE}.tmp.$$" "$PROGRESS_FILE"   # mv .tmp.NNNN '' → fatal
```

The crash only fires once `check_ux_dependencies()` flips `PROGRESS_TRACKING_ENABLED=true` (jq present) — which is why `doctor` and `detect-providers` survived but `discover` / `embrace` died deterministically with an internal `mv` error. Reported by another active session debugging a `discover` workflow today.

## Fix

Define `PROGRESS_FILE="${WORKSPACE_DIR}/progress.json"` next to `SESSION_FILE`, after `WORKSPACE_DIR` is resolved.

## Test plan

- [x] `bash scripts/orchestrate.sh discover --dry-run "test"` no longer crashes; `~/.claude-octopus/progress.json` is written with `phase`, `total_agents`, `completed_agents`
- [x] `bash scripts/orchestrate.sh tangle --dry-run "test"` reaches DEVELOP phase cleanly
- [x] `tests/run-all-tests.sh` still passes

## Dependencies

**Stacked on #270** (memory.sh pipefail leak). Without that fix the cascade kills orchestrate.sh before `init_progress_tracking()` is even reached, so this PR's smoke tests would still fail in CI on its own. Rebased onto `fix/memory-pipefail-leak` so the diff stays minimal but CI runs against a working orchestrate.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled progress tracking by adding a persistent progress file path for orchestration.
* **Bug Fixes**
  * Adjusted script error-handling behavior to be more tolerant of failures, reducing abrupt aborts and improving robustness during long-running operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->