### PR TITLE
fix(ink): compact delivery context

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1001,6 +1001,152 @@ Output as numbered list with [CODING] or [REASONING] prefix for each subtask."
     validate_tangle_results "$task_group" "$resolved_prompt"
 }
 
+ink_delivery_sanitize_context() {
+    sed -e 's/\[Synthesis failed - raw results attached\]/[Upstream phase synthesis failed; raw fallback omitted from compact delivery context]/g'
+}
+
+ink_delivery_file_label() {
+    local file="$1"
+    local base
+    base=$(basename "$file")
+
+    case "$base" in
+        probe-synthesis-*) echo "Probe Synthesis" ;;
+        grasp-consensus-*) echo "Grasp Consensus" ;;
+        tangle-validation-*) echo "Tangle Validation" ;;
+        *aggregate*) echo "Aggregate Result" ;;
+        *) echo "Supporting Result" ;;
+    esac
+}
+
+ink_delivery_append_excerpt() {
+    local file="$1"
+    local max_chars="$2"
+    local label
+    local size
+
+    [[ -f "$file" ]] || return 0
+    label=$(ink_delivery_file_label "$file")
+    size=$(wc -c < "$file" 2>/dev/null | tr -d '[:space:]')
+    size="${size:-0}"
+
+    echo "## Source: ${label}"
+    echo "- File: ${file}"
+    echo "- Size: ${size} bytes"
+    if [[ "$size" =~ ^[0-9]+$ && "$size" -gt "$max_chars" ]]; then
+        echo "- Included: first ${max_chars} bytes (truncated)"
+    else
+        echo "- Included: full file"
+    fi
+    echo ""
+    echo '```markdown'
+    if [[ "$size" =~ ^[0-9]+$ && "$size" -gt "$max_chars" ]]; then
+        head -c "$max_chars" "$file" 2>/dev/null | ink_delivery_sanitize_context
+        echo ""
+        echo "[... truncated by ink delivery context: original ${size} bytes, included ${max_chars} bytes ...]"
+    else
+        ink_delivery_sanitize_context < "$file"
+    fi
+    echo '```'
+    echo ""
+}
+
+build_ink_delivery_context() {
+    local tangle_results="${1:-}"
+    local max_file="${OCTOPUS_INK_FILE_CONTEXT_CHARS:-12000}"
+    local max_total="${OCTOPUS_INK_CONTEXT_CHARS:-60000}"
+
+    [[ "$max_file" =~ ^[0-9]+$ ]] || max_file=12000
+    [[ "$max_total" =~ ^[0-9]+$ ]] || max_total=60000
+    max_file=$((10#$max_file))
+    max_total=$((10#$max_total))
+    [[ "$max_file" -lt 1000 ]] && max_file=1000
+    [[ "$max_total" -lt 4000 ]] && max_total=4000
+
+    local -a files=()
+    local seen="|"
+    local candidate
+
+    for candidate in \
+        "$tangle_results" \
+        "$(ls -t "$RESULTS_DIR"/tangle-validation-*.md 2>/dev/null | head -1)" \
+        "$(ls -t "$RESULTS_DIR"/grasp-consensus-*.md 2>/dev/null | head -1)" \
+        "$(ls -t "$RESULTS_DIR"/probe-synthesis-*.md 2>/dev/null | head -1)"; do
+        [[ -n "$candidate" && -f "$candidate" ]] || continue
+        if [[ "$seen" != *"|$candidate|"* ]]; then
+            files+=("$candidate")
+            seen="${seen}${candidate}|"
+        fi
+    done
+
+    for candidate in "$RESULTS_DIR"/*.md; do
+        [[ -f "$candidate" ]] || continue
+        [[ "$candidate" == *aggregate* || "$candidate" == *delivery* ]] && continue
+        [[ "$seen" == *"|$candidate|"* ]] && continue
+        files+=("$candidate")
+        seen="${seen}${candidate}|"
+        [[ ${#files[@]} -ge 10 ]] && break
+    done
+
+    local tmp_context
+    tmp_context=$(mktemp "${TMPDIR:-/tmp}/octo-ink-context.XXXXXX") || return 1
+
+    {
+        echo "# Compact Delivery Context"
+        echo ""
+        echo "This context is bounded before synthesis. Full raw artifacts remain on disk in RESULTS_DIR."
+        echo ""
+        echo "## Context Budget"
+        echo "- Max per source file: ${max_file} bytes"
+        echo "- Max total context: ${max_total} bytes"
+        echo "- Source files selected: ${#files[@]}"
+        echo ""
+
+        for candidate in "${files[@]}"; do
+            ink_delivery_append_excerpt "$candidate" "$max_file"
+        done
+    } > "$tmp_context"
+
+    local total_size
+    total_size=$(wc -c < "$tmp_context" 2>/dev/null | tr -d '[:space:]')
+    total_size="${total_size:-0}"
+
+    if [[ "$total_size" =~ ^[0-9]+$ && "$total_size" -gt "$max_total" ]]; then
+        head -c "$max_total" "$tmp_context" 2>/dev/null
+        echo ""
+        echo ""
+        echo "[... compact delivery context truncated: original ${total_size} bytes, included ${max_total} bytes ...]"
+    else
+        cat "$tmp_context"
+    fi
+
+    rm -f "$tmp_context"
+}
+
+build_ink_fallback_delivery() {
+    local prompt="$1"
+    local sonnet_review="$2"
+    local compact_context="$3"
+
+    cat <<EOF
+Automated synthesis unavailable.
+
+## Executive Summary
+The delivery phase completed local checks, but the synthesis provider did not return a polished final narrative. This fallback is intentionally compact and does not attach raw phase artifacts.
+
+## Key Deliverables
+- Compact delivery context assembled from phase artifacts.
+- Quality review retained below when available.
+- Full raw artifacts remain available in RESULTS_DIR for manual inspection.
+
+## Quality Review
+${sonnet_review}
+
+## Compact Source Context
+${compact_context}
+EOF
+}
+
 # Phase 4: INK (Deliver) - Quality gates + final output
 # The octopus inks the final solution with precision
 ink_deliver() {
@@ -1054,15 +1200,11 @@ ink_deliver() {
     # Step 2: Synthesize final output
     log INFO "Step 2: Synthesizing final deliverable..."
 
-    local all_results=""
-    local result_count=0
-    for result in "$RESULTS_DIR"/*.md; do
-        [[ -f "$result" ]] || continue
-        [[ "$result" == *aggregate* || "$result" == *delivery* ]] && continue
-        all_results+="$(<"$result")\n\n"
-        ((result_count++)) || true
-        [[ $result_count -ge 10 ]] && break  # Limit context size
-    done
+    local all_results
+    all_results=$(build_ink_delivery_context "$tangle_results")
+    local result_count
+    result_count=$(grep -c '^## Source:' <<< "$all_results" 2>/dev/null || true)
+    result_count="${result_count:-0}"
 
     # Sonnet 4.6 quality review before synthesis
     log INFO "Step 2a: Sonnet 4.6 quality review..."
@@ -1130,6 +1272,11 @@ ${all_results}"
         local simplify_result
         simplify_result=$(run_agent_sync "claude-sonnet" "$simplify_prompt" 120 "code-reviewer" "ink") || true
         if [[ -n "$simplify_result" ]]; then
+            if [[ ${#simplify_result} -gt 12000 ]]; then
+                simplify_result="${simplify_result:0:12000}
+
+[... simplification review truncated to 12000 chars ...]"
+            fi
             all_results="${all_results}
 
 --- SIMPLIFICATION REVIEW ---
@@ -1151,12 +1298,12 @@ Original task: $prompt
 Quality Review (from Sonnet 4.6):
 $sonnet_review
 
-Results to synthesize:
+Compact source context to synthesize:
 $all_results"
 
     local delivery
     delivery=$(run_agent_sync "gemini" "$synthesis_prompt" 180 "synthesizer" "ink") || {
-        delivery="[Synthesis failed - raw results attached]\n\n$all_results"
+        delivery=$(build_ink_fallback_delivery "$prompt" "$sonnet_review" "$all_results")
     }
 
     # Step 3: Generate final document
@@ -1176,7 +1323,8 @@ $delivery
 
 ## Quality Certification
 - Pre-delivery checks: $([[ "$checks_passed" == "true" ]] && echo "PASSED" || echo "NEEDS REVIEW")
-- Results synthesized: $result_count files
+- Results synthesized: $result_count compact source files
+- Context policy: bounded excerpts; raw phase artifacts are not embedded on synthesis failure
 - Generated by: Claude Octopus Double Diamond
 - Timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 EOF

--- a/tests/unit/test-ink-compact-delivery.sh
+++ b/tests/unit/test-ink-compact-delivery.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Regression checks for compact /octo:ink delivery context.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKFLOWS="$PROJECT_ROOT/scripts/lib/workflows.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "ink compact delivery"
+
+test_case "workflows.sh has valid bash syntax"
+if bash -n "$WORKFLOWS" 2>/dev/null; then
+    test_pass
+else
+    test_fail "syntax error in workflows.sh"
+fi
+
+# shellcheck source=/dev/null
+source "$WORKFLOWS"
+
+TEST_ROOT="$(mktemp -d)"
+HOME="$TEST_ROOT/home"
+RESULTS_DIR="$TEST_ROOT/results"
+LOGS_DIR="$TEST_ROOT/logs"
+WORKSPACE_DIR="$TEST_ROOT/workspace"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$HOME" "$RESULTS_DIR" "$LOGS_DIR" "$WORKSPACE_DIR"
+
+make_payload() {
+    local token="$1"
+    local count="$2"
+    local i
+    for i in $(seq 1 "$count"); do
+        printf '%s line %04d: repeated raw provider output for delivery regression\n' "$token" "$i"
+    done
+}
+
+reset_results() {
+    rm -rf "$RESULTS_DIR"
+    mkdir -p "$RESULTS_DIR"
+}
+
+reset_results
+probe_file="$RESULTS_DIR/probe-synthesis-test.md"
+grasp_file="$RESULTS_DIR/grasp-consensus-test.md"
+tangle_file="$RESULTS_DIR/tangle-validation-test.md"
+
+{
+    echo "# Probe"
+    echo "[Synthesis failed - raw results attached]"
+    make_payload "PROBE_RAW" 180
+} > "$probe_file"
+
+printf '%s\n' "# Grasp" "Consensus: use bounded delivery context." > "$grasp_file"
+
+{
+    echo "# Tangle"
+    echo "### Quality Gate: PASSED"
+    make_payload "TANGLE_RAW" 180
+    echo "RAW_TAIL_SHOULD_NOT_APPEAR"
+} > "$tangle_file"
+
+OCTOPUS_INK_FILE_CONTEXT_CHARS=900
+OCTOPUS_INK_CONTEXT_CHARS=4200
+
+test_case "compact delivery context is bounded and sanitizes failed synthesis markers"
+context="$(build_ink_delivery_context "$tangle_file")"
+if [[ ${#context} -le 5200 ]] && \
+   [[ "$context" == *"## Source: Tangle Validation"* ]] && \
+   [[ "$context" == *"## Source: Grasp Consensus"* ]] && \
+   [[ "$context" == *"## Source: Probe Synthesis"* ]] && \
+   [[ "$context" == *"Upstream phase synthesis failed; raw fallback omitted"* ]] && \
+   [[ "$context" != *"[Synthesis failed - raw results attached]"* ]] && \
+   [[ "$context" == *"truncated by ink delivery context"* ]] && \
+   [[ "$context" != *"RAW_TAIL_SHOULD_NOT_APPEAR"* ]]; then
+    test_pass
+else
+    test_fail "compact delivery context did not stay bounded/sanitized"
+fi
+
+CYAN=""
+GREEN=""
+MAGENTA=""
+NC=""
+DRY_RUN=false
+SUPPORTS_BATCH_COMMAND=false
+OCTOPUS_REVIEW_4X10=false
+
+log() { :; }
+octopus_phase_banner() { :; }
+display_workflow_cost_estimate() { return 0; }
+retrospective_ceremony() { :; }
+score_cross_model_review() { echo "10:10:10:10"; }
+format_review_scorecard() { :; }
+write_structured_decision() { :; }
+octopus_complete() { :; }
+run_agent_sync() {
+    local provider="$1"
+    local phase="${5:-}"
+    if [[ "$provider" == "claude-sonnet" && "$phase" == "ink" ]]; then
+        printf '%s\n' \
+            "Security: 10/10" \
+            "Reliability: 10/10" \
+            "Performance: 10/10" \
+            "Accessibility: 10/10" \
+            "No issues found."
+        return 0
+    fi
+    return 1
+}
+
+test_case "ink fallback delivery does not attach raw phase artifacts"
+if ink_deliver "Implement the requested feature" "$tangle_file" >/dev/null 2>&1; then
+    delivery_file="$(ls -t "$RESULTS_DIR"/delivery-*.md 2>/dev/null | head -1)"
+    delivery_content="$(cat "$delivery_file")"
+    if [[ -n "$delivery_file" ]] && \
+       [[ "$delivery_content" == *"Automated synthesis unavailable."* ]] && \
+       [[ "$delivery_content" == *"Context policy: bounded excerpts"* ]] && \
+       [[ "$delivery_content" != *"[Synthesis failed - raw results attached]"* ]] && \
+       [[ "$delivery_content" != *"RAW_TAIL_SHOULD_NOT_APPEAR"* ]]; then
+        test_pass
+    else
+        test_fail "fallback delivery attached raw artifacts or propagated failed synthesis marker"
+    fi
+else
+    test_fail "ink_deliver returned non-zero in fallback scenario"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary
- Build a bounded compact delivery context instead of concatenating raw phase artifacts into ink prompts.
- Sanitize propagated `[Synthesis failed - raw results attached]` markers from upstream phase excerpts.
- Replace the synthesis-failure fallback with a compact fallback that does not attach raw artifacts.
- Add unit coverage for context bounds, marker sanitization, and fallback output.

## Motivation
A real `/octo:embrace` run produced a 4.3 MB delivery bundle and forced provider preflight summarization from 4,390,953 chars to 128,000 chars. The delivery phase had re-aggregated raw probe/grasp/tangle artifacts and propagated a failed-synthesis marker into the final deliverable.

## Validation
- `tests/unit/test-ink-compact-delivery.sh`
- `bash tests/unit/test-cross-model-review.sh`
- `bash tests/smoke/test-syntax.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved result synthesis with bounded context handling and sanitized output for better reliability.
  * Enhanced fallback delivery mechanism to integrate review and context information more effectively.

* **Tests**
  * Added test suite for compact delivery context validation and artifact verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->