### PR TITLE
fix(hooks): kill silent hook failures — EXIT trap + grep-no-match guards (#313)

### DIFF
--- a/hooks/agent-teams-phase-gate.sh
+++ b/hooks/agent-teams-phase-gate.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/agent-teams-phase-gate.sh
+++ b/hooks/agent-teams-phase-gate.sh
@@ -4,6 +4,13 @@
 # Triggers quality gate evaluation and phase transition
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Bridge configuration
 BRIDGE_DIR="${HOME}/.claude-octopus/bridge"

--- a/hooks/architecture-gate.sh
+++ b/hooks/architecture-gate.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/architecture-gate.sh
+++ b/hooks/architecture-gate.sh
@@ -5,6 +5,13 @@
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 # v8.8: Writes human-readable stderr on block (displayed by Claude Code v2.1.41+)
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read tool output from stdin
 output=$(cat 2>/dev/null || true)

--- a/hooks/budget-gate.sh
+++ b/hooks/budget-gate.sh
@@ -4,6 +4,13 @@
 # Reads OCTOPUS_MAX_COST_USD and compares against metrics-session.json
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # If no budget configured, always continue
 if [[ -z "${OCTOPUS_MAX_COST_USD:-}" ]]; then

--- a/hooks/budget-gate.sh
+++ b/hooks/budget-gate.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/careful-check.sh
+++ b/hooks/careful-check.sh
@@ -6,6 +6,13 @@
 #
 # Kill switch: OCTO_CAREFUL_MODE=off — disables all destructive command checks
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Kill switch — respect user's choice to disable careful mode entirely
 # (careful mode is opt-in via /octo:careful; OCTO_CAREFUL_MODE=off is the dedicated off-switch)
@@ -20,7 +27,7 @@ fi
 [[ -z "$INPUT" ]] && INPUT='{}'
 
 # Only gate Bash commands
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | head -1 | cut -d'"' -f4)
+TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' 2>/dev/null | head -1 | cut -d'"' -f4 || true)
 if [[ "$TOOL_NAME" != "Bash" ]]; then
     echo '{"decision":"allow"}'
     exit 0
@@ -38,7 +45,7 @@ fi
 if command -v jq &>/dev/null; then
     COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // .command // ""' 2>/dev/null || echo "")
 else
-    COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | head -1 | cut -d'"' -f4)
+    COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' 2>/dev/null | head -1 | cut -d'"' -f4 || true)
 fi
 # Also check raw input as fallback for escaped-quote edge cases
 CHECK_TEXT="${COMMAND}

--- a/hooks/careful-check.sh
+++ b/hooks/careful-check.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/code-quality-gate.sh
+++ b/hooks/code-quality-gate.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/code-quality-gate.sh
+++ b/hooks/code-quality-gate.sh
@@ -5,6 +5,13 @@
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 # v8.8: Writes human-readable stderr on block (displayed by Claude Code v2.1.41+)
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read tool output from stdin
 output=$(cat 2>/dev/null || true)

--- a/hooks/codex-exec-guard.sh
+++ b/hooks/codex-exec-guard.sh
@@ -4,6 +4,13 @@
 # WHY: `codex "prompt"` launches interactive TUI which fails in non-TTY (Claude Code Bash tool).
 #      `codex exec "prompt"` is the correct non-interactive mode.
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Note: this gate guards correctness (bare `codex "prompt"` hangs in non-TTY),
 # not user permission policy — so it runs regardless of bypassPermissions.

--- a/hooks/codex-exec-guard.sh
+++ b/hooks/codex-exec-guard.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/config-change-handler.sh
+++ b/hooks/config-change-handler.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/config-change-handler.sh
+++ b/hooks/config-change-handler.sh
@@ -5,6 +5,13 @@
 # v8.29.0: Expanded from fast-mode-only to full Octopus settings hot-reload
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 CONFIG_CHANGE_DATA=""
 if [[ ! -t 0 ]]; then

--- a/hooks/context-awareness.sh
+++ b/hooks/context-awareness.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/context-awareness.sh
+++ b/hooks/context-awareness.sh
@@ -14,6 +14,13 @@
 # Hook event: PostToolUse (blanket matcher)
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read stdin (required by hook protocol — drain to prevent SIGPIPE)
 if command -v timeout &>/dev/null; then

--- a/hooks/context-reinforcement.sh
+++ b/hooks/context-reinforcement.sh
@@ -7,6 +7,13 @@
 # Returns: {"decision":"continue","additionalContext":"<CONTEXT-REINFORCEMENT>...</CONTEXT-REINFORCEMENT>"}
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read JSON payload from stdin (required by hook protocol)
 if command -v timeout &>/dev/null; then

--- a/hooks/context-reinforcement.sh
+++ b/hooks/context-reinforcement.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/cwd-changed.sh
+++ b/hooks/cwd-changed.sh
@@ -4,6 +4,13 @@
 # Outputs additionalContext with project type detection for the new directory.
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read hook input from stdin (JSON with new_cwd field)
 INPUT=$(cat 2>/dev/null) || INPUT=""

--- a/hooks/cwd-changed.sh
+++ b/hooks/cwd-changed.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/discipline-inject.sh
+++ b/hooks/discipline-inject.sh
@@ -3,6 +3,13 @@
 # Only fires when OCTOPUS_DISCIPLINE=on in config
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 DISCIPLINE_CONF="${HOME}/.claude-octopus/config/discipline.conf"
 

--- a/hooks/discipline-inject.sh
+++ b/hooks/discipline-inject.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/discipline-task-gate.sh
+++ b/hooks/discipline-task-gate.sh
@@ -3,6 +3,13 @@
 # Only fires when discipline mode is on
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 DISCIPLINE_CONF="${HOME}/.claude-octopus/config/discipline.conf"
 

--- a/hooks/discipline-task-gate.sh
+++ b/hooks/discipline-task-gate.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/done-criteria.sh
+++ b/hooks/done-criteria.sh
@@ -12,6 +12,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read input with timeout guard
 if [ -t 0 ]; then exit 0; fi

--- a/hooks/done-criteria.sh
+++ b/hooks/done-criteria.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/elicitation-handler.sh
+++ b/hooks/elicitation-handler.sh
@@ -8,6 +8,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 MODE="${1:-request}"  # "request" or "result"
 LOG_DIR="${HOME}/.claude-octopus/logs"

--- a/hooks/elicitation-handler.sh
+++ b/hooks/elicitation-handler.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/freeze-check.sh
+++ b/hooks/freeze-check.sh
@@ -7,6 +7,13 @@
 #
 # Kill switch: OCTO_FREEZE_MODE=off — disables freeze boundary enforcement
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Kill switch — freeze mode is opt-in via /octo:freeze; OCTO_FREEZE_MODE=off is the dedicated off-switch
 [[ "${OCTO_FREEZE_MODE:-on}" == "off" ]] && { echo '{"decision":"allow"}'; exit 0; }
@@ -20,7 +27,7 @@ fi
 [[ -z "$INPUT" ]] && INPUT='{}'
 
 # Only gate Edit and Write tools
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | head -1 | cut -d'"' -f4)
+TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' 2>/dev/null | head -1 | cut -d'"' -f4 || true)
 if [[ "$TOOL_NAME" != "Edit" && "$TOOL_NAME" != "Write" ]]; then
     echo '{"decision":"allow"}'
     exit 0
@@ -41,7 +48,7 @@ if [[ -z "$FREEZE_DIR" ]]; then
 fi
 
 # Extract file_path from input
-FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' 2>/dev/null | head -1 | cut -d'"' -f4 || true)
 if [[ -z "$FILE_PATH" ]]; then
     echo '{"decision":"allow"}'
     exit 0

--- a/hooks/freeze-check.sh
+++ b/hooks/freeze-check.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/frontend-gate.sh
+++ b/hooks/frontend-gate.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/frontend-gate.sh
+++ b/hooks/frontend-gate.sh
@@ -5,6 +5,13 @@
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 # v8.8: Writes human-readable stderr on block (displayed by Claude Code v2.1.41+)
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read tool output from stdin
 output=$(cat 2>/dev/null || true)

--- a/hooks/instructions-loaded.sh
+++ b/hooks/instructions-loaded.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/instructions-loaded.sh
+++ b/hooks/instructions-loaded.sh
@@ -10,6 +10,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 SESSION_FILE="${HOME}/.claude-octopus/session.json"
 RESULTS_DIR="${HOME}/.claude-octopus/results"

--- a/hooks/octopus-statusline.sh
+++ b/hooks/octopus-statusline.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/octopus-statusline.sh
+++ b/hooks/octopus-statusline.sh
@@ -12,6 +12,13 @@
 # See: https://code.claude.com/docs/en/statusline
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read stdin — Claude Code always closes the pipe, no timeout needed
 input=$(cat 2>/dev/null || true)

--- a/hooks/output-compressor.sh
+++ b/hooks/output-compressor.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/output-compressor.sh
+++ b/hooks/output-compressor.sh
@@ -19,6 +19,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # --- Config ---
 COMPRESS_ENABLED="${OCTOPUS_COMPRESS_ENABLED:-true}"

--- a/hooks/perf-gate.sh
+++ b/hooks/perf-gate.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/perf-gate.sh
+++ b/hooks/perf-gate.sh
@@ -5,6 +5,13 @@
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 # v8.8: Writes human-readable stderr on block (displayed by Claude Code v2.1.41+)
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read tool output from stdin
 output=$(cat 2>/dev/null || true)

--- a/hooks/permission-denied-log.sh
+++ b/hooks/permission-denied-log.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/permission-denied-log.sh
+++ b/hooks/permission-denied-log.sh
@@ -8,6 +8,13 @@
 #
 # Hook event: PermissionDenied (CC v2.1.89+)
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Only log when careful mode is active
 CAREFUL_STATE="${HOME}/.claude-octopus/.careful-mode"

--- a/hooks/plan-mode-interceptor.sh
+++ b/hooks/plan-mode-interceptor.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/plan-mode-interceptor.sh
+++ b/hooks/plan-mode-interceptor.sh
@@ -8,6 +8,13 @@
 # Returns: {"decision":"continue","additionalContext":"<PLAN-MODE-RULES>...</PLAN-MODE-RULES>"}
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read JSON payload from stdin (required by hook protocol)
 if command -v timeout &>/dev/null; then

--- a/hooks/post-compact.sh
+++ b/hooks/post-compact.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/post-compact.sh
+++ b/hooks/post-compact.sh
@@ -8,6 +8,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 STATE_DIR="${HOME}/.claude-octopus/.octo"
 SNAPSHOT="${STATE_DIR}/pre-compact-snapshot.json"

--- a/hooks/post-tool-dispatch.sh
+++ b/hooks/post-tool-dispatch.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/post-tool-dispatch.sh
+++ b/hooks/post-tool-dispatch.sh
@@ -10,6 +10,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 HOOKS_DIR="${PLUGIN_ROOT}/hooks"

--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -7,6 +7,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 SESSION_FILE="${HOME}/.claude-octopus/session.json"
 STATE_DIR="${HOME}/.claude-octopus/.octo"

--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/provider-routing-validator.sh
+++ b/hooks/provider-routing-validator.sh
@@ -4,6 +4,13 @@
 # Part of Claude Code v2.1.12+ integration
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Get the plugin root directory
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"

--- a/hooks/provider-routing-validator.sh
+++ b/hooks/provider-routing-validator.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/quality-gate.sh
+++ b/hooks/quality-gate.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/quality-gate.sh
+++ b/hooks/quality-gate.sh
@@ -4,12 +4,20 @@
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 # v8.43: Added reference integrity check for cross-file dependencies
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 VALIDATION_FILE=$(ls -t ~/.claude-octopus/results/tangle-validation-*.md 2>/dev/null | head -1)
 
 if [[ -f "$VALIDATION_FILE" ]]; then
-    # Check if quality gate passed
-    STATUS=$(grep -E "^## (Quality Gate|Status):" "$VALIDATION_FILE" | head -1)
+    # Check if quality gate passed. `|| true` — grep-no-match must not cascade
+    # under `set -o pipefail` and trigger the silent-fail path (issue #313).
+    STATUS=$(grep -E "^## (Quality Gate|Status):" "$VALIDATION_FILE" 2>/dev/null | head -1 || true)
 
     if echo "$STATUS" | grep -qi "failed"; then
         echo '{"decision": "block", "reason": "Quality gate validation failed. Review tangle output before proceeding."}'

--- a/hooks/quality-gate.sh
+++ b/hooks/quality-gate.sh
@@ -3,7 +3,7 @@
 # Validates tangle output before continuing workflow
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 # v8.43: Added reference integrity check for cross-file dependencies
-set -eo pipefail  # -u dropped: bash 3.2 on macOS CI aborts (exit 134) on `local arr=()` + `${#arr[@]}` in check_reference_integrity. -e + pipefail still catch real failures.
+set -euo pipefail
 # EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
@@ -33,6 +33,11 @@ fi
 # Reference integrity check: scan recently created/modified files for broken references
 # Catches: HTML linking missing JS/CSS, scripts sourcing missing files, configs referencing missing paths
 check_reference_integrity() {
+    # Scope-local: disable -u because bash 3.2 (macOS CI) aborts (exit 134)
+    # on `local arr=()` + `${#arr[@]}` when the array stays empty. We re-enable
+    # -u on exit. See issue #313 PR #314 CI failure trail.
+    set +u
+    trap 'set -u' RETURN
     local issues=()
 
     # Find files modified in the last 10 minutes (likely tangle output)

--- a/hooks/quality-gate.sh
+++ b/hooks/quality-gate.sh
@@ -12,7 +12,7 @@ _octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] 
 trap _octo_hook_exit EXIT
 
 
-VALIDATION_FILE=$(ls -t ~/.claude-octopus/results/tangle-validation-*.md 2>/dev/null | head -1)
+VALIDATION_FILE=$(ls -t ~/.claude-octopus/results/tangle-validation-*.md 2>/dev/null | head -1 || true)
 
 if [[ -f "$VALIDATION_FILE" ]]; then
     # Check if quality gate passed. `|| true` — grep-no-match must not cascade

--- a/hooks/quality-gate.sh
+++ b/hooks/quality-gate.sh
@@ -3,7 +3,7 @@
 # Validates tangle output before continuing workflow
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 # v8.43: Added reference integrity check for cross-file dependencies
-set -euo pipefail
+set -eo pipefail  # -u dropped: bash 3.2 on macOS CI aborts (exit 134) on `local arr=()` + `${#arr[@]}` in check_reference_integrity. -e + pipefail still catch real failures.
 # EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that

--- a/hooks/scheduler-security-gate.sh
+++ b/hooks/scheduler-security-gate.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/scheduler-security-gate.sh
+++ b/hooks/scheduler-security-gate.sh
@@ -5,6 +5,13 @@
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Note: this gate enforces per-job allowlists the user set in their scheduled
 # job config — bypassPermissions (a global CC prompt-skip setting) should not

--- a/hooks/security-gate.sh
+++ b/hooks/security-gate.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/security-gate.sh
+++ b/hooks/security-gate.sh
@@ -5,6 +5,13 @@
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 # v8.8: Writes human-readable stderr on block (displayed by Claude Code v2.1.41+)
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read tool output from stdin
 output=$(cat 2>/dev/null || true)

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -8,6 +8,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 SESSION_FILE="${HOME}/.claude-octopus/session.json"
 METRICS_DIR="${HOME}/.claude-octopus/metrics"

--- a/hooks/session-start-memory.sh
+++ b/hooks/session-start-memory.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/session-start-memory.sh
+++ b/hooks/session-start-memory.sh
@@ -8,6 +8,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # --- 0. First-run detection (v9.19.2) ---
 # On very first install, auto-prompt the user to run /octo:setup

--- a/hooks/statusline-auto-repair.sh
+++ b/hooks/statusline-auto-repair.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/statusline-auto-repair.sh
+++ b/hooks/statusline-auto-repair.sh
@@ -5,6 +5,13 @@
 # settings.json points to it instead of a versioned cache path that goes stale.
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 RESOLVER_SRC="${CLAUDE_PLUGIN_ROOT}/hooks/statusline-resolver.sh"
 RESOLVER_DST="$HOME/.claude-octopus/statusline.sh"

--- a/hooks/stop-failure-log.sh
+++ b/hooks/stop-failure-log.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/stop-failure-log.sh
+++ b/hooks/stop-failure-log.sh
@@ -5,6 +5,13 @@
 # This hook is purely for telemetry — appends to error-log.jsonl.
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read hook input from stdin
 INPUT=$(cat 2>/dev/null) || INPUT=""

--- a/hooks/strategy-rotation.sh
+++ b/hooks/strategy-rotation.sh
@@ -14,6 +14,13 @@
 # Hook event: PostToolUse (matcher: Bash|Edit|Write)
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # ── Kill switch ──────────────────────────────────────────────────────
 [[ "${OCTO_STRATEGY_ROTATION:-on}" == "off" ]] && exit 0

--- a/hooks/strategy-rotation.sh
+++ b/hooks/strategy-rotation.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/subagent-result-capture.sh
+++ b/hooks/subagent-result-capture.sh
@@ -9,6 +9,13 @@
 # Returns: exit 0 (allow stop) — no JSON output needed
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 WORKSPACE_DIR="${OCTOPUS_WORKSPACE:-${HOME}/.claude-octopus}"
 TEAMS_DIR="${WORKSPACE_DIR}/agent-teams"

--- a/hooks/subagent-result-capture.sh
+++ b/hooks/subagent-result-capture.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/sysadmin-safety-gate.sh
+++ b/hooks/sysadmin-safety-gate.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/sysadmin-safety-gate.sh
+++ b/hooks/sysadmin-safety-gate.sh
@@ -4,6 +4,13 @@
 # Blocks destructive system commands without explicit confirmation patterns
 # Returns JSON decision: {"decision": "continue|block", "reason": "..."}
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read tool output from stdin
 if command -v timeout &>/dev/null; then

--- a/hooks/task-completed-transition.sh
+++ b/hooks/task-completed-transition.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/task-completed-transition.sh
+++ b/hooks/task-completed-transition.sh
@@ -4,6 +4,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 SESSION_FILE="${HOME}/.claude-octopus/session.json"
 

--- a/hooks/task-completion-checkpoint.sh
+++ b/hooks/task-completion-checkpoint.sh
@@ -4,6 +4,13 @@
 # Part of Claude Code v2.1.12+ integration
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Get the plugin root directory
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"

--- a/hooks/task-completion-checkpoint.sh
+++ b/hooks/task-completion-checkpoint.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/task-dependency-validator.sh
+++ b/hooks/task-dependency-validator.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/task-dependency-validator.sh
+++ b/hooks/task-dependency-validator.sh
@@ -4,6 +4,13 @@
 # Part of Claude Code v2.1.12+ integration
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # This hook receives task metadata via stdin when TaskCreate is called
 # Input format: JSON with task details

--- a/hooks/teammate-idle-dispatch.sh
+++ b/hooks/teammate-idle-dispatch.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/teammate-idle-dispatch.sh
+++ b/hooks/teammate-idle-dispatch.sh
@@ -4,6 +4,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 SESSION_FILE="${HOME}/.claude-octopus/session.json"
 

--- a/hooks/telemetry-webhook.sh
+++ b/hooks/telemetry-webhook.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/telemetry-webhook.sh
+++ b/hooks/telemetry-webhook.sh
@@ -8,6 +8,13 @@
 # Only fires if OCTOPUS_WEBHOOK_URL is set — zero noise when unconfigured
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 WEBHOOK_URL="${OCTOPUS_WEBHOOK_URL:-}"
 

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -15,6 +15,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read hook input from stdin
 if [ -t 0 ]; then exit 0; fi

--- a/hooks/version-advisory.sh
+++ b/hooks/version-advisory.sh
@@ -17,6 +17,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 STATE_DIR="${HOME}/.claude-octopus"
 STATE_FILE="${STATE_DIR}/state.json"

--- a/hooks/version-advisory.sh
+++ b/hooks/version-advisory.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/workflow-verification.sh
+++ b/hooks/workflow-verification.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/workflow-verification.sh
+++ b/hooks/workflow-verification.sh
@@ -8,6 +8,13 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 STATE_DIR="${HOME}/.claude-octopus/.octo"
 SNAPSHOT="${STATE_DIR}/pre-compact-snapshot.json"

--- a/hooks/worktree-setup.sh
+++ b/hooks/worktree-setup.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/hooks/worktree-setup.sh
+++ b/hooks/worktree-setup.sh
@@ -8,6 +8,13 @@
 # - All versions: Inject .octopus-env with provider API keys (always needed)
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read worktree info from stdin (JSON payload from Claude Code)
 WORKTREE_DATA=""

--- a/hooks/worktree-teardown.sh
+++ b/hooks/worktree-teardown.sh
@@ -4,6 +4,13 @@
 # Cleans up Octopus artifacts from the worktree path
 
 set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+trap _octo_hook_exit EXIT
+
 
 # Read worktree info from stdin (JSON payload from Claude Code)
 WORKTREE_DATA=""

--- a/hooks/worktree-teardown.sh
+++ b/hooks/worktree-teardown.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
 # ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
 # the hook's logic already handles. See issue #313.
-_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
 

--- a/tests/unit/test-hook-err-traps.sh
+++ b/tests/unit/test-hook-err-traps.sh
@@ -156,12 +156,15 @@ test_freeze_check_no_silent_fail_on_non_tool_input() {
 
 test_quality_gate_no_silent_fail_on_missing_validation() {
     test_case "quality-gate.sh exits 0 when no tangle-validation-*.md exists (was silent fail before #313 fix)"
-    local err_out code err
+    # Explicitly simulate a fresh environment (no ~/.claude-octopus/results/)
+    # — this was the exact failure path that CI hit but local repro missed.
+    local err_out code err tmphome
+    tmphome=$(mktemp -d)
     err_out=$(mktemp)
     code=0
-    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/quality-gate.sh" 2>"$err_out" >/dev/null || code=$?
+    echo "$VALID_STDIN" | HOME="$tmphome" bash "$PROJECT_ROOT/hooks/quality-gate.sh" 2>"$err_out" >/dev/null || code=$?
     err=$(<"$err_out")
-    rm -f "$err_out"
+    rm -rf "$tmphome" "$err_out"
     if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code stderr='${err:0:120}'"; fi
 }
 

--- a/tests/unit/test-hook-err-traps.sh
+++ b/tests/unit/test-hook-err-traps.sh
@@ -57,15 +57,23 @@ test_all_hooks_exit_clean_on_valid_input() {
     for hook_name in $registered; do
         local hook="$PROJECT_ROOT/hooks/$hook_name"
         [[ ! -f "$hook" ]] && continue
-        local err_out code
+        local err_out code err
         err_out=$(mktemp)
+        # `|| code=$?` both suppresses the framework's set -e and captures the
+        # real exit code. Without it, a non-zero hook aborts the test before
+        # test_fail runs — CI shows "FAIL" with no detail.
+        code=0
         echo "$VALID_STDIN" | \
             CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
             CLAUDE_SESSION_ID="test-session" \
-            bash "$hook" 2>"$err_out" >/dev/null
-        code=$?
+            bash "$hook" 2>"$err_out" >/dev/null || code=$?
+        err=$(<"$err_out")
         rm -f "$err_out"
-        [[ $code -ne 0 ]] && failing+=("$hook_name:exit=$code")
+        if [[ $code -ne 0 ]]; then
+            # Truncate stderr to avoid log overflow; embed for diagnosis
+            local short_err="${err:0:120}"
+            failing+=("$hook_name:exit=$code:stderr='$short_err'")
+        fi
     done
     if [[ ${#failing[@]} -eq 0 ]]; then
         test_pass
@@ -128,30 +136,33 @@ test_careful_check_no_silent_fail_on_non_tool_input() {
     test_case "careful-check.sh exits 0 on UserPromptSubmit stdin (was silent fail before #313 fix)"
     local err_out code
     err_out=$(mktemp)
-    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/careful-check.sh" 2>"$err_out" >/dev/null
-    code=$?
+    local code=0
+    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/careful-check.sh" 2>"$err_out" >/dev/null || code=$?
+    local err=$(<"$err_out")
     rm -f "$err_out"
-    if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code"; fi
+    if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code stderr='${err:0:120}'"; fi
 }
 
 test_freeze_check_no_silent_fail_on_non_tool_input() {
     test_case "freeze-check.sh exits 0 on UserPromptSubmit stdin (was silent fail before #313 fix)"
-    local err_out code
+    local err_out code err
     err_out=$(mktemp)
-    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/freeze-check.sh" 2>"$err_out" >/dev/null
-    code=$?
+    code=0
+    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/freeze-check.sh" 2>"$err_out" >/dev/null || code=$?
+    err=$(<"$err_out")
     rm -f "$err_out"
-    if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code"; fi
+    if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code stderr='${err:0:120}'"; fi
 }
 
 test_quality_gate_no_silent_fail_on_missing_validation() {
     test_case "quality-gate.sh exits 0 when no tangle-validation-*.md exists (was silent fail before #313 fix)"
-    local err_out code
+    local err_out code err
     err_out=$(mktemp)
-    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/quality-gate.sh" 2>"$err_out" >/dev/null
-    code=$?
+    code=0
+    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/quality-gate.sh" 2>"$err_out" >/dev/null || code=$?
+    err=$(<"$err_out")
     rm -f "$err_out"
-    if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code"; fi
+    if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code stderr='${err:0:120}'"; fi
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/unit/test-hook-err-traps.sh
+++ b/tests/unit/test-hook-err-traps.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# tests/unit/test-hook-err-traps.sh
+# Regression test for issue #313 — "No stderr output" silent hook failures.
+#
+# Enforces:
+#   1. Every hook that uses `set -e` also installs an EXIT trap that emits
+#      diagnostic stderr on non-zero exit.
+#   2. Every hook exits 0 under a minimal valid UserPromptSubmit-ish input
+#      (no silent pre-existing failures in the ``careful-check / freeze-check /
+#      quality-gate`` grep pipelines).
+#   3. A deliberately broken copy of a hook emits readable stderr (trap fires).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Hook ERR/EXIT trap hygiene (issue #313)"
+
+VALID_STDIN='{"hook_event_name":"UserPromptSubmit","session_id":"test","cwd":"/tmp","prompt":"test","transcript_path":"/dev/null"}'
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Every hook using `set -e` has the trap
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_all_set_e_hooks_have_exit_trap() {
+    test_case "all hooks using 'set -e' also register an EXIT trap"
+    local missing=()
+    for hook in "$PROJECT_ROOT"/hooks/*.sh; do
+        if grep -qE '^set -[eu]' "$hook" 2>/dev/null; then
+            if ! grep -qE 'trap _octo_hook_(err|exit)' "$hook" 2>/dev/null; then
+                missing+=("$(basename "$hook")")
+            fi
+        fi
+    done
+    if [[ ${#missing[@]} -eq 0 ]]; then
+        test_pass
+    else
+        test_fail "hooks missing trap: ${missing[*]}"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Every hook exits 0 under a minimal valid UserPromptSubmit payload
+# (detects pre-existing silent failures like the careful-check/freeze-check/quality-gate bugs)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_all_hooks_exit_clean_on_valid_input() {
+    test_case "no event-registered hook exits non-zero on minimal UserPromptSubmit stdin"
+    local failing=()
+    # Only test hooks actually registered in hooks.json — statusline-resolver /
+    # octopus-statusline live in hooks/ but are standalone runners, not event
+    # hooks, and would legitimately block on statusline-specific input.
+    local registered
+    registered=$(jq -r '.. | objects | .command? | select(.) | select(type=="string")' \
+        "$PROJECT_ROOT/.claude-plugin/hooks.json" 2>/dev/null \
+        | grep -oE '[a-z][a-z0-9-]+\.sh' | sort -u)
+    for hook_name in $registered; do
+        local hook="$PROJECT_ROOT/hooks/$hook_name"
+        [[ ! -f "$hook" ]] && continue
+        local err_out code
+        err_out=$(mktemp)
+        echo "$VALID_STDIN" | \
+            CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+            CLAUDE_SESSION_ID="test-session" \
+            bash "$hook" 2>"$err_out" >/dev/null
+        code=$?
+        rm -f "$err_out"
+        [[ $code -ne 0 ]] && failing+=("$hook_name:exit=$code")
+    done
+    if [[ ${#failing[@]} -eq 0 ]]; then
+        test_pass
+    else
+        test_fail "hooks failing on valid stdin: ${failing[*]}"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Trap semantics — a deliberately broken hook must emit readable stderr
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_trap_emits_stderr_on_forced_failure() {
+    test_case "EXIT trap emits diagnostic stderr when hook exits non-zero"
+    # Copy a real hook, inject a `false` AFTER the trap line, verify stderr
+    local src="$PROJECT_ROOT/hooks/user-prompt-submit.sh"
+    local tmp
+    tmp=$(mktemp)
+    # Insert `false` after the `trap _octo_hook_exit EXIT` line
+    awk '{print} /^trap _octo_hook_exit EXIT$/ && !done {print "false"; done=1}' "$src" > "$tmp"
+    local err_out code err
+    err_out=$(mktemp)
+    # `|| code=$?` both suppresses set -e and captures the real exit code.
+    code=0
+    echo "$VALID_STDIN" | CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$tmp" 2>"$err_out" >/dev/null || code=$?
+    err=$(<"$err_out")
+    rm -f "$tmp" "$err_out"
+    # Match on the stable "[hook:...] exit" pattern; the copied file has a random basename
+    if [[ $code -ne 0 && "$err" == *"[hook:"*"] exit"* ]]; then
+        test_pass
+    else
+        test_fail "expected exit!=0 with '[hook:...] exit' stderr, got exit=$code stderr='$err'"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Trap does NOT over-fire — normal clean exit produces no trap output
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_trap_silent_on_clean_exit() {
+    test_case "EXIT trap stays silent when hook exits 0"
+    local hook="$PROJECT_ROOT/hooks/user-prompt-submit.sh"
+    local err_out err
+    err_out=$(mktemp)
+    echo "$VALID_STDIN" | CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$hook" 2>"$err_out" >/dev/null
+    err=$(<"$err_out")
+    rm -f "$err_out"
+    if [[ "$err" != *"[hook:"* ]]; then
+        test_pass
+    else
+        test_fail "trap over-fired on clean exit: stderr='$err'"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Specific regressions — the 3 pre-existing silent failures
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_careful_check_no_silent_fail_on_non_tool_input() {
+    test_case "careful-check.sh exits 0 on UserPromptSubmit stdin (was silent fail before #313 fix)"
+    local err_out code
+    err_out=$(mktemp)
+    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/careful-check.sh" 2>"$err_out" >/dev/null
+    code=$?
+    rm -f "$err_out"
+    if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code"; fi
+}
+
+test_freeze_check_no_silent_fail_on_non_tool_input() {
+    test_case "freeze-check.sh exits 0 on UserPromptSubmit stdin (was silent fail before #313 fix)"
+    local err_out code
+    err_out=$(mktemp)
+    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/freeze-check.sh" 2>"$err_out" >/dev/null
+    code=$?
+    rm -f "$err_out"
+    if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code"; fi
+}
+
+test_quality_gate_no_silent_fail_on_missing_validation() {
+    test_case "quality-gate.sh exits 0 when no tangle-validation-*.md exists (was silent fail before #313 fix)"
+    local err_out code
+    err_out=$(mktemp)
+    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/quality-gate.sh" 2>"$err_out" >/dev/null
+    code=$?
+    rm -f "$err_out"
+    if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code"; fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RUN
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_all_set_e_hooks_have_exit_trap
+test_all_hooks_exit_clean_on_valid_input
+test_trap_emits_stderr_on_forced_failure
+test_trap_silent_on_clean_exit
+test_careful_check_no_silent_fail_on_non_tool_input
+test_freeze_check_no_silent_fail_on_non_tool_input
+test_quality_gate_no_silent_fail_on_missing_validation
+
+test_summary


### PR DESCRIPTION
Closes #313.

## What the user saw

```
UserPromptSubmit hook error
Failed with non-blocking status code: No stderr output
```

Completely un-actionable. Three plugin hooks registered for UserPromptSubmit; no way to tell which one failed.

## Investigation

Ran a 7-scenario failure matrix (empty stdin, malformed JSON, missing fields, null prompt, 50KB prompt, PATH without jq, valid baseline) × both UserPromptSubmit hooks × concurrent race × SIGPIPE probe = **all exit 0 cleanly**. The two UserPromptSubmit hooks aren't broken.

But the probe turned up **three pre-existing silent failures** in hooks registered on _other_ events:

| Hook | Event | Silent-fail trigger |
|------|-------|---------------------|
| `careful-check.sh` | PreToolUse | `grep -o '"tool_name":...'` missing on non-tool stdin |
| `freeze-check.sh` | PreToolUse | same |
| `quality-gate.sh` | PostToolUse | `grep -E "^## (Quality Gate\|Status):"` missing when no validation file |

All three use `VAR=$(pipe | grep ... | head -1 | cut -d...)` under `set -euo pipefail`. When grep finds no match, the pipeline exits non-zero and (on some bash versions with certain inheritance behavior) the script's final exit code inherits that — silently.

These hooks are registered with broad PreToolUse/PostToolUse matchers. Depending on harness routing, they can receive events that don't carry the fields they expect. The exit is non-zero but emits no stderr → the user sees the exact phrasing they reported.

## Fixes

### 1. EXIT trap on every hook with `set -e` (46 files)

```bash
_octo_hook_exit() { local c=$?; [[ $c -ne 0 ]] && echo "[hook:$(basename "$0")] exit $c at line ${BASH_LINENO[0]:-?}" >&2 || true; }
trap _octo_hook_exit EXIT
```

EXIT (not ERR) — avoids over-firing on harmless intermediate `grep -o` failures inside `$()`.

### 2. `|| true` on 3 silent-fail grep pipelines

- `careful-check.sh` — `TOOL_NAME` + `COMMAND` extractions
- `freeze-check.sh` — `TOOL_NAME` + `FILE_PATH` extractions
- `quality-gate.sh` — `STATUS` extraction from validation-file grep

### 3. Regression test

`tests/unit/test-hook-err-traps.sh` — **7 tests** covering:
- Every `set -e` hook has the EXIT trap
- Every event-registered hook exits 0 on minimal UserPromptSubmit stdin (guards the 3 silent-fail bugs from recurring)
- Trap fires + emits `[hook:...] exit` on forced failure
- Trap stays silent on clean exits
- Explicit per-hook regressions for `careful-check` / `freeze-check` / `quality-gate`

## Verification

| Suite | Result |
|-------|--------|
| `tests/unit/test-hook-err-traps.sh` | 7/7 pass |
| Full unit (`bash tests/run-all.sh unit`) | **87/87 pass** |
| Smoke (`bash tests/run-all.sh smoke`) | **12/12 pass** |

Pre-patch main reproduces `careful-check.sh` / `freeze-check.sh` / `quality-gate.sh` exiting 1 with empty stderr on non-matching input. Post-patch: all exit 0 cleanly.

## Files

| File(s) | Change |
|---------|--------|
| `hooks/*.sh` (46 files) | Add EXIT trap after `set -e...` line |
| `hooks/careful-check.sh` | `\|\| true` on 2 grep pipelines |
| `hooks/freeze-check.sh` | `\|\| true` on 2 grep pipelines |
| `hooks/quality-gate.sh` | `\|\| true` on 1 grep pipeline |
| `tests/unit/test-hook-err-traps.sh` | New — 7 tests |

## Test Plan

- [x] `bash tests/unit/test-hook-err-traps.sh` → 7/7 pass
- [x] `bash tests/run-all.sh unit` → 87/87 pass
- [x] `bash tests/run-all.sh smoke` → 12/12 pass
- [x] Pre-patch vs. post-patch diff on the 3 silent-failers: exit 1 → exit 0
- [x] Trap semantics verified with forced `false` injection after the trap line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hooks now emit a single human-readable stderr diagnostic only when they exit non‑zero, preserving silent success paths and avoiding noisy intermediate diagnostics.

* **Tests**
  * Added a regression test that validates hook exit-trap behavior: failing hooks must produce the expected stderr diagnostic and successful hooks remain silent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->