### PR TITLE
fix(tangle): wait on done markers with configurable deadline

### DIFF
--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -881,6 +881,15 @@ ${heuristic_ctx}"
         # Ensure file is fully written before background process exits
         sync
 
+        # Write completion marker — used by tangle_develop to detect thread end
+        # without relying on kill -0 (which tracks wrapper PID, not provider PID)
+        local _spawn_exit="${exit_code:-0}"
+        local _done_dir="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents"
+        local _done_tmp="${_done_dir}/${task_id}.done.tmp.$$"
+        local _done_file="${_done_dir}/${task_id}.done"
+        mkdir -p "$_done_dir" 2>/dev/null || true
+        echo "$_spawn_exit" > "$_done_tmp" && mv -f "$_done_tmp" "$_done_file" 2>/dev/null || true
+
         # v8.19.0: Cleanup heartbeat (self-terminating monitor handles this too)
         cleanup_heartbeat "$$" 2>/dev/null || true
     ) &

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -887,8 +887,11 @@ ${heuristic_ctx}"
         local _done_dir="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents"
         local _done_tmp="${_done_dir}/${task_id}.done.tmp.$$"
         local _done_file="${_done_dir}/${task_id}.done"
-        mkdir -p "$_done_dir" 2>/dev/null || true
-        echo "$_spawn_exit" > "$_done_tmp" && mv -f "$_done_tmp" "$_done_file" 2>/dev/null || true
+        if ! mkdir -p "$_done_dir" 2>/dev/null \
+           || ! { echo "$_spawn_exit" > "$_done_tmp" && mv -f "$_done_tmp" "$_done_file"; } 2>/dev/null; then
+            log WARN "Failed to write completion marker for $task_id (exit=$_spawn_exit)"
+            rm -f "$_done_tmp" 2>/dev/null || true
+        fi
 
         # v8.19.0: Cleanup heartbeat (self-terminating monitor handles this too)
         cleanup_heartbeat "$$" 2>/dev/null || true

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -891,6 +891,7 @@ Output as numbered list with [CODING] or [REASONING] prefix for each subtask."
     log INFO "Step 2: Parallel execution..."
     local subtask_num=0
     local pids=()
+    local task_ids=()
 
     fleet_dispatch_begin
     while IFS= read -r line; do
@@ -922,25 +923,54 @@ Output as numbered list with [CODING] or [REASONING] prefix for each subtask."
             pid=$(spawn_agent_capture_pid "$agent" "$subtask" "$task_id" "$role" "tangle")
             pids+=("$pid")
         fi
+        task_ids+=("$task_id")
         ((subtask_num++)) || true
     done <<< "$subtasks"
     fleet_dispatch_end
 
     log INFO "Spawned $subtask_num development threads"
 
-    # Wait with progress monitoring
+    # Wait with progress monitoring — poll .done marker files written by spawn_agent
+    # rather than kill -0 $pid (which tracks wrapper PID, not provider PID)
+    local _done_dir="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents"
+    local _deadline=$(( $(date +%s) + ${OCTOPUS_TANGLE_DEADLINE:-600} ))
     local completed=0
-    while [[ $completed -lt ${#pids[@]} ]]; do
+    local _failed_tasks=()
+    while [[ $completed -lt ${#task_ids[@]} ]]; do
         completed=0
-        for pid in "${pids[@]}"; do
-            if ! kill -0 "$pid" 2>/dev/null; then
+        for i in "${!task_ids[@]}"; do
+            local _done_file="${_done_dir}/${task_ids[$i]}.done"
+            if [[ -f "$_done_file" ]]; then
                 ((completed++)) || true
+            elif (( $(date +%s) > _deadline )); then
+                log WARN "Thread ${task_ids[$i]} deadline exceeded — killing and marking timeout"
+                # Kill wrapper PID if still alive (best-effort)
+                local _wrapper_pid="${pids[$i]:-}"
+                [[ -n "$_wrapper_pid" ]] && kill "$_wrapper_pid" 2>/dev/null || true
+                echo "timeout" > "$_done_file" 2>/dev/null || true
             fi
         done
-        echo -ne "\r${CYAN}Progress: $completed/${#pids[@]} subtasks complete${NC}"
+        echo -ne "\r${CYAN}Progress: $completed/${#task_ids[@]} subtasks complete${NC}"
         sleep 2
     done
     echo ""
+
+    # Report any failed subtasks
+    for i in "${!task_ids[@]}"; do
+        local _done_file="${_done_dir}/${task_ids[$i]}.done"
+        local _exit_val
+        _exit_val=$(cat "$_done_file" 2>/dev/null || echo "unknown")
+        if [[ "$_exit_val" != "0" ]]; then
+            log WARN "Subtask ${task_ids[$i]} finished with status: $_exit_val"
+            _failed_tasks+=("${task_ids[$i]}")
+        fi
+    done
+    [[ ${#_failed_tasks[@]} -gt 0 ]] && log WARN "${#_failed_tasks[@]}/${#task_ids[@]} subtasks failed: ${_failed_tasks[*]}"
+
+    # Cleanup done markers
+    for i in "${!task_ids[@]}"; do
+        rm -f "${_done_dir}/${task_ids[$i]}.done" 2>/dev/null || true
+    done
 
     # Cleanup tmux if enabled
     if [[ "$TMUX_MODE" == "true" ]]; then

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -912,6 +912,10 @@ Output as numbered list with [CODING] or [REASONING] prefix for each subtask."
         local task_id="tangle-${task_group}-${subtask_num}"
         local pane_title="$pane_icon Subtask $((subtask_num+1))"
 
+        # Tangle currently routes only CLI-backed codex/gemini workers. Its
+        # completion watcher relies on .done markers written by the legacy
+        # spawn path; add equivalent hook markers before routing Claude Agent
+        # Teams into this loop.
         if [[ "$TMUX_MODE" == "true" ]]; then
             # Use async+tmux spawning
             local pid
@@ -933,7 +937,9 @@ Output as numbered list with [CODING] or [REASONING] prefix for each subtask."
     # Wait with progress monitoring — poll .done marker files written by spawn_agent
     # rather than kill -0 $pid (which tracks wrapper PID, not provider PID)
     local _done_dir="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents"
-    local _deadline=$(( $(date +%s) + ${OCTOPUS_TANGLE_DEADLINE:-600} ))
+    local _tangle_max_wait="${OCTOPUS_TANGLE_DEADLINE:-$(( ${TIMEOUT:-600} + 60 ))}"
+    [[ "$_tangle_max_wait" =~ ^[0-9]+$ ]] || _tangle_max_wait=$(( ${TIMEOUT:-600} + 60 ))
+    local _deadline=$(( $(date +%s) + _tangle_max_wait ))
     local completed=0
     local _failed_tasks=()
     while [[ $completed -lt ${#task_ids[@]} ]]; do
@@ -944,10 +950,18 @@ Output as numbered list with [CODING] or [REASONING] prefix for each subtask."
                 ((completed++)) || true
             elif (( $(date +%s) > _deadline )); then
                 log WARN "Thread ${task_ids[$i]} deadline exceeded — killing and marking timeout"
-                # Kill wrapper PID if still alive (best-effort)
                 local _wrapper_pid="${pids[$i]:-}"
-                [[ -n "$_wrapper_pid" ]] && kill "$_wrapper_pid" 2>/dev/null || true
-                echo "timeout" > "$_done_file" 2>/dev/null || true
+                if [[ -n "$_wrapper_pid" ]]; then
+                    pkill -TERM -P "$_wrapper_pid" 2>/dev/null || true
+                    kill -TERM "$_wrapper_pid" 2>/dev/null || true
+                    sleep 1
+                    pkill -KILL -P "$_wrapper_pid" 2>/dev/null || true
+                    kill -KILL "$_wrapper_pid" 2>/dev/null || true
+                fi
+                mkdir -p "$_done_dir" 2>/dev/null || true
+                if [[ ! -f "$_done_file" ]] && ! echo "timeout" > "$_done_file" 2>/dev/null; then
+                    log WARN "Failed to write timeout marker for ${task_ids[$i]} at $_done_file"
+                fi
             fi
         done
         echo -ne "\r${CYAN}Progress: $completed/${#task_ids[@]} subtasks complete${NC}"

--- a/tests/unit/test-develop-md-file-resolution.sh
+++ b/tests/unit/test-develop-md-file-resolution.sh
@@ -65,6 +65,8 @@ DRY_RUN=false
 SUPPORTS_PARALLEL_FILE_SAFETY=false
 RESULTS_DIR="$(mktemp -d)"
 LOGS_DIR="$RESULTS_DIR/logs"
+WORKSPACE_DIR="$RESULTS_DIR/workspace"
+mkdir -p "$WORKSPACE_DIR/.octo/agents"
 DECOMPOSE_CAPTURE_FILE="$RESULTS_DIR/decompose.prompt"
 trap 'rm -rf "$RESULTS_DIR"' EXIT
 
@@ -121,6 +123,71 @@ if [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"This file should not be injected"* ]]; t
     test_fail "wildcard token was expanded and injected as a plan file"
 else
     test_pass
+fi
+
+test_case "deadline override marks stalled subtasks as timed out"
+WORKSPACE_DIR="$RESULTS_DIR/workspace"
+mkdir -p "$WORKSPACE_DIR/.octo/agents"
+LOG_CAPTURE_FILE="$RESULTS_DIR/tangle-deadline.log"
+DATE_COUNTER_FILE="$RESULTS_DIR/date-counter"
+SLEEP_COUNTER_FILE="$RESULTS_DIR/sleep-counter"
+EXPECTED_DONE_FILE="$WORKSPACE_DIR/.octo/agents/tangle-100-0.done"
+printf '0' > "$DATE_COUNTER_FILE"
+printf '0' > "$SLEEP_COUNTER_FILE"
+rm -f "$EXPECTED_DONE_FILE" "$LOG_CAPTURE_FILE"
+
+log() {
+    printf '%s %s\n' "${1:-}" "${2:-}" >> "$LOG_CAPTURE_FILE"
+}
+run_agent_sync() {
+    printf '%s\n' "1. [CODING] stalled implementation"
+}
+spawn_agent_capture_pid() {
+    printf '%s\n' "999999"
+}
+sleep() {
+    local count
+    count=$(<"$SLEEP_COUNTER_FILE")
+    count=$((count + 1))
+    printf '%s' "$count" > "$SLEEP_COUNTER_FILE"
+
+    # On the pre-override implementation this prevents the test from looping
+    # forever while still failing the behavioral assertion below.
+    if [[ $count -ge 2 && ! -f "$EXPECTED_DONE_FILE" ]]; then
+        printf '%s\n' "0" > "$EXPECTED_DONE_FILE"
+    fi
+}
+date() {
+    if [[ "${1:-}" == "+%s" ]]; then
+        local count
+        count=$(<"$DATE_COUNTER_FILE")
+        count=$((count + 1))
+        printf '%s' "$count" > "$DATE_COUNTER_FILE"
+        if [[ $count -le 2 ]]; then
+            printf '%s\n' "100"
+        else
+            printf '%s\n' "101"
+        fi
+        return 0
+    fi
+    command date "$@"
+}
+
+CAPTURED_VALIDATE_PROMPT=""
+deadline_override_ok=false
+if OCTOPUS_TANGLE_DEADLINE=0 tangle_develop "deadline override task" >/dev/null 2>&1 && \
+   grep -q "deadline exceeded" "$LOG_CAPTURE_FILE" && \
+   grep -q "finished with status: timeout" "$LOG_CAPTURE_FILE" && \
+   [[ "$CAPTURED_VALIDATE_PROMPT" == "deadline override task" ]]; then
+    deadline_override_ok=true
+fi
+unset -f date
+unset -f sleep
+
+if [[ "$deadline_override_ok" == "true" ]]; then
+    test_pass
+else
+    test_fail "OCTOPUS_TANGLE_DEADLINE did not force a stalled subtask timeout"
 fi
 
 test_summary


### PR DESCRIPTION
Summary:
- write atomic .done markers when spawned agents finish
- have tangle_develop poll those markers instead of kill -0 on wrapper PIDs
- log non-zero subtask exits and clean up markers after completion
- make the tangle watchdog deadline configurable with OCTOPUS_TANGLE_DEADLINE, preserving the 600s default

Tests:
- bash -n scripts/lib/workflows.sh
- bash tests/unit/test-develop-md-file-resolution.sh
- bash tests/smoke/test-fleet-dispatch-guard.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved background task reliability by adding atomic per-task completion markers to record outcomes and avoid race conditions.
  * Refactored parallel workflow monitoring to rely on persistent status markers, improving detection of failures and enforcing timeouts with best-effort termination of stalled work.
* **Tests**
  * Added a regression test simulating a stalled subtask to validate timeout behavior and associated logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
