### PR TITLE
fix(heuristics): stop score_result_file returning multi-line numbers

### DIFF
--- a/scripts/lib/heuristics.sh
+++ b/scripts/lib/heuristics.sh
@@ -38,28 +38,23 @@ score_result_file() {
         score=$((score + 40))
     fi
 
-    # Factor 2: Code blocks (0-20 pts, 5 pts each up to 4)
-    local code_blocks
-    code_blocks=$(grep -c '```' <<< "$content" 2>/dev/null || echo "0")
-    # Each pair of ``` = 1 code block, so divide by 2
-    local block_count=$(( code_blocks / 2 ))
+    # `grep -c` already prints 0 on no-match — the earlier `|| echo 0` fallback concatenated a 2nd zero and broke arithmetic.
+    local code_blocks block_count
+    code_blocks=$(grep -c '```' <<< "$content" 2>/dev/null) || code_blocks=0
+    block_count=$(( code_blocks / 2 ))
     [[ $block_count -gt 4 ]] && block_count=4
     score=$((score + block_count * 5))
 
-    # Factor 3: Specificity (0-20 pts) — file paths, function names, URLs
-    local specifics=0
-    grep -cE '\.(ts|js|py|sh|rs|go|md|json)[ :\)]|/[a-z]+/' <<< "$content" &>/dev/null && specifics=$((specifics + $(grep -cE '\.(ts|js|py|sh|rs|go|md|json)[ :\)]|/[a-z]+/' <<< "$content" 2>/dev/null || echo "0")))
+    local specifics
+    specifics=$(grep -cE '\.(ts|js|py|sh|rs|go|md|json)[ :\)]|/[a-z]+/' <<< "$content" 2>/dev/null) || specifics=0
     [[ $specifics -gt 20 ]] && specifics=20
     score=$((score + specifics))
 
-    # Factor 4: Structure (0-20 pts) — markdown headers, bullet lists, tables
-    local structure=0
-    local headers
-    headers=$(grep -c '^#' <<< "$content" 2>/dev/null || echo "0")
+    local structure=0 headers bullets
+    headers=$(grep -c '^#' <<< "$content" 2>/dev/null) || headers=0
     [[ $headers -gt 5 ]] && headers=5
     structure=$((structure + headers * 2))
-    local bullets
-    bullets=$(grep -c '^[[:space:]]*[-*]' <<< "$content" 2>/dev/null || echo "0")
+    bullets=$(grep -c '^[[:space:]]*[-*]' <<< "$content" 2>/dev/null) || bullets=0
     [[ $bullets -gt 5 ]] && bullets=5
     structure=$((structure + bullets * 2))
     [[ $structure -gt 20 ]] && structure=20

--- a/scripts/lib/heuristics.sh
+++ b/scripts/lib/heuristics.sh
@@ -16,6 +16,20 @@
 #   - Code block count (max 20 pts): concrete examples signal actionable content
 #   - Specificity (max 20 pts): named files/functions/URLs vs vague prose
 #   - Structure (max 20 pts): headers, lists, tables signal organized thinking
+# `grep -c` prints 0 AND exits 1 on no-match; naive `$(grep -c ... || echo 0)` concatenates a 2nd zero and breaks arithmetic.
+safe_count() {
+    local pattern="$1"
+    local content="$2"
+    local extra="${3:-}"
+    local n
+    if [[ "$extra" == "-E" ]]; then
+        n=$(grep -cE -- "$pattern" <<<"$content" 2>/dev/null) || n=0
+    else
+        n=$(grep -c -- "$pattern" <<<"$content" 2>/dev/null) || n=0
+    fi
+    printf '%s' "${n:-0}"
+}
+
 score_result_file() {
     local file="$1"
     [[ ! -f "$file" ]] && echo "0" && return
@@ -38,23 +52,22 @@ score_result_file() {
         score=$((score + 40))
     fi
 
-    # `grep -c` already prints 0 on no-match — the earlier `|| echo 0` fallback concatenated a 2nd zero and broke arithmetic.
     local code_blocks block_count
-    code_blocks=$(grep -c '```' <<< "$content" 2>/dev/null) || code_blocks=0
+    code_blocks=$(safe_count '```' "$content")
     block_count=$(( code_blocks / 2 ))
     [[ $block_count -gt 4 ]] && block_count=4
     score=$((score + block_count * 5))
 
     local specifics
-    specifics=$(grep -cE '\.(ts|js|py|sh|rs|go|md|json)[ :\)]|/[a-z]+/' <<< "$content" 2>/dev/null) || specifics=0
+    specifics=$(safe_count '\.(ts|js|py|sh|rs|go|md|json)[ :\)]|/[a-z]+/' "$content" -E)
     [[ $specifics -gt 20 ]] && specifics=20
     score=$((score + specifics))
 
     local structure=0 headers bullets
-    headers=$(grep -c '^#' <<< "$content" 2>/dev/null) || headers=0
+    headers=$(safe_count '^#' "$content")
     [[ $headers -gt 5 ]] && headers=5
     structure=$((structure + headers * 2))
-    bullets=$(grep -c '^[[:space:]]*[-*]' <<< "$content" 2>/dev/null) || bullets=0
+    bullets=$(safe_count '^[[:space:]]*[-*]' "$content")
     [[ $bullets -gt 5 ]] && bullets=5
     structure=$((structure + bullets * 2))
     [[ $structure -gt 20 ]] && structure=20

--- a/scripts/lib/memory.sh
+++ b/scripts/lib/memory.sh
@@ -6,8 +6,6 @@
 #   OCTOPUS_MEMORY_BACKEND  "auto" (default) | comma-separated list
 #   OCTOPUS_MEMORY_SCOPE    override scope label (default: repo basename)
 
-set -euo pipefail
-
 _MEMORY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _MEMORY_PLUGIN_DIR="$(cd "${_MEMORY_LIB_DIR}/../.." && pwd)"
 _MEMORY_BRIDGE_DIR="${_MEMORY_PLUGIN_DIR}/scripts"


### PR DESCRIPTION
## Summary

`score_result_file` deadlocks the orchestrator in `aggregate_results` →
`rank_results_by_signals` whenever any probe-phase result is scored. Reported
today by another active session that watched `discover` hang for 30+ minutes
after all 6 probe agents had written clean output — no
`probe-synthesis-*.md` was ever produced.

## Root cause

The signal counters used this pattern:

```bash
headers=$(grep -c '^#' <<< "$content" 2>/dev/null || echo "0")
```

`grep -c` is a bit of a footgun — it prints `0` on stdout *and* exits 1 when
there are no matches. So the `|| echo "0"` fallback fires on every no-match
and appends a **second** zero to stdout. The captured variable becomes the
literal two-line string `0\n0`, and the next `[[ $headers -gt 5 ]]` /
`$((structure + headers * 2))` blows up with:

```
heuristics.sh: line 63: [[: 0
0: arithmetic syntax error in expression (error token is "0")
```

Four counters in `score_result_file` use the same pattern: code blocks,
specificity, headers, bullets — so any file that fails to match *any one of
them* (e.g. a short probe result with no `^[[:space:]]*[-*]` bullets) lands in
the arithmetic error and the scoring function returns mid-computation.
Downstream, `aggregate_results` waits on the scoring loop and `discover`
appears to hang forever.

## Fix

Replace `$(cmd || echo 0)` with `var=$(cmd) || var=0`:

```bash
headers=$(grep -c '^#' <<< "$content" 2>/dev/null) || headers=0
```

`grep -c` still prints `0` to stdout on no-match, which lands in the variable;
the `||` branch re-sets it to the integer `0` for the error case only (e.g.
grep binary missing). Arithmetic stays single-line on every path. Applied to
all four counters.

## Verification

Replayed against an actual stuck session's results directory
(`results/*1776237232*`, 6 files spanning 1.5 KiB–10.7 KiB of real probe
output). Before the fix: arithmetic errors and function exit. After:

```
38  claude-sonnet-probe-1776237232-3.md
48  claude-sonnet-probe-1776237232-5.md
68  codex-probe-1776237232-0.md
68  codex-probe-1776237232-4.md
78  copilot-probe-1776237232-2.md
65  gemini-probe-1776237232-1.md
```

All 6 score cleanly, `rank_results_by_signals` completes, synthesis unblocks.

## Test plan

- [x] `score_result_file` returns a single integer for all 6 real probe files
- [x] `tests/run-all-tests.sh` → 137/137
- [x] `bash scripts/orchestrate.sh discover --dry-run "test"` reaches synthesis without the `[[: 0\n0` error

## Dependencies

**Stacked on #270** (memory.sh pipefail leak) for the same reason as #271,
#272, #273: without that fix `orchestrate.sh` aborts before `score_result_file`
is reached, so smoke tests on an unfixed main would falsely fail this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed arithmetic errors in quality-signal extraction that could corrupt numeric results.
  * Corrected fallback logic to reliably return zero when no matches are found.

* **Refactor**
  * Consolidated and simplified scoring control flow and variable handling for clearer logic.
  * Introduced a safer counting helper to make match counting more robust and avoid failure modes.

* **Chores**
  * Adjusted script execution behavior to improve compatibility and reduce unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->