### PR TITLE
chore: release v9.31.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.30.0 - Multi-LLM orchestration for Claude Code. Route tasks to Codex, Gemini, Perplexity, Copilot, Qwen, Ollama, and OpenCode. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
-      "version": "9.30.0",
+      "description": "v9.31.0 - Multi-LLM orchestration for Claude Code. Route tasks to Codex, Gemini, Perplexity, Copilot, Qwen, Ollama, and OpenCode. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
+      "version": "9.31.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.30.0",
-  "description": "v9.30.0 \u2014 Model defaults refreshed: Opus 4.7 for planning/strategy/security-review, GPT-5.4 for code-review/implementation. New GPT-5.4 prompting guide. Set OCTOPUS_LEGACY_ROLES=1 to opt out. Run /octo:setup.",
+  "version": "9.31.0",
+  "description": "v9.31.0 \u2014 Routing config now feeds review/parallel/debate; develop dispatch, quota watcher cleanup, probe output-dir, and docs paths fixed. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [9.31.0] - 2026-05-05
+
+### Fixed
+
+- Stream Gemini stderr in real time so failed subprocess output is visible immediately (#341).
+- Preserve provider env lookup and quota watcher cleanup under `set -e`, including shared quota watcher helpers and targeted PID cleanup (#337, #342).
+- Keep `/octo:develop` on the orchestrator path without recursive Skill calls or Claude-side parallel implementation, while preserving resolved `.md` plan prompts through fallback validation (#334, #339, #343).
+- Parse `probe-single --output-dir` correctly and replace placeholder `/path/to/orchestrate.sh` docs with real plugin path resolution (#345, closes #340, closes #344).
+
+### Changed
+
+- Wire `routing.features.review`, `routing.features.parallel`, and `routing.features.debate` into their runtime consumers with shared provider-to-agent routing and unique debate labels (#346).
+- Keep Claude and Codex install docs aligned with the shared `nyldn-plugins` marketplace flow (#335).
+
+---
+
 ## [9.30.0] - 2026-04-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-146_passing-brightgreen" alt="146 tests passing">
-  <img src="https://img.shields.io/badge/Version-9.30.0-blue" alt="Version 9.30.0">
+  <img src="https://img.shields.io/badge/Version-9.31.0-blue" alt="Version 9.31.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.83+-blueviolet" alt="Requires Claude Code v2.1.83+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.30.0",
+  "version": "9.31.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Release v9.31.0

Minor release for the merged review queue: provider routing consumers, develop dispatch/file-reference fixes, quota watcher cleanup, probe-single output-dir handling, docs path fixes, and Gemini stderr streaming.

### Local verification

- `jq empty package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json`
- `./scripts/sync-marketplace.sh --check`
- `claude plugin validate .claude-plugin/plugin.json`
- `claude plugin validate .claude-plugin/marketplace.json`
- `bash tests/unit/test-routing-features-consumers.sh` (15/15)
- `bash tests/unit/test-quota-watcher.sh` (2/2)
- `bash tests/unit/test-develop-md-file-resolution.sh` (8/8)
- `bash tests/unit/test-docs-sync.sh` (131/131)
- `bash tests/unit/test-doc-sync.sh` (38/38)
- `bash tests/unit/test-probe-single.sh` (30/30)
- `bash tests/unit/test-cursor-agent-provider.sh` (8/8)
- `bash tests/smoke/test-fleet-dispatch-guard.sh` (4/4)
- `git diff --check`
- `bash -n scripts/sync-marketplace.sh scripts/release.sh scripts/validate-release.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 9.31.0

* **Bug Fixes**
  * Fixed real-time output streaming for improved visibility
  * Improved cleanup and lifecycle handling
  * Corrected path resolution and output directory parsing

* **Changed**
  * Enhanced routing configuration for review, parallel, and debate workflows
  * Updated installation and marketplace documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->