### PR TITLE
fix: resolve plugin root dynamically for marketplace installs (#377)

### DIFF
--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -29,6 +29,23 @@ aliases:
 
 When the user invokes this command (e.g., `/octo:develop <arguments>`):
 
+**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
+
+```bash
+OCTO_ROOT="${HOME}/.claude-octopus/plugin"
+if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
+  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
+  if [[ -n "$cache" ]]; then
+    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
+    mkdir -p "${HOME}/.claude-octopus"
+    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  fi
+fi
+test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
+```
+
+If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+
 **Step 1 — Run provider preflight via Bash tool:**
 
 ```bash

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -29,22 +29,21 @@ aliases:
 
 When the user invokes this command (e.g., `/octo:develop <arguments>`):
 
-**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
+**Preflight — Ensure plugin root is resolvable (run via Bash tool FIRST):**
 
 ```bash
 OCTO_ROOT="${HOME}/.claude-octopus/plugin"
 if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
-  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
-  if [[ -n "$cache" ]]; then
-    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
-    mkdir -p "${HOME}/.claude-octopus"
-    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  helper="$OCTO_ROOT/scripts/helpers/ensure-plugin-root.sh"
+  if [[ ! -x "$helper" ]]; then
+    helper="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/helpers/ensure-plugin-root.sh" -print -quit 2>/dev/null)"
   fi
+  [[ -x "$helper" ]] && bash "$helper" >/dev/null 2>&1 || true
 fi
 test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
 ```
 
-If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+If the output is `plugin-root:missing`, stop and ask the user to run `/octo:setup`.
 
 **Step 1 — Run provider preflight via Bash tool:**
 

--- a/.claude/commands/factory.md
+++ b/.claude/commands/factory.md
@@ -27,6 +27,23 @@ Ask 3 clarifying questions:
 
 After receiving answers: validate spec path exists, set overrides, proceed.
 
+### Step 1.5: Ensure plugin root is resolvable (run via Bash tool)
+
+```bash
+OCTO_ROOT="${HOME}/.claude-octopus/plugin"
+if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
+  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
+  if [[ -n "$cache" ]]; then
+    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
+    mkdir -p "${HOME}/.claude-octopus"
+    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  fi
+fi
+test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
+```
+
+If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+
 ### Step 2: Check Provider Availability & Display Banner
 
 Check via bash:

--- a/.claude/commands/factory.md
+++ b/.claude/commands/factory.md
@@ -32,17 +32,16 @@ After receiving answers: validate spec path exists, set overrides, proceed.
 ```bash
 OCTO_ROOT="${HOME}/.claude-octopus/plugin"
 if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
-  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
-  if [[ -n "$cache" ]]; then
-    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
-    mkdir -p "${HOME}/.claude-octopus"
-    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  helper="$OCTO_ROOT/scripts/helpers/ensure-plugin-root.sh"
+  if [[ ! -x "$helper" ]]; then
+    helper="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/helpers/ensure-plugin-root.sh" -print -quit 2>/dev/null)"
   fi
+  [[ -x "$helper" ]] && bash "$helper" >/dev/null 2>&1 || true
 fi
 test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
 ```
 
-If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+If the output is `plugin-root:missing`, stop and ask the user to run `/octo:setup`.
 
 ### Step 2: Check Provider Availability & Display Banner
 

--- a/.claude/commands/model-config.md
+++ b/.claude/commands/model-config.md
@@ -180,6 +180,25 @@ AskUserQuestion({
 ```
 
 After selection, apply the change:
+
+**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
+
+```bash
+OCTO_ROOT="${HOME}/.claude-octopus/plugin"
+if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
+  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
+  if [[ -n "$cache" ]]; then
+    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
+    mkdir -p "${HOME}/.claude-octopus"
+    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  fi
+fi
+test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
+```
+
+If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+
+
 ```bash
 ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh set-model <provider> <model>
 ```

--- a/.claude/commands/model-config.md
+++ b/.claude/commands/model-config.md
@@ -20,6 +20,22 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo "provider | model | config | routing | cost"
 ```
 
+**Preflight — Ensure plugin root is resolvable (run via Bash tool):**
+
+```bash
+OCTO_ROOT="${HOME}/.claude-octopus/plugin"
+if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
+  helper="$OCTO_ROOT/scripts/helpers/ensure-plugin-root.sh"
+  if [[ ! -x "$helper" ]]; then
+    helper="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/helpers/ensure-plugin-root.sh" -print -quit 2>/dev/null)"
+  fi
+  [[ -x "$helper" ]] && bash "$helper" >/dev/null 2>&1 || true
+fi
+test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
+```
+
+If the output is `plugin-root:missing`, stop and ask the user to run `/octo:setup`.
+
 Run this unconditionally — even when arguments are provided or when going to interactive wizard. The explicit bash block ensures the banner emits even when the command routes straight to `AskUserQuestion` (which historically skipped the inline-prose instruction and broke E2E pattern matching — see #301).
 
 Interactive model configuration wizard. Detects installed providers, shows current settings, and guides users through configuration with AskUserQuestion.
@@ -180,24 +196,6 @@ AskUserQuestion({
 ```
 
 After selection, apply the change:
-
-**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
-
-```bash
-OCTO_ROOT="${HOME}/.claude-octopus/plugin"
-if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
-  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
-  if [[ -n "$cache" ]]; then
-    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
-    mkdir -p "${HOME}/.claude-octopus"
-    ln -sfn "$plugin_dir" "$OCTO_ROOT"
-  fi
-fi
-test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
-```
-
-If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
-
 
 ```bash
 ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh set-model <provider> <model>

--- a/.claude/commands/resume.md
+++ b/.claude/commands/resume.md
@@ -23,6 +23,25 @@ If you don't have the agent ID:
 ## Step 2: Resume
 
 Use the Bash tool to execute:
+
+**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
+
+```bash
+OCTO_ROOT="${HOME}/.claude-octopus/plugin"
+if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
+  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
+  if [[ -n "$cache" ]]; then
+    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
+    mkdir -p "${HOME}/.claude-octopus"
+    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  fi
+fi
+test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
+```
+
+If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+
+
 ```bash
 ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh agent-resume "$ARGUMENTS"
 ```

--- a/.claude/commands/resume.md
+++ b/.claude/commands/resume.md
@@ -24,22 +24,21 @@ If you don't have the agent ID:
 
 Use the Bash tool to execute:
 
-**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
+**Preflight check — Ensure plugin root is resolvable (run via Bash tool FIRST):**
 
 ```bash
 OCTO_ROOT="${HOME}/.claude-octopus/plugin"
 if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
-  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
-  if [[ -n "$cache" ]]; then
-    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
-    mkdir -p "${HOME}/.claude-octopus"
-    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  helper="$OCTO_ROOT/scripts/helpers/ensure-plugin-root.sh"
+  if [[ ! -x "$helper" ]]; then
+    helper="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/helpers/ensure-plugin-root.sh" -print -quit 2>/dev/null)"
   fi
+  [[ -x "$helper" ]] && bash "$helper" >/dev/null 2>&1 || true
 fi
 test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
 ```
 
-If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+If the output is `plugin-root:missing`, stop and ask the user to run `/octo:setup`.
 
 
 ```bash

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -146,6 +146,23 @@ const profile = {
 
 If the user includes `fresh` in the command text, do not treat it as a file path. Keep the normal target inference and set `history: "fresh"` so this run ignores prior PR review rounds.
 
+## Step 2.5: Ensure plugin root is resolvable (run via Bash tool)
+
+```bash
+OCTO_ROOT="${HOME}/.claude-octopus/plugin"
+if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
+  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
+  if [[ -n "$cache" ]]; then
+    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
+    mkdir -p "${HOME}/.claude-octopus"
+    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  fi
+fi
+test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
+```
+
+If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+
 ## Step 3: Execute Review Pipeline
 
 Run via Bash tool:

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -151,17 +151,16 @@ If the user includes `fresh` in the command text, do not treat it as a file path
 ```bash
 OCTO_ROOT="${HOME}/.claude-octopus/plugin"
 if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
-  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
-  if [[ -n "$cache" ]]; then
-    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
-    mkdir -p "${HOME}/.claude-octopus"
-    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  helper="$OCTO_ROOT/scripts/helpers/ensure-plugin-root.sh"
+  if [[ ! -x "$helper" ]]; then
+    helper="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/helpers/ensure-plugin-root.sh" -print -quit 2>/dev/null)"
   fi
+  [[ -x "$helper" ]] && bash "$helper" >/dev/null 2>&1 || true
 fi
 test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
 ```
 
-If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+If the output is `plugin-root:missing`, stop and ask the user to run `/octo:setup`.
 
 ## Step 3: Execute Review Pipeline
 

--- a/.claude/commands/schedule.md
+++ b/.claude/commands/schedule.md
@@ -12,6 +12,25 @@ Manage scheduled workflow jobs for the Claude Octopus scheduler.
 
 ## Usage
 
+
+**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
+
+```bash
+OCTO_ROOT="${HOME}/.claude-octopus/plugin"
+if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
+  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
+  if [[ -n "$cache" ]]; then
+    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
+    mkdir -p "${HOME}/.claude-octopus"
+    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  fi
+fi
+test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
+```
+
+If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+
+
 ```bash
 ${HOME}/.claude-octopus/plugin/scripts/scheduler/octopus-scheduler.sh [subcommand]
 ```

--- a/.claude/commands/schedule.md
+++ b/.claude/commands/schedule.md
@@ -13,22 +13,21 @@ Manage scheduled workflow jobs for the Claude Octopus scheduler.
 ## Usage
 
 
-**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
+**Preflight — Ensure plugin root is resolvable (run via Bash tool FIRST):**
 
 ```bash
 OCTO_ROOT="${HOME}/.claude-octopus/plugin"
 if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
-  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
-  if [[ -n "$cache" ]]; then
-    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
-    mkdir -p "${HOME}/.claude-octopus"
-    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  helper="$OCTO_ROOT/scripts/helpers/ensure-plugin-root.sh"
+  if [[ ! -x "$helper" ]]; then
+    helper="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/helpers/ensure-plugin-root.sh" -print -quit 2>/dev/null)"
   fi
+  [[ -x "$helper" ]] && bash "$helper" >/dev/null 2>&1 || true
 fi
 test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
 ```
 
-If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+If the output is `plugin-root:missing`, stop and ask the user to run `/octo:setup`.
 
 
 ```bash

--- a/.claude/commands/scheduler.md
+++ b/.claude/commands/scheduler.md
@@ -11,6 +11,25 @@ Manage the Claude Octopus scheduled workflow runner daemon.
 
 ## Usage
 
+
+**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
+
+```bash
+OCTO_ROOT="${HOME}/.claude-octopus/plugin"
+if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
+  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
+  if [[ -n "$cache" ]]; then
+    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
+    mkdir -p "${HOME}/.claude-octopus"
+    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  fi
+fi
+test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
+```
+
+If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+
+
 ```bash
 ${HOME}/.claude-octopus/plugin/scripts/scheduler/octopus-scheduler.sh start
 ${HOME}/.claude-octopus/plugin/scripts/scheduler/octopus-scheduler.sh stop

--- a/.claude/commands/scheduler.md
+++ b/.claude/commands/scheduler.md
@@ -12,22 +12,21 @@ Manage the Claude Octopus scheduled workflow runner daemon.
 ## Usage
 
 
-**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
+**Preflight — Ensure plugin root is resolvable (run via Bash tool FIRST):**
 
 ```bash
 OCTO_ROOT="${HOME}/.claude-octopus/plugin"
 if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
-  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
-  if [[ -n "$cache" ]]; then
-    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
-    mkdir -p "${HOME}/.claude-octopus"
-    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  helper="$OCTO_ROOT/scripts/helpers/ensure-plugin-root.sh"
+  if [[ ! -x "$helper" ]]; then
+    helper="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/helpers/ensure-plugin-root.sh" -print -quit 2>/dev/null)"
   fi
+  [[ -x "$helper" ]] && bash "$helper" >/dev/null 2>&1 || true
 fi
 test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
 ```
 
-If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+If the output is `plugin-root:missing`, stop and ask the user to run `/octo:setup`.
 
 
 ```bash

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -326,6 +326,25 @@ export OCTOPUS_REMOTE_STATUSLINE=off
 
 Re-run provider detection to confirm everything works:
 
+
+**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
+
+```bash
+OCTO_ROOT="${HOME}/.claude-octopus/plugin"
+if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
+  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
+  if [[ -n "$cache" ]]; then
+    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
+    mkdir -p "${HOME}/.claude-octopus"
+    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  fi
+fi
+test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
+```
+
+If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+
+
 ```bash
 ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh detect-providers
 ```

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -327,22 +327,21 @@ export OCTOPUS_REMOTE_STATUSLINE=off
 Re-run provider detection to confirm everything works:
 
 
-**Step 0 — Ensure plugin root is resolvable (run via Bash tool FIRST):**
+**Preflight — Ensure plugin root is resolvable (run via Bash tool FIRST):**
 
 ```bash
 OCTO_ROOT="${HOME}/.claude-octopus/plugin"
 if [[ ! -x "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
-  cache="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
-  if [[ -n "$cache" ]]; then
-    plugin_dir="$(cd "$(dirname "$(dirname "$cache")")" && pwd -P)"
-    mkdir -p "${HOME}/.claude-octopus"
-    ln -sfn "$plugin_dir" "$OCTO_ROOT"
+  helper="$OCTO_ROOT/scripts/helpers/ensure-plugin-root.sh"
+  if [[ ! -x "$helper" ]]; then
+    helper="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/helpers/ensure-plugin-root.sh" -print -quit 2>/dev/null)"
   fi
+  [[ -x "$helper" ]] && bash "$helper" >/dev/null 2>&1 || true
 fi
 test -x "$OCTO_ROOT/scripts/orchestrate.sh" && echo "plugin-root:ok" || echo "plugin-root:missing"
 ```
 
-If the output is `plugin-root:missing`, stop and tell the user to run `/octo:setup`.
+If the output is `plugin-root:missing`, stop and ask the user to reinstall `octo@nyldn-plugins`, then retry setup.
 
 
 ```bash

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -7,6 +7,12 @@
 # Exit code: always 0 (availability is informational, not an error)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+# Self-heal: ensure ~/.claude-octopus/plugin symlink exists before proceeding.
+# Marketplace installs may not have the symlink yet if SessionStart hook hasn't
+# fired. This is a no-op when the symlink is already healthy. (fixes #377)
+bash "${SCRIPT_DIR}/ensure-plugin-root.sh" 2>/dev/null || true
+
 source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
 

--- a/scripts/helpers/ensure-plugin-root.sh
+++ b/scripts/helpers/ensure-plugin-root.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Claude Octopus — Ensure ~/.claude-octopus/plugin symlink exists
+# Lightweight preflight for command files. Idempotent and safe to call
+# from LLM Bash tool context where ${CLAUDE_PLUGIN_ROOT} is NOT available.
+#
+# After marketplace install the SessionStart hook normally creates this
+# symlink, but if the hook hasn't fired yet (first command invoked before
+# session start) or silently errored, this script self-heals.
+#
+# Exit code: 0 on success, 1 if plugin root cannot be resolved.
+# See: https://github.com/nyldn/claude-octopus/issues/377
+
+set -eo pipefail
+
+STABLE_ROOT="${HOME}/.claude-octopus/plugin"
+
+# Fast path — already exists and points to a valid directory
+if [[ -d "$STABLE_ROOT" && -x "$STABLE_ROOT/scripts/orchestrate.sh" ]]; then
+    exit 0
+fi
+
+# --- Resolve plugin root ---
+PLUGIN_ROOT=""
+
+# Strategy 1: CLAUDE_PLUGIN_ROOT env var (set by CC in hook context)
+if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -d "${CLAUDE_PLUGIN_ROOT}" ]]; then
+    PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+fi
+
+# Strategy 2: Relative to this script (works when script is inside the plugin tree)
+if [[ -z "$PLUGIN_ROOT" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+    candidate="$(dirname "$(dirname "$SCRIPT_DIR")")"
+    if [[ -f "$candidate/scripts/orchestrate.sh" ]]; then
+        PLUGIN_ROOT="$candidate"
+    fi
+fi
+
+# Strategy 3: CC marketplace cache — find the latest installed version
+if [[ -z "$PLUGIN_ROOT" ]]; then
+    cache_base="${HOME}/.claude/plugins/cache/nyldn-plugins/octo"
+    if [[ -d "$cache_base" ]]; then
+        latest="$(ls -1d "$cache_base"/*/ 2>/dev/null | sort -V | tail -1)"
+        if [[ -n "$latest" && -f "${latest}scripts/orchestrate.sh" ]]; then
+            PLUGIN_ROOT="${latest%/}"
+        fi
+    fi
+fi
+
+# Strategy 4: Cowork / desktop-app plugin cache
+if [[ -z "$PLUGIN_ROOT" ]]; then
+    for search_root in \
+        "${HOME}/Library/Application Support/Claude" \
+        "${LOCALAPPDATA:-/dev/null}/Claude" \
+        "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude"; do
+        if [[ -d "$search_root" ]]; then
+            found="$(find "$search_root" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
+            if [[ -n "$found" ]]; then
+                PLUGIN_ROOT="$(cd "$(dirname "$(dirname "$found")")" && pwd -P)"
+                break
+            fi
+        fi
+    done
+fi
+
+if [[ -z "$PLUGIN_ROOT" ]]; then
+    echo "error: could not locate Octopus plugin root. Run /octo:setup or reinstall." >&2
+    exit 1
+fi
+
+# Canonicalize to physical path to avoid self-referential symlinks (#371)
+PLUGIN_ROOT="$(cd "$PLUGIN_ROOT" && pwd -P)"
+
+# Source the full self-heal helper if available (handles Windows shims etc.)
+if [[ -f "$PLUGIN_ROOT/scripts/lib/plugin-root.sh" ]]; then
+    source "$PLUGIN_ROOT/scripts/lib/plugin-root.sh"
+    if declare -f octo_ensure_stable_plugin_root >/dev/null 2>&1; then
+        octo_ensure_stable_plugin_root "$PLUGIN_ROOT" >/dev/null 2>&1
+        if [[ -d "$STABLE_ROOT" && -x "$STABLE_ROOT/scripts/orchestrate.sh" ]]; then
+            exit 0
+        fi
+    fi
+fi
+
+# Simple fallback: create symlink directly
+mkdir -p "${HOME}/.claude-octopus"
+
+# Remove stale symlink/file if present
+if [[ -L "$STABLE_ROOT" || -e "$STABLE_ROOT" ]]; then
+    rm -f "$STABLE_ROOT" 2>/dev/null || true
+fi
+
+ln -sfn "$PLUGIN_ROOT" "$STABLE_ROOT" 2>/dev/null || true
+
+# Verify
+if [[ -d "$STABLE_ROOT" && -x "$STABLE_ROOT/scripts/orchestrate.sh" ]]; then
+    exit 0
+else
+    echo "error: failed to create stable plugin root at $STABLE_ROOT" >&2
+    exit 1
+fi

--- a/scripts/helpers/ensure-plugin-root.sh
+++ b/scripts/helpers/ensure-plugin-root.sh
@@ -13,6 +13,12 @@
 set -eo pipefail
 
 STABLE_ROOT="${HOME}/.claude-octopus/plugin"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT_LIB="${SCRIPT_DIR}/../lib/plugin-root.sh"
+
+if [[ -f "$PLUGIN_ROOT_LIB" ]]; then
+    source "$PLUGIN_ROOT_LIB"
+fi
 
 # Fast path — already exists and points to a valid directory
 if [[ -d "$STABLE_ROOT" && -x "$STABLE_ROOT/scripts/orchestrate.sh" ]]; then
@@ -29,38 +35,15 @@ fi
 
 # Strategy 2: Relative to this script (works when script is inside the plugin tree)
 if [[ -z "$PLUGIN_ROOT" ]]; then
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
     candidate="$(dirname "$(dirname "$SCRIPT_DIR")")"
     if [[ -f "$candidate/scripts/orchestrate.sh" ]]; then
         PLUGIN_ROOT="$candidate"
     fi
 fi
 
-# Strategy 3: CC marketplace cache — find the latest installed version
-if [[ -z "$PLUGIN_ROOT" ]]; then
-    cache_base="${HOME}/.claude/plugins/cache/nyldn-plugins/octo"
-    if [[ -d "$cache_base" ]]; then
-        latest="$(ls -1d "$cache_base"/*/ 2>/dev/null | sort -V | tail -1)"
-        if [[ -n "$latest" && -f "${latest}scripts/orchestrate.sh" ]]; then
-            PLUGIN_ROOT="${latest%/}"
-        fi
-    fi
-fi
-
-# Strategy 4: Cowork / desktop-app plugin cache
-if [[ -z "$PLUGIN_ROOT" ]]; then
-    for search_root in \
-        "${HOME}/Library/Application Support/Claude" \
-        "${LOCALAPPDATA:-/dev/null}/Claude" \
-        "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude"; do
-        if [[ -d "$search_root" ]]; then
-            found="$(find "$search_root" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
-            if [[ -n "$found" ]]; then
-                PLUGIN_ROOT="$(cd "$(dirname "$(dirname "$found")")" && pwd -P)"
-                break
-            fi
-        fi
-    done
+# Strategy 3: Shared marketplace/cache discovery
+if [[ -z "$PLUGIN_ROOT" ]] && declare -f octo_discover_plugin_root >/dev/null 2>&1; then
+    PLUGIN_ROOT="$(octo_discover_plugin_root)" || true
 fi
 
 if [[ -z "$PLUGIN_ROOT" ]]; then
@@ -75,10 +58,11 @@ PLUGIN_ROOT="$(cd "$PLUGIN_ROOT" && pwd -P)"
 if [[ -f "$PLUGIN_ROOT/scripts/lib/plugin-root.sh" ]]; then
     source "$PLUGIN_ROOT/scripts/lib/plugin-root.sh"
     if declare -f octo_ensure_stable_plugin_root >/dev/null 2>&1; then
-        octo_ensure_stable_plugin_root "$PLUGIN_ROOT" >/dev/null 2>&1
+        helper_output="$(octo_ensure_stable_plugin_root "$PLUGIN_ROOT" 2>&1)" && helper_status=0 || helper_status=$?
         if [[ -d "$STABLE_ROOT" && -x "$STABLE_ROOT/scripts/orchestrate.sh" ]]; then
             exit 0
         fi
+        echo "warning: octo_ensure_stable_plugin_root did not create a valid stable root (exit=$helper_status): ${helper_output:-no output}" >&2
     fi
 fi
 

--- a/scripts/lib/plugin-root.sh
+++ b/scripts/lib/plugin-root.sh
@@ -38,9 +38,53 @@ octo_write_stable_script_shim() {
     chmod +x "$dst" 2>/dev/null || true
 }
 
+octo_discover_plugin_root() {
+    # Auto-discover the Octopus plugin root from CC marketplace cache or Cowork
+    # plugin cache. Returns the path on stdout, or empty string on failure.
+    # Used when CLAUDE_PLUGIN_ROOT is not set (LLM Bash tool context). (#377)
+    local candidate=""
+
+    # Strategy 1: CC marketplace cache (standard install path)
+    local cache_base="${HOME}/.claude/plugins/cache/nyldn-plugins/octo"
+    if [[ -d "$cache_base" ]]; then
+        candidate="$(ls -1d "$cache_base"/*/ 2>/dev/null | sort -V | tail -1)"
+        candidate="${candidate%/}"
+        if [[ -n "$candidate" && -f "${candidate}/scripts/orchestrate.sh" ]]; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    fi
+
+    # Strategy 2: Cowork / desktop-app plugin cache
+    local search_root
+    for search_root in \
+        "${HOME}/Library/Application Support/Claude" \
+        "${LOCALAPPDATA:-/dev/null}/Claude" \
+        "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude"; do
+        if [[ -d "$search_root" ]]; then
+            local found
+            found="$(find "$search_root" -maxdepth 8 -path "*/nyldn-plugins/octo/*/scripts/orchestrate.sh" -print -quit 2>/dev/null)"
+            if [[ -n "$found" ]]; then
+                candidate="$(cd "$(dirname "$(dirname "$found")")" 2>/dev/null && pwd -P)"
+                if [[ -n "$candidate" ]]; then
+                    printf '%s' "$candidate"
+                    return 0
+                fi
+            fi
+        fi
+    done
+
+    return 1
+}
+
 octo_ensure_stable_plugin_root() {
     local plugin_root="$1"
     local stable_root="${2:-${HOME}/.claude-octopus/plugin}"
+
+    # If plugin_root is empty or missing, try auto-discovery (#377)
+    if [[ -z "$plugin_root" || ! -d "$plugin_root" ]]; then
+        plugin_root="$(octo_discover_plugin_root)" || true
+    fi
 
     [[ -n "$plugin_root" && -d "$plugin_root" ]] || return 1
 

--- a/scripts/lib/plugin-root.sh
+++ b/scripts/lib/plugin-root.sh
@@ -47,7 +47,7 @@ octo_discover_plugin_root() {
     # Strategy 1: CC marketplace cache (standard install path)
     local cache_base="${HOME}/.claude/plugins/cache/nyldn-plugins/octo"
     if [[ -d "$cache_base" ]]; then
-        candidate="$(ls -1d "$cache_base"/*/ 2>/dev/null | sort -V | tail -1)"
+        candidate="$(ls -1dt "$cache_base"/*/ 2>/dev/null | head -1)"
         candidate="${candidate%/}"
         if [[ -n "$candidate" && -f "${candidate}/scripts/orchestrate.sh" ]]; then
             printf '%s' "$candidate"

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -17,6 +17,7 @@ source "${SCRIPT_DIR}/lib/plugin-root.sh" 2>/dev/null || true
 # Self-heal: ensure the stable symlink exists for LLM Bash tool access.
 # The SessionStart hook normally creates this, but if doctor (or any command)
 # is invoked before the hook fires, the symlink may be missing. (fixes #318)
+# Also handles marketplace installs where the hook may not have fired. (#377)
 if declare -f octo_ensure_stable_plugin_root >/dev/null 2>&1; then
     octo_ensure_stable_plugin_root "$PLUGIN_DIR" >/dev/null 2>&1 || true
 elif [[ ! -e "${HOME}/.claude-octopus/plugin" ]]; then


### PR DESCRIPTION
Closes #377

## Problem

After marketplace install (`claude plugin install octo@nyldn-plugins`), running any `/octo:*` command that invokes `orchestrate.sh` via the LLM Bash tool fails because `~/.claude-octopus/plugin` symlink does not exist yet. The SessionStart hook normally creates it, but if the hook hasn't fired (or silently errored), the hardcoded path is unresolvable.

## Fix

Multi-layered self-heal:

1. **`scripts/helpers/ensure-plugin-root.sh`** — new standalone preflight script that discovers the plugin root from CC marketplace cache (`~/.claude/plugins/cache/nyldn-plugins/octo/`) or Cowork plugin cache, and creates the symlink if missing.

2. **`scripts/lib/plugin-root.sh`** — new `octo_discover_plugin_root()` function that searches standard plugin cache locations. `octo_ensure_stable_plugin_root()` now auto-discovers if called with empty/invalid root.

3. **`scripts/helpers/check-providers.sh`** — calls `ensure-plugin-root.sh` as preflight so the symlink is repaired before provider availability checks.

4. **8 command `.md` files** — add Step 0 preflight that the LLM executes via Bash tool before invoking `orchestrate.sh`. This is the key fix: commands now self-bootstrap the symlink before relying on it.

## Testing

- `bash -n` passes on all modified `.sh` files
- `test-docs-sync.sh` passes (133/133)
- JSON validation passes on plugin.json and marketplace.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mandatory preflight checks across several commands that verify plugin availability and report "plugin-root:ok" or "plugin-root:missing".
  * Automatic discovery and self-healing of the plugin install when possible, preventing failed command runs.

* **Documentation**
  * Updated command docs to show preflight behavior and clear user instructions when the plugin is missing.

* **Chores**
  * Improved plugin-root discovery and validation logic for more robust operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->