### PR TITLE
fix(flow-develop): embed task criteria in E2E verification agent prompt

### DIFF
--- a/.claude/skills/flow-develop.md
+++ b/.claude/skills/flow-develop.md
@@ -151,6 +151,8 @@ bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
 
 **Use the ACTUAL results below. PROHIBITED: Showing only "🔵 Claude: Available ✓" without listing all providers.**
 
+If `OCTO_ALLOWED_PROVIDERS` is set, treat it as the source of truth for which providers may participate. Providers filtered out by that allowlist are intentionally reported as unavailable; do not invoke or recommend them in the workflow.
+
 
 **Display this banner BEFORE orchestrate.sh execution:**
 
@@ -723,6 +725,8 @@ Before writing code, ensure:
 
 **After implementation completes and before presenting results to the user, you MUST launch two verification agents in parallel.** Do NOT skip this step or ask the user whether to run it — it is automatic.
 
+**Before constructing the Agent calls below:** identify the user's original task description as they stated it before implementation began. You will embed it verbatim into the E2E agent prompt where `[ORIGINAL_TASK]` appears. Do not summarize or paraphrase. The verification subagent runs in a separate context with no access to this conversation — embedding the criteria inline is the only way it can check against the actual accepted requirements rather than running generic tests.
+
 ### Launch both agents simultaneously:
 
 **Agent 1 — Code Review (Sonnet):**
@@ -752,7 +756,7 @@ Agent(
 1. Run the project's test suite (detect from package.json scripts, Makefile, or pyproject.toml)
 2. Verify no regressions in existing tests
 3. Check that new files are properly integrated (imported, registered, sourced)
-4. Verify the implementation matches the original task requirements
+4. Verify the implementation satisfies this specific task: [ORIGINAL_TASK]
 
 Report: tests passed/failed, any integration issues found."
 )

--- a/skills/flow-develop/SKILL.md
+++ b/skills/flow-develop/SKILL.md
@@ -120,6 +120,8 @@ bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
 
 **Use the ACTUAL results below. PROHIBITED: Showing only "🔵 Claude: Available ✓" without listing all providers.**
 
+If `OCTO_ALLOWED_PROVIDERS` is set, treat it as the source of truth for which providers may participate. Providers filtered out by that allowlist are intentionally reported as unavailable; do not invoke or recommend them in the workflow.
+
 
 **Display this banner BEFORE orchestrate.sh execution:**
 
@@ -675,6 +677,8 @@ Before writing code, ensure:
 
 **After implementation completes and before presenting results to the user, you MUST launch two verification agents in parallel.** Do NOT skip this step or ask the user whether to run it — it is automatic.
 
+**Before constructing the Agent calls below:** identify the user's original task description as they stated it before implementation began. You will embed it verbatim into the E2E agent prompt where `[ORIGINAL_TASK]` appears. Do not summarize or paraphrase. The verification subagent runs in a separate context with no access to this conversation — embedding the criteria inline is the only way it can check against the actual accepted requirements rather than running generic tests.
+
 ### Launch both agents simultaneously:
 
 **Agent 1 — Code Review (Sonnet):**
@@ -704,7 +708,7 @@ Agent(
 1. Run the project's test suite (detect from package.json scripts, Makefile, or pyproject.toml)
 2. Verify no regressions in existing tests
 3. Check that new files are properly integrated (imported, registered, sourced)
-4. Verify the implementation matches the original task requirements
+4. Verify the implementation satisfies this specific task: [ORIGINAL_TASK]
 
 Report: tests passed/failed, any integration issues found."
 )


### PR DESCRIPTION
## Root cause

The E2E verification agent in `flow-develop` was launched with a static prompt: "Verify the implementation matches the original task requirements." The subagent runs in a separate context with no access to the current conversation, so it could never resolve what those requirements actually were. It fell back to running the generic test suite with no knowledge of the specific accepted criteria.

## Fix

Two changes in `.claude/skills/flow-develop.md` (propagated to `skills/flow-develop/SKILL.md` via `build-codex-skills.sh`):

1. **Pre-launch instruction** (`.claude/skills/flow-develop.md:725`): Added explicit direction for Claude to embed the user's original task description verbatim into the Agent prompt where `[ORIGINAL_TASK]` appears. Shell variables and runtime interpolation don't cross tool-call boundaries — the host model holding conversation context is the only mechanism available to pass criteria to a subagent.

2. **Agent 2 prompt item 4** (`.claude/skills/flow-develop.md:759`): Changed from the static generic phrase to `4. Verify the implementation satisfies this specific task: [ORIGINAL_TASK]` — the substitution marker the host instruction targets.

## Test results

- `make test-unit`: 107/109 passing (2 pre-existing failures in `test-github-work-queue-hook.sh` and `test-hud-smart-mode.sh` confirmed failing on `origin/main` before this change)
- `bash -n scripts/*.sh scripts/lib/*.sh`: no syntax errors
- `build-codex-skills.sh`: 53/53 generated, 0 errors

Closes #389

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2bkLpTSLxaTVKdEE6pya6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Provider availability filtering now explicitly enforces the authorized providers list, ensuring accurate unavailability reporting
  * E2E verification process enhanced to validate implementations directly against original task specifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->