### PR TITLE
chore: release v9.37.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.37.2"
+    "version": "9.37.3"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.37.2 - Multi-LLM orchestration for Claude Code with agent summaries, prompt-size preflight, research fanout, and Codex-compatible skills. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
-      "version": "9.37.2",
+      "description": "v9.37.3 - Multi-LLM orchestration for Claude Code with agent summaries, prompt-size preflight, research fanout, and Codex-compatible skills. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
+      "version": "9.37.3",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.37.2",
-  "description": "v9.37.2 \u2014 Agent summaries, prompt-size preflight, research fanout, and Codex-compatible portable skills. Run /octo:setup.",
+  "version": "9.37.3",
+  "description": "v9.37.3 \u2014 Agent summaries, prompt-size preflight, research fanout, and Codex-compatible portable skills. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.37.2",
+  "version": "9.37.3",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration — up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.37.2",
+  "version": "9.37.3",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.37.2"
+    "version": "9.37.3"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.37.2 - Multi-AI orchestration with agent summaries, prompt-size preflight, and Double Diamond workflow. 32 personas, 48 commands, 52 skills. Run /octo:setup after install.",
-      "version": "9.37.2",
+      "description": "v9.37.3 - Multi-AI orchestration with agent summaries, prompt-size preflight, and Double Diamond workflow. 32 personas, 48 commands, 52 skills. Run /octo:setup after install.",
+      "version": "9.37.3",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.37.2",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.37.2. Agent summaries, prompt-size preflight, 32 expert personas, 48 commands, 52 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.37.3",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.37.3. Agent summaries, prompt-size preflight, 32 expert personas, 48 commands, 52 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ---
 
+## [9.37.3] - 2026-05-11
+
+### Fixed
+
+- Sync the README version badge with the released plugin version so release validation passes after the #367 skill-path fix.
+
+---
+
 ## [9.37.2] - 2026-05-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.37.1-blue" alt="Version 9.37.1">
+  <img src="https://img.shields.io/badge/Version-9.37.3-blue" alt="Version 9.37.3">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.37.2",
+  "version": "9.37.3",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/tests/integration/test-plugin-expert-review.sh
+++ b/tests/integration/test-plugin-expert-review.sh
@@ -164,15 +164,15 @@ test_essential_documentation() {
 test_skills_structure() {
     print_test_header "Skills Structure"
 
-    # Check that skills directory exists
-    assert_dir_exists_custom ".claude/skills" "skills directory exists"
+    # Check that portable skills directory exists
+    assert_dir_exists_custom "skills" "portable skills directory exists"
 
     # Verify key skills exist (from plugin.json)
-    assert_file_exists ".claude/skills/flow-discover.md" "flow-discover skill exists"
-    assert_file_exists ".claude/skills/flow-define.md" "flow-define skill exists"
+    assert_file_exists "skills/flow-discover/SKILL.md" "flow-discover skill exists"
+    assert_file_exists "skills/flow-define/SKILL.md" "flow-define skill exists"
 
     # Check that skills have proper frontmatter structure
-    local skill_file="$PROJECT_ROOT/.claude/skills/flow-discover.md"
+    local skill_file="$PROJECT_ROOT/skills/flow-discover/SKILL.md"
     if [[ -f "$skill_file" ]]; then
         TOTAL_TESTS=$((TOTAL_TESTS + 1))
         if head -1 "$skill_file" | grep -q "^---$"; then
@@ -273,7 +273,7 @@ test_skill_quality() {
     local skill_count=0
     local skills_with_description=0
 
-    for skill_file in "$PROJECT_ROOT/.claude/skills"/*.md; do
+    for skill_file in "$PROJECT_ROOT"/skills/*/SKILL.md; do
         [[ -f "$skill_file" ]] || continue
         skill_count=$((skill_count + 1))
 
@@ -284,7 +284,10 @@ test_skill_quality() {
     done
 
     TOTAL_TESTS=$((TOTAL_TESTS + 1))
-    if [[ $skills_with_description -eq $skill_count ]]; then
+    if [[ $skill_count -eq 0 ]]; then
+        echo "  ✗ No skills discovered under skills/*/SKILL.md"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+    elif [[ $skills_with_description -eq $skill_count ]]; then
         echo "  ✓ All $skill_count skills have documentation"
         PASSED_TESTS=$((PASSED_TESTS + 1))
     else
@@ -306,7 +309,7 @@ test_plugin_json_schema() {
 
     # Check that skills array is not empty
     TOTAL_TESTS=$((TOTAL_TESTS + 1))
-    local skills_count=$(grep -o '\.claude/skills/[^"]*\.md' "$PROJECT_ROOT/.claude-plugin/plugin.json" | wc -l | tr -d ' ')
+    local skills_count=$(grep -o '"\./skills/[^"]*"' "$PROJECT_ROOT/.claude-plugin/plugin.json" | wc -l | tr -d ' ')
     if [[ $skills_count -gt 0 ]]; then
         echo "  ✓ plugin.json declares $skills_count skills"
         PASSED_TESTS=$((PASSED_TESTS + 1))

--- a/tests/unit/test-native-first-routing.sh
+++ b/tests/unit/test-native-first-routing.sh
@@ -6,16 +6,23 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$PROJECT_ROOT/tests/helpers/test-framework.sh"
 test_suite "Native First Routing"
 
-SKILL_FILE="$PROJECT_ROOT/.claude/skills/skill-native-escalation-routing.md"
+SKILL_FILE="$PROJECT_ROOT/skills/skill-native-escalation-routing/SKILL.md"
 PLUGIN_JSON="$PROJECT_ROOT/.claude-plugin/plugin.json"
 
-grep -q '^name: skill-native-escalation-routing$' "$SKILL_FILE"
-grep -q 'Claude-native first' "$SKILL_FILE"
-grep -q '/review' "$SKILL_FILE"
-grep -q '/security-review' "$SKILL_FILE"
-grep -q '/init' "$SKILL_FILE"
-grep -q 'multiple model opinions' "$SKILL_FILE"
-grep -q 'skill-native-escalation-routing.md' "$PLUGIN_JSON"
+test_case "native-first routing skill exists and is registered"
+if assert_file_exists "$SKILL_FILE" "portable skill directory contains SKILL.md" && \
+   assert_file_contains "$SKILL_FILE" '^name: skill-native-escalation-routing$' "skill has expected frontmatter name" && \
+   assert_file_contains "$SKILL_FILE" 'Claude-native first' "skill documents Claude-native first policy" && \
+   assert_file_contains "$SKILL_FILE" '/review' "skill documents /review routing" && \
+   assert_file_contains "$SKILL_FILE" '/security-review' "skill documents /security-review routing" && \
+   assert_file_contains "$SKILL_FILE" '/init' "skill documents /init routing" && \
+   assert_file_contains "$SKILL_FILE" 'multiple model opinions' "skill documents Octopus escalation criteria" && \
+   assert_file_contains "$PLUGIN_JSON" '\./skills/skill-native-escalation-routing' "plugin.json registers portable skill directory"; then
+    test_pass
+else
+    if [[ $TESTS_FAILED -eq 0 ]]; then
+        test_fail "native-first routing skill or plugin registration check failed"
+    fi
+fi
 
-echo "PASS: native-first routing skill exists and is registered"
 test_summary


### PR DESCRIPTION
## Summary
- Bump plugin and marketplace metadata to v9.37.3
- Sync the README version badge with the released plugin version
- Add a changelog entry for the release validation fix after #367

## Verification
- jq empty package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json .factory-plugin/marketplace.json
- jq skill path directory validation for .claude-plugin/plugin.json
- bash tests/unit/test-docs-sync.sh
- bash tests/smoke/test-debate-skill.sh
- bash tests/test-version-consistency.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version badge synchronization in documentation.

* **Chores**
  * Bumped package/plugin versions to 9.37.3 across manifests and marketplace entries.

* **Documentation**
  * Added changelog entry for 9.37.3 and updated README version badge.

* **Tests**
  * Updated unit and integration tests to validate relocated portable-skills layout and improved validation checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/369)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->