### PR TITLE
chore: release v9.29.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Claude Code",
-    "version": "9.29.0"
+    "version": "9.29.1"
   },
   "plugins": [
     {
       "name": "octo",
       "source": "./",
-      "description": "v9.29.0 - Multi-LLM orchestration for Claude Code. Route tasks to Codex, Gemini, Perplexity, Copilot, Qwen, Ollama, OpenCode. 137 CC feature flags, token compression (~7K/session saved), interactive setup wizard. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
-      "version": "9.29.0",
+      "description": "v9.29.1 - Multi-LLM orchestration for Claude Code. Route tasks to Codex, Gemini, Perplexity, Copilot, Qwen, Ollama, OpenCode. 137 CC feature flags, token compression (~7K/session saved), interactive setup wizard. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
+      "version": "9.29.1",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.29.0",
-  "description": "v9.29.0 — Model defaults refreshed: Opus 4.7 for planning/strategy/security-review, GPT-5.4 for code-review/implementation. New GPT-5.4 prompting guide. Set OCTOPUS_LEGACY_ROLES=1 to opt out. Run /octo:setup.",
+  "version": "9.29.1",
+  "description": "v9.29.1 \u2014 Model defaults refreshed: Opus 4.7 for planning/strategy/security-review, GPT-5.4 for code-review/implementation. New GPT-5.4 prompting guide. Set OCTOPUS_LEGACY_ROLES=1 to opt out. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [9.29.1] - 2026-04-22
+
+### Changed
+
+- Patch bundle: perplexity stdin + nested-JSON fix (#307/#310), v9.29 migration advisory + write-intent guardrail (#312), hook hardening eliminating silent failures (#313/#314), model-config banner fix (#301/#302), cache byte-format env compat.
+
+---
+
 ## [9.29.0] - 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-146_passing-brightgreen" alt="146 tests passing">
-  <img src="https://img.shields.io/badge/Version-9.29.0-blue" alt="Version 9.29.0">
+  <img src="https://img.shields.io/badge/Version-9.29.1-blue" alt="Version 9.29.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.83+-blueviolet" alt="Requires Claude Code v2.1.83+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.29.0",
+  "version": "9.29.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Release v9.29.1 — Patch bundle

Post-v9.29.0 fixes accumulated on main; bundling into a single patch release so marketplace users get them.

### What's included

| PR | Fix |
|---|---|
| #310 | Perplexity/OpenRouter stdin inheritance + nested JSON extraction (closes #307) |
| #312 | v9.29 migration advisory (SessionStart hook) + `/octo:dev` / `/octo:km` idempotence + write-intent guardrail |
| #314 | Hook hardening — EXIT trap + `\|\| true` guards across all 46 hooks, fixing 3 pre-existing silent-fail paths in `careful-check.sh`, `freeze-check.sh`, `quality-gate.sh` (closes #313) |
| #302 | `/octo:model-config` STEP 0 banner — guarantees output before `AskUserQuestion` so E2E pattern-matching works (external contributor fix, closes #301) |
| `38dc41e` | `fix(cache)`: use `awk` instead of `bc` for byte formatting (env compat) |

### Why patch, not minor

All 5 commits are bug fixes — no feature additions, no behavioral changes to routing/dispatch/commands beyond fixing broken paths. Role defaults from v9.29.0 remain unchanged.

### Verification

Every merged PR was green on CI (macOS + Ubuntu smoke + unit) before merging. 87/87 unit + 12/12 smoke green on main.

### Test Plan

- [x] `bash tests/run-all.sh smoke` — 12/12 (verified per-merge)
- [x] `bash tests/run-all.sh unit` — 87/87 (verified per-merge)
- [x] No behavioral change to v9.29.0 role routing — role-mapping tests unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 9.29.1.

* **Bug Fixes**
  * Improved stdin and nested-JSON handling.
  * Enhanced migration advisory with write-intent guardrail.
  * Hardened hook implementation to eliminate silent failures.
  * Fixed model-config banner display.
  * Improved cache byte-format environment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->