### PR TITLE
feat: add remote session defaults

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.33.0"
+    "version": "9.34.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.33.0 - Multi-LLM orchestration for Claude Code. Route tasks to Codex, Gemini, Perplexity, Copilot, Qwen, Ollama, and OpenCode. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
-      "version": "9.33.0",
+      "description": "v9.34.0 - Multi-LLM orchestration for Claude Code with remote/web session defaults, lightweight statusline, and setup/doctor tier hints. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
+      "version": "9.34.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.33.0",
-  "description": "v9.33.0 \u2014 Routing config now feeds review/parallel/debate; develop dispatch, quota watcher cleanup, probe output-dir, and docs paths fixed. Run /octo:setup.",
+  "version": "9.34.0",
+  "description": "v9.34.0 — Remote/web session defaults: autonomous routing, skipped provider probes, lightweight statusline, and setup/doctor tier hints. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude/commands/embrace.md
+++ b/.claude/commands/embrace.md
@@ -90,6 +90,17 @@ AskUserQuestion({
 
 After receiving answers, incorporate them into all subsequent phase invocations — use the scope to calibrate research depth, focus areas to weight provider perspectives, autonomy level to control phase transitions, and debate preference to gate Define→Develop handoffs.
 
+### Remote/Cloud Defaults
+
+If `CLAUDE_CODE_REMOTE=true` or `OCTOPUS_REMOTE_SESSION=true`, do not block on clarifying questions. Use these defaults unless the user's prompt says otherwise:
+
+- scope: infer from the prompt
+- focus: all relevant areas
+- autonomy: autonomous
+- debate gates: only if provider disagreement is detected
+
+Plan locally first, then run the approved `/octo:embrace` prompt in the hosted or remote-control session with `OCTOPUS_REMOTE_SESSION=true` set in that environment.
+
 ## Step 2: Check Provider Availability & Display Banner
 
 **MANDATORY: Run this bash command BEFORE the banner.**

--- a/.claude/commands/security.md
+++ b/.claude/commands/security.md
@@ -13,6 +13,12 @@ Use `/octo:security` when the user explicitly wants enhanced multi-LLM or advers
 
 **Your first output line MUST be:** `🐙 Octopus Security Audit`
 
+## Scheduled Claude Code Web Usage
+
+For recurring audits, schedule `/octo:security run a read-only security audit of this repository` as a Claude Code web or hosted task.
+
+Scheduled security runs must be read-only unless the user explicitly asks for remediation. Findings should be grouped as confirmed, disputed, or needs-human-review before any fix workflow starts.
+
 ## 🤖 INSTRUCTIONS FOR CLAUDE
 
 ### MANDATORY COMPLIANCE — DO NOT SKIP

--- a/.claude/commands/sentinel.md
+++ b/.claude/commands/sentinel.md
@@ -19,7 +19,16 @@ GitHub-aware work monitor that triages issues, PRs, and CI failures. Sentinel ob
 ```bash
 /octo:sentinel              # One-time triage scan
 /octo:sentinel --watch       # Continuous monitoring
+/octo:sentinel --canary      # Post-deploy canary monitoring
 ```
+
+## Scheduled Claude Code Web Usage
+
+For recurring triage, schedule Sentinel as a read-only Claude Code web or hosted task. Use `/octo:sentinel` for the normal scan and `/octo:sentinel --canary https://example.com` for post-deploy monitoring.
+
+Scheduled Sentinel should stay triage-only. It may recommend `/octo:debug`,
+`/octo:review`, or `/octo:embrace`, but it must not start remediation unless
+the user explicitly asks for it.
 
 ## What Sentinel Monitors
 

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -30,6 +30,8 @@ printf "copilot:%s\n" "$(command -v copilot >/dev/null 2>&1 && echo installed ||
 printf "qwen:%s\n" "$(command -v qwen >/dev/null 2>&1 && echo installed || echo missing)"
 printf "ollama:%s\n" "$(command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1 && echo running || command -v ollama >/dev/null 2>&1 && echo installed || echo missing)"
 printf "opencode:%s\n" "$(command -v opencode >/dev/null 2>&1 && echo installed || echo missing)"
+printf "remote_session:%s\n" "$([[ "${CLAUDE_CODE_REMOTE:-}" == "true" || "${OCTOPUS_REMOTE_SESSION:-}" == "true" ]] && echo true || echo false)"
+printf "octo_tier:%s\n" "${OCTO_TIER:-unset}"
 echo "=== Token Optimization ==="
 printf "rtk:%s\n" "$(command -v rtk >/dev/null 2>&1 && echo "installed $(rtk --version 2>&1 | head -1)" || echo missing)"
 printf "rtk_hook:%s\n" "$(grep -q 'rtk' "${HOME}/.claude/settings.json" 2>/dev/null && echo active || echo missing)"
@@ -60,6 +62,10 @@ Providers:
 Token Optimization:
   RTK:              [Installed + Hook active ✓ / Installed ✓ / Missing ✗]
   octo-compress:    [Available ✓ / Not in PATH]
+
+Session:
+  Remote/Web:       [Yes / No]
+  Project tier:     [unset / prototype / mvp / production]
 ```
 
 ## STEP 2a: v9.29 Migration Prompt (one-time, existing users only)
@@ -141,6 +147,7 @@ AskUserQuestion({
       {label: "Configure models", description: "Set which models are used for each workflow phase → launches /octo:model-config"},
       {label: "Set up token optimization (RTK)", description: "Install RTK for 60-90% token savings on bash output"},
       {label: "Change work mode", description: "Switch between Dev mode and Knowledge Work mode"},
+      {label: "Set project tier", description: "Set OCTO_TIER=prototype|mvp|production as a routing hint"},
       {label: "Fine-tune preferences", description: "Auto-routing, banner verbosity, telemetry, cost mode"},
       {label: "Troubleshoot an issue", description: "Diagnose a problem → launches /octo:doctor"},
       {label: "Done — everything looks good", description: "Exit setup"}
@@ -154,6 +161,7 @@ Route based on selection:
 - **Configure models** → Invoke `/octo:model-config` (the interactive model config wizard)
 - **Set up RTK** → Jump to the RTK section below
 - **Change work mode** → Jump to the Work Mode section (STEP 4)
+- **Set project tier** → Jump to Project Tier Hint (STEP 4c)
 - **Fine-tune preferences** → Jump to the Fine-tune section (STEP 5)
 - **Troubleshoot** → Suggest `/octo:doctor`
 - **Done** → Show "Run /octo:setup anytime to change these settings" and exit
@@ -257,6 +265,37 @@ AskUserQuestion({
 ```
 
 If "Yes", append `export ENABLE_PROMPT_CACHING_1H=1` to `~/.bashrc` (or `~/.zshrc` per `$SHELL`), only if not already present. Note to the user: this only affects Claude-to-Claude round-trips inside Claude Code. External CLI subshells (Codex, Gemini, Perplexity) are unaffected — their providers manage caching independently.
+
+## STEP 4c: Project Tier Hint
+
+`OCTO_TIER` is a routing and verification hint, not a hard policy.
+
+```javascript
+AskUserQuestion({
+  questions: [{
+    question: "What project tier should Octopus optimize for?",
+    header: "Tier",
+    multiSelect: false,
+    options: [
+      {label: "MVP (Recommended)", description: "Balanced checks, normal review, consensus on risky changes"},
+      {label: "Prototype", description: "Prefer speed, light review, lower provider spend"},
+      {label: "Production", description: "Full verification, security review, stronger consensus before merge/release"},
+      {label: "Leave unset", description: "Use default balanced behavior without a project hint"}
+    ]
+  }]
+})
+```
+
+If a tier is selected, append `export OCTO_TIER=<prototype|mvp|production>` to the user's shell profile or project-local environment, only if not already present.
+
+## Remote/Web Session Defaults
+
+If `remote_session:true` appears in the detection output, assume the user is in a Claude Code web/remote session. Do not launch interactive provider logins from this command. Explain that Octopus defaults to autonomous mode, skips provider probe calls, and uses the lightweight statusline unless overridden with:
+
+```bash
+export OCTOPUS_REMOTE_STATUSLINE=full
+export OCTOPUS_REMOTE_STATUSLINE=off
+```
 
 ## STEP 5: Verify & Summarize
 

--- a/.claude/skills/skill-doctor.md
+++ b/.claude/skills/skill-doctor.md
@@ -250,6 +250,34 @@ The doctor reports the active intensity profile — a single knob controlling ho
 
 ---
 
+## Project Tier Hint
+
+Also report `OCTO_TIER` when set. This is a recommendation hint, not a hard policy.
+
+| Tier | Doctor guidance |
+|------|-----------------|
+| `prototype` | Prefer faster checks and warn before high-cost provider fanout |
+| `mvp` | Use balanced defaults and consensus on risky changes |
+| `production` | Recommend full verification, security review, and stricter release gates |
+
+If unset, show `OCTO_TIER=unset` and suggest setting it only when the project has a stable risk profile.
+
+---
+
+## Remote Session Checks
+
+If `CLAUDE_CODE_REMOTE=true` or `OCTOPUS_REMOTE_SESSION=true`, report:
+
+- remote session detected
+- autonomous mode default active when no explicit autonomy is set
+- provider probes skipped to conserve time/quota
+- full HUD disabled unless `OCTOPUS_REMOTE_STATUSLINE=full`
+- provider CLIs may need to be installed in the cloud setup script
+
+Suggest `/octo:setup` only for configuration guidance; do not recommend interactive provider logins inside the remote session.
+
+---
+
 ## Runtime Context
 
 The doctor checks for project-level `RUNTIME.md` — a file that provides project-specific context (API endpoints, env vars, test commands, build steps) to orchestration prompts.

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.33.0",
+  "version": "9.34.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"
@@ -32,7 +32,7 @@
   "hooks": "./.claude-plugin/hooks.json",
   "interface": {
     "displayName": "Claude Octopus",
-    "shortDescription": "Multi-LLM orchestration \u2014 dispatch to 8 providers from one plugin.",
+    "shortDescription": "Multi-LLM orchestration — dispatch to 8 providers from one plugin.",
     "longDescription": "Claude Octopus orchestrates multiple AI providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) through structured Double Diamond workflows. 32 personas, 48 commands, 52 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch with circuit breakers, cost tracking, and model routing.",
     "developerName": "nyldn",
     "category": "Orchestration",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
-  "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.33.0",
+  "description": "Multi-LLM orchestration — up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
+  "version": "9.34.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.33.0"
+    "version": "9.34.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.33.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 48 commands, 52 skills. Run /octo:setup after install.",
-      "version": "9.33.0",
+      "description": "v9.34.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 48 commands, 52 skills. Run /octo:setup after install.",
+      "version": "9.34.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.33.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.33.0. 32 expert personas, 48 commands, 52 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.34.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.34.0. 32 expert personas, 48 commands, 52 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [9.34.0] - 2026-05-05
+
+### Added
+
+- Claude Code web/remote session ergonomics: remote sessions default to autonomous mode, skip provider probe calls, use a lightweight statusline, and document hosted-session setup.
+- `OCTO_TIER` project-tier hint docs for setup and doctor so Octopus can recommend verification depth and provider spend by project risk profile.
+
+---
+
 ## [9.33.0] - 2026-05-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-146_passing-brightgreen" alt="146 tests passing">
-  <img src="https://img.shields.io/badge/Version-9.33.0-blue" alt="Version 9.33.0">
+  <img src="https://img.shields.io/badge/Version-9.34.0-blue" alt="Version 9.34.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.83+-blueviolet" alt="Requires Claude Code v2.1.83+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -166,6 +166,48 @@ claude plugin marketplace add https://github.com/nyldn/plugins.git
 claude plugin install octo@nyldn-plugins
 ```
 </details>
+
+---
+
+## Claude Code Web and Remote Sessions
+
+When Claude Code is running in a hosted, web, or remote-control environment, set `OCTOPUS_REMOTE_SESSION=true` in that environment. If Claude Code itself exports `CLAUDE_CODE_REMOTE=true` or `CLAUDE_CODE_WEB=true`, Octopus detects that automatically. Remote sessions are treated as unattended by default:
+
+- `CLAUDE_OCTOPUS_AUTONOMY=autonomous` / `OCTOPUS_AUTONOMY=autonomous` unless already set
+- provider smoke tests and Codex tier probes are skipped
+- the statusline uses a lightweight remote-safe display
+
+Set `OCTOPUS_REMOTE_STATUSLINE=full` to opt back into the full local HUD, or `OCTOPUS_REMOTE_STATUSLINE=off` to suppress statusline output entirely.
+
+Cloud environment setup should install provider CLIs and expose only the credentials required for the workflow. Paste this into the cloud environment setup script:
+
+```bash
+#!/usr/bin/env bash
+set -e
+
+npm install -g @openai/codex @google/gemini-cli @qwen-code/qwen-code 2>/dev/null || true
+
+echo "Octopus cloud setup:"
+command -v codex >/dev/null 2>&1 && echo "  Codex CLI: installed" || echo "  Codex CLI: missing"
+command -v gemini >/dev/null 2>&1 && echo "  Gemini CLI: installed" || echo "  Gemini CLI: missing"
+command -v qwen >/dev/null 2>&1 && echo "  Qwen CLI: installed" || echo "  Qwen CLI: missing"
+command -v gh >/dev/null 2>&1 && echo "  GitHub CLI: installed" || echo "  GitHub CLI: optional, install if Sentinel needs GitHub"
+```
+
+Set environment variables in the cloud environment, not in the script:
+
+```bash
+OPENAI_API_KEY=...
+GEMINI_API_KEY=...
+PERPLEXITY_API_KEY=...   # optional
+OPENROUTER_API_KEY=...   # optional
+```
+
+Provider API calls require internet access from the hosted environment.
+
+For scheduled Claude Code tasks, run `/octo:sentinel` for triage and `/octo:security` for recurring audits. Keep jobs read-only by default and route fixes through `/octo:debug`, `/octo:review`, or `/octo:embrace` after triage.
+
+Set `OCTO_TIER=prototype|mvp|production` as a project hint. It does not hard-block behavior; it helps setup, doctor, and workflow prompts recommend the right amount of verification and provider spend.
 
 ---
 

--- a/commands/octo-embrace.md
+++ b/commands/octo-embrace.md
@@ -86,6 +86,17 @@ AskUserQuestion({
 
 Store context (scope, focus, autonomy, debate preference) for all phases.
 
+### Remote/Cloud Defaults
+
+If `CLAUDE_CODE_REMOTE=true` or `OCTOPUS_REMOTE_SESSION=true`, do not block on clarifying questions. Use these defaults unless the user's prompt says otherwise:
+
+- scope: infer from the prompt
+- focus: all relevant areas
+- autonomy: autonomous
+- debate gates: only if provider disagreement is detected
+
+Plan locally first, then run the approved `/octo:embrace` prompt in the hosted or remote-control session with `OCTOPUS_REMOTE_SESSION=true` set in that environment.
+
 ## Step 2: Check Provider Availability & Display Banner
 
 **MANDATORY: Run this bash command BEFORE the banner.**

--- a/commands/octo-security.md
+++ b/commands/octo-security.md
@@ -6,6 +6,12 @@ description: "Security audit with OWASP compliance and vulnerability detection"
 
 **Your first output line MUST be:** `🐙 Octopus Security Audit`
 
+## Scheduled Claude Code Web Usage
+
+For recurring audits, schedule `/octo:security run a read-only security audit of this repository` as a Claude Code web or hosted task.
+
+Scheduled security runs must be read-only unless the user explicitly asks for remediation. Findings should be grouped as confirmed, disputed, or needs-human-review before any fix workflow starts.
+
 ## 🤖 INSTRUCTIONS FOR CLAUDE
 
 ### MANDATORY COMPLIANCE — DO NOT SKIP

--- a/commands/octo-sentinel.md
+++ b/commands/octo-sentinel.md
@@ -29,6 +29,14 @@ GitHub-aware work monitor that triages issues, PRs, and CI failures. Sentinel ob
 /octo:sentinel --canary URL  # Monitor specific URL after deploy
 ```
 
+## Scheduled Claude Code Web Usage
+
+For recurring triage, schedule Sentinel as a read-only Claude Code web or hosted task. Use `/octo:sentinel` for the normal scan and `/octo:sentinel --canary https://example.com` for post-deploy monitoring.
+
+Scheduled Sentinel should stay triage-only. It may recommend `/octo:debug`,
+`/octo:review`, or `/octo:embrace`, but it must not start remediation unless
+the user explicitly asks for it.
+
 ## What Sentinel Monitors
 
 | Source | Filter | Recommended Action |

--- a/commands/octo-setup.md
+++ b/commands/octo-setup.md
@@ -22,6 +22,8 @@ printf "copilot:%s\n" "$(command -v copilot >/dev/null 2>&1 && echo installed ||
 printf "qwen:%s\n" "$(command -v qwen >/dev/null 2>&1 && echo installed || echo missing)"
 printf "ollama:%s\n" "$(command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1 && echo running || command -v ollama >/dev/null 2>&1 && echo installed || echo missing)"
 printf "opencode:%s\n" "$(command -v opencode >/dev/null 2>&1 && echo installed || echo missing)"
+printf "remote_session:%s\n" "$([[ "${CLAUDE_CODE_REMOTE:-}" == "true" || "${OCTOPUS_REMOTE_SESSION:-}" == "true" ]] && echo true || echo false)"
+printf "octo_tier:%s\n" "${OCTO_TIER:-unset}"
 echo "=== Token Optimization ==="
 printf "rtk:%s\n" "$(command -v rtk >/dev/null 2>&1 && echo "installed $(rtk --version 2>&1 | head -1)" || echo missing)"
 printf "rtk_hook:%s\n" "$(grep -q 'rtk' "${HOME}/.claude/settings.json" 2>/dev/null && echo active || echo missing)"
@@ -50,6 +52,10 @@ Providers:
 
 Token Optimization:
   RTK:              [Installed + Hook active ✓ / Installed ✓ / Missing ✗]
+
+Session:
+  Remote/Web:       [Yes / No]
+  Project tier:     [unset / prototype / mvp / production]
 ```
 
 ## STEP 3: Interactive Menu (ALWAYS show this)
@@ -67,6 +73,7 @@ AskUserQuestion({
       {label: "Configure models", description: "Set which models are used for each workflow phase → launches /octo:model-config"},
       {label: "Set up token optimization (RTK)", description: "Install RTK for 60-90% token savings on bash output"},
       {label: "Change work mode", description: "Switch between Dev mode and Knowledge Work mode"},
+      {label: "Set project tier", description: "Set OCTO_TIER=prototype|mvp|production as a routing hint"},
       {label: "Fine-tune preferences", description: "Auto-routing, banner verbosity, telemetry, cost mode"},
       {label: "Troubleshoot an issue", description: "Diagnose a problem → launches /octo:doctor"}
     ]
@@ -77,6 +84,27 @@ AskUserQuestion({
 Then route to the appropriate section below.
 
 **If providers are NOT yet configured or this is a first run**, also proceed with the full setup flow below after showing the menu.
+
+## Remote/Web Session Defaults
+
+If `remote_session:true` appears in the detection output, assume the user is in a Claude Code web/remote session. Do not launch interactive provider logins from this command. Explain that Octopus will default to autonomous mode, skip provider probe calls, and use the lightweight statusline unless overridden with:
+
+```bash
+export OCTOPUS_REMOTE_STATUSLINE=full   # enable full local HUD behavior
+export OCTOPUS_REMOTE_STATUSLINE=off    # suppress statusline output
+```
+
+## Project Tier Hint
+
+`OCTO_TIER` is a recommendation hint, not a hard policy:
+
+| Tier | Recommended behavior |
+|------|----------------------|
+| `prototype` | Prefer speed, light review, lower provider spend |
+| `mvp` | Balanced checks, normal review, consensus on risky changes |
+| `production` | Full verification, security review, stronger consensus before merge/release |
+
+If unset, offer to add `export OCTO_TIER=<tier>` to the user's shell profile or project-local environment.
 
 ---
 

--- a/hooks/octopus-hud.mjs
+++ b/hooks/octopus-hud.mjs
@@ -27,6 +27,15 @@ import { createInterface } from "node:readline";
 import https from "node:https";
 import { execFileSync } from "node:child_process";
 
+// Remote web sessions default to the lightweight bash statusline path to avoid
+// local keychain/OAuth probes and slow terminal-only HUD work.
+if (
+  (process.env.CLAUDE_CODE_REMOTE === "true" || process.env.OCTOPUS_REMOTE_SESSION === "true") &&
+  process.env.OCTOPUS_REMOTE_STATUSLINE !== "full"
+) {
+  process.exit(0);
+}
+
 // ── Section A: Constants + Colors ────────────────────────────────────────────
 
 const HOME = homedir();

--- a/hooks/octopus-statusline.sh
+++ b/hooks/octopus-statusline.sh
@@ -27,6 +27,21 @@ input=$(cat 2>/dev/null || true)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HUD_MJS="${SCRIPT_DIR}/octopus-hud.mjs"
 
+# Remote web sessions do not need the full terminal HUD or OAuth/keychain probes.
+if [[ "${CLAUDE_CODE_REMOTE:-}" == "true" || "${OCTOPUS_REMOTE_SESSION:-false}" == "true" ]]; then
+    case "${OCTOPUS_REMOTE_STATUSLINE:-minimal}" in
+        off) exit 0 ;;
+        full) ;;
+        *)
+            PCT=$(printf '%s' "$input" | grep -o '"used_percentage"[[:space:]]*:[[:space:]]*[0-9.]*' | head -1 | grep -o '[0-9.]*$' || true)
+            [[ -z "$PCT" ]] && PCT=0
+            PCT=${PCT%%.*}
+            echo "[Octopus] remote ${PCT}% context"
+            exit 0
+            ;;
+    esac
+fi
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # TIER 1: Node.js HUD — requires Node 16+ (for node: protocol imports)
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/hooks/session-start-memory.sh
+++ b/hooks/session-start-memory.sh
@@ -15,6 +15,31 @@ set -euo pipefail
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
+REMOTE_SESSION=false
+if [[ "${CLAUDE_CODE_REMOTE:-}" == "true" || "${CLAUDE_CODE_WEB:-}" == "true" || "${OCTOPUS_REMOTE_SESSION:-false}" == "true" ]]; then
+    REMOTE_SESSION=true
+    export OCTOPUS_REMOTE_SESSION=true
+    export CLAUDE_OCTOPUS_AUTONOMY="${CLAUDE_OCTOPUS_AUTONOMY:-${OCTOPUS_AUTONOMY:-autonomous}}"
+    export OCTOPUS_AUTONOMY="${OCTOPUS_AUTONOMY:-$CLAUDE_OCTOPUS_AUTONOMY}"
+
+    if mkdir -p "${HOME}/.claude-octopus" 2>/dev/null; then
+        SESSION_FILE="${HOME}/.claude-octopus/session.json"
+        if command -v jq >/dev/null 2>&1; then
+            if [[ -f "$SESSION_FILE" ]]; then
+                TMP="${SESSION_FILE}.tmp"
+                jq --arg autonomy "$OCTOPUS_AUTONOMY" \
+                    '.remote_session = true | .autonomy = (.autonomy // $autonomy)' \
+                    "$SESSION_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$SESSION_FILE" 2>/dev/null || rm -f "$TMP"
+            else
+                jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg autonomy "$OCTOPUS_AUTONOMY" \
+                    '{"remote_session": true, "autonomy": $autonomy, "session_start": $ts}' \
+                    > "$SESSION_FILE" 2>/dev/null || true
+            fi
+        elif [[ ! -f "$SESSION_FILE" ]]; then
+            printf '{"remote_session":true,"autonomy":"%s"}\n' "$OCTOPUS_AUTONOMY" > "$SESSION_FILE" 2>/dev/null || true
+        fi
+    fi
+fi
 
 # --- 0. First-run detection (v9.19.2) ---
 # On very first install, auto-prompt the user to run /octo:setup
@@ -22,6 +47,7 @@ SETUP_MARKER="${HOME}/.claude-octopus/.setup-complete"
 if [[ ! -f "$SETUP_MARKER" ]]; then
     mkdir -p "${HOME}/.claude-octopus"
     touch "$SETUP_MARKER"
+    [[ "$REMOTE_SESSION" == "true" ]] && exit 0
     echo "[🐙] Welcome to Claude Octopus! Running /octo:setup for first-time configuration..."
     # This additionalContext triggers Claude to invoke the setup skill
     exit 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.33.0",
+  "version": "9.34.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -412,6 +412,15 @@ detect_tier_openai() {
         fallback_tier="plus"
     fi
 
+    # Cloud/remote sessions should not spend time or quota on provider probes.
+    # The fallback is still cached so routing has a stable tier hint.
+    if [[ "${OCTOPUS_SKIP_PROVIDER_PROBES:-false}" == "true" || "${CLAUDE_CODE_REMOTE:-}" == "true" || "${OCTOPUS_REMOTE_SESSION:-false}" == "true" ]]; then
+        [[ "$VERBOSE" == "true" ]] && log DEBUG "Codex tier probe skipped for remote session, using fallback: $fallback_tier" || true
+        tier_cache_write "codex" "$fallback_tier"
+        echo "$fallback_tier"
+        return 0
+    fi
+
     # Attempt API detection with minimal test call
     if command -v codex &>/dev/null; then
         local test_response
@@ -1062,6 +1071,11 @@ provider_smoke_test() {
     # Skip if user opted out
     if [[ "$SKIP_SMOKE_TEST" == "true" ]]; then
         log DEBUG "Smoke test: skipped (--skip-smoke-test)"
+        return 0
+    fi
+
+    if [[ "${OCTOPUS_SKIP_PROVIDER_PROBES:-false}" == "true" || "${CLAUDE_CODE_REMOTE:-}" == "true" || "${OCTOPUS_REMOTE_SESSION:-false}" == "true" ]]; then
+        log DEBUG "Smoke test: skipped for remote session"
         return 0
     fi
 

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -37,6 +37,18 @@ else
     OCTOPUS_HOST="standalone"
 fi
 
+# Claude Code web/remote sessions should bias toward unattended execution and
+# avoid expensive local terminal affordances unless explicitly re-enabled.
+OCTOPUS_REMOTE_SESSION="${OCTOPUS_REMOTE_SESSION:-false}"
+if [[ "${CLAUDE_CODE_REMOTE:-}" == "true" || "${CLAUDE_CODE_WEB:-}" == "true" || "${OCTOPUS_REMOTE_SESSION}" == "true" ]]; then
+    OCTOPUS_REMOTE_SESSION="true"
+    export OCTOPUS_REMOTE_SESSION
+    export CLAUDE_OCTOPUS_AUTONOMY="${CLAUDE_OCTOPUS_AUTONOMY:-${OCTOPUS_AUTONOMY:-autonomous}}"
+    export OCTOPUS_AUTONOMY="${OCTOPUS_AUTONOMY:-$CLAUDE_OCTOPUS_AUTONOMY}"
+    export OCTOPUS_REMOTE_STATUSLINE="${OCTOPUS_REMOTE_STATUSLINE:-minimal}"
+    export OCTOPUS_SKIP_PROVIDER_PROBES="${OCTOPUS_SKIP_PROVIDER_PROBES:-true}"
+fi
+
 # Keep debug flag defined even when nounset is enabled by sourced scripts.
 OCTOPUS_DEBUG="${OCTOPUS_DEBUG:-false}"
 

--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -179,6 +179,34 @@ The doctor reports the active intensity profile — a single knob controlling ho
 
 ---
 
+## Project Tier Hint
+
+The doctor should also report `OCTO_TIER` when it is set. This is a project-level recommendation hint, not a hard policy.
+
+| Tier | Doctor guidance |
+|------|-----------------|
+| `prototype` | Prefer faster checks and warn before high-cost provider fanout |
+| `mvp` | Use balanced defaults and consensus on risky changes |
+| `production` | Recommend full verification, security review, and stricter release gates |
+
+If unset, show `OCTO_TIER=unset` and suggest setting it only when the project has a stable risk profile.
+
+---
+
+## Remote Session Checks
+
+If `CLAUDE_CODE_REMOTE=true` or `OCTOPUS_REMOTE_SESSION=true`, report:
+
+- remote session detected
+- autonomous mode default active when no explicit autonomy is set
+- provider probes skipped to conserve time/quota
+- full HUD disabled unless `OCTOPUS_REMOTE_STATUSLINE=full`
+- provider CLIs may need to be installed in the cloud setup script
+
+Suggest `/octo:setup` only for configuration guidance; do not recommend interactive provider logins inside the remote session.
+
+---
+
 ## Runtime Context
 
 The doctor checks for project-level `RUNTIME.md` — a file that provides project-specific context (API endpoints, env vars, test commands, build steps) to orchestration prompts.

--- a/tests/unit/test-remote-session.sh
+++ b/tests/unit/test-remote-session.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Tests for Claude Code web/remote session defaults.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Remote session defaults"
+
+pass() { test_case "$1"; test_pass; }
+fail() { test_case "$1"; test_fail "${2:-$1}"; }
+
+ORCHESTRATE="$PROJECT_ROOT/scripts/orchestrate.sh"
+SMOKE="$PROJECT_ROOT/scripts/lib/smoke.sh"
+STATUSLINE="$PROJECT_ROOT/hooks/octopus-statusline.sh"
+HUD="$PROJECT_ROOT/hooks/octopus-hud.mjs"
+SESSION_START="$PROJECT_ROOT/hooks/session-start-memory.sh"
+README="$PROJECT_ROOT/README.md"
+
+if grep -q 'CLAUDE_CODE_REMOTE' "$ORCHESTRATE" && grep -q 'OCTOPUS_REMOTE_SESSION' "$ORCHESTRATE"; then
+    pass "orchestrate.sh detects Claude Code remote sessions"
+else
+    fail "orchestrate.sh detects Claude Code remote sessions" "remote env guard missing"
+fi
+
+if grep -q 'OCTOPUS_SKIP_PROVIDER_PROBES' "$ORCHESTRATE" && grep -q 'CLAUDE_OCTOPUS_AUTONOMY.*autonomous' "$ORCHESTRATE"; then
+    pass "remote sessions default to autonomous mode and skip probes"
+else
+    fail "remote sessions default to autonomous mode and skip probes" "missing remote defaults"
+fi
+
+if grep -q 'OCTOPUS_SKIP_PROVIDER_PROBES' "$SMOKE" && grep -q 'Smoke test: skipped for remote session' "$SMOKE"; then
+    pass "provider smoke tests are skipped in remote sessions"
+else
+    fail "provider smoke tests are skipped in remote sessions" "smoke skip guard missing"
+fi
+
+if grep -q 'Codex tier probe skipped for remote session' "$SMOKE"; then
+    pass "Codex tier probe is skipped in remote sessions"
+else
+    fail "Codex tier probe is skipped in remote sessions" "tier probe guard missing"
+fi
+
+if grep -q 'OCTOPUS_REMOTE_STATUSLINE' "$STATUSLINE" && grep -q '\[Octopus\] remote' "$STATUSLINE"; then
+    pass "bash statusline has lightweight remote mode"
+else
+    fail "bash statusline has lightweight remote mode" "remote statusline fallback missing"
+fi
+
+remote_output=$(printf '{"used_percentage":42.9}\n' | CLAUDE_CODE_REMOTE=true "$STATUSLINE")
+if [[ "$remote_output" == "[Octopus] remote 42% context" ]]; then
+    pass "bash statusline emits lightweight remote context percentage"
+else
+    fail "bash statusline emits lightweight remote context percentage" "unexpected output: $remote_output"
+fi
+
+off_output=$(printf '{"used_percentage":42.9}\n' | CLAUDE_CODE_REMOTE=true OCTOPUS_REMOTE_STATUSLINE=off "$STATUSLINE")
+if [[ -z "$off_output" ]]; then
+    pass "remote statusline can be disabled"
+else
+    fail "remote statusline can be disabled" "unexpected output: $off_output"
+fi
+
+if grep -q 'full)' "$STATUSLINE"; then
+    pass "remote statusline full mode falls through to local HUD"
+else
+    fail "remote statusline full mode falls through to local HUD" "full opt-in missing"
+fi
+
+if grep -q 'OCTOPUS_REMOTE_STATUSLINE' "$HUD" && grep -q 'process.exit(0)' "$HUD"; then
+    pass "Node HUD exits early in remote sessions"
+else
+    fail "Node HUD exits early in remote sessions" "HUD remote early exit missing"
+fi
+
+if grep -q 'remote_session.*true' "$SESSION_START" && grep -q 'setup-complete' "$SESSION_START"; then
+    pass "SessionStart records remote sessions without first-run setup"
+else
+    fail "SessionStart records remote sessions without first-run setup" "remote session state missing"
+fi
+
+tmp_home=$(mktemp -d)
+session_output=$(HOME="$tmp_home" CLAUDE_CODE_REMOTE=true "$SESSION_START" 2>/dev/null || true)
+session_file="$tmp_home/.claude-octopus/session.json"
+if [[ -f "$tmp_home/.claude-octopus/.setup-complete" && -f "$session_file" && -z "$session_output" ]] &&
+   jq -e '.remote_session == true and .autonomy == "autonomous"' "$session_file" >/dev/null 2>&1; then
+    pass "SessionStart remote mode records state and suppresses first-run prompt"
+else
+    fail "SessionStart remote mode records state and suppresses first-run prompt" "remote state was not recorded correctly"
+fi
+
+tmp_home=$(mktemp -d)
+HOME="$tmp_home" CLAUDE_CODE_REMOTE=true OCTOPUS_AUTONOMY=supervised "$SESSION_START" >/dev/null 2>&1 || true
+if jq -e '.remote_session == true and .autonomy == "supervised"' "$tmp_home/.claude-octopus/session.json" >/dev/null 2>&1; then
+    pass "SessionStart preserves explicit remote autonomy"
+else
+    fail "SessionStart preserves explicit remote autonomy" "explicit autonomy was not preserved"
+fi
+
+if grep -q '## Claude Code Web and Remote Sessions' "$README" && grep -q 'OCTOPUS_REMOTE_SESSION=true' "$README"; then
+    pass "README documents Claude Code web and remote workflow"
+else
+    fail "README documents Claude Code web and remote workflow" "remote docs missing"
+fi
+
+if ! grep -R -q 'claude --remote\|claude --teleport' "$README" "$PROJECT_ROOT/commands" "$PROJECT_ROOT/.claude/commands"; then
+    pass "remote docs avoid unsupported Claude CLI flags"
+else
+    fail "remote docs avoid unsupported Claude CLI flags" "unsupported CLI flag documented"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary
- Add Claude Code hosted/remote-session defaults that set autonomous mode, skip provider probes, and use a lightweight statusline unless overridden
- Document remote/session setup, scheduled Sentinel/Security usage, and OCTO_TIER project-tier hints
- Bump plugin, package, marketplace, and public adapter manifests to v9.34.0

## Verification
- bash tests/unit/test-remote-session.sh
- bash tests/unit/test-docs-sync.sh
- bash tests/unit/test-hook-err-traps.sh
- bash tests/unit/test-enhanced-hud.sh
- bash tests/unit/test-auto-router-hooks.sh
- bash -n hooks/session-start-memory.sh hooks/octopus-statusline.sh scripts/orchestrate.sh scripts/lib/smoke.sh tests/unit/test-remote-session.sh
- node --check hooks/octopus-hud.mjs
- jq empty package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json .factory-plugin/marketplace.json
- ./scripts/sync-marketplace.sh --check
- git diff --cached --check
- claude plugin validate .claude-plugin/plugin.json
- claude plugin validate .claude-plugin/marketplace.json

## Notes
- Removed unsupported `claude --remote` / `claude --teleport` examples during re-evaluation; current Claude CLI help does not expose those flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v9.34.0

* **New Features**
  * Added support for Claude Code web and remote session execution with autonomous defaults, lightweight statusline output, and provider probe skipping.
  * Introduced project tier configuration (prototype/mvp/production) to guide verification depth and provider recommendations.

* **Documentation**
  * Enhanced guidance for remote and scheduled task workflows, including security audits, monitoring, and hosted session setup.
  * Updated setup wizard and diagnostic tools for remote session detection and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->