### PR TITLE
fix(qwen): drop --no-ask-user (invalid Qwen flag — Copilot CLI cross-contamination)

### DIFF
--- a/scripts/lib/qwen.sh
+++ b/scripts/lib/qwen.sh
@@ -56,7 +56,7 @@ qwen_execute() {
     [[ "${VERBOSE:-}" == "true" ]] && log DEBUG "qwen_execute: type=$agent_type, timeout=${timeout}s, auth=$(qwen_auth_method)" || true
 
     local response exit_code
-    response=$(timeout "$timeout" qwen -p "$prompt" --approval-mode yolo -o text --no-ask-user 2>&1) && exit_code=0 || exit_code=$?
+    response=$(timeout "$timeout" qwen -p "$prompt" --approval-mode yolo -o text 2>&1) && exit_code=0 || exit_code=$?
 
     # Handle errors
     if [[ $exit_code -ne 0 ]]; then


### PR DESCRIPTION
## Summary

`scripts/lib/qwen.sh` invokes `qwen` with `--no-ask-user`, but that flag is not a valid Qwen Code CLI option (verified against the [official Qwen Code headless docs](https://qwenlm.github.io/qwen-code-docs/en/users/features/headless): valid flags are `-p`, `-o`, `--yolo`/`-y`, `--approval-mode`, `--system-prompt`, `--continue`, `--resume`). Every Qwen invocation was failing on flag-parse.

## Root cause

`--no-ask-user` is the **Copilot CLI**'s flag — see `scripts/lib/copilot.sh:79,81` and `scripts/lib/dispatch.sh:103`. It looks like the flag got cross-contaminated into `qwen.sh` when the Qwen provider was first added. This is a strict CLI-arg-parser hard-fail (yargs/commander style), so the bug couldn't slip past silently.

## Fix
```diff
-response=\$(timeout \"\$timeout\" qwen -p \"\$prompt\" --approval-mode yolo -o text --no-ask-user 2>&1) ...
+response=\$(timeout \"\$timeout\" qwen -p \"\$prompt\" --approval-mode yolo -o text 2>&1) ...
```

`--approval-mode yolo` is already passed and provides the needed non-interactive behavior.

## Back-compat

No regression risk. `--approval-mode yolo` has been present in Qwen CLI since v0.1.x (Gemini CLI fork inheritance — Gemini's own provider in `dispatch.sh:73` only uses `-o text --approval-mode yolo`, never `--no-ask-user`). Removing the invalid flag fixes all Qwen versions, breaks none.

## Verification

- \`bash -n scripts/lib/qwen.sh\` — passes
- \`qwen --help | grep -E 'no-ask-user|approval-mode'\` — confirms `--no-ask-user` not present, `--approval-mode` present
- Confirmed `upstream/main:scripts/lib/qwen.sh:59` still has the broken flag (this fix is still needed)
- Spot-checked Qwen Code 0.14.x — same flag set throughout

## Why standalone

Per @nyldn's review on #274 (2026-04-17): *\"consider landing [the qwen fix] as a standalone PR first.\"*

## Note on previous force-push

This PR initially also bundled a `memory.sh` change. I noticed that conflicted with `cfaf6871 fix(#269)` (which correctly removes the top-level `set` directive entirely), so I dropped that commit and force-pushed. PR is now strictly the qwen one-liner.

## Suggested follow-up (NOT in this PR)

Worth considering a tiny test (e.g. \`tests/unit/test-adapter-flags.sh\` style) that asserts \`scripts/lib/qwen.sh\` does not contain Copilot-only flags, to catch future cross-contamination. Happy to open that as a separate PR if you'd like.

## Relation to #274

#274 will be closed and re-submitted as a focused Cursor Agent provider PR after this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Qwen CLI now prompts for user approval during execution instead of operating in non-interactive mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->