### PR TITLE
fix(probe): compact synthesis fallback

### DIFF
--- a/scripts/lib/heuristics.sh
+++ b/scripts/lib/heuristics.sh
@@ -114,6 +114,128 @@ rank_results_by_signals() {
     printf '%s\n' "${scored[@]}" | sort -t'|' -k1 -rn | cut -d'|' -f2
 }
 
+probe_synthesis_sanitize_context() {
+    sed \
+        -e 's/\[Auto-synthesis failed - raw findings below\]/[Prior auto-synthesis failed; raw fallback omitted from compact probe context]/g' \
+        -e 's/\[Synthesis failed - raw results attached\]/[Prior synthesis failed; raw fallback omitted from compact probe context]/g'
+}
+
+probe_synthesis_append_excerpt() {
+    local file="$1"
+    local max_chars="$2"
+    local score="${3:-}"
+    local size
+
+    [[ -f "$file" ]] || return 0
+    size=$(wc -c < "$file" 2>/dev/null | tr -d '[:space:]')
+    size="${size:-0}"
+
+    echo "## Source: $(basename "$file")${score:+ [Quality: ${score}/100]}"
+    echo "- File: ${file}"
+    echo "- Size: ${size} bytes"
+    if [[ "$size" =~ ^[0-9]+$ && "$size" -gt "$max_chars" ]]; then
+        echo "- Included: first ${max_chars} bytes (truncated)"
+    else
+        echo "- Included: full file"
+    fi
+    echo ""
+    echo '```markdown'
+    if [[ "$size" =~ ^[0-9]+$ && "$size" -gt "$max_chars" ]]; then
+        head -c "$max_chars" "$file" 2>/dev/null | probe_synthesis_sanitize_context
+        echo ""
+        echo "[... truncated by probe synthesis context: original ${size} bytes, included ${max_chars} bytes ...]"
+    else
+        probe_synthesis_sanitize_context < "$file"
+    fi
+    echo '```'
+    echo ""
+}
+
+build_probe_synthesis_context() {
+    local task_group="$1"
+    local max_file="${OCTOPUS_PROBE_SYNTHESIS_FILE_CHARS:-24000}"
+    local max_total="${OCTOPUS_PROBE_SYNTHESIS_CONTEXT_CHARS:-120000}"
+
+    [[ "$max_file" =~ ^[0-9]+$ ]] || max_file=24000
+    [[ "$max_total" =~ ^[0-9]+$ ]] || max_total=120000
+    max_file=$((10#$max_file))
+    max_total=$((10#$max_total))
+    [[ "$max_file" -lt 1000 ]] && max_file=1000
+    [[ "$max_total" -lt 4000 ]] && max_total=4000
+
+    local tmp_context
+    tmp_context=$(mktemp "${TMPDIR:-/tmp}/octo-probe-synthesis.XXXXXX") || return 1
+
+    local result_count=0
+    {
+        echo "# Compact Probe Synthesis Context"
+        echo ""
+        echo "This context is bounded before synthesis. Full raw probe artifacts remain on disk in RESULTS_DIR."
+        echo ""
+        echo "## Context Budget"
+        echo "- Max per source file: ${max_file} bytes"
+        echo "- Max total context: ${max_total} bytes"
+        echo ""
+
+        local ranked_file
+        while IFS= read -r ranked_file; do
+            [[ -z "$ranked_file" ]] && continue
+            [[ ! -f "$ranked_file" ]] && continue
+            grep -q "Status: FAILED" "$ranked_file" 2>/dev/null && continue
+            type octo_file_has_provider_rejection >/dev/null 2>&1 && octo_file_has_provider_rejection "$ranked_file" && continue
+            local file_size
+            file_size=$(wc -c < "$ranked_file" 2>/dev/null || echo "0")
+            [[ $file_size -le 500 ]] && continue
+            local score
+            score=$(score_result_file "$ranked_file")
+            probe_synthesis_append_excerpt "$ranked_file" "$max_file" "$score"
+            ((result_count++)) || true
+        done < <(rank_results_by_signals "$RESULTS_DIR" "probe-${task_group}")
+    } > "$tmp_context"
+
+    local total_size
+    total_size=$(wc -c < "$tmp_context" 2>/dev/null | tr -d '[:space:]')
+    total_size="${total_size:-0}"
+
+    if [[ "$total_size" =~ ^[0-9]+$ && "$total_size" -gt "$max_total" ]]; then
+        head -c "$max_total" "$tmp_context" 2>/dev/null
+        echo ""
+        echo ""
+        echo "[... compact probe synthesis context truncated: original ${total_size} bytes, included ${max_total} bytes ...]"
+    else
+        cat "$tmp_context"
+    fi
+
+    rm -f "$tmp_context"
+}
+
+build_probe_fallback_synthesis() {
+    local original_prompt="$1"
+    local result_count="$2"
+    local usable_results="$3"
+    local total_content_size="$4"
+    local compact_context="$5"
+
+    cat <<EOF
+Automated probe synthesis unavailable.
+
+## Key Findings
+The synthesis provider did not produce a coherent discovery summary. This fallback is intentionally compact and does not attach full raw probe artifacts.
+
+## Source Coverage
+- Usable research threads included: ${result_count}
+- Usable results reported by probe: ${usable_results}
+- Raw source bytes considered: ${total_content_size}
+- Full raw artifacts remain available in RESULTS_DIR for manual inspection.
+
+## Original Question
+${original_prompt}
+
+## Compact Source Context
+${compact_context}
+EOF
+}
+
 aggregate_results() {
     local _ts; _ts=$(date +%s)
     local filter="${1:-}"
@@ -254,7 +376,8 @@ synthesize_probe_results() {
 
     log INFO "Synthesizing research findings..."
 
-    # v7.19.0 P1.1: Gather all probe results with size filtering
+    # v7.19.0 P1.1: Gather probe result metrics with size filtering.
+    # Do not concatenate raw artifacts here; synthesis gets a bounded context below.
     local results=""
     local result_count=0
     local total_content_size=0
@@ -268,7 +391,6 @@ synthesize_probe_results() {
         file_size=$(wc -c < "$result" 2>/dev/null || echo "0")
 
         if [[ $file_size -gt 500 ]]; then
-            results+="$(<"$result")\n\n---\n\n"
             ((result_count++)) || true
             total_content_size=$((total_content_size + file_size))
         else
@@ -295,24 +417,14 @@ synthesize_probe_results() {
         log INFO "All $result_count results available for synthesis ($(numfmt --to=iec-i --suffix=B $total_content_size 2>/dev/null || echo "${total_content_size}B"))"
     fi
 
-    # v8.49.0: Rank results by quality signals before synthesis
-    # Re-collect results in ranked order so the synthesis LLM sees best content first
-    local ranked_results=""
-    local ranked_file
-    while IFS= read -r ranked_file; do
-        [[ -z "$ranked_file" ]] && continue
-        [[ ! -f "$ranked_file" ]] && continue
-        grep -q "Status: FAILED" "$ranked_file" 2>/dev/null && continue
-        type octo_file_has_provider_rejection >/dev/null 2>&1 && octo_file_has_provider_rejection "$ranked_file" && continue
-        local file_size
-        file_size=$(wc -c < "$ranked_file" 2>/dev/null || echo "0")
-        [[ $file_size -le 500 ]] && continue
-        local score
-        score=$(score_result_file "$ranked_file")
-        ranked_results+="--- [Quality: ${score}/100] ---\n$(<"$ranked_file")\n\n"
-    done < <(rank_results_by_signals "$RESULTS_DIR" "probe-${task_group}")
-    # Use ranked results if available, fall back to original collection
-    [[ -n "$ranked_results" ]] && results="$ranked_results"
+    # v8.49.0: Rank results by quality signals before synthesis.
+    # Keep the synthesis prompt bounded; full raw files remain on disk.
+    local compact_results
+    if compact_results=$(build_probe_synthesis_context "$task_group") && [[ -n "$compact_results" ]]; then
+        results="$compact_results"
+    else
+        results="# Compact Probe Synthesis Context"$'\n\n'"No bounded probe excerpts could be collected. Inspect RESULTS_DIR for raw artifacts."
+    fi
 
     # Use Gemini for intelligent synthesis
     # v8.49.0: Enhanced prompt with structured output, minority opinion preservation,
@@ -344,8 +456,8 @@ $results"
 
     local synthesis
     synthesis=$(run_agent_sync "gemini" "$synthesis_prompt" 180) || {
-        log WARN "Synthesis failed, using concatenation fallback"
-        synthesis="[Auto-synthesis failed - raw findings below]\n\n$results"
+        log WARN "Synthesis failed, using compact fallback"
+        synthesis=$(build_probe_fallback_synthesis "$original_prompt" "$result_count" "$usable_results" "$total_content_size" "$results")
     }
 
     cat > "$synthesis_file" << EOF
@@ -366,9 +478,12 @@ EOF
     cache_key=$(get_cache_key "$original_prompt")
     save_to_cache "$cache_key" "$synthesis_file"
 
+    local _green="${GREEN:-}"
+    local _cyan="${CYAN:-}"
+    local _nc="${NC:-}"
     echo ""
-    echo -e "${GREEN}✓${NC} Probe synthesis saved to: $synthesis_file"
-    echo -e "${CYAN}♻️${NC}  Cached for 1 hour (reuse if prompt unchanged)"
+    echo -e "${_green}✓${_nc} Probe synthesis saved to: $synthesis_file"
+    echo -e "${_cyan}♻️${_nc}  Cached for 1 hour (reuse if prompt unchanged)"
     echo ""
     guard_output "$(<"$synthesis_file")" "probe-synthesis"
 }

--- a/tests/unit/test-probe-compact-synthesis.sh
+++ b/tests/unit/test-probe-compact-synthesis.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Regression checks for compact probe synthesis fallback.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HEURISTICS="$PROJECT_ROOT/scripts/lib/heuristics.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "probe compact synthesis fallback"
+
+test_case "heuristics.sh has valid bash syntax"
+if bash -n "$HEURISTICS" 2>/dev/null; then
+    test_pass
+else
+    test_fail "syntax error in heuristics.sh"
+fi
+
+# shellcheck source=/dev/null
+source "$HEURISTICS"
+
+TEST_ROOT="$(mktemp -d)"
+HOME="$TEST_ROOT/home"
+RESULTS_DIR="$TEST_ROOT/results"
+LOGS_DIR="$TEST_ROOT/logs"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$HOME" "$RESULTS_DIR" "$LOGS_DIR"
+
+log() { :; }
+enhanced_error() { return 1; }
+get_cache_key() { echo "cache-key"; }
+save_to_cache() { :; }
+guard_output() { :; }
+run_agent_sync() { return 1; }
+
+make_payload() {
+    local token="$1"
+    local count="$2"
+    local i
+    for i in $(seq 1 "$count"); do
+        printf '%s line %04d: detailed probe finding with src/app/page.tsx and concrete notes\n' "$token" "$i"
+    done
+}
+
+task_group="compact"
+success_a="$RESULTS_DIR/codex-probe-${task_group}-0.md"
+success_b="$RESULTS_DIR/claude-sonnet-probe-${task_group}-1.md"
+failed="$RESULTS_DIR/gemini-probe-${task_group}-2.md"
+
+{
+    echo "# Agent: codex"
+    echo "# Phase: probe"
+    echo ""
+    echo "## Output"
+    make_payload "CODEX_RAW" 180
+    echo "RAW_TAIL_SHOULD_NOT_APPEAR"
+    echo ""
+    echo "## Status: SUCCESS"
+} > "$success_a"
+
+{
+    echo "# Agent: claude-sonnet"
+    echo "# Phase: probe"
+    echo ""
+    echo "## Output"
+    echo "[Auto-synthesis failed - raw findings below]"
+    make_payload "SONNET_RAW" 60
+    echo ""
+    echo "## Status: SUCCESS"
+} > "$success_b"
+
+{
+    echo "# Agent: gemini"
+    echo "# Phase: probe"
+    echo "## Status: FAILED (exit code: 1)"
+} > "$failed"
+
+OCTOPUS_PROBE_SYNTHESIS_FILE_CHARS=900
+OCTOPUS_PROBE_SYNTHESIS_CONTEXT_CHARS=4200
+
+test_case "compact probe context is bounded and sanitizes failed synthesis markers"
+context="$(build_probe_synthesis_context "$task_group")"
+if [[ ${#context} -le 5200 ]] && \
+   [[ "$context" == *"## Source: codex-probe-${task_group}-0.md"* ]] && \
+   [[ "$context" == *"## Source: claude-sonnet-probe-${task_group}-1.md"* ]] && \
+   [[ "$context" == *"truncated by probe synthesis context"* ]] && \
+   [[ "$context" == *"Prior auto-synthesis failed; raw fallback omitted"* ]] && \
+   [[ "$context" != *"[Auto-synthesis failed - raw findings below]"* ]] && \
+   [[ "$context" != *"RAW_TAIL_SHOULD_NOT_APPEAR"* ]] && \
+   [[ "$context" != *"gemini-probe-${task_group}-2.md"* ]]; then
+    test_pass
+else
+    test_fail "compact probe context did not stay bounded/sanitized"
+fi
+
+test_case "synthesis provider failure writes compact fallback, not raw dump"
+if synthesize_probe_results "$task_group" "Audit local templates" 2 >/dev/null 2>&1; then
+    synthesis_file="$RESULTS_DIR/probe-synthesis-${task_group}.md"
+    synthesis_content="$(cat "$synthesis_file")"
+    if [[ "$synthesis_content" == *"Automated probe synthesis unavailable."* ]] && \
+       [[ "$synthesis_content" == *"Compact Source Context"* ]] && \
+       [[ "$synthesis_content" != *"[Auto-synthesis failed - raw findings below]"* ]] && \
+       [[ "$synthesis_content" != *"RAW_TAIL_SHOULD_NOT_APPEAR"* ]]; then
+        test_pass
+    else
+        test_fail "probe fallback propagated raw artifacts"
+    fi
+else
+    test_fail "synthesize_probe_results returned non-zero in compact fallback scenario"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary
- keep probe synthesis inputs bounded before calling the synthesis provider
- replace raw-dump synthesis failure fallback with a compact fallback report
- sanitize prior synthesis-failure markers and exclude failed provider outputs from compact probe context

## Why this is separate
Checked the open upstream PRs before creating this branch. This does not fit the current Tangle, Embrace fail-fast, Codex exec, or Ink delivery PRs; it fixes Probe/Discover synthesis fallback behavior specifically.

## Tests
- bash tests/unit/test-probe-compact-synthesis.sh
- bash tests/unit/test-probe-single.sh
- bash tests/unit/test-agent-return-contracts.sh
- bash tests/smoke/test-syntax.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synthesis fallback handling to provide more reliable results when synthesis fails
  * Enhanced context management with size limits for better resource efficiency

* **Tests**
  * Added comprehensive test coverage for compact probe synthesis fallback behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->