### PR TITLE
fix: add jq fallback for JSON parsing in user-prompt-submit.sh

### DIFF
--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -25,15 +25,18 @@ else
 fi
 [[ -z "$INPUT" ]] && exit 0
 
-# Extract the user's prompt text
-if ! command -v python3 &>/dev/null; then
-    exit 0
-fi
-
-PROMPT=$(printf '%s' "$INPUT" | python3 -c "
+# Extract the user's prompt text — prefer python3, fall back to jq
+PROMPT=""
+if command -v python3 &>/dev/null; then
+    PROMPT=$(printf '%s' "$INPUT" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
 print(d.get('prompt', d.get('message', '')))" 2>/dev/null) || true
+elif command -v jq &>/dev/null; then
+    PROMPT=$(printf '%s' "$INPUT" | jq -r '(.prompt // .message // "")' 2>/dev/null) || true
+else
+    exit 0
+fi
 
 [[ -z "$PROMPT" ]] && exit 0
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`hooks/user-prompt-submit.sh` depends on `python3` for the initial JSON parsing step (extracting the prompt text from hook input). When `python3` is absent — which happens in minimal Docker containers, some CI environments, and development containers without Python — the hook exits with `exit 0` at line 29, silently disabling all intent classification and skill routing.

The rest of the hook already uses `jq` for session tracking (line 187), so `jq` is a natural and already-expected fallback. The hook offers no routing or auto-invoke functionality in python3-less environments, even though `jq` alone is sufficient for the initial JSON extraction.

## Fix

Replaced the early-exit guard with a python3-first / jq-fallback pattern for the prompt extraction step:

```bash
# Before: silently disabled the entire hook when python3 was absent
if ! command -v python3 &>/dev/null; then
    exit 0
fi
PROMPT=$(printf '%s' "$INPUT" | python3 -c "...") || true

# After: falls back to jq, exits cleanly only if neither is available
PROMPT=""
if command -v python3 &>/dev/null; then
    PROMPT=$(printf '%s' "$INPUT" | python3 -c "...") || true
elif command -v jq &>/dev/null; then
    PROMPT=$(printf '%s' "$INPUT" | jq -r '(.prompt // .message // "")' 2>/dev/null) || true
else
    exit 0
fi
```

The jq expression `(.prompt // .message // "")` is semantically equivalent to the Python `d.get('prompt', d.get('message', ''))`. No behavioral change in environments where python3 is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved prompt extraction reliability by adding fallback support for systems without Python 3, enhancing compatibility across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->