### PR TITLE
fix: reject non-HTTPS webhook URLs in telemetry-webhook.sh

### DIFF
--- a/hooks/telemetry-webhook.sh
+++ b/hooks/telemetry-webhook.sh
@@ -17,6 +17,13 @@ if [[ -z "$WEBHOOK_URL" ]]; then
     exit 0
 fi
 
+# Refuse non-HTTPS webhooks to prevent accidental plaintext transmission of
+# session metadata over untrusted networks
+if [[ ! "$WEBHOOK_URL" =~ ^https:// ]]; then
+    echo '{"decision": "continue"}'
+    exit 0
+fi
+
 # v8.41.0: When HTTP hooks are supported (CC v2.1.63+), the native HTTP hook entry
 # in hooks.json fires first and handles telemetry directly. This shell fallback only
 # runs on older CC versions or when HTTP hook expansion fails.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Medium)

`hooks/telemetry-webhook.sh` posts session metadata — `session_id`, `phase`, `tool_name`, `timestamp`, and `tool_output_length` — to whatever URL is set in `OCTOPUS_WEBHOOK_URL`. There is no validation on the URL scheme, so a misconfigured or environment-injected `http://` URL would transmit this metadata in plaintext.

While the payload contains only metadata (not tool output content), session IDs and tool name sequences across a session reveal the user's workflow structure. Over an unencrypted connection on a corporate network or shared Wi-Fi, this data is interceptable.

The OCTOPUS_WEBHOOK_URL is user-configured, but environment variables can be set via `.env` files, CI configuration injection, or workspace-level configuration — sources that a compromised dependency or misconfigured environment could influence.

## Fix

Added a URL scheme check immediately after the "no webhook configured" guard:

```bash
if [[ ! "$WEBHOOK_URL" =~ ^https:// ]]; then
    echo '{"decision": "continue"}'
    exit 0
fi
```

**Impact**: Zero behavioral change for correctly configured HTTPS webhooks. Non-HTTPS URLs silently no-op instead of transmitting over plaintext.

This is the minimal safe fix from the NLPM audit's FINDING-03 recommendation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Webhook URL validation now requires HTTPS protocol. Non-HTTPS webhook URLs will be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->