### PR TITLE
fix: ensure plugin symlink exists before first command (closes #318)

### DIFF
--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -7,6 +7,15 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Self-heal: ensure the stable symlink exists for LLM Bash tool access.
+# The SessionStart hook normally creates this, but if doctor (or any command)
+# is invoked before the hook fires, the symlink may be missing. (fixes #318)
+if [[ ! -e "${HOME}/.claude-octopus/plugin" ]]; then
+    mkdir -p "${HOME}/.claude-octopus"
+    ln -sfn "$PLUGIN_DIR" "${HOME}/.claude-octopus/plugin"
+fi
+
 # Cache platform detection — avoids repeated subprocess spawns (v8.33.0)
 OCTOPUS_PLATFORM="$(uname)"
 

--- a/scripts/session-manager.sh
+++ b/scripts/session-manager.sh
@@ -20,6 +20,15 @@ export_session_variables() {
     export OCTOPUS_GEMINI_SESSION="gemini-${OCTOPUS_SESSION_ID}"
     export OCTOPUS_CLAUDE_SESSION="claude-${OCTOPUS_SESSION_ID}"
 
+    # Bridge CLAUDE_PLUGIN_ROOT to a stable symlink for LLM Bash tool access.
+    # CLAUDE_PLUGIN_ROOT is set by Claude Code for hook execution but NOT
+    # available in the LLM's Bash shell. This symlink makes all skill
+    # references to ${HOME}/.claude-octopus/plugin/scripts/... resolve correctly.
+    # Created BEFORE session directories so the symlink exists even if mkdir fails.
+    local plugin_root="${CLAUDE_PLUGIN_ROOT:-$(dirname "$SCRIPT_DIR")}"
+    mkdir -p "${HOME}/.claude-octopus"
+    ln -sfn "$plugin_root" "${HOME}/.claude-octopus/plugin"
+
     # Session directories
     export OCTOPUS_SESSION_DIR="${HOME}/.claude-octopus/sessions/${OCTOPUS_SESSION_ID}"
     export OCTOPUS_SESSION_RESULTS="${OCTOPUS_SESSION_DIR}/results"
@@ -28,13 +37,6 @@ export_session_variables() {
 
     # Create session directories
     mkdir -p "$OCTOPUS_SESSION_RESULTS" "$OCTOPUS_SESSION_LOGS" "$OCTOPUS_SESSION_PLANS"
-
-    # Bridge CLAUDE_PLUGIN_ROOT to a stable symlink for LLM Bash tool access.
-    # CLAUDE_PLUGIN_ROOT is set by Claude Code for hook execution but NOT
-    # available in the LLM's Bash shell. This symlink makes all skill
-    # references to ${HOME}/.claude-octopus/plugin/scripts/... resolve correctly.
-    local plugin_root="${CLAUDE_PLUGIN_ROOT:-$(dirname "$SCRIPT_DIR")}"
-    ln -sfn "$plugin_root" "${HOME}/.claude-octopus/plugin"
 
     # Write session metadata
     cat > "${OCTOPUS_SESSION_DIR}/.session-metadata.json" <<EOF


### PR DESCRIPTION
## Problem

The `~/.claude-octopus/plugin` symlink is created by the SessionStart hook (`session-manager.sh export`). If the hook hasn't fired yet — e.g. running `/octo:doctor` as the very first command in a session — the symlink is missing and `cd ~/.claude-octopus/plugin` fails with "no such directory".

The user in #318 sees this every time because the symlink creation happened *after* the `mkdir -p` for session directories, so if that `mkdir` failed (permissions, etc.), `set -eo pipefail` would exit before creating the symlink.

## Fix

1. **session-manager.sh**: Move symlink creation BEFORE session directory setup. Create `~/.claude-octopus/` explicitly first, then the symlink. If anything after fails, the symlink already exists.

2. **orchestrate.sh**: Add a self-heal check at startup — if `~/.claude-octopus/plugin` doesn't exist, create it. This handles the case where the SessionStart hook hasn't fired yet but orchestrate.sh is invoked directly via the correct path.

Both changes are idempotent (`ln -sfn` overwrites, `mkdir -p` is safe).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin initialization by automatically ensuring required symlink is created early in the setup process, enhancing reliability of plugin access for the LLM Bash tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->