### PR TITLE
fix(routing): share Claude agent predicate

### DIFF
--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -12,9 +12,12 @@
 # Every parallel spawn loop MUST call fleet_dispatch_begin before the first
 # spawn_agent call and fleet_dispatch_end after the last one. The smoke test
 # tests/smoke/test-fleet-dispatch-guard.sh enforces this statically.
+_octopus_agent_sync_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if ! type start_quota_watcher >/dev/null 2>&1; then
-    _octopus_agent_sync_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     source "${_octopus_agent_sync_lib_dir}/quota-watcher.sh" 2>/dev/null || true
+fi
+if ! type is_claude_agent_type >/dev/null 2>&1; then
+    source "${_octopus_agent_sync_lib_dir}/routing.sh" 2>/dev/null || true
 fi
 
 fleet_dispatch_begin() {
@@ -52,29 +55,22 @@ should_use_agent_teams() {
 
     # User override: force native for Claude agents
     if [[ "$OCTOPUS_AGENT_TEAMS" == "native" ]]; then
-        case "$agent_type" in
-            claude|claude-sonnet|claude-opus|claude-opus-fast)
-                if [[ "$SUPPORTS_STABLE_AGENT_TEAMS" == "true" ]]; then
-                    return 0
-                else
-                    log "WARN" "Agent Teams forced but SUPPORTS_STABLE_AGENT_TEAMS not available"
-                    return 1
-                fi
-                ;;
-            *)
-                # Non-Claude agents always use legacy (external CLIs)
+        if is_claude_agent_type "$agent_type"; then
+            if [[ "$SUPPORTS_STABLE_AGENT_TEAMS" == "true" ]]; then
+                return 0
+            else
+                log "WARN" "Agent Teams forced but SUPPORTS_STABLE_AGENT_TEAMS not available"
                 return 1
-                ;;
-        esac
+            fi
+        fi
+
+        # Non-Claude agents always use legacy (external CLIs)
+        return 1
     fi
 
     # Auto mode: use teams for Claude agents when stable teams are available
-    if [[ "$SUPPORTS_STABLE_AGENT_TEAMS" == "true" ]]; then
-        case "$agent_type" in
-            claude|claude-sonnet|claude-opus|claude-opus-fast)
-                return 0
-                ;;
-        esac
+    if [[ "$SUPPORTS_STABLE_AGENT_TEAMS" == "true" ]] && is_claude_agent_type "$agent_type"; then
+        return 0
     fi
 
     return 1

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -6,9 +6,12 @@
 # Extracted from orchestrate.sh — v9.7.5
 # ═══════════════════════════════════════════════════════════════════════════════
 
+_model_resolver_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if ! declare -f _is_cursor_agent_binary >/dev/null 2>&1; then
-    _model_resolver_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     source "${_model_resolver_lib_dir}/cursor-agent.sh" 2>/dev/null || true
+fi
+if ! declare -f is_claude_agent_type >/dev/null 2>&1; then
+    source "${_model_resolver_lib_dir}/routing.sh" 2>/dev/null || true
 fi
 
 # v9.23.0: Opus default picker — prefers 4.7 when host supports it, falls back to 4.6.
@@ -259,15 +262,17 @@ is_agent_available_v2() {
     # Load config if needed
     [[ -z "$PROVIDER_CODEX_INSTALLED" ]] && load_providers_config
 
+    if is_claude_agent_type "$agent"; then
+        [[ "$PROVIDER_CLAUDE_INSTALLED" == "true" ]]
+        return
+    fi
+
     case "$agent" in
         codex|codex-standard|codex-mini|codex-max|codex-general|codex-review|codex-spark|codex-reasoning|codex-large-context)
             [[ "$PROVIDER_CODEX_INSTALLED" == "true" && "$PROVIDER_CODEX_AUTH_METHOD" != "none" ]]
             ;;
         gemini|gemini-fast|gemini-image)
             [[ "$PROVIDER_GEMINI_INSTALLED" == "true" && "$PROVIDER_GEMINI_AUTH_METHOD" != "none" ]]
-            ;;
-        claude|claude-sonnet|claude-opus)
-            [[ "$PROVIDER_CLAUDE_INSTALLED" == "true" ]]
             ;;
         openrouter|openrouter-*)
             [[ "$PROVIDER_OPENROUTER_ENABLED" == "true" && "$PROVIDER_OPENROUTER_API_KEY_SET" == "true" ]]

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -13,6 +13,14 @@ fi
 if ! declare -f is_claude_agent_type >/dev/null 2>&1; then
     source "${_model_resolver_lib_dir}/routing.sh" 2>/dev/null || true
 fi
+if ! declare -f is_claude_agent_type >/dev/null 2>&1; then
+    is_claude_agent_type() {
+        case "${1:-}" in
+            claude|claude-*) return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+fi
 
 # v9.23.0: Opus default picker — prefers 4.7 when host supports it, falls back to 4.6.
 # Respects OCTOPUS_OPUS_MODEL override (user-pinned version).

--- a/scripts/lib/routing.sh
+++ b/scripts/lib/routing.sh
@@ -12,6 +12,19 @@ _ROUTING_LOADED=1
 # PROVIDER CONFIG ROUTING HELPERS
 # ═══════════════════════════════════════════════════════════════════════════════
 
+is_claude_agent_type() {
+    local agent_type="${1:-}"
+
+    case "$agent_type" in
+        claude|claude-*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 # Resolve a provider/config token from providers.json into a concrete agent type.
 # Returns non-zero for unknown or unavailable agents so callers can skip safely.
 resolve_provider_to_agent() {

--- a/tests/test-provider-activation.sh
+++ b/tests/test-provider-activation.sh
@@ -254,7 +254,7 @@ echo -e "\033[0;34mTest Group 6: Agent Teams dispatch safety\033[0m"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # 6.1: should_use_agent_teams only returns 0 for Claude agents
-if grep -rA 20 'should_use_agent_teams()' $SCRIPTS_ALL | grep -q 'claude|claude-sonnet|claude-opus'; then
+if grep -rA 30 'should_use_agent_teams()' $SCRIPTS_ALL | grep -q 'is_claude_agent_type "$agent_type"'; then
     pass "6.1 Agent Teams only routes Claude agent types"
 else
     fail "6.1 Agent Teams may route non-Claude agents incorrectly"

--- a/tests/test-provider-activation.sh
+++ b/tests/test-provider-activation.sh
@@ -254,7 +254,8 @@ echo -e "\033[0;34mTest Group 6: Agent Teams dispatch safety\033[0m"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # 6.1: should_use_agent_teams only returns 0 for Claude agents
-if grep -rA 30 'should_use_agent_teams()' $SCRIPTS_ALL | grep -q 'is_claude_agent_type "$agent_type"'; then
+agent_teams_predicate_refs=$(grep -rA 30 'should_use_agent_teams()' $SCRIPTS_ALL | grep -c 'is_claude_agent_type "$agent_type"' || true)
+if [[ "$agent_teams_predicate_refs" -gt 0 ]]; then
     pass "6.1 Agent Teams only routes Claude agent types"
 else
     fail "6.1 Agent Teams may route non-Claude agents incorrectly"

--- a/tests/unit/test-agent-predicates.sh
+++ b/tests/unit/test-agent-predicates.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Unit tests for shared agent/provider predicate helpers.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ROUTING="$PROJECT_ROOT/scripts/lib/routing.sh"
+AGENT_SYNC="$PROJECT_ROOT/scripts/lib/agent-sync.sh"
+MODEL_RESOLVER="$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "shared agent predicates"
+
+test_case "is_claude_agent_type recognizes every Claude agent variant"
+# shellcheck source=/dev/null
+source "$ROUTING"
+if declare -f is_claude_agent_type >/dev/null 2>&1 && \
+   is_claude_agent_type "claude" && \
+   is_claude_agent_type "claude-sonnet" && \
+   is_claude_agent_type "claude-opus" && \
+   is_claude_agent_type "claude-opus-fast" && \
+   is_claude_agent_type "claude-opus-legacy"; then
+    test_pass
+else
+    test_fail "Claude predicate did not accept all supported Claude agent variants"
+fi
+
+test_case "is_claude_agent_type rejects non-Claude and empty values"
+if ! is_claude_agent_type "" && \
+   ! is_claude_agent_type "codex" && \
+   ! is_claude_agent_type "gemini" && \
+   ! is_claude_agent_type "my-claude-wrapper"; then
+    test_pass
+else
+    test_fail "Claude predicate accepted a non-Claude agent value"
+fi
+
+test_case "Agent Teams dispatch uses the shared Claude predicate"
+if grep -A 50 'should_use_agent_teams()' "$AGENT_SYNC" | grep -q 'is_claude_agent_type "\$agent_type"'; then
+    test_pass
+else
+    test_fail "should_use_agent_teams does not use is_claude_agent_type"
+fi
+
+test_case "Claude agent availability uses the shared predicate for fast variants"
+# shellcheck source=/dev/null
+source "$MODEL_RESOLVER"
+PROVIDER_CODEX_INSTALLED=false
+PROVIDER_CLAUDE_INSTALLED=false
+if ! is_agent_available_v2 "claude-opus-fast"; then
+    PROVIDER_CLAUDE_INSTALLED=true
+    if is_agent_available_v2 "claude-opus-fast"; then
+        test_pass
+    else
+        test_fail "claude-opus-fast was unavailable despite Claude provider being installed"
+    fi
+else
+    test_fail "claude-opus-fast bypassed Claude provider availability"
+fi
+
+test_summary

--- a/tests/unit/test-agent-predicates.sh
+++ b/tests/unit/test-agent-predicates.sh
@@ -39,7 +39,12 @@ else
 fi
 
 test_case "Agent Teams dispatch uses the shared Claude predicate"
-if grep -A 50 'should_use_agent_teams()' "$AGENT_SYNC" | grep -q 'is_claude_agent_type "\$agent_type"'; then
+if awk '
+    /should_use_agent_teams\(\)/, /^}/ {
+        if ($0 ~ /is_claude_agent_type "\$agent_type"/) found=1
+    }
+    END { exit(found ? 0 : 1) }
+' "$AGENT_SYNC"; then
     test_pass
 else
     test_fail "should_use_agent_teams does not use is_claude_agent_type"


### PR DESCRIPTION
Summary:
- add a shared is_claude_agent_type helper for Claude agent variants
- use it in Agent Teams dispatch routing and provider availability checks
- cover claude-opus-fast and claude-opus-legacy consistently

Tests:
- bash -n scripts/lib/routing.sh scripts/lib/agent-sync.sh scripts/lib/model-resolver.sh tests/unit/test-agent-predicates.sh
- bash tests/unit/test-agent-predicates.sh
- bash tests/test-provider-activation.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * More consistent and centralized agent-type detection to improve routing decisions.

* **Bug Fixes**
  * Conditional loading of auxiliary checks to avoid missing helpers and reduce race conditions.

* **Tests**
  * Added and updated tests to validate agent-detection and dispatch behavior for Claude and other agents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->