### PR TITLE
fix: harden remaining async PID call sites

### DIFF
--- a/scripts/async-tmux-features.sh
+++ b/scripts/async-tmux-features.sh
@@ -190,9 +190,10 @@ spawn_agent_async() {
         tmux_spawn_pane "$agent_type" "$task_id" "$pane_title"
     fi
 
-    # Spawn agent normally (already runs in background)
+    # Spawn agent and return the worker PID, not a short-lived wrapper from
+    # command substitution around spawn_agent.
     local pid
-    pid=$(spawn_agent "$agent_type" "$prompt" "$task_id" "$role" "$phase")
+    pid=$(spawn_agent_capture_pid "$agent_type" "$prompt" "$task_id" "$role" "$phase")
 
     echo "$pid"
 }

--- a/scripts/lib/auto-route.sh
+++ b/scripts/lib/auto-route.sh
@@ -55,6 +55,29 @@ match_routing_rule() {
     return 1
 }
 
+_auto_route_wait_for_pids() {
+    local max_wait="${1:-${TIMEOUT:-600}}"
+    shift || true
+    local pids=("$@")
+    local wait_start=$SECONDS
+
+    while [[ $((SECONDS - wait_start)) -lt $max_wait ]]; do
+        local all_done=true
+        local pid
+        for pid in "${pids[@]}"; do
+            [[ -z "$pid" ]] && continue
+            if kill -0 "$pid" 2>/dev/null; then
+                all_done=false
+                break
+            fi
+        done
+        [[ "$all_done" == "true" ]] && return 0
+        sleep 1
+    done
+
+    return 1
+}
+
 auto_route() {
     local prompt="$1"
     local prompt_lower
@@ -431,15 +454,22 @@ Focus on:
             local audit_dir
             audit_dir="${WORKSPACE:-$HOME/.claude-octopus}/results/audit-$(date +%Y%m%d-%H%M%S)"
             mkdir -p "$audit_dir"
+            local audit_group
+            audit_group=$(date +%s)
             local pids=()
             local domain_files=()
+            local agent_result_files=()
 
             # Phase 1: Parallel domain analysis
             echo -e "  ${CYAN}Phase 1/3: Parallel Domain Analysis${NC}"
             for domain in "${domains[@]}"; do
                 local domain_prompt
                 local domain_file="$audit_dir/$domain.md"
+                local agent_type="gemini-fast"
+                local task_id="audit-${domain}-${audit_group}"
+                local agent_result_file="${RESULTS_DIR}/${agent_type}-${task_id}.md"
                 domain_files+=("$domain_file")
+                agent_result_files+=("$agent_result_file")
 
                 case "$domain" in
                     performance)
@@ -475,19 +505,40 @@ Output a structured report with findings and recommendations." ;;
                 esac
 
                 echo -e "    ├─ Starting ${domain} audit..."
-                (spawn_agent "gemini-fast" "$domain_prompt" > "$domain_file" 2>&1) &
-                pids+=($!)
+                local pid=""
+                if pid=$(spawn_agent_capture_pid "$agent_type" "$domain_prompt" "$task_id" "auditor" "optimize-audit"); then
+                    pids+=("$pid")
+                else
+                    pids+=("")
+                    echo -e "      ${RED}✗${NC} ${domain} audit failed to spawn"
+                fi
             done
 
             # Wait for all audits to complete
             echo -e "    └─ Waiting for ${#pids[@]} audits to complete..."
             local failed=0
+            if ! _auto_route_wait_for_pids "${TIMEOUT:-600}" "${pids[@]}"; then
+                echo -e "      ${YELLOW}!${NC} One or more domain audits reached the timeout; collecting available results"
+            fi
             for i in "${!pids[@]}"; do
-                if ! wait "${pids[$i]}" 2>/dev/null; then
+                local domain="${domains[$i]}"
+                local domain_file="${domain_files[$i]}"
+                local agent_result_file="${agent_result_files[$i]}"
+                local pid="${pids[$i]:-}"
+                if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
                     ((failed++)) || true
-                    echo -e "      ${RED}✗${NC} ${domains[$i]} audit failed"
+                    echo -e "      ${RED}✗${NC} ${domain} audit timed out"
+                elif [[ -f "$agent_result_file" ]]; then
+                    cp "$agent_result_file" "$domain_file"
+                    if grep -q '^## Status: FAILED' "$agent_result_file" 2>/dev/null; then
+                        ((failed++)) || true
+                        echo -e "      ${RED}✗${NC} ${domain} audit failed"
+                    else
+                        echo -e "      ${GREEN}✓${NC} ${domain} audit complete"
+                    fi
                 else
-                    echo -e "      ${GREEN}✓${NC} ${domains[$i]} audit complete"
+                    ((failed++)) || true
+                    echo -e "      ${RED}✗${NC} ${domain} audit produced no result"
                 fi
             done
             echo ""
@@ -522,7 +573,20 @@ Create a unified report with:
 Format as markdown. Be specific and actionable."
 
             local synthesis_file="$audit_dir/synthesis.md"
-            spawn_agent "gemini" "$synthesis_prompt" > "$synthesis_file" 2>&1
+            local synthesis_task_id="audit-synthesis-${audit_group}"
+            local synthesis_result_file="${RESULTS_DIR}/gemini-${synthesis_task_id}.md"
+            local synthesis_pid=""
+            if synthesis_pid=$(spawn_agent_capture_pid "gemini" "$synthesis_prompt" "$synthesis_task_id" "synthesizer" "optimize-audit"); then
+                if ! _auto_route_wait_for_pids "${TIMEOUT:-600}" "$synthesis_pid"; then
+                    echo "Synthesis timed out; detailed domain reports are still included below." > "$synthesis_file"
+                elif [[ -f "$synthesis_result_file" ]]; then
+                    cp "$synthesis_result_file" "$synthesis_file"
+                else
+                    echo "Synthesis produced no result; detailed domain reports are still included below." > "$synthesis_file"
+                fi
+            else
+                echo "Synthesis failed to spawn; detailed domain reports are still included below." > "$synthesis_file"
+            fi
             echo ""
 
             # Phase 3: Generate final report

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -24,8 +24,11 @@ fan_out() {
 
     for agent in "${agents[@]}"; do
         local pid
-        pid=$(spawn_agent "$agent" "$prompt" "${task_group}-${agent}")
-        pids+=("$pid")
+        if pid=$(spawn_agent_capture_pid "$agent" "$prompt" "${task_group}-${agent}"); then
+            pids+=("$pid")
+        else
+            log WARN "Fan-out: failed to spawn $agent"
+        fi
         sleep 0.5
     done
 
@@ -157,15 +160,31 @@ parallel_execute() {
         done
 
         local pid
-        pid=$(spawn_agent "$agent" "$prompt" "$task_id")
-        pids+=("$pid")
-        ((running++)) || true
+        if pid=$(spawn_agent_capture_pid "$agent" "$prompt" "$task_id"); then
+            pids+=("$pid")
+            ((running++)) || true
+        else
+            log WARN "Skipping task $task_id: failed to spawn agent '$agent'"
+            ((skipped++)) || true
+            continue
+        fi
 
         log INFO "Progress: $completed/$task_count completed, $running running"
     done < <(jq -c '.tasks[]' "$tasks_file")
 
     log INFO "Waiting for remaining $running tasks to complete..."
-    wait
+    while [[ $running -gt 0 ]]; do
+        local saw_completion=false
+        for i in "${!pids[@]}"; do
+            if ! kill -0 "${pids[$i]}" 2>/dev/null; then
+                unset 'pids[i]'
+                ((running--)) || true
+                ((completed++)) || true
+                saw_completion=true
+            fi
+        done
+        [[ "$saw_completion" == "false" ]] && sleep 1
+    done
 
     if [[ $skipped -gt 0 ]]; then
         log WARN "Completed with $skipped skipped tasks (invalid/malformed)"
@@ -206,6 +225,7 @@ Output as a simple numbered list. Task: $main_prompt"
     log INFO "Phase 2: Mapping subtasks to agents"
     local subtask_num=0
     local agents=("codex" "gemini")
+    local pids=()
 
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
@@ -215,14 +235,30 @@ Output as a simple numbered list. Task: $main_prompt"
         subtask=$(echo "$line" | sed 's/^[0-9]*[\.\)]\s*//')
         local agent="${agents[$((subtask_num % ${#agents[@]}))]}"
 
-        spawn_agent "$agent" "$subtask" "${task_group}-subtask-${subtask_num}"
+        local pid
+        if pid=$(spawn_agent_capture_pid "$agent" "$subtask" "${task_group}-subtask-${subtask_num}"); then
+            pids+=("$pid")
+        else
+            log WARN "Map-Reduce: failed to spawn subtask $subtask_num with $agent"
+        fi
         ((subtask_num++)) || true
     done < "$decompose_result"
 
     log INFO "Spawned $subtask_num subtask agents"
 
     log INFO "Phase 3: Waiting for subtasks to complete..."
-    wait
+    local remaining=${#pids[@]}
+    while [[ $remaining -gt 0 ]]; do
+        remaining=0
+        for i in "${!pids[@]}"; do
+            if kill -0 "${pids[$i]}" 2>/dev/null; then
+                ((remaining++)) || true
+            else
+                unset 'pids[i]'
+            fi
+        done
+        [[ $remaining -gt 0 ]] && sleep 1
+    done
 
     aggregate_results "$task_group"
 }

--- a/tests/smoke/test-fleet-dispatch-guard.sh
+++ b/tests/smoke/test-fleet-dispatch-guard.sh
@@ -87,12 +87,26 @@ test_provider_pid_capture() {
     test_case "Parallel workflow waits track provider PIDs, not wrapper PIDs"
 
     local failed=0
+    local pid_capture_files=(
+        "scripts/lib/workflows.sh"
+        "scripts/lib/yaml-workflow.sh"
+        "scripts/lib/agent-utils.sh"
+        "scripts/lib/parallel.sh"
+        "scripts/lib/auto-route.sh"
+        "scripts/async-tmux-features.sh"
+    )
+    local pid_capture_paths=()
+    local rel
+    for rel in "${pid_capture_files[@]}"; do
+        pid_capture_paths+=("$PROJECT_ROOT/$rel")
+    done
+
     if ! grep -q '^spawn_agent_capture_pid()' "$PROJECT_ROOT/scripts/lib/spawn.sh"; then
         echo "  MISSING spawn_agent_capture_pid helper in scripts/lib/spawn.sh"
         failed=1
     fi
 
-    for rel in scripts/lib/workflows.sh scripts/lib/yaml-workflow.sh scripts/lib/agent-utils.sh; do
+    for rel in "${pid_capture_files[@]}"; do
         if ! grep -q 'spawn_agent_capture_pid' "$PROJECT_ROOT/$rel"; then
             echo "  MISSING provider PID capture in: $rel"
             failed=1
@@ -103,16 +117,14 @@ test_provider_pid_capture() {
     wrapper_tracking=$(
         {
             grep -RnE 'pids[^=]*[+]?=.*\$!' \
-                "$PROJECT_ROOT/scripts/lib/workflows.sh" \
-                "$PROJECT_ROOT/scripts/lib/yaml-workflow.sh" \
-                "$PROJECT_ROOT/scripts/lib/agent-utils.sh" 2>/dev/null || true
+                "${pid_capture_paths[@]}" 2>/dev/null || true
             awk '
                 /pid=\$!/ { pending=NR; line=$0; next }
                 pending && NR <= pending + 5 && /pids/ { print FILENAME ":" pending ":" line " ... " $0; pending=0 }
                 pending && NR > pending + 5 { pending=0 }
-            ' "$PROJECT_ROOT/scripts/lib/workflows.sh" \
-              "$PROJECT_ROOT/scripts/lib/yaml-workflow.sh" \
-              "$PROJECT_ROOT/scripts/lib/agent-utils.sh" 2>/dev/null || true
+            ' "${pid_capture_paths[@]}" 2>/dev/null || true
+            grep -RnE 'pid=\$\(spawn_agent[[:space:]]' \
+                "${pid_capture_paths[@]}" 2>/dev/null || true
         } | sed '/^$/d'
     )
     if [[ -n "$wrapper_tracking" ]]; then


### PR DESCRIPTION
## Summary
- route remaining parallel/fan-out/map-reduce agent launches through `spawn_agent_capture_pid`
- make optimize-audit collect real agent result files before synthesis
- make async/tmux dispatch return worker PIDs instead of command-substitution wrappers
- extend the fleet dispatch smoke guard across the remaining async PID-sensitive files

## Validation
- `bash -n scripts/lib/parallel.sh scripts/lib/auto-route.sh scripts/async-tmux-features.sh tests/smoke/test-fleet-dispatch-guard.sh`
- `bash tests/smoke/test-fleet-dispatch-guard.sh`
- `bash tests/smoke/test-syntax.sh`
- `bash tests/test-credential-isolation.sh`
- `bash tests/unit/test-review-run.sh`
- `bash tests/unit/test-probe-single.sh`
- `bash tests/unit/test-stdin-timeout-guards.sh`
- `bash tests/unit/test-gemini-provider.sh`
- runtime probes for `parallel_execute`, `spawn_agent_async`, and `_auto_route_wait_for_pids` using stubbed worker PIDs
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process tracking reliability for async operations.
  * Added timeout handling for long-running operations to prevent hangs.
  * Enhanced error recovery with fallback mechanisms for failed operations.

* **Tests**
  * Expanded validation coverage for process capture mechanisms across additional scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->