### PR TITLE
fix(embrace,discover): dispatch workflows directly

### DIFF
--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -91,13 +91,13 @@ Map the intensity answer:
 
 After receiving answers, incorporate them into the Skill invocation.
 
-### Step 2: Invoke Skill with Intensity
+### Step 2: Run Discovery via orchestrate.sh
 
-```
-Skill(skill: "octo:discover", args: "[intensity=quick|standard|deep] <user's arguments>")
+```bash
+cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh probe [intensity=quick|standard|deep] <user's arguments>
 ```
 
-Example: `Skill(skill: "octo:discover", args: "[intensity=standard] OAuth authentication patterns")`
+Example: `cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh probe [intensity=standard] OAuth authentication patterns`
 
 ### Step 3: Post-Completion — Interactive Next Steps
 

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -16,8 +16,8 @@ aliases:
 
 ### EXECUTION MECHANISM — NON-NEGOTIABLE
 
-**You MUST execute this command by invoking the corresponding skill via the Skill tool. You are PROHIBITED from:**
-- ❌ Using the Agent tool to research/implement yourself instead of invoking the skill
+**You MUST execute this command by running the discovery workflow through `orchestrate.sh`. You are PROHIBITED from:**
+- ❌ Using the Agent tool to research/implement yourself instead of invoking the workflow
 - ❌ Using WebFetch/Read/Grep as a substitute for multi-provider dispatch
 - ❌ Skipping `orchestrate.sh` calls because "I can do this faster directly"
 - ❌ Implementing the task using only Claude-native tools (Agent, Write, Edit)
@@ -28,15 +28,15 @@ aliases:
 
 When the user invokes this command (e.g., `/octo:discover <arguments>`):
 
-**✓ CORRECT - Use the Skill tool:**
-```
-Skill(skill: "octo:discover", args: "<user's arguments>")
+**✓ CORRECT - Run the orchestrated probe workflow:**
+```bash
+cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh probe <user's arguments>
 ```
 
 **✗ INCORRECT:**
 ```
-Skill(skill: "flow-discover", ...)  ❌ Wrong! Internal skill name, not resolvable by Skill tool
-Task(subagent_type: "octo:discover", ...)  ❌ Wrong! This is a skill, not an agent type
+Skill(skill: "octo:discover", ...)  ❌ Wrong here; recursive Skill dispatch can reload this command
+Task(subagent_type: "octo:discover", ...)  ❌ Wrong! This is a command workflow, not an agent type
 ```
 
 ### Step 1: Ask Clarifying Questions
@@ -89,7 +89,7 @@ Map the intensity answer:
 - "Standard" → `standard`
 - "Deep" → `deep`
 
-After receiving answers, incorporate them into the Skill invocation.
+After receiving answers, incorporate them into the `orchestrate.sh probe` invocation.
 
 ### Step 2: Run Discovery via orchestrate.sh
 
@@ -101,7 +101,7 @@ Example: `cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh pro
 
 ### Step 3: Post-Completion — Interactive Next Steps
 
-**CRITICAL: After the skill completes, you MUST ask the user what to do next. Do NOT end the session silently.**
+**CRITICAL: After discovery completes, you MUST ask the user what to do next. Do NOT end the session silently.**
 
 ```javascript
 AskUserQuestion({
@@ -124,7 +124,7 @@ AskUserQuestion({
 
 ---
 
-**Auto-loads the discover skill for the research/discovery phase.**
+**Runs the `probe` workflow for the research/discovery phase.**
 
 ## Quick Usage
 

--- a/.claude/commands/embrace.md
+++ b/.claude/commands/embrace.md
@@ -140,24 +140,24 @@ Scope: [answer]  Focus: [answer]  Autonomy: [answer]
 
 ### Phase 1 — Discover
 
-Invoke the discover skill:
-```
-Skill(skill: "octo:discover", args: "<user's prompt>")
+Run the discover phase via orchestrate.sh:
+```bash
+cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh probe <user's prompt>
 ```
 
-This will dispatch to Codex, Gemini, and other available providers via `orchestrate.sh probe-single`. Results saved to `~/.claude-octopus/results/probe-synthesis-*.md`.
+This will dispatch to Codex, Gemini, and other available providers. Results saved to `~/.claude-octopus/results/probe-synthesis-*.md`.
 
 **Supervised mode:** After Discover completes, present key findings and ask to proceed.
 **Semi-autonomous/Autonomous:** Proceed automatically.
 
 ### Phase 2 — Define
 
-Invoke the define skill:
-```
-Skill(skill: "octo:define", args: "<user's prompt>")
+Run the define phase via orchestrate.sh:
+```bash
+cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh grasp <user's prompt>
 ```
 
-This builds consensus across providers via `orchestrate.sh`. Results saved to `~/.claude-octopus/results/grasp-consensus-*.md`.
+This builds consensus across providers. Results saved to `~/.claude-octopus/results/grasp-consensus-*.md`.
 
 **Supervised mode:** Present consensus and ask to proceed.
 
@@ -190,12 +190,12 @@ AskUserQuestion({
 
 ### Phase 3 — Develop
 
-Invoke the develop skill:
-```
-Skill(skill: "octo:develop", args: "<user's prompt>")
+Run the develop phase via orchestrate.sh:
+```bash
+cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh tangle <user's prompt>
 ```
 
-This dispatches implementation via `orchestrate.sh tangle` with quality gates. Results saved to `~/.claude-octopus/results/tangle-validation-*.md`.
+This dispatches implementation with quality gates. Results saved to `~/.claude-octopus/results/tangle-validation-*.md`.
 
 ### Second Debate Gate (if "both gates" selected)
 
@@ -203,12 +203,12 @@ Same pattern as above but collaborative style, reviewing implementation quality.
 
 ### Phase 4 — Deliver
 
-Invoke the deliver skill:
-```
-Skill(skill: "octo:deliver", args: "<user's prompt>")
+Run the deliver phase via orchestrate.sh:
+```bash
+cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh ink <user's prompt>
 ```
 
-This runs multi-provider validation via `orchestrate.sh ink`. Results saved to `~/.claude-octopus/results/delivery-*.md`.
+This runs multi-provider validation. Results saved to `~/.claude-octopus/results/delivery-*.md`.
 
 ### Auto Code Review (MANDATORY)
 

--- a/.claude/commands/embrace.md
+++ b/.claude/commands/embrace.md
@@ -22,16 +22,16 @@ aliases:
 
 ## EXECUTION MECHANISM — NON-NEGOTIABLE
 
-**Each phase MUST be executed by invoking the corresponding skill using the Skill tool. You are PROHIBITED from:**
-- Using the Agent tool to do research yourself instead of invoking `/octo:discover`
+**Each phase MUST be executed through the `orchestrate.sh` entrypoint. Direct Skill calls for the workflow phases are not permitted because they can recursively reload command instructions. You are PROHIBITED from:**
+- Using the Agent tool to do research yourself instead of running the discovery phase
 - Using WebFetch/Read/Grep as a substitute for multi-provider research
-- Implementing code directly instead of invoking `/octo:develop`
-- Using a single code-reviewer agent instead of invoking `/octo:deliver`
+- Implementing code directly instead of running the develop phase
+- Using a single code-reviewer agent instead of running the deliver phase
 - Skipping `orchestrate.sh` calls because "I can do this faster directly"
 
 **The ENTIRE POINT of `/octo:embrace` is multi-LLM orchestration.** If you execute phases using only Claude-native tools (Agent, WebFetch, Write, Edit), you have violated the command's purpose even if you followed the phase structure.
 
-**Self-check after completion:** You should be able to list the Skill invocations and orchestrate.sh commands you ran. If you used only Claude-native tools, you executed incorrectly.
+**Self-check after completion:** You should be able to list the `orchestrate.sh` commands you ran. If you used only Claude-native tools, you executed incorrectly.
 
 ---
 
@@ -134,13 +134,14 @@ Provider Availability:
 Scope: [answer]  Focus: [answer]  Autonomy: [answer]
 ```
 
-## Step 3: Execute Phases via Skill Invocations
+## Step 3: Execute Phases via orchestrate.sh
 
-**CRITICAL: Each phase MUST be invoked as a separate skill. This ensures each phase's full enforcement instructions (including orchestrate.sh dispatch) load fresh into context.**
+**CRITICAL: Each phase MUST run through `orchestrate.sh`. Do not invoke `/octo:discover`, `/octo:define`, `/octo:develop`, or `/octo:deliver` via Skill calls inside this command; direct phase dispatch prevents recursive command loading.**
 
 ### Phase 1 — Discover
 
-Run the discover phase via orchestrate.sh:
+Run the Discover phase via orchestrate.sh:
+
 ```bash
 cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh probe <user's prompt>
 ```
@@ -153,6 +154,7 @@ This will dispatch to Codex, Gemini, and other available providers. Results save
 ### Phase 2 — Define
 
 Run the define phase via orchestrate.sh:
+
 ```bash
 cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh grasp <user's prompt>
 ```
@@ -191,6 +193,7 @@ AskUserQuestion({
 ### Phase 3 — Develop
 
 Run the develop phase via orchestrate.sh:
+
 ```bash
 cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh tangle <user's prompt>
 ```
@@ -204,6 +207,7 @@ Same pattern as above but collaborative style, reviewing implementation quality.
 ### Phase 4 — Deliver
 
 Run the deliver phase via orchestrate.sh:
+
 ```bash
 cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh ink <user's prompt>
 ```
@@ -255,8 +259,8 @@ AskUserQuestion({
 
 ## Quick Reference
 
-| Phase | Skill | orchestrate.sh | Output |
-|-------|-------|----------------|--------|
+| Phase | Command | orchestrate.sh | Output |
+|-------|---------|----------------|--------|
 | Discover | `/octo:discover` | `probe-single` per provider | `probe-synthesis-*.md` |
 | Define | `/octo:define` | `grasp` | `grasp-consensus-*.md` |
 | Develop | `/octo:develop` | `tangle` | `tangle-validation-*.md` |

--- a/tests/unit/test-execution-mechanism.sh
+++ b/tests/unit/test-execution-mechanism.sh
@@ -93,15 +93,27 @@ else
 fi
 
 echo ""
-echo "=== Embrace Chains Skills (Not One Big Bash Call) ==="
+echo "=== Embrace Chains Direct Workflow Dispatches ==="
 
 EMBRACE="$PROJECT_ROOT/.claude/commands/embrace.md"
 if [[ -f "$EMBRACE" ]]; then
-    skill_invocations=$(grep -c 'Skill(skill: "octo:' "$EMBRACE" 2>/dev/null || echo 0)
-    if [[ $skill_invocations -ge 4 ]]; then
-        pass "embrace.md chains $skill_invocations skill invocations"
+    missing_dispatches=()
+    for workflow in probe grasp tangle ink; do
+        if ! grep -q "orchestrate.sh ${workflow}" "$EMBRACE" 2>/dev/null; then
+            missing_dispatches+=("$workflow")
+        fi
+    done
+
+    if [[ ${#missing_dispatches[@]} -eq 0 ]]; then
+        pass "embrace.md chains direct orchestrate.sh workflow dispatches"
     else
-        fail "embrace.md only has $skill_invocations skill invocations" "Must chain at least 4 (discover+define+develop+deliver)"
+        fail "embrace.md missing direct workflow dispatches" "Missing: ${missing_dispatches[*]}"
+    fi
+
+    if grep -qE 'Skill\(skill: "octo:(discover|define|develop|deliver)"' "$EMBRACE" 2>/dev/null; then
+        fail "embrace.md contains recursive workflow Skill invocation" "Must call orchestrate.sh directly for discover/define/develop/deliver phases"
+    else
+        pass "embrace.md avoids recursive workflow Skill invocations"
     fi
 fi
 

--- a/tests/unit/test-execution-mechanism.sh
+++ b/tests/unit/test-execution-mechanism.sh
@@ -115,6 +115,8 @@ if [[ -f "$EMBRACE" ]]; then
     else
         pass "embrace.md avoids recursive workflow Skill invocations"
     fi
+else
+    fail "embrace.md not found" "$EMBRACE missing"
 fi
 
 echo ""


### PR DESCRIPTION
Summary:
- replace recursive octo Skill invocations in discover/embrace with direct orchestrate.sh workflow dispatches
- keep embrace as a phased workflow while avoiding recursive slash-command/skill calls
- update execution-mechanism coverage for direct probe/grasp/tangle/ink dispatches

Tests:
- bash tests/unit/test-execution-mechanism.sh
- bash tests/test-intent-questions.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated workflow guides to require running each phase via the orchestrator, revised examples and quick-reference wording, and clarified prohibited recursive tool usage.

* **Tests**
  * Adjusted validation tests to confirm workflows are documented with orchestrator-based dispatch and to fail if recursive tool invocation patterns appear.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/378)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->