### PR TITLE
fix(gemini-exec): stream stderr in real-time via tail -f

### DIFF
--- a/scripts/helpers/gemini-exec.sh
+++ b/scripts/helpers/gemini-exec.sh
@@ -63,6 +63,13 @@ for model in "${model_list[@]}"; do
     : > "$stdout_file"
 
     # Buffer per attempt so a failed attempt's partial stdout never leaks.
+    # Stream stderr in real-time via tail -f so the quota fast-fail watcher in
+    # agent-sync.sh / spawn.sh sees Gemini retry messages immediately instead of
+    # waiting for all 10 internal retries (~4 min) before gemini-exec exits.
+    : > "$err_file"
+    tail -f "$err_file" >&2 &
+    _tail_pid=$!
+
     set +e
     if [[ -n "$prompt_file" ]]; then
         gemini -m "$model" "$@" <"$prompt_file" >"$stdout_file" 2>"$err_file"
@@ -72,9 +79,11 @@ for model in "${model_list[@]}"; do
     last_exit=$?
     set -e
 
+    kill "$_tail_pid" 2>/dev/null; wait "$_tail_pid" 2>/dev/null || true
+
     if [[ $last_exit -eq 0 ]]; then
         cat "$stdout_file"
-        cat "$err_file" >&2
+        # stderr already streamed in real-time above — no reprint
         rm -f "$err_file"
         exit 0
     fi
@@ -91,9 +100,9 @@ for model in "${model_list[@]}"; do
         continue
     fi
 
-    printf '%s' "$last_err" >&2
+    # stderr already streamed in real-time — exit without reprinting
     exit "$last_exit"
 done
 
-printf '%s' "$last_err" >&2
+# stderr already streamed in real-time — exit without reprinting
 exit "$last_exit"


### PR DESCRIPTION
## Problem

Gemini CLI captures stderr internally and only flushes it on process exit — after 10 retries with exponential backoff (~4 min total). This prevented quota watchers in `agent-sync.sh` and `spawn.sh` from detecting exhaustion early: they were watching empty files for the full retry window.

## Fix

Stream the internal `$err_file` to the caller's stderr in real-time using `tail -f ... &` immediately after the file is created. Kill the tail process after Gemini exits.

Remove the deferred `printf '%s' "$last_err" >&2` and `cat "$err_file" >&2` reprints that were made redundant by the streaming.

## Impact

Quota messages are now visible within ~2s of the first failed attempt instead of ~4 min. **This is a prerequisite for the quota watchers in `agent-sync.sh` and `spawn.sh` to be effective** — without this fix, those watchers watch empty files regardless of their polling logic.

## Test

With a fake Gemini binary that writes quota errors to stderr, detection time dropped from ~4 min to 2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling by streaming errors in real-time during command execution instead of displaying them at the end, reducing redundant output and providing better visibility into execution progress and any encountered issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->