### PR TITLE
fix(develop): replace recursive Skill call with direct orchestrate.sh dispatch

### DIFF
--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -84,6 +84,14 @@ AskUserQuestion({
 
 **Dispatches to the develop workflow via `orchestrate.sh` for the implementation phase.**
 
+### Model and Effort Policy
+
+- For develop/tangle work on Opus 4.7, use `xhigh` for complex implementation and `medium` for trivial work.
+- Fast Opus 4.6 mode is 6x more expensive ($30/$150 per MTok vs $5/$25 standard), uses extra-usage billing, applies only to Opus 4.6, and trades cost for lower latency with equivalent quality.
+- Default to Opus 4.7 standard mode for multi-phase workflows; use fast mode only for interactive single-shot requests when explicitly selected.
+- Respect user overrides: `OCTOPUS_OPUS_MODE`, `OCTOPUS_OPUS_MODEL`, and `OCTOPUS_EFFORT_OVERRIDE`.
+- Record durable project memory for autonomy mode, provider availability, frequently used commands, prior project context, and model preferences.
+
 ## Quick Usage
 
 Just use natural language:

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -16,7 +16,14 @@ aliases:
 
 ### EXECUTION MECHANISM — NON-NEGOTIABLE
 
-**You MUST execute this command via the Bash tool calling `orchestrate.sh develop`. Do NOT use `Skill(skill: "octo:develop")` — it resolves back to this file causing an infinite loop.**
+**You MUST execute this command via the Bash tool calling `orchestrate.sh develop`. You are PROHIBITED from:**
+- Using `Skill(skill: "octo:develop")` because it resolves back to this file and loops
+- Using `Skill(skill: "flow-develop", ...)` because that internal name is not resolvable by the Skill tool
+- Using the Agent tool, WebFetch, Read, or Grep as a substitute for multi-provider dispatch
+- Skipping `orchestrate.sh` calls because "I can do this faster directly"
+- Implementing the task using only Claude-native tools
+
+**Multi-LLM orchestration is the purpose of this command.** If you execute using only Claude, you've violated the command's contract.
 
 ---
 
@@ -28,7 +35,7 @@ bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" develop "<user's ar
 ```
 
 **✗ INCORRECT:**
-```
+```text
 Skill(skill: "octo:develop", ...)  ❌ Resolves to this command file — infinite loop
 Skill(skill: "flow-develop", ...)  ❌ Internal name, not resolvable by Skill tool
 Task(subagent_type: "octo:develop", ...)  ❌ This is a skill, not an agent type
@@ -36,7 +43,7 @@ Task(subagent_type: "octo:develop", ...)  ❌ This is a skill, not an agent type
 
 ### Post-Completion — Interactive Next Steps
 
-**CRITICAL: After the skill completes, you MUST ask the user what to do next. Do NOT end the session silently.**
+**CRITICAL: After the workflow completes, you MUST ask the user what to do next. Do NOT end the session silently.**
 
 ```javascript
 AskUserQuestion({
@@ -59,7 +66,7 @@ AskUserQuestion({
 
 ---
 
-**Auto-loads the develop skill for the implementation phase.**
+**Dispatches to the develop workflow via `orchestrate.sh` for the implementation phase.**
 
 ## Quick Usage
 

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -29,7 +29,21 @@ aliases:
 
 When the user invokes this command (e.g., `/octo:develop <arguments>`):
 
-**Step 1 — Run orchestrate.sh via Bash tool:**
+**Step 1 — Run provider preflight via Bash tool:**
+
+```bash
+bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
+```
+
+Use the actual preflight output to display the workflow indicator before dispatch:
+
+```text
+🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider implementation mode
+```
+
+List available providers, mark missing providers as `(unavailable - skipping)`, and use the compact single-line banner when `OCTOPUS_COMPACT_BANNERS=true`. If no external provider is available, stop and tell the user to run `/octo:setup`; do not fall back to Claude-native implementation.
+
+**Step 2 — Run orchestrate.sh via Bash tool:**
 
 ```bash
 bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" develop "<user's arguments here>"

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -16,27 +16,22 @@ aliases:
 
 ### EXECUTION MECHANISM — NON-NEGOTIABLE
 
-**You MUST execute this command by invoking the corresponding skill via the Skill tool. You are PROHIBITED from:**
-- ❌ Using the Agent tool to research/implement yourself instead of invoking the skill
-- ❌ Using WebFetch/Read/Grep as a substitute for multi-provider dispatch
-- ❌ Skipping `orchestrate.sh` calls because "I can do this faster directly"
-- ❌ Implementing the task using only Claude-native tools (Agent, Write, Edit)
-
-**Multi-LLM orchestration is the purpose of this command.** If you execute using only Claude, you've violated the command's contract.
+**You MUST execute this command via the Bash tool calling `orchestrate.sh develop`. Do NOT use `Skill(skill: "octo:develop")` — it resolves back to this file causing an infinite loop.**
 
 ---
 
 When the user invokes this command (e.g., `/octo:develop <arguments>`):
 
-**✓ CORRECT - Use the Skill tool:**
-```
-Skill(skill: "octo:develop", args: "<user's arguments>")
+**Step 1 — Run orchestrate.sh via Bash tool:**
+```bash
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" develop "<user's arguments here>"
 ```
 
 **✗ INCORRECT:**
 ```
-Skill(skill: "flow-develop", ...)  ❌ Wrong! Internal skill name, not resolvable by Skill tool
-Task(subagent_type: "octo:develop", ...)  ❌ Wrong! This is a skill, not an agent type
+Skill(skill: "octo:develop", ...)  ❌ Resolves to this command file — infinite loop
+Skill(skill: "flow-develop", ...)  ❌ Internal name, not resolvable by Skill tool
+Task(subagent_type: "octo:develop", ...)  ❌ This is a skill, not an agent type
 ```
 
 ### Post-Completion — Interactive Next Steps

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -30,11 +30,13 @@ aliases:
 When the user invokes this command (e.g., `/octo:develop <arguments>`):
 
 **Step 1 — Run orchestrate.sh via Bash tool:**
+
 ```bash
 bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" develop "<user's arguments here>"
 ```
 
 **✗ INCORRECT:**
+
 ```text
 Skill(skill: "octo:develop", ...)  ❌ Resolves to this command file — infinite loop
 Skill(skill: "flow-develop", ...)  ❌ Internal name, not resolvable by Skill tool

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -41,7 +41,13 @@ Use the actual preflight output to display the workflow indicator before dispatc
 🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider implementation mode
 ```
 
-List available providers, mark missing providers as `(unavailable - skipping)`, and use the compact single-line banner when `OCTOPUS_COMPACT_BANNERS=true`. If no external provider is available, stop and tell the user to run `/octo:setup`; do not fall back to Claude-native implementation.
+List available providers and mark missing providers as `(unavailable - skipping)`. If `OCTOPUS_COMPACT_BANNERS=true`, use this compact single-line format:
+
+```text
+🐙 develop — Multi-provider implementation mode | codex ✓ | gemini (unavailable - skipping)
+```
+
+If no external provider is available, stop and tell the user to run `/octo:setup`; do not fall back to Claude-native implementation.
 
 **Step 2 — Run orchestrate.sh via Bash tool:**
 

--- a/commands/octo-develop.md
+++ b/commands/octo-develop.md
@@ -80,6 +80,14 @@ AskUserQuestion({
 
 **Dispatches to the develop workflow via `orchestrate.sh` for the implementation phase.**
 
+### Model and Effort Policy
+
+- For develop/tangle work on Opus 4.7, use `xhigh` for complex implementation and `medium` for trivial work.
+- Fast Opus 4.6 mode is 6x more expensive ($30/$150 per MTok vs $5/$25 standard), uses extra-usage billing, applies only to Opus 4.6, and trades cost for lower latency with equivalent quality.
+- Default to Opus 4.7 standard mode for multi-phase workflows; use fast mode only for interactive single-shot requests when explicitly selected.
+- Respect user overrides: `OCTOPUS_OPUS_MODE`, `OCTOPUS_OPUS_MODEL`, and `OCTOPUS_EFFORT_OVERRIDE`.
+- Record durable project memory for autonomy mode, provider availability, frequently used commands, prior project context, and model preferences.
+
 ## Quick Usage
 
 Just use natural language:

--- a/commands/octo-develop.md
+++ b/commands/octo-develop.md
@@ -12,11 +12,12 @@ description: "\"Development phase - Build solutions with multi-AI implementation
 
 ### EXECUTION MECHANISM — NON-NEGOTIABLE
 
-**You MUST execute this command by invoking the corresponding skill via the Skill tool. You are PROHIBITED from:**
-- ❌ Using the Agent tool to research/implement yourself instead of invoking the skill
-- ❌ Using WebFetch/Read/Grep as a substitute for multi-provider dispatch
-- ❌ Skipping `orchestrate.sh` calls because "I can do this faster directly"
-- ❌ Implementing the task using only Claude-native tools (Agent, Write, Edit)
+**You MUST execute this command via the Bash tool calling `orchestrate.sh develop`. You are PROHIBITED from:**
+- Using `Skill(skill: "octo:develop")` because it resolves back to this file and loops
+- Using `Skill(skill: "flow-develop", ...)` because that internal name is not resolvable by the Skill tool
+- Using the Agent tool, WebFetch, Read, or Grep as a substitute for multi-provider dispatch
+- Skipping `orchestrate.sh` calls because "I can do this faster directly"
+- Implementing the task using only Claude-native tools
 
 **Multi-LLM orchestration is the purpose of this command.** If you execute using only Claude, you've violated the command's contract.
 
@@ -24,20 +25,21 @@ description: "\"Development phase - Build solutions with multi-AI implementation
 
 When the user invokes this command (e.g., `/octo:develop <arguments>`):
 
-**✓ CORRECT - Use the Skill tool:**
-```
-Skill(skill: "octo:develop", args: "<user's arguments>")
+**Step 1 — Run orchestrate.sh via Bash tool:**
+```bash
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" develop "<user's arguments here>"
 ```
 
 **✗ INCORRECT:**
-```
-Skill(skill: "flow-develop", ...)  ❌ Wrong! Internal skill name, not resolvable by Skill tool
-Task(subagent_type: "octo:develop", ...)  ❌ Wrong! This is a skill, not an agent type
+```text
+Skill(skill: "octo:develop", ...)  ❌ Resolves to this command file — infinite loop
+Skill(skill: "flow-develop", ...)  ❌ Internal name, not resolvable by Skill tool
+Task(subagent_type: "octo:develop", ...)  ❌ This is a skill, not an agent type
 ```
 
 ### Post-Completion — Interactive Next Steps
 
-**CRITICAL: After the skill completes, you MUST ask the user what to do next. Do NOT end the session silently.**
+**CRITICAL: After the workflow completes, you MUST ask the user what to do next. Do NOT end the session silently.**
 
 ```javascript
 AskUserQuestion({
@@ -60,7 +62,7 @@ AskUserQuestion({
 
 ---
 
-**Auto-loads the develop skill for the implementation phase.**
+**Dispatches to the develop workflow via `orchestrate.sh` for the implementation phase.**
 
 ## Quick Usage
 

--- a/commands/octo-develop.md
+++ b/commands/octo-develop.md
@@ -25,7 +25,21 @@ description: "\"Development phase - Build solutions with multi-AI implementation
 
 When the user invokes this command (e.g., `/octo:develop <arguments>`):
 
-**Step 1 — Run orchestrate.sh via Bash tool:**
+**Step 1 — Run provider preflight via Bash tool:**
+
+```bash
+bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
+```
+
+Use the actual preflight output to display the workflow indicator before dispatch:
+
+```text
+🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider implementation mode
+```
+
+List available providers, mark missing providers as `(unavailable - skipping)`, and use the compact single-line banner when `OCTOPUS_COMPACT_BANNERS=true`. If no external provider is available, stop and tell the user to run `/octo:setup`; do not fall back to Claude-native implementation.
+
+**Step 2 — Run orchestrate.sh via Bash tool:**
 
 ```bash
 bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" develop "<user's arguments here>"

--- a/commands/octo-develop.md
+++ b/commands/octo-develop.md
@@ -26,11 +26,13 @@ description: "\"Development phase - Build solutions with multi-AI implementation
 When the user invokes this command (e.g., `/octo:develop <arguments>`):
 
 **Step 1 — Run orchestrate.sh via Bash tool:**
+
 ```bash
 bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" develop "<user's arguments here>"
 ```
 
 **✗ INCORRECT:**
+
 ```text
 Skill(skill: "octo:develop", ...)  ❌ Resolves to this command file — infinite loop
 Skill(skill: "flow-develop", ...)  ❌ Internal name, not resolvable by Skill tool

--- a/commands/octo-develop.md
+++ b/commands/octo-develop.md
@@ -37,7 +37,13 @@ Use the actual preflight output to display the workflow indicator before dispatc
 🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider implementation mode
 ```
 
-List available providers, mark missing providers as `(unavailable - skipping)`, and use the compact single-line banner when `OCTOPUS_COMPACT_BANNERS=true`. If no external provider is available, stop and tell the user to run `/octo:setup`; do not fall back to Claude-native implementation.
+List available providers and mark missing providers as `(unavailable - skipping)`. If `OCTOPUS_COMPACT_BANNERS=true`, use this compact single-line format:
+
+```text
+🐙 develop — Multi-provider implementation mode | codex ✓ | gemini (unavailable - skipping)
+```
+
+If no external provider is available, stop and tell the user to run `/octo:setup`; do not fall back to Claude-native implementation.
 
 **Step 2 — Run orchestrate.sh via Bash tool:**
 

--- a/tests/unit/test-execution-mechanism.sh
+++ b/tests/unit/test-execution-mechanism.sh
@@ -104,4 +104,26 @@ if [[ -f "$EMBRACE" ]]; then
         fail "embrace.md only has $skill_invocations skill invocations" "Must chain at least 4 (discover+define+develop+deliver)"
     fi
 fi
+
+echo ""
+echo "=== Develop Direct Dispatch Preserves Preflight ==="
+
+for develop_file in "$PROJECT_ROOT/.claude/commands/develop.md" "$PROJECT_ROOT/commands/octo-develop.md"; do
+    develop_name=$(basename "$develop_file")
+    if [[ -f "$develop_file" ]]; then
+        if grep -q 'helpers/check-providers.sh' "$develop_file"; then
+            pass "$develop_name checks provider availability before dispatch"
+        else
+            fail "$develop_name missing provider preflight" "Direct develop dispatch must run helpers/check-providers.sh before orchestrate.sh"
+        fi
+
+        if grep -q 'CLAUDE OCTOPUS ACTIVATED' "$develop_file"; then
+            pass "$develop_name displays workflow indicator before dispatch"
+        else
+            fail "$develop_name missing workflow indicator" "Direct develop dispatch must show the Octopus activation banner before orchestrate.sh"
+        fi
+    else
+        fail "$develop_name not found" "$develop_file missing"
+    fi
+done
 test_summary

--- a/tests/unit/test-execution-mechanism.sh
+++ b/tests/unit/test-execution-mechanism.sh
@@ -111,16 +111,29 @@ echo "=== Develop Direct Dispatch Preserves Preflight ==="
 for develop_file in "$PROJECT_ROOT/.claude/commands/develop.md" "$PROJECT_ROOT/commands/octo-develop.md"; do
     develop_name=$(basename "$develop_file")
     if [[ -f "$develop_file" ]]; then
-        if grep -q 'helpers/check-providers.sh' "$develop_file"; then
+        preflight_line=$(grep -n 'helpers/check-providers.sh' "$develop_file" | head -1 | cut -d: -f1 || true)
+        banner_line=$(grep -n 'CLAUDE OCTOPUS ACTIVATED' "$develop_file" | head -1 | cut -d: -f1 || true)
+        dispatch_line=$(grep -n 'orchestrate.sh" develop' "$develop_file" | head -1 | cut -d: -f1 || true)
+
+        if [[ -n "$preflight_line" && -n "$dispatch_line" && "$preflight_line" -lt "$dispatch_line" ]]; then
             pass "$develop_name checks provider availability before dispatch"
         else
             fail "$develop_name missing provider preflight" "Direct develop dispatch must run helpers/check-providers.sh before orchestrate.sh"
         fi
 
-        if grep -q 'CLAUDE OCTOPUS ACTIVATED' "$develop_file"; then
+        if [[ -n "$banner_line" && -n "$dispatch_line" && "$banner_line" -lt "$dispatch_line" ]]; then
             pass "$develop_name displays workflow indicator before dispatch"
         else
             fail "$develop_name missing workflow indicator" "Direct develop dispatch must show the Octopus activation banner before orchestrate.sh"
+        fi
+
+        if grep -q 'OCTOPUS_EFFORT_OVERRIDE' "$develop_file" \
+           && grep -q 'OCTOPUS_OPUS_MODE' "$develop_file" \
+           && grep -q 'Fast Opus 4.6 mode is 6x more expensive' "$develop_file" \
+           && grep -q 'project memory' "$develop_file"; then
+            pass "$develop_name documents model effort and memory policy"
+        else
+            fail "$develop_name missing model effort policy" "Develop command must document effort overrides, Fast Opus cost, and memory recording policy"
         fi
     else
         fail "$develop_name not found" "$develop_file missing"

--- a/tests/unit/test-execution-mechanism.sh
+++ b/tests/unit/test-execution-mechanism.sh
@@ -115,16 +115,24 @@ for develop_file in "$PROJECT_ROOT/.claude/commands/develop.md" "$PROJECT_ROOT/c
         banner_line=$(grep -n 'CLAUDE OCTOPUS ACTIVATED' "$develop_file" | head -1 | cut -d: -f1 || true)
         dispatch_line=$(grep -n 'orchestrate.sh" develop' "$develop_file" | head -1 | cut -d: -f1 || true)
 
-        if [[ -n "$preflight_line" && -n "$dispatch_line" && "$preflight_line" -lt "$dispatch_line" ]]; then
-            pass "$develop_name checks provider availability before dispatch"
+        if [[ -n "$dispatch_line" ]]; then
+            pass "$develop_name dispatches via orchestrate.sh develop"
         else
-            fail "$develop_name missing provider preflight" "Direct develop dispatch must run helpers/check-providers.sh before orchestrate.sh"
+            fail "$develop_name missing direct dispatch" "Develop docs must call orchestrate.sh develop"
         fi
 
-        if [[ -n "$banner_line" && -n "$dispatch_line" && "$banner_line" -lt "$dispatch_line" ]]; then
-            pass "$develop_name displays workflow indicator before dispatch"
-        else
-            fail "$develop_name missing workflow indicator" "Direct develop dispatch must show the Octopus activation banner before orchestrate.sh"
+        if [[ -n "$dispatch_line" ]]; then
+            if [[ -n "$preflight_line" && "$preflight_line" -lt "$dispatch_line" ]]; then
+                pass "$develop_name checks provider availability before dispatch"
+            else
+                fail "$develop_name missing provider preflight" "Direct develop dispatch must run helpers/check-providers.sh before orchestrate.sh"
+            fi
+
+            if [[ -n "$banner_line" && "$banner_line" -lt "$dispatch_line" ]]; then
+                pass "$develop_name displays workflow indicator before dispatch"
+            else
+                fail "$develop_name missing workflow indicator" "Direct develop dispatch must show the Octopus activation banner before orchestrate.sh"
+            fi
         fi
 
         if grep -q 'OCTOPUS_EFFORT_OVERRIDE' "$develop_file" \


### PR DESCRIPTION
## Problem

`/octo:develop` causes an infinite loop in Claude Code.

When the command file is loaded, it instructs Claude to call `Skill(skill: "octo:develop")`. In Claude Code's skill resolution, this resolves back to the same command file (not the internal `flow-develop` skill), creating a recursive loop that never executes `orchestrate.sh`.

Related to #38.

## Root Cause

Both the command (`commands/develop.md`, name: `develop`) and the skill (`skills/flow-develop.md`, alias: `develop`) resolve to `octo:develop` in the plugin namespace. Claude Code's `Skill` tool hits the command file instead of the skill, causing the loop.

## Fix

Replace `Skill(skill: "octo:develop")` with a direct `bash` call to `orchestrate.sh develop`, which is exactly what `flow-develop` would do if resolution worked correctly.

```bash
bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" develop "<user's arguments here>"
```

## Tested

Confirmed the loop is broken and `orchestrate.sh` is invoked directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Require dispatching development via the CLI orchestrator; forbid alternate dispatch methods or tool substitutions
  * Updated examples and wording to reflect the mandated Bash dispatch, added a provider preflight step and required activation banner, clarified post-completion behavior to always ask the user what to do next
  * Added a “Model and Effort Policy” section covering Opus mode/defaults, effort override env vars, and durable memory recording guidance
* **Tests**
  * Added a unit check ensuring docs include the provider preflight, activation banner, correct dispatch order, and model/effort/memory policy markers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->