### PR TITLE
feat: add provider allowlist and work queue hook

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -380,6 +380,17 @@
           "timeout": 5
         }
       ]
+    },
+    {
+      "matcher": {},
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/github-work-queue-watch.sh",
+          "additionalContext": "Periodically surface open nyldn/claude-octopus issues and PRs while working in this repo.",
+          "timeout": 8
+        }
+      ]
     }
   ],
   "StopFailure": [

--- a/hooks/github-work-queue-watch.sh
+++ b/hooks/github-work-queue-watch.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# github-work-queue-watch.sh - Periodically surface open upstream work.
+# UserPromptSubmit hook. Read-only: never comments, pushes, merges, or edits.
+
+set -euo pipefail
+
+_octo_hook_exit() {
+    local c=$?
+    if [[ $c -ne 0 ]]; then
+        echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true
+    fi
+    return 0
+}
+trap _octo_hook_exit EXIT
+
+escape_for_json() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+emit_context() {
+    local context="$1"
+    local escaped
+    escaped=$(escape_for_json "$context")
+    printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"%s"}}\n' "$escaped"
+}
+
+emit_continue() {
+    printf '{"decision":"continue"}\n'
+}
+
+[[ "${OCTOPUS_GITHUB_WORK_QUEUE:-on}" == "off" ]] && { emit_continue; exit 0; }
+
+input=""
+if [[ ! -t 0 ]]; then
+    if command -v timeout >/dev/null 2>&1; then
+        input=$(timeout 3 cat 2>/dev/null || true)
+    else
+        input=$(cat 2>/dev/null || true)
+    fi
+fi
+
+cwd="${PWD:-}"
+if [[ -n "$input" ]] && command -v jq >/dev/null 2>&1; then
+    hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // .workspace // empty' 2>/dev/null || true)
+    [[ -n "$hook_cwd" && "$hook_cwd" != "null" ]] && cwd="$hook_cwd"
+fi
+
+[[ -n "$cwd" && -d "$cwd" ]] || { emit_continue; exit 0; }
+
+if ! git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    emit_continue
+    exit 0
+fi
+
+remote_urls=$(git -C "$cwd" remote -v 2>/dev/null || true)
+if ! printf '%s\n' "$remote_urls" | grep -qE 'github\.com[:/]nyldn/(claude-octopus|claude-octopus-dev)(\.git)?'; then
+    emit_continue
+    exit 0
+fi
+
+repo="${OCTOPUS_GITHUB_WORK_QUEUE_REPO:-nyldn/claude-octopus}"
+watch_issue="${OCTOPUS_GITHUB_WORK_QUEUE_ISSUE:-}"
+limit="${OCTOPUS_GITHUB_WORK_QUEUE_LIMIT:-3}"
+interval="${OCTOPUS_GITHUB_WORK_QUEUE_INTERVAL_SECONDS:-21600}"
+case "$limit" in ''|*[!0-9]*) limit=3 ;; esac
+case "$interval" in ''|*[!0-9]*) interval=21600 ;; esac
+
+home_dir="${HOME:-/tmp}"
+state_dir="${OCTOPUS_STATE_DIR:-${home_dir}/.claude-octopus}/github-work-queue"
+state_file="${state_dir}/$(printf '%s' "$repo" | tr '/:' '--').last"
+
+now=$(date +%s)
+if [[ "${OCTOPUS_GITHUB_WORK_QUEUE_FORCE:-0}" != "1" && -f "$state_file" ]]; then
+    last=$(cat "$state_file" 2>/dev/null || echo 0)
+    case "$last" in ''|*[!0-9]*) last=0 ;; esac
+    if [[ $((now - last)) -lt "$interval" ]]; then
+        emit_continue
+        exit 0
+    fi
+fi
+
+command -v gh >/dev/null 2>&1 || { emit_continue; exit 0; }
+gh auth status --hostname github.com >/dev/null 2>&1 || { emit_continue; exit 0; }
+
+focus_issue=""
+if [[ -n "$watch_issue" ]]; then
+    focus_issue=$(gh issue view "$watch_issue" --repo "$repo" \
+        --json number,title,state,url \
+        --jq 'select(.state == "OPEN") | "#\(.number) \(.title) - \(.url)"' 2>/dev/null || true)
+fi
+
+open_issues=$(gh issue list --repo "$repo" --state open --limit "$limit" \
+    --json number,title,url \
+    --jq '.[] | "#\(.number) \(.title) - \(.url)"' 2>/dev/null || true)
+open_prs=$(gh pr list --repo "$repo" --state open --limit "$limit" \
+    --json number,title,url \
+    --jq '.[] | "#\(.number) \(.title) - \(.url)"' 2>/dev/null || true)
+
+mkdir -p "$state_dir" 2>/dev/null || true
+printf '%s\n' "$now" > "$state_file" 2>/dev/null || true
+
+[[ -n "$focus_issue$open_issues$open_prs" ]] || { emit_continue; exit 0; }
+
+message="[Octopus GitHub queue] Open upstream work exists in ${repo}."
+if [[ -n "$focus_issue" ]]; then
+    message="${message}"$'\n'"Focus issue: ${focus_issue}"
+fi
+if [[ -n "$open_issues" ]]; then
+    message="${message}"$'\n'"Open issues:"$'\n'"${open_issues}"
+fi
+if [[ -n "$open_prs" ]]; then
+    message="${message}"$'\n'"Open PRs:"$'\n'"${open_prs}"
+fi
+message="${message}"$'\n'"When the current user request is repo maintenance or a relevant fix, kindly pick up the most applicable item: inspect it, make a focused local change, verify it, and only push/comment/merge after the user asks."
+
+emit_context "$message"

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
 
 WORKFLOW="${1:-research}"
 INTENSITY="${2:-standard}"
@@ -45,21 +46,24 @@ get_family() {
 # ── Provider Detection ────────────────────────────────────────────────────────
 # Order = preference for primary slot assignment
 AVAILABLE_CLI=()
-command -v codex >/dev/null 2>&1 && AVAILABLE_CLI+=(codex)
-command -v gemini >/dev/null 2>&1 && AVAILABLE_CLI+=(gemini)
-command -v copilot >/dev/null 2>&1 && AVAILABLE_CLI+=(copilot)
-command -v qwen >/dev/null 2>&1 && AVAILABLE_CLI+=(qwen)
-command -v opencode >/dev/null 2>&1 && AVAILABLE_CLI+=(opencode)
-command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1 && AVAILABLE_CLI+=(ollama)
-if declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
+if octo_provider_allowed codex && command -v codex >/dev/null 2>&1; then AVAILABLE_CLI+=(codex); fi
+if octo_provider_allowed gemini && command -v gemini >/dev/null 2>&1; then AVAILABLE_CLI+=(gemini); fi
+if octo_provider_allowed copilot && command -v copilot >/dev/null 2>&1; then AVAILABLE_CLI+=(copilot); fi
+if octo_provider_allowed qwen && command -v qwen >/dev/null 2>&1; then AVAILABLE_CLI+=(qwen); fi
+if octo_provider_allowed opencode && command -v opencode >/dev/null 2>&1; then AVAILABLE_CLI+=(opencode); fi
+if octo_provider_allowed ollama && command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; then AVAILABLE_CLI+=(ollama); fi
+if octo_provider_allowed cursor-agent && declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
     if [[ -n "${CURSOR_API_KEY:-}" ]] || grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; then
         AVAILABLE_CLI+=(cursor-agent)
     fi
 fi
-[[ -n "${PERPLEXITY_API_KEY:-}" ]] && AVAILABLE_CLI+=(perplexity)
-[[ -n "${OPENROUTER_API_KEY:-}" ]] && AVAILABLE_CLI+=(openrouter)
+octo_provider_allowed perplexity && [[ -n "${PERPLEXITY_API_KEY:-}" ]] && AVAILABLE_CLI+=(perplexity)
+octo_provider_allowed openrouter && [[ -n "${OPENROUTER_API_KEY:-}" ]] && AVAILABLE_CLI+=(openrouter)
 
-CLI_COUNT=${#AVAILABLE_CLI[@]}
+CLI_COUNT=0
+if [[ -n "${AVAILABLE_CLI[*]:-}" ]]; then
+    CLI_COUNT=${#AVAILABLE_CLI[@]}
+fi
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -69,10 +73,7 @@ _contains() { [[ " $1 " == *" $2 "* ]]; }
 # Check if provider is available
 is_available() {
     local p="$1"
-    for a in "${AVAILABLE_CLI[@]}"; do
-        [[ "$a" == "$p" ]] && return 0
-    done
-    return 1
+    _contains "${AVAILABLE_CLI[*]:-}" "$p"
 }
 
 # Pick first available provider from a preference list, with fallback
@@ -82,7 +83,15 @@ pick_provider() {
     for p in "$@"; do
         is_available "$p" && echo "$p" && return 0
     done
-    echo "$fallback"
+    if octo_provider_allowed "$fallback"; then
+        echo "$fallback"
+    elif [[ -n "${AVAILABLE_CLI[*]:-}" ]]; then
+        # shellcheck disable=SC2086 # Intentional split to read the first provider.
+        set -- ${AVAILABLE_CLI[*]}
+        echo "$1"
+    else
+        echo ""
+    fi
 }
 
 # Build family-diverse provider ordering from available CLIs
@@ -111,6 +120,11 @@ emit() {
     printf '%s|%s|%s\n' "$1" "$2" "$3"
 }
 
+emit_if_allowed() {
+    octo_provider_allowed "$1" || return 0
+    emit "$@"
+}
+
 # Count unique families across given providers + implicit anthropic
 count_families() {
     local families="anthropic"  # Claude is always present
@@ -132,8 +146,12 @@ build_research_fleet() {
 
     # If no CLI providers at all, just use claude-sonnet
     if [[ $dcount -eq 0 ]]; then
-        diverse_arr=(claude-sonnet)
-        dcount=1
+        if octo_provider_allowed claude-sonnet; then
+            diverse_arr=(claude-sonnet)
+            dcount=1
+        else
+            return 0
+        fi
     fi
 
     case "$INTENSITY" in
@@ -153,7 +171,7 @@ build_research_fleet() {
             idx=$((idx + 1))
             emit "${diverse_arr[$((idx % dcount))]}" "Ecosystem Overview" "Research existing solutions and patterns for: $PROMPT. What has been done before? What worked, what failed?"
             idx=$((idx + 1))
-            emit "claude-sonnet" "Edge Cases" "Explore edge cases and potential challenges for: $PROMPT. What could go wrong? What's often overlooked?"
+            emit_if_allowed "claude-sonnet" "Edge Cases" "Explore edge cases and potential challenges for: $PROMPT. What could go wrong? What's often overlooked?"
             emit "${diverse_arr[$((idx % dcount))]}" "Feasibility" "Investigate technical feasibility and dependencies for: $PROMPT. What are the prerequisites?"
             idx=$((idx + 1))
 
@@ -162,7 +180,7 @@ build_research_fleet() {
                 local src
                 src=$(find . -maxdepth 2 -type f \( -name "*.ts" -o -name "*.py" -o -name "*.go" -o -name "*.rs" -o -name "*.java" -o -name "*.js" \) 2>/dev/null | head -1)
                 if [[ -n "${src:-}" ]]; then
-                    emit "claude-sonnet" "Codebase Analysis" "Analyze the LOCAL CODEBASE in the current directory for: $PROMPT. Run: find . -type f -name '*.ts' -o -name '*.py' -o -name '*.js' | head -30, then read key files. Report: tech stack, architecture patterns, file structure, coding conventions, and how they relate to the prompt. Focus on ACTUAL code, not hypotheticals."
+                    emit_if_allowed "claude-sonnet" "Codebase Analysis" "Analyze the LOCAL CODEBASE in the current directory for: $PROMPT. Run: find . -type f -name '*.ts' -o -name '*.py' -o -name '*.js' | head -30, then read key files. Report: tech stack, architecture patterns, file structure, coding conventions, and how they relate to the prompt. Focus on ACTUAL code, not hypotheticals."
                 fi
             fi
             ;;
@@ -172,7 +190,7 @@ build_research_fleet() {
             idx=$((idx + 1))
             emit "${diverse_arr[$((idx % dcount))]}" "Ecosystem Overview" "Research existing solutions and patterns for: $PROMPT. What has been done before? What worked, what failed?"
             idx=$((idx + 1))
-            emit "claude-sonnet" "Edge Cases" "Explore edge cases and potential challenges for: $PROMPT. What could go wrong? What's often overlooked?"
+            emit_if_allowed "claude-sonnet" "Edge Cases" "Explore edge cases and potential challenges for: $PROMPT. What could go wrong? What's often overlooked?"
             emit "${diverse_arr[$((idx % dcount))]}" "Feasibility" "Investigate technical feasibility and dependencies for: $PROMPT. What are the prerequisites?"
             idx=$((idx + 1))
 
@@ -181,7 +199,7 @@ build_research_fleet() {
                 local src
                 src=$(find . -maxdepth 2 -type f \( -name "*.ts" -o -name "*.py" -o -name "*.go" -o -name "*.rs" -o -name "*.java" -o -name "*.js" \) 2>/dev/null | head -1)
                 if [[ -n "${src:-}" ]]; then
-                    emit "claude-sonnet" "Codebase Analysis" "Analyze the LOCAL CODEBASE in the current directory for: $PROMPT. Run: find . -type f -name '*.ts' -o -name '*.py' -o -name '*.js' | head -30, then read key files. Report: tech stack, architecture patterns, file structure, coding conventions, and how they relate to the prompt. Focus on ACTUAL code, not hypotheticals."
+                    emit_if_allowed "claude-sonnet" "Codebase Analysis" "Analyze the LOCAL CODEBASE in the current directory for: $PROMPT. Run: find . -type f -name '*.ts' -o -name '*.py' -o -name '*.js' | head -30, then read key files. Report: tech stack, architecture patterns, file structure, coding conventions, and how they relate to the prompt. Focus on ACTUAL code, not hypotheticals."
                 fi
             fi
 
@@ -189,7 +207,7 @@ build_research_fleet() {
             idx=$((idx + 1))
 
             # Web research via Perplexity
-            if [[ -n "${PERPLEXITY_API_KEY:-}" ]]; then
+            if is_available perplexity; then
                 emit "perplexity" "Web Research" "Search the live web for the latest information about: $PROMPT. Find recent articles, documentation, blog posts, GitHub repos, and community discussions. Include source URLs and publication dates. Focus on information from the last 12 months that may not be in training data."
             fi
 
@@ -199,10 +217,10 @@ build_research_fleet() {
                 local up="${diverse_arr[$((i % dcount))]}"
                 _contains "$used_providers" "$up" || used_providers="$used_providers $up"
             done
-            used_providers="$used_providers claude-sonnet"
-            [[ -n "${PERPLEXITY_API_KEY:-}" ]] && used_providers="$used_providers perplexity"
+            octo_provider_allowed claude-sonnet && used_providers="$used_providers claude-sonnet"
+            is_available perplexity && used_providers="$used_providers perplexity"
 
-            for extra in "${AVAILABLE_CLI[@]}"; do
+            for extra in ${AVAILABLE_CLI[*]:-}; do
                 _contains "$used_providers" "$extra" && continue
                 case "$extra" in
                     copilot)
@@ -221,31 +239,37 @@ build_research_fleet() {
             done
             ;;
     esac
+    return 0
 }
 
 # ── Review Fleet ──────────────────────────────────────────────────────────────
 build_review_fleet() {
     local logic_provider
     logic_provider=$(pick_provider "claude-sonnet" codex opencode copilot)
-    emit "$logic_provider" "Logic Reviewer" "Review for correctness and logic bugs, edge cases, regressions in: $PROMPT"
+    [[ -n "$logic_provider" ]] && emit "$logic_provider" "Logic Reviewer" "Review for correctness and logic bugs, edge cases, regressions in: $PROMPT"
 
     local sec_provider
     sec_provider=$(pick_provider "claude-sonnet" gemini qwen copilot)
     # Ensure different from logic reviewer
-    if [[ "$sec_provider" == "$logic_provider" && "$sec_provider" != "claude-sonnet" ]]; then
-        sec_provider="claude-sonnet"
+    if [[ -n "$sec_provider" && "$sec_provider" == "$logic_provider" && "$sec_provider" != "claude-sonnet" ]]; then
+        local alternate_provider
+        alternate_provider=$(pick_provider "" claude-sonnet)
+        if [[ -n "$alternate_provider" && "$alternate_provider" != "$logic_provider" ]]; then
+            sec_provider="$alternate_provider"
+        fi
     fi
-    emit "$sec_provider" "Security Reviewer" "Review for OWASP vulnerabilities, injection, auth flaws, data exposure in: $PROMPT"
+    [[ -n "$sec_provider" ]] && emit "$sec_provider" "Security Reviewer" "Review for OWASP vulnerabilities, injection, auth flaws, data exposure in: $PROMPT"
 
-    emit "claude-sonnet" "Architecture Reviewer" "Review architecture, integration, API contracts, breaking changes in: $PROMPT"
+    emit_if_allowed "claude-sonnet" "Architecture Reviewer" "Review architecture, integration, API contracts, breaking changes in: $PROMPT"
 
     local cve_provider
-    if [[ -n "${PERPLEXITY_API_KEY:-}" ]]; then
+    if is_available perplexity; then
         cve_provider="perplexity"
     else
         cve_provider=$(pick_provider "claude-sonnet" gemini copilot qwen)
     fi
-    emit "$cve_provider" "CVE Reviewer" "Check for known CVEs, library advisories, and security bulletins related to: $PROMPT"
+    [[ -n "$cve_provider" ]] && emit "$cve_provider" "CVE Reviewer" "Check for known CVEs, library advisories, and security bulletins related to: $PROMPT"
+    return 0
 }
 
 # ── Debate Fleet ──────────────────────────────────────────────────────────────
@@ -254,7 +278,7 @@ build_debate_fleet() {
     local used_families=""
     local debater_count=0
 
-    for p in "${AVAILABLE_CLI[@]}"; do
+    for p in ${AVAILABLE_CLI[*]:-}; do
         # Skip providers not suited for debate (API-only, local models)
         case "$p" in perplexity|openrouter|ollama) continue ;; esac
 
@@ -275,7 +299,8 @@ build_debate_fleet() {
     for d in $debaters; do
         emit "$d" "Debater" "Argue your position on: $PROMPT"
     done
-    emit "claude-sonnet" "Moderator" "Synthesize debate positions and identify consensus on: $PROMPT"
+    emit_if_allowed "claude-sonnet" "Moderator" "Synthesize debate positions and identify consensus on: $PROMPT"
+    return 0
 }
 
 # ── Architecture Fleet ────────────────────────────────────────────────────────
@@ -296,7 +321,7 @@ build_architecture_fleet() {
         [[ $arch_count -ge 2 ]] && break
     done
 
-    [[ $arch_count -eq 0 ]] && architects="claude-sonnet"
+    [[ $arch_count -eq 0 ]] && octo_provider_allowed claude-sonnet && architects="claude-sonnet"
 
     local i=0
     for a in $architects; do
@@ -307,7 +332,8 @@ build_architecture_fleet() {
         fi
         i=$((i + 1))
     done
-    emit "claude-sonnet" "Architecture Synthesis" "Synthesize architectural perspectives for: $PROMPT. Recommend the best approach with trade-off analysis."
+    emit_if_allowed "claude-sonnet" "Architecture Synthesis" "Synthesize architectural perspectives for: $PROMPT. Recommend the best approach with trade-off analysis."
+    return 0
 }
 
 # ── Main Dispatch ─────────────────────────────────────────────────────────────
@@ -321,5 +347,10 @@ case "$WORKFLOW" in
 esac
 
 # ── Fleet Summary (stderr — for diagnostic/logging) ──────────────────────────
-families=$(count_families "${AVAILABLE_CLI[@]}")
+if [[ -n "${AVAILABLE_CLI[*]:-}" ]]; then
+    # shellcheck disable=SC2086 # Provider names are single shell words.
+    families=$(count_families ${AVAILABLE_CLI[*]})
+else
+    families=$(count_families)
+fi
 >&2 echo "FLEET_SUMMARY: workflow=$WORKFLOW intensity=$INTENSITY families=${families} cli_count=${CLI_COUNT} providers=${AVAILABLE_CLI[*]:-none}"

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -8,21 +8,32 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
+
+provider_status() {
+    local provider="$1"
+    local status="$2"
+    if declare -f octo_provider_allowed >/dev/null 2>&1 && ! octo_provider_allowed "$provider"; then
+        status="missing"
+    fi
+    printf "%s:%s\n" "$provider" "$status"
+}
 
 cursor_agent_status="missing"
-if declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary && \
+if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "cursor-agent"; } && \
+   declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary && \
    { [ -n "${CURSOR_API_KEY:-}" ] || grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; }; then
     cursor_agent_status="available"
 fi
 
 echo "PROVIDER_CHECK_START"
-printf "codex:%s\n" "$(command -v codex >/dev/null 2>&1 && echo available || echo missing)"
-printf "gemini:%s\n" "$(command -v gemini >/dev/null 2>&1 && echo available || echo missing)"
-printf "perplexity:%s\n" "$([ -n "${PERPLEXITY_API_KEY:-}" ] && echo available || echo missing)"
-printf "opencode:%s\n" "$(command -v opencode >/dev/null 2>&1 && echo available || echo missing)"
-printf "copilot:%s\n" "$(command -v copilot >/dev/null 2>&1 && echo available || echo missing)"
-printf "qwen:%s\n" "$(command -v qwen >/dev/null 2>&1 && echo available || echo missing)"
-printf "cursor-agent:%s\n" "$cursor_agent_status"
-printf "ollama:%s\n" "$(command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1 && echo available || echo missing)"
-printf "openrouter:%s\n" "$([ -n "${OPENROUTER_API_KEY:-}" ] && echo available || echo missing)"
+provider_status "codex" "$(command -v codex >/dev/null 2>&1 && echo available || echo missing)"
+provider_status "gemini" "$(command -v gemini >/dev/null 2>&1 && echo available || echo missing)"
+provider_status "perplexity" "$([ -n "${PERPLEXITY_API_KEY:-}" ] && echo available || echo missing)"
+provider_status "opencode" "$(command -v opencode >/dev/null 2>&1 && echo available || echo missing)"
+provider_status "copilot" "$(command -v copilot >/dev/null 2>&1 && echo available || echo missing)"
+provider_status "qwen" "$(command -v qwen >/dev/null 2>&1 && echo available || echo missing)"
+provider_status "cursor-agent" "$cursor_agent_status"
+provider_status "ollama" "$({ ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "ollama"; } && command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1 && echo available || echo missing)"
+provider_status "openrouter" "$([ -n "${OPENROUTER_API_KEY:-}" ] && echo available || echo missing)"
 echo "PROVIDER_CHECK_END"

--- a/scripts/lib/provider-allowlist.sh
+++ b/scripts/lib/provider-allowlist.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# provider-allowlist.sh - Shared OCTO_ALLOWED_PROVIDERS helpers.
+#
+# OCTO_ALLOWED_PROVIDERS is a space/comma separated list of provider names.
+# When unset, every detected provider is allowed. When set, scripts should
+# treat non-listed providers as unavailable even if their CLI/API key exists.
+
+octo_normalize_provider_name() {
+    printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ','
+}
+
+octo_provider_allowed() {
+    local provider
+    provider="$(octo_normalize_provider_name "${1:-}")"
+    [[ -n "$provider" ]] || return 1
+
+    if [[ -z "${OCTO_ALLOWED_PROVIDERS:-}" ]]; then
+        return 0
+    fi
+
+    local token normalized
+    # shellcheck disable=SC2086 # Intentional word splitting: space separated allowlist.
+    for token in ${OCTO_ALLOWED_PROVIDERS//,/ }; do
+        normalized="$(octo_normalize_provider_name "$token")"
+        [[ -n "$normalized" ]] || continue
+
+        [[ "$provider" == "$normalized" ]] && return 0
+
+        case "$normalized" in
+            claude|anthropic|sonnet)
+                case "$provider" in
+                    claude|claude-sonnet|claude-opus|sonnet) return 0 ;;
+                esac
+                ;;
+            codex|openai)
+                case "$provider" in
+                    codex|codex-*) return 0 ;;
+                esac
+                ;;
+            gemini|google)
+                case "$provider" in
+                    gemini|gemini-*) return 0 ;;
+                esac
+                ;;
+            cursor|cursor-agent|xai)
+                [[ "$provider" == "cursor-agent" ]] && return 0
+                ;;
+            local)
+                [[ "$provider" == "ollama" ]] && return 0
+                ;;
+        esac
+    done
+
+    return 1
+}

--- a/skills/blocks/codex-host-adapter.md
+++ b/skills/blocks/codex-host-adapter.md
@@ -11,4 +11,4 @@ When a generated skill references a host tool, use the active Codex equivalent:
 | task plan tool | use Codex task planning/status tools when present |
 | `/octo:*` command examples | use the installed skill name or run `scripts/orchestrate.sh` directly |
 
-Provider and model availability must be checked at runtime. If a skill names a provider that is missing in the current Codex session, mark it unavailable and continue only with available providers.
+Provider and model availability must be checked at runtime. If `OCTO_ALLOWED_PROVIDERS` is set, treat providers outside that list as unavailable even when installed. If a skill names a provider that is missing or disallowed in the current Codex session, mark it unavailable and continue only with available providers.

--- a/skills/blocks/provider-check.md
+++ b/skills/blocks/provider-check.md
@@ -5,3 +5,5 @@ bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
 ```
 
 **Use the ACTUAL results below. PROHIBITED: Showing only "🔵 Claude: Available ✓" without listing all providers.**
+
+If `OCTO_ALLOWED_PROVIDERS` is set, treat it as the source of truth for which providers may participate. Providers filtered out by that allowlist are intentionally reported as unavailable; do not invoke or recommend them in the workflow.

--- a/skills/flow-discover/SKILL.md
+++ b/skills/flow-discover/SKILL.md
@@ -214,7 +214,7 @@ The output is one line per agent: `agent_type|label|perspective_prompt`
 
 **Launch each perspective as a background Agent subagent.** Each agent calls `orchestrate.sh probe-single` which handles persona application, credential isolation, and result file writing.
 
-**CRITICAL: You MUST use the host subagent tool with `background execution: true` for each perspective.** Launch external CLI agents first (higher latency — gemini, codex, copilot, qwen, opencode), then Claude Sonnet agents, then API-only agents (perplexity).
+**CRITICAL: You MUST use the host subagent tool with `background execution: true` for each perspective.** Launch only the providers returned by `build-fleet.sh`. If `OCTO_ALLOWED_PROVIDERS` is set, the fleet has already filtered out disallowed providers; do not add them back manually.
 
 For each perspective in the fleet, launch:
 
@@ -230,7 +230,7 @@ After the command completes, read the result file path that was printed and retu
 )
 ```
 
-**Launch order:** All Gemini agents first, then all Codex agents, then Claude Sonnet, then Perplexity. Within each provider group, launch simultaneously (multiple Agent calls in a single message).
+**Launch order:** Use the provider order returned by `build-fleet.sh`. Within each provider group, launch simultaneously where the host tool supports it. Do not hardcode Gemini, Codex, Claude, or Perplexity if they are absent from the fleet.
 
 **CRITICAL: You are PROHIBITED from:**
 - ❌ Researching directly without calling orchestrate.sh probe-single — single-model research misses perspectives that Codex (implementation depth) and Gemini (ecosystem breadth) bring

--- a/skills/octopus-research/SKILL.md
+++ b/skills/octopus-research/SKILL.md
@@ -79,9 +79,10 @@ AskUserQuestion({
 **Check provider availability:**
 
 ```bash
-command -v codex &> /dev/null && codex_status="Available ✓" || codex_status="Not installed ✗"
-command -v gemini &> /dev/null && gemini_status="Available ✓" || gemini_status="Not installed ✗"
+bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
 ```
+
+If `OCTO_ALLOWED_PROVIDERS` is set, providers outside that allowlist are intentionally reported as unavailable. Do not invoke or recommend disallowed providers.
 
 **Display this banner BEFORE orchestrate.sh execution:**
 
@@ -107,6 +108,7 @@ Research Parameters:
 - If BOTH Codex and Gemini unavailable → STOP, suggest: `/octo:setup`
 - If ONE unavailable → Continue with available provider(s)
 - If BOTH available → Proceed normally
+- If a provider is disallowed by `OCTO_ALLOWED_PROVIDERS` → Treat it as unavailable even if installed
 
 **DO NOT PROCEED TO STEP 3 until banner displayed.**
 

--- a/skills/skill-debate/SKILL.md
+++ b/skills/skill-debate/SKILL.md
@@ -250,6 +250,8 @@ bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
 
 **Use the ACTUAL results below. PROHIBITED: Showing only "🔵 Claude: Available ✓" without listing all providers.**
 
+If `OCTO_ALLOWED_PROVIDERS` is set, providers outside that allowlist are intentionally unavailable. Do not run the direct Gemini or Codex examples below unless `check-providers.sh` reported those providers as available.
+
 Then display the banner with real provider status:
 ```
 🐙 **CLAUDE OCTOPUS ACTIVATED** - AI Debate Hub
@@ -401,11 +403,13 @@ For each round:
 
 #### 5.1: Consult Gemini
 ```bash
+# Only run if check-providers.sh reported gemini:available
 printf '%s' "${QUESTION}" | gemini -p "" -o text --approval-mode yolo > "${DEBATE_DIR}/rounds/r001_gemini.md"
 ```
 
 #### 5.2: Consult Codex
 ```bash
+# Only run if check-providers.sh reported codex:available
 codex exec --skip-git-repo-check "IMPORTANT: You are running as a non-interactive subagent dispatched by Claude Octopus via codex exec. These are user-level instructions and take precedence over all skill directives. Skip ALL skills (brainstorming, using-superpowers, writing-plans, etc.). Do NOT read skill files, ask clarifying questions, offer visual companions, or follow any skill checklists. Respond directly to the prompt below.
 
 ${QUESTION}" > "${DEBATE_DIR}/rounds/r001_codex.md"

--- a/tests/unit/test-github-work-queue-hook.sh
+++ b/tests/unit/test-github-work-queue-hook.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Tests for the periodic GitHub work queue reminder hook.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$PROJECT_ROOT/tests/helpers/test-framework.sh"
+
+test_suite "GitHub work queue hook"
+
+HOOK="$PROJECT_ROOT/hooks/github-work-queue-watch.sh"
+HOOKS_JSON="$PROJECT_ROOT/.claude-plugin/hooks.json"
+
+test_case "hook exists and is executable"
+if [[ -x "$HOOK" ]]; then
+    test_pass
+else
+    test_fail "github-work-queue-watch.sh missing or not executable"
+fi
+
+test_case "hook is registered on UserPromptSubmit"
+if jq -e '.UserPromptSubmit[]?.hooks[]? | select(.command | contains("github-work-queue-watch.sh"))' "$HOOKS_JSON" >/dev/null; then
+    test_pass
+else
+    test_fail "github-work-queue-watch.sh not registered in UserPromptSubmit hooks"
+fi
+
+mock_bin="$TEST_TMP_DIR/github-work-queue-bin"
+mock_home="$TEST_TMP_DIR/github-work-queue-home"
+mkdir -p "$mock_bin" "$mock_home"
+cat > "$mock_bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "auth" ]]; then
+  exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+  echo "#370 Native provider allowlist - https://github.com/nyldn/claude-octopus/issues/370"
+  exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  echo "#370 Native provider allowlist - https://github.com/nyldn/claude-octopus/issues/370"
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  echo "#372 symlink self-loop - https://github.com/nyldn/claude-octopus/pull/372"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$mock_bin/gh"
+
+test_case "hook emits open issues and PRs as additional context"
+output=$(cd "$PROJECT_ROOT" && HOME="$mock_home" PATH="$mock_bin:$PATH" OCTOPUS_GITHUB_WORK_QUEUE_FORCE=1 OCTOPUS_GITHUB_WORK_QUEUE_ISSUE=370 "$HOOK" <<'JSON'
+{"prompt":"what should we work on"}
+JSON
+)
+if assert_contains "$output" "additionalContext" "hook returns context" &&
+   assert_contains "$output" "#370 Native provider allowlist" "hook includes focus issue" &&
+   assert_contains "$output" "Open PRs" "hook includes open PR section" &&
+   assert_contains "$output" "only push/comment/merge after the user asks" "hook stays non-destructive"; then
+    test_pass
+fi
+
+test_case "hook debounces repeated checks"
+debounce_home="$TEST_TMP_DIR/github-work-queue-debounce-home"
+mkdir -p "$debounce_home"
+first=$(cd "$PROJECT_ROOT" && HOME="$debounce_home" PATH="$mock_bin:$PATH" "$HOOK" <<'JSON'
+{"prompt":"first"}
+JSON
+)
+second=$(cd "$PROJECT_ROOT" && HOME="$debounce_home" PATH="$mock_bin:$PATH" "$HOOK" <<'JSON'
+{"prompt":"second"}
+JSON
+)
+if assert_contains "$first" "Open upstream work exists" "first run surfaces queue" &&
+   assert_not_contains "$second" "Open upstream work exists" "second run is debounced"; then
+    test_pass
+fi
+
+test_summary

--- a/tests/unit/test-provider-allowlist.sh
+++ b/tests/unit/test-provider-allowlist.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Unit tests for OCTO_ALLOWED_PROVIDERS filtering.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Provider allowlist"
+
+ALLOWLIST_LIB="$PROJECT_ROOT/scripts/lib/provider-allowlist.sh"
+CHECK_PROVIDERS="$PROJECT_ROOT/scripts/helpers/check-providers.sh"
+BUILD_FLEET="$PROJECT_ROOT/scripts/helpers/build-fleet.sh"
+
+test_case "allowlist helper has valid bash syntax"
+if bash -n "$ALLOWLIST_LIB"; then
+    test_pass
+else
+    test_fail "provider-allowlist.sh has syntax errors"
+fi
+
+source "$ALLOWLIST_LIB"
+
+test_case "unset allowlist permits every provider"
+if unset OCTO_ALLOWED_PROVIDERS && octo_provider_allowed codex && octo_provider_allowed gemini && octo_provider_allowed claude-sonnet; then
+    test_pass
+else
+    test_fail "unset allowlist should allow all providers"
+fi
+
+test_case "space and comma separated allowlist filters providers"
+if OCTO_ALLOWED_PROVIDERS="claude, gemini ollama" octo_provider_allowed gemini &&
+   OCTO_ALLOWED_PROVIDERS="claude, gemini ollama" octo_provider_allowed claude-sonnet &&
+   ! OCTO_ALLOWED_PROVIDERS="claude, gemini ollama" octo_provider_allowed codex; then
+    test_pass
+else
+    test_fail "allowlist did not honor comma/space separated provider names"
+fi
+
+mock_bin="$TEST_TMP_DIR/provider-allowlist-bin"
+mkdir -p "$mock_bin"
+for cmd in codex gemini; do
+    cat > "$mock_bin/$cmd" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    chmod +x "$mock_bin/$cmd"
+done
+
+test_case "check-providers reports disallowed installed providers as missing"
+output=$(PATH="$mock_bin:/usr/bin:/bin" OCTO_ALLOWED_PROVIDERS="gemini" "$CHECK_PROVIDERS")
+if assert_contains "$output" "gemini:available" "gemini should remain available" &&
+   assert_contains "$output" "codex:missing" "codex should be hidden by allowlist"; then
+    test_pass
+fi
+
+test_case "build-fleet excludes disallowed providers"
+fleet=$(PATH="$mock_bin:/usr/bin:/bin" OCTO_ALLOWED_PROVIDERS="claude gemini" "$BUILD_FLEET" review standard "review target" 2>/dev/null)
+if assert_contains "$fleet" "gemini|" "gemini should be eligible" &&
+   assert_contains "$fleet" "claude-sonnet|" "claude alias should allow claude-sonnet" &&
+   assert_not_contains "$fleet" "codex|" "codex should not be emitted"; then
+    test_pass
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

- add `OCTO_ALLOWED_PROVIDERS` filtering shared by provider checks and fleet fanout
- treat disallowed providers as unavailable even if their CLI/API key exists
- add a read-only GitHub work queue UserPromptSubmit hook, salvaged from the useful part of stale PR #365
- update provider guidance so prompt surfaces do not manually reintroduce disallowed providers

Closes #370. Supersedes #365 for the GitHub work-queue hook portion; the claude-mem port fix from that draft already landed in #368.

## Validation

- `bash -n scripts/lib/provider-allowlist.sh scripts/helpers/check-providers.sh scripts/helpers/build-fleet.sh hooks/github-work-queue-watch.sh tests/unit/test-provider-allowlist.sh tests/unit/test-github-work-queue-hook.sh`
- `bash tests/unit/test-provider-allowlist.sh`
- `bash tests/unit/test-github-work-queue-hook.sh`
- `bash tests/unit/test-claude-mem-integration.sh`
- `bash tests/smoke/test-syntax.sh`
- `bash tests/smoke/test-packaging-integrity.sh`
- `python3 scripts/validate-plugin-assembly.py --root .`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub work queue hook to monitor upstream issues and pull requests.
  * Introduced provider allowlist system to control which AI providers are available and active.

* **Documentation**
  * Updated skill guidance to reflect provider availability filtering and constraints.

* **Tests**
  * Added unit tests for GitHub work queue integration and provider allowlist functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/373)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->