### PR TITLE
fix(develop): fallback Codex + remove deprecated --full-auto + quick mode routing

### DIFF
--- a/.claude/commands/quick.md
+++ b/.claude/commands/quick.md
@@ -43,17 +43,27 @@ Execute ad-hoc tasks without multi-AI orchestration overhead.
 
 ## What It Does
 
-1. Directly implements the change
-2. Creates atomic commit
-3. Updates state
-4. Generates summary
+1. Delegates the implementation to Codex CLI when available
+2. Uses Claude only as the host/supervisor and fallback
+3. Creates atomic commit
+4. Updates state
+5. Generates summary
 
 **Skips:** Research, planning, multi-AI validation
 
+## Execution Policy
+
+Quick mode is Codex-first by default. For any non-meta implementation task, your first tool action after the banner MUST be a Bash call to Codex CLI. Do not implement directly in Claude unless Codex is unavailable, unauthenticated, or fails. Before editing directly, check that Codex is available (`command -v codex`) and authenticated (`~/.codex/auth.json` or `OPENAI_API_KEY`).
+
+If Codex is available, delegate the task with `codex exec --skip-git-repo-check --full-auto --model gpt-5.4 -c model_reasoning_effort="medium" --sandbox workspace-write -`, passing the user request and relevant local repo instructions on stdin. Claude should only supervise, summarize the result, and perform small fallback edits if Codex fails.
+
+If Codex is unavailable or unauthenticated, fall back to Claude Sonnet. Do not use Opus for quick mode unless the user explicitly requests it.
+
 ## Cost
 
-Quick mode only uses Claude (included with Claude Code).
-No external provider costs.
+Quick mode uses Codex CLI first.
+Claude remains the host/supervisor and fallback only.
+No Gemini, Opus, research, or multi-AI validation costs.
 
 ## When to Escalate
 

--- a/.claude/skills/skill-quick.md
+++ b/.claude/skills/skill-quick.md
@@ -68,7 +68,7 @@ Fast-track execution for small tasks that don't need full Double Diamond workflo
 Quick mode follows a streamlined process:
 
 ```
-User Request → Direct Implementation → Atomic Commit → Summary
+User Request → Codex-first Implementation → Claude Fallback/Synthesis → Atomic Commit → Summary
 ```
 
 **What Quick Mode SKIPS:**
@@ -82,6 +82,7 @@ User Request → Direct Implementation → Atomic Commit → Summary
 - ✅ Atomic commits (git commit with description)
 - ✅ Summary generation (stored in .claude-octopus/quick/)
 - ✅ Change documentation
+- ✅ Codex-first execution for small implementation tasks
 
 ---
 
@@ -122,7 +123,11 @@ Quickly assess:
 
 ### Step 2: Make the Change
 
-Implement directly using appropriate tools:
+Delegate implementation to Codex CLI by default. For any non-meta implementation task, the first tool action after the banner MUST be a Bash call to `codex exec --skip-git-repo-check --full-auto --model gpt-5.4 -c model_reasoning_effort="medium" --sandbox workspace-write -` with the user request and relevant repo instructions on stdin. Claude remains the host/supervisor and fallback; do not implement directly in Claude while Codex is available.
+
+If Codex is unavailable, authenticated incorrectly, or fails, fall back to Claude Sonnet. Do not use Opus for quick mode unless the user explicitly requests it.
+
+When falling back or making final small edits, use appropriate tools:
 - **Edit** - For modifying existing files
 - **Write** - For creating new files (rare in quick mode)
 - **Bash** - For file operations, dependency updates
@@ -140,7 +145,7 @@ git commit -m "quick: [brief description]
 
 [Detailed explanation if needed]
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Codex <noreply@openai.com>"
 ```
 
 **Commit message format:**
@@ -223,7 +228,7 @@ echo "📝 Summary saved to: $summary_file"
    git add README.md
    git commit -m "quick: fix typo in README (recieve → receive)
 
-   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+   Co-Authored-By: Codex <noreply@openai.com>"
    ```
 
 4. **Record in state**
@@ -255,9 +260,9 @@ echo "📝 Summary saved to: $summary_file"
 - Faster for simple tasks
 
 ### Cost Savings 💰
-- No external provider API calls
-- Only uses Claude (included with Claude Code)
-- Efficient for ad-hoc work
+- Uses Codex CLI for quick work instead of spending the main Claude quota on implementation
+- Keeps Claude as host/supervisor and fallback only
+- Avoids Gemini, Opus, research, and multi-AI validation for ad-hoc work
 
 ### Still Tracked 📊
 - Commits recorded
@@ -326,8 +331,8 @@ Each summary includes:
 | Aspect | Quick Mode ⚡ | Full Workflow 🐙 |
 |--------|-------------|------------------|
 | **Time** | 1-3 minutes | 5-15 minutes |
-| **Cost** | Claude only | Codex + Gemini + Claude |
-| **Providers** | 1 (Claude) | 3 (multi-AI) |
+| **Cost** | Codex quick model + Claude host/fallback | Codex + Gemini + Claude |
+| **Providers** | 1 active provider (Codex) + Claude host | 3 (multi-AI) |
 | **Research** | None | Comprehensive |
 | **Planning** | None | Detailed |
 | **Validation** | Basic | Multi-AI review |

--- a/commands/octo-quick.md
+++ b/commands/octo-quick.md
@@ -41,17 +41,27 @@ Execute ad-hoc tasks without multi-AI orchestration overhead.
 
 ## What It Does
 
-1. Directly implements the change
-2. Creates atomic commit
-3. Updates state
-4. Generates summary
+1. Delegates the implementation to Codex CLI when available
+2. Uses Claude only as the host/supervisor and fallback
+3. Creates atomic commit
+4. Updates state
+5. Generates summary
 
 **Skips:** Research, planning, multi-AI validation
 
+## Execution Policy
+
+Quick mode is Codex-first by default. For any non-meta implementation task, your first tool action after the banner MUST be a Bash call to Codex CLI. Do not implement directly in Claude unless Codex is unavailable, unauthenticated, or fails. Before editing directly, check that Codex is available (`command -v codex`) and authenticated (`~/.codex/auth.json` or `OPENAI_API_KEY`).
+
+If Codex is available, delegate the task with `codex exec --skip-git-repo-check --full-auto --model gpt-5.4 -c model_reasoning_effort="medium" --sandbox workspace-write -`, passing the user request and relevant local repo instructions on stdin. Claude should only supervise, summarize the result, and perform small fallback edits if Codex fails.
+
+If Codex is unavailable or unauthenticated, fall back to Claude Sonnet. Do not use Opus for quick mode unless the user explicitly requests it.
+
 ## Cost
 
-Quick mode only uses Claude (included with Claude Code).
-No external provider costs.
+Quick mode uses Codex CLI first.
+Claude remains the host/supervisor and fallback only.
+No Gemini, Opus, research, or multi-AI validation costs.
 
 ## When to Escalate
 

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -40,19 +40,19 @@ get_agent_command() {
     case "$agent_type" in
         codex|codex-standard|codex-max|codex-mini|codex-general)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --skip-git-repo-check --full-auto --model ${model} ${sandbox_flag} -"
+            echo "codex exec --skip-git-repo-check --model ${model} ${sandbox_flag} -"
             ;;
         codex-spark)  # v8.9.0: Ultra-fast Spark model (1000+ tok/s)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --skip-git-repo-check --full-auto --model ${model} ${sandbox_flag} -"
+            echo "codex exec --skip-git-repo-check --model ${model} ${sandbox_flag} -"
             ;;
         codex-reasoning)  # v8.9.0: Reasoning models (o3, o3)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --skip-git-repo-check --full-auto --model ${model} ${sandbox_flag} -"
+            echo "codex exec --skip-git-repo-check --model ${model} ${sandbox_flag} -"
             ;;
         codex-large-context)  # v8.9.0: 1M context models (gpt-4.1)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
-            echo "codex exec --skip-git-repo-check --full-auto --model ${model} ${sandbox_flag} -"
+            echo "codex exec --skip-git-repo-check --model ${model} ${sandbox_flag} -"
             ;;
         gemini|gemini-fast|gemini-image)
             model=$(get_agent_model "$agent_type" "$phase" "$role")

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -771,8 +771,9 @@ ${context}Task: $prompt
 Output as numbered list with [CODING] or [REASONING] prefix for each subtask."
 
     local subtasks
-    subtasks=$(run_agent_sync "gemini" "$decompose_prompt" 120 "researcher" "tangle") || {
-        log WARN "Decomposition failed, falling back to direct execution"
+    subtasks=$(run_agent_sync "gemini" "$decompose_prompt" 120 "researcher" "tangle") || \
+    subtasks=$(run_agent_sync "codex" "$decompose_prompt" 120 "researcher" "tangle") || {
+        log WARN "Decomposition failed with all providers, falling back to direct execution"
         spawn_agent "codex" "$prompt" "tangle-${task_group}-direct" "implementer" "tangle"
         wait
         return

--- a/skills/octopus-quick/SKILL.md
+++ b/skills/octopus-quick/SKILL.md
@@ -61,7 +61,7 @@ Fast-track execution for small tasks that don't need full Double Diamond workflo
 Quick mode follows a streamlined process:
 
 ```
-User Request → Direct Implementation → Atomic Commit → Summary
+User Request → Codex-first Implementation → Claude Fallback/Synthesis → Atomic Commit → Summary
 ```
 
 **What Quick Mode SKIPS:**
@@ -75,6 +75,7 @@ User Request → Direct Implementation → Atomic Commit → Summary
 - ✅ Atomic commits (git commit with description)
 - ✅ Summary generation (stored in .claude-octopus/quick/)
 - ✅ Change documentation
+- ✅ Codex-first execution for small implementation tasks
 
 ---
 
@@ -115,7 +116,11 @@ Quickly assess:
 
 ### Step 2: Make the Change
 
-Implement directly using appropriate tools:
+Delegate implementation to Codex CLI by default. For any non-meta implementation task, the first tool action after the banner MUST be a Bash call to `codex exec --skip-git-repo-check --full-auto --model gpt-5.4 -c model_reasoning_effort="medium" --sandbox workspace-write -` with the user request and relevant repo instructions on stdin. Claude remains the host/supervisor and fallback; do not implement directly in Claude while Codex is available.
+
+If Codex is unavailable, authenticated incorrectly, or fails, fall back to Claude Sonnet. Do not use Opus for quick mode unless the user explicitly requests it.
+
+When falling back or making final small edits, use appropriate tools:
 - **Edit** - For modifying existing files
 - **Write** - For creating new files (rare in quick mode)
 - **Bash** - For file operations, dependency updates
@@ -133,7 +138,7 @@ git commit -m "quick: [brief description]
 
 [Detailed explanation if needed]
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Codex <noreply@openai.com>"
 ```
 
 **Commit message format:**
@@ -216,7 +221,7 @@ echo "📝 Summary saved to: $summary_file"
    git add README.md
    git commit -m "quick: fix typo in README (recieve → receive)
 
-   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+   Co-Authored-By: Codex <noreply@openai.com>"
    ```
 
 4. **Record in state**
@@ -248,9 +253,9 @@ echo "📝 Summary saved to: $summary_file"
 - Faster for simple tasks
 
 ### Cost Savings 💰
-- No external provider API calls
-- Only uses Claude (included with Claude Code)
-- Efficient for ad-hoc work
+- Uses Codex CLI for quick work instead of spending the main Claude quota on implementation
+- Keeps Claude as host/supervisor and fallback only
+- Avoids Gemini, Opus, research, and multi-AI validation for ad-hoc work
 
 ### Still Tracked 📊
 - Commits recorded
@@ -319,8 +324,8 @@ Each summary includes:
 | Aspect | Quick Mode ⚡ | Full Workflow 🐙 |
 |--------|-------------|------------------|
 | **Time** | 1-3 minutes | 5-15 minutes |
-| **Cost** | Claude only | Codex + Gemini + Claude |
-| **Providers** | 1 (Claude) | 3 (multi-AI) |
+| **Cost** | Codex quick model + Claude host/fallback | Codex + Gemini + Claude |
+| **Providers** | 1 active provider (Codex) + Claude host | 3 (multi-AI) |
 | **Research** | None | Comprehensive |
 | **Planning** | None | Detailed |
 | **Validation** | Basic | Multi-AI review |


### PR DESCRIPTION
## Changes

### 1. Fallback Codex for decomposition (`workflows.sh`)
When Gemini quota is exhausted during `tangle_develop` decomposition, fall back to Codex before giving up entirely. Prevents the full workflow from aborting on a single provider failure.

### 2. Remove deprecated `--full-auto` flag (`dispatch.sh`)
`--full-auto` was removed in Codex v0.128.0. Remove it from all 4 Codex variants (`codex`, `codex-spark`, `codex-reasoning`, `codex-large-context`). Sandbox mode is already controlled via `OCTOPUS_CODEX_SANDBOX`.

### 3. Quick mode routing through Codex (`.claude/commands/quick.md`, `skills/`)
Route `/octo:quick` through Codex for faster single-task execution.

## Note

Rebase of the original PR — scope reduced to these three changes. The quota watcher improvements have been extracted to #341 and #342 with proper fixes (targeted PID kill, real-time stderr streaming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated execution documentation to reflect Codex CLI as the primary execution provider, with Claude serving as host and fallback.

* **Execution Updates**
  * Improved execution flow to prioritize Codex CLI availability checks before falling back to Claude.
  * Enhanced fallback handling for Codex unavailability or authentication failures.
  * Streamlined command generation for Codex CLI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->