### PR TITLE
chore: release v9.29.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Claude Code",
-    "version": "9.29.1"
+    "version": "9.29.2"
   },
   "plugins": [
     {
       "name": "octo",
       "source": "./",
-      "description": "v9.29.1 - Multi-LLM orchestration for Claude Code. Route tasks to Codex, Gemini, Perplexity, Copilot, Qwen, Ollama, OpenCode. 137 CC feature flags, token compression (~7K/session saved), interactive setup wizard. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
-      "version": "9.29.1",
+      "description": "v9.29.2 - Multi-LLM orchestration for Claude Code. Route tasks to Codex, Gemini, Perplexity, Copilot, Qwen, Ollama, OpenCode. 137 CC feature flags, token compression (~7K/session saved), interactive setup wizard. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
+      "version": "9.29.2",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.29.1",
-  "description": "v9.29.1 \u2014 Model defaults refreshed: Opus 4.7 for planning/strategy/security-review, GPT-5.4 for code-review/implementation. New GPT-5.4 prompting guide. Set OCTOPUS_LEGACY_ROLES=1 to opt out. Run /octo:setup.",
+  "version": "9.29.2",
+  "description": "v9.29.2 \u2014 Model defaults refreshed: Opus 4.7 for planning/strategy/security-review, GPT-5.4 for code-review/implementation. New GPT-5.4 prompting guide. Set OCTOPUS_LEGACY_ROLES=1 to opt out. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -101,7 +101,7 @@ Launch agents in parallel using `run_in_background: true`:
 
 **Codex Agent** (if available):
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
 
 Think creatively about: [TOPIC]
 

--- a/.claude/commands/prd.md
+++ b/.claude/commands/prd.md
@@ -103,7 +103,7 @@ Include these sections:
 
 **If Codex is available:**
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
 
 You are a skeptical product reviewer. Challenge this PRD:
 

--- a/.claude/skills/flow-parallel.md
+++ b/.claude/skills/flow-parallel.md
@@ -188,7 +188,7 @@ fi
 ```bash
 WBS_CONTENT=$(<".octo/parallel/wbs.json")
 
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
 
 Review this Work Breakdown Structure for a parallel execution pipeline. Your job is to find problems BEFORE agents start working.
 

--- a/.claude/skills/flow-spec.md
+++ b/.claude/skills/flow-spec.md
@@ -253,7 +253,7 @@ Synthesize into the NLSpec template below. This is YOUR (Claude's) synthesis rol
 
 If Codex is available:
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
 
 Challenge this specification. You are an adversarial reviewer — your job is to find gaps, not confirm quality.
 

--- a/.claude/skills/skill-debate.md
+++ b/.claude/skills/skill-debate.md
@@ -57,7 +57,7 @@ Participants:
 
 **Codex CLI** (non-interactive headless mode):
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
 
 YOUR PROMPT HERE"
 ```
@@ -430,7 +430,7 @@ printf '%s' "${QUESTION}" | gemini -p "" -o text --approval-mode yolo > "${DEBAT
 
 #### 5.2: Consult Codex
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
 
 ${QUESTION}" > "${DEBATE_DIR}/rounds/r001_codex.md"
 ```
@@ -587,7 +587,7 @@ Claude:
 3. Round 1:
    - Launches Sonnet via Agent(model: sonnet, run_in_background: true) — pragmatic implementer
    - Calls printf '%s' "Should we use Redis..." | gemini -p "" -o text --approval-mode yolo
-   - Calls codex exec --full-auto "Should we use Redis or in-memory cache?"
+   - Calls codex exec --skip-git-repo-check --full-auto "Should we use Redis or in-memory cache?"
    - Waits for Sonnet completion
    - Writes own analysis (Opus) considering all three advisor perspectives
 4. Writes synthesis.md with final recommendation from all four participants

--- a/.claude/skills/skill-factory.md
+++ b/.claude/skills/skill-factory.md
@@ -87,7 +87,7 @@ If a second provider is available (Codex or Gemini), dispatch the challenge:
 SPEC_CONTENT=$(<"<spec_path>")
 
 # Challenge scenario coverage with a different provider
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
 
 You are a QA adversary. Given this specification and generated scenarios, identify coverage gaps.
 

--- a/.claude/skills/skill-staged-review.md
+++ b/.claude/skills/skill-staged-review.md
@@ -174,7 +174,7 @@ DIFF_CONTENT=$(git diff --cached 2>/dev/null || git diff HEAD~1..HEAD 2>/dev/nul
 
 **If Codex is available — dispatch logic review:**
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
 
 Review this code diff for LOGIC and CORRECTNESS issues only. Focus on:
 1. Logic bugs and off-by-one errors

--- a/.claude/skills/skill-tdd.md
+++ b/.claude/skills/skill-tdd.md
@@ -99,7 +99,7 @@ test('retry works', async () => {  // Vague name
 **If an external provider is available, dispatch the test specs for challenge:**
 
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
 
 Review these test specifications for a TDD workflow. Your job is to find gaps, not confirm quality.
 

--- a/.claude/skills/skill-ui-ux-design.md
+++ b/.claude/skills/skill-ui-ux-design.md
@@ -286,7 +286,7 @@ fi
 
 # 🔴 Codex — implementation-focused critique (font loading, CSS practicality, bundle impact)
 if [[ "$codex_available" == "true" ]]; then
-    codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
+    codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
 
 <critique prompt>" > /tmp/design-critique-codex.md &
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [9.29.2] - 2026-04-23
+
+### Changed
+
+- Fix: add --skip-git-repo-check to all codex exec invocations (#319)
+
+---
+
 ## [9.29.1] - 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-146_passing-brightgreen" alt="146 tests passing">
-  <img src="https://img.shields.io/badge/Version-9.29.1-blue" alt="Version 9.29.1">
+  <img src="https://img.shields.io/badge/Version-9.29.2-blue" alt="Version 9.29.2">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.83+-blueviolet" alt="Requires Claude Code v2.1.83+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/commands/octo-brainstorm.md
+++ b/commands/octo-brainstorm.md
@@ -91,7 +91,7 @@ Launch agents in parallel using `run_in_background: true`:
 
 **Codex Agent** (if available):
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
 
 Think creatively about: [TOPIC]
 

--- a/commands/octo-prd.md
+++ b/commands/octo-prd.md
@@ -110,7 +110,7 @@ Include these sections:
 
 **If Codex is available:**
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
 
 You are a skeptical product reviewer. Challenge this PRD:
 

--- a/hooks/quality-gate.sh
+++ b/hooks/quality-gate.sh
@@ -30,7 +30,8 @@ if [[ -f "$VALIDATION_FILE" ]]; then
     fi
 fi
 
-# Reference integrity check: scan recently created/modified files for broken references
+# Reference integrity check: scan recently created/modified files for broken references.
+# Only defined here — called below when VALIDATION_FILE exists (i.e. tangle was recently run).
 # Catches: HTML linking missing JS/CSS, scripts sourcing missing files, configs referencing missing paths
 check_reference_integrity() {
     # Scope-local: disable -u because bash 3.2 (macOS CI) aborts (exit 134)
@@ -115,7 +116,11 @@ check_reference_integrity() {
     fi
 }
 
-check_reference_integrity
+# Only scan for broken references when a tangle run actually happened recently.
+# Skipping when VALIDATION_FILE is absent avoids scanning the plugin source tree
+# in CI (where all .sh files are "recently modified" by the checkout), which
+# triggered Abort trap: 6 on bash 3.2 macOS. See issue #313.
+[[ -f "$VALIDATION_FILE" ]] && check_reference_integrity
 
 # No validation file or quality gate passed
 echo '{"decision": "continue"}'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.29.1",
+  "version": "9.29.2",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -76,7 +76,7 @@ get_agent_command() {
             esac
             echo "${gemini_env} ${gemini_exec} ${model} ${gemini_flags}"
             ;;
-        codex-review) echo "codex exec review" ;; # Code review mode (no sandbox support)
+        codex-review) echo "codex exec --skip-git-repo-check review" ;; # Code review mode (no sandbox support)
         claude) echo "claude${_BARE_OPT} --print" ;;                         # Claude Sonnet 4.6
         claude-sonnet) echo "claude${_BARE_OPT} --print --model sonnet" ;;        # Claude Sonnet explicit
         claude-opus)

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -416,7 +416,7 @@ detect_tier_openai() {
     if command -v codex &>/dev/null; then
         local test_response
         # Use 5-second timeout for minimal "ok" prompt (3 tokens)
-        test_response=$(run_with_timeout 5 codex exec "ok" 2>&1 || echo "")
+        test_response=$(run_with_timeout 5 codex exec --skip-git-repo-check "ok" 2>&1 || echo "")
 
         # Check for tier indicators in response
         # o3-mini/gpt-4 access suggests plus tier

--- a/skills/flow-spec/SKILL.md
+++ b/skills/flow-spec/SKILL.md
@@ -248,7 +248,7 @@ Synthesize into the NLSpec template below. This is YOUR (Claude's) synthesis rol
 
 If Codex is available:
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
 
 Challenge this specification. You are an adversarial reviewer — your job is to find gaps, not confirm quality.
 

--- a/skills/skill-debate/SKILL.md
+++ b/skills/skill-debate/SKILL.md
@@ -35,7 +35,7 @@ Participants:
 
 **Codex CLI** (non-interactive headless mode):
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
 
 YOUR PROMPT HERE"
 ```
@@ -410,7 +410,7 @@ printf '%s' "${QUESTION}" | gemini -p "" -o text --approval-mode yolo > "${DEBAT
 
 #### 5.2: Consult Codex
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
 
 ${QUESTION}" > "${DEBATE_DIR}/rounds/r001_codex.md"
 ```
@@ -567,7 +567,7 @@ Claude:
 3. Round 1:
    - Launches Sonnet via Agent(model: sonnet, run_in_background: true) — pragmatic implementer
    - Calls printf '%s' "Should we use Redis..." | gemini -p "" -o text --approval-mode yolo
-   - Calls codex exec --full-auto "Should we use Redis or in-memory cache?"
+   - Calls codex exec --skip-git-repo-check --full-auto "Should we use Redis or in-memory cache?"
    - Waits for Sonnet completion
    - Writes own analysis (Opus) considering all three advisor perspectives
 4. Writes synthesis.md with final recommendation from all four participants

--- a/skills/skill-staged-review/SKILL.md
+++ b/skills/skill-staged-review/SKILL.md
@@ -164,7 +164,7 @@ DIFF_CONTENT=$(git diff --cached 2>/dev/null || git diff HEAD~1..HEAD 2>/dev/nul
 
 **If Codex is available — dispatch logic review:**
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
 
 Review this code diff for LOGIC and CORRECTNESS issues only. Focus on:
 1. Logic bugs and off-by-one errors

--- a/skills/skill-tdd/SKILL.md
+++ b/skills/skill-tdd/SKILL.md
@@ -88,7 +88,7 @@ test('retry works', async () => {  // Vague name
 **If an external provider is available, dispatch the test specs for challenge:**
 
 ```bash
-codex exec --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
+codex exec --skip-git-repo-check --full-auto "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills. Respond directly to the prompt below.
 
 Review these test specifications for a TDD workflow. Your job is to find gaps, not confirm quality.
 

--- a/tests/unit/test-agent-ergonomics.sh
+++ b/tests/unit/test-agent-ergonomics.sh
@@ -18,7 +18,7 @@ pass() { test_case "$1"; test_pass; }
 fail() { test_case "$1"; test_fail "${2:-$1}"; }
 assert_contains() {
   local output="$1" pattern="$2" label="$3"
-  echo "$output" | grep -qE "$pattern" && pass "$label" || fail "$label" "missing: $pattern"
+  grep -qE "$pattern" <<< "$output" && pass "$label" || fail "$label" "missing: $pattern"
 }
 
 # ── readonly frontmatter ─────────────────────────────────────────────────────

--- a/tests/unit/test-copilot-provider.sh
+++ b/tests/unit/test-copilot-provider.sh
@@ -15,7 +15,7 @@ pass() { test_case "$1"; test_pass; }
 fail() { test_case "$1"; test_fail "${2:-$1}"; }
 assert_contains() {
   local output="$1" pattern="$2" label="$3"
-  echo "$output" | grep -qE "$pattern" && pass "$label" || fail "$label" "missing: $pattern"
+  grep -qE "$pattern" <<< "$output" && pass "$label" || fail "$label" "missing: $pattern"
 }
 
 # ── 1. File existence ────────────────────────────────────────────────────────

--- a/tests/unit/test-coverage-audit.sh
+++ b/tests/unit/test-coverage-audit.sh
@@ -15,12 +15,12 @@ fail() { test_case "$1"; test_fail "${2:-$1}"; }
 
 assert_contains() {
   local output="$1" pattern="$2" label="$3"
-  echo "$output" | grep -qE "$pattern" && pass "$label" || fail "$label" "missing: $pattern"
+  grep -qE "$pattern" <<< "$output" && pass "$label" || fail "$label" "missing: $pattern"
 }
 
 assert_not_contains() {
   local output="$1" pattern="$2" label="$3"
-  echo "$output" | grep -qE "$pattern" && fail "$label" "should not contain: $pattern" || pass "$label"
+  grep -qE "$pattern" <<< "$output" && fail "$label" "should not contain: $pattern" || pass "$label"
 }
 
 SKILL_CONTENT=$(<"$SKILL_FILE")

--- a/tests/unit/test-design-lineage.sh
+++ b/tests/unit/test-design-lineage.sh
@@ -15,12 +15,12 @@ fail() { test_case "$1"; test_fail "${2:-$1}"; }
 
 assert_contains() {
   local output="$1" pattern="$2" label="$3"
-  echo "$output" | grep -qE "$pattern" && pass "$label" || fail "$label" "missing: $pattern"
+  grep -qE "$pattern" <<< "$output" && pass "$label" || fail "$label" "missing: $pattern"
 }
 
 assert_not_contains() {
   local output="$1" pattern="$2" label="$3"
-  echo "$output" | grep -qE "$pattern" && fail "$label" "should not contain: $pattern" || pass "$label"
+  grep -qE "$pattern" <<< "$output" && fail "$label" "should not contain: $pattern" || pass "$label"
 }
 
 # ── File exists ──────────────────────────────────────────────────────────────

--- a/tests/unit/test-probe-single.sh
+++ b/tests/unit/test-probe-single.sh
@@ -19,7 +19,7 @@ pass() { test_case "$1"; test_pass; }
 fail() { test_case "$1"; test_fail "${2:-$1}"; }
 assert_contains() {
   local output="$1" pattern="$2" label="$3"
-  echo "$output" | grep -qE "$pattern" && pass "$label" || fail "$label" "missing: $pattern"
+  grep -qE "$pattern" <<< "$output" && pass "$label" || fail "$label" "missing: $pattern"
 }
 
 # ── probe_single_agent function exists ────────────────────────────────────────

--- a/tests/unit/test-review-run.sh
+++ b/tests/unit/test-review-run.sh
@@ -20,12 +20,12 @@ fail() { test_case "$1"; test_fail "${2:-$1}"; }
 
 assert_contains() {
   local output="$1" pattern="$2" label="$3"
-  echo "$output" | grep -qE "$pattern" && pass "$label" || fail "$label" "missing: $pattern"
+  grep -qE "$pattern" <<< "$output" && pass "$label" || fail "$label" "missing: $pattern"
 }
 
 assert_not_contains() {
   local output="$1" pattern="$2" label="$3"
-  echo "$output" | grep -qE "$pattern" && fail "$label" "should not contain: $pattern" || pass "$label"
+  grep -qE "$pattern" <<< "$output" && fail "$label" "should not contain: $pattern" || pass "$label"
 }
 
 # ── parse_review_md fixture ───────────────────────────────────────────────────


### PR DESCRIPTION
## Release v9.29.2

Fix: add `--skip-git-repo-check` to all codex exec invocations (#319)

### Changes

Codex CLI exits 1 when invoked outside a git repo unless `--skip-git-repo-check` is passed. This affected all skills that dispatch to Codex when the user is working in a non-git directory (docs folders, marketing workspaces, etc.).

**Fixed in:**
- `scripts/lib/dispatch.sh` — `codex-review` agent type case
- `scripts/lib/smoke.sh` — tier detection probe
- All 9 skill/command markdown files that supply `codex exec` command examples (brainstorm, prd, flow-parallel, flow-spec, skill-debate, skill-factory, skill-staged-review, skill-tdd, skill-ui-ux-design)
- Root-level build outputs synced

Closes #319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped release/version to 9.29.2.

* **Bug Fixes**
  * Codex executions now skip repository validation so commands run in non-git environments.
  * Reference integrity scan is skipped when no validation result exists to avoid unnecessary failures.

* **Documentation**
  * Release notes and README updated to reflect 9.29.2.

* **Tests**
  * Test helpers adjusted to feed captured output directly into the matcher for more reliable checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->