### PR TITLE
fix: add missing tools declaration to agents/personas/python-pro.md

### DIFF
--- a/agents/personas/python-pro.md
+++ b/agents/personas/python-pro.md
@@ -4,6 +4,7 @@ description: Master Python 3.12+ with modern features, async programming, perfor
 maxTurns: 15
 model: opus
 memory: local
+tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
 when_to_use: |
   - Python backend development (FastAPI, Django, Flask)
   - Async programming with asyncio


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`agents/personas/python-pro.md` has no `tools` declaration in its frontmatter. When Claude Code invokes this persona as a subagent, it defaults to text-only mode — no `Read`, `Bash`, `Write`, or any other tool access. The persona body extensively describes workflows that require tools: running tests, executing shell commands, reading project files, setting up Python environments, and profiling code.

This is an isolated omission — every other developer-workflow persona in `agents/personas/` (e.g. `frontend-developer`, `tdd-orchestrator`, `debugger`) correctly declares `tools`.

## Fix

Added `tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]` to the frontmatter, matching the tool set used by comparable developer personas in the same directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Python Professional assistant now includes an expanded toolkit with support for file operations (Read, Write, Edit), advanced file searching (Glob, Grep), and command-line execution (Bash). These additions enhance the assistant's ability to assist with complex development tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->