### PR TITLE
test: harden OpenClaw parity checks on macOS

### DIFF
--- a/tests/unit/test-openclaw-compat.sh
+++ b/tests/unit/test-openclaw-compat.sh
@@ -389,10 +389,10 @@ test_tool_naming_consistency() {
     local ok=true
     for tool in octopus_discover octopus_define octopus_develop octopus_deliver \
                 octopus_embrace octopus_debate octopus_review octopus_security; do
-        if ! echo "$mcp_tools" | grep -q "$tool"; then
+        if ! grep -q "$tool" <<< "$mcp_tools"; then
             ok=false
         fi
-        if ! echo "$oclaw_tools" | grep -q "$tool"; then
+        if ! grep -q "$tool" <<< "$oclaw_tools"; then
             ok=false
         fi
     done


### PR DESCRIPTION
## Summary

- replaces the remaining echo-piped grep checks in the OpenClaw/MCP parity test with here-strings
- fixes the macOS pipefail/SIGPIPE failure seen on the post-merge main Test Suite for v9.32.1

## Verification

- bash tests/unit/test-openclaw-compat.sh