### PR TITLE
fix: symlink self-loop in stable plugin-root self-heal (closes #371)

### DIFF
--- a/hooks/session-start-memory.sh
+++ b/hooks/session-start-memory.sh
@@ -141,7 +141,7 @@ EOFSET
 fi
 
 # --- 5. Query claude-mem for recent project context (v8.57.0) ---
-BRIDGE_SCRIPT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}/scripts/claude-mem-bridge.sh"
+BRIDGE_SCRIPT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd -P)}/scripts/claude-mem-bridge.sh"
 if [[ -x "$BRIDGE_SCRIPT" ]]; then
     MEM_CONTEXT=$("$BRIDGE_SCRIPT" context "" 3 2>/dev/null || echo "")
     if [[ -n "$MEM_CONTEXT" ]]; then
@@ -154,7 +154,7 @@ fi  # end SKIP_PREFS guard
 # --- 6. Cache hygiene advisory (v9.29.0) ---
 # Notify when 3+ stale octo cache versions exist. Auto-clean only when explicitly
 # opted in via OCTOPUS_AUTO_CLEAN_CACHE=1 — never delete without consent.
-HYGIENE_LIB="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}/scripts/lib/cache-hygiene.sh"
+HYGIENE_LIB="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd -P)}/scripts/lib/cache-hygiene.sh"
 if [[ -r "$HYGIENE_LIB" ]]; then
     # shellcheck disable=SC1090
     source "$HYGIENE_LIB"

--- a/scripts/agent-registry.sh
+++ b/scripts/agent-registry.sh
@@ -17,7 +17,7 @@
 
 set -eo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 REGISTRY_DIR="${HOME}/.claude-octopus/agents"
 REGISTRY_FILE="${REGISTRY_DIR}/registry.json"
 ARCHIVE_DIR="${REGISTRY_DIR}/archive"
@@ -273,7 +273,7 @@ cmd_health() {
     echo -e "${BLUE}Checking health of $count active agent(s)...${NC}"
     echo ""
 
-    local REACTIONS="${SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}/reactions.sh"
+    local REACTIONS="${SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd -P)}/reactions.sh"
 
     echo "$active_agents" | jq -r '.[].id' | while read -r id; do
         local branch current_status

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -18,7 +18,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
 
 WORKFLOW="${1:-research}"

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -6,7 +6,7 @@
 # Output format: one line per provider, "name:available" or "name:missing"
 # Exit code: always 0 (availability is informational, not an error)
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
 
 cursor_agent_status="missing"

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -10,8 +10,8 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 source "${PLUGIN_ROOT}/scripts/lib/cursor-agent.sh" 2>/dev/null || true
 source "${PLUGIN_ROOT}/scripts/lib/plugin-root.sh" 2>/dev/null || true
 

--- a/scripts/lib/plugin-root.sh
+++ b/scripts/lib/plugin-root.sh
@@ -46,6 +46,20 @@ octo_ensure_stable_plugin_root() {
 
     mkdir -p "$(dirname "$stable_root")"
 
+    # Defense in depth: if the existing stable_root already resolves to the same
+    # physical directory as plugin_root, leave it alone. Without this guard, a
+    # caller that passes the stable_root path as plugin_root (e.g., from a
+    # SCRIPT_DIR resolved without `pwd -P`) would cause us to `rm -f` the
+    # symlink and then `ln -s` it pointing at itself → ELOOP. See #371.
+    if [[ -L "$stable_root" ]]; then
+        local _resolved_plugin _resolved_stable
+        _resolved_plugin="$(cd "$plugin_root" 2>/dev/null && pwd -P)" || _resolved_plugin=""
+        _resolved_stable="$(cd "$stable_root" 2>/dev/null && pwd -P)" || _resolved_stable=""
+        if [[ -n "$_resolved_plugin" && "$_resolved_plugin" == "$_resolved_stable" ]]; then
+            return 0
+        fi
+    fi
+
     if [[ -L "$stable_root" || -f "$stable_root" ]]; then
         rm -f "$stable_root" 2>/dev/null || true
     fi

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -5,7 +5,12 @@
 
 set -eo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve the physical path (pwd -P) so SCRIPT_DIR points at the real install
+# directory even when the script is invoked through the ~/.claude-octopus/plugin
+# convenience symlink. Without -P, PLUGIN_DIR would equal the symlink itself,
+# which causes octo_ensure_stable_plugin_root to recreate the symlink pointing
+# at itself (ELOOP). See #371.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
 source "${SCRIPT_DIR}/lib/plugin-root.sh" 2>/dev/null || true
 

--- a/scripts/reactions.sh
+++ b/scripts/reactions.sh
@@ -14,7 +14,7 @@
 
 set -eo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 REGISTRY="${SCRIPT_DIR}/agent-registry.sh"
 REACTIONS_DIR="${HOME}/.claude-octopus/agents/reactions"
 CONFIG_OVERRIDE=".octo/reactions.conf"

--- a/scripts/scheduler/daemon.sh
+++ b/scripts/scheduler/daemon.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 source "${SCRIPT_DIR}/store.sh"
 source "${SCRIPT_DIR}/cron.sh"

--- a/scripts/scheduler/octopus-scheduler.sh
+++ b/scripts/scheduler/octopus-scheduler.sh
@@ -9,8 +9,8 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PLUGIN_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
 
 source "${SCRIPT_DIR}/store.sh"
 source "${SCRIPT_DIR}/cron.sh"

--- a/scripts/scheduler/policy.sh
+++ b/scripts/scheduler/policy.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_DIR}/store.sh"
 
 # Allowed workflows (must match orchestrate.sh subcommands)

--- a/scripts/scheduler/runner.sh
+++ b/scripts/scheduler/runner.sh
@@ -5,8 +5,8 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PLUGIN_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
 
 source "${SCRIPT_DIR}/store.sh"
 source "${SCRIPT_DIR}/policy.sh"

--- a/scripts/session-manager.sh
+++ b/scripts/session-manager.sh
@@ -4,7 +4,10 @@
 
 set -eo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve physical path so the fallback `dirname "$SCRIPT_DIR"` plugin_root
+# (used when CLAUDE_PLUGIN_ROOT is unset) is the real install path rather than
+# the convenience symlink — prevents self-referential symlink creation. See #371.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_DIR}/lib/session-id.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/plugin-root.sh" 2>/dev/null || true
 

--- a/scripts/session-manager.sh
+++ b/scripts/session-manager.sh
@@ -33,7 +33,14 @@ export_session_variables() {
     # available in the LLM's Bash shell. This symlink makes all skill
     # references to ${HOME}/.claude-octopus/plugin/scripts/... resolve correctly.
     # Created BEFORE session directories so the symlink exists even if mkdir fails.
-    local plugin_root="${CLAUDE_PLUGIN_ROOT:-$(dirname "$SCRIPT_DIR")}"
+    #
+    # IMPORTANT: canonicalize plugin_root to its physical path before passing
+    # to the self-heal. Claude Code may set CLAUDE_PLUGIN_ROOT to the stable
+    # symlink path itself, which would otherwise cause octo_ensure_stable_plugin_root
+    # to recreate the symlink pointing at itself (ELOOP). See #371.
+    local plugin_root_raw="${CLAUDE_PLUGIN_ROOT:-$(dirname "$SCRIPT_DIR")}"
+    local plugin_root
+    plugin_root="$(cd "$plugin_root_raw" 2>/dev/null && pwd -P)" || plugin_root="$plugin_root_raw"
     if declare -f octo_ensure_stable_plugin_root >/dev/null 2>&1; then
         octo_ensure_stable_plugin_root "$plugin_root" >/dev/null 2>&1 || true
     else


### PR DESCRIPTION
## Summary

Closes #371. Fixes the `~/.claude-octopus/plugin` convenience symlink getting corrupted into a self-loop on every `/octo:*` invocation, producing \`Too many levels of symbolic links\` (ELOOP) on every subsequent access.

## Root cause

Several scripts compute their install path via:

\`\`\`bash
SCRIPT_DIR=\"\$(cd \"\$(dirname \"\${BASH_SOURCE[0]}\")\" && pwd)\"
\`\`\`

Without \`-P\`, \`pwd\` returns the *logical* path with the symlink preserved. When invoked through \`~/.claude-octopus/plugin/...\` (the convenience symlink that every slash-command bash block resolves), \`PLUGIN_DIR=\$(dirname \"\$SCRIPT_DIR\")\` ends up being the symlink itself, not the real install. That value flows into \`octo_ensure_stable_plugin_root\` in \`scripts/lib/plugin-root.sh\`, which unconditionally:

1. \`rm -f\` the (correct) symlink at the stable root
2. \`ln -s \"\$plugin_root\" \"\$stable_root\"\` — both sides now identical → self-referential symlink

Reproduces deterministically with a 2-step recipe (see #371 for the original repro).

## Changes — 5 logical commits

1. **fix(symlink-self-loop): resolve SCRIPT_DIR with pwd -P** — The minimal fix for the two self-heal callers (\`scripts/orchestrate.sh:8\`, \`scripts/session-manager.sh:7\`).

2. **fix(plugin-root): guard against destroying a healthy stable symlink** — Defense-in-depth in \`octo_ensure_stable_plugin_root\`: if the existing \`stable_root\` symlink already resolves to the same physical directory as \`plugin_root\`, return 0 without touching it. Also short-circuits the recurring rm+ln churn on every invocation. Catches the bug-class even if a future caller passes a non-physical path.

3. **chore(scripts): use pwd -P consistently** — Apply the same normalization to other runtime-reachable scripts (\`agent-registry.sh\`, \`reactions.sh\`, \`install-deps.sh\`, \`helpers/build-fleet.sh\`, \`helpers/check-providers.sh\`, \`scheduler/octopus-scheduler.sh\`). None feed the self-heal today, but the consistency prevents the bug-class from regressing if any of them ever does.

4. **fix(session-manager): canonicalize CLAUDE_PLUGIN_ROOT before self-heal** — Claude Code's runtime sets \`CLAUDE_PLUGIN_ROOT\` to the symlink path in normal installs. \`session-manager.sh\` previously fed that env var straight into \`octo_ensure_stable_plugin_root\` without canonicalization, so commit 1's \`pwd -P\` fix only repaired the fallback branch. After this commit, commit 2's guard is genuinely defense-in-depth rather than the primary defense for this path.

5. **chore(scheduler,hooks): pwd -P hygiene for remaining symlink-reachable scripts** — \`scheduler/daemon.sh\`, \`runner.sh\`, \`policy.sh\` (sourced today; defensive against direct invocation via cron or similar), and the two \`CLAUDE_PLUGIN_ROOT\` fallbacks in \`hooks/session-start-memory.sh\`.

Maintainer-only scripts (\`validate-release.sh\`, \`sync-marketplace.sh\`) are intentionally untouched — they run only from \`hooks/pre-push\` in a developer checkout, never via the user-install symlink.

## Test plan

Verified in an isolated sandbox (no risk to a real install):

- [x] Reproduced the bug on \`upstream/main\`: symlink becomes self-loop after first invocation through it, subsequent invocations fail with \`too many levels of symbolic links\` (exit 127).
- [x] With patches applied: 5/5 consecutive invocations through the symlink kept it healthy; invocation via the real cache path also kept it healthy.
- [x] Guard isolation test: with commits 1/3/4 reverted (only commit 2 applied), simulated a buggy caller passing the symlink path as \`plugin_root\` — guard returns 0, symlink preserved.
- [x] Bash syntax checked (\`bash -n\`) on every modified script.

Maintainer todos for review:
- [ ] Confirm \`CLAUDE_PLUGIN_ROOT\` is indeed set to the symlink path in the Claude Code runtime (the in-source comment at \`session-manager.sh:28-31\` implies so; commit 4's rationale rests on this).
- [ ] Sanity check on Windows Git Bash — the stable-root code uses script shims (not symlinks) there, so \`[[ -L \"\$stable_root\" ]]\` is false and the new guard short-circuits cleanly to the existing shim writer.

## Notes for reviewers

This PR went through two independent adversarial reviews before submission. Notable adjustments from review:
- Commit 4 was added after the first round noted that \`CLAUDE_PLUGIN_ROOT\` bypassed the original commit-1 fix entirely.
- Commit 5's scheduler hygiene was added after the same review flagged that scheduler runners would regress if ever invoked directly via the symlink.
- A regression test could be added under \`tests/\` if you'd like (e.g., a unit test calling \`octo_ensure_stable_plugin_root\` with \`plugin_root == stable_root\` and asserting the symlink isn't self-referential). Happy to add it if requested — left out to keep PR scope tight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed symlink path resolution across deployment, scheduling, and orchestration scripts to prevent incorrect directory lookups.
  * Added protection against self-referential symlink loops in plugin root configuration.

* **Chores**
  * Standardized physical path resolution across multiple installation and runtime scripts for improved consistency in symlinked environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/372)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->