### PR TITLE
fix: support Windows Git Bash doctor paths

### DIFF
--- a/.claude/commands/doctor.md
+++ b/.claude/commands/doctor.md
@@ -10,10 +10,38 @@ allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 
 Run environment diagnostics across 12 check categories. Identifies issues AND offers to fix them interactively.
 
-## Step 1: Run Full Diagnostics
+## Step 1: Resolve Plugin Root and Run Full Diagnostics
+
+Use this resolver before running any Octopus script. It avoids relying on the
+`~/.claude-octopus/plugin` symlink, which may be unavailable on Windows Git
+Bash installs. Run this as a single Bash call.
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor --verbose
+OCTO_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  OCTO_PLUGIN_ROOT="${HOME}/.claude-octopus/plugin"
+fi
+if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]] && command -v octopus >/dev/null 2>&1; then
+  OCTO_BIN="$(command -v octopus)"
+  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd)"
+fi
+if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  OCTO_PLUGIN_ROOT="$(
+    find "${HOME}/.claude/plugins" -type f -path "*/scripts/orchestrate.sh" -print 2>/dev/null \
+      | sed 's#/scripts/orchestrate.sh$##' \
+      | grep -E '(nyldn-plugins|claude-octopus|/octo(/[0-9]|$))' \
+      | sort \
+      | tail -1
+  )"
+fi
+if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  echo "Claude Octopus plugin root not found. Reinstall the octo plugin, then retry /octo:doctor."
+  exit 1
+fi
+mkdir -p "${HOME}/.claude-octopus"
+ln -sfn "$OCTO_PLUGIN_ROOT" "${HOME}/.claude-octopus/plugin" 2>/dev/null || true
+export OCTO_PLUGIN_ROOT
+cd "$OCTO_PLUGIN_ROOT" && bash scripts/orchestrate.sh doctor --verbose
 ```
 
 ## Step 2: Run Dependency Check
@@ -31,9 +59,12 @@ After diagnostics complete, analyze the output for fixable issues. For EACH fixa
 1. **Missing providers** — offer to install Codex/Gemini CLI
 2. **Expired auth** — offer to run login commands
 3. **RTK not installed** — offer brew/cargo install (saves 60-90% tokens)
-4. **RTK hook not configured** — offer `rtk init -g`
+4. **RTK hook not configured on macOS/Linux** — offer `rtk init -g`
 5. **Missing deps** — offer `install-deps.sh install`
 6. **Stale state** — offer cleanup
+
+On Windows Git Bash, do not offer `rtk init -g` for hook remediation. RTK uses
+CLAUDE.md injection mode there, so treat the hook check as skipped.
 
 **Example: Multiple fixable issues found:**
 
@@ -45,7 +76,7 @@ AskUserQuestion({
     multiSelect: true,
     options: [
       {label: "Install RTK", description: "brew install rtk — saves 60-90% tokens on bash output"},
-      {label: "Configure RTK hook", description: "rtk init -g — auto-compress bash output"},
+      {label: "Configure RTK hook", description: "rtk init -g — auto-compress bash output on macOS/Linux"},
       {label: "Install missing deps", description: "Run install-deps.sh install"},
       {label: "Skip all", description: "I'll fix these manually"}
     ]
@@ -76,7 +107,11 @@ Always include at the end of doctor output:
 ```bash
 echo "=== Token Optimization ==="
 echo "RTK: $(command -v rtk >/dev/null 2>&1 && echo "installed $(rtk --version 2>&1 | head -1)" || echo "not installed")"
-echo "RTK Hook: $(grep -q 'rtk' "${HOME}/.claude/settings.json" 2>/dev/null && echo "active" || echo "not configured")"
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) rtk_hook_status="skipped (Windows Git Bash uses RTK CLAUDE.md injection mode)" ;;
+  *) rtk_hook_status="$(grep -q 'rtk' "${HOME}/.claude/settings.json" 2>/dev/null && echo "active" || echo "not configured")" ;;
+esac
+echo "RTK Hook: $rtk_hook_status"
 echo "Compressor: $(wc -l < "${HOME}/.claude-octopus/analytics/compression.jsonl" 2>/dev/null || echo 0) events"
 echo "octo-compress: $(command -v octo-compress >/dev/null 2>&1 && echo "available" || echo "not in PATH")"
 ```

--- a/.claude/skills/skill-doctor.md
+++ b/.claude/skills/skill-doctor.md
@@ -44,10 +44,38 @@ Run environment diagnostics across 11 check categories. Identifies misconfigured
 
 ## The Process
 
-### Step 1: Run Full Diagnostics
+### Step 1: Resolve Plugin Root and Run Full Diagnostics
+
+Use this resolver before running Octopus scripts. Do not assume
+`~/.claude-octopus/plugin` exists; Windows Git Bash installs may not support the
+stable symlink. Run this as a single Bash call.
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor
+OCTO_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  OCTO_PLUGIN_ROOT="${HOME}/.claude-octopus/plugin"
+fi
+if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]] && command -v octopus >/dev/null 2>&1; then
+  OCTO_BIN="$(command -v octopus)"
+  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd)"
+fi
+if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  OCTO_PLUGIN_ROOT="$(
+    find "${HOME}/.claude/plugins" -type f -path "*/scripts/orchestrate.sh" -print 2>/dev/null \
+      | sed 's#/scripts/orchestrate.sh$##' \
+      | grep -E '(nyldn-plugins|claude-octopus|/octo(/[0-9]|$))' \
+      | sort \
+      | tail -1
+  )"
+fi
+if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  echo "Claude Octopus plugin root not found. Reinstall the octo plugin, then retry /octo:doctor."
+  exit 1
+fi
+mkdir -p "${HOME}/.claude-octopus"
+ln -sfn "$OCTO_PLUGIN_ROOT" "${HOME}/.claude-octopus/plugin" 2>/dev/null || true
+export OCTO_PLUGIN_ROOT
+cd "$OCTO_PLUGIN_ROOT" && bash scripts/orchestrate.sh doctor
 ```
 
 This runs all 11 check categories and displays a formatted report.
@@ -120,7 +148,11 @@ AskUserQuestion({
 ```
 If user chooses install, run it, then offer hook setup.
 
-**RTK installed but hook not configured:**
+**RTK installed but hook not configured on macOS/Linux:**
+
+On Windows Git Bash, do not offer `rtk init -g`. RTK uses CLAUDE.md injection
+mode there, so report the hook check as skipped.
+
 ```javascript
 AskUserQuestion({
   questions: [{
@@ -128,7 +160,7 @@ AskUserQuestion({
     header: "RTK Hook",
     multiSelect: false,
     options: [
-      {label: "Run rtk init -g (Recommended)", description: "Auto-installs Claude Code bash hook"},
+      {label: "Run rtk init -g (Recommended)", description: "Auto-installs Claude Code bash hook on macOS/Linux"},
       {label: "Skip", description: "I'll configure it later"}
     ]
   }]
@@ -195,7 +227,7 @@ All checks pass — no action needed.
 | Stale state | Delete `.octo/state.json` and re-initialize |
 | Invalid hooks.json | Check `hooks.json` syntax — must be valid JSON |
 | RTK not installed | Offer to install: `brew install rtk && rtk init -g` (saves 60-90% tokens). Use AskUserQuestion to offer brew vs cargo install. |
-| RTK installed but hook not configured | Offer to configure: use AskUserQuestion to offer `rtk init -g` for automatic bash output compression |
+| RTK installed but hook not configured | On macOS/Linux, offer `rtk init -g`; on Windows Git Bash, report skipped because RTK uses CLAUDE.md injection mode |
 | RTK gain stats unavailable | Run some bash commands first, then check `rtk gain` to see token savings |
 | Conflicting plugins | Uninstall conflicting plugins or adjust scope |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Resolve the installed Octopus plugin root in `/octo:doctor` before invoking scripts so Windows Git Bash installs do not depend on `~/.claude-octopus/plugin` symlink creation (#360).
+- Skip RTK hook remediation warnings on Windows Git Bash, where RTK uses CLAUDE.md injection mode instead of the macOS/Linux hook path (#361).
+
 ---
 
 ## [9.37.0] - 2026-05-08

--- a/commands/octo-doctor.md
+++ b/commands/octo-doctor.md
@@ -9,10 +9,38 @@ allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 
 Run environment diagnostics across 12 check categories. Identifies issues AND offers to fix them interactively.
 
-## Step 1: Run Full Diagnostics
+## Step 1: Resolve Plugin Root and Run Full Diagnostics
+
+Use this resolver before running any Octopus script. It avoids relying on the
+`~/.claude-octopus/plugin` symlink, which may be unavailable on Windows Git
+Bash installs. Run this as a single Bash call.
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor --verbose
+OCTO_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  OCTO_PLUGIN_ROOT="${HOME}/.claude-octopus/plugin"
+fi
+if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]] && command -v octopus >/dev/null 2>&1; then
+  OCTO_BIN="$(command -v octopus)"
+  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd)"
+fi
+if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  OCTO_PLUGIN_ROOT="$(
+    find "${HOME}/.claude/plugins" -type f -path "*/scripts/orchestrate.sh" -print 2>/dev/null \
+      | sed 's#/scripts/orchestrate.sh$##' \
+      | grep -E '(nyldn-plugins|claude-octopus|/octo(/[0-9]|$))' \
+      | sort \
+      | tail -1
+  )"
+fi
+if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  echo "Claude Octopus plugin root not found. Reinstall the octo plugin, then retry /octo:doctor."
+  exit 1
+fi
+mkdir -p "${HOME}/.claude-octopus"
+ln -sfn "$OCTO_PLUGIN_ROOT" "${HOME}/.claude-octopus/plugin" 2>/dev/null || true
+export OCTO_PLUGIN_ROOT
+cd "$OCTO_PLUGIN_ROOT" && bash scripts/orchestrate.sh doctor --verbose
 ```
 
 ## Step 2: Run Dependency Check
@@ -30,9 +58,12 @@ After diagnostics complete, analyze the output for fixable issues. For EACH fixa
 1. **Missing providers** — offer to install Codex/Gemini CLI
 2. **Expired auth** — offer to run login commands
 3. **RTK not installed** — offer brew/cargo install (saves 60-90% tokens)
-4. **RTK hook not configured** — offer `rtk init -g`
+4. **RTK hook not configured on macOS/Linux** — offer `rtk init -g`
 5. **Missing deps** — offer `install-deps.sh install`
 6. **Stale state** — offer cleanup
+
+On Windows Git Bash, do not offer `rtk init -g` for hook remediation. RTK uses
+CLAUDE.md injection mode there, so treat the hook check as skipped.
 
 **Example: Multiple fixable issues found:**
 
@@ -44,7 +75,7 @@ AskUserQuestion({
     multiSelect: true,
     options: [
       {label: "Install RTK", description: "brew install rtk — saves 60-90% tokens on bash output"},
-      {label: "Configure RTK hook", description: "rtk init -g — auto-compress bash output"},
+      {label: "Configure RTK hook", description: "rtk init -g — auto-compress bash output on macOS/Linux"},
       {label: "Install missing deps", description: "Run install-deps.sh install"},
       {label: "Skip all", description: "I'll fix these manually"}
     ]
@@ -75,7 +106,11 @@ Always include at the end of doctor output:
 ```bash
 echo "=== Token Optimization ==="
 echo "RTK: $(command -v rtk >/dev/null 2>&1 && echo "installed $(rtk --version 2>&1 | head -1)" || echo "not installed")"
-echo "RTK Hook: $(grep -q 'rtk' "${HOME}/.claude/settings.json" 2>/dev/null && echo "active" || echo "not configured")"
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) rtk_hook_status="skipped (Windows Git Bash uses RTK CLAUDE.md injection mode)" ;;
+  *) rtk_hook_status="$(grep -q 'rtk' "${HOME}/.claude/settings.json" 2>/dev/null && echo "active" || echo "not configured")" ;;
+esac
+echo "RTK Hook: $rtk_hook_status"
 echo "Compressor: $(wc -l < "${HOME}/.claude-octopus/analytics/compression.jsonl" 2>/dev/null || echo 0) events"
 echo "octo-compress: $(command -v octo-compress >/dev/null 2>&1 && echo "available" || echo "not in PATH")"
 ```

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "${PLUGIN_ROOT}/scripts/lib/cursor-agent.sh" 2>/dev/null || true
+source "${PLUGIN_ROOT}/scripts/lib/plugin-root.sh" 2>/dev/null || true
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -108,13 +109,19 @@ check_deps() {
         if [[ -f "$settings_file" ]] && grep -q 'rtk' "$settings_file" 2>/dev/null; then
             rtk_hook="yes"
         fi
-        if [[ "$rtk_hook" == "yes" ]]; then
+        if declare -f octo_is_windows_git_bash >/dev/null 2>&1 && octo_is_windows_git_bash; then
+            ok+=("rtk:RTK ${rtk_ver} installed; hook check skipped on Windows Git Bash (RTK uses CLAUDE.md injection mode)")
+        elif [[ "$rtk_hook" == "yes" ]]; then
             ok+=("rtk:RTK ${rtk_ver} installed, hook active (bash output compression enabled)")
         else
             warnings+=("rtk:RTK ${rtk_ver} installed but Claude Code hook not configured. Run: rtk init -g")
         fi
     else
-        warnings+=("rtk:RTK not installed (optional) — saves 60-90% tokens on bash output. Install: brew install rtk && rtk init -g. Run /octo:doctor for guided setup.")
+        if declare -f octo_is_windows_git_bash >/dev/null 2>&1 && octo_is_windows_git_bash; then
+            warnings+=("rtk:RTK not installed (optional) — saves tokens on bash output. On Windows Git Bash, install RTK and use its CLAUDE.md injection mode instead of rtk init -g.")
+        else
+            warnings+=("rtk:RTK not installed (optional) — saves 60-90% tokens on bash output. Install: brew install rtk && rtk init -g. Run /octo:doctor for guided setup.")
+        fi
     fi
 
     # Statusline resolver

--- a/scripts/lib/plugin-root.sh
+++ b/scripts/lib/plugin-root.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Plugin root helpers for Claude Octopus.
+# Source-safe: no main execution block.
+
+octo_is_windows_git_bash() {
+    local uname_s="${1:-}"
+    if [[ -z "$uname_s" ]]; then
+        uname_s="$(uname -s 2>/dev/null || true)"
+    fi
+
+    case "$uname_s" in
+        MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    esac
+
+    [[ "${OS:-}" == "Windows_NT" ]] && {
+        [[ -n "${MSYSTEM:-}" ]] || [[ -n "${MINGW_PREFIX:-}" ]] ||
+        [[ "${OSTYPE:-}" == msys* ]] || [[ "${OSTYPE:-}" == mingw* ]] ||
+        [[ "${OSTYPE:-}" == cygwin* ]]
+    }
+}
+
+octo_write_stable_script_shim() {
+    local plugin_root="$1"
+    local stable_root="$2"
+    local rel_path="$3"
+    local src="${plugin_root}/${rel_path}"
+    local dst="${stable_root}/${rel_path}"
+
+    [[ -f "$src" ]] || return 0
+
+    local quoted_src
+    printf -v quoted_src '%q' "$src"
+    mkdir -p "$(dirname "$dst")"
+    {
+        printf '%s\n' '#!/usr/bin/env bash'
+        printf 'exec %s "$@"\n' "$quoted_src"
+    } > "$dst"
+    chmod +x "$dst" 2>/dev/null || true
+}
+
+octo_ensure_stable_plugin_root() {
+    local plugin_root="$1"
+    local stable_root="${2:-${HOME}/.claude-octopus/plugin}"
+
+    [[ -n "$plugin_root" && -d "$plugin_root" ]] || return 1
+
+    mkdir -p "$(dirname "$stable_root")"
+
+    if [[ -L "$stable_root" || -f "$stable_root" ]]; then
+        rm -f "$stable_root" 2>/dev/null || true
+    fi
+
+    if [[ ! -e "$stable_root" ]]; then
+        ln -s "$plugin_root" "$stable_root" 2>/dev/null || true
+    fi
+
+    if [[ -L "$stable_root" && -x "$stable_root/scripts/orchestrate.sh" ]]; then
+        return 0
+    fi
+
+    if [[ -e "$stable_root" && ! -d "$stable_root" ]]; then
+        rm -f "$stable_root" 2>/dev/null || true
+    fi
+
+    # Windows Git Bash often cannot create native symlinks without Developer
+    # Mode/admin rights. Keep the stable path usable by writing tiny wrappers
+    # for script entry points referenced by commands and skills.
+    mkdir -p "$stable_root"
+    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/orchestrate.sh"
+    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/install-deps.sh"
+    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/helpers/check-providers.sh"
+    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/scheduler/octopus-scheduler.sh"
+    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/state-manager.sh"
+    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/octo-state.sh"
+    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/agent-registry.sh"
+    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/reactions.sh"
+    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/migrate-todos.sh"
+    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/claude-mem-bridge.sh"
+
+    [[ -x "$stable_root/scripts/orchestrate.sh" ]]
+}

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -7,11 +7,14 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+source "${SCRIPT_DIR}/lib/plugin-root.sh" 2>/dev/null || true
 
 # Self-heal: ensure the stable symlink exists for LLM Bash tool access.
 # The SessionStart hook normally creates this, but if doctor (or any command)
 # is invoked before the hook fires, the symlink may be missing. (fixes #318)
-if [[ ! -e "${HOME}/.claude-octopus/plugin" ]]; then
+if declare -f octo_ensure_stable_plugin_root >/dev/null 2>&1; then
+    octo_ensure_stable_plugin_root "$PLUGIN_DIR" >/dev/null 2>&1 || true
+elif [[ ! -e "${HOME}/.claude-octopus/plugin" ]]; then
     mkdir -p "${HOME}/.claude-octopus"
     ln -sfn "$PLUGIN_DIR" "${HOME}/.claude-octopus/plugin"
 fi

--- a/scripts/session-manager.sh
+++ b/scripts/session-manager.sh
@@ -6,6 +6,7 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/session-id.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/lib/plugin-root.sh" 2>/dev/null || true
 
 # Export session variables for Claude Code v2.1.9+
 export_session_variables() {
@@ -30,8 +31,12 @@ export_session_variables() {
     # references to ${HOME}/.claude-octopus/plugin/scripts/... resolve correctly.
     # Created BEFORE session directories so the symlink exists even if mkdir fails.
     local plugin_root="${CLAUDE_PLUGIN_ROOT:-$(dirname "$SCRIPT_DIR")}"
-    mkdir -p "${HOME}/.claude-octopus"
-    ln -sfn "$plugin_root" "${HOME}/.claude-octopus/plugin"
+    if declare -f octo_ensure_stable_plugin_root >/dev/null 2>&1; then
+        octo_ensure_stable_plugin_root "$plugin_root" >/dev/null 2>&1 || true
+    else
+        mkdir -p "${HOME}/.claude-octopus"
+        ln -sfn "$plugin_root" "${HOME}/.claude-octopus/plugin"
+    fi
 
     # Session directories
     export OCTOPUS_SESSION_DIR="${HOME}/.claude-octopus/sessions/${OCTOPUS_SESSION_ID}"

--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -35,10 +35,38 @@ Run environment diagnostics across 11 check categories. Identifies misconfigured
 
 ## The Process
 
-### Step 1: Run Full Diagnostics
+### Step 1: Resolve Plugin Root and Run Full Diagnostics
+
+Use this resolver before running Octopus scripts. Do not assume
+`~/.claude-octopus/plugin` exists; Windows Git Bash installs may not support the
+stable symlink. Run this as a single Bash call.
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor
+OCTO_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  OCTO_PLUGIN_ROOT="${HOME}/.claude-octopus/plugin"
+fi
+if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]] && command -v octopus >/dev/null 2>&1; then
+  OCTO_BIN="$(command -v octopus)"
+  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd)"
+fi
+if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  OCTO_PLUGIN_ROOT="$(
+    find "${HOME}/.claude/plugins" -type f -path "*/scripts/orchestrate.sh" -print 2>/dev/null \
+      | sed 's#/scripts/orchestrate.sh$##' \
+      | grep -E '(nyldn-plugins|claude-octopus|/octo(/[0-9]|$))' \
+      | sort \
+      | tail -1
+  )"
+fi
+if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
+  echo "Claude Octopus plugin root not found. Reinstall the octo plugin, then retry /octo:doctor."
+  exit 1
+fi
+mkdir -p "${HOME}/.claude-octopus"
+ln -sfn "$OCTO_PLUGIN_ROOT" "${HOME}/.claude-octopus/plugin" 2>/dev/null || true
+export OCTO_PLUGIN_ROOT
+cd "$OCTO_PLUGIN_ROOT" && bash scripts/orchestrate.sh doctor
 ```
 
 This runs all 11 check categories and displays a formatted report.
@@ -111,7 +139,11 @@ AskUserQuestion({
 ```
 If user chooses install, run it, then offer hook setup.
 
-**RTK installed but hook not configured:**
+**RTK installed but hook not configured on macOS/Linux:**
+
+On Windows Git Bash, do not offer `rtk init -g`. RTK uses CLAUDE.md injection
+mode there, so report the hook check as skipped.
+
 ```javascript
 AskUserQuestion({
   questions: [{
@@ -119,7 +151,7 @@ AskUserQuestion({
     header: "RTK Hook",
     multiSelect: false,
     options: [
-      {label: "Run rtk init -g (Recommended)", description: "Auto-installs Claude Code bash hook"},
+      {label: "Run rtk init -g (Recommended)", description: "Auto-installs Claude Code bash hook on macOS/Linux"},
       {label: "Skip", description: "I'll configure it later"}
     ]
   }]
@@ -184,7 +216,7 @@ All checks pass — no action needed.
 | Stale state | Delete `.octo/state.json` and re-initialize |
 | Invalid hooks.json | Check `hooks.json` syntax — must be valid JSON |
 | RTK not installed | Offer to install: `brew install rtk && rtk init -g` (saves 60-90% tokens). Use AskUserQuestion to offer brew vs cargo install. |
-| RTK installed but hook not configured | Offer to configure: use AskUserQuestion to offer `rtk init -g` for automatic bash output compression |
+| RTK installed but hook not configured | On macOS/Linux, offer `rtk init -g`; on Windows Git Bash, report skipped because RTK uses CLAUDE.md injection mode |
 | RTK gain stats unavailable | Run some bash commands first, then check `rtk gain` to see token savings |
 | Conflicting plugins | Uninstall conflicting plugins or adjust scope |
 

--- a/tests/unit/test-windows-doctor-compat.sh
+++ b/tests/unit/test-windows-doctor-compat.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Tests for Windows Git Bash doctor/plugin-root compatibility.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$PROJECT_ROOT/tests/helpers/test-framework.sh"
+
+test_suite "Windows doctor compatibility"
+
+test_case "platform helper detects Windows Git Bash families"
+source "$PROJECT_ROOT/scripts/lib/plugin-root.sh"
+if octo_is_windows_git_bash "MINGW64_NT-10.0" &&
+   octo_is_windows_git_bash "MSYS_NT-10.0" &&
+   octo_is_windows_git_bash "CYGWIN_NT-10.0" &&
+   ! octo_is_windows_git_bash "Darwin"; then
+    test_pass
+else
+    test_fail "Windows Git Bash detection did not match expected platforms"
+fi
+
+test_case "doctor commands use portable plugin-root discovery"
+doctor_source="$(< "$PROJECT_ROOT/.claude/commands/doctor.md")"
+doctor_generated="$(< "$PROJECT_ROOT/commands/octo-doctor.md")"
+if assert_contains "$doctor_source" 'find "${HOME}/.claude/plugins"' "source command searches Claude plugin installs" &&
+   assert_contains "$doctor_source" 'cd "$OCTO_PLUGIN_ROOT" && bash scripts/orchestrate.sh doctor --verbose' "source command runs doctor from resolved root" &&
+   assert_contains "$doctor_generated" 'find "${HOME}/.claude/plugins"' "generated command searches Claude plugin installs" &&
+   assert_contains "$doctor_generated" 'cd "$OCTO_PLUGIN_ROOT" && bash scripts/orchestrate.sh doctor --verbose' "generated command runs doctor from resolved root"; then
+    test_pass
+fi
+
+test_case "install-deps skips RTK hook warning on Windows Git Bash"
+tmp_home="$TEST_TMP_DIR/win-home"
+mock_bin="$TEST_TMP_DIR/mock-win-bin"
+mkdir -p "$tmp_home" "$mock_bin"
+printf '%s\n' '#!/usr/bin/env bash' 'echo MINGW64_NT-10.0' > "$mock_bin/uname"
+printf '%s\n' '#!/usr/bin/env bash' 'echo "rtk 0.0.0-test"' > "$mock_bin/rtk"
+chmod +x "$mock_bin/uname" "$mock_bin/rtk"
+
+output="$(HOME="$tmp_home" PATH="$mock_bin:$PATH" bash "$PROJECT_ROOT/scripts/install-deps.sh" check 2>&1 || true)"
+if assert_contains "$output" "hook check skipped on Windows Git Bash" "Windows RTK hook check is skipped" &&
+   assert_not_contains "$output" "hook not configured" "Windows RTK check should not warn about missing Claude hook" &&
+   assert_not_contains "$output" "Run: rtk init -g" "Windows RTK check should not recommend rtk init -g"; then
+    test_pass
+fi
+
+test_case "session manager writes stable script shims when symlink root is unavailable"
+shim_home="$TEST_TMP_DIR/shim-home"
+mkdir -p "$shim_home/.claude-octopus/plugin"
+HOME="$shim_home" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$PROJECT_ROOT/scripts/session-manager.sh" export >/dev/null
+shim="$shim_home/.claude-octopus/plugin/scripts/orchestrate.sh"
+if assert_file_exists "$shim" "orchestrate shim exists" &&
+   assert_file_contains "$shim" "$PROJECT_ROOT/scripts/orchestrate.sh" "shim points at real plugin root"; then
+    test_pass
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

- resolve the installed Octopus plugin root before `/octo:doctor` invokes scripts
- create stable script shims when `~/.claude-octopus/plugin` symlink creation is unavailable
- skip RTK hook remediation warnings on Windows Git Bash, where RTK uses CLAUDE.md injection mode
- add targeted Windows doctor compatibility tests

## Fixes

Closes #360
Closes #361

## Validation

- `bash tests/unit/test-windows-doctor-compat.sh`
- `bash tests/unit/test-rtk-detection.sh`
- `bash tests/smoke/test-syntax.sh`
- `bash tests/smoke/test-packaging-integrity.sh`
- `bash scripts/build-codex-skills.sh --check`
- `claude plugin validate .`
- `./scripts/orchestrate.sh doctor --json` with isolated temp `HOME`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Octopus plugin root resolution to work reliably across platforms, including Windows Git Bash.
  * Fixed RTK remediation behavior: now correctly skips hook configuration on Windows Git Bash, which uses alternative injection mode.

* **Documentation**
  * Updated doctor command documentation with enhanced plugin discovery steps and platform-specific guidance for RTK configuration.

* **Tests**
  * Added comprehensive Windows Git Bash compatibility test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->