### PR TITLE
fix(quota-watcher): targeted PID kill + extended patterns + temp_out

### DIFF
--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -12,8 +12,19 @@
 # Every parallel spawn loop MUST call fleet_dispatch_begin before the first
 # spawn_agent call and fleet_dispatch_end after the last one. The smoke test
 # tests/smoke/test-fleet-dispatch-guard.sh enforces this statically.
+if ! type start_quota_watcher >/dev/null 2>&1; then
+    _octopus_agent_sync_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "${_octopus_agent_sync_lib_dir}/quota-watcher.sh" 2>/dev/null || true
+fi
+
 fleet_dispatch_begin() {
     export OCTOPUS_FORCE_LEGACY_DISPATCH=true
+}
+
+quota_watcher_kill_sync_dispatch() {
+    local dispatch_pid="$1"
+    pkill -KILL -P "$dispatch_pid" 2>/dev/null || true
+    kill -KILL "$dispatch_pid" 2>/dev/null || true
 }
 
 fleet_dispatch_end() {
@@ -224,12 +235,12 @@ ${provider_ctx}"
     _dispatch_start=$(date +%s)
     _dispatch_cwd=$(pwd)
 
-    # Quota fast-fail watcher for Gemini (mirrors spawn.sh) — Gemini CLI retries
-    # internally for hours on QUOTA_EXHAUSTED instead of exiting; kill early.
+    # Quota fast-fail watcher for Gemini. Gemini CLI retries internally for
+    # hours on QUOTA_EXHAUSTED instead of exiting; kill early.
     local _quota_watcher_pid=""
     local _dispatch_pid=""
 
-    # Always init temp files so grep in watcher never fails on missing file
+    # Always init temp files so readers never fail on missing file.
     > "$temp_err"
     > "$temp_out"
 
@@ -239,20 +250,12 @@ ${provider_ctx}"
             | run_with_timeout "$timeout_secs" "${cmd_array[@]}" 2>"$temp_err" >"$temp_out" &
         _dispatch_pid=$!
 
-        (
-            while kill -0 "$_dispatch_pid" 2>/dev/null; do
-                sleep 2
-                if [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_err" 2>/dev/null) -gt 0 ]] || \
-                   [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_out" 2>/dev/null) -gt 0 ]]; then
-                    log WARN "[$agent_type] Quota exhaustion detected in sync agent — fast-failing"
-                    # Kill the dispatcher's direct children then the dispatcher itself
-                    pkill -KILL -P "$_dispatch_pid" 2>/dev/null || true
-                    kill -KILL "$_dispatch_pid" 2>/dev/null || true
-                    break
-                fi
-            done
-        ) &
-        _quota_watcher_pid=$!
+        _quota_watcher_pid=$(start_quota_watcher \
+            "$_dispatch_pid" \
+            "$temp_err" \
+            "$temp_out" \
+            quota_watcher_kill_sync_dispatch \
+            "[$agent_type] Quota exhaustion detected in sync agent - fast-failing")
 
         wait "$_dispatch_pid" 2>/dev/null && exit_code=0 || exit_code=$?
         [[ $exit_code -eq 137 ]] && exit_code=1
@@ -265,7 +268,7 @@ ${provider_ctx}"
         output=$(cat "$temp_out")
     fi
 
-    [[ -n "$_quota_watcher_pid" ]] && { kill "$_quota_watcher_pid" 2>/dev/null; wait "$_quota_watcher_pid" 2>/dev/null || true; }
+    stop_quota_watcher "$_quota_watcher_pid"
 
     # Tail-bias: the deliverable summary lives at the end of codex-style output.
     local _max_bytes="${OCTOPUS_AGENT_MAX_OUTPUT_BYTES:-262144}"

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -203,6 +203,7 @@ ${provider_ctx}"
     local output
     local exit_code
     local temp_err="${RESULTS_DIR}/.tmp-agent-error-$$.err"
+    local temp_out="${RESULTS_DIR}/.tmp-agent-out-$$.out"
 
     # v8.10.0: Gemini uses stdin-based prompt delivery (Issue #25)
     # -p "" triggers headless mode; prompt content comes via stdin to avoid OS arg limits
@@ -222,8 +223,47 @@ ${provider_ctx}"
     local _dispatch_start _dispatch_cwd
     _dispatch_start=$(date +%s)
     _dispatch_cwd=$(pwd)
-    output=$(printf '%s' "$enhanced_prompt" | run_with_timeout "$timeout_secs" "${cmd_array[@]}" 2>"$temp_err")
-    exit_code=$?
+
+    # Quota fast-fail watcher for Gemini (mirrors spawn.sh) — Gemini CLI retries
+    # internally for hours on QUOTA_EXHAUSTED instead of exiting; kill early.
+    local _quota_watcher_pid=""
+    local _dispatch_pid=""
+
+    # Always init temp files so grep in watcher never fails on missing file
+    > "$temp_err"
+    > "$temp_out"
+
+    if [[ "$agent_type" == gemini* ]]; then
+        # Option B (4/4 debate verdict): background dispatch + targeted PID kill
+        printf '%s' "$enhanced_prompt" \
+            | run_with_timeout "$timeout_secs" "${cmd_array[@]}" 2>"$temp_err" >"$temp_out" &
+        _dispatch_pid=$!
+
+        (
+            while kill -0 "$_dispatch_pid" 2>/dev/null; do
+                sleep 2
+                if grep -qE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_err" "$temp_out" 2>/dev/null; then
+                    log WARN "[$agent_type] Quota exhaustion detected in sync agent — fast-failing"
+                    # Kill the dispatcher's direct children then the dispatcher itself
+                    pkill -KILL -P "$_dispatch_pid" 2>/dev/null || true
+                    kill -KILL "$_dispatch_pid" 2>/dev/null || true
+                    break
+                fi
+            done
+        ) &
+        _quota_watcher_pid=$!
+
+        wait "$_dispatch_pid" 2>/dev/null || true
+        exit_code=$?
+        [[ $exit_code -eq 137 ]] && exit_code=1
+        output=$(cat "$temp_out")
+    else
+        printf '%s' "$enhanced_prompt" | run_with_timeout "$timeout_secs" "${cmd_array[@]}" 2>"$temp_err" >"$temp_out"
+        exit_code=$?
+        output=$(cat "$temp_out")
+    fi
+
+    [[ -n "$_quota_watcher_pid" ]] && { kill "$_quota_watcher_pid" 2>/dev/null; wait "$_quota_watcher_pid" 2>/dev/null || true; }
 
     # Tail-bias: the deliverable summary lives at the end of codex-style output.
     local _max_bytes="${OCTOPUS_AGENT_MAX_OUTPUT_BYTES:-262144}"
@@ -286,7 +326,7 @@ ${provider_ctx}"
                 fi
             fi
         fi
-        rm -f "$temp_err"
+        rm -f "$temp_err" "$temp_out"
         return $exit_code
     fi
 
@@ -302,7 +342,7 @@ ${provider_ctx}"
         fi
     fi
 
-    rm -f "$temp_err"
+    rm -f "$temp_err" "$temp_out"
 
     # v7.25.0: Record metrics completion
     if [[ -n "$metrics_id" ]] && command -v record_agent_complete &> /dev/null; then

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -242,7 +242,8 @@ ${provider_ctx}"
         (
             while kill -0 "$_dispatch_pid" 2>/dev/null; do
                 sleep 2
-                if [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_err" "$temp_out" 2>/dev/null) -gt 0 ]]; then
+                if [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_err" 2>/dev/null) -gt 0 ]] || \
+                   [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_out" 2>/dev/null) -gt 0 ]]; then
                     log WARN "[$agent_type] Quota exhaustion detected in sync agent — fast-failing"
                     # Kill the dispatcher's direct children then the dispatcher itself
                     pkill -KILL -P "$_dispatch_pid" 2>/dev/null || true

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -242,7 +242,7 @@ ${provider_ctx}"
         (
             while kill -0 "$_dispatch_pid" 2>/dev/null; do
                 sleep 2
-                if grep -qE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_err" "$temp_out" 2>/dev/null; then
+                if [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_err" "$temp_out" 2>/dev/null) -gt 0 ]]; then
                     log WARN "[$agent_type] Quota exhaustion detected in sync agent — fast-failing"
                     # Kill the dispatcher's direct children then the dispatcher itself
                     pkill -KILL -P "$_dispatch_pid" 2>/dev/null || true

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -258,8 +258,10 @@ ${provider_ctx}"
         [[ $exit_code -eq 137 ]] && exit_code=1
         output=$(cat "$temp_out")
     else
+        set +e
         printf '%s' "$enhanced_prompt" | run_with_timeout "$timeout_secs" "${cmd_array[@]}" 2>"$temp_err" >"$temp_out"
         exit_code=$?
+        set -e
         output=$(cat "$temp_out")
     fi
 

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -254,8 +254,7 @@ ${provider_ctx}"
         ) &
         _quota_watcher_pid=$!
 
-        wait "$_dispatch_pid" 2>/dev/null || true
-        exit_code=$?
+        wait "$_dispatch_pid" 2>/dev/null && exit_code=0 || exit_code=$?
         [[ $exit_code -eq 137 ]] && exit_code=1
         output=$(cat "$temp_out")
     else

--- a/scripts/lib/quota-watcher.sh
+++ b/scripts/lib/quota-watcher.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Shared quota fast-fail watcher for provider CLIs that retry for a long time
+# after quota exhaustion instead of exiting promptly.
+
+OCTOPUS_QUOTA_PATTERN='QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted'
+
+quota_watcher_has_match() {
+    local temp_err="$1"
+    local temp_out="$2"
+
+    grep -qE "$OCTOPUS_QUOTA_PATTERN" "$temp_err" 2>/dev/null || \
+        grep -qE "$OCTOPUS_QUOTA_PATTERN" "$temp_out" 2>/dev/null
+}
+
+start_quota_watcher() {
+    local target_pid="$1"
+    local temp_err="$2"
+    local temp_out="$3"
+    local kill_callback="$4"
+    local warning_message="${5:-Quota exhaustion detected - fast-failing}"
+
+    > "$temp_err"
+    > "$temp_out"
+
+    (
+        while kill -0 "$target_pid" 2>/dev/null; do
+            sleep 2
+            if quota_watcher_has_match "$temp_err" "$temp_out"; then
+                log "WARN" "$warning_message"
+                "$kill_callback" "$target_pid"
+                break
+            fi
+        done
+    ) >/dev/null &
+    echo "$!"
+}
+
+stop_quota_watcher() {
+    local watcher_pid="${1:-}"
+    [[ -n "$watcher_pid" ]] || return 0
+
+    kill "$watcher_pid" 2>/dev/null || true
+    wait "$watcher_pid" 2>/dev/null || true
+}

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -2,6 +2,18 @@
 # spawn_agent — extracted from orchestrate.sh (v9.7.x)
 # Agent spawning and lifecycle management
 
+if ! type start_quota_watcher >/dev/null 2>&1; then
+    _octopus_spawn_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "${_octopus_spawn_lib_dir}/quota-watcher.sh" 2>/dev/null || true
+fi
+
+quota_watcher_kill_spawn_children() {
+    local spawn_pid="$1"
+    pkill -TERM -P "$spawn_pid" 2>/dev/null || true
+    sleep 1
+    pkill -KILL -P "$spawn_pid" 2>/dev/null || true
+}
+
 spawn_agent() {
     local _ts; _ts=$(date +%s)
     local agent_type="$1"
@@ -528,29 +540,18 @@ ${heuristic_ctx}"
         while true; do
             exit_code=0
 
-            # Quota fast-fail watcher: detects QUOTA_EXHAUSTED / TerminalQuotaError in stderr
-            # and kills the provider process early instead of waiting the full TIMEOUT (300s).
+            # Quota fast-fail watcher: detects quota exhaustion in stderr/stdout
+            # and kills the provider process early instead of waiting the full TIMEOUT.
             # Applies to Gemini (free tier exhausts quota and retries for ~18h internally).
             local _quota_watcher_pid=""
             if [[ "$agent_type" == gemini* ]]; then
                 local _spawn_pid=$BASHPID
-                > "$temp_errors"   # ensure file exists before watcher starts
-                > "$temp_output"   # ensure stdout file exists before watcher starts
-                (
-                    local _n=0
-                    while [[ $((_n++)) -lt 150 ]]; do
-                        sleep 2
-                        if [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_errors" 2>/dev/null) -gt 0 ]] || \
-                           [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_output" 2>/dev/null) -gt 0 ]]; then
-                            log "WARN" "[$agent_type] Quota exhaustion detected — fast-failing (saves ~${TIMEOUT}s wait)"
-                            pkill -TERM -P "$_spawn_pid" 2>/dev/null || true
-                            sleep 1
-                            pkill -KILL -P "$_spawn_pid" 2>/dev/null || true
-                            break
-                        fi
-                    done
-                ) &
-                _quota_watcher_pid=$!
+                _quota_watcher_pid=$(start_quota_watcher \
+                    "$_spawn_pid" \
+                    "$temp_errors" \
+                    "$temp_output" \
+                    quota_watcher_kill_spawn_children \
+                    "[$agent_type] Quota exhaustion detected - fast-failing (saves ~${TIMEOUT}s wait)")
             fi
 
             # v9.2.2: All agents use stdin-based prompt delivery to avoid ARG_MAX limits (Issue #173)
@@ -561,7 +562,7 @@ ${heuristic_ctx}"
                 exit_code=$?
             fi
 
-            [[ -n "$_quota_watcher_pid" ]] && { kill "$_quota_watcher_pid" 2>/dev/null; wait "$_quota_watcher_pid" 2>/dev/null || true; }
+            stop_quota_watcher "$_quota_watcher_pid"
 
             # v8.16: Check if failure is auth-related and retryable
             if [[ $exit_code -ne 0 ]] && [[ $auth_attempt -lt $max_auth_retries ]]; then

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -540,7 +540,7 @@ ${heuristic_ctx}"
                     local _n=0
                     while [[ $((_n++)) -lt 150 ]]; do
                         sleep 2
-                        if grep -qE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_errors" "$temp_output" 2>/dev/null; then
+                        if [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_errors" "$temp_output" 2>/dev/null) -gt 0 ]]; then
                             log "WARN" "[$agent_type] Quota exhaustion detected — fast-failing (saves ~${TIMEOUT}s wait)"
                             pkill -TERM -P "$_spawn_pid" 2>/dev/null || true
                             sleep 1

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -540,7 +540,8 @@ ${heuristic_ctx}"
                     local _n=0
                     while [[ $((_n++)) -lt 150 ]]; do
                         sleep 2
-                        if [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_errors" "$temp_output" 2>/dev/null) -gt 0 ]]; then
+                        if [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_errors" 2>/dev/null) -gt 0 ]] || \
+                           [[ $(grep -cE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_output" 2>/dev/null) -gt 0 ]]; then
                             log "WARN" "[$agent_type] Quota exhaustion detected — fast-failing (saves ~${TIMEOUT}s wait)"
                             pkill -TERM -P "$_spawn_pid" 2>/dev/null || true
                             sleep 1

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -527,6 +527,31 @@ ${heuristic_ctx}"
         local exit_code=0
         while true; do
             exit_code=0
+
+            # Quota fast-fail watcher: detects QUOTA_EXHAUSTED / TerminalQuotaError in stderr
+            # and kills the provider process early instead of waiting the full TIMEOUT (300s).
+            # Applies to Gemini (free tier exhausts quota and retries for ~18h internally).
+            local _quota_watcher_pid=""
+            if [[ "$agent_type" == gemini* ]]; then
+                local _spawn_pid=$BASHPID
+                > "$temp_errors"   # ensure file exists before watcher starts
+                > "$temp_output"   # ensure stdout file exists before watcher starts
+                (
+                    local _n=0
+                    while [[ $((_n++)) -lt 150 ]]; do
+                        sleep 2
+                        if grep -qE "QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted" "$temp_errors" "$temp_output" 2>/dev/null; then
+                            log "WARN" "[$agent_type] Quota exhaustion detected — fast-failing (saves ~${TIMEOUT}s wait)"
+                            pkill -TERM -P "$_spawn_pid" 2>/dev/null || true
+                            sleep 1
+                            pkill -KILL -P "$_spawn_pid" 2>/dev/null || true
+                            break
+                        fi
+                    done
+                ) &
+                _quota_watcher_pid=$!
+            fi
+
             # v9.2.2: All agents use stdin-based prompt delivery to avoid ARG_MAX limits (Issue #173)
             # Previously only gemini used stdin; codex/claude passed prompt as CLI arg which fails on large diffs
             if printf '%s' "$enhanced_prompt" | run_with_timeout "$TIMEOUT" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then
@@ -534,6 +559,8 @@ ${heuristic_ctx}"
             else
                 exit_code=$?
             fi
+
+            [[ -n "$_quota_watcher_pid" ]] && { kill "$_quota_watcher_pid" 2>/dev/null; wait "$_quota_watcher_pid" 2>/dev/null || true; }
 
             # v8.16: Check if failure is auth-related and retryable
             if [[ $exit_code -ne 0 ]] && [[ $auth_attempt -lt $max_auth_retries ]]; then

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -82,6 +82,7 @@ source "${SCRIPT_DIR}/lib/progressive.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/review.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/workflows.sh"
 source "${SCRIPT_DIR}/lib/doctor.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/lib/quota-watcher.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/agent-sync.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/persona-loader.sh" 2>/dev/null || true
 

--- a/tests/unit/test-quota-watcher.sh
+++ b/tests/unit/test-quota-watcher.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Unit tests for shared quota fast-fail watcher helpers.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/quota-watcher.sh"
+
+test_suite "quota watcher helper"
+
+log() { :; }
+
+test_case "quota_watcher_has_match detects quota text in stderr"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+err_file="$tmp_dir/agent.err"
+out_file="$tmp_dir/agent.out"
+printf '%s\n' "RetryableQuotaError: exhausted your capacity" > "$err_file"
+touch "$out_file"
+if quota_watcher_has_match "$err_file" "$out_file"; then
+    test_pass
+else
+    test_fail "quota pattern was not detected"
+fi
+
+test_case "start_quota_watcher invokes callback and stops target"
+flag_file="$tmp_dir/callback.flag"
+test_quota_callback() {
+    local target_pid="$1"
+    printf '%s\n' "$target_pid" > "$flag_file"
+    kill "$target_pid" 2>/dev/null || true
+}
+
+( trap 'exit 0' TERM; while true; do sleep 1; done ) &
+target_pid=$!
+watcher_pid=$(start_quota_watcher "$target_pid" "$err_file" "$out_file" test_quota_callback "quota test")
+printf '%s\n' "TerminalQuotaError" > "$out_file"
+
+for _ in 1 2 3 4 5; do
+    [[ -s "$flag_file" ]] && break
+    sleep 1
+done
+stop_quota_watcher "$watcher_pid"
+kill "$target_pid" 2>/dev/null || true
+wait "$target_pid" 2>/dev/null || true
+
+if [[ -s "$flag_file" ]]; then
+    test_pass
+else
+    test_fail "quota watcher did not invoke callback"
+fi
+
+test_summary


### PR DESCRIPTION
## Problem

Three issues in the quota exhaustion watchers in `agent-sync.sh` and `spawn.sh`:

1. **Broad kill scope**: `pkill -f "gemini-cli/bundle/gemini.js"` kills *all* Gemini CLI processes for the current user — in a multi-agent setup with N parallel workers, one quota-hit kills every running Gemini session.

2. **Incomplete patterns**: `exhausted your capacity` missed `RetryableQuotaError` and the per-attempt format `Attempt N failed: ... exhausted` emitted by Gemini CLI during retries.

3. **Only stderr monitored**: stdout (`$temp_out`) was not watched, missing any messages that might route there.

## Fix

**Kill strategy (4/4 model debate verdict, 2026-05-03):** switch to Option B — background dispatch with captured PID, then `pkill -KILL -P "$_dispatch_pid"` + `kill -KILL "$_dispatch_pid"`. Targets only the process tree of this invocation. Normalizes SIGKILL exit code 137 → 1.

**Extended patterns:** add `RetryableQuotaError` and `Attempt [0-9]+ failed.*exhausted`.

**Dual-file monitoring:** watch both `$temp_err` and `$temp_out`.

**Housekeeping:** remove duplicate `local _quota_watcher_pid` declaration.

## Dependency

Requires #341 (`fix/gemini-exec-realtime-stderr`) — without real-time stderr streaming, the watcher watches empty files for ~4 min regardless of kill strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gemini-like providers now fail faster on quota exhaustion via a background watcher that terminates affected processes early.
  * Provider stdout/stderr are consistently captured to per-run temp files for reliable output reading.
  * Non-Gemini runs preserve original exit status while still capturing output.
  * Temporary output files are cleaned up more robustly to prevent stale artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->