### PR TITLE
Wire routing.features.* (review, parallel, debate) to their consumers

### DIFF
--- a/scripts/lib/debate.sh
+++ b/scripts/lib/debate.sh
@@ -30,10 +30,57 @@ grapple_debate() {
         rounds=3
     fi
 
+    # v9.31.0: Resolve participants from .routing.features.debate (providers.json).
+    # The /octo:model-config wizard writes a "Debate participants" array to that
+    # path; before this change there was no consumer. Slots A/B/C drive every
+    # run_agent_sync call, prompt label, and synthesis attribution below.
+    # Default trio: codex, gemini, claude-sonnet (preserves prior behavior).
+    local agent_a="codex" label_a="Codex" label_a_upper="CODEX"
+    local agent_b="gemini" label_b="Gemini" label_b_upper="GEMINI"
+    local agent_c="claude-sonnet" label_c="Sonnet" label_c_upper="SONNET"
+
+    local _debate_config_file="${HOME}/.claude-octopus/config/providers.json"
+    if [[ -f "$_debate_config_file" ]] && command -v jq >/dev/null 2>&1; then
+        local _participants _participant_count
+        _participants=$(jq -r '
+            (.routing.features.debate // [])
+            | if type == "array" then .[] else empty end
+        ' "$_debate_config_file" 2>/dev/null)
+        if [[ -n "$_participants" ]]; then
+            _participant_count=$(printf '%s\n' "$_participants" | grep -cv '^$')
+            if [[ "$_participant_count" -gt 3 ]]; then
+                log WARN "Debate supports 3 participants; using first 3 of $_participant_count from .routing.features.debate"
+            fi
+            local _slot_idx=0
+            local _provider _agent _label _label_upper
+            while IFS= read -r _provider; do
+                [[ -z "$_provider" ]] && continue
+                _agent=""; _label=""; _label_upper=""
+                case "$_provider" in
+                    claude|claude-sonnet)    _agent="claude-sonnet"; _label="Sonnet"; _label_upper="SONNET" ;;
+                    claude-opus)             _agent="claude-opus";   _label="Opus";   _label_upper="OPUS" ;;
+                    codex|codex-*)           _agent="$_provider";    _label="Codex";  _label_upper="CODEX" ;;
+                    gemini|gemini-*)         _agent="$_provider";    _label="Gemini"; _label_upper="GEMINI" ;;
+                    openrouter|openrouter-*) _agent="$_provider";    _label="OpenRouter"; _label_upper="OPENROUTER" ;;
+                    qwen|qwen-*)             _agent="$_provider";    _label="Qwen";   _label_upper="QWEN" ;;
+                    perplexity|perplexity-*) _agent="$_provider";    _label="Perplexity"; _label_upper="PERPLEXITY" ;;
+                    *) continue ;;
+                esac
+                case "$_slot_idx" in
+                    0) agent_a="$_agent"; label_a="$_label"; label_a_upper="$_label_upper" ;;
+                    1) agent_b="$_agent"; label_b="$_label"; label_b_upper="$_label_upper" ;;
+                    2) agent_c="$_agent"; label_c="$_label"; label_c_upper="$_label_upper"; break ;;
+                esac
+                _slot_idx=$((_slot_idx + 1))
+            done <<< "$_participants"
+            log INFO "Debate participants (from config): $label_a ($agent_a) vs $label_b ($agent_b) vs $label_c ($agent_c)"
+        fi
+    fi
+
     echo ""
     echo -e "${RED}${_BOX_TOP}${NC}"
     echo -e "${RED}║  🤼 GRAPPLE - Adversarial Cross-Model Review              ║${NC}"
-    echo -e "${RED}║  Codex vs Gemini vs Sonnet 4.6 debate (${rounds} rounds)  ║${NC}"
+    echo -e "${RED}║  ${label_a} vs ${label_b} vs ${label_c} debate (${rounds} rounds)  ║${NC}"
     if [[ "$debate_mode" == "blinded" ]]; then
     echo -e "${RED}║  Mode: Blinded (independent evaluation, no anchoring)     ║${NC}"
     fi
@@ -45,7 +92,7 @@ grapple_debate() {
     if [[ "$DRY_RUN" == "true" ]]; then
         log INFO "[DRY-RUN] Would grapple on: $prompt"
         log INFO "[DRY-RUN] Principles: $principles"
-        log INFO "[DRY-RUN] Round 1: Generate competing proposals (Codex + Gemini + Sonnet 4.6)"
+        log INFO "[DRY-RUN] Round 1: Generate competing proposals (${label_a} + ${label_b} + ${label_c})"
         log INFO "[DRY-RUN] Round 2: Cross-critique (each critiques the other two)"
         log INFO "[DRY-RUN] Round 3: Synthesis and winner determination"
         return 0
@@ -86,7 +133,7 @@ DEBATE INTEGRITY RULES (MANDATORY — follow these in every response):
 - PROPORTIONAL: A minor style issue is NOT a critical flaw. A fundamental architecture mistake is NOT a 'minor concern'. Calibrate severity honestly."
 
     local codex_proposal gemini_proposal sonnet_proposal
-    codex_proposal=$(run_agent_sync "codex" "
+    codex_proposal=$(run_agent_sync "$agent_a" "
 $no_explore_constraint
 
 You are formulating a HYPOTHESIS. Propose your best approach to this task:
@@ -106,13 +153,13 @@ Be thorough and practical." 120 "implementer" "grapple")
 
     if [[ $? -ne 0 || -z "$codex_proposal" ]]; then
         echo ""
-        echo -e "${RED}❌ Codex proposal generation failed${NC}"
+        echo -e "${RED}❌ ${label_a} proposal generation failed${NC}"
         echo -e "   Check logs: ${LOGS_DIR}/"
-        log ERROR "Grapple debate failed: Codex proposal empty or error"
+        log ERROR "Grapple debate failed: ${label_a} proposal empty or error"
         return 1
     fi
 
-    gemini_proposal=$(run_agent_sync "gemini" "
+    gemini_proposal=$(run_agent_sync "$agent_b" "
 $no_explore_constraint
 
 You are formulating a HYPOTHESIS. Propose your best approach to this task:
@@ -132,13 +179,13 @@ Be thorough and practical." 120 "researcher" "grapple")
 
     if [[ $? -ne 0 || -z "$gemini_proposal" ]]; then
         echo ""
-        echo -e "${RED}❌ Gemini proposal generation failed${NC}"
+        echo -e "${RED}❌ ${label_b} proposal generation failed${NC}"
         echo -e "   Check logs: ${LOGS_DIR}/"
-        log ERROR "Grapple debate failed: Gemini proposal empty or error"
+        log ERROR "Grapple debate failed: ${label_b} proposal empty or error"
         return 1
     fi
 
-    sonnet_proposal=$(run_agent_sync "claude-sonnet" "
+    sonnet_proposal=$(run_agent_sync "$agent_c" "
 $no_explore_constraint
 
 You are formulating a HYPOTHESIS. Propose your best approach to this task:
@@ -158,9 +205,9 @@ Be thorough and practical." 120 "researcher" "grapple")
 
     if [[ $? -ne 0 || -z "$sonnet_proposal" ]]; then
         echo ""
-        echo -e "${RED}❌ Sonnet proposal generation failed${NC}"
+        echo -e "${RED}❌ ${label_c} proposal generation failed${NC}"
         echo -e "   Check logs: ${LOGS_DIR}/"
-        log ERROR "Grapple debate failed: Sonnet proposal empty or error"
+        log ERROR "Grapple debate failed: ${label_c} proposal empty or error"
         return 1
     fi
 
@@ -183,7 +230,7 @@ Be thorough and practical." 120 "researcher" "grapple")
         # ── BLINDED MODE: Each model evaluates independently against criteria ──
         # No model sees another's proposals — prevents anchoring bias
 
-        codex_critique=$(run_agent_sync "codex-review" "
+        codex_critique=$(run_agent_sync "$agent_a" "
 $no_explore_constraint
 
 You are an INDEPENDENT EVALUATOR. You have NOT seen any other model's proposals.
@@ -203,12 +250,12 @@ Provide your INDEPENDENT assessment:
 $debate_integrity_rules" 90 "code-reviewer" "grapple")
 
         if [[ $? -ne 0 || -z "$codex_critique" ]]; then
-            echo -e "${RED}❌ Codex evaluation failed${NC}"
-            log ERROR "Grapple debate failed: Codex blinded evaluation empty or error"
+            echo -e "${RED}❌ ${label_a} evaluation failed${NC}"
+            log ERROR "Grapple debate failed: ${label_a} blinded evaluation empty or error"
             return 1
         fi
 
-        gemini_critique=$(run_agent_sync "gemini" "
+        gemini_critique=$(run_agent_sync "$agent_b" "
 $no_explore_constraint
 
 You are an INDEPENDENT EVALUATOR. You have NOT seen any other model's proposals.
@@ -228,12 +275,12 @@ Provide your INDEPENDENT assessment:
 $debate_integrity_rules" 90 "security-auditor" "grapple")
 
         if [[ $? -ne 0 || -z "$gemini_critique" ]]; then
-            echo -e "${RED}❌ Gemini evaluation failed${NC}"
-            log ERROR "Grapple debate failed: Gemini blinded evaluation empty or error"
+            echo -e "${RED}❌ ${label_b} evaluation failed${NC}"
+            log ERROR "Grapple debate failed: ${label_b} blinded evaluation empty or error"
             return 1
         fi
 
-        sonnet_critique=$(run_agent_sync "claude-sonnet" "
+        sonnet_critique=$(run_agent_sync "$agent_c" "
 $no_explore_constraint
 
 You are an INDEPENDENT EVALUATOR. You have NOT seen any other model's proposals.
@@ -253,24 +300,24 @@ Provide your INDEPENDENT assessment:
 $debate_integrity_rules" 90 "code-reviewer" "grapple")
 
         if [[ $? -ne 0 || -z "$sonnet_critique" ]]; then
-            echo -e "${RED}❌ Sonnet evaluation failed${NC}"
-            log ERROR "Grapple debate failed: Sonnet blinded evaluation empty or error"
+            echo -e "${RED}❌ ${label_c} evaluation failed${NC}"
+            log ERROR "Grapple debate failed: ${label_c} blinded evaluation empty or error"
             return 1
         fi
 
     else
         # ── CROSS-CRITIQUE MODE (default): ACH falsification ──
 
-        # Codex falsifies Gemini + Sonnet hypotheses
-        codex_critique=$(run_agent_sync "codex-review" "
+        # ${label_a} falsifies ${label_b} + ${label_c} hypotheses
+        codex_critique=$(run_agent_sync "$agent_a" "
 $no_explore_constraint
 
 You are a FALSIFIER using Analysis of Competing Hypotheses (ACH). Your job is to DISPROVE these proposals by testing their stated assumptions.
 
-HYPOTHESIS 1 (from Gemini):
+HYPOTHESIS 1 (from ${label_b}):
 $gemini_proposal
 
-HYPOTHESIS 2 (from Sonnet 4.6):
+HYPOTHESIS 2 (from ${label_c}):
 $sonnet_proposal
 
 For each hypothesis, attempt to falsify it:
@@ -286,21 +333,21 @@ Focus on falsification, not preference. An approach with unfalsified assumptions
 $debate_integrity_rules" 90 "code-reviewer" "grapple")
 
         if [[ $? -ne 0 || -z "$codex_critique" ]]; then
-            echo -e "${RED}❌ Codex critique generation failed${NC}"
-            log ERROR "Grapple debate failed: Codex critique empty or error"
+            echo -e "${RED}❌ ${label_a} critique generation failed${NC}"
+            log ERROR "Grapple debate failed: ${label_a} critique empty or error"
             return 1
         fi
 
-        # Gemini falsifies Codex + Sonnet hypotheses
-        gemini_critique=$(run_agent_sync "gemini" "
+        # ${label_b} falsifies ${label_a} + ${label_c} hypotheses
+        gemini_critique=$(run_agent_sync "$agent_b" "
 $no_explore_constraint
 
 You are a FALSIFIER using Analysis of Competing Hypotheses (ACH). Your job is to DISPROVE these proposals by testing their stated assumptions.
 
-HYPOTHESIS 1 (from Codex):
+HYPOTHESIS 1 (from ${label_a}):
 $codex_proposal
 
-HYPOTHESIS 2 (from Sonnet 4.6):
+HYPOTHESIS 2 (from ${label_c}):
 $sonnet_proposal
 
 For each hypothesis, attempt to falsify it:
@@ -316,21 +363,21 @@ Focus on falsification, not preference. An approach with unfalsified assumptions
 $debate_integrity_rules" 90 "security-auditor" "grapple")
 
         if [[ $? -ne 0 || -z "$gemini_critique" ]]; then
-            echo -e "${RED}❌ Gemini critique generation failed${NC}"
-            log ERROR "Grapple debate failed: Gemini critique empty or error"
+            echo -e "${RED}❌ ${label_b} critique generation failed${NC}"
+            log ERROR "Grapple debate failed: ${label_b} critique empty or error"
             return 1
         fi
 
-        # Sonnet falsifies Codex + Gemini hypotheses
-        sonnet_critique=$(run_agent_sync "claude-sonnet" "
+        # ${label_c} falsifies ${label_a} + ${label_b} hypotheses
+        sonnet_critique=$(run_agent_sync "$agent_c" "
 $no_explore_constraint
 
 You are a FALSIFIER using Analysis of Competing Hypotheses (ACH). Your job is to DISPROVE these proposals by testing their stated assumptions.
 
-HYPOTHESIS 1 (from Codex):
+HYPOTHESIS 1 (from ${label_a}):
 $codex_proposal
 
-HYPOTHESIS 2 (from Gemini):
+HYPOTHESIS 2 (from ${label_b}):
 $gemini_proposal
 
 For each hypothesis, attempt to falsify it:
@@ -345,8 +392,8 @@ $principle_text}
 $debate_integrity_rules" 90 "code-reviewer" "grapple")
 
         if [[ $? -ne 0 || -z "$sonnet_critique" ]]; then
-            echo -e "${RED}❌ Sonnet critique generation failed${NC}"
-            log ERROR "Grapple debate failed: Sonnet critique empty or error"
+            echo -e "${RED}❌ ${label_c} critique generation failed${NC}"
+            log ERROR "Grapple debate failed: ${label_c} critique empty or error"
             return 1
         fi
     fi
@@ -360,20 +407,20 @@ $debate_integrity_rules" 90 "code-reviewer" "grapple")
             echo -e "${CYAN}[Round $i/$rounds] Rebuttal and refinement...${NC}"
             echo ""
 
-            # Codex defends and refines
+            # ${label_a} defends and refines
             local codex_rebuttal
-            codex_rebuttal=$(run_agent_sync "codex" "
+            codex_rebuttal=$(run_agent_sync "$agent_a" "
 $no_explore_constraint
 
-You are DEFENDING your implementation against critiques from Gemini and Sonnet.
+You are DEFENDING your implementation against critiques from ${label_b} and ${label_c}.
 
 YOUR ORIGINAL PROPOSAL:
 $codex_proposal
 
-CRITIQUE FROM GEMINI:
+CRITIQUE FROM ${label_b_upper}:
 $gemini_critique
 
-CRITIQUE FROM SONNET:
+CRITIQUE FROM ${label_c_upper}:
 $sonnet_critique
 
 Respond to both critiques by:
@@ -386,26 +433,26 @@ Be specific, technical, and constructive. Focus on improving the solution." 120 
 
             if [[ $? -ne 0 || -z "$codex_rebuttal" ]]; then
                 echo ""
-                echo -e "${RED}❌ Codex rebuttal generation failed${NC}"
+                echo -e "${RED}❌ ${label_a} rebuttal generation failed${NC}"
                 echo -e "   Check logs: ${LOGS_DIR}/"
-                log ERROR "Grapple debate failed: Codex rebuttal empty or error (round $i)"
+                log ERROR "Grapple debate failed: ${label_a} rebuttal empty or error (round $i)"
                 return 1
             fi
 
-            # Gemini defends and refines
+            # ${label_b} defends and refines
             local gemini_rebuttal
-            gemini_rebuttal=$(run_agent_sync "gemini" "
+            gemini_rebuttal=$(run_agent_sync "$agent_b" "
 $no_explore_constraint
 
-You are DEFENDING your implementation against critiques from Codex and Sonnet.
+You are DEFENDING your implementation against critiques from ${label_a} and ${label_c}.
 
 YOUR ORIGINAL PROPOSAL:
 $gemini_proposal
 
-CRITIQUE FROM CODEX:
+CRITIQUE FROM ${label_a_upper}:
 $codex_critique
 
-CRITIQUE FROM SONNET:
+CRITIQUE FROM ${label_c_upper}:
 $sonnet_critique
 
 Respond to both critiques by:
@@ -418,26 +465,26 @@ Be specific, technical, and constructive. Focus on improving the solution." 120 
 
             if [[ $? -ne 0 || -z "$gemini_rebuttal" ]]; then
                 echo ""
-                echo -e "${RED}❌ Gemini rebuttal generation failed${NC}"
+                echo -e "${RED}❌ ${label_b} rebuttal generation failed${NC}"
                 echo -e "   Check logs: ${LOGS_DIR}/"
-                log ERROR "Grapple debate failed: Gemini rebuttal empty or error (round $i)"
+                log ERROR "Grapple debate failed: ${label_b} rebuttal empty or error (round $i)"
                 return 1
             fi
 
-            # Sonnet defends and refines
+            # ${label_c} defends and refines
             local sonnet_rebuttal
-            sonnet_rebuttal=$(run_agent_sync "claude-sonnet" "
+            sonnet_rebuttal=$(run_agent_sync "$agent_c" "
 $no_explore_constraint
 
-You are DEFENDING your implementation against critiques from Codex and Gemini.
+You are DEFENDING your implementation against critiques from ${label_a} and ${label_b}.
 
 YOUR ORIGINAL PROPOSAL:
 $sonnet_proposal
 
-CRITIQUE FROM CODEX:
+CRITIQUE FROM ${label_a_upper}:
 $codex_critique
 
-CRITIQUE FROM GEMINI:
+CRITIQUE FROM ${label_b_upper}:
 $gemini_critique
 
 Respond to both critiques by:
@@ -450,9 +497,9 @@ Be specific, technical, and constructive. Focus on improving the solution." 120 
 
             if [[ $? -ne 0 || -z "$sonnet_rebuttal" ]]; then
                 echo ""
-                echo -e "${RED}❌ Sonnet rebuttal generation failed${NC}"
+                echo -e "${RED}❌ ${label_c} rebuttal generation failed${NC}"
                 echo -e "   Check logs: ${LOGS_DIR}/"
-                log ERROR "Grapple debate failed: Sonnet rebuttal empty or error (round $i)"
+                log ERROR "Grapple debate failed: ${label_c} rebuttal empty or error (round $i)"
                 return 1
             fi
 
@@ -507,22 +554,22 @@ $quorum_result"
 You are the JUDGE synthesizing a $rounds-round BLINDED debate between three AI models.
 Each model proposed independently (Round 1) and evaluated independently (Round 2) — no model saw another's work. This prevents anchoring bias but means models may have identified different concerns.
 
-CODEX PROPOSAL:
+${label_a_upper} PROPOSAL:
 $codex_proposal
 
-GEMINI PROPOSAL:
+${label_b_upper} PROPOSAL:
 $gemini_proposal
 
-SONNET 4.6 PROPOSAL:
+${label_c_upper} PROPOSAL:
 $sonnet_proposal
 
-CODEX'S INDEPENDENT EVALUATION:
+${label_a_upper}'S INDEPENDENT EVALUATION:
 $codex_critique
 
-GEMINI'S INDEPENDENT EVALUATION:
+${label_b_upper}'S INDEPENDENT EVALUATION:
 $gemini_critique
 
-SONNET'S INDEPENDENT EVALUATION:
+${label_c_upper}'S INDEPENDENT EVALUATION:
 $sonnet_critique
 
 $debate_integrity_rules
@@ -560,22 +607,22 @@ Be specific and actionable. Format as markdown."
 
 You are the JUDGE evaluating a $rounds-round ACH (Analysis of Competing Hypotheses) debate between three AI models. Your role is to determine which hypotheses SURVIVED falsification, not which 'feels best'.
 
-CODEX HYPOTHESIS:
+${label_a_upper} HYPOTHESIS:
 $codex_proposal
 
-GEMINI HYPOTHESIS:
+${label_b_upper} HYPOTHESIS:
 $gemini_proposal
 
-SONNET 4.6 HYPOTHESIS:
+${label_c_upper} HYPOTHESIS:
 $sonnet_proposal
 
-CODEX'S FALSIFICATION ATTEMPTS (against Gemini + Sonnet):
+${label_a_upper}'S FALSIFICATION ATTEMPTS (against ${label_b} + ${label_c}):
 $codex_critique
 
-GEMINI'S FALSIFICATION ATTEMPTS (against Codex + Sonnet):
+${label_b_upper}'S FALSIFICATION ATTEMPTS (against ${label_a} + ${label_c}):
 $gemini_critique
 
-SONNET'S FALSIFICATION ATTEMPTS (against Codex + Gemini):
+${label_c_upper}'S FALSIFICATION ATTEMPTS (against ${label_a} + ${label_b}):
 $sonnet_critique
 
 $debate_integrity_rules
@@ -631,32 +678,32 @@ Be specific and actionable. Format as markdown."
 **Rounds:** $rounds
 **Mode:** $debate_mode
 **Principles:** $principles
-**Participants:** Codex, Gemini, Sonnet 4.6
+**Participants:** ${label_a}, ${label_b}, ${label_c}
 
 ---
 
 ## Round 1: Proposals
 
-### Codex Proposal
+### ${label_a} Proposal
 $codex_proposal
 
-### Gemini Proposal
+### ${label_b} Proposal
 $gemini_proposal
 
-### Sonnet 4.6 Proposal
+### ${label_c} Proposal
 $sonnet_proposal
 
 ---
 
 ## Round 2: $(if [[ "$debate_mode" == "blinded" ]]; then echo "Independent Evaluations (Blinded)"; else echo "Cross-Critique"; fi)
 
-### Codex's $(if [[ "$debate_mode" == "blinded" ]]; then echo "Evaluation"; else echo "Critique (of Gemini + Sonnet)"; fi)
+### ${label_a}'s $(if [[ "$debate_mode" == "blinded" ]]; then echo "Evaluation"; else echo "Critique (of ${label_b} + ${label_c})"; fi)
 $codex_critique
 
-### Gemini's $(if [[ "$debate_mode" == "blinded" ]]; then echo "Evaluation"; else echo "Critique (of Codex + Sonnet)"; fi)
+### ${label_b}'s $(if [[ "$debate_mode" == "blinded" ]]; then echo "Evaluation"; else echo "Critique (of ${label_a} + ${label_c})"; fi)
 $gemini_critique
 
-### Sonnet's $(if [[ "$debate_mode" == "blinded" ]]; then echo "Evaluation"; else echo "Critique (of Codex + Gemini)"; fi)
+### ${label_c}'s $(if [[ "$debate_mode" == "blinded" ]]; then echo "Evaluation"; else echo "Critique (of ${label_a} + ${label_b})"; fi)
 $sonnet_critique
 
 ---
@@ -677,7 +724,7 @@ EOF
     echo ""
     echo -e "${CYAN}📊 Debate Summary:${NC}"
     echo -e "  Topic: ${prompt:0:70}..."
-    echo -e "  Participants: ${RED}Codex${NC} vs ${YELLOW}Gemini${NC} vs ${BLUE}Sonnet 4.6${NC}"
+    echo -e "  Participants: ${RED}${label_a}${NC} vs ${YELLOW}${label_b}${NC} vs ${BLUE}${label_c}${NC}"
     echo -e "  Principles: $principles"
     echo ""
     echo -e "${YELLOW}💡 Next Steps:${NC}"
@@ -699,7 +746,7 @@ EOF
         "Debate concluded on: ${prompt:0:80}" \
         "" \
         "high" \
-        "3-way debate (Codex vs Gemini vs Sonnet) with $rounds rounds" \
+        "3-way debate (${label_a} vs ${label_b} vs ${label_c}) with $rounds rounds" \
         "" 2>/dev/null || true
 
     # v8.18.0: Earn skill from debate synthesis

--- a/scripts/lib/debate.sh
+++ b/scripts/lib/debate.sh
@@ -47,7 +47,8 @@ grapple_debate() {
             | if type == "array" then .[] else empty end
         ' "$_debate_config_file" 2>/dev/null)
         if [[ -n "$_participants" ]]; then
-            _participant_count=$(printf '%s\n' "$_participants" | grep -cv '^$')
+            _participant_count=$(printf '%s\n' "$_participants" | grep -cv '^$' || true)
+            _participant_count="${_participant_count:-0}"
             if [[ "$_participant_count" -gt 3 ]]; then
                 log WARN "Debate supports 3 participants; using first 3 of $_participant_count from .routing.features.debate"
             fi
@@ -55,17 +56,12 @@ grapple_debate() {
             local _provider _agent _label _label_upper
             while IFS= read -r _provider; do
                 [[ -z "$_provider" ]] && continue
-                _agent=""; _label=""; _label_upper=""
-                case "$_provider" in
-                    claude|claude-sonnet)    _agent="claude-sonnet"; _label="Sonnet"; _label_upper="SONNET" ;;
-                    claude-opus)             _agent="claude-opus";   _label="Opus";   _label_upper="OPUS" ;;
-                    codex|codex-*)           _agent="$_provider";    _label="Codex";  _label_upper="CODEX" ;;
-                    gemini|gemini-*)         _agent="$_provider";    _label="Gemini"; _label_upper="GEMINI" ;;
-                    openrouter|openrouter-*) _agent="$_provider";    _label="OpenRouter"; _label_upper="OPENROUTER" ;;
-                    qwen|qwen-*)             _agent="$_provider";    _label="Qwen";   _label_upper="QWEN" ;;
-                    perplexity|perplexity-*) _agent="$_provider";    _label="Perplexity"; _label_upper="PERPLEXITY" ;;
-                    *) continue ;;
-                esac
+                if ! _agent=$(resolve_provider_to_agent "$_provider"); then
+                    log WARN "Debate: skipping unknown agent '$_provider' (not in AVAILABLE_AGENTS)"
+                    continue
+                fi
+                _label=$(agent_display_label "$_agent") || continue
+                _label_upper=$(agent_display_label_upper "$_agent") || continue
                 case "$_slot_idx" in
                     0) agent_a="$_agent"; label_a="$_label"; label_a_upper="$_label_upper" ;;
                     1) agent_b="$_agent"; label_b="$_label"; label_b_upper="$_label_upper" ;;
@@ -637,7 +633,7 @@ TASK: Evaluate based on falsification survival. Provide:
 [For each hypothesis: which assumptions were falsified vs survived. Rate robustness.]
 
 ## Most Robust Approach
-[Which hypothesis has the most unfalsified assumptions — codex, gemini, sonnet, or hybrid]
+[Which hypothesis has the most unfalsified assumptions — ${label_a_upper}, ${label_b_upper}, ${label_c_upper}, or hybrid]
 
 ## Falsified Elements to Avoid
 [Concrete things that were disproven — do NOT include these in the final approach]

--- a/scripts/lib/debate.sh
+++ b/scripts/lib/debate.sh
@@ -2,6 +2,19 @@
 # lib/debate.sh — Adversarial cross-model debate (extracted from orchestrate.sh)
 # Provides: grapple_debate
 
+debate_label_upper() {
+    printf '%s\n' "$1" | tr '[:lower:]' '[:upper:]'
+}
+
+debate_labels_match() {
+    local label="$1"
+    local label_upper="$2"
+    local existing_label="$3"
+    local existing_upper="$4"
+
+    [[ "$label" == "$existing_label" || "$label_upper" == "$existing_upper" ]]
+}
+
 # ═══════════════════════════════════════════════════════════════════════════
 # CROSSFIRE - Adversarial Cross-Model Review
 # Two tentacles wrestling—adversarial debate until consensus 🤼
@@ -76,6 +89,27 @@ grapple_debate() {
             else
                 log INFO "Debate config had no valid participants; using defaults: $label_a ($agent_a) vs $label_b ($agent_b) vs $label_c ($agent_c)"
             fi
+        fi
+    fi
+
+    # Keep debate attribution labels unique even when multiple configured
+    # providers resolve to the same display family, e.g. claude and claude-sonnet.
+    if debate_labels_match "$label_b" "$label_b_upper" "$label_a" "$label_a_upper"; then
+        label_b="$agent_b"
+        label_b_upper=$(debate_label_upper "$label_b")
+        if debate_labels_match "$label_b" "$label_b_upper" "$label_a" "$label_a_upper"; then
+            label_b="${agent_b}-b"
+            label_b_upper=$(debate_label_upper "$label_b")
+        fi
+    fi
+    if debate_labels_match "$label_c" "$label_c_upper" "$label_a" "$label_a_upper" || \
+       debate_labels_match "$label_c" "$label_c_upper" "$label_b" "$label_b_upper"; then
+        label_c="$agent_c"
+        label_c_upper=$(debate_label_upper "$label_c")
+        if debate_labels_match "$label_c" "$label_c_upper" "$label_a" "$label_a_upper" || \
+           debate_labels_match "$label_c" "$label_c_upper" "$label_b" "$label_b_upper"; then
+            label_c="${agent_c}-c"
+            label_c_upper=$(debate_label_upper "$label_c")
         fi
     fi
 

--- a/scripts/lib/debate.sh
+++ b/scripts/lib/debate.sh
@@ -45,7 +45,7 @@ grapple_debate() {
         _participants=$(jq -r '
             (.routing.features.debate // [])
             | if type == "array" then .[] else empty end
-        ' "$_debate_config_file" 2>/dev/null)
+        ' "$_debate_config_file" 2>/dev/null || true)
         if [[ -n "$_participants" ]]; then
             _participant_count=$(printf '%s\n' "$_participants" | grep -cv '^$' || true)
             _participant_count="${_participant_count:-0}"
@@ -53,6 +53,7 @@ grapple_debate() {
                 log WARN "Debate supports 3 participants; using first 3 of $_participant_count from .routing.features.debate"
             fi
             local _slot_idx=0
+            local _resolved_count=0
             local _provider _agent _label _label_upper
             while IFS= read -r _provider; do
                 [[ -z "$_provider" ]] && continue
@@ -67,9 +68,14 @@ grapple_debate() {
                     1) agent_b="$_agent"; label_b="$_label"; label_b_upper="$_label_upper" ;;
                     2) agent_c="$_agent"; label_c="$_label"; label_c_upper="$_label_upper"; break ;;
                 esac
+                _resolved_count=$((_resolved_count + 1))
                 _slot_idx=$((_slot_idx + 1))
             done <<< "$_participants"
-            log INFO "Debate participants (from config): $label_a ($agent_a) vs $label_b ($agent_b) vs $label_c ($agent_c)"
+            if [[ "$_resolved_count" -gt 0 ]]; then
+                log INFO "Debate participants (from config): $label_a ($agent_a) vs $label_b ($agent_b) vs $label_c ($agent_c)"
+            else
+                log INFO "Debate config had no valid participants; using defaults: $label_a ($agent_a) vs $label_b ($agent_b) vs $label_c ($agent_c)"
+            fi
         fi
     fi
 

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -24,7 +24,7 @@ _fan_out_agents_from_config() {
     jq -r '
         (.routing.features.parallel // [])
         | if type == "array" then .[] else empty end
-    ' "$config_file" 2>/dev/null
+    ' "$config_file" 2>/dev/null || true
 }
 
 fan_out() {

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -12,14 +12,49 @@
 # Extracted from orchestrate.sh (v9.7.8)
 # Source-safe: no main execution block.
 
+# _fan_out_agents_from_config (v9.31.0): read .routing.features.parallel from
+# providers.json. /octo:model-config wizard writes this array under "Parallel
+# execution providers"; before this change there was no consumer.
+# Output: one agent_type per line. Empty when config absent/empty/missing.
+_fan_out_agents_from_config() {
+    local config_file="${HOME}/.claude-octopus/config/providers.json"
+    [[ ! -f "$config_file" ]] && return 0
+    command -v jq >/dev/null 2>&1 || return 0
+
+    jq -r '
+        (.routing.features.parallel // [])
+        | if type == "array" then .[] else empty end
+    ' "$config_file" 2>/dev/null
+}
+
 fan_out() {
     local prompt="$1"
-    local agents=("codex" "gemini")
+    local agents=()
     local pids=()
     local task_group
     task_group=$(date +%s)
 
-    log INFO "Fan-out: Sending prompt to ${#agents[@]} agents"
+    # v9.31.0: honor wizard-configured participants if present
+    local _configured
+    _configured=$(_fan_out_agents_from_config)
+    if [[ -n "$_configured" ]]; then
+        while IFS= read -r _a; do
+            [[ -z "$_a" ]] && continue
+            # Resolve generic 'claude' to a concrete agent_type
+            [[ "$_a" == "claude" ]] && _a="claude-sonnet"
+            # Skip unknown agent_types so a typo cannot break /octo:multi
+            if [[ " $AVAILABLE_AGENTS " == *" $_a "* ]]; then
+                agents+=("$_a")
+            else
+                log WARN "Fan-out: skipping unknown agent '$_a' (not in AVAILABLE_AGENTS)"
+            fi
+        done <<< "$_configured"
+    fi
+
+    # Fallback to original default pair when config absent or all entries invalid
+    [[ ${#agents[@]} -eq 0 ]] && agents=("codex" "gemini")
+
+    log INFO "Fan-out: Sending prompt to ${#agents[@]} agents (${agents[*]})"
     echo ""
 
     for agent in "${agents[@]}"; do

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -40,11 +40,9 @@ fan_out() {
     if [[ -n "$_configured" ]]; then
         while IFS= read -r _a; do
             [[ -z "$_a" ]] && continue
-            # Resolve generic 'claude' to a concrete agent_type
-            [[ "$_a" == "claude" ]] && _a="claude-sonnet"
-            # Skip unknown agent_types so a typo cannot break /octo:multi
-            if [[ " $AVAILABLE_AGENTS " == *" $_a "* ]]; then
-                agents+=("$_a")
+            local _resolved
+            if _resolved=$(resolve_provider_to_agent "$_a"); then
+                agents+=("$_resolved")
             else
                 log WARN "Fan-out: skipping unknown agent '$_a' (not in AVAILABLE_AGENTS)"
             fi

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -42,13 +42,118 @@ parse_review_md() {
     log DEBUG "parse_review_md: always=$(echo "$REVIEW_ALWAYS_CHECK" | wc -l) style=$(echo "$REVIEW_STYLE_RULES" | wc -l) skip=$(echo "$REVIEW_SKIP_PATTERNS" | wc -l)"
 }
 
-# build_review_fleet: builds active agent list based on available providers
-# WHY: fleet is dynamic — if Perplexity is not configured, fall back to
-# Gemini search; if Codex is unavailable, fall back to claude-sonnet.
+# _review_fleet_from_config (v9.31.0): build fleet from routing.features.review
+# in providers.json. /octo:model-config wizard already writes a "Review providers"
+# array to this path; before this change there was no consumer, so the wizard's
+# selection had no effect. Returns empty when config absent/empty so callers fall
+# back to the cascade.
+# Output: agent_type:role:specialty triples, newline-separated.
+_review_fleet_from_config() {
+    local config_file="${HOME}/.claude-octopus/config/providers.json"
+    [[ ! -f "$config_file" ]] && return 0
+    command -v jq >/dev/null 2>&1 || return 0
+
+    local participants
+    participants=$(jq -r '
+        (.routing.features.review // [])
+        | if type == "array" then .[] else empty end
+    ' "$config_file" 2>/dev/null)
+    [[ -z "$participants" ]] && return 0
+
+    local fleet=""
+    local has_logic=false has_security=false has_arch=false has_cve=false has_diversity=false
+
+    while IFS= read -r provider; do
+        [[ -z "$provider" ]] && continue
+        case "$provider" in
+            codex|codex-*)
+                if [[ "$has_logic" == "false" ]]; then
+                    fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+                    has_logic=true
+                fi
+                ;;
+            opencode|opencode-*)
+                if [[ "$has_logic" == "false" ]]; then
+                    fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+                    has_logic=true
+                fi
+                ;;
+            gemini|gemini-*)
+                if [[ "$has_security" == "false" ]]; then
+                    fleet+="${provider}:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+                    has_security=true
+                fi
+                ;;
+            claude|claude-sonnet|claude-opus)
+                if [[ "$has_arch" == "false" ]]; then
+                    local agent="${provider}"
+                    [[ "$provider" == "claude" ]] && agent="claude-sonnet"
+                    fleet+="${agent}:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
+                    has_arch=true
+                fi
+                ;;
+            perplexity|perplexity-*)
+                if [[ "$has_cve" == "false" ]]; then
+                    fleet+="${provider}:cve-reviewer:known CVEs, library advisories, live web search"$'\n'
+                    has_cve=true
+                fi
+                ;;
+            openrouter|openrouter-*)
+                if [[ "$has_diversity" == "false" ]]; then
+                    fleet+="${provider}:diversity-reviewer:cross-family perspective on logic, missed assumptions, training-data divergence from primary providers"$'\n'
+                    has_diversity=true
+                fi
+                ;;
+            qwen|qwen-*)
+                if [[ "$has_security" == "false" ]]; then
+                    fleet+="${provider}:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+                    has_security=true
+                elif [[ "$has_diversity" == "false" ]]; then
+                    fleet+="${provider}:diversity-reviewer:cross-family perspective on logic and assumptions"$'\n'
+                    has_diversity=true
+                fi
+                ;;
+            copilot|copilot-*)
+                if [[ "$has_cve" == "false" ]]; then
+                    fleet+="${provider}:cve-reviewer:known CVEs via web search, library advisories"$'\n'
+                    has_cve=true
+                elif [[ "$has_diversity" == "false" ]]; then
+                    fleet+="${provider}:diversity-reviewer:cross-perspective review"$'\n'
+                    has_diversity=true
+                fi
+                ;;
+        esac
+    done <<< "$participants"
+
+    [[ -z "$fleet" ]] && return 0
+
+    # Anchor: always include arch-reviewer (claude-sonnet) if config didn't supply one.
+    # Architecture context bridges per-finding noise from the specialist agents.
+    if [[ "$has_arch" == "false" ]]; then
+        fleet+="claude-sonnet:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
+    fi
+
+    log INFO "review fleet: config-driven (.routing.features.review)"
+    echo "$fleet"
+}
+
+# build_review_fleet: builds active agent list. Config-driven if
+# .routing.features.review is set in ~/.claude-octopus/config/providers.json
+# (the path /octo:model-config writes to); otherwise falls back to the original
+# command -v cascade so existing installations are unchanged.
 # Returns a newline-separated list of "agent_type:role:specialty" triples.
 # NOTE: Uses command -v for provider detection — safe with set -euo pipefail.
 build_review_fleet() {
     local fleet=""
+
+    # v9.31.0: honor wizard-configured participants if present
+    fleet=$(_review_fleet_from_config)
+    if [[ -n "$fleet" ]]; then
+        echo "$fleet"
+        return 0
+    fi
+
+    # ── Cascade fallback (original behavior — no config or empty config) ──
 
     # logic-reviewer: Codex (OpenAI) → OpenCode → Copilot → claude-sonnet fallback
     if command -v codex >/dev/null 2>&1; then

--- a/scripts/lib/routing.sh
+++ b/scripts/lib/routing.sh
@@ -9,6 +9,65 @@
 _ROUTING_LOADED=1
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# PROVIDER CONFIG ROUTING HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Resolve a provider/config token from providers.json into a concrete agent type.
+# Returns non-zero for unknown or unavailable agents so callers can skip safely.
+resolve_provider_to_agent() {
+    local provider="$1"
+    local agent=""
+
+    case "$provider" in
+        claude)                 agent="claude-sonnet" ;;
+        claude-sonnet|claude-opus|claude-opus-fast)
+                                agent="$provider" ;;
+        codex|codex-standard|codex-max|codex-mini|codex-general|codex-spark|codex-reasoning|codex-large-context|codex-review)
+                                agent="$provider" ;;
+        gemini|gemini-fast|gemini-image)
+                                agent="$provider" ;;
+        openrouter|openrouter-glm5|openrouter-kimi|openrouter-deepseek)
+                                agent="$provider" ;;
+        perplexity|perplexity-fast)
+                                agent="$provider" ;;
+        qwen|qwen-research)     agent="$provider" ;;
+        copilot|copilot-research)
+                                agent="$provider" ;;
+        cursor-agent|ollama)    agent="$provider" ;;
+        *)                      return 1 ;;
+    esac
+
+    if [[ -n "${AVAILABLE_AGENTS:-}" && " $AVAILABLE_AGENTS " != *" $agent "* ]]; then
+        return 1
+    fi
+
+    echo "$agent"
+}
+
+agent_display_label() {
+    local agent="$1"
+    case "$agent" in
+        claude-opus*) echo "Opus" ;;
+        claude*) echo "Sonnet" ;;
+        codex*) echo "Codex" ;;
+        gemini*) echo "Gemini" ;;
+        openrouter*) echo "OpenRouter" ;;
+        qwen*) echo "Qwen" ;;
+        perplexity*) echo "Perplexity" ;;
+        copilot*) echo "Copilot" ;;
+        cursor-agent) echo "Cursor Agent" ;;
+        ollama) echo "Ollama" ;;
+        *) return 1 ;;
+    esac
+}
+
+agent_display_label_upper() {
+    local label
+    label=$(agent_display_label "$1") || return 1
+    printf '%s\n' "$label" | tr '[:lower:]' '[:upper:]'
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # TASK CLASSIFICATION
 # ═══════════════════════════════════════════════════════════════════════════════
 

--- a/tests/unit/test-routing-features-consumers.sh
+++ b/tests/unit/test-routing-features-consumers.sh
@@ -59,6 +59,15 @@ assert_file_has "$DEBATE" 'resolve_provider_to_agent "\$_provider"' \
 assert_file_has "$DEBATE" 'grep -cv .*\|\| true' \
     "debate participant count is pipefail-safe"
 
+assert_file_has "$DEBATE" '2>/dev/null \|\| true' \
+    "debate config jq read is failure-tolerant"
+
+assert_file_has "$PARALLEL" '2>/dev/null \|\| true' \
+    "parallel config jq read is failure-tolerant"
+
+assert_file_has "$DEBATE" '_resolved_count' \
+    "debate config logging is gated on resolved participants"
+
 assert_file_lacks "$DEBATE" 'codex, gemini, sonnet, or hybrid' \
     "debate synthesis choices are not hardcoded"
 

--- a/tests/unit/test-routing-features-consumers.sh
+++ b/tests/unit/test-routing-features-consumers.sh
@@ -85,4 +85,61 @@ else
     test_fail "provider resolver did not map/validate expected tokens"
 fi
 
+test_case "fan_out consumes configured parallel providers at runtime"
+if (
+    tmp_home=$(mktemp -d)
+    trap 'rm -rf "$tmp_home"' EXIT
+    export HOME="$tmp_home"
+    mkdir -p "$HOME/.claude-octopus/config"
+    cat > "$HOME/.claude-octopus/config/providers.json" <<'JSON'
+{"routing":{"features":{"parallel":["claude","gemini","missing-provider"]}}}
+JSON
+    AVAILABLE_AGENTS="claude-sonnet gemini"
+    RESULTS_DIR="$tmp_home/results"
+    CYAN=""
+    NC=""
+    log() { :; }
+    sleep() { :; }
+    spawn_agent_capture_pid() {
+        printf '%s\n' "$1" >> "$tmp_home/spawned"
+        echo "$$"
+    }
+    source "$PARALLEL"
+    fan_out "runtime provider config" >/dev/null
+    grep -qx "claude-sonnet" "$tmp_home/spawned" && \
+        grep -qx "gemini" "$tmp_home/spawned" && \
+        ! grep -qx "missing-provider" "$tmp_home/spawned"
+); then
+    test_pass
+else
+    test_fail "fan_out did not consume configured providers correctly"
+fi
+
+test_case "grapple_debate keeps duplicate display labels unique at runtime"
+if (
+    tmp_home=$(mktemp -d)
+    trap 'rm -rf "$tmp_home"' EXIT
+    export HOME="$tmp_home"
+    mkdir -p "$HOME/.claude-octopus/config"
+    cat > "$HOME/.claude-octopus/config/providers.json" <<'JSON'
+{"routing":{"features":{"debate":["claude","claude-sonnet"]}}}
+JSON
+    AVAILABLE_AGENTS="claude-sonnet"
+    DRY_RUN=true
+    RED=""
+    CYAN=""
+    NC=""
+    _BOX_TOP=""
+    _BOX_BOT=""
+    PLUGIN_DIR="$PROJECT_ROOT"
+    log() { :; }
+    source "$DEBATE"
+    output=$(grapple_debate "runtime debate config" "default" 3 "standard")
+    grep -q "Sonnet vs claude-sonnet vs claude-sonnet-c" <<< "$output"
+); then
+    test_pass
+else
+    test_fail "grapple_debate did not make duplicate labels unique"
+fi
+
 test_summary

--- a/tests/unit/test-routing-features-consumers.sh
+++ b/tests/unit/test-routing-features-consumers.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Static regression checks for routing.features.* consumers.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ROUTING="$PROJECT_ROOT/scripts/lib/routing.sh"
+PARALLEL="$PROJECT_ROOT/scripts/lib/parallel.sh"
+DEBATE="$PROJECT_ROOT/scripts/lib/debate.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "routing.features consumers"
+
+assert_file_has() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    test_case "$label"
+    if grep -qE "$pattern" "$file"; then
+        test_pass
+    else
+        test_fail "pattern not found in $(basename "$file"): $pattern"
+    fi
+}
+
+assert_file_lacks() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    test_case "$label"
+    if grep -qE "$pattern" "$file"; then
+        test_fail "unexpected pattern found in $(basename "$file"): $pattern"
+    else
+        test_pass
+    fi
+}
+
+for file in "$ROUTING" "$PARALLEL" "$DEBATE"; do
+    test_case "$(basename "$file") has valid bash syntax"
+    if bash -n "$file" 2>/dev/null; then
+        test_pass
+    else
+        test_fail "syntax error in $file"
+    fi
+done
+
+assert_file_has "$ROUTING" '^resolve_provider_to_agent\(\)' \
+    "shared provider resolver exists"
+
+assert_file_has "$PARALLEL" 'resolve_provider_to_agent "\$_a"' \
+    "fan_out uses shared provider resolver"
+
+assert_file_has "$DEBATE" 'resolve_provider_to_agent "\$_provider"' \
+    "debate uses shared provider resolver"
+
+assert_file_has "$DEBATE" 'grep -cv .*\|\| true' \
+    "debate participant count is pipefail-safe"
+
+assert_file_lacks "$DEBATE" 'codex, gemini, sonnet, or hybrid' \
+    "debate synthesis choices are not hardcoded"
+
+assert_file_has "$DEBATE" '\$\{label_a_upper\}, \$\{label_b_upper\}, \$\{label_c_upper\}, or hybrid' \
+    "debate synthesis choices use dynamic labels"
+
+test_case "provider resolver maps configured tokens to available agents"
+AVAILABLE_AGENTS="codex gemini claude-sonnet claude-opus openrouter qwen perplexity"
+source "$ROUTING"
+if [[ "$(resolve_provider_to_agent claude)" == "claude-sonnet" ]] \
+   && [[ "$(resolve_provider_to_agent openrouter)" == "openrouter" ]] \
+   && ! resolve_provider_to_agent missing-provider >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "provider resolver did not map/validate expected tokens"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

The `/octo:model-config` wizard prompts users for "Review providers", "Parallel execution providers", and "Debate participants", and writes their selections to `.routing.features.{review,parallel,debate}` in `~/.claude-octopus/config/providers.json`. Before this PR no consumer read those paths — the wizard's selections had no effect. Each affected command (`/octo:review`, `/octo:multi`, `/octo:debate`) used a hard-coded participant list and ignored user configuration.

This PR connects all three documented config knobs to their consumers in a backward-compatible way.

## Commits

1. **`scripts/lib/review.sh`** — `build_review_fleet()` reads `.routing.features.review` and assigns each listed provider to a review role (logic, security, arch, cve, diversity). Falls back to the original `command -v` cascade when config is absent or empty. Recognizes `openrouter` as a fifth role (`diversity-reviewer`) for cross-family perspective. Anchors the fleet with `claude-sonnet:arch-reviewer` when no Claude entry is configured.

2. **`scripts/lib/parallel.sh`** — `fan_out()` reads `.routing.features.parallel` and uses it as the agents list. Validates each entry against `AVAILABLE_AGENTS` so a typo cannot break `/octo:multi`. Falls back to the original `(codex, gemini)` pair when config is absent or all entries are invalid.

3. **`scripts/lib/debate.sh`** — `grapple_debate()` introduces three named slots (A/B/C) with both an agent_type and a label per slot. The first three resolved entries from `.routing.features.debate` override the defaults. Synthesis prompt headers, result-file headings, and the conclusion ceremony all track the active slot identities so the JUDGE and saved transcripts get correct attribution. WARN log fires when more than 3 participants are configured (debate caps at 3 by design — see "Limits" below).

## Why

Three separate features (review, parallel, debate) all collected user config that nothing consumed. That's worse than not exposing the option at all — the wizard's questions have no effect, and a user who configures `["claude","codex","gemini","openrouter"]` for `/octo:review` silently gets the cascaded default fleet instead.

Concrete request that surfaced this: "I want `/octo:review`, `/octo:multi`, and `/octo:debate` to include Codex, Gemini, Claude, and Qwen-via-OpenRouter by default." With `routing.features.*` already wired by the wizard and `providers.openrouter.default` already pointing at `qwen/qwen3-coder-plus`, this PR is the missing piece.

## Risk assessment

Low. All three changes are additive: each gates the new config-driven path on `.routing.features.<feature>` being a non-empty array, falling back to the unchanged hard-coded behavior otherwise. No existing user gets a different fleet/agents/participants unless they have explicitly configured one via the wizard.

## Test results

Smoke-tested each function with three configurations:

**`build_review_fleet`:**
- Config `["claude","codex","gemini","openrouter"]` → 4-role fleet (`arch:claude-sonnet`, `logic:codex`, `security:gemini`, `diversity:openrouter`).
- Empty array `[]` and missing `providers.json` → falls back to original cascade.
- Unknown providers in the array → silently skipped; cascade runs if all unknown.

**`fan_out`:**
- Config with 4 entries → 4-agent fan-out.
- No config → falls back to `(codex, gemini)`.
- Invalid entries → skipped with WARN; remaining valid entries proceed.

**`grapple_debate`:**
- Default (no config) → `Codex vs Gemini vs Sonnet` (note: lost `4.6` suffix from prior `Sonnet 4.6` wording — minor cosmetic regression in the box header).
- Config `["claude","codex","gemini","openrouter"]` → first 3 used: `Sonnet vs Codex vs Gemini`; openrouter dropped with WARN.
- Config `["codex","gemini","openrouter"]` → `Codex vs Gemini vs OpenRouter`.
- Synthesis prompt labels track the active slot identities — JUDGE sees `OPENROUTER HYPOTHESIS:` not `SONNET HYPOTHESIS:` when slot C is OpenRouter.

## Limits

- **Debate is capped at 3 participants.** Round 2 cross-critique is structured as a 3×2 matrix (each participant falsifies the other two), and Round 3 rebuttals follow the same shape. Going to N-way would require arrayizing proposals/critiques/rebuttals and loop-building the cross-critique prompts — bigger refactor, happy to follow up if you'd like. WARN log makes the truncation visible.
- **Minor codex-review behavior change.** Round 2 cross-critique previously used `codex-review` as the slot-A agent (a review-specialized variant of codex). After the slot refactor, slot A uses its configured agent_type uniformly across rounds. Both `codex-review` and `codex` resolve to the same model, so cost/quality is unchanged; the only difference is the internal agent_type tag in metrics.
- **Sonnet's `4.6` suffix dropped in default box header.** `label_c` defaults to `"Sonnet"` (short form) so config remaps stay symmetric (e.g., `Codex`, `Gemini`, `OpenRouter`, `Sonnet`). Restoring the `4.6` suffix in the default would make the configurable form awkward (`Sonnet 4.6` vs `OpenRouter` mismatch). Open to suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reviewer, debate participant, and parallel-worker selection can be driven by a local config file; debate banners, transcripts, prompts, and startup logs now show configured participant names and agent identities. Duplicated display names are auto-disambiguated; an architecture reviewer is ensured if none configured.

* **Chores**
  * If config is missing/invalid, the system falls back to prior defaults; unresolvable entries are skipped with warnings and the chosen agent count/identities are logged.

* **Tests**
  * Added unit tests to validate provider→agent resolution and prevent hardcoded participant choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->