### PR TITLE
fix(review): accept diff files as review targets

### DIFF
--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -201,6 +201,29 @@ build_review_fleet() {
     echo "$fleet"
 }
 
+# review_collect_diff: resolves a review target to unified diff content.
+# Targets can be built-in scopes (staged, working-tree), a PR number, a git
+# pathspec, or an already-generated .diff/.patch file.
+review_collect_diff() {
+    local target="$1"
+    local diff_content=""
+
+    case "$target" in
+        staged)       diff_content=$(git diff --cached 2>/dev/null || true) ;;
+        working-tree) diff_content=$(git diff 2>/dev/null || true) ;;
+        [0-9]*)       diff_content=$(gh pr diff "$target" 2>/dev/null || true) ;;
+        *)
+            if [[ -f "$target" ]] && [[ -r "$target" ]] && head -n 20 "$target" 2>/dev/null | grep -Eq "^(diff --git|--- |\+\+\+ |@@ )"; then
+                diff_content=$(cat "$target" 2>/dev/null || true)
+            else
+                diff_content=$(git diff HEAD -- "$target" 2>/dev/null || true)
+            fi
+            ;;
+    esac
+
+    printf '%s' "$diff_content"
+}
+
 # review_run: canonical 3-round multi-LLM code review pipeline
 # WHY: replaces the single-model "codex exec review" dispatch with a
 # v9.0: Provider report card — prints post-run summary of provider status
@@ -363,12 +386,7 @@ review_run() {
 
     # ── Collect diff ─────────────────────────────────────────────────────────
     local diff_content=""
-    case "$target" in
-        staged)       diff_content=$(git diff --cached 2>/dev/null || true) ;;
-        working-tree) diff_content=$(git diff 2>/dev/null || true) ;;
-        [0-9]*)       diff_content=$(gh pr diff "$target" 2>/dev/null || true) ;;
-        *)            diff_content=$(git diff HEAD -- "$target" 2>/dev/null || true) ;;
-    esac
+    diff_content=$(review_collect_diff "$target")
 
     if [[ -z "$diff_content" ]]; then
         log WARN "review_run: no diff found for target=$target"

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -213,7 +213,7 @@ review_collect_diff() {
         working-tree) diff_content=$(git diff 2>/dev/null || true) ;;
         [0-9]*)       diff_content=$(gh pr diff "$target" 2>/dev/null || true) ;;
         *)
-            if [[ -f "$target" ]] && [[ -r "$target" ]] && head -n 20 "$target" 2>/dev/null | grep -Eq "^(diff --git|--- |\+\+\+ |@@ )"; then
+            if [[ -f "$target" ]] && [[ -r "$target" ]] && head -n 20 "$target" 2>/dev/null | grep -Ec "^(diff --git|--- |\+\+\+ |@@ )" >/dev/null; then
                 diff_content=$(cat "$target" 2>/dev/null || true)
             else
                 diff_content=$(git diff HEAD -- "$target" 2>/dev/null || true)

--- a/tests/unit/test-review-run.sh
+++ b/tests/unit/test-review-run.sh
@@ -66,6 +66,9 @@ assert_contains "$(grep -c 'build_review_fleet' "$ALL_SRC" 2>/dev/null || echo 0
 assert_contains "$(grep -c 'review_run' "$ALL_SRC" 2>/dev/null || echo 0)" \
   "[1-9]" "review_run: function exists"
 
+assert_contains "$(grep -c 'review_collect_diff' "$ALL_SRC" 2>/dev/null || echo 0)" \
+  "[1-9]" "review_collect_diff: function exists"
+
 assert_contains "$(grep 'normal\|nit\|pre.existing' "$ALL_SRC" 2>/dev/null | head -5)" \
   "normal|nit|pre.existing" "severity model: all three levels referenced"
 
@@ -103,6 +106,23 @@ assert_contains "$(grep 'post_inline_comments.*findings_file.*||' "$ALL_SRC" 2>/
 
 assert_contains "$(grep -A2 'commit_id.*headRefOid' "$ALL_SRC" 2>/dev/null | head -10)" \
   'commit_id' "post_inline_comments: empty commit_id guarded"
+
+# ── diff target file support ─────────────────────────────────────────────────
+
+source "$PROJECT_ROOT/scripts/lib/review.sh"
+
+DIFF_TARGET="$TMPDIR_TEST/review-target.diff"
+cat > "$DIFF_TARGET" <<'EOF'
+diff --git a/foo.txt b/foo.txt
+--- a/foo.txt
++++ b/foo.txt
+@@ -1 +1 @@
+-old
++new
+EOF
+
+assert_contains "$(review_collect_diff "$DIFF_TARGET")" \
+  "diff --git a/foo.txt b/foo.txt" "review_collect_diff: reads unified diff file targets"
 
 # ── MCP schema ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Extract review target diff resolution into review_collect_diff
- Read existing unified diff/patch files directly instead of treating them as git pathspecs
- Add a regression test for .diff file targets

## Test
- bash -n scripts/lib/review.sh
- bash tests/unit/test-review-run.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated change-collection logic to uniformly resolve diffs from staged changes, working tree, pull requests, and explicit diff files, improving reliability when resolving targets while preserving the existing review flow.

* **Tests**
  * Added unit tests to validate the refactored diff-collection behavior, including handling of file-based diffs and ensuring the resolver is present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->