### PR TITLE
chore: release v9.37.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.37.3"
+    "version": "9.37.4"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.37.3 - Multi-LLM orchestration for Claude Code with agent summaries, prompt-size preflight, research fanout, and Codex-compatible skills. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
-      "version": "9.37.3",
+      "description": "v9.37.4 - Multi-LLM orchestration for Claude Code with agent summaries, prompt-size preflight, research fanout, and Codex-compatible skills. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
+      "version": "9.37.4",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.37.3",
-  "description": "v9.37.3 \u2014 Agent summaries, prompt-size preflight, research fanout, and Codex-compatible portable skills. Run /octo:setup.",
+  "version": "9.37.4",
+  "description": "v9.37.4 \u2014 Agent summaries, prompt-size preflight, research fanout, and Codex-compatible portable skills. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.37.3",
+  "version": "9.37.4",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"
@@ -31,8 +31,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Claude Octopus",
-    "shortDescription": "Multi-LLM orchestration — dispatch to 8 providers from one plugin.",
-    "longDescription": "Claude Octopus orchestrates multiple AI providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) through structured Double Diamond workflows. 32 personas, 48 commands, 52 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch includes prompt-size preflight, agent summary tables, circuit breakers, cost tracking, and model routing.",
+    "shortDescription": "Multi-LLM orchestration \u2014 dispatch to 8 providers from one plugin.",
+    "longDescription": "Claude Octopus orchestrates multiple AI providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) through structured Double Diamond workflows. 32 personas, 48 commands, 53 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch includes prompt-size preflight, agent summary tables, circuit breakers, cost tracking, and model routing.",
     "developerName": "nyldn",
     "category": "Orchestration",
     "capabilities": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
-  "description": "Multi-LLM orchestration — up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.37.3",
+  "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
+  "version": "9.37.4",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.37.3"
+    "version": "9.37.4"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.37.3 - Multi-AI orchestration with agent summaries, prompt-size preflight, and Double Diamond workflow. 32 personas, 48 commands, 52 skills. Run /octo:setup after install.",
-      "version": "9.37.3",
+      "description": "v9.37.4 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 48 commands, 53 skills. Run /octo:setup after install.",
+      "version": "9.37.4",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.37.3",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.37.3. Agent summaries, prompt-size preflight, 32 expert personas, 48 commands, 52 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.37.4",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.37.4. 32 expert personas, 48 commands, 53 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [9.37.4] - 2026-05-13
+
+### Added
+
+- Add `OCTO_ALLOWED_PROVIDERS` so users can restrict Octopus provider checks and fleet fanout to an explicit provider set (#370).
+- Add a read-only GitHub work queue hook that periodically surfaces open Octopus issues and PRs while working in the repo.
+
+### Fixed
+
+- Prevent the stable `~/.claude-octopus/plugin` self-heal path from recreating the plugin symlink as a self-referential loop (#371).
+- Update release validation to understand directory-based plugin skill registrations.
+
+---
+
 ## [Unreleased]
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.37.3-blue" alt="Version 9.37.3">
+  <img src="https://img.shields.io/badge/Version-9.37.4-blue" alt="Version 9.37.4">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.37.3",
+  "version": "9.37.4",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -322,8 +322,13 @@ echo ""
 # ============================================================================
 echo "🎯 Checking skill registration..."
 
-SKILL_FILES=$(ls "$ROOT_DIR/.claude/skills/"*.md 2>/dev/null | xargs -n1 basename | sort)
-REGISTERED_SKILLS=$(grep -o '\.claude/skills/[^"]*\.md' "$ROOT_DIR/.claude-plugin/plugin.json" | sed 's|.*\.claude/skills/||' | sort)
+if command -v jq >/dev/null 2>&1 && jq -e '.skills[]? | select(startswith("./skills/"))' "$ROOT_DIR/.claude-plugin/plugin.json" >/dev/null 2>&1; then
+    SKILL_FILES=$(find "$ROOT_DIR/skills" -mindepth 2 -maxdepth 2 -name "SKILL.md" -type f 2>/dev/null | sed "s|^$ROOT_DIR/skills/||;s|/SKILL.md$||" | sort)
+    REGISTERED_SKILLS=$(jq -r '.skills[]? | select(startswith("./skills/")) | sub("^\\./skills/"; "") | sub("/$"; "")' "$ROOT_DIR/.claude-plugin/plugin.json" | sort)
+else
+    SKILL_FILES=$(ls "$ROOT_DIR/.claude/skills/"*.md 2>/dev/null | xargs -n1 basename | sort)
+    REGISTERED_SKILLS=$(grep -o '\.claude/skills/[^"]*\.md' "$ROOT_DIR/.claude-plugin/plugin.json" | sed 's|.*\.claude/skills/||' | sort)
+fi
 
 for skill_file in $SKILL_FILES; do
     if ! echo "$REGISTERED_SKILLS" | grep -q "^${skill_file}$"; then
@@ -354,7 +359,14 @@ echo ""
 echo "🏷️  Checking skill frontmatter format..."
 
 invalid_skill_names=0
-for skill_file in "$ROOT_DIR/.claude/skills/"*.md; do
+if command -v jq >/dev/null 2>&1 && jq -e '.skills[]? | select(startswith("./skills/"))' "$ROOT_DIR/.claude-plugin/plugin.json" >/dev/null 2>&1; then
+    SKILL_FRONTMATTER_FILES=("$ROOT_DIR"/skills/*/SKILL.md)
+else
+    SKILL_FRONTMATTER_FILES=("$ROOT_DIR"/.claude/skills/*.md)
+fi
+
+for skill_file in "${SKILL_FRONTMATTER_FILES[@]}"; do
+    [[ -f "$skill_file" ]] || continue
     skill_name=$(sed -n '2p' "$skill_file" | grep -o 'name: .*' | sed 's/name: //' || true)
     # Skip if no name found (might be a different format)
     if [[ -z "$skill_name" ]]; then
@@ -395,6 +407,15 @@ fi
 
 echo ""
 
+# Release artifact creation is intentionally limited to a clean main checkout.
+# Running validation on a dirty release branch should validate files only, not
+# create tags/releases that point at the wrong commit.
+CURRENT_BRANCH=$(git -C "$ROOT_DIR" branch --show-current 2>/dev/null || echo "")
+WORKTREE_DIRTY=$(git -C "$ROOT_DIR" status --porcelain 2>/dev/null || echo "")
+can_create_release_artifacts() {
+    [[ "$CURRENT_BRANCH" == "main" && -z "$WORKTREE_DIRTY" ]]
+}
+
 # ============================================================================
 # 9. GIT TAG CHECK & AUTO-CREATE
 # ============================================================================
@@ -416,16 +437,21 @@ if git tag -l "$EXPECTED_TAG" | grep -q "$EXPECTED_TAG"; then
     fi
 else
     echo -e "  ${YELLOW}NOTE: Tag $EXPECTED_TAG not yet created${NC}"
-    echo -e "  ${GREEN}  Auto-creating tag...${NC}"
+    if can_create_release_artifacts; then
+        echo -e "  ${GREEN}  Auto-creating tag...${NC}"
 
-    # Extract CHANGELOG entry for tag message
-    TAG_MESSAGE=$(awk "/## \[$PLUGIN_VERSION\]/,/^## \[/" "$ROOT_DIR/CHANGELOG.md" | head -20 | tail -n +2)
-    if [[ -n "$TAG_MESSAGE" ]]; then
-        git tag -a "$EXPECTED_TAG" -m "$TAG_MESSAGE"
-        echo -e "  ${GREEN}✓ Tag $EXPECTED_TAG created with CHANGELOG excerpt${NC}"
+        # Extract CHANGELOG entry for tag message
+        TAG_MESSAGE=$(awk "/## \[$PLUGIN_VERSION\]/,/^## \[/" "$ROOT_DIR/CHANGELOG.md" | head -20 | tail -n +2)
+        if [[ -n "$TAG_MESSAGE" ]]; then
+            git tag -a "$EXPECTED_TAG" -m "$TAG_MESSAGE"
+            echo -e "  ${GREEN}✓ Tag $EXPECTED_TAG created with CHANGELOG excerpt${NC}"
+        else
+            git tag -a "$EXPECTED_TAG" -m "Release $EXPECTED_TAG"
+            echo -e "  ${GREEN}✓ Tag $EXPECTED_TAG created${NC}"
+        fi
     else
-        git tag -a "$EXPECTED_TAG" -m "Release $EXPECTED_TAG"
-        echo -e "  ${GREEN}✓ Tag $EXPECTED_TAG created${NC}"
+        echo -e "  ${YELLOW}  Deferring tag creation until release changes are merged to clean main${NC}"
+        ((warnings++)) || true
     fi
 fi
 
@@ -481,7 +507,7 @@ else
             # Check if tag exists on remote
             REMOTE_TAG_SHA=$(git ls-remote origin "refs/tags/$EXPECTED_TAG" 2>/dev/null | cut -f1)
 
-            if [[ -n "$REMOTE_TAG_SHA" ]]; then
+            if [[ -n "$REMOTE_TAG_SHA" ]] && can_create_release_artifacts; then
                 echo -e "  ${GREEN}  Auto-creating GitHub release from CHANGELOG...${NC}"
 
                 # Extract CHANGELOG entry for this version
@@ -501,7 +527,7 @@ else
                     ((warnings++)) || true
                 fi
             else
-                echo -e "  ${YELLOW}  Tag not yet pushed to remote - will create release after push${NC}"
+                echo -e "  ${YELLOW}  Release creation deferred until tag exists on clean main${NC}"
             fi
         fi
     fi
@@ -514,6 +540,11 @@ echo ""
 # ============================================================================
 push_tag_if_needed() {
     local tag="$1"
+    if ! can_create_release_artifacts; then
+        echo -e "${YELLOW}NOTE: Not pushing/creating release artifacts outside a clean main checkout${NC}"
+        return 0
+    fi
+
     if git tag -l "$tag" | grep -q "$tag"; then
         REMOTE_TAG_SHA=$(git ls-remote origin "refs/tags/$tag^{}" 2>/dev/null | cut -f1)
         if [[ -z "$REMOTE_TAG_SHA" ]]; then


### PR DESCRIPTION
## Release v9.37.4

### Added
- `OCTO_ALLOWED_PROVIDERS` filtering for provider checks and fleet fanout (#370)
- read-only GitHub work queue hook for open Octopus issues/PRs

### Fixed
- stable plugin symlink self-heal no longer creates a self-referential ELOOP path (#371)
- release validation now understands directory-based plugin skill registrations and no longer creates tags/releases from dirty release branches

### Validation
- `bash scripts/validate-release.sh`
- `python3 scripts/validate-plugin-assembly.py --root .`
- `bash tests/test-version-consistency.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `OCTO_ALLOWED_PROVIDERS` configuration for restricting provider checks and fleet fanout
  * Added read-only GitHub work queue hook
  * Expanded skill set from 52 to 53 capabilities

* **Bug Fixes**
  * Fixed stable plugin self-heal path preventing self-referential symlink loop
  * Updated release validation to support directory-based plugin skill registrations

Version bumped to 9.37.4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/374)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->