### PR TITLE
fix: v9.29 migration advisory + mode-command idempotence + write-intent guardrail

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -212,6 +212,12 @@
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/hooks/statusline-auto-repair.sh",
           "timeout": 5
+        },
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/version-advisory.sh",
+          "additionalContext": "One-line advisory when plugin version changes between sessions",
+          "timeout": 5
         }
       ]
     },

--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -13,20 +13,22 @@ Switch to **Dev Work Mode**, optimized for software development.
 
 When this command is executed:
 
-1. **Check current mode:**
-   - Config file: `.claude/claude-octopus.local.md`
-   - If file doesn't exist, user is already in Dev Work Mode (default)
-   - Use bash `test -f` to check existence before reading
+1. **Check current mode** via `.claude/claude-octopus.local.md`:
+   - If file does NOT exist → user is already in Dev Work Mode (default). **Do not create the file.** Show confirmation only, then exit.
+   - If file exists and `knowledge_mode: false` → user is already in Dev Work Mode. **Do not rewrite the file.** Show confirmation only, then exit.
+   - If file exists and `knowledge_mode: true` → proceed to step 2.
 
-2. **Switch to Dev Work mode:**
-   - Create/update `.claude/claude-octopus.local.md` with YAML frontmatter
-   - Set `knowledge_mode: false`
-   - Confirm the switch with current mode details
+2. **Switch to Dev Work mode** (only if a real transition is needed):
+   - Before writing, state one sentence: "Switching Knowledge Work → Dev Work — updating `.claude/claude-octopus.local.md` (`knowledge_mode: true` → `false`)."
+   - Update the existing file's `knowledge_mode` field to `false` (preserve any other keys in frontmatter).
+   - Confirm the switch.
 
 3. **Show confirmation:**
    - Display Dev Work Mode emoji (🔧)
    - List active personas
-   - Suggest available commands (octo build, octo review, etc.)
+   - Suggest available commands (`/octo:develop`, `/octo:review`, `/octo:tdd`, etc.)
+
+**Rule (v9.30+):** Never create or rewrite `.claude/claude-octopus.local.md` when the user is already in the target mode. The v9.29 behavior over-executed — it wrote config for a state the user was already in, without explanation. Skip the Write tool entirely when there's nothing to change. See `agents/principles/write-intent.md` for the general principle.
 
 ## Usage
 

--- a/.claude/commands/km.md
+++ b/.claude/commands/km.md
@@ -17,23 +17,21 @@ Toggle between **Dev Work Mode** and **Knowledge Work Mode**.
 When this command is executed:
 
 1. **Parse the argument:**
-   - No argument or "on": Switch to Knowledge Work mode (set `knowledge_mode: true`)
-   - "off": Switch to Dev Work mode (set `knowledge_mode: false`)
+   - No argument or "on" → target mode = Knowledge Work (`knowledge_mode: true`)
+   - "off" → target mode = Dev Work (`knowledge_mode: false`)
 
-2. **Check for config file:**
-   - Config file: `.claude/claude-octopus.local.md`
-   - If file doesn't exist when switching, create it
-   - Use bash `test -f` to check existence before reading
+2. **Check current mode** via `.claude/claude-octopus.local.md`:
+   - Target is Dev Work AND file does NOT exist → user is already in Dev Work Mode (default). **Do not create the file.** Show confirmation only, then exit.
+   - File exists AND current `knowledge_mode` already equals the target → **Do not rewrite the file.** Show confirmation only, then exit.
+   - Otherwise → proceed to step 3 (real transition needed).
 
-3. **Switch to Knowledge Work mode (no argument or "on"):**
-   - Create/update `.claude/claude-octopus.local.md` with YAML frontmatter
-   - Set `knowledge_mode: true`
-   - Confirm with emoji 🎓 and active personas
+3. **Switch modes** (only when a real transition is required):
+   - Before writing, state one sentence: "Switching to Knowledge Work — creating `.claude/claude-octopus.local.md` (`knowledge_mode: true`)." (or the equivalent for Dev Work).
+   - If the file does not exist, create it with minimal frontmatter containing only the fields being set.
+   - If the file exists, update only the `knowledge_mode` field; preserve any other keys.
+   - Confirm with the target mode's emoji (🎓 / 🔧) and active personas.
 
-4. **Switch to Dev Work mode ("off"):**
-   - Create/update `.claude/claude-octopus.local.md` with YAML frontmatter
-   - Set `knowledge_mode: false`
-   - Confirm with emoji 🔧 and active personas
+**Rule (v9.30+):** Never create or rewrite `.claude/claude-octopus.local.md` when the user is already in the target mode. The v9.29 behavior over-executed — it wrote config for a state the user was already in, without explanation. Skip the Write tool entirely when there's nothing to change. See `agents/principles/write-intent.md` for the general principle.
 
 ## Usage
 

--- a/agents/principles/write-intent.md
+++ b/agents/principles/write-intent.md
@@ -1,0 +1,59 @@
+---
+name: write-intent-principle
+domain: general
+description: Announce intent before writing files — one sentence stating what, where, and why, with an idempotence check that skips the Write entirely when state is already correct.
+---
+
+# Write-Intent Principle
+
+Before creating, overwriting, or rewriting any file as part of a command, skill, or agent workflow, you MUST:
+
+## 1. Check for idempotence first
+
+If the desired state already matches the current state, **do not call Write at all.** Confirm the state to the user and exit. The most common bug this prevents is writing config for a mode / setting / flag the user is already in — that's noise, not value.
+
+Examples of state to check before writing:
+- Target mode matches current mode → skip
+- Target frontmatter field matches current field → skip
+- Generated file is byte-identical to what you'd write → skip
+
+## 2. Announce intent in one sentence
+
+When a Write **is** needed, say what you're about to do **before** calling the tool. Format:
+
+> Writing `<path>` (create | update | overwrite) — `<field/change>` — because `<why>`.
+
+Example:
+
+> Updating `.claude/claude-octopus.local.md` — setting `knowledge_mode: false` (was `true`) — because the user requested `/octo:dev`.
+
+## 3. Never write "empty" config
+
+Do not create a config file populated with defaults just to "mark" a state. Absent config is a legitimate state — it means "use defaults". Creating a file to restate defaults adds noise, makes diffs confusing, and implies the user opted into something they didn't.
+
+## 4. Respect scope
+
+Before writing to `.claude/`, `~/.claude-octopus/`, `~/.claude/`, or any user-owned directory from a command/skill, consider whether the file should live in:
+- The plugin (committed, shipped to all users)
+- The user's home (`~/.claude/`) — persists across projects
+- The project workspace (`.claude/`) — per-project
+- `~/.claude/scratchpad/<session-id>/` — ephemeral working files
+
+A user-facing command that writes to an unexpected scope (e.g. a "mode switch" that writes to project `.claude/`) needs to say *which* scope in its intent sentence.
+
+## Anti-Patterns (reject in review)
+
+- ❌ `/octo:dev` writes `.claude/claude-octopus.local.md` when the file didn't exist and the user was already in default Dev Work Mode.
+- ❌ A "setup" wizard silently creates configuration for every possible option even when not selected.
+- ❌ An idempotent-looking operation overwrites a file with identical content, bumping its mtime and confusing build systems.
+- ❌ A skill announces "I'll update your config" and then writes without showing the diff or field being changed.
+
+## Correct Patterns
+
+- ✅ Check current state → already matches target → confirm to user → exit without Write.
+- ✅ "Switching Knowledge Work → Dev Work — updating `.claude/claude-octopus.local.md` (`knowledge_mode: true` → `false`)." followed by the Write.
+- ✅ "No `.claude/claude-octopus.local.md` exists — you're in default Dev Work Mode. Nothing to change." followed by no Write.
+
+## Scope
+
+This principle applies to **all** Write operations initiated by skills, commands, and agents in this plugin. Tests in `tests/unit/test-write-intent.sh` enforce that user-facing mode-switch commands carry the idempotence check in their implementation instructions.

--- a/hooks/version-advisory.sh
+++ b/hooks/version-advisory.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Claude Octopus — SessionStart Version Advisory (v9.29.0+)
+#
+# When the plugin version jumps between sessions, emit a ONE-LINE advisory
+# so existing users find out about behavioral changes (e.g. role routing,
+# default model shifts) without having to manually run /octo:setup.
+#
+# This hook:
+#   1. Reads the current plugin version from .claude-plugin/plugin.json
+#   2. Compares it to the `last_seen_version` stored in ~/.claude-octopus/state.json
+#   3. If different (and not first-run), emits a one-line advisory referencing
+#      the CHANGELOG entry for the target version
+#   4. Updates `last_seen_version` in state.json
+#   5. Stays silent on no-change or first-run (session-start-memory.sh handles first-run)
+#
+# Hook event: SessionStart (runs after session-start-memory.sh first-run gate)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set -euo pipefail
+
+STATE_DIR="${HOME}/.claude-octopus"
+STATE_FILE="${STATE_DIR}/state.json"
+SETUP_MARKER="${STATE_DIR}/.setup-complete"
+PLUGIN_MANIFEST="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"
+
+# Silent exit on missing prereqs — never block session start
+[[ ! -f "$PLUGIN_MANIFEST" ]] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# First-run is handled by session-start-memory.sh — don't double-prompt
+[[ ! -f "$SETUP_MARKER" ]] && exit 0
+
+CURRENT_VERSION=$(jq -r '.version // "unknown"' "$PLUGIN_MANIFEST" 2>/dev/null || echo "unknown")
+[[ "$CURRENT_VERSION" == "unknown" || -z "$CURRENT_VERSION" ]] && exit 0
+
+# Read (or seed) last_seen_version
+mkdir -p "$STATE_DIR"
+if [[ ! -f "$STATE_FILE" ]]; then
+    echo '{}' > "$STATE_FILE"
+fi
+
+LAST_SEEN=$(jq -r '.last_seen_version // empty' "$STATE_FILE" 2>/dev/null)
+
+# Already up to date — stay quiet
+if [[ "$LAST_SEEN" == "$CURRENT_VERSION" ]]; then
+    exit 0
+fi
+
+# First time we're recording a version (not a real upgrade) — seed silently
+if [[ -z "$LAST_SEEN" ]]; then
+    TMP=$(mktemp "${STATE_FILE}.XXXXXX")
+    jq --arg v "$CURRENT_VERSION" '. + {last_seen_version: $v}' "$STATE_FILE" > "$TMP" \
+        && mv "$TMP" "$STATE_FILE"
+    exit 0
+fi
+
+# Version changed — advisory. Keep it to one or two lines, non-blocking.
+# We echo to stdout so Claude Code surfaces it as session context.
+cat <<EOF
+🐙 Claude Octopus updated: ${LAST_SEEN} → ${CURRENT_VERSION}
+   Review changes: /octo:setup (or see CHANGELOG for role routing / default model shifts).
+   Opt out of new routing: export OCTOPUS_LEGACY_ROLES=1
+EOF
+
+# Persist new version so we don't advise again next session
+TMP=$(mktemp "${STATE_FILE}.XXXXXX")
+jq --arg v "$CURRENT_VERSION" '.last_seen_version = $v' "$STATE_FILE" > "$TMP" \
+    && mv "$TMP" "$STATE_FILE"
+
+exit 0

--- a/tests/unit/test-write-intent.sh
+++ b/tests/unit/test-write-intent.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# tests/unit/test-write-intent.sh
+# Enforces the write-intent principle (agents/principles/write-intent.md):
+#   - Mode-switch commands MUST carry the idempotence check in their instructions
+#   - Version-advisory hook MUST exist and be wired into SessionStart hooks.json
+#   - Principle file itself MUST exist and be well-formed
+#
+# Regression target: the v9.29 bug where /octo:dev silently created
+# .claude/claude-octopus.local.md for a user already in default Dev Work Mode.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Write-intent principle enforcement (v9.30+)"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Principle file exists and is well-formed
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_principle_file_exists() {
+    test_case "agents/principles/write-intent.md exists"
+    if [[ -f "$PROJECT_ROOT/agents/principles/write-intent.md" ]]; then
+        test_pass
+    else
+        test_fail "principle file not found"
+    fi
+}
+
+test_principle_has_idempotence_section() {
+    test_case "principle mandates idempotence check before Write"
+    local content
+    content=$(<"$PROJECT_ROOT/agents/principles/write-intent.md")
+    if grep -qi "idempotence\|already match\|skip the Write" <<< "$content"; then
+        test_pass
+    else
+        test_fail "principle does not mention idempotence / already-matching state"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# /octo:dev carries the idempotence guard
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_dev_checks_existing_state_first() {
+    test_case "/octo:dev instructions check current state before writing"
+    local content
+    content=$(<"$PROJECT_ROOT/.claude/commands/dev.md")
+    # Must mention both: "does NOT exist → show confirmation only" AND "already in Dev Work Mode"
+    if grep -qi "do not create the file\|Do not rewrite the file" <<< "$content"; then
+        test_pass
+    else
+        test_fail "dev.md does not instruct 'do not create/rewrite' when already in target mode"
+    fi
+}
+
+test_dev_references_write_intent_principle() {
+    test_case "/octo:dev cross-references the write-intent principle"
+    local content
+    content=$(<"$PROJECT_ROOT/.claude/commands/dev.md")
+    if grep -q 'write-intent\.md\|write-intent-principle' <<< "$content"; then
+        test_pass
+    else
+        test_fail "dev.md does not reference agents/principles/write-intent.md"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# /octo:km carries the idempotence guard
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_km_checks_existing_state_first() {
+    test_case "/octo:km instructions check current state before writing"
+    local content
+    content=$(<"$PROJECT_ROOT/.claude/commands/km.md")
+    if grep -qi "do not create the file\|Do not rewrite the file" <<< "$content"; then
+        test_pass
+    else
+        test_fail "km.md does not instruct 'do not create/rewrite' when target mode matches current"
+    fi
+}
+
+test_km_references_write_intent_principle() {
+    test_case "/octo:km cross-references the write-intent principle"
+    local content
+    content=$(<"$PROJECT_ROOT/.claude/commands/km.md")
+    if grep -q 'write-intent\.md\|write-intent-principle' <<< "$content"; then
+        test_pass
+    else
+        test_fail "km.md does not reference agents/principles/write-intent.md"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Version-advisory SessionStart hook
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_version_advisory_hook_exists() {
+    test_case "hooks/version-advisory.sh exists and is executable"
+    local hook="$PROJECT_ROOT/hooks/version-advisory.sh"
+    if [[ -f "$hook" && -x "$hook" ]]; then
+        test_pass
+    else
+        test_fail "hook missing or not executable: $hook"
+    fi
+}
+
+test_version_advisory_wired_in_hooks_json() {
+    test_case "version-advisory.sh registered in SessionStart hooks"
+    local hooks_json="$PROJECT_ROOT/.claude-plugin/hooks.json"
+    if command -v jq >/dev/null 2>&1; then
+        # Check that some SessionStart hook references version-advisory.sh
+        local found
+        found=$(jq -r '.SessionStart[]?.hooks[]?.command // empty' "$hooks_json" 2>/dev/null | grep -c 'version-advisory\.sh' || true)
+        found=${found:-0}
+        if [[ "$found" -ge 1 ]]; then
+            test_pass
+        else
+            test_fail "hooks.json has no SessionStart entry pointing to version-advisory.sh"
+        fi
+    else
+        # jq missing — fall back to grep
+        if grep -q 'version-advisory\.sh' "$hooks_json"; then
+            test_pass
+        else
+            test_fail "hooks.json does not reference version-advisory.sh"
+        fi
+    fi
+}
+
+test_version_advisory_skips_on_first_run() {
+    test_case "version-advisory.sh exits silently when setup-complete marker is absent"
+    local hook="$PROJECT_ROOT/hooks/version-advisory.sh"
+    # Simulate: fresh HOME with no .setup-complete, stubbed plugin root
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local output
+    output=$(HOME="$tmpdir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$hook" 2>&1 || true)
+    rm -rf "$tmpdir"
+    if [[ -z "$output" ]]; then
+        test_pass
+    else
+        test_fail "first-run should be silent, got output: $output"
+    fi
+}
+
+test_version_advisory_seeds_on_unknown_last_seen() {
+    test_case "version-advisory.sh seeds state.json silently when last_seen_version missing"
+    local hook="$PROJECT_ROOT/hooks/version-advisory.sh"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.claude-octopus"
+    touch "$tmpdir/.claude-octopus/.setup-complete"
+    local output
+    output=$(HOME="$tmpdir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$hook" 2>&1 || true)
+    local seeded
+    seeded=$(jq -r '.last_seen_version // empty' "$tmpdir/.claude-octopus/state.json" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if [[ -z "$output" && -n "$seeded" ]]; then
+        test_pass
+    else
+        test_fail "expected silent seed; got output='$output' seeded='$seeded'"
+    fi
+}
+
+test_version_advisory_emits_on_version_change() {
+    test_case "version-advisory.sh emits advisory when version jumps"
+    local hook="$PROJECT_ROOT/hooks/version-advisory.sh"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.claude-octopus"
+    touch "$tmpdir/.claude-octopus/.setup-complete"
+    # Seed state with a stale old version
+    echo '{"last_seen_version":"9.28.0"}' > "$tmpdir/.claude-octopus/state.json"
+    local output
+    output=$(HOME="$tmpdir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$hook" 2>&1 || true)
+    rm -rf "$tmpdir"
+    if grep -qi 'updated.*9\.28\.0.*9\.29' <<< "$output" && grep -q '/octo:setup\|OCTOPUS_LEGACY_ROLES' <<< "$output"; then
+        test_pass
+    else
+        test_fail "advisory missing or malformed. Got: $output"
+    fi
+}
+
+test_version_advisory_silent_when_no_change() {
+    test_case "version-advisory.sh stays silent on second run (same version)"
+    local hook="$PROJECT_ROOT/hooks/version-advisory.sh"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.claude-octopus"
+    touch "$tmpdir/.claude-octopus/.setup-complete"
+    # First run: seeds silently
+    HOME="$tmpdir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$hook" >/dev/null 2>&1 || true
+    # Second run: should produce nothing
+    local output
+    output=$(HOME="$tmpdir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$hook" 2>&1 || true)
+    rm -rf "$tmpdir"
+    if [[ -z "$output" ]]; then
+        test_pass
+    else
+        test_fail "expected silent second run, got: $output"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RUN
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_principle_file_exists
+test_principle_has_idempotence_section
+test_dev_checks_existing_state_first
+test_dev_references_write_intent_principle
+test_km_checks_existing_state_first
+test_km_references_write_intent_principle
+test_version_advisory_hook_exists
+test_version_advisory_wired_in_hooks_json
+test_version_advisory_skips_on_first_run
+test_version_advisory_seeds_on_unknown_last_seen
+test_version_advisory_emits_on_version_change
+test_version_advisory_silent_when_no_change
+
+test_summary


### PR DESCRIPTION
Three related follow-ups to v9.29.0, driven by real user feedback after upgrading.

## What users hit

1. Upgraded from v9.28.0 → v9.29.0 (role routing changed — Opus 4.7 for planning/strategy/security) and **never saw a prompt** about it. The migration prompt only fired on `/octo:setup`, which most users don't run post-upgrade.
2. Ran `/octo:dev` (default mode), and it **silently created** `.claude/claude-octopus.local.md` without explaining what it was writing, where, or why. The user was already in Dev Work Mode — no file was needed.

## What this PR changes

### 1. `hooks/version-advisory.sh` + registration in `.claude-plugin/hooks.json`

One-line SessionStart advisory when `last_seen_version` in `~/.claude-octopus/state.json` differs from the current `plugin.json` version. Non-blocking; self-seeding; silent on no-change and first-run.

Example output when a 9.28 → 9.29 upgrade is detected:
```
🐙 Claude Octopus updated: 9.28.0 → 9.29.0
   Review changes: /octo:setup (or see CHANGELOG for role routing / default model shifts).
   Opt out of new routing: export OCTOPUS_LEGACY_ROLES=1
```

### 2. `/octo:dev` and `/octo:km` idempotence (`.claude/commands/{dev,km}.md`)

Both commands now short-circuit when target mode already matches current state:
- No file creation when user is already in default Dev Work Mode
- No rewrite when `knowledge_mode` already equals target
- When a real transition IS needed, the command states the change in one sentence **before** calling Write

### 3. `agents/principles/write-intent.md`

New shared principle: (1) idempotence check first, (2) announce intent in one sentence, (3) never create "empty" config files for defaults, (4) respect scope (plugin / user home / project / scratchpad). Both mode commands cross-reference it.

## Verification

- **12 new tests** in `tests/unit/test-write-intent.sh`:
  - Principle file exists + has idempotence language
  - `dev.md` and `km.md` both carry the "do not create/rewrite" guard
  - Both cross-reference the principle file
  - `version-advisory.sh` exists, is executable, is registered in `hooks.json`
  - Silent on first-run, silent on seed, silent on no-change; emits advisory only on real version jump
- **86/86 unit suites pass**, **12/12 smoke suites pass**
- **Manual smoke**: version-advisory behavior verified end-to-end for 4 scenarios (fresh seed, same version, stale version, second-run-silent)

## Files

| File | Change |
|------|--------|
| `hooks/version-advisory.sh` | New — 60 lines |
| `.claude-plugin/hooks.json` | +5 lines (SessionStart registration) |
| `.claude/commands/dev.md` | Rewrote implementation instructions (idempotence + intent) |
| `.claude/commands/km.md` | Rewrote implementation instructions (idempotence + intent) |
| `agents/principles/write-intent.md` | New — 60 lines |
| `tests/unit/test-write-intent.sh` | New — 180 lines (12 tests) |

## Test Plan

- [x] `bash tests/unit/test-write-intent.sh` → 12/12 pass
- [x] `bash tests/run-all.sh unit` → 86/86 pass
- [x] `bash tests/run-all.sh smoke` → 12/12 pass
- [x] Manual: simulated 9.28 → 9.29 upgrade, advisory fired; second session silent; same-version silent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session startup now displays a version advisory when detecting plugin updates, with changelog reference and opt-out instructions.

* **Improvements**
  * Commands now prevent redundant configuration file writes by verifying state changes before writing.
  * Enhanced workflow consistency for mode-switching operations.

* **Documentation**
  * Added write-intent principles defining mandatory workflows for command and agent operations to ensure idempotence and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->