### PR TITLE
fix(develop): resolve .md file references before injecting into decompose prompt

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -759,20 +759,41 @@ tangle_develop() {
     # Step 1: Decompose into validated subtasks
     log INFO "Step 1: Task decomposition..."
 
-    # Résoudre les références de fichiers .md dans le prompt
+    # Resolve a referenced Markdown plan file without letting grep/head trip
+    # pipefail when the prompt has no file token.
     local resolved_prompt="$prompt"
-    local file_ref
-    file_ref=$(echo "$prompt" | grep -oE '[^[:space:]]+\.md' | head -1)
-    file_ref="${file_ref/#\~/$HOME}"   # expand ~ que [[ -f ]] ne résout pas entre guillemets
+    local file_ref=""
+    local raw_file_ref=""
+    local token
+    for token in $prompt; do
+        if [[ "$token" == *.md ]]; then
+            raw_file_ref="$token"
+            file_ref="${token/#\~/$HOME}"
+            break
+        fi
+    done
     if [[ -n "$file_ref" && -f "$file_ref" ]]; then
         local file_content
         file_content=$(<"$file_ref")
-        resolved_prompt="Implement the code changes described in the following plan. Do NOT modify the plan file itself (${file_ref}).
-
---- PLAN: ${file_ref} ---
+        local plan_block="--- PLAN: ${file_ref} ---
 ${file_content}
 --- END PLAN ---"
-        log INFO "Resolved file reference: ${file_ref} — injecting content into decompose prompt"
+        local trimmed_prompt="$prompt"
+        trimmed_prompt="${trimmed_prompt#"${trimmed_prompt%%[![:space:]]*}"}"
+        trimmed_prompt="${trimmed_prompt%"${trimmed_prompt##*[![:space:]]}"}"
+
+        if [[ "$trimmed_prompt" == "$raw_file_ref" || "$trimmed_prompt" == "$file_ref" ]]; then
+            resolved_prompt="Implement the code changes described in the following plan. Do NOT modify the plan file itself (${file_ref}).
+
+${plan_block}"
+        else
+            resolved_prompt="${prompt}
+
+The following referenced plan file has been resolved. Use it as implementation context and do NOT modify the plan file itself (${file_ref}).
+
+${plan_block}"
+        fi
+        log INFO "Resolved file reference: ${file_ref} - injecting content into decompose prompt"
     fi
 
     local decompose_prompt="Decompose this task into subtasks that can be executed in parallel.

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -763,6 +763,7 @@ tangle_develop() {
     local resolved_prompt="$prompt"
     local file_ref
     file_ref=$(echo "$prompt" | grep -oE '[^[:space:]]+\.md' | head -1)
+    file_ref="${file_ref/#\~/$HOME}"   # expand ~ que [[ -f ]] ne résout pas entre guillemets
     if [[ -n "$file_ref" && -f "$file_ref" ]]; then
         local file_content
         file_content=$(<"$file_ref")

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -758,6 +758,22 @@ tangle_develop() {
 
     # Step 1: Decompose into validated subtasks
     log INFO "Step 1: Task decomposition..."
+
+    # Résoudre les références de fichiers .md dans le prompt
+    local resolved_prompt="$prompt"
+    local file_ref
+    file_ref=$(echo "$prompt" | grep -oE '[^[:space:]]+\.md' | head -1)
+    if [[ -n "$file_ref" && -f "$file_ref" ]]; then
+        local file_content
+        file_content=$(<"$file_ref")
+        resolved_prompt="Implement the code changes described in the following plan. Do NOT modify the plan file itself (${file_ref}).
+
+--- PLAN: ${file_ref} ---
+${file_content}
+--- END PLAN ---"
+        log INFO "Resolved file reference: ${file_ref} — injecting content into decompose prompt"
+    fi
+
     local decompose_prompt="Decompose this task into subtasks that can be executed in parallel.
 Each subtask should be:
 - Self-contained and independently verifiable
@@ -766,14 +782,15 @@ Each subtask should be:
 
 **Cohesion rule:** If the task produces a single deliverable (one file, one script, one page, one config), keep it as ONE subtask — do not split it. Only decompose when subtasks are truly independent with no cross-file references between them. Aim for 2-6 subtasks; fewer is better when the work is tightly coupled.
 
-${context}Task: $prompt
+${context}Task: $resolved_prompt
 
 Output as numbered list with [CODING] or [REASONING] prefix for each subtask."
 
     local subtasks
-    subtasks=$(run_agent_sync "gemini" "$decompose_prompt" 120 "researcher" "tangle") || {
-        log WARN "Decomposition failed, falling back to direct execution"
-        spawn_agent "codex" "$prompt" "tangle-${task_group}-direct" "implementer" "tangle"
+    subtasks=$(run_agent_sync "gemini" "$decompose_prompt" 120 "researcher" "tangle") || \
+    subtasks=$(run_agent_sync "codex" "$decompose_prompt" 120 "researcher" "tangle") || {
+        log WARN "Decomposition failed with all providers, falling back to direct execution"
+        spawn_agent "codex" "$resolved_prompt" "tangle-${task_group}-direct" "implementer" "tangle"
         wait
         return
     }

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -765,6 +765,8 @@ tangle_develop() {
     local file_ref=""
     local raw_file_ref=""
     local token
+    local noglob_was_set=false
+    [[ "$-" == *f* ]] && noglob_was_set=true || set -f
     for token in $prompt; do
         if [[ "$token" == *.md ]]; then
             raw_file_ref="$token"
@@ -772,6 +774,7 @@ tangle_develop() {
             break
         fi
     done
+    [[ "$noglob_was_set" == "false" ]] && set +f
     if [[ -n "$file_ref" && -f "$file_ref" ]]; then
         local file_content
         file_content=$(<"$file_ref")
@@ -888,7 +891,7 @@ Output as numbered list with [CODING] or [REASONING] prefix for each subtask."
 
     # Step 3: Validation gate
     log INFO "Step 3: Validation gate..."
-    validate_tangle_results "$task_group" "$prompt"
+    validate_tangle_results "$task_group" "$resolved_prompt"
 }
 
 # Phase 4: INK (Deliver) - Quality gates + final output

--- a/tests/unit/test-develop-md-file-resolution.sh
+++ b/tests/unit/test-develop-md-file-resolution.sh
@@ -44,9 +44,6 @@ fi
 assert_lacks 'grep -oE .*\.\.md.*head -1|grep -oE .*\\.md.*head -1' \
     "plan reference scan avoids grep|head pipeline"
 
-assert_has 'for token in \$prompt; do' \
-    "plan reference scan uses a shell token loop"
-
 assert_has 'trimmed_prompt=' \
     "plan reference handling detects file-only prompts"
 
@@ -55,5 +52,75 @@ assert_has 'resolved_prompt="\$\{prompt\}' \
 
 assert_has 'spawn_agent "codex" "\$resolved_prompt"' \
     "direct fallback receives resolved prompt"
+
+source "$WORKFLOWS"
+
+CAPTURED_DECOMPOSE_PROMPT=""
+CAPTURED_VALIDATE_PROMPT=""
+CYAN=""
+MAGENTA=""
+NC=""
+TMUX_MODE=false
+DRY_RUN=false
+SUPPORTS_PARALLEL_FILE_SAFETY=false
+RESULTS_DIR="$(mktemp -d)"
+LOGS_DIR="$RESULTS_DIR/logs"
+DECOMPOSE_CAPTURE_FILE="$RESULTS_DIR/decompose.prompt"
+trap 'rm -rf "$RESULTS_DIR"' EXIT
+
+log() { :; }
+octopus_phase_banner() { :; }
+design_review_ceremony() { :; }
+display_workflow_cost_estimate() { return 0; }
+reset_provider_lockouts() { :; }
+fleet_dispatch_begin() { :; }
+fleet_dispatch_end() { :; }
+run_agent_sync() {
+    printf '%s' "$2" > "$DECOMPOSE_CAPTURE_FILE"
+    printf '%s\n' "No numbered subtasks required"
+}
+validate_tangle_results() {
+    CAPTURED_VALIDATE_PROMPT="$2"
+}
+
+run_tangle_case() {
+    CAPTURED_DECOMPOSE_PROMPT=""
+    CAPTURED_VALIDATE_PROMPT=""
+    rm -f "$DECOMPOSE_CAPTURE_FILE"
+    tangle_develop "$1" >/dev/null || return 1
+    [[ -f "$DECOMPOSE_CAPTURE_FILE" ]] && CAPTURED_DECOMPOSE_PROMPT=$(<"$DECOMPOSE_CAPTURE_FILE")
+}
+
+test_case "plan file references inject content while preserving prompt text"
+plan_file="$RESULTS_DIR/session-plan.md"
+printf '%s\n' "Update scripts/lib/workflows.sh with the regression fix." > "$plan_file"
+run_tangle_case "please implement $plan_file carefully"
+if [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"please implement"* ]] && \
+   [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"Update scripts/lib/workflows.sh with the regression fix."* ]]; then
+    test_pass
+else
+    test_fail "resolved prompt did not preserve instructions and plan content"
+fi
+
+test_case "validation receives resolved plan content"
+if [[ "$CAPTURED_VALIDATE_PROMPT" == *"Update scripts/lib/workflows.sh with the regression fix."* ]]; then
+    test_pass
+else
+    test_fail "validate_tangle_results received raw prompt instead of resolved content"
+fi
+
+test_case "wildcard-looking Markdown tokens are not glob-expanded"
+glob_dir="$RESULTS_DIR/glob-case"
+mkdir -p "$glob_dir"
+printf '%s\n' "This file should not be injected from a wildcard prompt." > "$glob_dir/noise.md"
+(
+    cd "$glob_dir"
+    run_tangle_case "review *.md"
+)
+if [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"This file should not be injected"* ]]; then
+    test_fail "wildcard token was expanded and injected as a plan file"
+else
+    test_pass
+fi
 
 test_summary

--- a/tests/unit/test-develop-md-file-resolution.sh
+++ b/tests/unit/test-develop-md-file-resolution.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Static regression checks for /octo:develop Markdown plan reference handling.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKFLOWS="$PROJECT_ROOT/scripts/lib/workflows.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "develop Markdown plan resolution"
+
+assert_has() {
+    local pattern="$1"
+    local label="$2"
+    test_case "$label"
+    if grep -qE "$pattern" "$WORKFLOWS"; then
+        test_pass
+    else
+        test_fail "pattern not found: $pattern"
+    fi
+}
+
+assert_lacks() {
+    local pattern="$1"
+    local label="$2"
+    test_case "$label"
+    if grep -qE "$pattern" "$WORKFLOWS"; then
+        test_fail "unexpected pattern found: $pattern"
+    else
+        test_pass
+    fi
+}
+
+test_case "workflows.sh has valid bash syntax"
+if bash -n "$WORKFLOWS" 2>/dev/null; then
+    test_pass
+else
+    test_fail "syntax error in workflows.sh"
+fi
+
+assert_lacks 'grep -oE .*\.\.md.*head -1|grep -oE .*\\.md.*head -1' \
+    "plan reference scan avoids grep|head pipeline"
+
+assert_has 'for token in \$prompt; do' \
+    "plan reference scan uses a shell token loop"
+
+assert_has 'trimmed_prompt=' \
+    "plan reference handling detects file-only prompts"
+
+assert_has 'resolved_prompt="\$\{prompt\}' \
+    "plan reference handling preserves surrounding user instructions"
+
+assert_has 'spawn_agent "codex" "\$resolved_prompt"' \
+    "direct fallback receives resolved prompt"
+
+test_summary


### PR DESCRIPTION
## Problem

`/octo:develop .claude/session-plan.md` was passing the raw path string to agents. Agents received a filename, not the plan content — the decomposition step was working with a 30-character path instead of the actual implementation plan.

## Fix

In `tangle_develop()`, before building the decompose prompt: detect a `.md` path in the user prompt, read the file content, and replace the prompt with an explicit wrapper that embeds the full content:

```
Implement the code changes described in the following plan. Do NOT modify the plan file itself.

--- PLAN: .claude/session-plan.md ---
<file content>
--- END PLAN ---
```

The resolved prompt is used both for the `decompose_prompt` Gemini/Codex call and the direct Codex fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Decomposition now detects and injects referenced Markdown plan files into the prompt while ensuring those files are not modified.
  * Clarified fallback message to read “Decomposition failed with all providers,” improving troubleshooting.

* **Tests**
  * Added unit tests validating Markdown plan detection, prompt resolution, preservation of surrounding instructions, and decomposition/validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->