### PR TITLE
fix(spawn): wait for inner agent subshell before returning PID

### DIFF
--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -823,6 +823,8 @@ ${heuristic_ctx}"
         echo "$pid:$agent_type:$task_id" >> "$PID_FILE"
     fi
 
+    wait "$pid" 2>/dev/null || true
+
     log INFO "Agent spawned with PID: $pid"
     echo "$pid"
 }


### PR DESCRIPTION
## Problem

`probe_discover` backgrounds the outer `spawn_agent` wrappers and tracks their PIDs:

```bash
spawn_agent ... &
pids+=($!)
```

Inside `spawn_agent`, the real work runs in an inner subshell:

```bash
(
    # ... set up env, run claude/codex/gemini agent ...
) &
pid=$!
```

The outer wrapper captures that inner PID, writes it to the PID file, then **exits** — in about 1 second. `display_rich_progress` tracks the outer wrapper PIDs, sees them all go dead almost immediately, concludes all agents have finished, and triggers synthesis. At that point the inner agent subshells are still running and the output files are empty or partial.

Result: every multi-provider probe returns an empty synthesis, making the whole orchestration useless.

## Fix

Add `wait "$pid" 2>/dev/null || true` in `spawn_agent` after the PID file write, before the `log INFO` line. This keeps the outer wrapper alive until the inner agent subshell completes. `display_rich_progress` now sees accurate liveness and synthesis fires only after real output exists.

```diff
+    wait "$pid" 2>/dev/null || true
+
     log INFO "Agent spawned with PID: $pid"
     echo "$pid"
 }
```

## Verification

Tested on WSL2/Debian with `OCTOPUS_DISPATCH_STRATEGY=full` dispatching codex + gemini + claude-sonnet. Before the fix: synthesis triggered with 0B output files. After: all agents completed with real output (codex: 255KB, claude-sonnet: 23K+16K, gemini: 8K+8K).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal process management for background agent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->