### PR TITLE
Fix claude-mem port discovery and add work queue hook

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -380,6 +380,17 @@
           "timeout": 5
         }
       ]
+    },
+    {
+      "matcher": {},
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/github-work-queue-watch.sh",
+          "additionalContext": "Periodically surface open nyldn/claude-octopus issues and PRs while working in this repo.",
+          "timeout": 8
+        }
+      ]
     }
   ],
   "StopFailure": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add a debounced, read-only GitHub work queue hook that periodically surfaces open `nyldn/claude-octopus` issues and PRs while working in this repo, with explicit guidance to fix relevant items kindly and only push/comment/merge after user approval.
+
+### Fixed
+
+- Discover the `claude-mem` worker port from `~/.claude-mem/settings.json` or the per-UID default instead of hardcoding `37777` on Linux/macOS (#363).
+
 ---
 
 ## [9.37.1] - 2026-05-08

--- a/hooks/github-work-queue-watch.sh
+++ b/hooks/github-work-queue-watch.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# github-work-queue-watch.sh - Periodically surface open upstream work.
+# UserPromptSubmit hook. Read-only: never comments, pushes, merges, or edits.
+
+set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur.
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
+trap _octo_hook_exit EXIT
+
+escape_for_json() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+emit_context() {
+    local context="$1"
+    local escaped
+    escaped=$(escape_for_json "$context")
+    printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"%s"}}\n' "$escaped"
+}
+
+emit_continue() {
+    printf '{"decision":"continue"}\n'
+}
+
+[[ "${OCTOPUS_GITHUB_WORK_QUEUE:-on}" == "off" ]] && { emit_continue; exit 0; }
+
+input=""
+if [[ ! -t 0 ]]; then
+    if command -v timeout >/dev/null 2>&1; then
+        input=$(timeout 3 cat 2>/dev/null || true)
+    else
+        input=$(cat 2>/dev/null || true)
+    fi
+fi
+
+cwd="${PWD:-}"
+if [[ -n "$input" ]] && command -v jq >/dev/null 2>&1; then
+    hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // .workspace // empty' 2>/dev/null || true)
+    [[ -n "$hook_cwd" && "$hook_cwd" != "null" ]] && cwd="$hook_cwd"
+fi
+
+[[ -n "$cwd" && -d "$cwd" ]] || { emit_continue; exit 0; }
+
+if ! git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    emit_continue
+    exit 0
+fi
+
+remote_urls=$(git -C "$cwd" remote -v 2>/dev/null || true)
+if ! printf '%s\n' "$remote_urls" | grep -qE 'github\.com[:/]nyldn/(claude-octopus|claude-octopus-dev)(\.git)?'; then
+    emit_continue
+    exit 0
+fi
+
+repo="${OCTOPUS_GITHUB_WORK_QUEUE_REPO:-nyldn/claude-octopus}"
+watch_issue="${OCTOPUS_GITHUB_WORK_QUEUE_ISSUE:-363}"
+limit="${OCTOPUS_GITHUB_WORK_QUEUE_LIMIT:-3}"
+interval="${OCTOPUS_GITHUB_WORK_QUEUE_INTERVAL_SECONDS:-21600}"
+case "$limit" in ''|*[!0-9]*) limit=3 ;; esac
+case "$interval" in ''|*[!0-9]*) interval=21600 ;; esac
+home_dir="${HOME:-/tmp}"
+state_dir="${OCTOPUS_STATE_DIR:-${home_dir}/.claude-octopus}/github-work-queue"
+state_file="${state_dir}/$(printf '%s' "$repo" | tr '/:' '--').last"
+
+now=$(date +%s)
+if [[ "${OCTOPUS_GITHUB_WORK_QUEUE_FORCE:-0}" != "1" && -f "$state_file" ]]; then
+    last=$(cat "$state_file" 2>/dev/null || echo 0)
+    case "$last" in ''|*[!0-9]*) last=0 ;; esac
+    if [[ $((now - last)) -lt "$interval" ]]; then
+        emit_continue
+        exit 0
+    fi
+fi
+
+command -v gh >/dev/null 2>&1 || { emit_continue; exit 0; }
+gh auth status --hostname github.com >/dev/null 2>&1 || { emit_continue; exit 0; }
+
+focus_issue=""
+if [[ -n "$watch_issue" ]]; then
+    focus_issue=$(gh issue view "$watch_issue" --repo "$repo" \
+        --json number,title,state,url \
+        --jq 'select(.state == "OPEN") | "#\(.number) \(.title) - \(.url)"' 2>/dev/null || true)
+fi
+
+open_issues=$(gh issue list --repo "$repo" --state open --limit "$limit" \
+    --json number,title,url \
+    --jq '.[] | "#\(.number) \(.title) - \(.url)"' 2>/dev/null || true)
+open_prs=$(gh pr list --repo "$repo" --state open --limit "$limit" \
+    --json number,title,url \
+    --jq '.[] | "#\(.number) \(.title) - \(.url)"' 2>/dev/null || true)
+
+mkdir -p "$state_dir" 2>/dev/null || true
+printf '%s\n' "$now" > "$state_file" 2>/dev/null || true
+
+[[ -n "$focus_issue$open_issues$open_prs" ]] || { emit_continue; exit 0; }
+
+message="[Octopus GitHub queue] Open upstream work exists in ${repo}."
+if [[ -n "$focus_issue" ]]; then
+    message="${message}"$'\n'"Focus issue: ${focus_issue}"
+fi
+if [[ -n "$open_issues" ]]; then
+    message="${message}"$'\n'"Open issues:"$'\n'"${open_issues}"
+fi
+if [[ -n "$open_prs" ]]; then
+    message="${message}"$'\n'"Open PRs:"$'\n'"${open_prs}"
+fi
+message="${message}"$'\n'"When the current user request is repo maintenance or a relevant fix, kindly pick up the most applicable item: inspect it, make a focused local change, verify it, and only push/comment/merge after the user asks."
+
+emit_context "$message"

--- a/scripts/claude-mem-bridge.sh
+++ b/scripts/claude-mem-bridge.sh
@@ -5,7 +5,41 @@
 
 set -euo pipefail
 
-CLAUDE_MEM_PORT="${CLAUDE_MEM_PORT:-37777}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/plugin-root.sh" 2>/dev/null || true
+
+claude_mem_default_port() {
+    local discovered=""
+    local settings="${CLAUDE_MEM_SETTINGS_FILE:-${HOME:-}/.claude-mem/settings.json}"
+
+    if [[ -f "$settings" ]] && command -v jq >/dev/null 2>&1; then
+        discovered=$(jq -r '.CLAUDE_MEM_WORKER_PORT // empty' "$settings" 2>/dev/null || true)
+        case "$discovered" in
+            ''|*[!0-9]*) discovered="" ;;
+        esac
+    fi
+
+    if [[ -n "$discovered" ]]; then
+        printf '%s\n' "$discovered"
+        return 0
+    fi
+
+    # claude-mem uses a fixed worker port on Windows; Linux/macOS use
+    # 37700 + (uid % 100). Preserve Windows while avoiding a stale Linux default.
+    if declare -f octo_is_windows_git_bash >/dev/null 2>&1 && octo_is_windows_git_bash; then
+        printf '37777\n'
+        return 0
+    fi
+
+    local uid=""
+    uid=$(id -u 2>/dev/null || true)
+    case "$uid" in
+        ''|*[!0-9]*) printf '37777\n' ;;
+        *) printf '%s\n' "$((37700 + uid % 100))" ;;
+    esac
+}
+
+CLAUDE_MEM_PORT="${CLAUDE_MEM_PORT:-$(claude_mem_default_port)}"
 CLAUDE_MEM_HOST="${CLAUDE_MEM_HOST:-localhost}"
 CLAUDE_MEM_URL="http://${CLAUDE_MEM_HOST}:${CLAUDE_MEM_PORT}"
 CLAUDE_MEM_TIMEOUT=3  # seconds — fast fail

--- a/tests/unit/test-claude-mem-integration.sh
+++ b/tests/unit/test-claude-mem-integration.sh
@@ -51,6 +51,58 @@ else
     fail "Bridge suppresses stderr" "missing 2>/dev/null"
 fi
 
+# ── 3b. Bridge discovers claude-mem worker port ─────────────────────
+
+mock_bridge_bin="$TEST_TMP_DIR/claude-mem-mock-bin"
+mkdir -p "$mock_bridge_bin"
+cat > "$mock_bridge_bin/curl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CURL_ARGS_FILE"
+exit 1
+SH
+chmod +x "$mock_bridge_bin/curl"
+
+test_case "Bridge reads claude-mem worker port from settings"
+settings_home="$TEST_TMP_DIR/claude-mem-settings-home"
+mkdir -p "$settings_home/.claude-mem"
+printf '{"CLAUDE_MEM_WORKER_PORT":37742}\n' > "$settings_home/.claude-mem/settings.json"
+settings_curl_args="$TEST_TMP_DIR/claude-mem-settings-curl.txt"
+CURL_ARGS_FILE="$settings_curl_args" HOME="$settings_home" PATH="$mock_bridge_bin:$PATH" "$BRIDGE" available >/dev/null || true
+if grep -q 'localhost:37742/api/health' "$settings_curl_args" 2>/dev/null; then
+    test_pass
+else
+    test_fail "expected bridge health check to use settings port 37742"
+fi
+
+test_case "Bridge derives Linux/macOS default port from UID"
+uid_home="$TEST_TMP_DIR/claude-mem-uid-home"
+uid_bin="$TEST_TMP_DIR/claude-mem-uid-bin"
+uid_curl_args="$TEST_TMP_DIR/claude-mem-uid-curl.txt"
+mkdir -p "$uid_home" "$uid_bin"
+printf '%s\n' '#!/usr/bin/env bash' 'echo 1001' > "$uid_bin/id"
+chmod +x "$uid_bin/id"
+CURL_ARGS_FILE="$uid_curl_args" HOME="$uid_home" PATH="$uid_bin:$mock_bridge_bin:$PATH" "$BRIDGE" available >/dev/null || true
+if grep -q 'localhost:37701/api/health' "$uid_curl_args" 2>/dev/null; then
+    test_pass
+else
+    test_fail "expected bridge health check to use UID-derived port 37701"
+fi
+
+test_case "Bridge preserves Windows Git Bash default port"
+win_home="$TEST_TMP_DIR/claude-mem-win-home"
+win_bin="$TEST_TMP_DIR/claude-mem-win-bin"
+win_curl_args="$TEST_TMP_DIR/claude-mem-win-curl.txt"
+mkdir -p "$win_home" "$win_bin"
+printf '%s\n' '#!/usr/bin/env bash' 'echo MINGW64_NT-10.0' > "$win_bin/uname"
+printf '%s\n' '#!/usr/bin/env bash' 'echo 1001' > "$win_bin/id"
+chmod +x "$win_bin/uname" "$win_bin/id"
+CURL_ARGS_FILE="$win_curl_args" HOME="$win_home" PATH="$win_bin:$mock_bridge_bin:$PATH" "$BRIDGE" available >/dev/null || true
+if grep -q 'localhost:37777/api/health' "$win_curl_args" 2>/dev/null; then
+    test_pass
+else
+    test_fail "expected bridge health check to keep Windows default port 37777"
+fi
+
 # ── 4. Doctor check for companion plugin ─────────────────────────────
 
 if grep -c 'companion-claude-mem' "$ORCH" >/dev/null 2>&1; then

--- a/tests/unit/test-github-work-queue-hook.sh
+++ b/tests/unit/test-github-work-queue-hook.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Tests for the periodic GitHub work queue reminder hook.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$PROJECT_ROOT/tests/helpers/test-framework.sh"
+
+test_suite "GitHub work queue hook"
+
+HOOK="$PROJECT_ROOT/hooks/github-work-queue-watch.sh"
+HOOKS_JSON="$PROJECT_ROOT/.claude-plugin/hooks.json"
+
+test_case "hook exists and is executable"
+if [[ -x "$HOOK" ]]; then
+    test_pass
+else
+    test_fail "github-work-queue-watch.sh missing or not executable"
+fi
+
+test_case "hook is registered on UserPromptSubmit"
+if jq -e '.UserPromptSubmit[]?.hooks[]? | select(.command | contains("github-work-queue-watch.sh"))' "$HOOKS_JSON" >/dev/null; then
+    test_pass
+else
+    test_fail "github-work-queue-watch.sh not registered in UserPromptSubmit hooks"
+fi
+
+mock_bin="$TEST_TMP_DIR/github-work-queue-bin"
+mock_home="$TEST_TMP_DIR/github-work-queue-home"
+mkdir -p "$mock_bin" "$mock_home"
+cat > "$mock_bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "auth" ]]; then
+  exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+  echo "#363 claude-mem-bridge.sh hardcodes port 37777 - https://github.com/nyldn/claude-octopus/issues/363"
+  exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  echo "#363 claude-mem-bridge.sh hardcodes port 37777 - https://github.com/nyldn/claude-octopus/issues/363"
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  echo "#364 release v9.37.1 - https://github.com/nyldn/claude-octopus/pull/364"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$mock_bin/gh"
+
+test_case "hook emits open issues and PRs as additional context"
+output=$(cd "$PROJECT_ROOT" && HOME="$mock_home" PATH="$mock_bin:$PATH" OCTOPUS_GITHUB_WORK_QUEUE_FORCE=1 "$HOOK" <<'JSON'
+{"prompt":"what should we work on"}
+JSON
+)
+if assert_contains "$output" "additionalContext" "hook returns context" &&
+   assert_contains "$output" "#363 claude-mem-bridge.sh hardcodes port 37777" "hook includes focus issue" &&
+   assert_contains "$output" "Open PRs" "hook includes open PR section" &&
+   assert_contains "$output" "only push/comment/merge after the user asks" "hook stays non-destructive"; then
+    test_pass
+fi
+
+test_case "hook debounces repeated checks"
+debounce_home="$TEST_TMP_DIR/github-work-queue-debounce-home"
+mkdir -p "$debounce_home"
+first=$(cd "$PROJECT_ROOT" && HOME="$debounce_home" PATH="$mock_bin:$PATH" "$HOOK" <<'JSON'
+{"prompt":"first"}
+JSON
+)
+second=$(cd "$PROJECT_ROOT" && HOME="$debounce_home" PATH="$mock_bin:$PATH" "$HOOK" <<'JSON'
+{"prompt":"second"}
+JSON
+)
+if assert_contains "$first" "Open upstream work exists" "first run surfaces queue" &&
+   assert_not_contains "$second" "Open upstream work exists" "second run is debounced"; then
+    test_pass
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

- Fix `scripts/claude-mem-bridge.sh` so it discovers the claude-mem worker port from `~/.claude-mem/settings.json`, then falls back to `37700 + (uid % 100)` on Linux/macOS while preserving `37777` for Windows Git Bash.
- Add a debounced, read-only `UserPromptSubmit` hook that periodically surfaces open `nyldn/claude-octopus` issues and PRs while working in this repo, with guidance to make focused fixes and only push/comment/merge after user approval.
- Add regression coverage for issue #363 and the new GitHub work queue hook.

Closes #363.

## Validation

- `bash tests/unit/test-claude-mem-integration.sh`
- `bash tests/unit/test-github-work-queue-hook.sh`
- `bash tests/unit/test-hook-err-traps.sh`
- `bash tests/unit/test-stdin-timeout-guards.sh`
- `bash tests/smoke/test-syntax.sh`
- `bash tests/smoke/test-packaging-integrity.sh`
- `claude plugin validate .claude-plugin/plugin.json && claude plugin validate .claude-plugin/marketplace.json`
- `python3 scripts/validate-plugin-assembly.py --root . && git diff --check`
- Live hook smoke test with `OCTOPUS_GITHUB_WORK_QUEUE_FORCE=1` against `nyldn/claude-octopus`.
