### PR TITLE
Fix provider env lookup under set -e

### DIFF
--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -49,15 +49,21 @@ build_provider_env() {
     # v9.2.1: Try resolving env vars before building isolated env (Issue #177)
     case "$provider" in
         codex*)
-            [[ -z "${OPENAI_API_KEY:-}" ]] && resolve_provider_env "OPENAI_API_KEY" 2>/dev/null
+            if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+                resolve_provider_env "OPENAI_API_KEY" 2>/dev/null || true
+            fi
             PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "OPENAI_API_KEY=${OPENAI_API_KEY:-}" "TMPDIR=${TMPDIR:-/tmp}")
             if [[ ${#_trace_env[@]} -gt 0 ]]; then
                 PROVIDER_ENV_ARRAY+=("${_trace_env[@]}")
             fi
             ;;
         gemini*)
-            [[ -z "${GEMINI_API_KEY:-}" ]] && resolve_provider_env "GEMINI_API_KEY" 2>/dev/null
-            [[ -z "${GOOGLE_API_KEY:-}" ]] && resolve_provider_env "GOOGLE_API_KEY" 2>/dev/null
+            if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+                resolve_provider_env "GEMINI_API_KEY" 2>/dev/null || true
+            fi
+            if [[ -z "${GOOGLE_API_KEY:-}" ]]; then
+                resolve_provider_env "GOOGLE_API_KEY" 2>/dev/null || true
+            fi
             PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "GEMINI_API_KEY=${GEMINI_API_KEY:-}" "GOOGLE_API_KEY=${GOOGLE_API_KEY:-}" "NODE_NO_WARNINGS=1" "TMPDIR=${TMPDIR:-/tmp}")
             if [[ ${#_trace_env[@]} -gt 0 ]]; then
                 PROVIDER_ENV_ARRAY+=("${_trace_env[@]}")
@@ -65,12 +71,16 @@ build_provider_env() {
             ;;
         perplexity*)
             # perplexity_execute is a shell function — env -i cannot exec it (#300)
-            [[ -z "${PERPLEXITY_API_KEY:-}" ]] && resolve_provider_env "PERPLEXITY_API_KEY" 2>/dev/null
+            if [[ -z "${PERPLEXITY_API_KEY:-}" ]]; then
+                resolve_provider_env "PERPLEXITY_API_KEY" 2>/dev/null || true
+            fi
             return 0
             ;;
         openrouter*)
             # openrouter_execute is a shell function — env -i cannot exec it (#300)
-            [[ -z "${OPENROUTER_API_KEY:-}" ]] && resolve_provider_env "OPENROUTER_API_KEY" 2>/dev/null
+            if [[ -z "${OPENROUTER_API_KEY:-}" ]]; then
+                resolve_provider_env "OPENROUTER_API_KEY" 2>/dev/null || true
+            fi
             return 0
             ;;
         *)

--- a/tests/test-credential-isolation.sh
+++ b/tests/test-credential-isolation.sh
@@ -43,7 +43,7 @@ else
 fi
 
 # 1.2 Codex scoping — only OPENAI_API_KEY
-CODEX_ENV=$(grep -A5 'codex\*)' "$ALL_SRC" | grep 'PROVIDER_ENV_ARRAY=.*env -i' | head -1)
+CODEX_ENV=$(grep -A12 'codex\*)' "$ALL_SRC" | grep 'PROVIDER_ENV_ARRAY=.*env -i' | head -1 || true)
 if echo "$CODEX_ENV" | grep -q 'OPENAI_API_KEY'; then
   pass "Codex env includes OPENAI_API_KEY"
 else
@@ -57,7 +57,7 @@ else
 fi
 
 # 1.3 Gemini scoping — only GEMINI_API_KEY + GOOGLE_API_KEY
-GEMINI_ENV=$(grep -A5 'gemini\*)' "$ALL_SRC" | grep 'PROVIDER_ENV_ARRAY=.*env -i' | head -1)
+GEMINI_ENV=$(grep -A16 'gemini\*)' "$ALL_SRC" | grep 'PROVIDER_ENV_ARRAY=.*env -i' | head -1 || true)
 if echo "$GEMINI_ENV" | grep -q 'GEMINI_API_KEY'; then
   pass "Gemini env includes GEMINI_API_KEY"
 else
@@ -73,7 +73,7 @@ fi
 # 1.4 Perplexity — shell function provider, env -i skipped (#300)
 # perplexity_execute is a bash function dispatched by get_agent_command();
 # env -i cannot exec shell functions, so build_provider_env returns empty.
-PERP_CASE=$(grep -A50 'build_provider_env()' "$ALL_SRC" | grep -A5 'perplexity\*)' | head -6)
+PERP_CASE=$(grep -A70 'build_provider_env()' "$ALL_SRC" | grep -A10 'perplexity\*)' | head -11 || true)
 PERP_ENV=$(echo "$PERP_CASE" | grep 'env -i' | head -1 || true)
 if echo "$PERP_CASE" | grep -q 'resolve_provider_env.*PERPLEXITY_API_KEY'; then
   pass "Perplexity resolves PERPLEXITY_API_KEY before dispatch"
@@ -98,6 +98,31 @@ if grep -A20 'build_provider_env()' "$ALL_SRC" | grep -q 'MINGW.*return 0\|MSYS.
 else
   pass "Windows PATH spaces do not disable env isolation"
 fi
+
+# 1.6 Missing API keys are tolerated under set -e (#336)
+for provider in codex gemini perplexity openrouter; do
+  test_case "build_provider_env $provider tolerates absent API keys under set -e"
+  tmp_home=$(mktemp -d)
+  tmp_pwd=$(mktemp -d)
+  case_output=""
+  if case_output=$(HOME="$tmp_home" bash -c '
+      set -eo pipefail
+      cd "$1"
+      unset OPENAI_API_KEY GEMINI_API_KEY GOOGLE_API_KEY PERPLEXITY_API_KEY OPENROUTER_API_KEY
+      source "$2/scripts/lib/provider-routing.sh"
+      build_provider_env "$3"
+      echo ok
+    ' _ "$tmp_pwd" "$PLUGIN_DIR" "$provider" 2>&1); then
+    if [[ "$case_output" == *"ok"* ]]; then
+      test_pass
+    else
+      test_fail "build_provider_env $provider returned without confirmation"
+    fi
+  else
+    test_fail "build_provider_env $provider exited under set -e: $case_output"
+  fi
+  rm -rf "$tmp_home" "$tmp_pwd"
+done
 
 # ─────────────────────────────────────────────────────────────────────
 # Suite 2: build_provider_env() is wired into spawn_agent()

--- a/tests/test-v8.24.0-perplexity-integration.sh
+++ b/tests/test-v8.24.0-perplexity-integration.sh
@@ -111,7 +111,7 @@ else
 fi
 
 # Test 2.4: JSON payload with model
-if grep -A20 "^perplexity_execute()" "$_ORCH_ALL_TMP" | grep -q '"model"'; then
+if grep -A35 "^perplexity_execute()" "$_ORCH_ALL_TMP" | grep -q '"model"'; then
     pass "perplexity_execute sends model in payload"
 else
     fail "perplexity_execute missing model in payload"


### PR DESCRIPTION
## Summary
- fixes #336 by making `build_provider_env()` treat provider env lookup as best-effort under `set -e`
- adds a regression test that runs codex, gemini, perplexity, and openrouter env setup with all API keys absent
- widens stale static test windows after multiline-safe shell blocks

## Verification
- `bash tests/test-credential-isolation.sh` — 25/25
- `bash tests/test-v8.24.0-perplexity-integration.sh` — 35/35
- `bash tests/unit/test-perplexity-issue-307.sh` — 6/6
- `bash tests/unit/test-probe-single.sh` — 30/30
- `bash tests/smoke/test-fleet-dispatch-guard.sh` — 4/4
- `bash tests/unit/test-provider-reliability.sh` — 30/30
- `bash tests/unit/test-docs-sync.sh` — 131/131
- `git diff --check && bash -n scripts/lib/provider-routing.sh scripts/lib/spawn.sh scripts/lib/perplexity.sh scripts/orchestrate.sh tests/test-credential-isolation.sh tests/test-v8.24.0-perplexity-integration.sh && ! rg -n '\[\[[^\n]+\]\][[:space:]]*&&[[:space:]]*resolve_provider_env' scripts`
- manual reproduction: `set -eo pipefail`, no provider API keys, isolated HOME/PWD, `build_provider_env` for codex/gemini/perplexity/openrouter reaches completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system resilience for AI providers (Codex, Gemini, Perplexity, OpenRouter); system now gracefully handles missing API credentials without disrupting operation.

* **Tests**
  * Strengthened credential isolation test coverage to verify system stability when provider API keys are unset or unavailable.
  * Improved test assertions for better provider integration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->