### PR TITLE
chore: release v9.29.0 — model defaults refresh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Claude Code",
-    "version": "9.28.0"
+    "version": "9.29.0"
   },
   "plugins": [
     {
       "name": "octo",
       "source": "./",
-      "description": "v9.28.0 - Multi-LLM orchestration for Claude Code. Route tasks to Codex, Gemini, Perplexity, Copilot, Qwen, Ollama, OpenCode. 137 CC feature flags, token compression (~7K/session saved), interactive setup wizard. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
-      "version": "9.28.0",
+      "description": "v9.29.0 - Multi-LLM orchestration for Claude Code. Route tasks to Codex, Gemini, Perplexity, Copilot, Qwen, Ollama, OpenCode. 137 CC feature flags, token compression (~7K/session saved), interactive setup wizard. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
+      "version": "9.29.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.28.0",
-  "description": "v9.28.0 \u2014 Multi-LLM orchestration for Claude Code with Double Diamond workflows, provider routing, safety gates, and automation. Use '/octo:auto' or just describe what you need. Run /octo:setup.",
+  "version": "9.29.0",
+  "description": "v9.29.0 — Model defaults refreshed: Opus 4.7 for planning/strategy/security-review, GPT-5.4 for code-review/implementation. New GPT-5.4 prompting guide. Set OCTOPUS_LEGACY_ROLES=1 to opt out. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -62,6 +62,70 @@ Token Optimization:
   octo-compress:    [Available ✓ / Not in PATH]
 ```
 
+## STEP 2a: v9.29 Migration Prompt (one-time, existing users only)
+
+**Before showing the main menu, check if this is an existing user upgrading from ≤9.28.**
+
+Run this bash check — skip migration if state is fresh (first-run) or already ≥9.29:
+
+```bash
+STATE_FILE="${HOME}/.claude-octopus/state.json"
+if [[ -f "$STATE_FILE" ]] && command -v jq >/dev/null 2>&1; then
+  LAST_VERSION=$(jq -r '.last_version // "0.0.0"' "$STATE_FILE" 2>/dev/null)
+  MODEL_DEFAULTS_V2=$(jq -r '.model_defaults_v2 // "unset"' "$STATE_FILE" 2>/dev/null)
+  # Version compare: show migration only if last_version is between 1.x and 9.28
+  if [[ "$LAST_VERSION" != "0.0.0" ]] && [[ "$MODEL_DEFAULTS_V2" == "unset" ]]; then
+    printf "MIGRATION_PROMPT_NEEDED\nlast_version=%s\n" "$LAST_VERSION"
+  fi
+fi
+```
+
+**If `MIGRATION_PROMPT_NEEDED` appears**, show this AskUserQuestion BEFORE the main menu:
+
+```javascript
+AskUserQuestion({
+  questions: [{
+    question: "v9.29.0 refreshed model defaults based on April 2026 benchmarks. Planning + security reviews now use Claude Opus 4.7 (best on SWE-bench Pro + LMArena). Code review + implementation stay on GPT-5.4 (best on Terminal-Bench + edge cases). Opus is ~2x the cost of GPT-5.4 per MTok — this will increase planning-phase cost. How would you like to proceed?",
+    header: "v9.29 Models",
+    multiSelect: false,
+    options: [
+      {label: "Accept new defaults (Recommended)", description: "Use Opus 4.7 for planning/strategy/security, GPT-5.4 for review/implementation"},
+      {label: "Keep v9.28 defaults (GPT-5.4 everywhere)", description: "Sets OCTOPUS_LEGACY_ROLES=1 in your shell profile"},
+      {label: "Open /octo:model-config", description: "Customize per-role routing directly"},
+      {label: "See the diff", description: "Show before/after routing table, then ask again"}
+    ]
+  }]
+})
+```
+
+**Route based on selection:**
+
+- **Accept new defaults** → Write `model_defaults_v2=accepted` and `last_version=9.29.0` to `~/.claude-octopus/state.json`. Continue to STEP 3.
+- **Keep v9.28 defaults** → Append `export OCTOPUS_LEGACY_ROLES=1` to the user's shell profile (detect `~/.zshrc` vs `~/.bashrc` via `$SHELL`), notify them to reload the shell, then write `model_defaults_v2=legacy` + `last_version=9.29.0`. Continue to STEP 3.
+- **Open /octo:model-config** → Invoke that command. Do NOT write state — defer to whatever the user picks there.
+- **See the diff** → Print the routing table below, then re-ask the question.
+
+**Diff table to show:**
+
+```
+Role                 v9.28 (old)                v9.29 (new)
+architect            codex:gpt-5.4              claude-opus:claude-opus-4.7   (was GPT-5.4)
+reviewer             codex-review:gpt-5.4       codex-review:gpt-5.4          (alias → code-reviewer)
+code-reviewer        —                          codex-review:gpt-5.4          (NEW, same as reviewer)
+security-reviewer    —                          claude-opus:claude-opus-4.7   (NEW, split from reviewer)
+implementer          codex:gpt-5.4              codex:gpt-5.4                 (unchanged)
+implementer-heavy    —                          claude-opus:claude-opus-4.7   (NEW, opt-in via role name)
+synthesizer          claude:claude-sonnet-4.6   claude:claude-sonnet-4.6      (unchanged)
+strategist           claude-opus:claude-opus-4.6 claude-opus:claude-opus-4.7  (already on 4.7 via resolver)
+researcher           gemini:gemini-3.1-pro      gemini:gemini-3.1-pro         (unchanged)
+
+Cost impact (per MTok): Opus 4.7 $5/$25 vs GPT-5.4 $2.50/$15 — roughly 2x for planning phases.
+Graceful fallback: roles requiring Opus silently downshift to GPT-5.4 if no Anthropic auth.
+Opt-out anytime: OCTOPUS_LEGACY_ROLES=1
+```
+
+**WHY:** Existing users should not silently inherit the new defaults without a chance to opt out. The one-time prompt gates the behavior change on explicit consent, surfaces cost impact, and writes state so the prompt doesn't recur. Skip entirely for fresh installs (they have no prior mental model to migrate).
+
 ## STEP 3: Interactive Menu (ALWAYS show — even for returning users)
 
 **Always present this menu after the dashboard, regardless of current setup state:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [9.29.0] - 2026-04-22
+
+### Changed
+
+- **Role default refresh based on April 2026 benchmarks**: `architect`, `strategist`, and new `security-reviewer` role now default to Claude Opus 4.7 (SWE-bench Pro 64.3 vs 57.7, MCP-Atlas tool use +9.2, LMArena #1). `code-reviewer` and `implementer` stay on GPT-5.4 (Terminal-Bench 75.1, edge-case review). `reviewer` is preserved as an alias for `code-reviewer`.
+- **New opt-in `implementer-heavy` role** for greenfield / large refactors / UI-heavy builds — routes to Claude Opus 4.7. Not auto-selected; callers must request it explicitly.
+- **New `plugin/docs/GPT-5.4-PROMPTING.md`** — condensed OpenAI prompt guidance (reasoning effort tiers, output contracts, tool persistence, `phase` field, `gpt-5.4-mini` patterns). Referenced from Codex dispatchers and code-reviewer persona.
+- **Migration prompt** in `/octo:setup` fires once for users upgrading from ≤9.28: explains the routing change, surfaces the Opus 4.7 cost impact (~2x GPT-5.4), offers `OCTOPUS_LEGACY_ROLES=1` opt-out to restore v9.28 mapping.
+
+### Opt-out
+
+Set `OCTOPUS_LEGACY_ROLES=1` to restore the v9.28 role mapping verbatim.
+
+---
+
 ## [9.28.0] - 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-146_passing-brightgreen" alt="146 tests passing">
-  <img src="https://img.shields.io/badge/Version-9.28.0-blue" alt="Version 9.28.0">
+  <img src="https://img.shields.io/badge/Version-9.29.0-blue" alt="Version 9.29.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.83+-blueviolet" alt="Requires Claude Code v2.1.83+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -246,16 +246,18 @@ Claude Octopus coordinates up to eight AI providers — one per tentacle:
 
 | Provider | Role |
 |----------|------|
-| 🔴 Codex (OpenAI) | Implementation depth — code patterns, technical analysis, architecture |
-| 🟡 Gemini (Google) | Ecosystem breadth — alternatives, security review, research synthesis |
+| 🔴 Codex (OpenAI, GPT-5.4) | Code review + implementation — edge-case hunting, terminal-heavy execution, patch/test loops |
+| 🟡 Gemini (Google) | Ecosystem breadth — alternatives, research synthesis |
 | 🟣 Perplexity | Live web search — CVE lookups, dependency research, current docs |
 | 🌐 OpenRouter | Alternative model routing — access 100+ models via single API |
 | 🟢 Copilot (GitHub) | Zero-cost research — uses existing GitHub Copilot subscription |
 | 🟤 Qwen (Alibaba) | Free-tier research — 1,000-2,000 requests/day via Qwen OAuth |
 | ⚫ Ollama (Local) | Zero-cost local LLM — offline, privacy-sensitive, fallback |
-| 🔵 Claude (Anthropic) | Orchestration — quality gates, consensus building, final synthesis |
+| 🔵 Claude (Anthropic, Opus 4.7 + Sonnet 4.6) | Architecture, strategy, security review, orchestration, consensus, final synthesis |
 
 Providers run in parallel for research, sequentially for problem scoping, and adversarially for review. A 75% consensus quality gate prevents questionable work from shipping. Only Claude is required — all others are optional and auto-detected.
+
+**v9.29.0 role defaults** (April 2026 benchmark refresh): `architect`, `strategist`, and `security-reviewer` default to Claude Opus 4.7 (leads SWE-bench Pro 64.3, MCP-Atlas tool use +9.2, LMArena #1). `code-reviewer` and `implementer` default to GPT-5.4 (leads Terminal-Bench 75.1, edge-case review). Opt out with `OCTOPUS_LEGACY_ROLES=1` to restore the v9.28 mapping. See [CHANGELOG](CHANGELOG.md#9290---2026-04-22) and [GPT-5.4 prompting guide](docs/GPT-5.4-PROMPTING.md).
 
 ### Four Phases: Discover, Define, Develop, Deliver
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,22 +34,43 @@ Claude Octopus coordinates **eight AI providers** — one per tentacle to give y
 |----------|----------|------------------|-------------|
 | **Codex CLI** | `codex exec --model gpt-5.4` | GPT-5.4 | Your `OPENAI_API_KEY` |
 | **Gemini CLI** | `gemini -y -m gemini-3.1-pro-preview` | Gemini 3.1 Pro Preview | Your `GEMINI_API_KEY` |
-| **Claude** | Built-in | Claude Sonnet 4.6 / Opus 4.6 | Your Claude Code subscription |
+| **Claude** | Built-in | Claude Sonnet 4.6 / Opus 4.7 | Your Claude Code subscription |
 | **Perplexity** | API-only | Sonar Pro / Sonar | Your `PERPLEXITY_API_KEY` |
 | **OpenRouter** | API-only | 100+ models (GLM-5, Kimi K2.5, DeepSeek R1, etc.) | Your `OPENROUTER_API_KEY` |
 | **Ollama** *(optional)* | `ollama run <model>` | Local models (llama3.3, mistral, etc.) | Free (local) |
 | **Copilot** *(optional)* | `copilot -p` | GitHub models (Claude/GPT/Gemini) | GitHub Copilot subscription |
 | **Qwen** *(optional)* | `qwen -p` | Qwen3-Coder | Qwen OAuth (free tier) |
 
-> **Note:** Models are as of March 2026. The orchestrate.sh script uses the latest available models. Only Claude is required — all others are optional and auto-detected.
+> **Note:** Models are as of April 2026. The orchestrate.sh script uses the latest available models. Only Claude is required — all others are optional and auto-detected.
+
+### Role → Model Mapping (v9.29+)
+
+Role defaults refreshed based on April 2026 benchmark consensus. See [GPT-5.4 prompting guide](./GPT-5.4-PROMPTING.md) for dispatcher patterns.
+
+| Role                 | Default Model         | Why                                                                 |
+|----------------------|-----------------------|---------------------------------------------------------------------|
+| `architect`          | Claude Opus 4.7       | SWE-bench Pro 64.3, MCP-Atlas +9.2, LMArena #1; UI/UX taste         |
+| `strategist`         | Claude Opus 4.7       | Premium arbitration, architecture tradeoffs                         |
+| `security-reviewer`  | Claude Opus 4.7       | Adversarial reasoning                                               |
+| `code-reviewer`      | GPT-5.4               | Edge-case hunting; Terminal-Bench 75.1                              |
+| `reviewer` (alias)   | → `code-reviewer`     | Back-compat for v9.28 callers                                       |
+| `implementer`        | GPT-5.4               | Terminal-heavy execution, iterative patch/test loops                |
+| `implementer-heavy`  | Claude Opus 4.7       | Opt-in only; greenfield / large refactors / UI-heavy builds         |
+| `synthesizer`        | Claude Sonnet 4.6     | Best aggregator price/quality                                       |
+| `researcher`         | Gemini 3.1 Pro Preview| Broad research + synthesis                                          |
+
+**Opt-out:** `OCTOPUS_LEGACY_ROLES=1` restores the v9.28 mapping (GPT-5.4 everywhere for architect/reviewer/implementer, Opus 4.6 for strategist).
+
+**Graceful fallback:** when the preferred CLI is unavailable (e.g. no Anthropic auth for architect), `lib/agents.sh` silently downshifts and logs a single notice instead of failing.
 
 ### What Each Provider Excels At
 
 | Provider | Strengths | Best For |
 |----------|-----------|----------|
-| **Codex (OpenAI)** | Code generation, structured output, technical analysis | Implementation approaches, code patterns, API design |
+| **Codex (OpenAI, GPT-5.4)** | Edge-case hunting, terminal execution, patch/test loops | Code review (`code-reviewer`), default implementation (`implementer`) |
 | **Gemini (Google)** | Research synthesis, documentation, broad knowledge | Ecosystem research, best practices, alternative perspectives |
-| **Claude** | Strategic synthesis, nuanced analysis, code review | Final synthesis, quality assessment, moderation |
+| **Claude (Opus 4.7)** | Planning, architecture, adversarial reasoning, UI/UX taste | `architect`, `strategist`, `security-reviewer`, `implementer-heavy` |
+| **Claude (Sonnet 4.6)** | Aggregation, final synthesis, workhorse summarization | `synthesizer`; included with Claude Code subscription |
 | **Perplexity** | Live web search, CVE lookups, current docs | Discover phase research, dependency analysis |
 | **OpenRouter** | Access to 100+ models, cost routing | Alternative perspectives, budget-conscious workflows |
 | **Ollama** *(optional)* | Zero-cost, offline, privacy | Brainstorming, fallback, air-gapped environments |

--- a/docs/COMMAND-REFERENCE.md
+++ b/docs/COMMAND-REFERENCE.md
@@ -277,6 +277,8 @@ Configure which AI models are used across Claude Octopus workflows.
 
 **Per-phase routing:** Different models can be configured for Discover, Define, Develop, and Deliver phases. Use `show phases` to view the current routing table.
 
+**Role-based defaults (v9.29+):** `architect`, `strategist`, and `security-reviewer` use Claude Opus 4.7; `code-reviewer` and `implementer` use GPT-5.4; `synthesizer` uses Claude Sonnet 4.6. See [ARCHITECTURE.md — Role → Model Mapping](../docs/ARCHITECTURE.md#role--model-mapping-v929) for rationale. Opt out with `OCTOPUS_LEGACY_ROLES=1`.
+
 ---
 
 ### `/octo:km`

--- a/docs/GPT-5.4-PROMPTING.md
+++ b/docs/GPT-5.4-PROMPTING.md
@@ -1,0 +1,104 @@
+# GPT-5.4 Prompting Guide (for Octopus Dispatchers)
+
+Condensed from the official OpenAI GPT-5.4 prompt guidance:
+<https://developers.openai.com/api/docs/guides/prompt-guidance>
+
+Consulted by `lib/dispatch.sh` Codex prompt builders and by the `code-reviewer`, `implementer`, and `python-pro`/`typescript-pro` personas. Keep edits synchronized with upstream OpenAI guidance.
+
+## 1. Reasoning Effort
+
+GPT-5.4 supports five effort levels: `none` < `low` < `medium` < `high` < `xhigh`. Higher ≠ better output — it just trades latency + cost for depth.
+
+| Effort  | When to use                                                          |
+|---------|----------------------------------------------------------------------|
+| `none`  | Extraction, classification, triage. Speed > depth.                   |
+| `low`   | Latency-sensitive tasks with a minor reasoning component.            |
+| `medium`| Default for most Octopus phases (probe, grasp, review).              |
+| `high`  | Complex implementation (tangle, security analysis).                  |
+| `xhigh` | Long agentic loops only. Expensive. Reserve for multi-step work.     |
+
+**Rule:** Before raising effort, tighten the prompt first. Stronger output contracts beat higher effort for most failures.
+
+## 2. Output Contracts
+
+Constrain structure and volume explicitly. GPT-5.4 tends toward verbose prose by default.
+
+```
+Return ONLY these sections, in this order:
+- Summary (1 sentence)
+- Findings (bulleted, max 5)
+- Recommendation (1 sentence)
+
+Do not add preamble. Do not wrap in markdown fences unless requested.
+Prefer concise, information-dense writing.
+```
+
+For structured output (JSON, SQL, patch files): explicitly say "Output only the requested format. No prose. No markdown fences unless requested."
+
+## 3. Tool Persistence
+
+GPT-5.4 will sometimes stop at the first plausible answer. For agentic loops:
+
+```
+Use tools whenever they materially improve correctness.
+Do not stop early if another tool call is likely to improve the answer.
+Parallelize independent retrieval steps. Sequence dependent work.
+Do not skip prerequisite steps just because the final action seems obvious.
+```
+
+## 4. `phase` Field in Multi-Step Loops
+
+When replaying prior assistant turns, preserve `phase` metadata. Missing `phase` causes GPT-5.4 to misinterpret working commentary as a final answer.
+
+- `phase=working` → intermediate thinking, tool output summarization
+- `phase=final`   → user-facing answer
+
+`lib/dispatch.sh` already tags Octopus tangle/ink iterations with phase markers — keep these intact when composing multi-turn prompts.
+
+## 5. Instruction Priority
+
+Explicit hierarchies prevent drift:
+
+```
+Priority order (highest first):
+1. Safety and honesty constraints
+2. The most recent user instruction
+3. Earlier instructions in this conversation
+4. Style / tone defaults
+
+If a newer instruction conflicts with an earlier one, follow the newer.
+```
+
+When updating a plan mid-conversation, state scope (what's replaced), override (what's new), and what carries forward.
+
+## 6. Anti-Patterns
+
+- **Empty-result acceptance.** Don't conclude "no matches" without a retry fallback.
+- **Skipped prerequisites.** Multi-step workflows commonly skip setup steps.
+- **Effort over prompt.** Users frequently crank effort instead of tightening prompt; usually prompt wins.
+- **Implicit ambiguity.** For `gpt-5.4-mini`, enumerate every edge case — don't rely on "you MUST".
+- **Unbounded verbosity.** GPT-5.4 is chatty by default. Always set output contracts.
+
+## 7. `gpt-5.4-mini` (Budget Tier)
+
+Mini is ~10x cheaper ($0.25/$2 MTok) but brittle to implicit instructions:
+
+- Put critical rules first, before context.
+- Use numbered steps for tool-use workflows.
+- Specify edge cases and ambiguity behavior explicitly.
+- Prefer structural scaffolding ("Step 1: …  Step 2: …") over narrative prose.
+
+## 8. Octopus-Specific Notes
+
+- **`/octo:review`** — dispatches to GPT-5.4 by default (edge-case strength). Use `effort=medium` + output contract requiring `severity`, `file:line`, `rationale`.
+- **`/octo:security`** — routes to Claude Opus 4.7 by default (adversarial reasoning). Skip this guide for that path.
+- **`/octo:develop`** — Codex dispatchers auto-inject the output contract block for patch generation. Don't add a second "no preamble" instruction — it's already there.
+- **Cost ceiling** — `xhigh` effort ~2x `high` latency and cost. Only set `xhigh` when the user invoked `/octo:deep` or the task type is `security` / `architecture-heavy`.
+
+## Maintenance
+
+When OpenAI updates the official guide, refresh this document. Tag the version in the first git-log entry. Callers reference this path directly — don't rename without updating:
+
+```
+grep -rn 'GPT-5.4-PROMPTING\.md' plugin/
+```

--- a/hooks/session-start-memory.sh
+++ b/hooks/session-start-memory.sh
@@ -43,12 +43,15 @@ else
     done
 fi
 
+SKIP_PREFS=0
 if [[ -z "$PREFS_FILE" || ! -f "$PREFS_FILE" ]]; then
-    # No persisted preferences — first session or memory cleared
-    exit 0
+    # No persisted preferences — first session or memory cleared.
+    # Skip prefs/managed-settings/claude-mem blocks but still run cache hygiene.
+    SKIP_PREFS=1
 fi
 
 # --- 2. Parse preferences and inject into session ---
+if [[ "$SKIP_PREFS" == "0" ]]; then
 AUTONOMY=""
 PROVIDERS=""
 
@@ -111,6 +114,30 @@ if [[ -x "$BRIDGE_SCRIPT" ]]; then
     if [[ -n "$MEM_CONTEXT" ]]; then
         echo "[Octopus] claude-mem context available:"
         echo "$MEM_CONTEXT"
+    fi
+fi
+fi  # end SKIP_PREFS guard
+
+# --- 6. Cache hygiene advisory (v9.29.0) ---
+# Notify when 3+ stale octo cache versions exist. Auto-clean only when explicitly
+# opted in via OCTOPUS_AUTO_CLEAN_CACHE=1 — never delete without consent.
+HYGIENE_LIB="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}/scripts/lib/cache-hygiene.sh"
+if [[ -r "$HYGIENE_LIB" ]]; then
+    # shellcheck disable=SC1090
+    source "$HYGIENE_LIB"
+    STALE_COUNT=$(octo_cache_stale 2>/dev/null | grep -c . || true)
+    STALE_COUNT="${STALE_COUNT:-0}"
+    if [[ "$STALE_COUNT" -ge 3 ]]; then
+        STALE_BYTES=$(octo_cache_stale_bytes 2>/dev/null || echo 0)
+        STALE_HUMAN=$(octo_cache_format_bytes "$STALE_BYTES" 2>/dev/null || echo "")
+        if [[ "${OCTOPUS_AUTO_CLEAN_CACHE:-0}" == "1" ]]; then
+            CLEANED=$(octo_cache_clean 2>/dev/null | grep -c '^removed:' || true)
+            CLEANED="${CLEANED:-0}"
+            [[ "$CLEANED" -gt 0 ]] && \
+                echo "[🐙] Cleaned ${CLEANED} stale octo cache version(s) — ${STALE_HUMAN} reclaimed"
+        else
+            echo "[🐙] ${STALE_COUNT} stale octo cache version(s) (${STALE_HUMAN}). Run /octo:doctor to clean, or set OCTOPUS_AUTO_CLEAN_CACHE=1."
+        fi
     fi
 fi
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.28.0",
+  "version": "9.29.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -16,16 +16,40 @@ _BARE_OPT="${_BARE_OPT:-}"
 
 # Role-to-agent mapping (function-based for bash 3.x compatibility)
 # Returns agent:model format for a given role
+#
+# v9.29: Role defaults refreshed based on April 2026 benchmark + forum consensus.
+#   - architect/strategist/security-reviewer → claude-opus (SWE-bench Pro 64.3, LMArena #1, MCP-Atlas +9.2)
+#   - code-reviewer/implementer              → gpt-5.4    (Terminal-Bench 75.1, edge-case review)
+# Opt-out:   OCTOPUS_LEGACY_ROLES=1 restores the v9.28 mapping.
+# Fallback:  consumers (see lib/agents.sh get_fallback_agent) silently downshift when the
+#            preferred CLI is unavailable (e.g. no Anthropic auth → architect → gpt-5.4).
 get_role_mapping() {
     local role="$1"
+
+    # Legacy opt-out — v9.28 mapping, preserved verbatim.
+    if [[ "${OCTOPUS_LEGACY_ROLES:-0}" == "1" ]]; then
+        case "$role" in
+            architect)    echo "codex:gpt-5.4" ;;
+            researcher)   echo "gemini:gemini-3.1-pro-preview" ;;
+            reviewer|code-reviewer|security-reviewer) echo "codex-review:gpt-5.4" ;;
+            implementer|implementer-heavy) echo "codex:gpt-5.4" ;;
+            synthesizer)  echo "claude:claude-sonnet-4.6" ;;
+            strategist)   echo "claude-opus:claude-opus-4.6" ;;
+            *)            echo "codex:gpt-5.4" ;;
+        esac
+        return 0
+    fi
+
     case "$role" in
-        architect)    echo "codex:gpt-5.4" ;;                  # System design, planning (v8.48: GPT-5.4)
-        researcher)   echo "gemini:gemini-3.1-pro-preview" ;;   # Deep investigation
-        reviewer)     echo "codex-review:gpt-5.4" ;;          # Code review, validation (v8.48: GPT-5.4)
-        implementer)  echo "codex:gpt-5.4" ;;                 # Code generation (v8.48: GPT-5.4)
-        synthesizer)  echo "claude:claude-sonnet-4.6" ;;      # Result aggregation (v8.17: Sonnet 4.6)
-        strategist)   echo "claude-opus:claude-opus-4.6" ;;   # Premium synthesis (v8.0: Opus 4.6)
-        *)            echo "codex:gpt-5.4" ;;                 # Default (v8.48: GPT-5.4)
+        architect)         echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-4.7)" ;;  # Planning, UI/UX, architecture
+        researcher)        echo "gemini:gemini-3.1-pro-preview" ;;                                          # Deep investigation
+        reviewer|code-reviewer) echo "codex-review:gpt-5.4" ;;                                              # Code review, edge cases; `reviewer` = alias
+        security-reviewer) echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-4.7)" ;;  # Adversarial reasoning
+        implementer)       echo "codex:gpt-5.4" ;;                                                          # Default code generation; terminal-heavy
+        implementer-heavy) echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-4.7)" ;;  # Opt-in: greenfield/refactor/UI-heavy
+        synthesizer)       echo "claude:claude-sonnet-4.6" ;;                                               # Result aggregation
+        strategist)        echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-4.7)" ;;  # Premium synthesis
+        *)                 echo "codex:gpt-5.4" ;;                                                          # Safe default
     esac
 }
 

--- a/scripts/lib/cache-hygiene.sh
+++ b/scripts/lib/cache-hygiene.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# cache-hygiene.sh — detect and clean stale octo plugin cache versions.
+# All functions are read-only by default; cleanup is opt-in via octo_cache_clean.
+#
+# Layout: ~/.claude/plugins/cache/nyldn-plugins/octo/<version>/
+#
+# Keep policy: current + 1 previous (for rollback safety). Override via
+# OCTOPUS_CACHE_KEEP=N (must be >=1).
+
+OCTO_CACHE_DIR="${HOME}/.claude/plugins/cache/nyldn-plugins/octo"
+
+# Versions on disk, sorted oldest → newest.
+octo_cache_versions() {
+    [[ -d "$OCTO_CACHE_DIR" ]] || return 0
+    # -V handles semver; tolerate macOS sort which lacks -V on older systems
+    if sort -V </dev/null >/dev/null 2>&1; then
+        ls -1 "$OCTO_CACHE_DIR" 2>/dev/null | sort -V
+    else
+        ls -1 "$OCTO_CACHE_DIR" 2>/dev/null | sort
+    fi
+}
+
+# Active version, derived from CLAUDE_PLUGIN_ROOT (set by CC at hook time).
+# Returns empty when not running inside a hook context.
+octo_cache_active_version() {
+    [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]] || return 0
+    case "$CLAUDE_PLUGIN_ROOT" in
+        */cache/nyldn-plugins/octo/*) basename "$CLAUDE_PLUGIN_ROOT" ;;
+    esac
+}
+
+# Versions safe to delete (everything except the last $keep).
+# Defaults to keeping current + 1 previous.
+octo_cache_stale() {
+    local keep="${OCTOPUS_CACHE_KEEP:-2}"
+    [[ "$keep" =~ ^[1-9][0-9]*$ ]] || keep=2
+    local total
+    total=$(octo_cache_versions | wc -l | tr -d ' ')
+    [[ "$total" -le "$keep" ]] && return 0
+    local drop=$((total - keep))
+    octo_cache_versions | head -n "$drop"
+}
+
+# Total bytes used by stale versions (for user-facing reports).
+octo_cache_stale_bytes() {
+    local v size=0 path
+    while IFS= read -r v; do
+        [[ -z "$v" ]] && continue
+        path="${OCTO_CACHE_DIR}/${v}"
+        [[ -d "$path" ]] || continue
+        # du -sk: 1024-byte blocks, portable across macOS/Linux
+        local kb
+        kb=$(du -sk "$path" 2>/dev/null | awk '{print $1}')
+        [[ -n "$kb" ]] && size=$((size + kb * 1024))
+    done < <(octo_cache_stale)
+    printf '%s' "$size"
+}
+
+# Human-readable size formatter (KB/MB/GB).
+octo_cache_format_bytes() {
+    local b="${1:-0}"
+    if [[ "$b" -ge 1073741824 ]]; then
+        printf '%.1fGB' "$(echo "scale=1; $b/1073741824" | bc 2>/dev/null || echo "$b")"
+    elif [[ "$b" -ge 1048576 ]]; then
+        printf '%.1fMB' "$(echo "scale=1; $b/1048576" | bc 2>/dev/null || echo "$b")"
+    elif [[ "$b" -ge 1024 ]]; then
+        printf '%.1fKB' "$(echo "scale=1; $b/1024" | bc 2>/dev/null || echo "$b")"
+    else
+        printf '%dB' "$b"
+    fi
+}
+
+# Delete stale versions. Skips the active version even if older than the keep
+# window (defensive — should never happen, but cheap insurance).
+# Outputs one line per deletion. Non-zero exit only on filesystem error.
+octo_cache_clean() {
+    local active stale_versions deleted=0
+    active=$(octo_cache_active_version)
+    while IFS= read -r v; do
+        [[ -z "$v" ]] && continue
+        if [[ -n "$active" && "$v" == "$active" ]]; then
+            continue
+        fi
+        local path="${OCTO_CACHE_DIR}/${v}"
+        [[ -d "$path" ]] || continue
+        if rm -rf "$path" 2>/dev/null; then
+            echo "removed: $v"
+            deleted=$((deleted + 1))
+        else
+            echo "failed: $v" >&2
+        fi
+    done < <(octo_cache_stale)
+    [[ "$deleted" -gt 0 ]] || echo "no stale versions to remove"
+}
+
+# Direct CLI: list | stale | clean | size
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    case "${1:-list}" in
+        list)  octo_cache_versions ;;
+        stale) octo_cache_stale ;;
+        size)  octo_cache_format_bytes "$(octo_cache_stale_bytes)" ;;
+        clean) octo_cache_clean ;;
+        *) echo "Usage: $0 {list|stale|size|clean}" >&2; exit 1 ;;
+    esac
+fi

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -1187,6 +1187,50 @@ doctor_check_recurrence() {
     fi
 }
 
+# --- Category 12: Plugin cache hygiene (v9.29.0) ---
+# Reports stale octo cache versions so users can reclaim disk space.
+# Cleanup is interactive — never deletes from this check.
+doctor_check_cache() {
+    local hygiene_lib="${OCTOPUS_LIB_DIR:-$(dirname "${BASH_SOURCE[0]}")}/cache-hygiene.sh"
+    if [[ ! -r "$hygiene_lib" ]]; then
+        doctor_add "cache-hygiene-lib" "cache" "info" \
+            "cache-hygiene.sh not found — skipping" "$hygiene_lib"
+        return
+    fi
+    # shellcheck disable=SC1090
+    source "$hygiene_lib"
+
+    local total stale_count
+    total=$(octo_cache_versions | wc -l | tr -d ' ')
+    stale_count=$(octo_cache_stale | grep -c . || true)
+    stale_count="${stale_count:-0}"
+
+    if [[ "$total" -eq 0 ]]; then
+        doctor_add "cache-versions" "cache" "info" \
+            "No octo cache directory yet" "$OCTO_CACHE_DIR"
+        return
+    fi
+
+    local active="${CLAUDE_PLUGIN_ROOT:+$(octo_cache_active_version)}"
+    local active_msg=""
+    [[ -n "$active" ]] && active_msg=" (active: ${active})"
+
+    if [[ "$stale_count" -eq 0 ]]; then
+        doctor_add "cache-versions" "cache" "pass" \
+            "${total} octo version(s) cached${active_msg}" "Within keep window (${OCTOPUS_CACHE_KEEP:-2})"
+        return
+    fi
+
+    local bytes human stale_list
+    bytes=$(octo_cache_stale_bytes)
+    human=$(octo_cache_format_bytes "$bytes")
+    stale_list=$(octo_cache_stale | tr '\n' ',' | sed 's/,$//;s/,/, /g')
+
+    doctor_add "cache-stale-versions" "cache" "warn" \
+        "${stale_count} stale octo version(s) — ${human}${active_msg}" \
+        "Stale: ${stale_list}. Run: bash \$CLAUDE_PLUGIN_ROOT/scripts/lib/cache-hygiene.sh clean (or set OCTOPUS_AUTO_CLEAN_CACHE=1)"
+}
+
 # --- Output: Human-readable ---
 doctor_output_human() {
     local verbose="${1:-false}"
@@ -1296,7 +1340,7 @@ do_doctor() {
     DOCTOR_RESULTS_DETAIL=()
 
     # Run checks (filtered if category specified)
-    local categories=(providers auth config state smoke hooks scheduler skills conflicts agents recurrence)
+    local categories=(providers auth config state smoke hooks scheduler skills conflicts agents recurrence cache)
     for cat in "${categories[@]}"; do
         if [[ -z "$category_filter" || "$category_filter" == "$cat" ]]; then
             "doctor_check_${cat}"

--- a/tests/unit/test-cache-hygiene.sh
+++ b/tests/unit/test-cache-hygiene.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/lib/cache-hygiene.sh — stale plugin cache detection.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/scripts/lib/cache-hygiene.sh"
+
+# shellcheck disable=SC1090
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Cache Hygiene (v9.29.0)"
+
+# Each test gets a fake $HOME so we never touch the real cache.
+make_fake_home() {
+    local h
+    h=$(mktemp -d)
+    mkdir -p "$h/.claude/plugins/cache/nyldn-plugins/octo"
+    echo "$h"
+}
+
+seed_versions() {
+    local home="$1"; shift
+    local v
+    for v in "$@"; do
+        mkdir -p "$home/.claude/plugins/cache/nyldn-plugins/octo/$v"
+        # write ~1KB so size math has something to chew on
+        head -c 1024 /dev/urandom > "$home/.claude/plugins/cache/nyldn-plugins/octo/$v/payload"
+    done
+}
+
+test_lib_sourceable() {
+    test_case "cache-hygiene.sh is readable and syntactically valid"
+    [[ -r "$LIB" ]] && bash -n "$LIB" && test_pass || test_fail "lib missing or has syntax errors"
+}
+
+test_versions_empty() {
+    test_case "octo_cache_versions is empty when no cache exists"
+    local fh; fh=$(mktemp -d)  # no octo dir
+    local out
+    out=$(HOME="$fh" bash -c "source '$LIB'; octo_cache_versions" || true)
+    rm -rf "$fh"
+    [[ -z "$out" ]] && test_pass || test_fail "expected empty, got: $out"
+}
+
+test_versions_sorted() {
+    test_case "octo_cache_versions returns versions sorted oldest→newest"
+    local fh; fh=$(make_fake_home)
+    seed_versions "$fh" 9.10.0 9.2.0 9.28.0
+    local out
+    out=$(HOME="$fh" bash -c "source '$LIB'; octo_cache_versions" | tr '\n' ',' | sed 's/,$//')
+    rm -rf "$fh"
+    [[ "$out" == "9.2.0,9.10.0,9.28.0" ]] \
+        && test_pass \
+        || test_fail "expected 9.2.0,9.10.0,9.28.0 got: $out"
+}
+
+test_stale_keeps_default_two() {
+    test_case "octo_cache_stale keeps the 2 newest by default"
+    local fh; fh=$(make_fake_home)
+    seed_versions "$fh" 9.25.0 9.26.0 9.27.0 9.28.0
+    local out
+    out=$(HOME="$fh" bash -c "source '$LIB'; octo_cache_stale" | tr '\n' ',' | sed 's/,$//')
+    rm -rf "$fh"
+    [[ "$out" == "9.25.0,9.26.0" ]] \
+        && test_pass \
+        || test_fail "expected 9.25.0,9.26.0 got: $out"
+}
+
+test_stale_respects_keep_env() {
+    test_case "OCTOPUS_CACHE_KEEP overrides default keep window"
+    local fh; fh=$(make_fake_home)
+    seed_versions "$fh" 9.25.0 9.26.0 9.27.0 9.28.0
+    local out
+    out=$(HOME="$fh" OCTOPUS_CACHE_KEEP=1 bash -c "source '$LIB'; octo_cache_stale" | tr '\n' ',' | sed 's/,$//')
+    rm -rf "$fh"
+    [[ "$out" == "9.25.0,9.26.0,9.27.0" ]] \
+        && test_pass \
+        || test_fail "expected 9.25.0,9.26.0,9.27.0 got: $out"
+}
+
+test_stale_under_threshold() {
+    test_case "octo_cache_stale returns nothing when total ≤ keep"
+    local fh; fh=$(make_fake_home)
+    seed_versions "$fh" 9.27.0 9.28.0
+    local out
+    out=$(HOME="$fh" bash -c "source '$LIB'; octo_cache_stale" || true)
+    rm -rf "$fh"
+    [[ -z "$out" ]] && test_pass || test_fail "expected empty, got: $out"
+}
+
+test_active_version_extracted() {
+    test_case "octo_cache_active_version reads CLAUDE_PLUGIN_ROOT"
+    local out
+    out=$(CLAUDE_PLUGIN_ROOT=/some/cache/nyldn-plugins/octo/9.28.0 \
+          bash -c "source '$LIB'; octo_cache_active_version")
+    [[ "$out" == "9.28.0" ]] \
+        && test_pass \
+        || test_fail "expected 9.28.0 got: $out"
+}
+
+test_clean_skips_active() {
+    test_case "octo_cache_clean refuses to delete the active version"
+    local fh; fh=$(make_fake_home)
+    seed_versions "$fh" 9.25.0 9.26.0 9.27.0 9.28.0
+    HOME="$fh" CLAUDE_PLUGIN_ROOT="$fh/.claude/plugins/cache/nyldn-plugins/octo/9.25.0" \
+        OCTOPUS_CACHE_KEEP=1 \
+        bash -c "source '$LIB'; octo_cache_clean" >/dev/null
+    local survivors
+    survivors=$(HOME="$fh" bash -c "source '$LIB'; octo_cache_versions" | tr '\n' ',' | sed 's/,$//')
+    rm -rf "$fh"
+    # active 9.25.0 survives despite being in stale list; 9.28.0 also survives (kept)
+    [[ "$survivors" == *"9.25.0"* && "$survivors" == *"9.28.0"* ]] \
+        && test_pass \
+        || test_fail "active version was deleted, survivors: $survivors"
+}
+
+test_clean_removes_stale() {
+    test_case "octo_cache_clean removes versions outside the keep window"
+    local fh; fh=$(make_fake_home)
+    seed_versions "$fh" 9.25.0 9.26.0 9.27.0 9.28.0
+    HOME="$fh" bash -c "source '$LIB'; octo_cache_clean" >/dev/null
+    local survivors
+    survivors=$(HOME="$fh" bash -c "source '$LIB'; octo_cache_versions" | tr '\n' ',' | sed 's/,$//')
+    rm -rf "$fh"
+    [[ "$survivors" == "9.27.0,9.28.0" ]] \
+        && test_pass \
+        || test_fail "expected 9.27.0,9.28.0 got: $survivors"
+}
+
+test_format_bytes() {
+    test_case "octo_cache_format_bytes renders human-readable sizes"
+    local out
+    out=$(bash -c "source '$LIB'; octo_cache_format_bytes 1048576")
+    [[ "$out" == "1.0MB" ]] \
+        && test_pass \
+        || test_fail "expected 1.0MB got: $out"
+}
+
+test_lib_sourceable
+test_versions_empty
+test_versions_sorted
+test_stale_keeps_default_two
+test_stale_respects_keep_env
+test_stale_under_threshold
+test_active_version_extracted
+test_clean_skips_active
+test_clean_removes_stale
+test_format_bytes
+
+test_summary

--- a/tests/unit/test-cost-projections.sh
+++ b/tests/unit/test-cost-projections.sh
@@ -15,12 +15,15 @@ fail() { test_case "$1"; test_fail "${2:-$1}"; }
 
 assert_contains() {
   local output="$1" pattern="$2" label="$3"
-  echo "$output" | grep -qE "$pattern" && pass "$label" || fail "$label" "missing: $pattern"
+  # Herestring avoids macOS BSD-grep SIGPIPE on `echo | grep -q` under set -o pipefail:
+  # grep exits on first match before echo finishes writing → pipeline reports failure
+  # → pass branch never runs → false negative. No pipe, no SIGPIPE.
+  grep -qE "$pattern" <<< "$output" && pass "$label" || fail "$label" "missing: $pattern"
 }
 
 assert_not_contains() {
   local output="$1" pattern="$2" label="$3"
-  echo "$output" | grep -qE "$pattern" && fail "$label" "should not contain: $pattern" || pass "$label"
+  grep -qE "$pattern" <<< "$output" && fail "$label" "should not contain: $pattern" || pass "$label"
 }
 
 # ── File exists ──────────────────────────────────────────────────────────────

--- a/tests/unit/test-metric-loop.sh
+++ b/tests/unit/test-metric-loop.sh
@@ -19,7 +19,7 @@ COMMAND_CONTENT="$(<"$COMMAND_FILE")"
 
 # ── Skill: Metric Verification Mode section exists ───────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc '## Metric Verification Mode' 2>/dev/null; then
+if grep -q '## Metric Verification Mode' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: has 'Metric Verification Mode' section"
 else
     fail "skill: has 'Metric Verification Mode' section" "section heading not found"
@@ -27,7 +27,7 @@ fi
 
 # ── Skill: git commit with experiment: prefix ────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc 'experiment:' 2>/dev/null; then
+if grep -q 'experiment:' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: mentions git commit with experiment: prefix"
 else
     fail "skill: mentions git commit with experiment: prefix" "experiment: prefix not found"
@@ -35,7 +35,7 @@ fi
 
 # ── Skill: git revert on regression ──────────────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc 'git revert HEAD --no-edit' 2>/dev/null; then
+if grep -q 'git revert HEAD --no-edit' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: mentions git revert on regression"
 else
     fail "skill: mentions git revert on regression" "git revert pattern not found"
@@ -43,7 +43,7 @@ fi
 
 # ── Skill: Guard command documented ──────────────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc 'Guard.*command' 2>/dev/null; then
+if grep -q 'Guard.*command' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: documents Guard command"
 else
     fail "skill: documents Guard command" "Guard command not documented"
@@ -51,7 +51,7 @@ fi
 
 # ── Skill: JSONL experiment log ──────────────────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc '\.jsonl' 2>/dev/null; then
+if grep -q '\.jsonl' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: mentions JSONL experiment log"
 else
     fail "skill: mentions JSONL experiment log" ".jsonl not found"
@@ -59,7 +59,7 @@ fi
 
 # ── Skill: experiments directory path ────────────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc '\.claude-octopus/experiments' 2>/dev/null; then
+if grep -q '\.claude-octopus/experiments' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: specifies .claude-octopus/experiments/ directory"
 else
     fail "skill: specifies .claude-octopus/experiments/ directory" "experiments directory path not found"
@@ -67,7 +67,7 @@ fi
 
 # ── Skill: Direction parameter ───────────────────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc 'Direction.*higher.*lower\|Direction.*lower.*higher' 2>/dev/null; then
+if grep -q 'Direction.*higher.*lower\|Direction.*lower.*higher' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: documents Direction parameter (higher/lower)"
 else
     fail "skill: documents Direction parameter (higher/lower)" "Direction higher|lower not found"
@@ -75,7 +75,7 @@ fi
 
 # ── Skill: baseline on iteration 0 ──────────────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc 'Iteration 0.*Baseline\|Establish Baseline\|baseline' 2>/dev/null; then
+if grep -q 'Iteration 0.*Baseline\|Establish Baseline\|baseline' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: establishes baseline on iteration 0"
 else
     fail "skill: establishes baseline on iteration 0" "baseline establishment not found"
@@ -83,7 +83,7 @@ fi
 
 # ── Skill: resume behavior documented ────────────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc 'Resume Behavior\|resume.*experiment' 2>/dev/null; then
+if grep -q 'Resume Behavior\|resume.*experiment' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: documents resume behavior"
 else
     fail "skill: documents resume behavior" "resume behavior not documented"
@@ -91,7 +91,7 @@ fi
 
 # ── Skill: atomic one-change-per-iteration principle ─────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc 'One change per iteration\|one atomic change\|ONE focused change' 2>/dev/null; then
+if grep -q 'One change per iteration\|one atomic change\|ONE focused change' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: enforces one change per iteration"
 else
     fail "skill: enforces one change per iteration" "atomic change principle not found"
@@ -99,7 +99,7 @@ fi
 
 # ── Skill: simplicity wins principle ─────────────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc 'Simplicity wins\|simplicity wins' 2>/dev/null; then
+if grep -q 'Simplicity wins\|simplicity wins' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: includes simplicity wins principle"
 else
     fail "skill: includes simplicity wins principle" "simplicity wins not found"
@@ -107,7 +107,7 @@ fi
 
 # ── Skill: mechanical verification (not subjective) ─────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc 'Mechanical verification\|mechanical.*verification\|no subjective' 2>/dev/null; then
+if grep -q 'Mechanical verification\|mechanical.*verification\|no subjective' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: emphasizes mechanical (not subjective) verification"
 else
     fail "skill: emphasizes mechanical (not subjective) verification" "mechanical verification not found"
@@ -117,7 +117,7 @@ fi
 
 has_all_fields=true
 for field in iteration timestamp metric best status description commit; do
-    if ! echo "$SKILL_CONTENT" | grep -qc "\"$field\"" 2>/dev/null; then
+    if ! grep -q "\"$field\"" <<< "$SKILL_CONTENT" 2>/dev/null; then
         has_all_fields=false
         break
     fi
@@ -130,7 +130,7 @@ fi
 
 # ── Skill: fallback to standard behavior ─────────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc 'Falls back.*standard\|Falls back.*current\|no metric.*specified' 2>/dev/null; then
+if grep -q 'Falls back.*standard\|Falls back.*current\|no metric.*specified' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: falls back to standard behavior without metric"
 else
     fail "skill: falls back to standard behavior without metric" "fallback behavior not documented"
@@ -138,7 +138,7 @@ fi
 
 # ── Skill: Iterations parameter (bounded mode) ──────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc 'Iterations.*N\|Iterations.*max' 2>/dev/null; then
+if grep -q 'Iterations.*N\|Iterations.*max' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: documents Iterations parameter for bounded mode"
 else
     fail "skill: documents Iterations parameter for bounded mode" "Iterations parameter not found"
@@ -148,7 +148,7 @@ fi
 
 has_all_statuses=true
 for status in kept reverted error; do
-    if ! echo "$SKILL_CONTENT" | grep -qc "\"$status\"" 2>/dev/null; then
+    if ! grep -q "\"$status\"" <<< "$SKILL_CONTENT" 2>/dev/null; then
         has_all_statuses=false
         break
     fi
@@ -161,7 +161,7 @@ fi
 
 # ── Skill: no attribution references ─────────────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qic 'autoresearch\|karpathy\|pi-autoresearch' 2>/dev/null; then
+if grep -qi 'autoresearch\|karpathy\|pi-autoresearch' <<< "$SKILL_CONTENT" 2>/dev/null; then
     fail "skill: no attribution references" "found prohibited attribution reference"
 else
     pass "skill: no attribution references"
@@ -169,7 +169,7 @@ fi
 
 # ── Skill: original content preserved ────────────────────────────────────────
 
-if echo "$SKILL_CONTENT" | grep -qc '## The Process' 2>/dev/null; then
+if grep -q '## The Process' <<< "$SKILL_CONTENT" 2>/dev/null; then
     pass "skill: original content preserved (The Process section exists)"
 else
     fail "skill: original content preserved (The Process section exists)" "original section missing"
@@ -177,7 +177,7 @@ fi
 
 # ── Command: references metric mode ──────────────────────────────────────────
 
-if echo "$COMMAND_CONTENT" | grep -qc 'Metric.*Mode\|metric.*mode\|Metric.*Verification' 2>/dev/null; then
+if grep -q 'Metric.*Mode\|metric.*mode\|Metric.*Verification' <<< "$COMMAND_CONTENT" 2>/dev/null; then
     pass "command: references metric mode"
 else
     fail "command: references metric mode" "metric mode not referenced in loop.md"
@@ -185,7 +185,7 @@ fi
 
 # ── Command: shows metric example ────────────────────────────────────────────
 
-if echo "$COMMAND_CONTENT" | grep -qc 'Metric:.*Direction:' 2>/dev/null; then
+if grep -q 'Metric:.*Direction:' <<< "$COMMAND_CONTENT" 2>/dev/null; then
     pass "command: shows metric mode example with Metric: and Direction:"
 else
     fail "command: shows metric mode example with Metric: and Direction:" "example not found"
@@ -193,7 +193,7 @@ fi
 
 # ── Command: documents Guard parameter ───────────────────────────────────────
 
-if echo "$COMMAND_CONTENT" | grep -qc 'Guard:' 2>/dev/null; then
+if grep -q 'Guard:' <<< "$COMMAND_CONTENT" 2>/dev/null; then
     pass "command: documents Guard parameter"
 else
     fail "command: documents Guard parameter" "Guard: not found in loop.md"
@@ -201,7 +201,7 @@ fi
 
 # ── Command: documents Iterations parameter ──────────────────────────────────
 
-if echo "$COMMAND_CONTENT" | grep -qc 'Iterations:' 2>/dev/null; then
+if grep -q 'Iterations:' <<< "$COMMAND_CONTENT" 2>/dev/null; then
     pass "command: documents Iterations parameter"
 else
     fail "command: documents Iterations parameter" "Iterations: not found in loop.md"
@@ -209,7 +209,7 @@ fi
 
 # ── Command: original content preserved ──────────────────────────────────────
 
-if echo "$COMMAND_CONTENT" | grep -qc '## Integration with Other Skills' 2>/dev/null; then
+if grep -q '## Integration with Other Skills' <<< "$COMMAND_CONTENT" 2>/dev/null; then
     pass "command: original content preserved (Integration section exists)"
 else
     fail "command: original content preserved (Integration section exists)" "original section missing"
@@ -217,7 +217,7 @@ fi
 
 # ── Command: no attribution references ───────────────────────────────────────
 
-if echo "$COMMAND_CONTENT" | grep -qic 'autoresearch\|karpathy\|pi-autoresearch' 2>/dev/null; then
+if grep -qi 'autoresearch\|karpathy\|pi-autoresearch' <<< "$COMMAND_CONTENT" 2>/dev/null; then
     fail "command: no attribution references" "found prohibited attribution reference"
 else
     pass "command: no attribution references"

--- a/tests/unit/test-role-mapping-v929.sh
+++ b/tests/unit/test-role-mapping-v929.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+# tests/unit/test-role-mapping-v929.sh
+# Tests v9.29 role mapping refresh (Opus 4.7 for planning/security, GPT-5.4 for code-review/implementation).
+# Ensures:
+#   - New roles (code-reviewer, security-reviewer, implementer-heavy) resolve correctly
+#   - Legacy alias (reviewer) still maps to code-reviewer equivalent
+#   - OCTOPUS_LEGACY_ROLES=1 restores v9.28 mapping verbatim
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "v9.29 Role Mapping Refresh"
+
+# agent-utils.sh references PLUGIN_DIR at source time — stub before loading.
+export PLUGIN_DIR="${PLUGIN_DIR:-$PROJECT_ROOT}"
+# Source the role mapping functions. agent-utils.sh references opus_default_model() from
+# lib/model-resolver.sh and persona-loader functions — source both, tolerate missing helpers.
+# shellcheck disable=SC1091
+source "$PROJECT_ROOT/scripts/lib/model-resolver.sh" 2>/dev/null || true
+# shellcheck disable=SC1091
+source "$PROJECT_ROOT/scripts/lib/agent-utils.sh" 2>/dev/null || true
+
+# Fallback opus_default_model stub if resolver didn't source (tests must run in isolation)
+if ! declare -f opus_default_model >/dev/null 2>&1; then
+    opus_default_model() { echo "claude-opus-4.7"; }
+fi
+
+# Force Opus 4.7 for deterministic assertions
+export SUPPORTS_OPUS_4_7=true
+unset OCTOPUS_OPUS_MODEL
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# v9.29 DEFAULTS (OCTOPUS_LEGACY_ROLES unset)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_architect_is_opus() {
+    test_case "architect → claude-opus:claude-opus-4.7"
+    unset OCTOPUS_LEGACY_ROLES
+    local mapping
+    mapping=$(get_role_mapping "architect")
+    if [[ "$mapping" == "claude-opus:claude-opus-4.7" ]]; then
+        test_pass
+    else
+        test_fail "expected claude-opus:claude-opus-4.7, got $mapping"
+    fi
+}
+
+test_code_reviewer_is_gpt_54() {
+    test_case "code-reviewer → codex-review:gpt-5.4"
+    unset OCTOPUS_LEGACY_ROLES
+    local mapping
+    mapping=$(get_role_mapping "code-reviewer")
+    if [[ "$mapping" == "codex-review:gpt-5.4" ]]; then
+        test_pass
+    else
+        test_fail "expected codex-review:gpt-5.4, got $mapping"
+    fi
+}
+
+test_reviewer_alias_for_code_reviewer() {
+    test_case "reviewer (legacy alias) → same as code-reviewer"
+    unset OCTOPUS_LEGACY_ROLES
+    local old new
+    old=$(get_role_mapping "reviewer")
+    new=$(get_role_mapping "code-reviewer")
+    if [[ "$old" == "$new" ]]; then
+        test_pass
+    else
+        test_fail "reviewer=$old should equal code-reviewer=$new"
+    fi
+}
+
+test_security_reviewer_is_opus() {
+    test_case "security-reviewer → claude-opus:claude-opus-4.7"
+    unset OCTOPUS_LEGACY_ROLES
+    local mapping
+    mapping=$(get_role_mapping "security-reviewer")
+    if [[ "$mapping" == "claude-opus:claude-opus-4.7" ]]; then
+        test_pass
+    else
+        test_fail "expected claude-opus:claude-opus-4.7, got $mapping"
+    fi
+}
+
+test_implementer_stays_gpt_54() {
+    test_case "implementer → codex:gpt-5.4 (unchanged from v9.28)"
+    unset OCTOPUS_LEGACY_ROLES
+    local mapping
+    mapping=$(get_role_mapping "implementer")
+    if [[ "$mapping" == "codex:gpt-5.4" ]]; then
+        test_pass
+    else
+        test_fail "expected codex:gpt-5.4, got $mapping"
+    fi
+}
+
+test_implementer_heavy_is_opus() {
+    test_case "implementer-heavy → claude-opus:claude-opus-4.7 (opt-in)"
+    unset OCTOPUS_LEGACY_ROLES
+    local mapping
+    mapping=$(get_role_mapping "implementer-heavy")
+    if [[ "$mapping" == "claude-opus:claude-opus-4.7" ]]; then
+        test_pass
+    else
+        test_fail "expected claude-opus:claude-opus-4.7, got $mapping"
+    fi
+}
+
+test_strategist_is_opus_47() {
+    test_case "strategist → claude-opus:claude-opus-4.7 (resolver picks 4.7)"
+    unset OCTOPUS_LEGACY_ROLES
+    local mapping
+    mapping=$(get_role_mapping "strategist")
+    if [[ "$mapping" == "claude-opus:claude-opus-4.7" ]]; then
+        test_pass
+    else
+        test_fail "expected claude-opus:claude-opus-4.7, got $mapping"
+    fi
+}
+
+test_synthesizer_is_sonnet() {
+    test_case "synthesizer → claude:claude-sonnet-4.6 (unchanged)"
+    unset OCTOPUS_LEGACY_ROLES
+    local mapping
+    mapping=$(get_role_mapping "synthesizer")
+    if [[ "$mapping" == "claude:claude-sonnet-4.6" ]]; then
+        test_pass
+    else
+        test_fail "expected claude:claude-sonnet-4.6, got $mapping"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LEGACY OPT-OUT (OCTOPUS_LEGACY_ROLES=1 restores v9.28)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_legacy_architect_is_gpt_54() {
+    test_case "OCTOPUS_LEGACY_ROLES=1: architect → codex:gpt-5.4 (v9.28 behavior)"
+    export OCTOPUS_LEGACY_ROLES=1
+    local mapping
+    mapping=$(get_role_mapping "architect")
+    unset OCTOPUS_LEGACY_ROLES
+    if [[ "$mapping" == "codex:gpt-5.4" ]]; then
+        test_pass
+    else
+        test_fail "expected codex:gpt-5.4 under legacy, got $mapping"
+    fi
+}
+
+test_legacy_security_reviewer_falls_back() {
+    test_case "OCTOPUS_LEGACY_ROLES=1: security-reviewer → codex-review:gpt-5.4 (unified v9.28 reviewer)"
+    export OCTOPUS_LEGACY_ROLES=1
+    local mapping
+    mapping=$(get_role_mapping "security-reviewer")
+    unset OCTOPUS_LEGACY_ROLES
+    if [[ "$mapping" == "codex-review:gpt-5.4" ]]; then
+        test_pass
+    else
+        test_fail "expected codex-review:gpt-5.4 under legacy, got $mapping"
+    fi
+}
+
+test_legacy_strategist_is_opus_46() {
+    test_case "OCTOPUS_LEGACY_ROLES=1: strategist → claude-opus-4.6 (v9.28 literal)"
+    export OCTOPUS_LEGACY_ROLES=1
+    local mapping
+    mapping=$(get_role_mapping "strategist")
+    unset OCTOPUS_LEGACY_ROLES
+    if [[ "$mapping" == "claude-opus:claude-opus-4.6" ]]; then
+        test_pass
+    else
+        test_fail "expected claude-opus:claude-opus-4.6 under legacy, got $mapping"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# AGENT/MODEL SPLIT HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_get_role_agent_for_architect() {
+    test_case "get_role_agent architect → claude-opus"
+    unset OCTOPUS_LEGACY_ROLES
+    local agent
+    agent=$(get_role_agent "architect")
+    if [[ "$agent" == "claude-opus" ]]; then
+        test_pass
+    else
+        test_fail "expected claude-opus, got $agent"
+    fi
+}
+
+test_get_role_model_for_code_reviewer() {
+    test_case "get_role_model code-reviewer → gpt-5.4"
+    unset OCTOPUS_LEGACY_ROLES
+    local model
+    model=$(get_role_model "code-reviewer")
+    if [[ "$model" == "gpt-5.4" ]]; then
+        test_pass
+    else
+        test_fail "expected gpt-5.4, got $model"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RUN
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_architect_is_opus
+test_code_reviewer_is_gpt_54
+test_reviewer_alias_for_code_reviewer
+test_security_reviewer_is_opus
+test_implementer_stays_gpt_54
+test_implementer_heavy_is_opus
+test_strategist_is_opus_47
+test_synthesizer_is_sonnet
+test_legacy_architect_is_gpt_54
+test_legacy_security_reviewer_falls_back
+test_legacy_strategist_is_opus_46
+test_get_role_agent_for_architect
+test_get_role_model_for_code_reviewer
+
+test_summary


### PR DESCRIPTION
## Release v9.29.0

**Role defaults refreshed based on April 2026 benchmark consensus.**

### Summary

| Role                 | v9.28               | v9.29                        | Rationale                                                     |
|----------------------|---------------------|------------------------------|---------------------------------------------------------------|
| `architect`          | gpt-5.4             | **claude-opus-4.7**          | SWE-bench Pro 64.3 vs 57.7, MCP-Atlas +9.2, LMArena #1        |
| `strategist`         | claude-opus-4.6     | **claude-opus-4.7**          | resolver picks 4.7 when supported                             |
| `security-reviewer`  | *(part of reviewer)*| **claude-opus-4.7**          | adversarial reasoning; new role (split from `reviewer`)       |
| `code-reviewer`      | *(was `reviewer`)*  | **gpt-5.4**                  | Terminal-Bench 75.1, edge-case hunting                        |
| `reviewer` (alias)   | gpt-5.4             | → `code-reviewer`            | back-compat alias                                             |
| `implementer`        | gpt-5.4             | gpt-5.4                      | unchanged                                                     |
| `implementer-heavy`  | —                   | **claude-opus-4.7** (opt-in) | greenfield / large refactors / UI-heavy; not auto-routed      |
| `synthesizer`        | claude-sonnet-4.6   | claude-sonnet-4.6            | unchanged                                                     |
| `researcher`         | gemini-3.1-pro      | gemini-3.1-pro               | unchanged                                                     |

### Also

- **New** `docs/GPT-5.4-PROMPTING.md` — reasoning effort tiers, output contracts, tool persistence, `phase` field, `gpt-5.4-mini` patterns
- **New** `/octo:setup` STEP 2a migration prompt — fires once for users upgrading from ≤9.28, surfaces ~2x cost impact, offers `OCTOPUS_LEGACY_ROLES=1` opt-out
- **New** `tests/unit/test-role-mapping-v929.sh` — 13 tests, all pass

### Opt-out

Set `OCTOPUS_LEGACY_ROLES=1` to restore the v9.28 role mapping verbatim. Graceful fallback in `lib/agents.sh` downshifts silently when the preferred CLI is unavailable.

### Verification

- 12/12 smoke suites green
- 84/84 unit suites green (including 13 new tests)
- Env-var matrix verified: `SUPPORTS_OPUS_4_7=true/false`, `OCTOPUS_OPUS_MODEL=claude-opus-4.6`, `OCTOPUS_LEGACY_ROLES=1` all behave correctly
- No caller breakage: `grep -rln get_role_(mapping|agent|model)` returns only agent-utils.sh + session.sh comment + new test

### Test Plan

- [x] Unit: `bash tests/run-all.sh unit` → 84/84 pass
- [x] Smoke: `bash tests/run-all.sh smoke` → 12/12 pass
- [x] Manual env-var matrix verification
- [x] Debate gate (adversarial review) → REVISE→PROCEED with 4 accepted revisions (skip agents/config.yaml; drop auto-complexity-4 routing; cost disclosure in migration prompt; graceful CLI fallback)
- [x] Code-reviewer agent review → no issues found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role→model defaults updated (Claude Opus 4.7 for architect/strategist/security; GPT‑5.4 for code‑review/implementer) and a v9.29 one‑time migration prompt with an opt‑out via environment flag.
  * Cache hygiene CLI and startup advisory with stale-cache reporting and optional auto‑clean.

* **Documentation**
  * Added GPT‑5.4 prompting guide; updated README, changelog, architecture and command reference to reflect v9.29 defaults.

* **Tests**
  * Added cache-hygiene and v9.29 role‑mapping test suites; updated unit tests.

* **Chores**
  * Bumped package/plugin version to 9.29.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->