### PR TITLE
feat: release v9.35.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.34.0"
+    "version": "9.35.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.34.0 - Multi-LLM orchestration for Claude Code with remote/web session defaults, lightweight statusline, and setup/doctor tier hints. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
-      "version": "9.34.0",
+      "description": "v9.35.0 - Multi-LLM orchestration for Claude Code with remote/web session defaults, lightweight statusline, and setup/doctor tier hints. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
+      "version": "9.35.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.34.0",
-  "description": "v9.34.0 — Remote/web session defaults: autonomous routing, skipped provider probes, lightweight statusline, and setup/doctor tier hints. Run /octo:setup.",
+  "version": "9.35.0",
+  "description": "v9.35.0 \u2014 Remote/web session defaults: autonomous routing, skipped provider probes, lightweight statusline, and setup/doctor tier hints. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -156,6 +156,10 @@ The pipeline runs 3 rounds (parallel fleet → verification → synthesis) and o
 
 Round-aware PR history is enabled automatically for open PR reviews. Local state is stored at `~/.claude-octopus/pr-state/<host>/<owner>/<repo>/<pr>.json` and is used to show addressed, persistent, new, and regressed finding counts across repeated `/octo:review` runs. Set `OCTOPUS_PR_HISTORY=0` before invoking the command to disable all history reads and writes.
 
+Each review also writes a local proof packet under `~/.claude-octopus/runs/<run-id>/`. The packet includes `state.json`, `proof.jsonl`, `summary.md`, findings artifacts, and provider substitution records so review claims can be checked after the chat scroll is gone. Set `OCTOPUS_PROOF_PACKET=0` to disable proof packet writes.
+
+If a project already has `graphify-out/GRAPH_REPORT.md`, `/octo:review` also passes a compact Graphify companion context into the reviewer prompt as an orientation map. This is passive: Octopus does not build or refresh the graph during review, and `OCTOPUS_GRAPHIFY=0` disables the injection.
+
 ## What `/octo:review` checks
 
 - Correctness: logic bugs, edge cases, regressions, unreachable code

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -32,6 +32,10 @@ printf "ollama:%s\n" "$(command -v ollama >/dev/null 2>&1 && curl -sf http://loc
 printf "opencode:%s\n" "$(command -v opencode >/dev/null 2>&1 && echo installed || echo missing)"
 printf "remote_session:%s\n" "$([[ "${CLAUDE_CODE_REMOTE:-}" == "true" || "${OCTOPUS_REMOTE_SESSION:-}" == "true" ]] && echo true || echo false)"
 printf "octo_tier:%s\n" "${OCTO_TIER:-unset}"
+echo "=== Companions ==="
+printf "graphify:%s\n" "$(command -v graphify >/dev/null 2>&1 && echo installed || echo missing)"
+GRAPHIFY_OUT_DIR="${GRAPHIFY_OUT:-graphify-out}"
+printf "graphify_graph:%s\n" "$([ -f "${GRAPHIFY_OUT_DIR}/graph.json" ] && [ -f "${GRAPHIFY_OUT_DIR}/GRAPH_REPORT.md" ] && echo available || echo missing)"
 echo "=== Token Optimization ==="
 printf "rtk:%s\n" "$(command -v rtk >/dev/null 2>&1 && echo "installed $(rtk --version 2>&1 | head -1)" || echo missing)"
 printf "rtk_hook:%s\n" "$(grep -q 'rtk' "${HOME}/.claude/settings.json" 2>/dev/null && echo active || echo missing)"
@@ -62,6 +66,9 @@ Providers:
 Token Optimization:
   RTK:              [Installed + Hook active ✓ / Installed ✓ / Missing ✗]
   octo-compress:    [Available ✓ / Not in PATH]
+
+Companions:
+  Graphify:         [CLI installed ✓ / Missing] [Graph available ✓ / Missing]
 
 Session:
   Remote/Web:       [Yes / No]
@@ -146,6 +153,7 @@ AskUserQuestion({
       {label: "Add or configure a provider", description: "Install Codex, Gemini, Perplexity, Copilot, Qwen, or OpenCode"},
       {label: "Configure models", description: "Set which models are used for each workflow phase → launches /octo:model-config"},
       {label: "Set up token optimization (RTK)", description: "Install RTK for 60-90% token savings on bash output"},
+      {label: "Set up Graphify companion", description: "Detect or install Graphify for optional knowledge-graph context"},
       {label: "Change work mode", description: "Switch between Dev mode and Knowledge Work mode"},
       {label: "Set project tier", description: "Set OCTO_TIER=prototype|mvp|production as a routing hint"},
       {label: "Fine-tune preferences", description: "Auto-routing, banner verbosity, telemetry, cost mode"},
@@ -160,6 +168,7 @@ Route based on selection:
 - **Add or configure a provider** → Continue to the provider install flow below
 - **Configure models** → Invoke `/octo:model-config` (the interactive model config wizard)
 - **Set up RTK** → Jump to the RTK section below
+- **Set up Graphify companion** → Jump to the Graphify Companion section below
 - **Change work mode** → Jump to the Work Mode section (STEP 4)
 - **Set project tier** → Jump to Project Tier Hint (STEP 4c)
 - **Fine-tune preferences** → Jump to the Fine-tune section (STEP 5)
@@ -287,6 +296,22 @@ AskUserQuestion({
 ```
 
 If a tier is selected, append `export OCTO_TIER=<prototype|mvp|production>` to the user's shell profile or project-local environment, only if not already present.
+
+## Graphify Companion
+
+Graphify is optional and is not a provider. If `graphify-out/GRAPH_REPORT.md` already exists, Octopus uses it as a compact architecture map for escalated workflows such as `/octo:review`; it does not build or refresh graphs automatically.
+
+To install and initialize Graphify when the user opts in:
+
+```bash
+uv tool install graphifyy
+graphify extract .
+graphify claude install
+graphify codex install
+graphify hook install
+```
+
+Use `OCTOPUS_GRAPHIFY=0` to disable passive Graphify context injection.
 
 ## Remote/Web Session Defaults
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.34.0",
+  "version": "9.35.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"
@@ -32,7 +32,7 @@
   "hooks": "./.claude-plugin/hooks.json",
   "interface": {
     "displayName": "Claude Octopus",
-    "shortDescription": "Multi-LLM orchestration — dispatch to 8 providers from one plugin.",
+    "shortDescription": "Multi-LLM orchestration \u2014 dispatch to 8 providers from one plugin.",
     "longDescription": "Claude Octopus orchestrates multiple AI providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) through structured Double Diamond workflows. 32 personas, 48 commands, 52 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch with circuit breakers, cost tracking, and model routing.",
     "developerName": "nyldn",
     "category": "Orchestration",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
-  "description": "Multi-LLM orchestration — up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.34.0",
+  "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
+  "version": "9.35.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.34.0"
+    "version": "9.35.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.34.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 48 commands, 52 skills. Run /octo:setup after install.",
-      "version": "9.34.0",
+      "description": "v9.35.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 48 commands, 52 skills. Run /octo:setup after install.",
+      "version": "9.35.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.34.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.34.0. 32 expert personas, 48 commands, 52 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.35.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.35.0. 32 expert personas, 48 commands, 52 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [9.35.0] - 2026-05-05
+
+### Added
+
+- Add local proof packets for `/octo:review`, including JSONL evidence, findings artifacts, provider substitution records, and a markdown summary under `~/.claude-octopus/runs/`.
+- Add optional Graphify companion detection and passive `/octo:review` context injection from existing `graphify-out/GRAPH_REPORT.md` files.
+
+---
+
 ## [9.34.0] - 2026-05-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-146_passing-brightgreen" alt="146 tests passing">
-  <img src="https://img.shields.io/badge/Version-9.34.0-blue" alt="Version 9.34.0">
+  <img src="https://img.shields.io/badge/Version-9.35.0-blue" alt="Version 9.35.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.83+-blueviolet" alt="Requires Claude Code v2.1.83+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/commands/octo-review.md
+++ b/commands/octo-review.md
@@ -143,6 +143,10 @@ The pipeline runs 3 rounds (parallel fleet → verification → synthesis) and o
 
 Round-aware PR history is enabled automatically for open PR reviews. Local state is stored at `~/.claude-octopus/pr-state/<host>/<owner>/<repo>/<pr>.json` and is used to show addressed, persistent, new, and regressed finding counts across repeated `/octo:review` runs. Set `OCTOPUS_PR_HISTORY=0` before invoking the command to disable all history reads and writes.
 
+Each review also writes a local proof packet under `~/.claude-octopus/runs/<run-id>/`. The proof packet includes `state.json`, `proof.jsonl`, `summary.md`, findings artifacts, and provider substitution records so review claims can be checked after the chat scroll is gone. Set `OCTOPUS_PROOF_PACKET=0` to disable proof packet writes.
+
+If a project already has `graphify-out/GRAPH_REPORT.md`, `/octo:review` also passes a compact Graphify companion context into the reviewer prompt as an orientation map. This is passive: Octopus does not build or refresh the graph during review, and `OCTOPUS_GRAPHIFY=0` disables the injection.
+
 ## What `/octo:review` checks
 
 - Correctness: logic bugs, edge cases, regressions, unreachable code

--- a/commands/octo-setup.md
+++ b/commands/octo-setup.md
@@ -24,6 +24,10 @@ printf "ollama:%s\n" "$(command -v ollama >/dev/null 2>&1 && curl -sf http://loc
 printf "opencode:%s\n" "$(command -v opencode >/dev/null 2>&1 && echo installed || echo missing)"
 printf "remote_session:%s\n" "$([[ "${CLAUDE_CODE_REMOTE:-}" == "true" || "${OCTOPUS_REMOTE_SESSION:-}" == "true" ]] && echo true || echo false)"
 printf "octo_tier:%s\n" "${OCTO_TIER:-unset}"
+echo "=== Companions ==="
+printf "graphify:%s\n" "$(command -v graphify >/dev/null 2>&1 && echo installed || echo missing)"
+GRAPHIFY_OUT_DIR="${GRAPHIFY_OUT:-graphify-out}"
+printf "graphify_graph:%s\n" "$([ -f "${GRAPHIFY_OUT_DIR}/graph.json" ] && [ -f "${GRAPHIFY_OUT_DIR}/GRAPH_REPORT.md" ] && echo available || echo missing)"
 echo "=== Token Optimization ==="
 printf "rtk:%s\n" "$(command -v rtk >/dev/null 2>&1 && echo "installed $(rtk --version 2>&1 | head -1)" || echo missing)"
 printf "rtk_hook:%s\n" "$(grep -q 'rtk' "${HOME}/.claude/settings.json" 2>/dev/null && echo active || echo missing)"
@@ -53,6 +57,9 @@ Providers:
 Token Optimization:
   RTK:              [Installed + Hook active ✓ / Installed ✓ / Missing ✗]
 
+Companions:
+  Graphify:         [CLI installed ✓ / Missing] [Graph available ✓ / Missing]
+
 Session:
   Remote/Web:       [Yes / No]
   Project tier:     [unset / prototype / mvp / production]
@@ -72,6 +79,7 @@ AskUserQuestion({
       {label: "Add or configure a provider", description: "Install Codex, Gemini, Perplexity, Copilot, Qwen, or OpenCode"},
       {label: "Configure models", description: "Set which models are used for each workflow phase → launches /octo:model-config"},
       {label: "Set up token optimization (RTK)", description: "Install RTK for 60-90% token savings on bash output"},
+      {label: "Set up Graphify companion", description: "Detect or install Graphify for optional knowledge-graph context"},
       {label: "Change work mode", description: "Switch between Dev mode and Knowledge Work mode"},
       {label: "Set project tier", description: "Set OCTO_TIER=prototype|mvp|production as a routing hint"},
       {label: "Fine-tune preferences", description: "Auto-routing, banner verbosity, telemetry, cost mode"},
@@ -107,6 +115,22 @@ export OCTOPUS_REMOTE_STATUSLINE=off    # suppress statusline output
 If unset, offer to add `export OCTO_TIER=<tier>` to the user's shell profile or project-local environment.
 
 ---
+
+## Graphify Companion
+
+Graphify is optional and is not a provider. If `graphify-out/GRAPH_REPORT.md` already exists, Octopus uses it as a compact architecture map for escalated workflows such as `/octo:review`; it does not build or refresh graphs automatically.
+
+Setup options:
+
+```bash
+uv tool install graphifyy
+graphify extract .
+graphify claude install
+graphify codex install
+graphify hook install
+```
+
+Use `OCTOPUS_GRAPHIFY=0` to disable passive Graphify context injection.
 
 ## Dependency Check
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.34.0",
+  "version": "9.35.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -8,6 +8,11 @@ if ! declare -f _is_cursor_agent_binary >/dev/null 2>&1; then
     source "${_doctor_lib_dir}/cursor-agent.sh" 2>/dev/null || true
 fi
 
+if ! declare -f octo_graphify_status_json >/dev/null 2>&1; then
+    _doctor_lib_dir="${_doctor_lib_dir:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+    source "${_doctor_lib_dir}/graphify.sh" 2>/dev/null || true
+fi
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # MODULAR DOCTOR SYSTEM (v8.16.0)
 # 8 check categories, structured results, category filtering, JSON output
@@ -270,6 +275,68 @@ doctor_check_providers() {
             doctor_add "provider-fallbacks" "providers" "pass" \
                 "No recent provider fallbacks" ""
         fi
+    fi
+}
+
+# --- Category 1b: Optional companions ---
+doctor_check_companions() {
+    if ! declare -f octo_graphify_status_json >/dev/null 2>&1; then
+        doctor_add "graphify-companion" "companions" "info" \
+            "Graphify companion unavailable" "scripts/lib/graphify.sh not loaded"
+        return 0
+    fi
+
+    local project_root status installed version bin graph_exists report_exists needs_update out_dir hook_status
+    project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+    status=$(octo_graphify_status_json "$project_root" 2>/dev/null || true)
+    if [[ -z "$status" ]]; then
+        doctor_add "graphify-companion" "companions" "info" \
+            "Graphify companion disabled" "Set OCTOPUS_GRAPHIFY=1 to re-enable"
+        return 0
+    fi
+
+    installed=$(printf '%s' "$status" | jq -r '.installed')
+    version=$(printf '%s' "$status" | jq -r '.version')
+    bin=$(printf '%s' "$status" | jq -r '.bin')
+    graph_exists=$(printf '%s' "$status" | jq -r '.graph_exists')
+    report_exists=$(printf '%s' "$status" | jq -r '.report_exists')
+    needs_update=$(printf '%s' "$status" | jq -r '.needs_update')
+    out_dir=$(printf '%s' "$status" | jq -r '.out_dir')
+    hook_status=$(printf '%s' "$status" | jq -r '.hook_status // ""')
+
+    if [[ "$installed" == "true" ]]; then
+        doctor_add "graphify-cli" "companions" "pass" \
+            "Graphify CLI installed (v${version})" "$bin"
+    else
+        doctor_add "graphify-cli" "companions" "info" \
+            "Graphify CLI not installed (optional)" "uv tool install graphifyy"
+    fi
+
+    if [[ "$graph_exists" == "true" && "$report_exists" == "true" ]]; then
+        doctor_add "graphify-graph" "companions" "pass" \
+            "Graphify graph available" "$out_dir"
+    elif [[ "$graph_exists" == "true" || "$report_exists" == "true" ]]; then
+        doctor_add "graphify-graph" "companions" "warn" \
+            "Graphify output incomplete" "Expected both graph.json and GRAPH_REPORT.md under $out_dir"
+    else
+        doctor_add "graphify-graph" "companions" "info" \
+            "No Graphify graph for this project" "Run graphify extract . when a graph map would help"
+    fi
+
+    if [[ "$needs_update" == "true" ]]; then
+        doctor_add "graphify-freshness" "companions" "warn" \
+            "Graphify graph may be stale" "needs_update flag present under $out_dir"
+    elif [[ "$graph_exists" == "true" ]]; then
+        doctor_add "graphify-freshness" "companions" "pass" \
+            "No Graphify stale flag found" "$out_dir"
+    else
+        doctor_add "graphify-freshness" "companions" "info" \
+            "Graphify freshness not applicable" "No graphify-out graph found"
+    fi
+
+    if [[ "$installed" == "true" && -n "$hook_status" ]]; then
+        doctor_add "graphify-hooks" "companions" "info" \
+            "Graphify hook status checked" "$hook_status"
     fi
 }
 
@@ -1379,7 +1446,7 @@ do_doctor() {
     DOCTOR_RESULTS_DETAIL=()
 
     # Run checks (filtered if category specified)
-    local categories=(providers auth config state smoke hooks scheduler skills conflicts agents recurrence cache)
+    local categories=(providers companions auth config state smoke hooks scheduler skills conflicts agents recurrence cache)
     for cat in "${categories[@]}"; do
         if [[ -z "$category_filter" || "$category_filter" == "$cat" ]]; then
             "doctor_check_${cat}"

--- a/scripts/lib/graphify.sh
+++ b/scripts/lib/graphify.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Optional Graphify companion helpers.
+#
+# Graphify is not an Octopus provider. These helpers detect an existing local
+# knowledge graph and pass a compact orientation packet into escalated workflows.
+
+octo_graphify_enabled() {
+    case "${OCTOPUS_GRAPHIFY:-1}" in
+        0|false|FALSE|off|OFF|no|NO) return 1 ;;
+    esac
+    command -v jq >/dev/null 2>&1
+}
+
+octo_graphify_bin() {
+    if [[ -n "${OCTOPUS_GRAPHIFY_BIN:-}" ]]; then
+        [[ -x "$OCTOPUS_GRAPHIFY_BIN" ]] || return 1
+        printf '%s\n' "$OCTOPUS_GRAPHIFY_BIN"
+        return 0
+    fi
+    command -v graphify 2>/dev/null
+}
+
+octo_graphify_out_dir() {
+    local project_root="${1:-$(pwd)}"
+    local out="${GRAPHIFY_OUT:-graphify-out}"
+    case "$out" in
+        /*) printf '%s\n' "$out" ;;
+        *) printf '%s/%s\n' "${project_root%/}" "$out" ;;
+    esac
+}
+
+octo_graphify_install_hint() {
+    cat <<'EOF'
+Install Graphify with:
+  uv tool install graphifyy
+
+Then, inside a project:
+  graphify extract .
+  graphify claude install
+  graphify codex install
+  graphify hook install
+EOF
+}
+
+_octo_graphify_version() {
+    local bin="$1"
+    local raw version
+    raw=$("$bin" --version 2>&1 | head -1 || true)
+    version=$(printf '%s' "$raw" | grep -oE '[0-9]+(\.[0-9]+){1,3}' | head -1 || true)
+    printf '%s\n' "${version:-unknown}"
+}
+
+_octo_graphify_hook_status() {
+    local bin="$1"
+    "$bin" hook status 2>/dev/null | head -20 || true
+}
+
+octo_graphify_status_json() {
+    local project_root="${1:-$(pwd)}"
+    local enabled="false"
+    octo_graphify_enabled && enabled="true"
+
+    local bin="" installed="false" version="missing" hook_status=""
+    if [[ "$enabled" == "true" ]]; then
+        bin=$(octo_graphify_bin 2>/dev/null || true)
+        if [[ -n "$bin" ]]; then
+            installed="true"
+            version=$(_octo_graphify_version "$bin")
+            hook_status=$(_octo_graphify_hook_status "$bin")
+        fi
+    fi
+
+    local out_dir graph_path report_path wiki_path needs_update_path
+    local graph_exists="false" report_exists="false" wiki_exists="false" needs_update="false"
+    out_dir=$(octo_graphify_out_dir "$project_root")
+    graph_path="$out_dir/graph.json"
+    report_path="$out_dir/GRAPH_REPORT.md"
+    wiki_path="$out_dir/wiki/index.md"
+    needs_update_path=""
+
+    [[ -f "$graph_path" ]] && graph_exists="true"
+    [[ -f "$report_path" ]] && report_exists="true"
+    [[ -f "$wiki_path" ]] && wiki_exists="true"
+    if [[ -e "$out_dir/needs_update" ]]; then
+        needs_update="true"
+        needs_update_path="$out_dir/needs_update"
+    elif [[ -e "$out_dir/.needs_update" ]]; then
+        needs_update="true"
+        needs_update_path="$out_dir/.needs_update"
+    fi
+
+    jq -n \
+        --argjson enabled "$enabled" \
+        --argjson installed "$installed" \
+        --arg bin "$bin" \
+        --arg version "$version" \
+        --arg out_dir "$out_dir" \
+        --arg graph_path "$graph_path" \
+        --arg report_path "$report_path" \
+        --arg wiki_path "$wiki_path" \
+        --arg needs_update_path "$needs_update_path" \
+        --arg hook_status "$hook_status" \
+        --argjson graph_exists "$graph_exists" \
+        --argjson report_exists "$report_exists" \
+        --argjson wiki_exists "$wiki_exists" \
+        --argjson needs_update "$needs_update" \
+        '{
+          enabled: $enabled,
+          installed: $installed,
+          bin: $bin,
+          version: $version,
+          out_dir: $out_dir,
+          graph_path: $graph_path,
+          report_path: $report_path,
+          wiki_path: $wiki_path,
+          graph_exists: $graph_exists,
+          report_exists: $report_exists,
+          wiki_exists: $wiki_exists,
+          needs_update: $needs_update,
+          needs_update_path: $needs_update_path,
+          hook_status: $hook_status
+        }'
+}
+
+octo_graphify_context_for_prompt() {
+    local project_root="${1:-$(pwd)}"
+    local max_chars="${2:-12000}"
+
+    octo_graphify_enabled || return 0
+
+    local graphify_status report_path graph_path needs_update installed version hook_status
+    graphify_status=$(octo_graphify_status_json "$project_root" 2>/dev/null || true)
+    [[ -n "$graphify_status" ]] || return 0
+
+    report_path=$(printf '%s' "$graphify_status" | jq -r '.report_path')
+    graph_path=$(printf '%s' "$graphify_status" | jq -r '.graph_path')
+    needs_update=$(printf '%s' "$graphify_status" | jq -r '.needs_update')
+    installed=$(printf '%s' "$graphify_status" | jq -r '.installed')
+    version=$(printf '%s' "$graphify_status" | jq -r '.version')
+    hook_status=$(printf '%s' "$graphify_status" | jq -r '.hook_status // ""')
+
+    [[ -f "$report_path" ]] || return 0
+
+    local freshness="current"
+    [[ "$needs_update" == "true" ]] && freshness="needs_update flag present"
+
+    {
+        echo "Graphify companion context (optional; existing local graph only)"
+        echo "Source report: $report_path"
+        echo "Graph JSON: $graph_path"
+        echo "Graphify CLI: installed=${installed} version=${version}"
+        echo "Freshness: $freshness"
+        if [[ -n "$hook_status" ]]; then
+            echo "Hook status: $(printf '%s' "$hook_status" | tr '\n' ';' | sed 's/;$//')"
+        fi
+        echo ""
+        echo "Use this as an orientation map, not a replacement for exact source reads."
+        echo "For cross-module relationship questions, prefer graphify query/path/explain when the CLI is installed."
+        echo "Do not build or refresh graphs unless the user explicitly asked for Graphify work or graph maintenance is already in scope."
+        echo ""
+        echo "Report excerpt:"
+        echo '```markdown'
+        sed -n '1,220p' "$report_path"
+        echo '```'
+    } | cut -c "1-${max_chars}"
+}

--- a/scripts/lib/proof-packet.sh
+++ b/scripts/lib/proof-packet.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Durable proof packet helpers.
+#
+# Proof packets are local-only run artifacts. They make escalated Octopus
+# workflows auditable without turning the plugin into a full project manager.
+
+octo_proof_enabled() {
+    case "${OCTOPUS_PROOF_PACKET:-1}" in
+        0|false|FALSE|off|OFF|no|NO) return 1 ;;
+    esac
+    command -v jq >/dev/null 2>&1
+}
+
+octo_proof_sanitize_id() {
+    local raw="${1:-}"
+    local sanitized
+    sanitized=$(printf '%s' "$raw" \
+        | tr '[:upper:]' '[:lower:]' \
+        | tr -cs 'a-z0-9._-' '-' \
+        | sed 's/^-//; s/-$//; s/--*/-/g')
+    if [[ -z "$sanitized" ]]; then
+        sanitized="run-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+    fi
+    printf '%s\n' "$sanitized"
+}
+
+_octo_proof_now() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+_octo_proof_json_object() {
+    local json="${1:-}"
+    [[ -z "$json" ]] && json="{}"
+    jq -c -n --arg value "$json" 'try ($value | fromjson) catch $value'
+}
+
+octo_proof_init() {
+    local workflow="${1:-workflow}"
+    local goal="${2:-}"
+    local profile_json="${3:-}"
+    [[ -z "$profile_json" ]] && profile_json="{}"
+
+    octo_proof_enabled || return 1
+
+    local run_id root run_dir started_at profile_value
+    run_id=$(octo_proof_sanitize_id "${OCTOPUS_PROOF_RUN_ID:-${CLAUDE_CODE_SESSION:-${workflow}-$(date -u +%Y%m%dT%H%M%SZ)-$$}}")
+    root="${OCTOPUS_PROOF_ROOT:-${HOME}/.claude-octopus/runs}"
+    run_dir="${root}/${run_id}"
+    started_at=$(_octo_proof_now)
+    profile_value=$(_octo_proof_json_object "$profile_json")
+
+    mkdir -p "$run_dir/artifacts"
+    : > "$run_dir/proof.jsonl"
+
+    jq -n \
+        --arg workflow "$workflow" \
+        --arg goal "$goal" \
+        --arg run_id "$run_id" \
+        --arg run_dir "$run_dir" \
+        --arg started_at "$started_at" \
+        --argjson profile "$profile_value" \
+        '{
+          schema: 1,
+          run_id: $run_id,
+          workflow: $workflow,
+          goal: $goal,
+          status: "running",
+          started_at: $started_at,
+          finished_at: null,
+          run_dir: $run_dir,
+          profile: $profile
+        }' > "$run_dir/state.json"
+
+    octo_proof_event "$run_dir" "started" "$(jq -n \
+        --arg workflow "$workflow" \
+        --arg goal "$goal" \
+        --argjson profile "$profile_value" \
+        '{workflow:$workflow, goal:$goal, profile:$profile}')"
+
+    printf '%s\n' "$run_dir"
+}
+
+octo_proof_event() {
+    local run_dir="$1"
+    local type="$2"
+    local data_json="${3:-}"
+    [[ -z "$data_json" ]] && data_json="{}"
+
+    [[ -n "$run_dir" && -d "$run_dir" ]] || return 0
+    octo_proof_enabled || return 0
+
+    local at
+    at=$(_octo_proof_now)
+    jq -c -n \
+        --arg at "$at" \
+        --arg type "$type" \
+        --arg data "$data_json" \
+        '{at:$at, type:$type, data:(try ($data | fromjson) catch $data)}' >> "$run_dir/proof.jsonl"
+}
+
+octo_proof_artifact() {
+    local run_dir="$1"
+    local kind="$2"
+    local path="$3"
+    local note="${4:-}"
+    local exists="false"
+    [[ -e "$path" ]] && exists="true"
+
+    octo_proof_event "$run_dir" "artifact" "$(jq -n \
+        --arg kind "$kind" \
+        --arg path "$path" \
+        --arg note "$note" \
+        --argjson exists "$exists" \
+        '{kind:$kind, path:$path, note:$note, exists:$exists}')"
+}
+
+octo_proof_command() {
+    local run_dir="$1"
+    local command_text="$2"
+    local exit_code="${3:-0}"
+    local output_ref="${4:-}"
+
+    octo_proof_event "$run_dir" "command" "$(jq -n \
+        --arg command "$command_text" \
+        --arg output_ref "$output_ref" \
+        --arg exit_code "$exit_code" \
+        '{command:$command, exit_code:($exit_code|tonumber? // $exit_code), output_ref:$output_ref}')"
+}
+
+octo_proof_claim() {
+    local run_dir="$1"
+    local claim="$2"
+    local claim_status="${3:-unverified}"
+    local evidence="${4:-}"
+
+    octo_proof_event "$run_dir" "claim" "$(jq -n \
+        --arg claim "$claim" \
+        --arg status "$claim_status" \
+        --arg evidence "$evidence" \
+        '{claim:$claim, status:$status, evidence:$evidence}')"
+}
+
+octo_proof_capture_provider_status() {
+    local run_dir="$1"
+    local status_file="$2"
+
+    [[ -n "$run_dir" && -d "$run_dir" && -f "$status_file" ]] || return 0
+    octo_proof_enabled || return 0
+
+    while IFS='|' read -r provider provider_status detail; do
+        [[ -z "${provider:-}" ]] && continue
+        detail="${detail:-}"
+        octo_proof_event "$run_dir" "provider_status" "$(jq -n \
+            --arg provider "$provider" \
+            --arg status "$provider_status" \
+            --arg detail "$detail" \
+            '{provider:$provider, status:$status, detail:$detail}')"
+
+        case "$provider_status" in
+            fallback|auth-failed)
+                local replacement=""
+                if [[ "$detail" == *"->"* ]]; then
+                    replacement="${detail##*->}"
+                    replacement="${replacement#"${replacement%%[![:space:]]*}"}"
+                fi
+                octo_proof_event "$run_dir" "provider_substitution" "$(jq -n \
+                    --arg provider "$provider" \
+                    --arg status "$provider_status" \
+                    --arg detail "$detail" \
+                    --arg replacement "$replacement" \
+                    '{provider:$provider, status:$status, detail:$detail, replacement:$replacement}')"
+                ;;
+        esac
+    done < "$status_file"
+}
+
+octo_proof_finalize() {
+    local run_dir="$1"
+    local verdict="${2:-unknown}"
+    local summary="${3:-}"
+
+    [[ -n "$run_dir" && -d "$run_dir" ]] || return 0
+    octo_proof_enabled || return 0
+
+    local finished_at state_file tmp_file
+    finished_at=$(_octo_proof_now)
+    state_file="$run_dir/state.json"
+    tmp_file=$(mktemp "${TMPDIR:-/tmp}/octopus-proof-state.XXXXXX")
+
+    if [[ -f "$state_file" ]]; then
+        jq \
+            --arg status "$verdict" \
+            --arg summary "$summary" \
+            --arg finished_at "$finished_at" \
+            '.status = $status | .summary = $summary | .finished_at = $finished_at' \
+            "$state_file" > "$tmp_file"
+        mv "$tmp_file" "$state_file"
+    else
+        rm -f "$tmp_file"
+    fi
+
+    octo_proof_event "$run_dir" "finalized" "$(jq -n \
+        --arg verdict "$verdict" \
+        --arg summary "$summary" \
+        '{verdict:$verdict, summary:$summary}')"
+
+    {
+        echo "# Octopus Proof Packet"
+        echo ""
+        jq -r '"Workflow: " + (.workflow // "unknown")' "$state_file" 2>/dev/null || echo "Workflow: unknown"
+        echo "Verdict: $verdict"
+        jq -r '"Run ID: " + (.run_id // "unknown")' "$state_file" 2>/dev/null || true
+        jq -r '"Started: " + (.started_at // "unknown")' "$state_file" 2>/dev/null || true
+        echo "Finished: $finished_at"
+        jq -r '"Goal: " + (.goal // "")' "$state_file" 2>/dev/null || true
+        echo ""
+        echo "Summary: $summary"
+        echo ""
+        echo "## Artifacts"
+        jq -r '
+          select(.type == "artifact")
+          | "- " + (.data.kind // "artifact") + ": " + (.data.path // "") +
+            (if (.data.note // "") != "" then " (" + .data.note + ")" else "" end)
+        ' "$run_dir/proof.jsonl" 2>/dev/null || true
+        echo ""
+        echo "## Provider Substitutions"
+        jq -r '
+          select(.type == "provider_substitution")
+          | "- " + (.data.provider // "provider") + ": " + (.data.status // "unknown") +
+            (if (.data.detail // "") != "" then " - " + .data.detail else "" end)
+        ' "$run_dir/proof.jsonl" 2>/dev/null || true
+        echo ""
+        echo "Raw events: $run_dir/proof.jsonl"
+    } > "$run_dir/summary.md"
+}

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -338,6 +338,11 @@ review_run() {
     local findings_file="$results_dir/review-findings-${timestamp}.json"
     mkdir -p "$results_dir"
 
+    local proof_dir=""
+    if declare -F octo_proof_init >/dev/null 2>&1 && octo_proof_enabled; then
+        proof_dir=$(octo_proof_init "review" "target=${target} focus=${focus}" "$profile_json" 2>/dev/null || true)
+    fi
+
     log INFO "review_run: target=$target focus=$focus provenance=$provenance autonomy=$autonomy history=$history"
 
     # ── REVIEW.md ────────────────────────────────────────────────────────────
@@ -345,6 +350,15 @@ review_run() {
     local review_context=""
     if [[ -n "$REVIEW_ALWAYS_CHECK" || -n "$REVIEW_STYLE_RULES" ]]; then
         review_context="Repository review rules (from REVIEW.md):\nAlways check:\n${REVIEW_ALWAYS_CHECK}\nStyle:\n${REVIEW_STYLE_RULES}"
+    fi
+
+    # Graphify companion context is passive: use an existing graph report when
+    # present, but never build or refresh a graph from /octo:review itself.
+    local graphify_context=""
+    if declare -F octo_graphify_context_for_prompt >/dev/null 2>&1; then
+        local graphify_root
+        graphify_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+        graphify_context=$(octo_graphify_context_for_prompt "$graphify_root" 12000 2>/dev/null || true)
     fi
 
     # ── Collect diff ─────────────────────────────────────────────────────────
@@ -359,6 +373,14 @@ review_run() {
     if [[ -z "$diff_content" ]]; then
         log WARN "review_run: no diff found for target=$target"
         echo '{"findings":[],"message":"No changes found to review"}' > "$findings_file"
+        if [[ -n "$proof_dir" ]]; then
+            octo_proof_artifact "$proof_dir" "review-findings" "$findings_file" "no changes found"
+            octo_proof_claim "$proof_dir" "No changes found to review" "verified" "$findings_file"
+            octo_proof_capture_provider_status "$proof_dir" "$provider_status_file"
+            octo_proof_finalize "$proof_dir" "no_changes" "No changes found to review."
+            echo "Proof packet: $proof_dir"
+        fi
+        rm -f "$provider_status_file"
         render_terminal_report "$findings_file"
         return 0
     fi
@@ -421,10 +443,27 @@ review_run() {
     fi
     export TIMEOUT="$review_timeout"
 
+    if [[ -n "$proof_dir" ]]; then
+        octo_proof_event "$proof_dir" "review_scope" "$(jq -n \
+            --arg target "$target" \
+            --arg focus "$focus" \
+            --arg provenance "$provenance" \
+            --arg autonomy "$autonomy" \
+            --arg publish "$publish" \
+            --arg debate "$debate" \
+            --arg history "$history" \
+            --argjson diff_lines "$diff_lines" \
+            '{target:$target, focus:$focus, provenance:$provenance, autonomy:$autonomy, publish:$publish, debate:$debate, history:$history, diff_lines:$diff_lines}')"
+    fi
+
     # ── ROUND 1: Parallel agent fleet ────────────────────────────────────────
     log INFO "review_run: Round 1 — parallel specialist fleet (timeout=${review_timeout}s, diff=${diff_lines} lines)"
     local fleet
     fleet=$(build_review_fleet)
+
+    if [[ -n "$proof_dir" ]]; then
+        octo_proof_event "$proof_dir" "provider_fleet" "$(printf '%s\n' "$fleet" | jq -R -s 'split("\n")[:-1]')"
+    fi
 
     local agent_prompt_base
     agent_prompt_base="You are a code reviewer. Review the following diff and return ONLY a JSON object with a 'findings' array.
@@ -438,6 +477,7 @@ Severity guide:
 
 ${review_context}
 ${review_history_context}
+${graphify_context}
 
 Focus areas for this review: ${focus}
 Provenance: ${provenance}
@@ -531,6 +571,13 @@ ${agent_prompt_base}"
     if [[ $_r1_failed -ge $_r1_total ]] && [[ $_r1_total -gt 0 ]]; then
         log ERROR "review_run: ALL Round 1 providers failed ($_r1_failed/$_r1_total). Review output is unreliable."
         echo "{\"findings\":[],\"warning\":\"All $_r1_total review providers failed. No code was actually reviewed. Run /octo:doctor to diagnose provider issues.\"}" > "$findings_file"
+        if [[ -n "$proof_dir" ]]; then
+            octo_proof_artifact "$proof_dir" "review-findings" "$findings_file" "all providers failed"
+            octo_proof_claim "$proof_dir" "Code was reviewed by at least one provider" "contradicted" "$findings_file"
+            octo_proof_capture_provider_status "$proof_dir" "$provider_status_file"
+            octo_proof_finalize "$proof_dir" "fail" "All ${_r1_total} Round 1 review providers failed."
+            echo "Proof packet: $proof_dir"
+        fi
         render_terminal_report "$findings_file"
         print_provider_report "$provider_status_file"
         return 1
@@ -633,6 +680,10 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
     echo "$final_json" > "$findings_file"
     log INFO "review_run: findings saved to $findings_file"
 
+    if [[ -n "$proof_dir" ]]; then
+        octo_proof_artifact "$proof_dir" "review-findings" "$findings_file" "final review findings"
+    fi
+
     if [[ -n "$review_state_file" ]] && declare -F pr_review_state_append_round >/dev/null 2>&1; then
         local final_findings classification providers_json
         final_findings=$(echo "$final_json" | jq -c '.findings // []' 2>/dev/null || echo "[]")
@@ -643,6 +694,9 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
         review_timeline=$(pr_review_state_render_timeline "$review_state_file" "$review_head_sha" "$classification" "$current_round" 2>/dev/null || true)
         if pr_review_state_append_round "$review_state_file" "$review_host" "$review_repo" "$review_pr_number" "$review_head_sha" "$providers_json" "$final_findings" "$classification" 2>/dev/null; then
             log INFO "review_run: round-aware state saved to $review_state_file"
+            if [[ -n "$proof_dir" ]]; then
+                octo_proof_artifact "$proof_dir" "review-history-state" "$review_state_file" "round-aware PR review state"
+            fi
         fi
     fi
 
@@ -671,6 +725,25 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
     if [[ -n "$review_timeline" ]]; then
         echo ""
         echo "$review_timeline"
+    fi
+
+    if [[ -n "$proof_dir" ]]; then
+        local proof_finding_count proof_warning proof_verdict proof_summary
+        proof_finding_count=$(jq '.findings | length' "$findings_file" 2>/dev/null || echo "0")
+        proof_warning=$(jq -r '.warning // empty' "$findings_file" 2>/dev/null || true)
+        if [[ -n "$proof_warning" ]]; then
+            proof_verdict="fail"
+        elif [[ "$proof_finding_count" -gt 0 ]]; then
+            proof_verdict="findings"
+        else
+            proof_verdict="pass"
+        fi
+        proof_summary="/octo:review completed with ${proof_finding_count} finding(s)."
+        octo_proof_claim "$proof_dir" "Review findings were written to disk" "verified" "$findings_file"
+        octo_proof_capture_provider_status "$proof_dir" "$provider_status_file"
+        octo_proof_finalize "$proof_dir" "$proof_verdict" "$proof_summary"
+        echo ""
+        echo "Proof packet: $proof_dir"
     fi
 
     # v9.0: Print provider report card — always last, impossible to miss

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -92,6 +92,8 @@ source "${SCRIPT_DIR}/lib/preflight.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/dispatch.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/progressive.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/pr-review-state.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/lib/proof-packet.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/lib/graphify.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/review.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/workflows.sh"
 source "${SCRIPT_DIR}/lib/doctor.sh" 2>/dev/null || true

--- a/tests/unit/test-graphify-companion-integration.sh
+++ b/tests/unit/test-graphify-companion-integration.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Static integration checks for optional Graphify companion wiring.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ORCH="$PROJECT_ROOT/scripts/orchestrate.sh"
+REVIEW_LIB="$PROJECT_ROOT/scripts/lib/review.sh"
+DOCTOR_LIB="$PROJECT_ROOT/scripts/lib/doctor.sh"
+GRAPHIFY_LIB="$PROJECT_ROOT/scripts/lib/graphify.sh"
+CLAUDE_SETUP="$PROJECT_ROOT/.claude/commands/setup.md"
+CODEX_SETUP="$PROJECT_ROOT/commands/octo-setup.md"
+CLAUDE_REVIEW="$PROJECT_ROOT/.claude/commands/review.md"
+CODEX_REVIEW="$PROJECT_ROOT/commands/octo-review.md"
+CHANGELOG="$PROJECT_ROOT/CHANGELOG.md"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Graphify companion integration"
+
+assert_file_has() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    test_case "$label"
+    if grep -qE "$pattern" "$file"; then
+        test_pass
+    else
+        test_fail "pattern not found in $(basename "$file"): $pattern"
+    fi
+}
+
+assert_file_lacks() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    test_case "$label"
+    if grep -qE "$pattern" "$file"; then
+        test_fail "unexpected pattern found in $(basename "$file"): $pattern"
+    else
+        test_pass
+    fi
+}
+
+test_case "graphify.sh has valid bash syntax"
+if [[ -f "$GRAPHIFY_LIB" ]] && bash -n "$GRAPHIFY_LIB" 2>/dev/null; then
+    test_pass
+else
+    test_fail "missing or invalid $GRAPHIFY_LIB"
+fi
+
+assert_file_has "$ORCH" 'lib/graphify\.sh' \
+    "orchestrate.sh sources Graphify companion module"
+
+assert_file_has "$REVIEW_LIB" 'octo_graphify_context_for_prompt' \
+    "review_run reads Graphify companion context"
+
+assert_file_has "$REVIEW_LIB" 'Graphify companion context' \
+    "review prompt labels Graphify context"
+
+assert_file_lacks "$REVIEW_LIB" 'graphify extract' \
+    "review_run does not auto-build Graphify graphs"
+
+assert_file_has "$DOCTOR_LIB" 'doctor_check_companions' \
+    "doctor has companion category"
+
+assert_file_has "$DOCTOR_LIB" 'graphify-cli' \
+    "doctor checks Graphify CLI"
+
+assert_file_has "$DOCTOR_LIB" 'graphify-graph' \
+    "doctor checks existing Graphify graph"
+
+assert_file_has "$DOCTOR_LIB" 'graphify-freshness' \
+    "doctor checks Graphify freshness"
+
+assert_file_has "$CLAUDE_SETUP" 'graphify' \
+    "Claude setup detects Graphify"
+
+assert_file_has "$CODEX_SETUP" 'graphify' \
+    "Codex setup detects Graphify"
+
+assert_file_has "$CLAUDE_REVIEW" 'Graphify' \
+    "Claude review documents Graphify companion"
+
+assert_file_has "$CODEX_REVIEW" 'Graphify' \
+    "Codex review documents Graphify companion"
+
+assert_file_has "$CHANGELOG" 'Graphify' \
+    "changelog notes Graphify companion"
+
+test_summary

--- a/tests/unit/test-graphify-companion.sh
+++ b/tests/unit/test-graphify-companion.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Unit tests for optional Graphify companion integration.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GRAPHIFY_LIB="$PROJECT_ROOT/scripts/lib/graphify.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Graphify companion"
+
+if [[ -f "$GRAPHIFY_LIB" ]]; then
+    # shellcheck source=/dev/null
+    source "$GRAPHIFY_LIB"
+fi
+
+assert_function_exists() {
+    local fn="$1"
+    test_case "function exists: $fn"
+    if declare -F "$fn" >/dev/null 2>&1; then
+        test_pass
+    else
+        test_fail "missing function: $fn"
+    fi
+}
+
+test_case "graphify.sh has valid bash syntax"
+if [[ -f "$GRAPHIFY_LIB" ]] && bash -n "$GRAPHIFY_LIB" 2>/dev/null; then
+    test_pass
+else
+    test_fail "missing or invalid $GRAPHIFY_LIB"
+fi
+
+for fn in \
+    octo_graphify_enabled \
+    octo_graphify_bin \
+    octo_graphify_out_dir \
+    octo_graphify_status_json \
+    octo_graphify_context_for_prompt \
+    octo_graphify_install_hint
+do
+    assert_function_exists "$fn"
+done
+
+test_case "OCTOPUS_GRAPHIFY=0 disables companion"
+if declare -F octo_graphify_enabled >/dev/null 2>&1; then
+    if OCTOPUS_GRAPHIFY=0 octo_graphify_enabled; then
+        test_fail "expected Graphify companion to be disabled"
+    else
+        test_pass
+    fi
+else
+    test_fail "octo_graphify_enabled is not defined"
+fi
+
+test_case "status reports missing CLI and missing graph"
+if declare -F octo_graphify_status_json >/dev/null 2>&1; then
+    tmp_root=$(mktemp -d)
+    status=$(OCTOPUS_GRAPHIFY_BIN="$tmp_root/missing-graphify" octo_graphify_status_json "$tmp_root")
+    if jq -e '.installed == false and .graph_exists == false and .report_exists == false and .enabled == true' <<< "$status" >/dev/null; then
+        test_pass
+    else
+        test_fail "unexpected status for missing CLI/graph: $status"
+    fi
+    rm -rf "$tmp_root"
+else
+    test_fail "octo_graphify_status_json is not defined"
+fi
+
+test_case "status reports installed CLI, graph, report, hook, and stale flag"
+if declare -F octo_graphify_status_json >/dev/null 2>&1; then
+    tmp_root=$(mktemp -d)
+    mock_bin="$tmp_root/graphify"
+    cat > "$mock_bin" <<'MOCK'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "graphify 0.7.7" ;;
+  hook)
+    if [[ "${2:-}" == "status" ]]; then
+      echo "post-commit: installed"
+      echo "post-checkout: installed"
+    fi
+    ;;
+  *) echo "Usage: graphify <command>" ;;
+esac
+MOCK
+    chmod +x "$mock_bin"
+    mkdir -p "$tmp_root/graphify-out"
+    echo '{"nodes":[],"edges":[]}' > "$tmp_root/graphify-out/graph.json"
+    echo "# Graph Report" > "$tmp_root/graphify-out/GRAPH_REPORT.md"
+    : > "$tmp_root/graphify-out/needs_update"
+    status=$(OCTOPUS_GRAPHIFY_BIN="$mock_bin" octo_graphify_status_json "$tmp_root")
+    if jq -e '.installed == true and .version == "0.7.7" and .graph_exists == true and .report_exists == true and .needs_update == true and (.hook_status | test("post-commit: installed"))' <<< "$status" >/dev/null; then
+        test_pass
+    else
+        test_fail "unexpected status for installed CLI/graph: $status"
+    fi
+    rm -rf "$tmp_root"
+else
+    test_fail "octo_graphify_status_json is not defined"
+fi
+
+test_case "context prompt includes report excerpt and avoids auto-build guidance"
+if declare -F octo_graphify_context_for_prompt >/dev/null 2>&1; then
+    tmp_root=$(mktemp -d)
+    mock_bin="$tmp_root/graphify"
+    printf '#!/usr/bin/env bash\necho "graphify 0.7.7"\n' > "$mock_bin"
+    chmod +x "$mock_bin"
+    mkdir -p "$tmp_root/graphify-out"
+    echo '{"nodes":[],"edges":[]}' > "$tmp_root/graphify-out/graph.json"
+    cat > "$tmp_root/graphify-out/GRAPH_REPORT.md" <<'REPORT'
+# Graph Report
+
+## God Nodes
+- Review Pipeline
+
+## Suggested Questions
+- How does review state connect to provider fallback handling?
+REPORT
+    context=$(OCTOPUS_GRAPHIFY_BIN="$mock_bin" octo_graphify_context_for_prompt "$tmp_root" 2000)
+    if grep -q "Graphify companion context" <<< "$context" \
+       && grep -q "Review Pipeline" <<< "$context" \
+       && grep -q "Use this as an orientation map" <<< "$context" \
+       && ! grep -q "graphify extract" <<< "$context"; then
+        test_pass
+    else
+        test_fail "context prompt was unexpected: $context"
+    fi
+    rm -rf "$tmp_root"
+else
+    test_fail "octo_graphify_context_for_prompt is not defined"
+fi
+
+test_case "context helper can be sourced from zsh shells"
+if command -v zsh >/dev/null 2>&1; then
+    tmp_root=$(mktemp -d)
+    mock_bin="$tmp_root/graphify"
+    printf '#!/usr/bin/env bash\necho "graphify 0.7.7"\n' > "$mock_bin"
+    chmod +x "$mock_bin"
+    mkdir -p "$tmp_root/graphify-out"
+    echo '{"nodes":[],"edges":[]}' > "$tmp_root/graphify-out/graph.json"
+    echo "# Graph Report" > "$tmp_root/graphify-out/GRAPH_REPORT.md"
+    context=$(
+        TMP_ROOT="$tmp_root" \
+        MOCK_BIN="$mock_bin" \
+        GRAPHIFY_LIB="$GRAPHIFY_LIB" \
+        zsh -fc 'source "$GRAPHIFY_LIB"; OCTOPUS_GRAPHIFY_BIN="$MOCK_BIN" octo_graphify_context_for_prompt "$TMP_ROOT" 2000'
+    )
+    if grep -q "Graphify companion context" <<< "$context"; then
+        test_pass
+    else
+        test_fail "zsh-sourced context prompt was unexpected: $context"
+    fi
+    rm -rf "$tmp_root"
+else
+    test_skip "zsh not installed"
+fi
+
+test_case "context prompt is empty when graph report is absent"
+if declare -F octo_graphify_context_for_prompt >/dev/null 2>&1; then
+    tmp_root=$(mktemp -d)
+    context=$(OCTOPUS_GRAPHIFY_BIN="$tmp_root/missing-graphify" octo_graphify_context_for_prompt "$tmp_root" 2000)
+    if [[ -z "$context" ]]; then
+        test_pass
+    else
+        test_fail "expected empty context without graph report, got: $context"
+    fi
+    rm -rf "$tmp_root"
+else
+    test_fail "octo_graphify_context_for_prompt is not defined"
+fi
+
+test_summary

--- a/tests/unit/test-proof-packet-integration.sh
+++ b/tests/unit/test-proof-packet-integration.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Static integration checks for proof-packet wiring.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ORCH="$PROJECT_ROOT/scripts/orchestrate.sh"
+REVIEW_LIB="$PROJECT_ROOT/scripts/lib/review.sh"
+PROOF_LIB="$PROJECT_ROOT/scripts/lib/proof-packet.sh"
+CLAUDE_CMD="$PROJECT_ROOT/.claude/commands/review.md"
+CODEX_CMD="$PROJECT_ROOT/commands/octo-review.md"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "proof packet integration"
+
+assert_file_has() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    test_case "$label"
+    if grep -qE "$pattern" "$file"; then
+        test_pass
+    else
+        test_fail "pattern not found in $(basename "$file"): $pattern"
+    fi
+}
+
+test_case "proof-packet.sh has valid bash syntax"
+if [[ -f "$PROOF_LIB" ]] && bash -n "$PROOF_LIB" 2>/dev/null; then
+    test_pass
+else
+    test_fail "missing or invalid $PROOF_LIB"
+fi
+
+assert_file_has "$ORCH" 'lib/proof-packet\.sh' \
+    "orchestrate.sh sources proof packet module"
+
+assert_file_has "$REVIEW_LIB" 'octo_proof_init' \
+    "review_run initializes a proof packet"
+
+assert_file_has "$REVIEW_LIB" 'octo_proof_artifact' \
+    "review_run records findings artifacts"
+
+assert_file_has "$REVIEW_LIB" 'octo_proof_capture_provider_status' \
+    "review_run captures provider status"
+
+assert_file_has "$REVIEW_LIB" 'octo_proof_finalize' \
+    "review_run finalizes the proof packet"
+
+assert_file_has "$CLAUDE_CMD" '~/.claude-octopus/runs' \
+    "Claude slash command documents proof packet location"
+
+assert_file_has "$CLAUDE_CMD" 'OCTOPUS_PROOF_PACKET=0' \
+    "Claude slash command documents proof packet opt-out"
+
+assert_file_has "$CODEX_CMD" 'proof packet' \
+    "Codex command mirrors proof packet behavior"
+
+test_summary

--- a/tests/unit/test-proof-packet.sh
+++ b/tests/unit/test-proof-packet.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Unit tests for durable Octopus proof packets.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROOF_LIB="$PROJECT_ROOT/scripts/lib/proof-packet.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "proof packet"
+
+if [[ -f "$PROOF_LIB" ]]; then
+    # shellcheck source=/dev/null
+    source "$PROOF_LIB"
+fi
+
+assert_function_exists() {
+    local fn="$1"
+    test_case "function exists: $fn"
+    if declare -F "$fn" >/dev/null 2>&1; then
+        test_pass
+    else
+        test_fail "missing function: $fn"
+    fi
+}
+
+test_case "proof-packet.sh has valid bash syntax"
+if [[ -f "$PROOF_LIB" ]] && bash -n "$PROOF_LIB" 2>/dev/null; then
+    test_pass
+else
+    test_fail "missing or invalid $PROOF_LIB"
+fi
+
+for fn in \
+    octo_proof_enabled \
+    octo_proof_sanitize_id \
+    octo_proof_init \
+    octo_proof_event \
+    octo_proof_artifact \
+    octo_proof_command \
+    octo_proof_claim \
+    octo_proof_capture_provider_status \
+    octo_proof_finalize
+do
+    assert_function_exists "$fn"
+done
+
+test_case "OCTOPUS_PROOF_PACKET=0 disables proof packets"
+if declare -F octo_proof_enabled >/dev/null 2>&1; then
+    if OCTOPUS_PROOF_PACKET=0 octo_proof_enabled; then
+        test_fail "expected proof packets to be disabled"
+    else
+        test_pass
+    fi
+else
+    test_fail "octo_proof_enabled is not defined"
+fi
+
+test_case "init creates sanitized run directory and state"
+if declare -F octo_proof_init >/dev/null 2>&1; then
+    tmp_home=$(mktemp -d)
+    HOME="$tmp_home"
+    OCTOPUS_PROOF_ROOT="$tmp_home/proofs"
+    OCTOPUS_PROOF_RUN_ID="review run / 123"
+    run_dir=$(octo_proof_init "review" "review staged changes" '{"target":"staged"}')
+    if [[ "$run_dir" == "$tmp_home/proofs/review-run-123" ]] \
+       && [[ -f "$run_dir/proof.jsonl" ]] \
+       && [[ -f "$run_dir/state.json" ]] \
+       && jq -e '.schema == 1 and .workflow == "review" and .status == "running"' "$run_dir/state.json" >/dev/null; then
+        test_pass
+    else
+        test_fail "proof packet directory or state was not initialized correctly"
+    fi
+    rm -rf "$tmp_home"
+else
+    test_fail "octo_proof_init is not defined"
+fi
+
+test_case "events, claims, commands, and artifacts append valid JSONL"
+if declare -F octo_proof_event >/dev/null 2>&1; then
+    tmp_home=$(mktemp -d)
+    HOME="$tmp_home"
+    OCTOPUS_PROOF_ROOT="$tmp_home/proofs"
+    OCTOPUS_PROOF_RUN_ID="events"
+    run_dir=$(octo_proof_init "review" "goal" '{}')
+    octo_proof_event "$run_dir" "custom" '{"hello":"world"}'
+    octo_proof_claim "$run_dir" "all tests passed" "verified" "tests/unit/test-proof-packet.sh"
+    octo_proof_command "$run_dir" "npm test" "0" "logs/test.txt"
+    octo_proof_artifact "$run_dir" "review-findings" "$run_dir/findings.json" "final review findings"
+    if jq -s -e '
+        length == 5
+        and .[1].type == "custom"
+        and .[2].type == "claim"
+        and .[2].data.status == "verified"
+        and .[3].type == "command"
+        and .[3].data.exit_code == 0
+        and .[4].type == "artifact"
+      ' "$run_dir/proof.jsonl" >/dev/null; then
+        test_pass
+    else
+        test_fail "proof.jsonl did not contain valid expected events"
+    fi
+    rm -rf "$tmp_home"
+else
+    test_fail "octo_proof_event is not defined"
+fi
+
+test_case "provider status capture records fallback substitutions"
+if declare -F octo_proof_capture_provider_status >/dev/null 2>&1; then
+    tmp_home=$(mktemp -d)
+    HOME="$tmp_home"
+    OCTOPUS_PROOF_ROOT="$tmp_home/proofs"
+    OCTOPUS_PROOF_RUN_ID="providers"
+    run_dir=$(octo_proof_init "review" "goal" '{}')
+    status_file="$tmp_home/provider-status.txt"
+    {
+        echo "codex|fallback|Round 2 -> claude-sonnet"
+        echo "gemini|ok|Round 1 findings"
+        echo "perplexity|auth-failed|PERPLEXITY_API_KEY missing"
+    } > "$status_file"
+    octo_proof_capture_provider_status "$run_dir" "$status_file"
+    if jq -s -e '
+        [.[].type] | index("provider_substitution")
+      ' "$run_dir/proof.jsonl" >/dev/null \
+       && jq -s -e '
+        [.[] | select(.type == "provider_status" and .data.provider == "gemini" and .data.status == "ok")] | length == 1
+      ' "$run_dir/proof.jsonl" >/dev/null \
+       && jq -s -e '
+        [.[] | select(.type == "provider_substitution" and .data.provider == "codex" and .data.status == "fallback")] | length == 1
+      ' "$run_dir/proof.jsonl" >/dev/null; then
+        test_pass
+    else
+        test_fail "provider status capture did not record fallback substitutions"
+    fi
+    rm -rf "$tmp_home"
+else
+    test_fail "octo_proof_capture_provider_status is not defined"
+fi
+
+test_case "finalize updates state and writes markdown summary"
+if declare -F octo_proof_finalize >/dev/null 2>&1; then
+    tmp_home=$(mktemp -d)
+    HOME="$tmp_home"
+    OCTOPUS_PROOF_ROOT="$tmp_home/proofs"
+    OCTOPUS_PROOF_RUN_ID="finalize"
+    run_dir=$(octo_proof_init "review" "goal" '{}')
+    octo_proof_artifact "$run_dir" "findings" "$run_dir/findings.json" "review output"
+    octo_proof_finalize "$run_dir" "pass" "No issues found."
+    if jq -e '.status == "pass" and .summary == "No issues found."' "$run_dir/state.json" >/dev/null \
+       && grep -q "Proof Packet" "$run_dir/summary.md" \
+       && grep -q "Verdict: pass" "$run_dir/summary.md" \
+       && grep -q "review output" "$run_dir/summary.md"; then
+        test_pass
+    else
+        test_fail "finalized state or markdown summary was incorrect"
+    fi
+    rm -rf "$tmp_home"
+else
+    test_fail "octo_proof_finalize is not defined"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary
- add durable local proof packets for /octo:review runs
- add optional Graphify companion detection and passive review context injection
- bump plugin, adapter manifests, README badge, and changelog to v9.35.0

## Verification
- bash -n scripts/lib/graphify.sh scripts/lib/proof-packet.sh scripts/lib/doctor.sh scripts/lib/review.sh scripts/orchestrate.sh
- bash tests/unit/test-graphify-companion.sh
- bash tests/unit/test-graphify-companion-integration.sh
- bash tests/unit/test-proof-packet.sh
- bash tests/unit/test-proof-packet-integration.sh
- bash tests/unit/test-pr-review-state.sh
- bash tests/unit/test-review-history-integration.sh
- bash tests/smoke/test-syntax.sh
- bash tests/test-version-consistency.sh
- git diff --check
- claude plugin validate .claude-plugin/plugin.json
- claude plugin validate .claude-plugin/marketplace.json
- ./scripts/orchestrate.sh doctor companions --json
- no-diff /octo:review smoke with proof packet output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v9.35.0 Release Notes

* **New Features**
  * Added local proof packets for /octo:review, automatically storing evidence, findings, and artifacts. Disable with OCTOPUS_PROOF_PACKET=0.
  * Added optional Graphify companion integration for passive graph context injection into reviews. Disable with OCTOPUS_GRAPHIFY=0.

* **Documentation**
  * Updated setup and review guides to document proof packet and Graphify companion functionality.

* **Chores**
  * Version bumped to 9.35.0 across all plugins and manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->