### PR TITLE
fix(tangle): fall back on empty decomposition

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -887,6 +887,19 @@ Output as numbered list with [CODING] or [REASONING] prefix for each subtask."
     echo "$subtasks"
     echo ""
 
+    local parseable_subtask_count=0
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        [[ "$line" =~ ^[0-9]+[\.\)] ]] && ((parseable_subtask_count++)) || true
+    done <<< "$subtasks"
+
+    if [[ $parseable_subtask_count -eq 0 ]]; then
+        log WARN "Decomposition produced no parseable subtasks, falling back to direct execution"
+        spawn_agent "codex" "$resolved_prompt" "tangle-${task_group}-direct" "implementer" "tangle"
+        wait
+        return
+    fi
+
     # Step 2: Parallel execution with progress tracking
     log INFO "Step 2: Parallel execution..."
     local subtask_num=0

--- a/tests/unit/test-develop-md-file-resolution.sh
+++ b/tests/unit/test-develop-md-file-resolution.sh
@@ -79,10 +79,15 @@ fleet_dispatch_begin() { :; }
 fleet_dispatch_end() { :; }
 run_agent_sync() {
     printf '%s' "$2" > "$DECOMPOSE_CAPTURE_FILE"
-    printf '%s\n' "No numbered subtasks required"
+    printf '%s\n' "1. [CODING] Validate resolved plan context"
 }
 validate_tangle_results() {
     CAPTURED_VALIDATE_PROMPT="$2"
+}
+spawn_agent_capture_pid() {
+    local task_id="$3"
+    printf '0\n' > "$WORKSPACE_DIR/.octo/agents/${task_id}.done"
+    printf '12345\n'
 }
 
 run_tangle_case() {

--- a/tests/unit/test-tangle-direct-fallback.sh
+++ b/tests/unit/test-tangle-direct-fallback.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Regression checks for /octo:develop fallback when decomposition is unusable.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKFLOWS="$PROJECT_ROOT/scripts/lib/workflows.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "tangle direct fallback"
+
+test_case "workflows.sh has valid bash syntax"
+if bash -n "$WORKFLOWS" 2>/dev/null; then
+    test_pass
+else
+    test_fail "syntax error in workflows.sh"
+fi
+
+# shellcheck source=/dev/null
+source "$WORKFLOWS"
+
+CYAN=""
+GREEN=""
+MAGENTA=""
+NC=""
+TMUX_MODE=false
+DRY_RUN=false
+SUPPORTS_PARALLEL_FILE_SAFETY=false
+RESULTS_DIR="$(mktemp -d)"
+LOGS_DIR="$RESULTS_DIR/logs"
+WORKSPACE_DIR="$RESULTS_DIR/workspace"
+mkdir -p "$WORKSPACE_DIR/.octo/agents"
+trap 'rm -rf "$RESULTS_DIR"' EXIT
+
+DIRECT_PROMPT=""
+DIRECT_TASK_ID=""
+VALIDATION_CALLED=false
+
+log() { :; }
+octopus_phase_banner() { :; }
+display_workflow_cost_estimate() { return 0; }
+reset_provider_lockouts() { :; }
+design_review_ceremony() { :; }
+fleet_dispatch_begin() { :; }
+fleet_dispatch_end() { :; }
+run_agent_sync() {
+    printf '%s\n' "This task should be handled directly."
+}
+spawn_agent() {
+    DIRECT_PROMPT="$2"
+    DIRECT_TASK_ID="$3"
+}
+validate_tangle_results() {
+    VALIDATION_CALLED=true
+}
+
+original_prompt="Update src/lib/templates/NA10_HANDLE_SILENCE.ts and do not modify src/lib/render/renderEmailTemplate.ts."
+
+tangle_develop "$original_prompt" >/dev/null
+
+test_case "unparseable decomposition falls back to direct execution"
+if [[ "$DIRECT_TASK_ID" == tangle-*-direct ]]; then
+    test_pass
+else
+    test_fail "direct fallback was not used when decomposition produced no numbered subtasks"
+fi
+
+test_case "direct fallback receives the resolved original prompt"
+if [[ "$DIRECT_PROMPT" == *"src/lib/templates/NA10_HANDLE_SILENCE.ts"* ]] && \
+   [[ "$DIRECT_PROMPT" == *"do not modify src/lib/render/renderEmailTemplate.ts"* ]]; then
+    test_pass
+else
+    test_fail "direct fallback did not receive the original task constraints"
+fi
+
+test_case "fallback returns before tangle validation"
+if [[ "$VALIDATION_CALLED" == "false" ]]; then
+    test_pass
+else
+    test_fail "validation ran even though no subtasks were spawned"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

- Fall back to direct execution when `/octo:develop` decomposition returns no parseable numbered subtasks.
- Reuse the same direct `codex` fallback path already used when all decomposition providers fail.
- Add regression coverage for the "provider succeeded but decomposition was unusable" case.

## Why

`tangle_develop` already has a direct fallback when both decomposition providers fail. However, if a provider returns a non-empty response that is not a numbered subtask list, the current code spawns zero workers and continues to validation. That makes an unusable decomposition look like a normal tangle run.

This change treats "no parseable subtasks" as decomposition failure and falls back to direct execution with the resolved original prompt.

## Verification

- `bash tests/unit/test-tangle-direct-fallback.sh`
- `bash tests/unit/test-develop-md-file-resolution.sh`
- `bash tests/unit/test-gate-thresholds.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workflow decomposition to fall back to direct execution when subtasks cannot be properly parsed.

* **Tests**
  * Added regression tests for workflow fallback behavior and subtask decomposition edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->