### PR TITLE
fix(hooks): strengthen auto-router behavior

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -204,6 +204,11 @@
         },
         {
           "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/auto-router-inject.sh",
+          "timeout": 3
+        },
+        {
+          "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start-memory.sh",
           "additionalContext": "Restore persisted user preferences and session sync from auto-memory",
           "timeout": 30

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -141,7 +141,7 @@ AskUserQuestion({
       {label: "Configure models", description: "Set which models are used for each workflow phase → launches /octo:model-config"},
       {label: "Set up token optimization (RTK)", description: "Install RTK for 60-90% token savings on bash output"},
       {label: "Change work mode", description: "Switch between Dev mode and Knowledge Work mode"},
-      {label: "Fine-tune preferences", description: "Banner verbosity, telemetry, cost mode"},
+      {label: "Fine-tune preferences", description: "Auto-routing, banner verbosity, telemetry, cost mode"},
       {label: "Troubleshoot an issue", description: "Diagnose a problem → launches /octo:doctor"},
       {label: "Done — everything looks good", description: "Exit setup"}
     ]

--- a/commands/octo-setup.md
+++ b/commands/octo-setup.md
@@ -67,7 +67,7 @@ AskUserQuestion({
       {label: "Configure models", description: "Set which models are used for each workflow phase → launches /octo:model-config"},
       {label: "Set up token optimization (RTK)", description: "Install RTK for 60-90% token savings on bash output"},
       {label: "Change work mode", description: "Switch between Dev mode and Knowledge Work mode"},
-      {label: "Fine-tune preferences", description: "Banner verbosity, telemetry, cost mode"},
+      {label: "Fine-tune preferences", description: "Auto-routing, banner verbosity, telemetry, cost mode"},
       {label: "Troubleshoot an issue", description: "Diagnose a problem → launches /octo:doctor"}
     ]
   }]
@@ -301,7 +301,7 @@ AskUserQuestion({
     header: "Fine-tune",
     multiSelect: false,
     options: [
-      {label: "Yes, let's configure it", description: "Set work mode, verbosity, and telemetry preferences"},
+      {label: "Yes, let's configure it", description: "Set work mode, auto-routing, verbosity, and telemetry preferences"},
       {label: "Skip for now", description: "Use defaults — you can run /octo:setup anytime to change these"}
     ]
   }]
@@ -320,6 +320,16 @@ AskUserQuestion({
       options: [
         {label: "Software development", description: "Dev mode — optimized for building features, debugging, code review"},
         {label: "Research & analysis", description: "Knowledge Work mode — optimized for research, reports, strategy work"}
+      ]
+    },
+    {
+      question: "How should Octopus handle strong plain-language intents like 'review this PR' or 'should we use X or Y'?",
+      header: "Auto-route",
+      multiSelect: false,
+      options: [
+        {label: "Auto-invoke strong matches (default)", description: "High-confidence prompts route directly to the matching /octo workflow"},
+        {label: "Suggest only", description: "Show the detected workflow but let Claude continue unless you choose it"},
+        {label: "Off", description: "Disable plain-language routing; explicit /octo:* commands still work"}
       ]
     },
     {
@@ -348,6 +358,9 @@ AskUserQuestion({
 
 - Work mode "Software development" → run `/octo:dev` or note that Dev mode is the default
 - Work mode "Research & analysis" → run `/octo:km on`
+- Auto-route "Auto-invoke strong matches" → write `{"auto_router_mode":"invoke"}` to `~/.claude-octopus/preferences.json`
+- Auto-route "Suggest only" → write `{"auto_router_mode":"suggest"}` to `~/.claude-octopus/preferences.json`
+- Auto-route "Off" → write `{"auto_router_mode":"off"}` to `~/.claude-octopus/preferences.json`
 - Compact banners selected → write `OCTOPUS_COMPACT_BANNERS=true` to shell profile and inform user to restart terminal (or add to `~/.zshrc`)
 - Telemetry opt-out selected → write `OCTOPUS_TELEMETRY_OPT_OUT=1` to shell profile and inform user
 

--- a/hooks/auto-router-inject.sh
+++ b/hooks/auto-router-inject.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# auto-router-inject.sh - Compact SessionStart routing contract.
+#
+# Inject one small, explicit contract early in the session so hook-provided
+# routing instructions are honored.
+
+set -euo pipefail
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
+trap _octo_hook_exit EXIT
+
+escape_for_json() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+emit_session_context() {
+    local context="$1"
+    local escaped
+    escaped=$(escape_for_json "$context")
+
+    if [[ -n "${CURSOR_PLUGIN_ROOT:-}" ]]; then
+        printf '{"additional_context":"%s"}\n' "$escaped"
+    elif [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -z "${COPILOT_CLI:-}" ]]; then
+        printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$escaped"
+    else
+        printf '{"additionalContext":"%s"}\n' "$escaped"
+    fi
+}
+
+normalize_router_mode() {
+    local raw
+    raw=$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+    case "$raw" in
+        off|disabled|disable|none|0) echo "off" ;;
+        suggest|suggestion|advisory|hint|hints|false|no) echo "suggest" ;;
+        invoke|auto|auto-invoke|autoinvoke|mandatory|true|yes|on|1) echo "invoke" ;;
+        *) return 1 ;;
+    esac
+}
+
+json_pref_value() {
+    local file="$1"
+    local key="$2"
+    [[ -f "$file" ]] || return 1
+    command -v python3 &>/dev/null || return 1
+    python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    value = data.get(sys.argv[2], None)
+    if value is not None:
+        print(str(value))
+except Exception:
+    pass
+" "$file" "$key" 2>/dev/null
+}
+
+AUTO_ROUTER_MODE="invoke"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+SETTINGS_FILE="${PLUGIN_ROOT}/settings.json"
+[[ -f "$SETTINGS_FILE" ]] || SETTINGS_FILE="${PLUGIN_ROOT}/.claude-plugin/settings.json"
+
+if [[ -f "$SETTINGS_FILE" ]]; then
+    _setting_router=$(json_pref_value "$SETTINGS_FILE" "OCTOPUS_AUTO_ROUTER_MODE" || true)
+    _setting_legacy=$(json_pref_value "$SETTINGS_FILE" "OCTOPUS_AUTO_INVOKE" || true)
+    if [[ -n "$_setting_router" ]] && _mode=$(normalize_router_mode "$_setting_router"); then
+        AUTO_ROUTER_MODE="$_mode"
+    elif [[ -n "$_setting_legacy" ]] && _mode=$(normalize_router_mode "$_setting_legacy"); then
+        AUTO_ROUTER_MODE="$_mode"
+    fi
+fi
+
+PREFS_FILE="${HOME}/.claude-octopus/preferences.json"
+if [[ -f "$PREFS_FILE" ]]; then
+    _pref_router=$(json_pref_value "$PREFS_FILE" "auto_router_mode" || true)
+    _pref_legacy=$(json_pref_value "$PREFS_FILE" "auto_invoke" || true)
+    if [[ -n "$_pref_router" ]] && _mode=$(normalize_router_mode "$_pref_router"); then
+        AUTO_ROUTER_MODE="$_mode"
+    elif [[ -n "$_pref_legacy" ]] && _mode=$(normalize_router_mode "$_pref_legacy"); then
+        AUTO_ROUTER_MODE="$_mode"
+    fi
+fi
+
+if [[ -n "${OCTOPUS_AUTO_ROUTER_MODE:-}" ]] && _mode=$(normalize_router_mode "$OCTOPUS_AUTO_ROUTER_MODE"); then
+    AUTO_ROUTER_MODE="$_mode"
+elif [[ -n "${OCTOPUS_AUTO_INVOKE:-}" ]] && _mode=$(normalize_router_mode "$OCTOPUS_AUTO_INVOKE"); then
+    AUTO_ROUTER_MODE="$_mode"
+fi
+
+[[ "$AUTO_ROUTER_MODE" == "off" ]] && exit 0
+
+read -r -d '' CONTEXT <<'ROUTER' || true
+<OCTOPUS-AUTO-ROUTER>
+Octopus prompt hooks may add UserPromptSubmit routing context. If that context says "MANDATORY: Invoke Skill(...)", invoke that Skill before answering. Do not answer directly first.
+
+Strong plain-language routes include: review -> octo:review, debate/compare/should-we -> octo:debate, research/investigate/explore -> octo:discover, security/threat-model -> octo:security, debug/failing/stacktrace -> octo:debug, write-tests/TDD -> octo:tdd, implement/execute-plan -> octo:develop.
+
+If the hook only says "Detected intent" or "Tip", treat it as a suggestion and continue normally unless the user asks to route.
+</OCTOPUS-AUTO-ROUTER>
+ROUTER
+
+CONTEXT="${CONTEXT/OCTOPUS-AUTO-ROUTER>/OCTOPUS-AUTO-ROUTER mode=\"$AUTO_ROUTER_MODE\">}"
+emit_session_context "$CONTEXT"

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -6,7 +6,8 @@
 #
 # v9.11.0: Auto-invoke mode — strong signals fire immediately,
 # weak signals fire on repeat intent in the same session.
-# Controlled by OCTOPUS_AUTO_INVOKE setting (default: true).
+# Controlled by OCTOPUS_AUTO_ROUTER_MODE=off|suggest|invoke.
+# Legacy OCTOPUS_AUTO_INVOKE remains supported.
 #
 # v9.6.0: Confidence levels (HIGH/LOW), provider pre-warming,
 # persona context injection on HIGH confidence.
@@ -22,6 +23,65 @@ set -euo pipefail
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
+escape_for_json() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+emit_user_prompt_context() {
+    local context="$1"
+    local escaped
+    escaped=$(escape_for_json "$context")
+
+    if [[ -n "${CURSOR_PLUGIN_ROOT:-}" ]]; then
+        printf '{"additional_context":"%s"}\n' "$escaped"
+    elif [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -z "${COPILOT_CLI:-}" ]]; then
+        printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"%s"}}\n' "$escaped"
+    else
+        printf '{"additionalContext":"%s"}\n' "$escaped"
+    fi
+}
+
+emit_user_prompt_title() {
+    local title="$1"
+    local escaped
+    escaped=$(escape_for_json "$title")
+    printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","sessionTitle":"%s"}}\n' "$escaped"
+}
+
+normalize_router_mode() {
+    local raw
+    raw=$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+    case "$raw" in
+        off|disabled|disable|none|0) echo "off" ;;
+        suggest|suggestion|advisory|hint|hints|false|no) echo "suggest" ;;
+        invoke|auto|auto-invoke|autoinvoke|mandatory|true|yes|on|1) echo "invoke" ;;
+        *) return 1 ;;
+    esac
+}
+
+json_pref_value() {
+    local file="$1"
+    local key="$2"
+    [[ -f "$file" ]] || return 1
+    command -v python3 &>/dev/null || return 1
+    python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    value = data.get(sys.argv[2], None)
+    if value is not None:
+        print(str(value))
+except Exception:
+    pass
+" "$file" "$key" 2>/dev/null
+}
 
 # Read hook input from stdin
 if [ -t 0 ]; then exit 0; fi
@@ -68,7 +128,7 @@ if [[ "$PROMPT_LOWER" == /octo:* ]] || [[ "$PROMPT_LOWER" == "octo:"* ]]; then
             _TITLE_FILE="${HOME}/.claude-octopus/.session-titled-${_SESSION_ID:-unknown}"
             if [[ ! -f "$_TITLE_FILE" ]]; then
                 touch "$_TITLE_FILE" 2>/dev/null || true
-                printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","sessionTitle":"Octopus: /octo:%s"}}\n' "$_CMD"
+                emit_user_prompt_title "Octopus: /octo:${_CMD}"
                 exit 0
             fi
         fi
@@ -81,50 +141,45 @@ if [[ "$PROMPT" == *"<command-message>octo:"* ]] || [[ "$PROMPT" == *"<command-n
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# SETTINGS: Load auto-invoke preference
+# SETTINGS: Load auto-router preference
 # Precedence (highest wins): Env var > preferences.json > settings.json > default
 # ═══════════════════════════════════════════════════════════════════════════════
-AUTO_INVOKE="true"  # Default: ON
+AUTO_ROUTER_MODE="invoke"  # Default preserves legacy strong-signal auto-invoke.
 
-# Tier 1: settings.json (plugin default)
-SETTINGS_FILE="${CLAUDE_PLUGIN_ROOT:-.}/.claude-plugin/settings.json"
-if [[ -f "$SETTINGS_FILE" ]] && command -v python3 &>/dev/null; then
-    _setting=$(python3 -c "
-import json, sys
-try:
-    with open(sys.argv[1]) as f:
-        s = json.load(f)
-    v = s.get('OCTOPUS_AUTO_INVOKE', None)
-    if v is not None:
-        print(str(v).lower())
-except: pass" "$SETTINGS_FILE" 2>/dev/null) || true
-    [[ "$_setting" == "false" || "$_setting" == "off" ]] && AUTO_INVOKE="false"
-    [[ "$_setting" == "true" || "$_setting" == "on" ]] && AUTO_INVOKE="true"
+# Tier 1: settings.json (plugin default). Prefer the current plugin-root
+# settings.json path, but keep the old .claude-plugin/settings.json fallback.
+SETTINGS_FILE="${CLAUDE_PLUGIN_ROOT:-.}/settings.json"
+[[ -f "$SETTINGS_FILE" ]] || SETTINGS_FILE="${CLAUDE_PLUGIN_ROOT:-.}/.claude-plugin/settings.json"
+if [[ -f "$SETTINGS_FILE" ]]; then
+    _setting_router=$(json_pref_value "$SETTINGS_FILE" "OCTOPUS_AUTO_ROUTER_MODE" || true)
+    _setting_legacy=$(json_pref_value "$SETTINGS_FILE" "OCTOPUS_AUTO_INVOKE" || true)
+    if [[ -n "$_setting_router" ]] && _mode=$(normalize_router_mode "$_setting_router"); then
+        AUTO_ROUTER_MODE="$_mode"
+    elif [[ -n "$_setting_legacy" ]] && _mode=$(normalize_router_mode "$_setting_legacy"); then
+        AUTO_ROUTER_MODE="$_mode"
+    fi
 fi
 
 # Tier 2: preferences.json (user preference, survives sessions)
 PREFS_FILE="${HOME}/.claude-octopus/preferences.json"
-if [[ -f "$PREFS_FILE" ]] && command -v python3 &>/dev/null; then
-    _pref=$(python3 -c "
-import json, sys
-try:
-    with open(sys.argv[1]) as f:
-        p = json.load(f)
-    v = p.get('auto_invoke', None)
-    if v is not None:
-        print(str(v).lower())
-except: pass" "$PREFS_FILE" 2>/dev/null) || true
-    [[ "$_pref" == "false" || "$_pref" == "off" ]] && AUTO_INVOKE="false"
-    [[ "$_pref" == "true" || "$_pref" == "on" ]] && AUTO_INVOKE="true"
+if [[ -f "$PREFS_FILE" ]]; then
+    _pref_router=$(json_pref_value "$PREFS_FILE" "auto_router_mode" || true)
+    _pref_legacy=$(json_pref_value "$PREFS_FILE" "auto_invoke" || true)
+    if [[ -n "$_pref_router" ]] && _mode=$(normalize_router_mode "$_pref_router"); then
+        AUTO_ROUTER_MODE="$_mode"
+    elif [[ -n "$_pref_legacy" ]] && _mode=$(normalize_router_mode "$_pref_legacy"); then
+        AUTO_ROUTER_MODE="$_mode"
+    fi
 fi
 
 # Tier 3: Env var (highest priority — runtime override for CI/automation)
-if [[ -n "${OCTOPUS_AUTO_INVOKE:-}" ]]; then
-    case "${OCTOPUS_AUTO_INVOKE}" in
-        false|off|0|no) AUTO_INVOKE="false" ;;
-        true|on|1|yes)  AUTO_INVOKE="true" ;;
-    esac
+if [[ -n "${OCTOPUS_AUTO_ROUTER_MODE:-}" ]] && _mode=$(normalize_router_mode "$OCTOPUS_AUTO_ROUTER_MODE"); then
+    AUTO_ROUTER_MODE="$_mode"
+elif [[ -n "${OCTOPUS_AUTO_INVOKE:-}" ]] && _mode=$(normalize_router_mode "$OCTOPUS_AUTO_INVOKE"); then
+    AUTO_ROUTER_MODE="$_mode"
 fi
+
+[[ "$AUTO_ROUTER_MODE" == "off" ]] && exit 0
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # INTENT CLASSIFICATION — keyword matching (must be fast, <100ms)
@@ -134,55 +189,73 @@ CONFIDENCE="LOW"
 KEYWORD_HITS=0
 SIGNAL_STRENGTH="weak"  # weak or strong — strong signals auto-invoke on first match
 
-# Strong signals: compound phrases that almost always mean the specific intent
-# Weak signals: single words that appear in many contexts
-case "$PROMPT_LOWER" in
-    # Security — strong signals
-    *"security audit"*|*"owasp"*|*"vulnerability scan"*|*"threat model"*|*"cve"*)
-        INTENT="security"; KEYWORD_HITS=2; SIGNAL_STRENGTH="strong" ;;
-    *"security"*|*"vulnerability"*)
-        INTENT="security"; KEYWORD_HITS=1 ;;
+# Ordered to match /octo:auto: specific/specialized workflows first, broad
+# build and quick paths last. Compound phrases are strong; broad single words
+# stay weak so the hook nudges instead of over-taking the prompt.
+set_intent() {
+    INTENT="$1"
+    KEYWORD_HITS="$2"
+    SIGNAL_STRENGTH="$3"
+}
 
-    # Code review — strong signals
-    *"code review"*|*"pr review"*|*"review code"*|*"review this pr"*|*"review my changes"*)
-        INTENT="review"; KEYWORD_HITS=2; SIGNAL_STRENGTH="strong" ;;
-    *"review"*)
-        INTENT="review"; KEYWORD_HITS=1 ;;
+if [[ -z "$INTENT" ]]; then
+    case "$PROMPT_LOWER" in
+        *"end-to-end"*|*"complete lifecycle"*|*"full workflow"*|*"entire project"*|*"whole system"*)
+            set_intent "embrace" 2 "strong" ;;
+        *"multi-llm"*|*"multi-provider"*|*"all providers"*|*"force multi"*|*"cross-model"*)
+            set_intent "multi" 2 "strong" ;;
+        *"team of teams"*|*"decompose"*|*"work packages"*|*"split into"*|*"parallel"*)
+            set_intent "parallel" 2 "strong" ;;
+        *"nlspec"*|*"requirements doc"*|*"define scope"*|*"write spec"*|*"specification"*)
+            set_intent "spec" 2 "strong" ;;
+        *"security audit"*|*"owasp"*|*"vulnerability scan"*|*"threat model"*|*"cve"*|*"attack surface"*|*"pentest"*)
+            set_intent "security" 2 "strong" ;;
+        *"security"*|*"vulnerability"*)
+            set_intent "security" 1 "weak" ;;
+        *"test-driven"*|*"test first"*|*"tdd"*|*"test coverage"*|*"write tests"*|*"unit test"*|*"test suite"*)
+            set_intent "tdd" 2 "strong" ;;
+        *"debug"*|*"fix bug"*|*"fix this bug"*|*"troubleshoot"*|*"stack trace"*|*"traceback"*|*"error trace"*|*"stacktrace"*|*"failing"*|*"crash"*)
+            set_intent "debug" 2 "strong" ;;
+        *"not working"*|*"broken"*|*"error"*)
+            set_intent "debug" 1 "weak" ;;
+        *"ui design"*|*"ux design"*|*"wireframe"*|*"mockup"*|*"design system"*|*"layout"*|*"prototype"*)
+            set_intent "design-ui-ux" 2 "strong" ;;
+        *"prd"*|*"product requirements"*|*"product spec"*|*"feature requirements"*)
+            set_intent "prd" 2 "strong" ;;
+        *"brainstorm"*|*"ideate"*|*"ideas"*|*"thought experiment"*|*"what if"*)
+            set_intent "brainstorm" 2 "strong" ;;
+        *"presentation"*|*"slides"*|*"slide deck"*|*"pitch deck"*|*"deck"*)
+            set_intent "deck" 2 "strong" ;;
+        *"documentation"*|*"api docs"*|*"write docs"*|*"readme"*|*"docstring"*)
+            set_intent "docs" 2 "strong" ;;
+    esac
+fi
 
-    # Debugging — strong signals (stack traces, explicit debug requests)
-    *"stack trace"*|*"traceback"*|*"fix bug"*|*"fix this bug"*|*"debug"*)
-        INTENT="debug"; KEYWORD_HITS=2; SIGNAL_STRENGTH="strong" ;;
-    *"not working"*|*"broken"*|*"error"*)
-        INTENT="debug"; KEYWORD_HITS=1 ;;
+if [[ -z "$INTENT" ]]; then
+    case "$PROMPT_LOWER" in
+        *"research options"*|*"research "*|*"investigate "*|*"explore "*|*"study "*|*"understand patterns"*|*"analyze ecosystem"*)
+            set_intent "discover" 2 "strong" ;;
+        *"code review"*|*"pr review"*|*"review code"*|*"review this pr"*|*"review my changes"*|*"check quality"*|*"audit code"*)
+            set_intent "review" 2 "strong" ;;
+        *"validate"*|*"inspect"*|*"verify"*|*"review"*)
+            set_intent "review" 1 "weak" ;;
+        *"should we "*|*" vs "*|*" versus "*|*"decide between"*|*"which is better"*|*"trade-off"*|*"tradeoff"*|*"compare alternatives"*|*"compare "*)
+            set_intent "debate" 2 "strong" ;;
+    esac
+fi
 
-    # Testing — strong signals
-    *"tdd"*|*"test coverage"*|*"write tests"*|*"unit test"*|*"test suite"*)
-        INTENT="tdd"; KEYWORD_HITS=2; SIGNAL_STRENGTH="strong" ;;
-    *"test"*)
-        INTENT="tdd"; KEYWORD_HITS=1 ;;
-
-    # Multi-file implementation — strong signal
-    *"implement the following plan"*|*"implement this plan"*|*"execute the plan"*)
-        INTENT="develop"; KEYWORD_HITS=3; SIGNAL_STRENGTH="strong" ;;
-
-    # Research — moderate signals
-    *"research"*|*"explore options"*|*"investigate"*|*"compare alternatives"*)
-        INTENT="research"; KEYWORD_HITS=1; [[ "$PROMPT_LOWER" == *"research"* && "$PROMPT_LOWER" == *"options"* ]] && { KEYWORD_HITS=2; SIGNAL_STRENGTH="strong"; } ;;
-
-    # Design
-    *"design system"*|*"ui design"*|*"ux design"*|*"mockup"*)
-        INTENT="design-ui-ux"; KEYWORD_HITS=2; SIGNAL_STRENGTH="strong" ;;
-    *"design"*|*"ui"*|*"ux"*)
-        INTENT="design-ui-ux"; KEYWORD_HITS=1 ;;
-
-    # Refactoring
-    *"refactor"*|*"simplify"*|*"clean up"*)
-        INTENT="develop"; KEYWORD_HITS=1 ;;
-
-    # Performance
-    *"performance"*|*"optimize"*|*"slow"*|*"latency"*)
-        INTENT="develop"; KEYWORD_HITS=1 ;;
-esac
+if [[ -z "$INTENT" ]]; then
+    case "$PROMPT_LOWER" in
+        *"implement the following plan"*|*"implement this plan"*|*"execute the plan"*)
+            set_intent "develop" 3 "strong" ;;
+        *"build "*|*"create "*|*"implement "*|*"develop "*|*"refactor"*|*"simplify"*|*"clean up"*|*"performance"*|*"optimize"*|*"slow"*|*"latency"*)
+            set_intent "develop" 1 "weak" ;;
+        *"make "*)
+            set_intent "plan" 1 "weak" ;;
+        *"quick"*|*"just do it"*|*"simple"*|*"fast"*|*"straightforward"*)
+            set_intent "quick" 1 "weak" ;;
+    esac
+fi
 
 # Determine confidence level
 [[ $KEYWORD_HITS -ge 2 ]] && CONFIDENCE="HIGH"
@@ -227,13 +300,24 @@ fi
 # Map intent to /octo: skill name
 SKILL_NAME=""
 case "$INTENT" in
+    embrace)        SKILL_NAME="octo:embrace" ;;
+    multi)          SKILL_NAME="octo:multi" ;;
+    parallel)       SKILL_NAME="octo:parallel" ;;
+    spec)           SKILL_NAME="octo:spec" ;;
     security)       SKILL_NAME="octo:security" ;;
     review)         SKILL_NAME="octo:review" ;;
+    debate)         SKILL_NAME="octo:debate" ;;
     debug)          SKILL_NAME="octo:debug" ;;
     tdd)            SKILL_NAME="octo:tdd" ;;
     develop)        SKILL_NAME="octo:develop" ;;
-    research)       SKILL_NAME="octo:research" ;;
+    discover)       SKILL_NAME="octo:discover" ;;
     design-ui-ux)   SKILL_NAME="octo:design-ui-ux" ;;
+    prd)            SKILL_NAME="octo:prd" ;;
+    brainstorm)     SKILL_NAME="octo:brainstorm" ;;
+    deck)           SKILL_NAME="octo:deck" ;;
+    docs)           SKILL_NAME="octo:docs" ;;
+    plan)           SKILL_NAME="octo:plan" ;;
+    quick)          SKILL_NAME="octo:quick" ;;
 esac
 
 # Determine if we should auto-invoke
@@ -241,7 +325,7 @@ esac
 SHOULD_AUTO_INVOKE=false
 if [[ "$_OCTO_EXPLICIT" == "true" ]]; then
     SHOULD_AUTO_INVOKE=false
-elif [[ "$AUTO_INVOKE" == "true" && -n "$SKILL_NAME" ]]; then
+elif [[ "$AUTO_ROUTER_MODE" == "invoke" && -n "$SKILL_NAME" ]]; then
     if [[ "$SIGNAL_STRENGTH" == "strong" && "$CONFIDENCE" == "HIGH" ]]; then
         # Strong signal + HIGH confidence = auto-invoke on first match
         SHOULD_AUTO_INVOKE=true
@@ -257,12 +341,10 @@ fi
 if [[ -n "$INTENT" ]]; then
     if [[ "$SHOULD_AUTO_INVOKE" == "true" ]]; then
         # Auto-invoke: inject MANDATORY skill invocation instruction
-        # Escape the prompt for safe JSON embedding
-        ESCAPED_ARGS=$(printf '%s' "$PROMPT" | python3 -c "
-import sys, json
-print(json.dumps(sys.stdin.read())[1:-1])" 2>/dev/null) || true
+        # Escape the prompt once for the Skill args string inside JSON output.
+        ESCAPED_ARGS=$(escape_for_json "$PROMPT")
 
-        CONTEXT_MSG="[🐙 Octopus] Auto-invoke: ${INTENT} (${CONFIDENCE}, ${SIGNAL_STRENGTH}). MANDATORY: Invoke Skill(skill: \\\"${SKILL_NAME}\\\", args: \\\"${ESCAPED_ARGS}\\\") before responding. The skill handles the full response."
+        CONTEXT_MSG="[🐙 Octopus] Auto-invoke: ${INTENT} (${CONFIDENCE}, ${SIGNAL_STRENGTH}). MANDATORY: Invoke Skill(skill: \"${SKILL_NAME}\", args: \"${ESCAPED_ARGS}\") before responding. The skill handles the full response."
     else
         # Standard behavior: inject persona context only
         CONTEXT_MSG="[🐙 Octopus] Detected intent: ${INTENT} (${CONFIDENCE} confidence)."
@@ -277,13 +359,13 @@ print(json.dumps(sys.stdin.read())[1:-1])" 2>/dev/null) || true
             [[ -n "$PERSONA_HINT" ]] && CONTEXT_MSG="${CONTEXT_MSG} ${PERSONA_HINT}"
 
             # Soft nudge for HIGH confidence that didn't auto-invoke
-            if [[ "$AUTO_INVOKE" == "true" && -n "$SKILL_NAME" ]]; then
+            if [[ "$AUTO_ROUTER_MODE" != "off" && -n "$SKILL_NAME" ]]; then
                 CONTEXT_MSG="${CONTEXT_MSG} Tip: /${SKILL_NAME} available for multi-AI analysis."
             fi
         fi
     fi
 
-    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"${CONTEXT_MSG}\"}}"
+    emit_user_prompt_context "$CONTEXT_MSG"
     exit 0
 fi
 

--- a/tests/unit/test-auto-router-hooks.sh
+++ b/tests/unit/test-auto-router-hooks.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Tests for Octopus auto-router hook behavior.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Octopus auto-router hooks"
+
+HOOK="$PROJECT_ROOT/hooks/user-prompt-submit.sh"
+SESSION_HOOK="$PROJECT_ROOT/hooks/auto-router-inject.sh"
+
+run_prompt_hook() {
+    local prompt="$1"
+    local mode="${2:-invoke}"
+    local home_dir="$TEST_TMP_DIR/home-${RANDOM}"
+    mkdir -p "$home_dir/.claude-octopus"
+    printf '{"hook_event_name":"UserPromptSubmit","session_id":"test-session","cwd":"/tmp","prompt":%s}\n' \
+        "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$prompt")" |
+        HOME="$home_dir" \
+        CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+        OCTOPUS_AUTO_ROUTER_MODE="$mode" \
+        "$HOOK"
+}
+
+run_cursor_prompt_hook() {
+    local prompt="$1"
+    local home_dir="$TEST_TMP_DIR/home-cursor-${RANDOM}"
+    mkdir -p "$home_dir/.claude-octopus"
+    printf '{"hook_event_name":"UserPromptSubmit","session_id":"test-session","cwd":"/tmp","prompt":%s}\n' \
+        "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$prompt")" |
+        HOME="$home_dir" \
+        CURSOR_PLUGIN_ROOT="$PROJECT_ROOT" \
+        OCTOPUS_AUTO_ROUTER_MODE="invoke" \
+        "$HOOK"
+}
+
+pass() { test_case "$1"; test_pass; }
+fail() { test_case "$1"; test_fail "${2:-$1}"; }
+
+test_case "routes decision prompts to debate"
+output="$(run_prompt_hook "should we use Redis or Memcached for session state?")"
+if [[ "$output" == *'Skill(skill: \"octo:debate\"'* ]]; then
+    test_pass
+else
+    test_fail "expected octo:debate auto-invoke, got: ${output:-<empty>}"
+fi
+
+test_case "routes research prompts to discover skill"
+output="$(run_prompt_hook "research options for OAuth authentication patterns")"
+if [[ "$output" == *'Skill(skill: \"octo:discover\"'* ]] && [[ "$output" != *'octo:research'* ]]; then
+    test_pass
+else
+    test_fail "expected octo:discover and no octo:research, got: ${output:-<empty>}"
+fi
+
+test_case "suggest mode does not inject mandatory skill call"
+output="$(run_prompt_hook "review this PR for regressions" "suggest")"
+if [[ "$output" == *"Detected intent: review"* ]] && [[ "$output" != *"MANDATORY: Invoke Skill"* ]]; then
+    test_pass
+else
+    test_fail "expected suggest-only context, got: ${output:-<empty>}"
+fi
+
+test_case "off mode leaves prompt untouched"
+output="$(run_prompt_hook "review this PR for regressions" "off")"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "expected empty output when off, got: $output"
+fi
+
+test_case "Cursor output uses additional_context without Claude hookSpecificOutput"
+output="$(run_cursor_prompt_hook "review this PR for regressions")"
+if [[ "$output" == *'"additional_context"'* ]] && [[ "$output" != *'hookSpecificOutput'* ]]; then
+    test_pass
+else
+    test_fail "expected Cursor-style additional_context only, got: ${output:-<empty>}"
+fi
+
+test_case "SessionStart auto-router injection hook exists and emits routing contract"
+if [[ -x "$SESSION_HOOK" ]]; then
+    output="$(HOME="$TEST_TMP_DIR/home-session" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$SESSION_HOOK" <<< '{"hook_event_name":"SessionStart"}')"
+    if [[ "$output" == *"OCTOPUS-AUTO-ROUTER"* ]] && [[ "$output" == *"octo:debate"* ]]; then
+        test_pass
+    else
+        test_fail "expected routing contract output, got: ${output:-<empty>}"
+    fi
+else
+    test_fail "missing executable hook: $SESSION_HOOK"
+fi
+
+test_summary

--- a/tests/unit/test-hook-err-traps.sh
+++ b/tests/unit/test-hook-err-traps.sh
@@ -17,6 +17,58 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Hook ERR/EXIT trap hygiene (issue #313)"
 
 VALID_STDIN='{"hook_event_name":"UserPromptSubmit","session_id":"test","cwd":"/tmp","prompt":"test","transcript_path":"/dev/null"}'
+HOOK_TIMEOUT_SECONDS="${HOOK_TIMEOUT_SECONDS:-5}"
+
+run_hook_with_deadline() {
+    local hook="$1"
+    local err_out="$2"
+    local out_out="${3:-/dev/null}"
+    local home_dir code
+
+    home_dir=$(mktemp -d "$TEST_TMP_DIR/hook-home-$(basename "$hook" .sh).XXXXXX")
+    code=0
+    VALID_STDIN_ENV="$VALID_STDIN" \
+    HOOK_PATH="$hook" \
+    ERR_OUT="$err_out" \
+    OUT_OUT="$out_out" \
+    HOME_DIR="$home_dir" \
+    PROJECT_ROOT_ENV="$PROJECT_ROOT" \
+    CLAUDE_SESSION_ID_ENV="test-session" \
+    HOOK_TIMEOUT_SECONDS_ENV="$HOOK_TIMEOUT_SECONDS" \
+    python3 <<'PY' || code=$?
+import os
+import subprocess
+import sys
+
+hook = os.environ["HOOK_PATH"]
+payload = os.environ["VALID_STDIN_ENV"] + "\n"
+timeout = float(os.environ["HOOK_TIMEOUT_SECONDS_ENV"])
+
+env = os.environ.copy()
+env["HOME"] = os.environ["HOME_DIR"]
+env["CLAUDE_PLUGIN_ROOT"] = os.environ["PROJECT_ROOT_ENV"]
+env["CLAUDE_SESSION_ID"] = os.environ["CLAUDE_SESSION_ID_ENV"]
+
+with open(os.environ["OUT_OUT"], "wb") as stdout, open(os.environ["ERR_OUT"], "wb") as stderr:
+    try:
+        result = subprocess.run(
+            ["bash", hook],
+            input=payload.encode(),
+            stdout=stdout,
+            stderr=stderr,
+            env=env,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        stderr.write(f"hook timed out after {timeout:g}s\n".encode())
+        sys.exit(124)
+
+sys.exit(result.returncode)
+PY
+    rm -rf "$home_dir"
+    return "$code"
+}
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Every hook using `set -e` has the trap
@@ -63,10 +115,7 @@ test_all_hooks_exit_clean_on_valid_input() {
         # real exit code. Without it, a non-zero hook aborts the test before
         # test_fail runs — CI shows "FAIL" with no detail.
         code=0
-        echo "$VALID_STDIN" | \
-            CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
-            CLAUDE_SESSION_ID="test-session" \
-            bash "$hook" 2>"$err_out" >/dev/null || code=$?
+        run_hook_with_deadline "$hook" "$err_out" >/dev/null || code=$?
         err=$(<"$err_out")
         rm -f "$err_out"
         if [[ $code -ne 0 ]]; then
@@ -98,7 +147,7 @@ test_trap_emits_stderr_on_forced_failure() {
     err_out=$(mktemp)
     # `|| code=$?` both suppresses set -e and captures the real exit code.
     code=0
-    echo "$VALID_STDIN" | CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$tmp" 2>"$err_out" >/dev/null || code=$?
+    run_hook_with_deadline "$tmp" "$err_out" >/dev/null || code=$?
     err=$(<"$err_out")
     rm -f "$tmp" "$err_out"
     # Match on the stable "[hook:...] exit" pattern; the copied file has a random basename
@@ -118,7 +167,7 @@ test_trap_silent_on_clean_exit() {
     local hook="$PROJECT_ROOT/hooks/user-prompt-submit.sh"
     local err_out err
     err_out=$(mktemp)
-    echo "$VALID_STDIN" | CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$hook" 2>"$err_out" >/dev/null
+    run_hook_with_deadline "$hook" "$err_out" >/dev/null
     err=$(<"$err_out")
     rm -f "$err_out"
     if [[ "$err" != *"[hook:"* ]]; then
@@ -137,7 +186,7 @@ test_careful_check_no_silent_fail_on_non_tool_input() {
     local err_out code
     err_out=$(mktemp)
     local code=0
-    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/careful-check.sh" 2>"$err_out" >/dev/null || code=$?
+    run_hook_with_deadline "$PROJECT_ROOT/hooks/careful-check.sh" "$err_out" >/dev/null || code=$?
     local err=$(<"$err_out")
     rm -f "$err_out"
     if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code stderr='${err:0:120}'"; fi
@@ -148,7 +197,7 @@ test_freeze_check_no_silent_fail_on_non_tool_input() {
     local err_out code err
     err_out=$(mktemp)
     code=0
-    echo "$VALID_STDIN" | bash "$PROJECT_ROOT/hooks/freeze-check.sh" 2>"$err_out" >/dev/null || code=$?
+    run_hook_with_deadline "$PROJECT_ROOT/hooks/freeze-check.sh" "$err_out" >/dev/null || code=$?
     err=$(<"$err_out")
     rm -f "$err_out"
     if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code stderr='${err:0:120}'"; fi
@@ -158,13 +207,12 @@ test_quality_gate_no_silent_fail_on_missing_validation() {
     test_case "quality-gate.sh exits 0 when no tangle-validation-*.md exists (was silent fail before #313 fix)"
     # Explicitly simulate a fresh environment (no ~/.claude-octopus/results/)
     # — this was the exact failure path that CI hit but local repro missed.
-    local err_out code err tmphome
-    tmphome=$(mktemp -d)
+    local err_out code err
     err_out=$(mktemp)
     code=0
-    echo "$VALID_STDIN" | HOME="$tmphome" bash "$PROJECT_ROOT/hooks/quality-gate.sh" 2>"$err_out" >/dev/null || code=$?
+    run_hook_with_deadline "$PROJECT_ROOT/hooks/quality-gate.sh" "$err_out" >/dev/null || code=$?
     err=$(<"$err_out")
-    rm -rf "$tmphome" "$err_out"
+    rm -f "$err_out"
     if [[ $code -eq 0 ]]; then test_pass; else test_fail "exit=$code stderr='${err:0:120}'"; fi
 }
 


### PR DESCRIPTION
## Summary
- add a compact SessionStart routing contract for Octopus auto-routing
- expand UserPromptSubmit routing for debate/discover and add off/suggest/invoke modes
- make hook trap hygiene tests hermetic and bounded so stale local state cannot hang the suite

## Tests
- tests/unit/test-auto-router-hooks.sh
- tests/unit/test-hook-err-traps.sh
- tests/unit/test-prompt-submit-v2.sh
- tests/smoke/test-syntax.sh
- tests/smoke/test-packaging-integrity.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-routing capability to automatically handle user intents based on configured mode (off, suggest, or invoke).
  * Auto-routing mode can now be configured during the setup wizard's "Fine-tune preferences" step.

* **Documentation**
  * Updated setup documentation to include auto-routing configuration options and mode descriptions.

* **Tests**
  * Added test coverage for auto-routing functionality and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->