### PR TITLE
feat: add round-aware PR review history

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -67,7 +67,7 @@ If `AUTONOMY_MODE` env var is `autonomous`, or session is running headlessly, or
 1. Run `git diff --cached` — if non-empty, `target=staged`
 2. Run `gh pr view --json number` — if open PR exists, set `target=<pr_number>`
 3. Otherwise `target=working-tree`
-4. Set `provenance=unknown`, `autonomy=autonomous`, `publish=ask`, `debate=auto`, `focus=["correctness","security","architecture","tdd"]`
+4. Set `provenance=unknown`, `autonomy=autonomous`, `publish=ask`, `debate=auto`, `history=auto`, `focus=["correctness","security","architecture","tdd"]`
 
 **Otherwise (supervised mode), you MUST use AskUserQuestion to ask these questions:**
 
@@ -135,9 +135,12 @@ const profile = {
   provenance: <answer>,                // "human" | "ai-assisted" | "autonomous" | "unknown"
   autonomy: <detected mode>,           // "supervised" | "autonomous"
   publish: <answer>,                   // "ask" | "auto" | "never"
-  debate: "auto"                       // always default to auto debate
+  debate: "auto",                      // always default to auto debate
+  history: "auto"                      // "auto" | "fresh"
 }
 ```
+
+If the user includes `fresh` in the command text, do not treat it as a file path. Keep the normal target inference and set `history: "fresh"` so this run ignores prior PR review rounds.
 
 ## Step 3: Execute Review Pipeline
 
@@ -150,6 +153,8 @@ ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh code-review '<profile-json
 Where `<profile-json>` is the JSON profile built in Step 2.
 
 The pipeline runs 3 rounds (parallel fleet → verification → synthesis) and outputs findings. If a PR is open and publish is not "never", it offers to post inline comments.
+
+Round-aware PR history is enabled automatically for open PR reviews. Local state is stored at `~/.claude-octopus/pr-state/<host>/<owner>/<repo>/<pr>.json` and is used to show addressed, persistent, new, and regressed finding counts across repeated `/octo:review` runs. Set `OCTOPUS_PR_HISTORY=0` before invoking the command to disable all history reads and writes.
 
 ## What `/octo:review` checks
 

--- a/commands/octo-review.md
+++ b/commands/octo-review.md
@@ -46,7 +46,7 @@ If `AUTONOMY_MODE` env var is `autonomous`, or session is running headlessly, or
 1. Run `git diff --cached` — if non-empty, `target=staged`
 2. Run `gh pr view --json number` — if open PR exists, set `target=<pr_number>`
 3. Otherwise `target=working-tree`
-4. Set `provenance=unknown`, `autonomy=autonomous`, `publish=ask`, `debate=auto`, `focus=["correctness","security","architecture","tdd"]`
+4. Set `provenance=unknown`, `autonomy=autonomous`, `publish=ask`, `debate=auto`, `history=auto`, `focus=["correctness","security","architecture","tdd"]`
 
 **Otherwise (supervised mode), you MUST use AskUserQuestion to ask these questions:**
 
@@ -122,9 +122,12 @@ const profile = {
   provenance: <answer>,                // "human" | "ai-assisted" | "autonomous" | "unknown"
   autonomy: <detected mode>,           // "supervised" | "autonomous"
   publish: <answer>,                   // "ask" | "auto" | "never"
-  debate: "auto"                       // always default to auto debate
+  debate: "auto",                      // always default to auto debate
+  history: "auto"                      // "auto" | "fresh"
 }
 ```
+
+If the user includes `fresh` in the command text, do not treat it as a file path. Keep the normal target inference and set `history: "fresh"` so this run ignores prior PR review rounds.
 
 ## Step 3: Execute Review Pipeline
 
@@ -137,6 +140,8 @@ ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh code-review '<profile-json
 Where `<profile-json>` is the JSON profile built in Step 2.
 
 The pipeline runs 3 rounds (parallel fleet → verification → synthesis) and outputs findings. If a PR is open and publish is not "never", it offers to post inline comments.
+
+Round-aware PR history is enabled automatically for open PR reviews. Local state is stored at `~/.claude-octopus/pr-state/<host>/<owner>/<repo>/<pr>.json` and is used to show addressed, persistent, new, and regressed finding counts across repeated `/octo:review` runs. Set `OCTOPUS_PR_HISTORY=0` before invoking the command to disable all history reads and writes.
 
 ## What `/octo:review` checks
 

--- a/scripts/lib/pr-review-state.sh
+++ b/scripts/lib/pr-review-state.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Round-aware PR review state helpers.
+#
+# State is intentionally local-only. It lets repeated /octo:review runs on the
+# same PR compare current findings with the previous run without changing the
+# public finding contract emitted by review.sh.
+
+pr_review_state_enabled() {
+    case "${OCTOPUS_PR_HISTORY:-1}" in
+        0|false|FALSE|off|OFF|no|NO) return 1 ;;
+    esac
+    command -v jq >/dev/null 2>&1
+}
+
+pr_review_state_path() {
+    local host="$1"
+    local repo="$2"
+    local pr_number="$3"
+    printf '%s/.claude-octopus/pr-state/%s/%s/%s.json\n' "$HOME" "$host" "$repo" "$pr_number"
+}
+
+pr_review_state_validate() {
+    local state_file="$1"
+    [[ -f "$state_file" ]] || return 1
+    jq -e '.schema == 1 and (.rounds | type == "array") and (.pr | type == "object")' "$state_file" >/dev/null 2>&1
+}
+
+pr_review_state_next_round() {
+    local state_file="$1"
+    if ! pr_review_state_validate "$state_file"; then
+        echo "1"
+        return 0
+    fi
+    jq -r '([.rounds[].n] | max // 0) + 1' "$state_file" 2>/dev/null || echo "1"
+}
+
+pr_review_state_previous_round() {
+    local state_file="$1"
+    pr_review_state_validate "$state_file" || return 1
+    jq -c '.rounds[-1] // empty' "$state_file"
+}
+
+pr_review_state_append_round() {
+    local state_file="$1"
+    local host="$2"
+    local repo="$3"
+    local pr_number="$4"
+    local head_sha="$5"
+    local providers_json="$6"
+    local findings_json="$7"
+    local classification_json="$8"
+
+    mkdir -p "$(dirname "$state_file")"
+
+    local base_json
+    if pr_review_state_validate "$state_file"; then
+        base_json=$(cat "$state_file")
+    else
+        base_json=$(jq -n \
+            --arg host "$host" \
+            --arg repo "$repo" \
+            --arg pr "$pr_number" \
+            '{schema:1, pr:{host:$host, repo:$repo, number:($pr|tonumber? // $pr)}, rounds:[]}')
+    fi
+
+    local round_n
+    round_n=$(printf '%s' "$base_json" | jq -r '([.rounds[].n] | max // 0) + 1')
+
+    local written_at
+    written_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    local tmp_file
+    tmp_file=$(mktemp "${TMPDIR:-/tmp}/octopus-pr-state.XXXXXX")
+    printf '%s' "$base_json" | jq \
+        --arg host "$host" \
+        --arg repo "$repo" \
+        --arg pr "$pr_number" \
+        --argjson n "$round_n" \
+        --arg at "$written_at" \
+        --arg head "$head_sha" \
+        --argjson providers "$providers_json" \
+        --argjson findings "$findings_json" \
+        --argjson classification "$classification_json" \
+        '.schema = 1
+         | .pr = {host:$host, repo:$repo, number:($pr|tonumber? // $pr)}
+         | .rounds += [{
+             n:$n,
+             at:$at,
+             head_sha:$head,
+             providers:$providers,
+             classification:$classification,
+             findings:$findings
+           }]' > "$tmp_file"
+    mv "$tmp_file" "$state_file"
+}
+
+_pr_review_state_finding_key_filter() {
+    cat <<'JQ'
+def key: [(.file // ""), ((.line // 0)|tostring), (.title // "")] | join("\u001f");
+JQ
+}
+
+pr_review_state_classify_findings() {
+    local previous_json="${1:-[]}"
+    local current_json="${2:-[]}"
+
+    jq -n \
+        --argjson previous "$previous_json" \
+        --argjson current "$current_json" \
+        "$(_pr_review_state_finding_key_filter)
+         ($previous | map(. + {_key:key})) as \$prev
+         | ($current | map(. + {_key:key})) as \$curr
+         | {
+             addressed: ([\$prev[] | select((.status // \"open\") != \"addressed\") | select(. as \$p | [\$curr[] | select(._key == \$p._key)] | length == 0)] | length),
+             persistent: ([\$curr[] | select(. as \$c | [\$prev[] | select(._key == \$c._key and ((.status // \"open\") != \"addressed\"))] | length > 0)] | length),
+             new: ([\$curr[] | select(. as \$c | [\$prev[] | select(._key == \$c._key)] | length == 0)] | length),
+             regressed: ([\$curr[] | select(. as \$c | [\$prev[] | select(._key == \$c._key and ((.status // \"open\") == \"addressed\"))] | length > 0)] | length)
+           }"
+}
+
+pr_review_state_diff_since() {
+    local previous_sha="$1"
+    local current_sha="${2:-HEAD}"
+
+    git cat-file -e "${previous_sha}^{commit}" 2>/dev/null || return 1
+    git cat-file -e "${current_sha}^{commit}" 2>/dev/null || return 1
+    git diff "${previous_sha}..${current_sha}"
+}
+
+pr_review_state_context_for_prompt() {
+    local state_file="$1"
+    local since_diff="${2:-}"
+    local max_chars="${3:-12000}"
+
+    pr_review_state_validate "$state_file" || return 0
+
+    local previous_round previous_findings classification
+    previous_round=$(pr_review_state_previous_round "$state_file") || return 0
+    previous_findings=$(printf '%s' "$previous_round" | jq -c '.findings // []')
+    classification=$(printf '%s' "$previous_round" | jq -c '.classification // {}')
+
+    local context
+    context="Prior round-aware review context:
+Previous round: $(printf '%s' "$previous_round" | jq -r '.n')
+Previous head SHA: $(printf '%s' "$previous_round" | jq -r '.head_sha // "unknown"')
+Previous classification: ${classification}
+Previous findings JSON: ${previous_findings}"
+
+    if [[ -n "$since_diff" ]]; then
+        context="${context}
+
+Diff since previous review round:
+\`\`\`
+${since_diff}
+\`\`\`"
+    fi
+
+    printf '%s' "$context" | cut -c "1-${max_chars}"
+}
+
+pr_review_state_render_timeline() {
+    local state_file="$1"
+    local current_sha="${2:-HEAD}"
+    local classification_override="${3:-}"
+    local round_override="${4:-}"
+
+    pr_review_state_validate "$state_file" || return 0
+
+    local previous_round
+    previous_round=$(pr_review_state_previous_round "$state_file") || return 0
+
+    local next_round addressed persistent new regressed previous_head
+    next_round="${round_override:-$(pr_review_state_next_round "$state_file")}"
+    previous_head=$(printf '%s' "$previous_round" | jq -r '.head_sha // "unknown"')
+    if [[ -n "$classification_override" ]]; then
+        addressed=$(printf '%s' "$classification_override" | jq -r '.addressed // 0')
+        persistent=$(printf '%s' "$classification_override" | jq -r '.persistent // 0')
+        new=$(printf '%s' "$classification_override" | jq -r '.new // 0')
+        regressed=$(printf '%s' "$classification_override" | jq -r '.regressed // 0')
+    else
+        addressed=$(printf '%s' "$previous_round" | jq -r '.classification.addressed // 0')
+        persistent=$(printf '%s' "$previous_round" | jq -r '.classification.persistent // 0')
+        new=$(printf '%s' "$previous_round" | jq -r '.classification.new // 0')
+        regressed=$(printf '%s' "$previous_round" | jq -r '.classification.regressed // 0')
+    fi
+
+    cat <<EOF
+Round-aware review timeline
+Round ${next_round}: ${current_sha}
+Previous round head: ${previous_head}
+Addressed: ${addressed}
+Persistent: ${persistent}
+New: ${new}
+Regressed: ${regressed}
+EOF
+}

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -303,13 +303,18 @@ review_run() {
     local profile_json="${1:-"{}"}"
 
     # Parse profile fields (with defaults)
-    local target focus provenance autonomy publish debate
+    local target focus provenance autonomy publish debate history
     target=$(echo "$profile_json"     | jq -r '.target     // "staged"')
     focus=$(echo "$profile_json"      | jq -r '.focus      // ["correctness","security","architecture","tdd"]  | join(",")')
     provenance=$(echo "$profile_json" | jq -r '.provenance // "unknown"')
     autonomy=$(echo "$profile_json"   | jq -r '.autonomy   // "supervised"')
     publish=$(echo "$profile_json"    | jq -r '.publish    // "ask"')
     debate=$(echo "$profile_json"     | jq -r '.debate     // "auto"')
+    history=$(echo "$profile_json"    | jq -r '.history    // "auto"')
+    if [[ "$target" == "fresh" ]]; then
+        target="working-tree"
+        history="fresh"
+    fi
 
     # v9.0: Provider status tracking for post-run report card
     local provider_status_file
@@ -333,7 +338,7 @@ review_run() {
     local findings_file="$results_dir/review-findings-${timestamp}.json"
     mkdir -p "$results_dir"
 
-    log INFO "review_run: target=$target focus=$focus provenance=$provenance autonomy=$autonomy"
+    log INFO "review_run: target=$target focus=$focus provenance=$provenance autonomy=$autonomy history=$history"
 
     # ── REVIEW.md ────────────────────────────────────────────────────────────
     parse_review_md
@@ -366,6 +371,43 @@ review_run() {
         done <<< "$REVIEW_SKIP_PATTERNS"
     fi
 
+    # ── Round-aware PR review state (#322) ───────────────────────────────────
+    # OCTOPUS_PR_HISTORY=0 disables all local history read/write.
+    local review_pr_number="" review_repo="" review_host="github.com" review_head_sha=""
+    local review_state_file="" review_previous_findings="[]" review_history_context="" review_timeline=""
+    if declare -F pr_review_state_enabled >/dev/null 2>&1 && pr_review_state_enabled; then
+        if [[ "$target" =~ ^[0-9]+$ ]]; then
+            review_pr_number="$target"
+            review_head_sha=$(gh pr view "$target" --json headRefOid -q .headRefOid 2>/dev/null || true)
+        else
+            review_pr_number=$(gh pr view --json number -q .number 2>/dev/null || true)
+            review_head_sha=$(gh pr view --json headRefOid -q .headRefOid 2>/dev/null || true)
+        fi
+        [[ -z "$review_head_sha" ]] && review_head_sha=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+
+        if [[ -n "$review_pr_number" ]]; then
+            local repo_json
+            repo_json=$(gh repo view --json nameWithOwner,url 2>/dev/null || echo '{}')
+            review_repo=$(echo "$repo_json" | jq -r '.nameWithOwner // empty')
+            review_host=$(echo "$repo_json" | jq -r '(.url // "") | sub("^https?://";"") | split("/")[0] // "github.com"')
+            [[ -z "$review_host" || "$review_host" == "null" ]] && review_host="github.com"
+
+            if [[ -n "$review_repo" ]]; then
+                review_state_file=$(pr_review_state_path "$review_host" "$review_repo" "$review_pr_number")
+                if [[ "$history" != "fresh" ]] && pr_review_state_validate "$review_state_file"; then
+                    local previous_round previous_head since_last_round_diff
+                    previous_round=$(pr_review_state_previous_round "$review_state_file" 2>/dev/null || true)
+                    previous_head=$(echo "$previous_round" | jq -r '.head_sha // empty' 2>/dev/null || true)
+                    review_previous_findings=$(echo "$previous_round" | jq -c '.findings // []' 2>/dev/null || echo "[]")
+                    if [[ -n "$previous_head" && "$previous_head" != "unknown" ]]; then
+                        since_last_round_diff=$(pr_review_state_diff_since "$previous_head" "$review_head_sha" 2>/dev/null || true)
+                    fi
+                    review_history_context=$(pr_review_state_context_for_prompt "$review_state_file" "$since_last_round_diff" 12000)
+                fi
+            fi
+        fi
+    fi
+
     # ── Scale timeout by diff size (#303) ───────────────────────────────────
     local diff_lines
     diff_lines=$(echo "$diff_content" | wc -l | tr -d ' ')
@@ -395,6 +437,7 @@ Severity guide:
 - pre-existing: bug not introduced by this PR (purple)
 
 ${review_context}
+${review_history_context}
 
 Focus areas for this review: ${focus}
 Provenance: ${provenance}
@@ -590,6 +633,19 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
     echo "$final_json" > "$findings_file"
     log INFO "review_run: findings saved to $findings_file"
 
+    if [[ -n "$review_state_file" ]] && declare -F pr_review_state_append_round >/dev/null 2>&1; then
+        local final_findings classification providers_json
+        final_findings=$(echo "$final_json" | jq -c '.findings // []' 2>/dev/null || echo "[]")
+        classification=$(pr_review_state_classify_findings "$review_previous_findings" "$final_findings" 2>/dev/null || echo '{"addressed":0,"persistent":0,"new":0,"regressed":0}')
+        providers_json=$(printf '%s\n' "${round1_agent_types[@]}" | jq -R -s 'split("\n")[:-1]' 2>/dev/null || echo "[]")
+        local current_round
+        current_round=$(pr_review_state_next_round "$review_state_file")
+        review_timeline=$(pr_review_state_render_timeline "$review_state_file" "$review_head_sha" "$classification" "$current_round" 2>/dev/null || true)
+        if pr_review_state_append_round "$review_state_file" "$review_host" "$review_repo" "$review_pr_number" "$review_head_sha" "$providers_json" "$final_findings" "$classification" 2>/dev/null; then
+            log INFO "review_run: round-aware state saved to $review_state_file"
+        fi
+    fi
+
     # ── Output ────────────────────────────────────────────────────────────────
     local pr_number=""
     pr_number=$(gh pr view --json number -q .number 2>/dev/null || true)
@@ -610,6 +666,11 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
         fi
     else
         render_terminal_report "$findings_file"
+    fi
+
+    if [[ -n "$review_timeline" ]]; then
+        echo ""
+        echo "$review_timeline"
     fi
 
     # v9.0: Print provider report card — always last, impossible to miss

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -79,6 +79,7 @@ source "${SCRIPT_DIR}/lib/providers.sh"
 source "${SCRIPT_DIR}/lib/preflight.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/dispatch.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/progressive.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/lib/pr-review-state.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/review.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/workflows.sh"
 source "${SCRIPT_DIR}/lib/doctor.sh" 2>/dev/null || true

--- a/tests/unit/test-pr-review-state.sh
+++ b/tests/unit/test-pr-review-state.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Unit tests for round-aware PR review state helpers.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+STATE_LIB="$PROJECT_ROOT/scripts/lib/pr-review-state.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "PR review state"
+
+if [[ -f "$STATE_LIB" ]]; then
+    # shellcheck source=/dev/null
+    source "$STATE_LIB"
+fi
+
+assert_function_exists() {
+    local fn="$1"
+    test_case "function exists: $fn"
+    if declare -F "$fn" >/dev/null 2>&1; then
+        test_pass
+    else
+        test_fail "missing function: $fn"
+    fi
+}
+
+test_case "pr-review-state.sh has valid bash syntax"
+if [[ -f "$STATE_LIB" ]] && bash -n "$STATE_LIB" 2>/dev/null; then
+    test_pass
+else
+    test_fail "missing or invalid $STATE_LIB"
+fi
+
+for fn in \
+    pr_review_state_enabled \
+    pr_review_state_path \
+    pr_review_state_validate \
+    pr_review_state_append_round \
+    pr_review_state_next_round \
+    pr_review_state_previous_round \
+    pr_review_state_classify_findings \
+    pr_review_state_diff_since \
+    pr_review_state_context_for_prompt \
+    pr_review_state_render_timeline
+do
+    assert_function_exists "$fn"
+done
+
+test_case "state path includes host owner repo and PR number"
+if declare -F pr_review_state_path >/dev/null 2>&1; then
+    tmp_home=$(mktemp -d)
+    HOME="$tmp_home"
+    path=$(pr_review_state_path "github.com" "nyldn/claude-octopus" "322")
+    expected="$tmp_home/.claude-octopus/pr-state/github.com/nyldn/claude-octopus/322.json"
+    rm -rf "$tmp_home"
+    if [[ "$path" == "$expected" ]]; then
+        test_pass
+    else
+        test_fail "expected $expected, got $path"
+    fi
+else
+    test_fail "pr_review_state_path is not defined"
+fi
+
+test_case "OCTOPUS_PR_HISTORY=0 disables state"
+if declare -F pr_review_state_enabled >/dev/null 2>&1; then
+    if OCTOPUS_PR_HISTORY=0 pr_review_state_enabled; then
+        test_fail "expected disabled when OCTOPUS_PR_HISTORY=0"
+    else
+        test_pass
+    fi
+else
+    test_fail "pr_review_state_enabled is not defined"
+fi
+
+test_case "append round creates versioned schema and next round increments"
+if declare -F pr_review_state_append_round >/dev/null 2>&1; then
+    tmp_home=$(mktemp -d)
+    HOME="$tmp_home"
+    state_file=$(pr_review_state_path "github.com" "nyldn/claude-octopus" "322")
+    findings='[{"id":"f-001","providers":["codex"],"severity":"normal","file":"scripts/foo.sh","line":42,"category":"logic","title":"Missing null check","detail":"detail","confidence":0.92,"status":"open"}]'
+    classification='{"addressed":0,"persistent":0,"new":1,"regressed":0}'
+    pr_review_state_append_round "$state_file" "github.com" "nyldn/claude-octopus" "322" "abc123" '["codex","gemini"]' "$findings" "$classification"
+    if jq -e '.schema == 1 and .pr.host == "github.com" and .pr.repo == "nyldn/claude-octopus" and .pr.number == 322 and (.rounds | length) == 1 and .rounds[0].n == 1' "$state_file" >/dev/null \
+       && [[ "$(pr_review_state_next_round "$state_file")" == "2" ]]; then
+        test_pass
+    else
+        test_fail "state schema or next round value was incorrect"
+    fi
+    rm -rf "$tmp_home"
+else
+    test_fail "pr_review_state_append_round is not defined"
+fi
+
+test_case "previous round returns latest round object"
+if declare -F pr_review_state_previous_round >/dev/null 2>&1; then
+    tmp_home=$(mktemp -d)
+    HOME="$tmp_home"
+    state_file=$(pr_review_state_path "github.com" "nyldn/claude-octopus" "322")
+    pr_review_state_append_round "$state_file" "github.com" "nyldn/claude-octopus" "322" "sha1" '["codex"]' '[]' '{"addressed":0,"persistent":0,"new":0,"regressed":0}'
+    pr_review_state_append_round "$state_file" "github.com" "nyldn/claude-octopus" "322" "sha2" '["gemini"]' '[]' '{"addressed":0,"persistent":0,"new":0,"regressed":0}'
+    if [[ "$(pr_review_state_previous_round "$state_file" | jq -r '.n')" == "2" ]]; then
+        test_pass
+    else
+        test_fail "did not return the latest round"
+    fi
+    rm -rf "$tmp_home"
+else
+    test_fail "pr_review_state_previous_round is not defined"
+fi
+
+test_case "finding classifier reports addressed persistent new and regressed"
+if declare -F pr_review_state_classify_findings >/dev/null 2>&1; then
+    previous='[
+      {"id":"a","file":"a.sh","line":1,"title":"A","status":"open"},
+      {"id":"b","file":"b.sh","line":2,"title":"B","status":"open"},
+      {"id":"c","file":"c.sh","line":3,"title":"C","status":"addressed"}
+    ]'
+    current='[
+      {"file":"a.sh","line":1,"title":"A"},
+      {"file":"c.sh","line":3,"title":"C"},
+      {"file":"d.sh","line":4,"title":"D"}
+    ]'
+    result=$(pr_review_state_classify_findings "$previous" "$current")
+    if jq -e '.addressed == 1 and .persistent == 1 and .new == 1 and .regressed == 1' <<< "$result" >/dev/null; then
+        test_pass
+    else
+        test_fail "unexpected classification: $result"
+    fi
+else
+    test_fail "pr_review_state_classify_findings is not defined"
+fi
+
+test_case "diff since previous SHA degrades when SHA is unavailable"
+if declare -F pr_review_state_diff_since >/dev/null 2>&1; then
+    tmp_repo=$(mktemp -d)
+    (
+        cd "$tmp_repo"
+        git init -q
+        git -c user.name=Octo -c user.email=octo@example.com commit --allow-empty -m init >/dev/null
+        if pr_review_state_diff_since "missing-sha" "HEAD" >/dev/null 2>&1; then
+            exit 1
+        fi
+    )
+    status=$?
+    rm -rf "$tmp_repo"
+    if [[ "$status" -eq 0 ]]; then
+        test_pass
+    else
+        test_fail "expected missing SHA to return non-zero"
+    fi
+else
+    test_fail "pr_review_state_diff_since is not defined"
+fi
+
+test_case "context prompt includes prior findings and since-last-round diff"
+if declare -F pr_review_state_context_for_prompt >/dev/null 2>&1; then
+    tmp_home=$(mktemp -d)
+    tmp_repo=$(mktemp -d)
+    HOME="$tmp_home"
+    state_file=$(pr_review_state_path "github.com" "nyldn/claude-octopus" "322")
+    pr_review_state_append_round "$state_file" "github.com" "nyldn/claude-octopus" "322" "sha1" '["codex"]' '[{"file":"a.sh","line":1,"title":"A","severity":"normal","status":"open"}]' '{"addressed":0,"persistent":0,"new":1,"regressed":0}'
+    context=$(pr_review_state_context_for_prompt "$state_file" "diff --git a/a.sh b/a.sh" 2000)
+    rm -rf "$tmp_home" "$tmp_repo"
+    if grep -q "Prior round-aware review context" <<< "$context" \
+       && grep -q '"title":"A"' <<< "$context" \
+       && grep -q "diff --git" <<< "$context"; then
+        test_pass
+    else
+        test_fail "context did not include prior findings and diff"
+    fi
+else
+    test_fail "pr_review_state_context_for_prompt is not defined"
+fi
+
+test_case "timeline renders carry-over counts"
+if declare -F pr_review_state_render_timeline >/dev/null 2>&1; then
+    tmp_home=$(mktemp -d)
+    HOME="$tmp_home"
+    state_file=$(pr_review_state_path "github.com" "nyldn/claude-octopus" "322")
+    pr_review_state_append_round "$state_file" "github.com" "nyldn/claude-octopus" "322" "abc123" '["codex"]' '[]' '{"addressed":2,"persistent":1,"new":3,"regressed":0}'
+    timeline=$(pr_review_state_render_timeline "$state_file" "def456")
+    rm -rf "$tmp_home"
+    if grep -q "Round 2" <<< "$timeline" \
+       && grep -q "Addressed: 2" <<< "$timeline" \
+       && grep -q "Persistent: 1" <<< "$timeline" \
+       && grep -q "New: 3" <<< "$timeline"; then
+        test_pass
+    else
+        test_fail "timeline output was unexpected: $timeline"
+    fi
+else
+    test_fail "pr_review_state_render_timeline is not defined"
+fi
+
+test_summary

--- a/tests/unit/test-review-history-integration.sh
+++ b/tests/unit/test-review-history-integration.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Static integration checks for round-aware /octo:review wiring.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ORCH="$PROJECT_ROOT/scripts/orchestrate.sh"
+REVIEW_LIB="$PROJECT_ROOT/scripts/lib/review.sh"
+STATE_LIB="$PROJECT_ROOT/scripts/lib/pr-review-state.sh"
+CLAUDE_CMD="$PROJECT_ROOT/.claude/commands/review.md"
+CODEX_CMD="$PROJECT_ROOT/commands/octo-review.md"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "round-aware review integration"
+
+assert_file_has() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    test_case "$label"
+    if grep -qE "$pattern" "$file"; then
+        test_pass
+    else
+        test_fail "pattern not found in $(basename "$file"): $pattern"
+    fi
+}
+
+test_case "pr-review-state.sh has valid bash syntax"
+if [[ -f "$STATE_LIB" ]] && bash -n "$STATE_LIB" 2>/dev/null; then
+    test_pass
+else
+    test_fail "missing or invalid $STATE_LIB"
+fi
+
+assert_file_has "$ORCH" 'lib/pr-review-state\.sh' \
+    "orchestrate.sh sources review state module"
+
+assert_file_has "$REVIEW_LIB" '\.history[[:space:]]*//[[:space:]]*"auto"' \
+    "review_run parses structured history profile"
+
+assert_file_has "$REVIEW_LIB" 'pr_review_state_context_for_prompt' \
+    "review_run augments prompt with prior round context"
+
+assert_file_has "$REVIEW_LIB" 'pr_review_state_render_timeline' \
+    "review_run renders inline round timeline"
+
+assert_file_has "$REVIEW_LIB" 'pr_review_state_append_round' \
+    "review_run persists final findings as a new round"
+
+assert_file_has "$REVIEW_LIB" 'OCTOPUS_PR_HISTORY' \
+    "review_run honors global history opt-out"
+
+assert_file_has "$CLAUDE_CMD" 'fresh' \
+    "Claude slash command documents fresh mode"
+
+assert_file_has "$CLAUDE_CMD" 'OCTOPUS_PR_HISTORY=0' \
+    "Claude slash command documents global opt-out"
+
+assert_file_has "$CLAUDE_CMD" '~/.claude-octopus/pr-state' \
+    "Claude slash command documents local state path"
+
+assert_file_has "$CODEX_CMD" 'history' \
+    "Codex command mirrors structured history profile"
+
+test_summary


### PR DESCRIPTION
## Summary
- add local round-aware PR review state under `~/.claude-octopus/pr-state/<host>/<owner>/<repo>/<pr>.json`
- wire `/octo:review` to load prior PR findings, include since-last-round context, persist each final review round, and render addressed/persistent/new/regressed counts
- document `history: "auto"`, `fresh`, and `OCTOPUS_PR_HISTORY=0` in Claude and Codex command surfaces

Closes #322.

## Verification
- `bash tests/unit/test-pr-review-state.sh`
- `bash tests/unit/test-review-history-integration.sh`
- `bash tests/unit/test-review-run.sh`
- `bash tests/unit/test-review-autonomy-tdd.sh`
- `bash tests/unit/test-cross-model-review.sh`
- `make test-unit` (93 suites, 0 failures)
- `bash -n scripts/lib/pr-review-state.sh scripts/lib/review.sh scripts/orchestrate.sh`
- `jq empty .claude-plugin/plugin.json .claude-plugin/marketplace.json package.json`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Round-aware PR review tracking: automatically classify findings across repeated reviews as addressed, persistent, new, or regressed
  * Review history persistence: previous findings stored locally and automatically referenced in subsequent reviews
  * Optional opt-out via `OCTOPUS_PR_HISTORY=0` environment variable
  * Fresh mode: force new review without prior history context

* **Documentation**
  * Updated `/octo:review` command documentation with history behavior, local state location (`~/.claude-octopus/pr-state/`), and configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->