### PR TITLE
Update README to simplify plugin installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
 claude plugin marketplace add https://github.com/nyldn/plugins.git
 claude plugin install octo@nyldn-plugins
 
-
 # Then inside Claude Code:
 /octo:setup
 ```
@@ -165,7 +164,6 @@ rm -rf ~/.claude/plugins/cache/nyldn-plugins/octo
 claude plugin marketplace remove nyldn-plugins
 claude plugin marketplace add https://github.com/nyldn/plugins.git
 claude plugin install octo@nyldn-plugins
-claude plugin install img@nyldn-plugins # optional, same shared marketplace
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -49,15 +49,11 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
 # Terminal (not inside a Claude Code session):
 claude plugin marketplace add https://github.com/nyldn/plugins.git
 claude plugin install octo@nyldn-plugins
-claude plugin install img@nyldn-plugins # optional, same shared marketplace
+
 
 # Then inside Claude Code:
 /octo:setup
 ```
-
-`nyldn-plugins` is a shared marketplace catalog at
-`https://github.com/nyldn/plugins.git`, and it also makes
-`img@nyldn-plugins` available.
 
 That's it. Setup detects installed providers, shows what's missing, and walks you through configuration. You need **zero** external providers to start — Claude is built in.
 

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -51,8 +51,16 @@ echo ""
 echo "📦 Checking version synchronization..."
 
 PLUGIN_VERSION=$(grep '"version"' "$ROOT_DIR/.claude-plugin/plugin.json" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
-MARKETPLACE_VERSION=$(grep '"version"' "$ROOT_DIR/.claude-plugin/marketplace.json" | grep -v "1.0.0" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
 PACKAGE_VERSION=$(grep '"version"' "$ROOT_DIR/package.json" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
+
+MARKETPLACE_VERSION=""
+if ! command -v jq >/dev/null 2>&1; then
+    echo -e "  ${RED}ERROR: jq is required to parse marketplace.json${NC}"
+    ((errors++)) || true
+elif ! MARKETPLACE_VERSION=$(jq -r '.plugins[] | select(.name == "octo") | .version // empty' "$ROOT_DIR/.claude-plugin/marketplace.json"); then
+    echo -e "  ${RED}ERROR: unable to parse octo version from marketplace.json${NC}"
+    ((errors++)) || true
+fi
 
 # Check README badge
 README_BADGE_VERSION=$(grep -o 'Version-[0-9.]*' "$ROOT_DIR/README.md" | head -1 | sed 's/Version-//')

--- a/tests/smoke/test-debate-skill.sh
+++ b/tests/smoke/test-debate-skill.sh
@@ -150,7 +150,7 @@ test_version_consistency() {
 
     local plugin_version=$(grep '"version"' "$plugin_json" | head -1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')
     local package_version=$(grep '"version"' "$package_json" | head -1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')
-    local marketplace_version=$(grep -A 3 '"octo"' "$marketplace_json" | grep '"version"' | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+    local marketplace_version=$(jq -r '.plugins[] | select(.name == "octo") | .version // empty' "$marketplace_json")
 
     if [[ "$plugin_version" == "$package_version" ]] && \
        [[ "$package_version" == "$marketplace_version" ]]; then

--- a/tests/smoke/test-debate-skill.sh
+++ b/tests/smoke/test-debate-skill.sh
@@ -150,7 +150,17 @@ test_version_consistency() {
 
     local plugin_version=$(grep '"version"' "$plugin_json" | head -1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')
     local package_version=$(grep '"version"' "$package_json" | head -1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')
-    local marketplace_version=$(jq -r '.plugins[] | select(.name == "octo") | .version // empty' "$marketplace_json")
+
+    if ! command -v jq >/dev/null 2>&1; then
+        test_fail "jq is required to parse marketplace.json"
+        return 1
+    fi
+
+    local marketplace_version
+    if ! marketplace_version=$(jq -r '.plugins[] | select(.name == "octo") | .version // empty' "$marketplace_json"); then
+        test_fail "Unable to parse octo version from marketplace.json"
+        return 1
+    fi
 
     if [[ "$plugin_version" == "$package_version" ]] && \
        [[ "$package_version" == "$marketplace_version" ]]; then

--- a/tests/unit/test-docs-sync.sh
+++ b/tests/unit/test-docs-sync.sh
@@ -312,8 +312,17 @@ check_marketplace_version() {
   # Extract version from plugin.json
   local plugin_version=$(grep '"version"' "$plugin_json" | head -n 1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 
+  if ! command -v jq >/dev/null 2>&1; then
+    fail "jq is required to parse marketplace.json"
+    return 1
+  fi
+
   # Extract the octo plugin version, not marketplace metadata or sibling plugins.
-  local marketplace_version=$(jq -r '.plugins[] | select(.name == "octo") | .version // empty' "$marketplace_json")
+  local marketplace_version
+  if ! marketplace_version=$(jq -r '.plugins[] | select(.name == "octo") | .version // empty' "$marketplace_json"); then
+    fail "Unable to parse octo version from marketplace.json"
+    return 1
+  fi
 
   # Check if versions match
   if [ "$plugin_version" = "$marketplace_version" ]; then
@@ -327,6 +336,30 @@ check_marketplace_version() {
     pass "marketplace.json description starts with version (v${plugin_version})"
   else
     fail "marketplace.json description should start with 'v${plugin_version} - ...'"
+  fi
+}
+
+# Check release validation parses the octo marketplace entry explicitly
+check_release_validator_marketplace_parser() {
+  info "\nValidating release marketplace parser..."
+
+  local release_validator="scripts/validate-release.sh"
+
+  if [ ! -f "$release_validator" ]; then
+    fail "validate-release.sh not found"
+    return 1
+  fi
+
+  if grep -Fq '.plugins[] | select(.name == "octo") | .version' "$release_validator"; then
+    pass "validate-release.sh selects octo marketplace version explicitly"
+  else
+    fail "validate-release.sh should select octo marketplace version explicitly"
+  fi
+
+  if grep -Fq 'grep -v "1.0.0"' "$release_validator"; then
+    fail "validate-release.sh should not filter marketplace versions with grep -v 1.0.0"
+  else
+    pass "validate-release.sh does not use marketplace version heuristic filter"
   fi
 }
 
@@ -391,6 +424,7 @@ check_workflow_skills
 check_hooks_config
 check_debate_skill
 check_marketplace_version
+check_release_validator_marketplace_parser
 check_command_frontmatter
 
 # Summary

--- a/tests/unit/test-docs-sync.sh
+++ b/tests/unit/test-docs-sync.sh
@@ -312,8 +312,8 @@ check_marketplace_version() {
   # Extract version from plugin.json
   local plugin_version=$(grep '"version"' "$plugin_json" | head -n 1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 
-  # Extract version field from marketplace.json
-  local marketplace_version=$(grep '"version"' "$marketplace_json" | tail -n 1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+  # Extract the octo plugin version, not marketplace metadata or sibling plugins.
+  local marketplace_version=$(jq -r '.plugins[] | select(.name == "octo") | .version // empty' "$marketplace_json")
 
   # Check if versions match
   if [ "$plugin_version" = "$marketplace_version" ]; then


### PR DESCRIPTION
Removed optional plugin installation instructions and related information.

## Description
Brief description of changes.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [ ] Code passes `bash -n scripts/orchestrate.sh`
- [ ] Shell scripts pass `bash -n` syntax check
- [ ] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync: `scripts/build-openclaw.sh --check`
- [ ] New skills/commands registered in `.claude-plugin/plugin.json`
- [ ] Version bump (if releasing): package.json + plugin.json + marketplace.json + README.md + CHANGELOG.md
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (for features/fixes)

## Testing
How was this tested? Which test suites were run?

```bash
# Run pre-push suite
bash tests/run-pre-push.sh

# Run specific test
bash tests/unit/test-<name>.sh
```

## Related Issues
Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Quickstart now requires adding the shared plugin marketplace and installing the octo plugin before running setup; the previously optional img plugin step was removed. Quickstart and troubleshooting clean-reinstall instructions now reference the shared marketplace as the source for available providers.

* **Tests**
  * Tests and validation script now parse the octo marketplace version using jq, require jq be present, emit explicit errors on parse failure, and include a new unit check validating the marketplace parser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->