### PR TITLE
fix: stop silent test aborts (((VAR++)) + set -e) and fix BSD sed portability

### DIFF
--- a/scripts/build-factory-skills.sh
+++ b/scripts/build-factory-skills.sh
@@ -75,7 +75,7 @@ for src in "$SKILLS_SRC"/*.md; do
   # Extract trigger content to enrich description
   trigger=""
   if echo "$frontmatter" | grep -q "^trigger:"; then
-    trigger="$(echo "$frontmatter" | sed -n '/^trigger:/,/^[a-z_]*:/{ /^trigger:/d; /^[a-z_]*:/d; p; }' | sed 's/^  //' | head -5)"
+    trigger="$(echo "$frontmatter" | awk '/^trigger:/{found=1;next} /^[a-z_]*:/{found=0} found{sub(/^  /,"");print}' | head -5)"
   fi
 
   # Build Factory-compatible description

--- a/scripts/build-factory-skills.sh
+++ b/scripts/build-factory-skills.sh
@@ -72,10 +72,20 @@ for src in "$SKILLS_SRC"/*.md; do
   description="$(echo "$frontmatter" | grep "^description:" | head -1 | sed 's/^description: *//' | sed 's/^"//' | sed 's/"$//')"
   description="$(normalize_single_line "$description")"
 
-  # Extract trigger content to enrich description
+  # Extract trigger content to enrich description.
+  # Uses <<< "$frontmatter" (no pipelines) and awk's internal `exit` after 5 lines
+  # so neither grep -q nor head -n can SIGPIPE the pipeline under `set -euo pipefail`.
   trigger=""
-  if echo "$frontmatter" | grep -q "^trigger:"; then
-    trigger="$(echo "$frontmatter" | awk '/^trigger:/{found=1;next} /^[a-z_]*:/{found=0} found{sub(/^  /,"");print}' | head -5)"
+  if grep -qF "trigger:" <<< "$frontmatter" 2>/dev/null; then
+    trigger="$(awk '
+      /^trigger:/ { found=1; next }
+      found && /^[a-z_][a-z_]*:/ { exit }
+      found {
+        sub(/^  /, "")
+        print
+        if (++count == 5) exit
+      }
+    ' <<< "$frontmatter")"
   fi
 
   # Build Factory-compatible description

--- a/tests/test-enforcement-pattern.sh
+++ b/tests/test-enforcement-pattern.sh
@@ -98,7 +98,7 @@ echo "Test 3: Checking frontmatter has 'execution_mode: enforced'..."
 skills_with_mode=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "^execution_mode: enforced" "$skill_file"; then
-        ((skills_with_mode++))
+        ((++skills_with_mode))
     else
         fail "$(basename "$skill_file") missing 'execution_mode: enforced'" \
              "Should be in frontmatter YAML"
@@ -114,7 +114,7 @@ echo "Test 4: Checking frontmatter has 'pre_execution_contract'..."
 skills_with_contract=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "pre_execution_contract:" "$skill_file"; then
-        ((skills_with_contract++))
+        ((++skills_with_contract))
     else
         fail "$(basename "$skill_file") missing 'pre_execution_contract'" \
              "Should list blocking prerequisites in frontmatter"
@@ -130,7 +130,7 @@ echo "Test 5: Checking frontmatter has 'validation_gates'..."
 skills_with_gates=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "validation_gates:" "$skill_file"; then
-        ((skills_with_gates++))
+        ((++skills_with_gates))
     else
         fail "$(basename "$skill_file") missing 'validation_gates'" \
              "Should list post-execution verifications in frontmatter"
@@ -146,7 +146,7 @@ echo "Test 6: Checking for 'EXECUTION CONTRACT' section..."
 skills_with_contract_section=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "EXECUTION CONTRACT (MANDATORY - CANNOT SKIP)" "$skill_file"; then
-        ((skills_with_contract_section++))
+        ((++skills_with_contract_section))
     else
         fail "$(basename "$skill_file") missing EXECUTION CONTRACT section" \
              "Should have '## ⚠️ EXECUTION CONTRACT (MANDATORY - CANNOT SKIP)'"
@@ -163,7 +163,7 @@ skills_with_steps=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "### STEP 1:" "$skill_file" && \
        grep -q "### STEP 2:" "$skill_file"; then
-        ((skills_with_steps++))
+        ((++skills_with_steps))
     else
         fail "$(basename "$skill_file") missing numbered blocking steps" \
              "Should have '### STEP 1:', '### STEP 2:', etc."
@@ -183,7 +183,7 @@ for skill_file in "${ENFORCE_SKILLS[@]}"; do
     cannot_skip_count=$(grep -c "CANNOT SKIP\|DO NOT PROCEED" "$skill_file" || echo 0)
 
     if [[ $must_count -ge 1 && $prohibited_count -ge 1 && $cannot_skip_count -ge 1 ]]; then
-        ((skills_with_imperatives++))
+        ((++skills_with_imperatives))
     else
         fail "$(basename "$skill_file") weak imperative language" \
              "Should use 'You MUST', 'PROHIBITED from', 'CANNOT SKIP/DO NOT PROCEED'"
@@ -200,13 +200,13 @@ skills_with_bash_call=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q '\.claude-octopus/plugin/scripts/orchestrate\.sh' "$skill_file" && \
        grep -q "You MUST execute this command via the Bash tool" "$skill_file"; then
-        ((skills_with_bash_call++))
+        ((++skills_with_bash_call))
     elif [[ "$(basename "$skill_file")" == "flow-discover.md" ]] && \
          grep -q '\.claude-octopus/plugin/scripts/orchestrate\.sh' "$skill_file" && \
          grep -q "You MUST use the Agent tool" "$skill_file"; then
         # v8.54.0: flow-discover uses Agent tool for parallel probe-single dispatch
         # instead of a single Bash(orchestrate.sh probe) call
-        ((skills_with_bash_call++))
+        ((++skills_with_bash_call))
     else
         fail "$(basename "$skill_file") missing explicit tool requirement" \
              "Should require Bash tool (or Agent tool for flow-discover) for orchestrate.sh"
@@ -223,7 +223,7 @@ skills_with_validation=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -qi "validation gate" "$skill_file" && \
        grep -q "VALIDATION FAILED\|VALIDATION PASSED" "$skill_file"; then
-        ((skills_with_validation++))
+        ((++skills_with_validation))
     else
         fail "$(basename "$skill_file") missing validation gate" \
              "Should have 'Validation Gate' with VALIDATION FAILED/PASSED checks"
@@ -240,14 +240,14 @@ skills_with_file_check=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "find.*results.*-name.*synthesis.*-mmin" "$skill_file" || \
        grep -q "find.*results.*-name.*validation.*-mmin" "$skill_file"; then
-        ((skills_with_file_check++))
+        ((++skills_with_file_check))
     elif [[ "$(basename "$skill_file")" == "flow-discover.md" ]] && \
          grep -q 'probe-synthesis-' "$skill_file" && \
          grep -q 'VALIDATION FAILED\|VALIDATION PASSED' "$skill_file"; then
         # v8.54.0: flow-discover uses Agent-based execution where Claude writes
         # the synthesis file directly and holds the path — no find -mmin needed.
         # Still requires VALIDATION FAILED/PASSED gate check.
-        ((skills_with_file_check++))
+        ((++skills_with_file_check))
     else
         fail "$(basename "$skill_file") missing synthesis file check" \
              "Should verify synthesis files exist (find -mmin or direct file check)"
@@ -265,7 +265,7 @@ for skill_file in "${ENFORCE_SKILLS[@]}"; do
     prohibition_count=$(grep -c "❌" "$skill_file" || echo 0)
 
     if [[ $prohibition_count -ge 3 ]]; then
-        ((skills_with_prohibitions++))
+        ((++skills_with_prohibitions))
     else
         fail "$(basename "$skill_file") missing prohibition statements" \
              "Should have at least 3 ❌ prohibition statements"
@@ -282,7 +282,7 @@ skills_with_tasks=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "TaskCreate" "$skill_file" && \
        grep -q "TaskUpdate" "$skill_file"; then
-        ((skills_with_tasks++))
+        ((++skills_with_tasks))
     else
         fail "$(basename "$skill_file") missing task management" \
              "Should reference TaskCreate and TaskUpdate"
@@ -299,7 +299,7 @@ skills_with_no_fallback=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "DO NOT substitute" "$skill_file" && \
        grep -q "Report the failure" "$skill_file"; then
-        ((skills_with_no_fallback++))
+        ((++skills_with_no_fallback))
     else
         fail "$(basename "$skill_file") missing no-fallback error handling" \
              "Should say 'DO NOT substitute' and 'Report the failure'"
@@ -316,7 +316,7 @@ skills_with_provider_check=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if (grep -q "command -v codex" "$skill_file" && grep -q "command -v gemini" "$skill_file") || \
        grep -q "check-providers\|build-fleet" "$skill_file"; then
-        ((skills_with_provider_check++))
+        ((++skills_with_provider_check))
     else
         fail "$(basename "$skill_file") missing provider availability check" \
              "Should check 'command -v codex/gemini' or reference check-providers.sh/build-fleet.sh"
@@ -332,7 +332,7 @@ echo "Test 16: Checking for visual indicators requirement..."
 skills_with_indicators=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "🐙.*CLAUDE OCTOPUS ACTIVATED" "$skill_file"; then
-        ((skills_with_indicators++))
+        ((++skills_with_indicators))
     else
         fail "$(basename "$skill_file") missing visual indicators" \
              "Should require '🐙 **CLAUDE OCTOPUS ACTIVATED**' banner"
@@ -349,7 +349,7 @@ skills_with_estimates=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "💰 Estimated Cost" "$skill_file" && \
        grep -q "⏱️.*Estimated Time" "$skill_file"; then
-        ((skills_with_estimates++))
+        ((++skills_with_estimates))
     else
         fail "$(basename "$skill_file") missing cost/time estimates" \
              "Should show '💰 Estimated Cost' and '⏱️ Estimated Time'"
@@ -366,7 +366,7 @@ skills_with_attribution=0
 for skill_file in "${ENFORCE_SKILLS[@]}"; do
     if grep -q "Multi-AI.*powered by Claude Octopus" "$skill_file" && \
        grep -q "Providers: 🔴 Codex | 🟡 Gemini | 🔵 Claude" "$skill_file"; then
-        ((skills_with_attribution++))
+        ((++skills_with_attribution))
     else
         fail "$(basename "$skill_file") missing attribution footer" \
              "Should include 'Multi-AI powered by Claude Octopus' and provider list"
@@ -393,7 +393,7 @@ for skill_file in "${ENFORCE_SKILLS[@]}"; do
     fi
 
     if [[ $suggestive_count -eq 0 ]]; then
-        ((skills_without_suggestive++))
+        ((++skills_without_suggestive))
     else
         fail "$(basename "$skill_file") has suggestive language in EXECUTION CONTRACT" \
              "Should use imperative for Claude's actions: 'Claude should', 'you should execute', 'recommended to execute', 'consider calling'"
@@ -411,22 +411,22 @@ specific_checks=0
 # skill-deep-research & flow-discover use probe-synthesis
 if grep -q "probe-synthesis-\*.md" "$PROJECT_ROOT/.claude/skills/skill-deep-research.md" && \
    grep -q "probe-synthesis-\*.md" "$PROJECT_ROOT/.claude/skills/flow-discover.md"; then
-    ((specific_checks++))
+    ((++specific_checks))
 fi
 
 # flow-define uses grasp-synthesis
 if grep -q "grasp-synthesis-\*.md" "$PROJECT_ROOT/.claude/skills/flow-define.md"; then
-    ((specific_checks++))
+    ((++specific_checks))
 fi
 
 # flow-develop uses tangle-synthesis
 if grep -q "tangle-synthesis-\*.md" "$PROJECT_ROOT/.claude/skills/flow-develop.md"; then
-    ((specific_checks++))
+    ((++specific_checks))
 fi
 
 # flow-deliver uses ink-validation
 if grep -q "ink-validation-\*.md" "$PROJECT_ROOT/.claude/skills/flow-deliver.md"; then
-    ((specific_checks++))
+    ((++specific_checks))
 fi
 
 if [[ $specific_checks -eq 4 ]]; then

--- a/tests/test-intent-contract-skill.sh
+++ b/tests/test-intent-contract-skill.sh
@@ -97,11 +97,11 @@ grep -qi "context.*constraint\|constraint.*context" "$SKILL_FILE" && has_context
 grep -qi "validation checklist\|validation.*check" "$SKILL_FILE" && has_validation=true
 
 passed_components=0
-$has_job_statement && ((passed_components++))
-$has_success_criteria && ((passed_components++))
-$has_boundaries && ((passed_components++))
-$has_context && ((passed_components++))
-$has_validation && ((passed_components++))
+$has_job_statement && ((++passed_components))
+$has_success_criteria && ((++passed_components))
+$has_boundaries && ((++passed_components))
+$has_context && ((++passed_components))
+$has_validation && ((++passed_components))
 
 if [[ $passed_components -ge 4 ]]; then
     pass "Has $passed_components/5 key contract components"
@@ -174,9 +174,9 @@ fi
 echo ""
 echo "Test 12: Checking for workflow integration documentation..."
 workflows_mentioned=0
-grep -qi "embrace" "$SKILL_FILE" && ((workflows_mentioned++))
-grep -qi "discover\|probe" "$SKILL_FILE" && ((workflows_mentioned++))
-grep -qi "plan\|/plan" "$SKILL_FILE" && ((workflows_mentioned++))
+grep -qi "embrace" "$SKILL_FILE" && ((++workflows_mentioned))
+grep -qi "discover\|probe" "$SKILL_FILE" && ((++workflows_mentioned))
+grep -qi "plan\|/plan" "$SKILL_FILE" && ((++workflows_mentioned))
 
 if [[ $workflows_mentioned -ge 2 ]]; then
     pass "Documents integration with $workflows_mentioned workflow(s)"

--- a/tests/test-lifecycle-commands.sh
+++ b/tests/test-lifecycle-commands.sh
@@ -22,14 +22,14 @@ echo -e "${BLUE}🧪 Testing v7.22.0 Lifecycle Commands${NC}"
 echo ""
 
 pass() {
-    ((TEST_COUNT++))
-    ((PASS_COUNT++))
+    ((++TEST_COUNT))
+    ((++PASS_COUNT))
     echo -e "${GREEN}✅ PASS${NC}: $1"
 }
 
 fail() {
-    ((TEST_COUNT++))
-    ((FAIL_COUNT++))
+    ((++TEST_COUNT))
+    ((++FAIL_COUNT))
     echo -e "${RED}❌ FAIL${NC}: $1"
     echo -e "   ${YELLOW}$2${NC}"
 }

--- a/tests/test-model-config-v849.sh
+++ b/tests/test-model-config-v849.sh
@@ -16,8 +16,8 @@ PASSED=0
 FAILED=0
 TOTAL=0
 
-pass() { ((PASSED++)); ((TOTAL++)); echo -e "\033[0;32m✓\033[0m $1"; }
-fail() { ((FAILED++)); ((TOTAL++)); echo -e "\033[0;31m✗\033[0m $1"; }
+pass() { ((++PASSED)); ((++TOTAL)); echo -e "\033[0;32m✓\033[0m $1"; }
+fail() { ((++FAILED)); ((++TOTAL)); echo -e "\033[0;31m✗\033[0m $1"; }
 
 echo "Testing Model Config v8.49.0 Improvements"
 echo "==========================================="

--- a/tests/test-octo-state.sh
+++ b/tests/test-octo-state.sh
@@ -27,14 +27,14 @@ echo ""
 
 # Helper functions
 pass() {
-    ((TEST_COUNT++))
-    ((PASS_COUNT++))
+    ((++TEST_COUNT))
+    ((++PASS_COUNT))
     echo -e "${GREEN}✅ PASS${NC}: $1"
 }
 
 fail() {
-    ((TEST_COUNT++))
-    ((FAIL_COUNT++))
+    ((++TEST_COUNT))
+    ((++FAIL_COUNT))
     echo -e "${RED}❌ FAIL${NC}: $1"
     echo -e "   ${YELLOW}$2${NC}"
 }

--- a/tests/test-provider-activation.sh
+++ b/tests/test-provider-activation.sh
@@ -23,14 +23,14 @@ FAIL=0
 TOTAL=0
 
 pass() {
-    ((PASS++)) || true
-    ((TOTAL++)) || true
+    ((++PASS)) || true
+    ((++TOTAL)) || true
     echo -e "  \033[0;32m✓\033[0m $1"
 }
 
 fail() {
-    ((FAIL++)) || true
-    ((TOTAL++)) || true
+    ((++FAIL)) || true
+    ((++TOTAL)) || true
     echo -e "  \033[0;31m✗\033[0m $1"
     if [[ -n "${2:-}" ]]; then
         echo -e "    \033[0;33m→ $2\033[0m"
@@ -181,7 +181,7 @@ fi
 # Exclude: pricing tables, dead code, config templates, comments, help text, sparks
 stale_in_routing=0
 while IFS= read -r line; do
-    ((stale_in_routing++)) || true
+    ((++stale_in_routing)) || true
 done < <(grep -nE '\b"gpt-5\.3-codex"\b' "$ORCHESTRATE" 2>/dev/null | grep -v 'pricing\|cost_per\|config_template\|default_config\|select_codex_model_for_context\|#.*gpt-5\.3' 2>/dev/null || true)
 if [[ $stale_in_routing -eq 0 ]]; then
     pass "4.3 No stale gpt-5.3-codex in active model routing"

--- a/tests/test-v8.41.0-feature-adoption.sh
+++ b/tests/test-v8.41.0-feature-adoption.sh
@@ -14,8 +14,8 @@ PASS=0
 FAIL=0
 ERRORS=""
 
-pass() { ((PASS++)); echo "  ✓ $1"; }
-fail() { ((FAIL++)); ERRORS="${ERRORS}\n  ✗ $1"; echo "  ✗ $1"; }
+pass() { ((++PASS)); echo "  ✓ $1"; }
+fail() { ((++FAIL)); ERRORS="${ERRORS}\n  ✗ $1"; echo "  ✗ $1"; }
 
 echo "═══════════════════════════════════════════════════════════════"
 echo "Test Suite: v8.41.0 Feature Adoption"

--- a/tests/test-v8.48.0-cc-v2172-sync.sh
+++ b/tests/test-v8.48.0-cc-v2172-sync.sh
@@ -129,7 +129,7 @@ done
 # Use grep -c with || true to avoid pipefail issues
 max_in_effort=0
 while IFS= read -r line; do
-  ((max_in_effort++)) || true
+  ((++max_in_effort)) || true
 done < <(grep -n 'effort.*"max"\|effort_level.*max' "$ALL_SRC" 2>/dev/null | grep -v '#.*max\|comment\|OCTOPUS_MAX' 2>/dev/null || true)
 if [[ "$max_in_effort" -eq 0 ]]; then
   pass "No 'max' effort level in effort mapping (v2.1.72 compat)"

--- a/tests/test-version-check.sh
+++ b/tests/test-version-check.sh
@@ -224,46 +224,46 @@ tests_failed=0
 # 2.1.10 == 2.1.10 (should pass)
 if version_compare "2.1.10" "2.1.10"; then
     echo "PASS: 2.1.10 >= 2.1.10"
-    ((tests_passed++))
+    ((++tests_passed))
 else
     echo "FAIL: 2.1.10 >= 2.1.10"
-    ((tests_failed++))
+    ((++tests_failed))
 fi
 
 # 2.1.11 > 2.1.10 (should pass)
 if version_compare "2.1.11" "2.1.10"; then
     echo "PASS: 2.1.11 >= 2.1.10"
-    ((tests_passed++))
+    ((++tests_passed))
 else
     echo "FAIL: 2.1.11 >= 2.1.10"
-    ((tests_failed++))
+    ((++tests_failed))
 fi
 
 # 2.1.9 < 2.1.10 (should fail)
 if version_compare "2.1.9" "2.1.10"; then
     echo "FAIL: 2.1.9 should be < 2.1.10"
-    ((tests_failed++))
+    ((++tests_failed))
 else
     echo "PASS: 2.1.9 < 2.1.10 (correctly identified)"
-    ((tests_passed++))
+    ((++tests_passed))
 fi
 
 # 3.0.0 > 2.1.10 (should pass)
 if version_compare "3.0.0" "2.1.10"; then
     echo "PASS: 3.0.0 >= 2.1.10"
-    ((tests_passed++))
+    ((++tests_passed))
 else
     echo "FAIL: 3.0.0 >= 2.1.10"
-    ((tests_failed++))
+    ((++tests_failed))
 fi
 
 # 1.9.9 < 2.1.10 (should fail)
 if version_compare "1.9.9" "2.1.10"; then
     echo "FAIL: 1.9.9 should be < 2.1.10"
-    ((tests_failed++))
+    ((++tests_failed))
 else
     echo "PASS: 1.9.9 < 2.1.10 (correctly identified)"
-    ((tests_passed++))
+    ((++tests_passed))
 fi
 
 echo ""

--- a/tests/unit/test-cc-v2184-91-sync.sh
+++ b/tests/unit/test-cc-v2184-91-sync.sh
@@ -90,7 +90,7 @@ while IFS= read -r line; do
   ver=$(echo "$line" | grep -o '"2\.[0-9]\.[0-9]*"' | tr -d '"')
   if [[ -n "$prev" && -n "$ver" ]]; then
     if [[ "$(printf '%s\n%s' "$prev" "$ver" | sort -V | head -1)" != "$prev" ]]; then
-      ((out_of_order++)) || true
+      ((++out_of_order)) || true
     fi
   fi
   [[ -n "$ver" ]] && prev="$ver"
@@ -263,7 +263,7 @@ for hook in "$HOOKS_DIR"/*.sh; do
   [[ "$name" == "statusline-resolver.sh" ]] && continue
   if ! grep -q 'set -euo pipefail' "$hook"; then
     fail "$name" "missing set -euo pipefail"
-    ((missing_pipefail++)) || true
+    ((++missing_pipefail)) || true
   fi
 done
 if [[ $missing_pipefail -eq 0 ]]; then

--- a/tests/unit/test-docs-sync.sh
+++ b/tests/unit/test-docs-sync.sh
@@ -21,15 +21,15 @@ declare -a FAILURES
 # Helper functions
 pass() {
   echo -e "${GREEN}✓${NC} $1"
-  ((PASSED_TESTS++)) || true
-  ((TOTAL_TESTS++)) || true
+  ((++PASSED_TESTS)) || true
+  ((++TOTAL_TESTS)) || true
 }
 
 fail() {
   echo -e "${RED}✗${NC} $1"
   FAILURES+=("$1")
-  ((FAILED_TESTS++)) || true
-  ((TOTAL_TESTS++)) || true
+  ((++FAILED_TESTS)) || true
+  ((++TOTAL_TESTS)) || true
 }
 
 warn() {

--- a/tests/unit/test-enhanced-hud.sh
+++ b/tests/unit/test-enhanced-hud.sh
@@ -9,8 +9,8 @@ HUD_MJS="$PLUGIN_ROOT/hooks/octopus-hud.mjs"
 
 PASS=0 FAIL=0
 
-assert_pass() { ((PASS++)); echo "  ✓ $1"; }
-assert_fail() { ((FAIL++)); echo "  ✗ $1"; }
+assert_pass() { ((++PASS)); echo "  ✓ $1"; }
+assert_fail() { ((++FAIL)); echo "  ✗ $1"; }
 
 echo "============================================================"
 echo "Enhanced HUD Tests"

--- a/tests/unit/test-security-functions.sh
+++ b/tests/unit/test-security-functions.sh
@@ -34,15 +34,15 @@ ORCHESTRATE_SH="$ALL_SRC"
 # Helper functions
 pass() {
     echo -e "${GREEN}✓${NC} $1"
-    ((PASSED_TESTS++))
-    ((TOTAL_TESTS++))
+    ((++PASSED_TESTS))
+    ((++TOTAL_TESTS))
 }
 
 fail() {
     echo -e "${RED}✗${NC} $1"
     FAILURES+=("$1")
-    ((FAILED_TESTS++))
-    ((TOTAL_TESTS++))
+    ((++FAILED_TESTS))
+    ((++TOTAL_TESTS))
 }
 
 warn() {


### PR DESCRIPTION
## Summary

Fixes the two remaining unfixed bugs from #276 (items 3 and 5, originally in closed PRs #272 and #273).

### Bug 1: `((VAR++))` + `set -e` silently aborts 13 test files

`((VAR++))` evaluates to `0` on the first call (postfix returns old value before incrementing). Bash treats exit code 0-from-arithmetic as success, but the *expression value* `0` makes `((...))` return exit code 1. With `set -e`, the script aborts before any test actually runs. The test appears to pass (exit 0 from the header echo) with 0 failures — because nothing ran.

**Fix**: `((++VAR))` — pre-increment returns the new value, never `0`.

**Files fixed**: 13 test files across `tests/` and `tests/unit/`.

### Bug 2: GNU-only `sed` in `build-factory-skills.sh:78`

BSD sed (macOS) rejects command grouping inside address ranges (`sed -n "/start/,/end/{ ... }"`). This causes the Portability Lint CI check to fail on every PR.

**Fix**: Replaced with a portable `awk` in/out-of-block state machine.

Ref: #276 items 3 and 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved build-time parsing for more reliable trigger extraction.
  * Standardized increment semantics across test scripts for consistency.
* **Tests**
  * Updated test helpers and suites to use uniform counter behavior, improving test-reporting consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->