### PR TITLE
fix: add implementation-status caveat to skill-extract description

### DIFF
--- a/skills/skill-extract/SKILL.md
+++ b/skills/skill-extract/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-extract
 version: 1.0.0
-description: "Reverse-engineer design systems, tokens, and components from live products or screenshots"
+description: "Reverse-engineer design systems, tokens, and components from live products or screenshots. NOTE: This skill is in early development — token extraction, component analysis, architecture detection, and URL extraction are not yet implemented. Only CLI scaffolding and metadata generation are functional."
 ---
 
 # Extract Skill - Implementation Guide


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`skills/skill-extract/SKILL.md` documents itself as having broad capabilities (token extraction, component analysis, architecture detection, Storybook generation, URL extraction, quality gates) but the bottom of the file explicitly marks approximately 70% of these features as "In Progress" or "Planned":

```
**In Progress**:
- 🚧 Token extraction pipeline
- 🚧 Component analysis engine
- 🚧 Architecture detection
- 🚧 PRD generation
- 🚧 Quality gates

**Planned**:
- ⏳ Storybook scaffold generation
- ⏳ C4 diagram generation
- ⏳ URL extraction mode
```

When this skill is invoked — either directly or via auto-routing — Claude reads the full description claiming these features exist, and tries to execute them. Since the workflows are documented but not implemented, Claude produces undefined, inconsistent output without any warning.

The description field (used by skill routers and users to decide whether to invoke this skill) gives no indication of this limitation.

## Fix

Updated the frontmatter `description` field to include a clear NOT-YET-IMPLEMENTED caveat naming the unimplemented capabilities. The skill body itself is unchanged.

This is the minimal fix that gives users and routing logic accurate information before invocation. A more thorough fix would gate the unimplemented sections with explicit capability checks, but updating the description prevents the immediate silent-failure behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill metadata to clearly mark the feature as early development and clarify which capabilities are currently functional versus planned for future implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->