### PR TITLE
fix: resolve orchestrate.sh placeholder paths + probe-single --output-dir parsing (closes #340, closes #344)

### DIFF
--- a/.claude/commands/model-config.md
+++ b/.claude/commands/model-config.md
@@ -181,7 +181,7 @@ AskUserQuestion({
 
 After selection, apply the change:
 ```bash
-/path/to/orchestrate.sh set-model <provider> <model>
+${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh set-model <provider> <model>
 ```
 
 Then confirm: `✓ Set <provider> default → <model>`

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -144,7 +144,7 @@ const profile = {
 Run via Bash tool:
 
 ```bash
-/path/to/orchestrate.sh code-review '<profile-json>'
+${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh code-review '<profile-json>'
 ```
 
 Where `<profile-json>` is the JSON profile built in Step 2.

--- a/commands/octo-model-config.md
+++ b/commands/octo-model-config.md
@@ -177,7 +177,7 @@ AskUserQuestion({
 
 After selection, apply the change:
 ```bash
-/path/to/orchestrate.sh set-model <provider> <model>
+${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh set-model <provider> <model>
 ```
 
 Then confirm: `✓ Set <provider> default → <model>`

--- a/commands/octo-review.md
+++ b/commands/octo-review.md
@@ -131,7 +131,7 @@ const profile = {
 Run via Bash tool:
 
 ```bash
-/path/to/orchestrate.sh code-review '<profile-json>'
+${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh code-review '<profile-json>'
 ```
 
 Where `<profile-json>` is the JSON profile built in Step 2.

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -2159,7 +2159,7 @@ case "$COMMAND" in
         # v8.54.0: Single-agent probe for multi-agentic skill dispatch
         # Called by Claude's Agent tool (one per perspective) instead of monolithic probe
         # v9.29.3: Parse --output-dir flag from any position (fixes #340)
-        local _ps_args=()
+        _ps_args=()
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 --output-dir)
@@ -2586,9 +2586,9 @@ case "$COMMAND" in
             echo "Usage: $(basename "$0") agent-resume <agent-id> [prompt] [task-id]"
             exit 1
         fi
-        local _agent_id="$1"
-        local _resume_prompt="${2:-Continue where you left off.}"
-        local _resume_task="${3:-$(date +%s)}"
+        _agent_id="$1"
+        _resume_prompt="${2:-Continue where you left off.}"
+        _resume_task="${3:-$(date +%s)}"
         resume_agent "$_agent_id" "$_resume_prompt" "$_resume_task" || {
             log ERROR "resume_agent failed for agent_id=$_agent_id"
             log INFO "Requirements: SUPPORTS_CONTINUATION=true (CC v2.1.55+) AND SUPPORTS_STABLE_AGENT_TEAMS=true"

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -2158,8 +2158,29 @@ case "$COMMAND" in
     probe-single)
         # v8.54.0: Single-agent probe for multi-agentic skill dispatch
         # Called by Claude's Agent tool (one per perspective) instead of monolithic probe
+        # v9.29.3: Parse --output-dir flag from any position (fixes #340)
+        local _ps_args=()
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --output-dir)
+                    if [[ -n "${2:-}" ]]; then
+                        RESULTS_DIR="$2"
+                        mkdir -p "$RESULTS_DIR" 2>/dev/null || true
+                        shift 2
+                    else
+                        echo "Error: --output-dir requires a directory argument" >&2
+                        exit 1
+                    fi
+                    ;;
+                *)
+                    _ps_args+=("$1")
+                    shift
+                    ;;
+            esac
+        done
+        set -- "${_ps_args[@]}"
         if [[ $# -lt 3 ]]; then
-            echo "Usage: $(basename "$0") probe-single <agent_type> <perspective> <task_id> [original_prompt]"
+            echo "Usage: $(basename "$0") probe-single <agent_type> <perspective> <task_id> [original_prompt] [--output-dir <dir>]"
             exit 1
         fi
         probe_single_agent "$1" "$2" "$3" "${4:-}"

--- a/tests/unit/test-compound-init.sh
+++ b/tests/unit/test-compound-init.sh
@@ -26,7 +26,7 @@ fi
 INIT_BLOCK=$(grep -A80 'init-workflow)' "$ORCHESTRATE" | head -85)
 
 for field in workflow providers models capabilities files paths; do
-    if echo "$INIT_BLOCK" | grep -q "\"$field\"" 2>/dev/null; then
+    if grep -q "\"$field\"" <<< "$INIT_BLOCK" 2>/dev/null; then
         pass "init-workflow JSON has '$field' field"
     else
         fail "init-workflow JSON has '$field' field" "missing in output"
@@ -36,7 +36,7 @@ done
 # ── Provider detection for all 4 providers ──────────────────────────────────
 
 for provider in codex gemini claude perplexity; do
-    if echo "$INIT_BLOCK" | grep -q "${provider}" 2>/dev/null; then
+    if grep -q "${provider}" <<< "$INIT_BLOCK" 2>/dev/null; then
         pass "init-workflow detects $provider provider"
     else
         fail "init-workflow detects $provider provider" "missing $provider detection"
@@ -45,7 +45,7 @@ done
 
 # ── Model resolution uses get_agent_model ───────────────────────────────────
 
-if echo "$INIT_BLOCK" | grep -q 'get_agent_model' 2>/dev/null; then
+if grep -q 'get_agent_model' <<< "$INIT_BLOCK" 2>/dev/null; then
     pass "init-workflow uses get_agent_model for resolution"
 else
     fail "init-workflow uses get_agent_model for resolution" "missing get_agent_model call"
@@ -54,7 +54,7 @@ fi
 # ── Resolves 4 key roles ───────────────────────────────────────────────────
 
 for role in researcher implementer reviewer synthesizer; do
-    if echo "$INIT_BLOCK" | grep -q "$role" 2>/dev/null; then
+    if grep -q "$role" <<< "$INIT_BLOCK" 2>/dev/null; then
         pass "init-workflow resolves $role role model"
     else
         fail "init-workflow resolves $role role model" "missing $role"
@@ -63,7 +63,7 @@ done
 
 # ── Has --help flag ─────────────────────────────────────────────────────────
 
-if echo "$INIT_BLOCK" | grep -q '\-\-help' 2>/dev/null; then
+if grep -q '\-\-help' <<< "$INIT_BLOCK" 2>/dev/null; then
     pass "init-workflow has --help support"
 else
     fail "init-workflow has --help support" "missing --help handler"

--- a/tests/unit/test-compound-init.sh
+++ b/tests/unit/test-compound-init.sh
@@ -23,10 +23,16 @@ fi
 
 # ── Returns JSON with expected fields ───────────────────────────────────────
 
-INIT_BLOCK=$(grep -A80 'init-workflow)' "$ORCHESTRATE" | head -85)
+INIT_BLOCK=$(awk '
+    /init-workflow\)/ { in_block = 1 }
+    in_block {
+        print
+        if ($0 ~ /^[[:space:]]*;;[[:space:]]*$/) exit
+    }
+' "$ORCHESTRATE")
 
 for field in workflow providers models capabilities files paths; do
-    if grep -q "\"$field\"" <<< "$INIT_BLOCK" 2>/dev/null; then
+    if grep -q "\"$field\"" <<< "$INIT_BLOCK"; then
         pass "init-workflow JSON has '$field' field"
     else
         fail "init-workflow JSON has '$field' field" "missing in output"
@@ -36,7 +42,7 @@ done
 # ── Provider detection for all 4 providers ──────────────────────────────────
 
 for provider in codex gemini claude perplexity; do
-    if grep -q "${provider}" <<< "$INIT_BLOCK" 2>/dev/null; then
+    if grep -q "${provider}" <<< "$INIT_BLOCK"; then
         pass "init-workflow detects $provider provider"
     else
         fail "init-workflow detects $provider provider" "missing $provider detection"
@@ -45,7 +51,7 @@ done
 
 # ── Model resolution uses get_agent_model ───────────────────────────────────
 
-if grep -q 'get_agent_model' <<< "$INIT_BLOCK" 2>/dev/null; then
+if grep -q 'get_agent_model' <<< "$INIT_BLOCK"; then
     pass "init-workflow uses get_agent_model for resolution"
 else
     fail "init-workflow uses get_agent_model for resolution" "missing get_agent_model call"
@@ -54,7 +60,7 @@ fi
 # ── Resolves 4 key roles ───────────────────────────────────────────────────
 
 for role in researcher implementer reviewer synthesizer; do
-    if grep -q "$role" <<< "$INIT_BLOCK" 2>/dev/null; then
+    if grep -q "$role" <<< "$INIT_BLOCK"; then
         pass "init-workflow resolves $role role model"
     else
         fail "init-workflow resolves $role role model" "missing $role"
@@ -63,7 +69,7 @@ done
 
 # ── Has --help flag ─────────────────────────────────────────────────────────
 
-if grep -q '\-\-help' <<< "$INIT_BLOCK" 2>/dev/null; then
+if grep -q '\-\-help' <<< "$INIT_BLOCK"; then
     pass "init-workflow has --help support"
 else
     fail "init-workflow has --help support" "missing --help handler"

--- a/tests/unit/test-crash-recovery.sh
+++ b/tests/unit/test-crash-recovery.sh
@@ -107,7 +107,7 @@ test_sanitize_private_keys() {
     local func_body
     func_body=$(sed -n '/^sanitize_secrets()/,/^}/p' "$ALL_SRC")
 
-    if grep -q 'PRIVATE KEY.*REDACTED\|BEGIN.*REDACTED' <<< "$func_body"; then
+    if grep -qE 'PRIVATE KEY.*REDACTED|BEGIN.*REDACTED' <<< "$func_body"; then
         test_pass
     else
         test_fail "Private key sanitization not found"
@@ -163,7 +163,7 @@ test_checkpoint_debounce() {
     local func_body
     func_body=$(sed -n '/^save_agent_checkpoint()/,/^}/p' "$ALL_SRC")
 
-    if grep -q "300\|5 min" <<< "$func_body"; then
+    if grep -qE "300|5 min" <<< "$func_body"; then
         test_pass
     else
         test_fail "5-minute debounce not found"
@@ -199,7 +199,9 @@ test_checkpoint_truncation() {
 test_checkpoint_in_spawn_agent_failure() {
     test_case "Checkpoint saved in spawn_agent failure path"
 
-    if grep -B 5 -A 5 "save_agent_checkpoint" "$ALL_SRC" | grep -q "FAILED\|failed\|spawn_agent"; then
+    local failure_context
+    failure_context=$(grep -B 5 -A 5 "save_agent_checkpoint" "$ALL_SRC" || true)
+    if grep -qE "FAILED|failed|spawn_agent" <<< "$failure_context"; then
         test_pass
     else
         test_fail "Checkpoint not saved on failure"

--- a/tests/unit/test-crash-recovery.sh
+++ b/tests/unit/test-crash-recovery.sh
@@ -41,7 +41,7 @@ test_sanitize_api_keys() {
     local func_body
     func_body=$(sed -n '/^sanitize_secrets()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q 'sk-.*REDACTED'; then
+    if grep -q 'sk-.*REDACTED' <<< "$func_body"; then
         test_pass
     else
         test_fail "sk-* API key sanitization not found"
@@ -54,7 +54,7 @@ test_sanitize_aws_keys() {
     local func_body
     func_body=$(sed -n '/^sanitize_secrets()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q 'AKIA.*REDACTED'; then
+    if grep -q 'AKIA.*REDACTED' <<< "$func_body"; then
         test_pass
     else
         test_fail "AKIA* AWS key sanitization not found"
@@ -67,7 +67,7 @@ test_sanitize_github_tokens() {
     local func_body
     func_body=$(sed -n '/^sanitize_secrets()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q 'ghp_.*REDACTED' && echo "$func_body" | grep -q 'gho_.*REDACTED'; then
+    if grep -q 'ghp_.*REDACTED' <<< "$func_body" && grep -q 'gho_.*REDACTED' <<< "$func_body"; then
         test_pass
     else
         test_fail "GitHub token sanitization not found"
@@ -80,7 +80,7 @@ test_sanitize_bearer_tokens() {
     local func_body
     func_body=$(sed -n '/^sanitize_secrets()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q 'Bearer.*REDACTED'; then
+    if grep -q 'Bearer.*REDACTED' <<< "$func_body"; then
         test_pass
     else
         test_fail "Bearer token sanitization not found"
@@ -93,7 +93,7 @@ test_sanitize_jwt_tokens() {
     local func_body
     func_body=$(sed -n '/^sanitize_secrets()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q 'eyJ.*REDACTED'; then
+    if grep -q 'eyJ.*REDACTED' <<< "$func_body"; then
         test_pass
     else
         test_fail "JWT token sanitization not found"
@@ -106,7 +106,7 @@ test_sanitize_private_keys() {
     local func_body
     func_body=$(sed -n '/^sanitize_secrets()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q 'PRIVATE KEY.*REDACTED\|BEGIN.*REDACTED'; then
+    if grep -q 'PRIVATE KEY.*REDACTED\|BEGIN.*REDACTED' <<< "$func_body"; then
         test_pass
     else
         test_fail "Private key sanitization not found"
@@ -119,10 +119,10 @@ test_sanitize_connection_strings() {
     local func_body
     func_body=$(sed -n '/^sanitize_secrets()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q 'postgres://.*REDACTED' && \
-       echo "$func_body" | grep -q 'mysql://.*REDACTED' && \
-       echo "$func_body" | grep -q 'mongodb://.*REDACTED' && \
-       echo "$func_body" | grep -q 'redis://.*REDACTED'; then
+    if grep -q 'postgres://.*REDACTED' <<< "$func_body" && \
+       grep -q 'mysql://.*REDACTED' <<< "$func_body" && \
+       grep -q 'mongodb://.*REDACTED' <<< "$func_body" && \
+       grep -q 'redis://.*REDACTED' <<< "$func_body"; then
         test_pass
     else
         test_fail "Connection string sanitization not found"
@@ -135,7 +135,7 @@ test_sanitize_password_patterns() {
     local func_body
     func_body=$(sed -n '/^sanitize_secrets()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q 'password=.*REDACTED'; then
+    if grep -q 'password=.*REDACTED' <<< "$func_body"; then
         test_pass
     else
         test_fail "Password pattern sanitization not found"
@@ -148,8 +148,8 @@ test_sanitize_gitlab_slack() {
     local func_body
     func_body=$(sed -n '/^sanitize_secrets()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q 'glpat-.*REDACTED' && \
-       echo "$func_body" | grep -q 'xox.*REDACTED'; then
+    if grep -q 'glpat-.*REDACTED' <<< "$func_body" && \
+       grep -q 'xox.*REDACTED' <<< "$func_body"; then
         test_pass
     else
         test_fail "GitLab/Slack sanitization not found"
@@ -162,7 +162,7 @@ test_checkpoint_debounce() {
     local func_body
     func_body=$(sed -n '/^save_agent_checkpoint()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q "300\|5 min"; then
+    if grep -q "300\|5 min" <<< "$func_body"; then
         test_pass
     else
         test_fail "5-minute debounce not found"
@@ -175,7 +175,7 @@ test_checkpoint_expiry() {
     local func_body
     func_body=$(sed -n '/^load_agent_checkpoint()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q "86400"; then
+    if grep -q "86400" <<< "$func_body"; then
         test_pass
     else
         test_fail "24h expiry (86400) not found"
@@ -188,7 +188,7 @@ test_checkpoint_truncation() {
     local func_body
     func_body=$(sed -n '/^save_agent_checkpoint()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q "4096"; then
+    if grep -q "4096" <<< "$func_body"; then
         test_pass
     else
         test_fail "4096 char truncation not found"

--- a/tests/unit/test-crash-recovery.sh
+++ b/tests/unit/test-crash-recovery.sh
@@ -11,6 +11,7 @@ test_suite "Crash-Recovery with Secret Sanitization"
 
 # Combined search target (functions decomposed to lib/ in v9.7.7+)
 ALL_SRC=$(mktemp)
+trap 'rm -f "$ALL_SRC"' EXIT
 cat "$PROJECT_ROOT/scripts/orchestrate.sh" "$PROJECT_ROOT/scripts/lib/"*.sh > "$ALL_SRC" 2>/dev/null
 
 test_sanitize_secrets_function_exists() {
@@ -259,5 +260,4 @@ test_checkpoint_in_spawn_agent_start
 test_cleanup_in_embrace
 test_dry_run_with_crash_recovery
 
-rm -f "$ALL_SRC"
 test_summary

--- a/tests/unit/test-probe-single.sh
+++ b/tests/unit/test-probe-single.sh
@@ -34,7 +34,7 @@ assert_contains "$(grep -c 'probe-single)' "$ALL_SRC" 2>/dev/null || echo 0)" \
 
 # ── probe-single calls probe_single_agent ────────────────────────────────────
 
-assert_contains "$(grep -A10 'probe-single)' "$ALL_SRC" | head -15)" \
+assert_contains "$(grep -A40 'probe-single)' "$ALL_SRC" | head -45)" \
   "probe_single_agent" "probe-single: dispatch calls probe_single_agent()"
 
 # ── probe_single_agent writes result files ───────────────────────────────────


### PR DESCRIPTION
## Fixes

### Issue #344 — placeholder path in review.md and model-config.md

Four command files used `/path/to/orchestrate.sh` as a placeholder that never got resolved at runtime. Claude would fail to find the script and fall back to single-provider execution.

**Changed files:**
- `.claude/commands/review.md` (line 147)
- `.claude/commands/model-config.md` (line 184)
- `commands/octo-review.md` (line 134)
- `commands/octo-model-config.md` (line 180)

All now use `${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh`, matching the convention in other commands.

### Issue #340 — probe-single fails with --output-dir flag

The `probe-single` case handler treated all arguments as positional. When `--output-dir ~/.claude-octopus/results` was appended, `--output-dir` became the `task_id` parameter, producing a malformed filename `.tmp---output-dir.out`.

Now parses `--output-dir` from any argument position before processing positional args. Also updates `RESULTS_DIR` so the probe output lands in the specified directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /octo:review command for structured multi-provider code reviews with scope-drift checks and automated review checks
  * Added optional --output-dir for probe-single to place results in a custom location

* **Bug Fixes**
  * Fixed orchestration invocation in model-config and review flows to use the correct in-repo orchestrator

* **Documentation**
  * Updated command docs to reflect accurate orchestration paths and usage

* **Tests**
  * Improved unit tests for probe, init, crash-recovery, and related flows for more robust pattern detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->