### PR TITLE
Harden Embrace runner with conformance tests

### DIFF
--- a/.claude/commands/embrace.md
+++ b/.claude/commands/embrace.md
@@ -1,6 +1,6 @@
 ---
 command: embrace
-description: "Full Double Diamond workflow - Research → Define → Develop → Deliver"
+description: "Full Double Diamond workflow - Research -> Define -> Develop -> Deliver"
 aliases:
   - full-cycle
   - complete-workflow
@@ -10,258 +10,64 @@ aliases:
 
 **Your first output line MUST be:** `🐙 Octopus Embrace`
 
-## MANDATORY COMPLIANCE — DO NOT SKIP
+## Mandatory Contract
 
-**When the user invokes `/octo:embrace`, you MUST execute the full multi-LLM workflow below. You are PROHIBITED from:**
-- Deciding the task is "too simple" for the workflow
-- Doing the task directly instead of running the phases
-- Skipping phases because you judge them unnecessary
-- Substituting your own approach for the structured workflow
+`/octo:embrace` is a runner-driven workflow. Claude may collect user preferences
+and summarize artifacts, but it must not execute phases manually or substitute
+local implementation work for a failed phase.
 
-**The user chose `/octo:embrace` deliberately.** Respect that choice.
-
-## EXECUTION MECHANISM — NON-NEGOTIABLE
-
-**Each phase MUST be executed through the `orchestrate.sh` entrypoint. Direct Skill calls for the workflow phases are not permitted because they can recursively reload command instructions. You are PROHIBITED from:**
-- Using the Agent tool to do research yourself instead of running the discovery phase
-- Using WebFetch/Read/Grep as a substitute for multi-provider research
-- Implementing code directly instead of running the develop phase
-- Using a single code-reviewer agent instead of running the deliver phase
-- Skipping `orchestrate.sh` calls because "I can do this faster directly"
-
-**The ENTIRE POINT of `/octo:embrace` is multi-LLM orchestration.** If you execute phases using only Claude-native tools (Agent, WebFetch, Write, Edit), you have violated the command's purpose even if you followed the phase structure.
-
-**Self-check after completion:** You should be able to list the `orchestrate.sh` commands you ran. If you used only Claude-native tools, you executed incorrectly.
-
----
+Forbidden during an Embrace run:
+- Running Discover, Define, Develop, or Deliver as separate ad hoc steps.
+- Implementing code directly after a failed Develop/Tangle phase.
+- Treating a chat debate as a gate unless an `embrace-gate-*.md` artifact exists.
+- Reporting success from narrative memory instead of runner artifacts.
 
 ## Step 1: Ask Clarifying Questions
 
-```javascript
-AskUserQuestion({
-  questions: [
-    {
-      question: "What's the scope of this project?",
-      header: "Scope",
-      multiSelect: false,
-      options: [
-        {label: "Small feature", description: "Single component or small addition"},
-        {label: "Medium feature", description: "Multiple components or moderate complexity"},
-        {label: "Large feature", description: "System-wide changes or new subsystem"},
-        {label: "Full system", description: "Complete application or major architecture"}
-      ]
-    },
-    {
-      question: "What areas require the most attention?",
-      header: "Focus Areas",
-      multiSelect: true,
-      options: [
-        {label: "Architecture design", description: "System structure and design patterns"},
-        {label: "Security", description: "Authentication, authorization, data protection"},
-        {label: "Performance", description: "Speed, scalability, optimization"},
-        {label: "User experience", description: "UI/UX and usability"}
-      ]
-    },
-    {
-      question: "What's your preferred level of autonomy?",
-      header: "Autonomy",
-      multiSelect: false,
-      options: [
-        {label: "Supervised (default)", description: "Review and approve after each phase"},
-        {label: "Semi-autonomous", description: "Only intervene if quality gates fail"},
-        {label: "Autonomous", description: "Run all 4 phases automatically"},
-        {label: "Manual", description: "I'll guide each step explicitly"}
-      ]
-    },
-    {
-      question: "Should critical decisions be stress-tested with a Multi-LLM debate?",
-      header: "Multi-LLM Debate Gates",
-      multiSelect: false,
-      options: [
-        {label: "Yes — debate at Define→Develop gate", description: "Recommended for Large/Full scope"},
-        {label: "Yes — debate at both gates", description: "Maximum rigor, uses external API credits"},
-        {label: "No — skip debates", description: "Standard workflow without debate checkpoints"},
-        {label: "Only if disagreement detected", description: "Auto-trigger when providers diverge"}
-      ]
-    }
-  ]
-})
-```
+Use `AskUserQuestion` to collect:
+- scope: small, medium, large, or full system
+- focus areas: architecture, security, performance, user experience
+- autonomy: supervised, semi-autonomous, autonomous, or manual
+- debate gates: none, Define->Develop, both gates, or only on disagreement
 
-After receiving answers, incorporate them into all subsequent phase invocations — use the scope to calibrate research depth, focus areas to weight provider perspectives, autonomy level to control phase transitions, and debate preference to gate Define→Develop handoffs.
+If running in a remote/cloud session, default to autonomous and infer scope/focus
+from the prompt unless the user provided explicit choices.
 
-### Remote/Cloud Defaults
+## Step 2: Check Provider Availability
 
-If `CLAUDE_CODE_REMOTE=true` or `OCTOPUS_REMOTE_SESSION=true`, do not block on clarifying questions. Use these defaults unless the user's prompt says otherwise:
-
-- scope: infer from the prompt
-- focus: all relevant areas
-- autonomy: autonomous
-- debate gates: only if provider disagreement is detected
-
-Plan locally first, then run the approved `/octo:embrace` prompt in the hosted or remote-control session with `OCTOPUS_REMOTE_SESSION=true` set in that environment.
-
-## Step 2: Check Provider Availability & Display Banner
-
-**MANDATORY: Run this bash command BEFORE the banner.**
+Run the provider checker before starting the workflow:
 
 ```bash
-echo "PROVIDER_CHECK_START"
-printf "codex:%s\n" "$(command -v codex >/dev/null 2>&1 && echo available || echo missing)"
-printf "gemini:%s\n" "$(command -v gemini >/dev/null 2>&1 && echo available || echo missing)"
-printf "perplexity:%s\n" "$([ -n "${PERPLEXITY_API_KEY:-}" ] && echo available || echo missing)"
-printf "opencode:%s\n" "$(command -v opencode >/dev/null 2>&1 && echo available || echo missing)"
-printf "copilot:%s\n" "$(command -v copilot >/dev/null 2>&1 && echo available || echo missing)"
-printf "qwen:%s\n" "$(command -v qwen >/dev/null 2>&1 && echo available || echo missing)"
-printf "ollama:%s\n" "$(command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1 && echo available || echo missing)"
-printf "openrouter:%s\n" "$([ -n "${OPENROUTER_API_KEY:-}" ] && echo available || echo missing)"
-echo "PROVIDER_CHECK_END"
+bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
 ```
 
-Display banner with ACTUAL results:
+Display the actual provider status from that command. Do not replace it with an
+inline provider check.
 
-```
-🐙 **CLAUDE OCTOPUS ACTIVATED** - Full Double Diamond Workflow
-🐙 Embrace: [Brief description]
+## Step 3: Run The Single Embrace Runner
 
-Phases: 🔍 Discover → 🎯 Define → 🛠️ Develop → ✅ Deliver
+Map the debate answer to `OCTOPUS_DEBATE_GATES`:
+- none -> `none`
+- Define->Develop -> `define`
+- both gates -> `both`
+- only on disagreement -> `auto`
 
-Provider Availability:
-🔴 Codex CLI: [status]    🟡 Gemini CLI: [status]
-🟣 Perplexity: [status]   🟤 OpenCode: [status]
-🔵 Claude: Available ✓
-
-Scope: [answer]  Focus: [answer]  Autonomy: [answer]
-```
-
-## Step 3: Execute Phases via orchestrate.sh
-
-**CRITICAL: Each phase MUST run through `orchestrate.sh`. Do not invoke `/octo:discover`, `/octo:define`, `/octo:develop`, or `/octo:deliver` via Skill calls inside this command; direct phase dispatch prevents recursive command loading.**
-
-### Phase 1 — Discover
-
-Run the Discover phase via orchestrate.sh:
+Then run exactly one Embrace runner command:
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh probe <user's prompt>
+cd "${HOME}/.claude-octopus/plugin" && OCTOPUS_DEBATE_GATES="<mapped-value>" bash scripts/orchestrate.sh embrace "<user prompt>"
 ```
 
-This will dispatch to Codex, Gemini, and other available providers. Results saved to `~/.claude-octopus/results/probe-synthesis-*.md`.
+The runner owns all phase transitions, required artifacts, debate-gate artifacts,
+and failure stops.
 
-**Supervised mode:** After Discover completes, present key findings and ask to proceed.
-**Semi-autonomous/Autonomous:** Proceed automatically.
+## Step 4: Present Runner Artifacts
 
-### Phase 2 — Define
+After the runner exits, summarize only what the artifacts prove:
+- `probe-synthesis-*.md`
+- `grasp-consensus-*.md`
+- `embrace-gate-*.md` when requested
+- `tangle-validation-*.md`
+- `delivery-*.md`
 
-Run the define phase via orchestrate.sh:
-
-```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh grasp <user's prompt>
-```
-
-This builds consensus across providers. Results saved to `~/.claude-octopus/results/grasp-consensus-*.md`.
-
-**Supervised mode:** Present consensus and ask to proceed.
-
-### Debate Gate (if enabled)
-
-If user selected debate gates at Define→Develop transition:
-1. Read consensus from `~/.claude-octopus/results/grasp-consensus-*.md`
-2. Run a quick adversarial debate challenging the approach:
-
-```
-Skill(skill: "octo:debate", args: "Given this consensus, what are the biggest risks? What alternatives were dismissed too quickly? --rounds 1 --debate-style adversarial --max-words 200")
-```
-
-3. If risks surface, present via AskUserQuestion:
-```javascript
-AskUserQuestion({
-  questions: [{
-    question: "The debate gate surfaced concerns. How should we proceed?",
-    header: "Debate Gate",
-    multiSelect: false,
-    options: [
-      {label: "Proceed anyway", description: "Accept risks and continue to Develop"},
-      {label: "Revise approach", description: "Adjust plan based on debate findings"},
-      {label: "Run deeper debate", description: "Thorough 3-round debate before deciding"},
-      {label: "Stop and review", description: "Pause for manual review"}
-    ]
-  }]
-})
-```
-
-### Phase 3 — Develop
-
-Run the develop phase via orchestrate.sh:
-
-```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh tangle <user's prompt>
-```
-
-This dispatches implementation with quality gates. Results saved to `~/.claude-octopus/results/tangle-validation-*.md`.
-
-### Second Debate Gate (if "both gates" selected)
-
-Same pattern as above but collaborative style, reviewing implementation quality.
-
-### Phase 4 — Deliver
-
-Run the deliver phase via orchestrate.sh:
-
-```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh ink <user's prompt>
-```
-
-This runs multi-provider validation. Results saved to `~/.claude-octopus/results/delivery-*.md`.
-
-### Auto Code Review (MANDATORY)
-
-After Develop completes, launch two verification agents in background:
-
-```
-Agent(model: "sonnet", subagent_type: "feature-dev:code-reviewer", run_in_background: true,
-  description: "Code review: embrace deliver",
-  prompt: "Review all code changes from this session. Check git diff. Focus on bugs, security, logic errors. Report only high-confidence issues.")
-
-Agent(model: "sonnet", run_in_background: true,
-  description: "E2E test: embrace deliver",
-  prompt: "Run the project's test suite and verify no regressions. Report tests passed/failed.")
-```
-
-Include findings in final results.
-
-## Step 4: Present Results & Next Steps
-
-**MANDATORY: Present results AND ask what to do next.**
-
-Read result files from `~/.claude-octopus/results/` and present a concise synthesis. Then:
-
-```javascript
-AskUserQuestion({
-  questions: [{
-    question: "The embrace workflow has completed all 4 phases. What next?",
-    header: "Next Steps",
-    multiSelect: false,
-    options: [
-      {label: "Review phase outputs in detail", description: "Walk through each phase's findings"},
-      {label: "Refine the implementation", description: "Make adjustments based on results"},
-      {label: "Run another iteration", description: "Re-run specific phases with updated context"},
-      {label: "Start a new task", description: "Move on to something else"},
-      {label: "Export results", description: "Save a summary document"}
-    ]
-  }]
-})
-```
-
-**PROHIBITED: Ending the session without asking this question.**
-
----
-
-## Quick Reference
-
-| Phase | Command | orchestrate.sh | Output |
-|-------|---------|----------------|--------|
-| Discover | `/octo:discover` | `probe-single` per provider | `probe-synthesis-*.md` |
-| Define | `/octo:define` | `grasp` | `grasp-consensus-*.md` |
-| Develop | `/octo:develop` | `tangle` | `tangle-validation-*.md` |
-| Deliver | `/octo:deliver` | `ink` | `delivery-*.md` |
+If the runner exits non-zero, report the failed phase and stop. Do not continue manually unless the user explicitly starts a separate non-Embrace task.

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -277,6 +277,14 @@ ${provider_ctx}"
 
     stop_quota_watcher "$_quota_watcher_pid"
 
+    # Codex can emit the useful final response on stderr while exiting 0 in
+    # non-interactive dispatch contexts. Treat that as degraded usable output
+    # instead of losing the response downstream.
+    if [[ "$agent_type" == codex* && -z "$output" && -s "$temp_err" ]] && \
+       ! octo_file_has_provider_rejection "$temp_err"; then
+        output=$(cat "$temp_err")
+    fi
+
     # Tail-bias: the deliverable summary lives at the end of codex-style output.
     local _max_bytes="${OCTOPUS_AGENT_MAX_OUTPUT_BYTES:-262144}"
     local _sync_output_truncated=false

--- a/scripts/lib/error-tracking.sh
+++ b/scripts/lib/error-tracking.sh
@@ -196,11 +196,23 @@ octo_file_has_provider_rejection() {
     return 1
 }
 
+octo_file_has_codex_stdin_closed() {
+    local stderr_file="${1:-}"
+    [[ -n "$stderr_file" && -f "$stderr_file" ]] || return 1
+
+    grep -q 'write_stdin failed: stdin is closed' "$stderr_file" 2>/dev/null
+}
+
 classify_agent_output() {
     local output_file="$1"
     local exit_code="${2:-0}"
     local agent="${3:-unknown}"
     local stderr_file="${4:-}"
+
+    if [[ "$agent" == codex* ]] && octo_file_has_codex_stdin_closed "$stderr_file"; then
+        echo "failed:Codex tool stdin closed (avoid write_stdin in non-interactive sessions)"
+        return 0
+    fi
 
     if [[ "$exit_code" -eq 124 || "$exit_code" -eq 143 ]]; then
         echo "timeout:Timed out before completion"
@@ -218,6 +230,11 @@ classify_agent_output() {
     fi
 
     if [[ ! -s "$output_file" ]]; then
+        if [[ "$agent" == codex* && -n "$stderr_file" && -s "$stderr_file" ]] && \
+           ! octo_file_has_provider_rejection "$stderr_file"; then
+            echo "degraded:Output captured on stderr"
+            return 0
+        fi
         echo "failed:Empty output"
         return 0
     fi

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -119,6 +119,24 @@ $challenge_result
             fi
         fi
 
+        # Always leave a validation artifact before any branch can abort,
+        # escalate, or retry. Embrace treats this file as the transition
+        # contract between Develop and Deliver.
+        cat > "$validation_file" << EOF
+# TANGLE Phase Validation Report
+## Task: $original_prompt
+## Generated: $(date)
+
+### Quality Gate: ${gate_status}
+- Success Rate: ${success_rate}% (threshold: ${QUALITY_THRESHOLD}%)
+- Successful: ${success_count}/${total} providers
+- Failed: ${fail_count}/${total} providers
+- Retry Attempts: ${quality_retry_count}/${MAX_QUALITY_RETRIES}
+
+### Subtask Results
+$results
+EOF
+
         # ═══════════════════════════════════════════════════════════════════════
         # CONDITIONAL BRANCHING - Quality gate decision tree
         # ═══════════════════════════════════════════════════════════════════════

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1349,6 +1349,135 @@ EOF
     echo ""
 }
 
+embrace_contract_mode_enabled() {
+    [[ "${OCTOPUS_EMBRACE_CONTRACTS:-true}" == "true" || "${OCTOPUS_CONFORMANCE_MODE:-false}" == "true" ]]
+}
+
+embrace_latest_artifact() {
+    local pattern="$1"
+    ls -t $pattern 2>/dev/null | head -1
+}
+
+embrace_require_phase_artifact() {
+    local phase="$1"
+    local pattern="$2"
+    local artifact
+    artifact=$(embrace_latest_artifact "$pattern")
+
+    if [[ -z "$artifact" || ! -s "$artifact" ]]; then
+        log ERROR "Embrace contract violation: missing ${phase} artifact (${pattern})"
+        return 1
+    fi
+
+    printf '%s\n' "$artifact"
+}
+
+embrace_tangle_allows_delivery() {
+    local validation_file="$1"
+
+    if [[ -z "$validation_file" || ! -f "$validation_file" ]]; then
+        log ERROR "Embrace contract violation: missing tangle validation artifact"
+        return 1
+    fi
+
+    if grep -q "Quality Gate: FAILED" "$validation_file" 2>/dev/null; then
+        log ERROR "Embrace contract violation: tangle failed; refusing to start delivery"
+        return 1
+    fi
+
+    return 0
+}
+
+embrace_gate_requested() {
+    local gate="$1"
+    local setting="${OCTOPUS_DEBATE_GATES:-none}"
+
+    case "$setting:$gate" in
+        both:define|both:deliver|define:define|define-develop:define|deliver:deliver|delivery:deliver)
+            return 0 ;;
+        auto:*)
+            return 1 ;;
+        *)
+            return 1 ;;
+    esac
+}
+
+embrace_run_debate_gate() {
+    local gate="$1"
+    local source_file="$2"
+    local prompt="$3"
+    local task_group="$4"
+    local gate_file="${RESULTS_DIR}/embrace-gate-${gate}-${task_group}.md"
+
+    if [[ "${OCTOPUS_CONFORMANCE_SKIP_GATE_ARTIFACT:-}" == "all" || \
+          "${OCTOPUS_CONFORMANCE_SKIP_GATE_ARTIFACT:-}" == "$gate" ]]; then
+        log WARN "Conformance mode: intentionally skipping gate artifact for ${gate}"
+        return 0
+    fi
+
+    local source_excerpt=""
+    [[ -n "$source_file" && -f "$source_file" ]] && source_excerpt=$(head -c 4000 "$source_file" 2>/dev/null || true)
+
+    local debate_output=""
+    if [[ "${OCTOPUS_CONFORMANCE_MODE:-false}" == "true" ]]; then
+        debate_output="Conformance debate gate stub: ${gate} reviewed ${source_file:-no-source}."
+    else
+        debate_output=$(run_agent_sync "claude-sonnet" "Run a concise adversarial Embrace debate gate.
+
+Gate: ${gate}
+Original task: ${prompt}
+
+Source artifact:
+${source_excerpt}
+
+Output:
+1. Biggest risks
+2. Required amendments, if any
+3. Verdict: PROCEED or STOP" 120 "code-reviewer" "embrace-gate") || {
+            debate_output="[Debate gate provider unavailable - manual review required]"
+        }
+    fi
+
+    local gate_status="PROCEED"
+    if echo "$debate_output" | grep -qiE 'verdict:[[:space:]]*STOP|status:[[:space:]]*STOP|(^|[[:space:]])STOP($|[[:space:]])'; then
+        gate_status="STOP"
+    fi
+
+    cat > "$gate_file" << EOF
+# EMBRACE Gate: ${gate}
+## Task: ${prompt}
+## Source: ${source_file}
+## Generated: $(date)
+## Status: ${gate_status}
+
+${debate_output}
+
+---
+*Embrace debate gate artifact (task group: ${task_group})*
+EOF
+
+    log INFO "Debate gate artifact: $gate_file"
+    echo -e "${GREEN}✓${NC} Debate gate saved to: $gate_file"
+}
+
+embrace_require_gate_artifact() {
+    local gate="$1"
+    local task_group="$2"
+    local gate_file="${RESULTS_DIR}/embrace-gate-${gate}-${task_group}.md"
+
+    if [[ ! -s "$gate_file" ]]; then
+        log ERROR "Embrace contract violation: debate gate requested but artifact missing (${gate_file})"
+        return 1
+    fi
+
+    if grep -q "Status: STOP" "$gate_file" 2>/dev/null; then
+        log ERROR "Embrace debate gate blocked workflow: ${gate}"
+        return 1
+    fi
+
+    return 0
+}
+
 # ── Extracted from orchestrate.sh ──
 format_workflow_banner() {
     local workflow="$1"
@@ -1385,6 +1514,22 @@ embrace_full_workflow() {
     echo ""
 
     log INFO "Starting complete Double Diamond workflow"
+
+    if [[ "${OCTOPUS_CONFORMANCE_MODE:-false}" == "true" ]]; then
+        export OCTOPUS_SKIP_COST_PROMPT=true
+        export OCTOPUS_SKIP_PHASE_COST_PROMPT=true
+        export OCTOPUS_SKIP_PROVIDER_PROBES=true
+        export SKIP_SMOKE_TEST=true
+        export OCTOPUS_ANTISYCOPHANCY=false
+        export OCTOPUS_YAML_RUNTIME=disabled
+        export AUTONOMY_MODE="${AUTONOMY_MODE:-autonomous}"
+        export ON_FAIL_ACTION="${ON_FAIL_ACTION:-abort}"
+    elif embrace_contract_mode_enabled && [[ "${OCTOPUS_YAML_RUNTIME:-auto}" == "auto" ]]; then
+        # The hardcoded runner is currently the path with transition contracts
+        # and debate-gate artifact enforcement. YAML can still be forced via
+        # OCTOPUS_YAML_RUNTIME=enabled when explicitly validating that runtime.
+        export OCTOPUS_YAML_RUNTIME=disabled
+    fi
 
     # v8.49.0: Clean up expired results from prior runs
     cleanup_old_results
@@ -1591,8 +1736,17 @@ ${obs_ctx}"
         echo ""
         echo -e "${CYAN}[1/4] Starting PROBE phase (Discover)...${NC}"
         echo ""
-        probe_discover "$prompt"
-        probe_synthesis=$(ls -t "$RESULTS_DIR"/probe-synthesis-*.md 2>/dev/null | head -1)
+        local probe_rc=0
+        probe_discover "$prompt" || probe_rc=$?
+        if ! probe_synthesis=$(embrace_require_phase_artifact "probe" "$RESULTS_DIR/probe-synthesis-*.md"); then
+            _write_embrace_session_state "probe" "failed"
+            return 1
+        fi
+        if [[ $probe_rc -ne 0 ]]; then
+            log ERROR "PROBE phase failed after writing artifact: $probe_synthesis"
+            _write_embrace_session_state "probe" "failed"
+            return "$probe_rc"
+        fi
 
         # v7.25.0: Display phase metrics
         if command -v display_phase_metrics &> /dev/null; then
@@ -1620,8 +1774,17 @@ ${obs_ctx}"
         echo ""
         echo -e "${CYAN}[2/4] Starting GRASP phase (Define)...${NC}"
         echo ""
-        grasp_define "$prompt" "$probe_synthesis"
-        grasp_consensus=$(ls -t "$RESULTS_DIR"/grasp-consensus-*.md 2>/dev/null | head -1)
+        local grasp_rc=0
+        grasp_define "$prompt" "$probe_synthesis" || grasp_rc=$?
+        if ! grasp_consensus=$(embrace_require_phase_artifact "grasp" "$RESULTS_DIR/grasp-consensus-*.md"); then
+            _write_embrace_session_state "grasp" "failed"
+            return 1
+        fi
+        if [[ $grasp_rc -ne 0 ]]; then
+            log ERROR "GRASP phase failed after writing artifact: $grasp_consensus"
+            _write_embrace_session_state "grasp" "failed"
+            return "$grasp_rc"
+        fi
 
         # v7.25.0: Display phase metrics
         if command -v display_phase_metrics &> /dev/null; then
@@ -1635,6 +1798,10 @@ ${obs_ctx}"
         _write_embrace_session_state "grasp" "completed"
         save_session_checkpoint "grasp" "completed" "$grasp_consensus"
         handle_autonomy_checkpoint "grasp" "completed"
+        if embrace_gate_requested "define"; then
+            embrace_run_debate_gate "define-develop" "$grasp_consensus" "$prompt" "$task_group"
+            embrace_require_gate_artifact "define-develop" "$task_group" || return 1
+        fi
         sleep 1
     else
         grasp_consensus=$(get_phase_output "grasp")
@@ -1649,8 +1816,12 @@ ${obs_ctx}"
         echo ""
         echo -e "${CYAN}[3/4] Starting TANGLE phase (Develop)...${NC}"
         echo ""
-        tangle_develop "$prompt" "$grasp_consensus"
-        tangle_validation=$(ls -t "$RESULTS_DIR"/tangle-validation-*.md 2>/dev/null | head -1)
+        local tangle_rc=0
+        tangle_develop "$prompt" "$grasp_consensus" || tangle_rc=$?
+        if ! tangle_validation=$(embrace_require_phase_artifact "tangle" "$RESULTS_DIR/tangle-validation-*.md"); then
+            _write_embrace_session_state "tangle" "failed"
+            return 1
+        fi
 
         # v7.25.0: Display phase metrics
         if command -v display_phase_metrics &> /dev/null; then
@@ -1660,7 +1831,7 @@ ${obs_ctx}"
         # Check quality gate status for autonomy
         local tangle_status="completed"
         if grep -q "Quality Gate: FAILED" "$tangle_validation" 2>/dev/null; then
-            tangle_status="warning"
+            tangle_status="failed"
         fi
         # v8.14.0: Capture phase context in persistent state
         update_context "develop" "$(head -20 "$tangle_validation" 2>/dev/null | tr '\n' ' ')" 2>/dev/null || true
@@ -1669,6 +1840,15 @@ ${obs_ctx}"
         _write_embrace_session_state "tangle" "$tangle_status"
         save_session_checkpoint "tangle" "$tangle_status" "$tangle_validation"
         handle_autonomy_checkpoint "tangle" "$tangle_status"
+        if [[ $tangle_rc -ne 0 ]]; then
+            log ERROR "TANGLE phase failed; stopping before Deliver"
+            return "$tangle_rc"
+        fi
+        embrace_tangle_allows_delivery "$tangle_validation" || return 1
+        if embrace_gate_requested "deliver"; then
+            embrace_run_debate_gate "deliver" "$tangle_validation" "$prompt" "$task_group"
+            embrace_require_gate_artifact "deliver" "$task_group" || return 1
+        fi
         sleep 1
     else
         tangle_validation=$(get_phase_output "tangle")
@@ -1676,13 +1856,20 @@ ${obs_ctx}"
         log INFO "Skipping tangle phase (resuming)"
     fi
 
+    embrace_tangle_allows_delivery "$tangle_validation" || return 1
+
     # Phase 4: INK (Deliver)
     export OCTOPUS_WORKFLOW_PHASE="ink"
     _write_embrace_session_state "ink" "running"
     echo ""
     echo -e "${CYAN}[4/4] Starting INK phase (Deliver)...${NC}"
     echo ""
-    ink_deliver "$prompt" "$tangle_validation"
+    local ink_rc=0
+    ink_deliver "$prompt" "$tangle_validation" || ink_rc=$?
+    if [[ $ink_rc -ne 0 ]]; then
+        _write_embrace_session_state "ink" "failed"
+        return "$ink_rc"
+    fi
 
     # v7.25.0: Display phase metrics
     if command -v display_phase_metrics &> /dev/null; then
@@ -1691,7 +1878,10 @@ ${obs_ctx}"
 
     # v8.14.0: Capture phase context in persistent state
     local ink_output
-    ink_output=$(ls -t "$RESULTS_DIR"/delivery-*.md 2>/dev/null | head -1)
+    ink_output=$(embrace_require_phase_artifact "ink" "$RESULTS_DIR/delivery-*.md") || {
+        _write_embrace_session_state "ink" "failed"
+        return 1
+    }
     update_context "deliver" "$(head -20 "$ink_output" 2>/dev/null | tr '\n' ' ')" 2>/dev/null || true
 
     OCTOPUS_COMPLETED_PHASES=4

--- a/tests/integration/test-embrace-conformance.sh
+++ b/tests/integration/test-embrace-conformance.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Tokenless Embrace conformance tests. Providers are mocked through PATH.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "embrace conformance"
+
+BASE_TMP="${TEST_TMP_DIR}/embrace-conformance"
+FAKE_BIN="${BASE_TMP}/bin"
+ORIGINAL_PATH="$PATH"
+
+write_fake_providers() {
+    mkdir -p "$FAKE_BIN"
+
+    cat > "$FAKE_BIN/codex" <<'SH'
+#!/usr/bin/env bash
+input="$(cat)"
+[[ -f "$HOME/.octo-fake-mode" ]] && source "$HOME/.octo-fake-mode"
+printf 'codex %s\n' "$*" >> "$HOME/providers.log"
+
+emit_long() {
+    local title="$1"
+    echo "$title"
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+        echo "codex detail ${i}: deterministic conformance evidence for Embrace orchestration contracts and artifact checks."
+    done
+}
+
+if [[ "${OCTO_FAKE_CODEX_STDERR_ONLY:-false}" == "true" ]]; then
+    emit_long "codex usable stderr-only response" >&2
+    exit 0
+fi
+
+if [[ "$input" == *"Decompose this task into subtasks"* ]]; then
+    if [[ "${OCTO_FAKE_TANGLE_FAIL:-false}" == "true" ]]; then
+        echo "1. [CODING] TANGLE_SUBTASK_FAIL"
+    else
+        echo "1. [CODING] Implement deterministic conformance marker"
+    fi
+    exit 0
+fi
+
+if [[ "${OCTO_FAKE_TANGLE_FAIL:-false}" == "true" && "$input" == *"TANGLE_SUBTASK_FAIL"* ]]; then
+    echo "codex simulated tangle failure" >&2
+    exit 1
+fi
+
+emit_long "codex deterministic response"
+SH
+
+    cat > "$FAKE_BIN/gemini" <<'SH'
+#!/usr/bin/env bash
+input="$(cat)"
+[[ -f "$HOME/.octo-fake-mode" ]] && source "$HOME/.octo-fake-mode"
+printf 'gemini %s\n' "$*" >> "$HOME/providers.log"
+
+emit_long() {
+    local title="$1"
+    echo "$title"
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+        echo "gemini detail ${i}: deterministic conformance evidence for Embrace orchestration contracts and artifact checks."
+    done
+}
+
+if [[ "${OCTO_FAKE_GEMINI_QUOTA:-false}" == "true" ]]; then
+    echo "QUOTA_EXHAUSTED: fake Gemini quota exhausted" >&2
+    exit 1
+fi
+
+if [[ "$input" == *"Decompose this task into subtasks"* ]]; then
+    if [[ "${OCTO_FAKE_TANGLE_FAIL:-false}" == "true" ]]; then
+        echo "1. [CODING] TANGLE_SUBTASK_FAIL"
+    else
+        echo "1. [CODING] Implement deterministic conformance marker"
+    fi
+    exit 0
+fi
+
+if [[ "$input" == *"Rate each dimension explicitly"* ]]; then
+    echo "Security: 10/10"
+    echo "Reliability: 10/10"
+    echo "Performance: 10/10"
+    echo "Accessibility: 10/10"
+    exit 0
+fi
+
+emit_long "gemini deterministic response"
+SH
+
+    cat > "$FAKE_BIN/claude" <<'SH'
+#!/usr/bin/env bash
+input="$(cat)"
+[[ -f "$HOME/.octo-fake-mode" ]] && source "$HOME/.octo-fake-mode"
+printf 'claude %s\n' "$*" >> "$HOME/providers.log"
+
+if [[ "$input" == *"Rate each dimension explicitly"* ]]; then
+    echo "Security: 10/10"
+    echo "Reliability: 10/10"
+    echo "Performance: 10/10"
+    echo "Accessibility: 10/10"
+    exit 0
+fi
+
+echo "claude deterministic response"
+for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    echo "claude detail ${i}: deterministic conformance evidence for Embrace orchestration contracts and artifact checks."
+done
+SH
+
+    chmod +x "$FAKE_BIN/codex" "$FAKE_BIN/gemini" "$FAKE_BIN/claude"
+}
+
+run_embrace_case() {
+    local name="$1"
+    shift
+    local run_dir="${BASE_TMP}/${name}"
+    local workspace="${run_dir}/workspace"
+    local home="${run_dir}/home"
+    local out="${run_dir}/out.txt"
+    local rc_file="${run_dir}/rc.txt"
+
+    rm -rf "$run_dir"
+    mkdir -p "$workspace" "$home"
+    cat > "$home/.octo-fake-mode" <<EOF
+OCTO_FAKE_TANGLE_FAIL="${OCTO_FAKE_TANGLE_FAIL:-false}"
+OCTO_FAKE_GEMINI_QUOTA="${OCTO_FAKE_GEMINI_QUOTA:-false}"
+OCTO_FAKE_CODEX_STDERR_ONLY="${OCTO_FAKE_CODEX_STDERR_ONLY:-false}"
+EOF
+
+    set +e
+    env \
+        HOME="$home" \
+        PATH="$FAKE_BIN:$ORIGINAL_PATH" \
+        OPENAI_API_KEY="fake-openai-key" \
+        GEMINI_API_KEY="fake-gemini-key" \
+        CLAUDE_OCTOPUS_WORKSPACE="$workspace" \
+        OCTOPUS_CONFORMANCE_MODE=true \
+        OCTOPUS_SKIP_COST_PROMPT=true \
+        OCTOPUS_SKIP_PROVIDER_PROBES=true \
+        SKIP_SMOKE_TEST=true \
+        OCTOPUS_DEBATE_GATES="${OCTOPUS_DEBATE_GATES:-both}" \
+        OCTOPUS_DISPATCH_STRATEGY=full \
+        OCTOPUS_TANGLE_DEADLINE=30 \
+        OCTOPUS_AGENT_MAX_OUTPUT_BYTES=65536 \
+        OCTO_FAKE_TANGLE_FAIL="${OCTO_FAKE_TANGLE_FAIL:-false}" \
+        OCTO_FAKE_GEMINI_QUOTA="${OCTO_FAKE_GEMINI_QUOTA:-false}" \
+        OCTO_FAKE_CODEX_STDERR_ONLY="${OCTO_FAKE_CODEX_STDERR_ONLY:-false}" \
+        OCTOPUS_CONFORMANCE_SKIP_GATE_ARTIFACT="${OCTOPUS_CONFORMANCE_SKIP_GATE_ARTIFACT:-}" \
+        "$@" \
+        bash "$PROJECT_ROOT/scripts/orchestrate.sh" --timeout 30 embrace "conformance ${name}" \
+        >"$out" 2>&1
+    local rc=$?
+    set -e
+
+    echo "$rc" > "$rc_file"
+    echo "$run_dir"
+}
+
+assert_file_glob() {
+    local pattern="$1"
+    compgen -G "$pattern" >/dev/null
+}
+
+write_fake_providers
+
+test_case "successful run writes all phase and gate artifacts without live providers"
+run_dir="$(OCTOPUS_DEBATE_GATES=both run_embrace_case success)"
+rc="$(cat "$run_dir/rc.txt")"
+results="$run_dir/workspace/results"
+if [[ "$rc" == "0" ]] && \
+   assert_file_glob "$results/probe-synthesis-*.md" && \
+   assert_file_glob "$results/grasp-consensus-*.md" && \
+   assert_file_glob "$results/tangle-validation-*.md" && \
+   assert_file_glob "$results/delivery-*.md" && \
+   assert_file_glob "$results/embrace-gate-define-develop-*.md" && \
+   assert_file_glob "$results/embrace-gate-deliver-*.md" && \
+   grep -q '^codex ' "$run_dir/home/providers.log" && \
+   grep -q '^gemini ' "$run_dir/home/providers.log" && \
+   grep -q '^claude ' "$run_dir/home/providers.log"; then
+    test_pass
+else
+    test_fail "expected successful conformance run with all artifacts; rc=${rc}; output=$(tail -40 "$run_dir/out.txt")"
+fi
+
+test_case "failed tangle stops before delivery but preserves validation artifact"
+run_dir="$(OCTOPUS_DEBATE_GATES=none OCTO_FAKE_TANGLE_FAIL=true run_embrace_case tangle-failed)"
+rc="$(cat "$run_dir/rc.txt")"
+results="$run_dir/workspace/results"
+if [[ "$rc" != "0" ]] && \
+   assert_file_glob "$results/tangle-validation-*.md" && \
+   ! assert_file_glob "$results/delivery-*.md" && \
+   grep -q "Quality Gate: FAILED" "$results"/tangle-validation-*.md; then
+    test_pass
+else
+    test_fail "expected tangle failure to block delivery; rc=${rc}; output=$(tail -40 "$run_dir/out.txt")"
+fi
+
+test_case "requested missing debate gate artifact fails the workflow"
+run_dir="$(OCTOPUS_DEBATE_GATES=both OCTOPUS_CONFORMANCE_SKIP_GATE_ARTIFACT=define-develop run_embrace_case missing-gate)"
+rc="$(cat "$run_dir/rc.txt")"
+results="$run_dir/workspace/results"
+if [[ "$rc" != "0" ]] && \
+   assert_file_glob "$results/grasp-consensus-*.md" && \
+   ! assert_file_glob "$results/embrace-gate-define-develop-*.md" && \
+   ! assert_file_glob "$results/tangle-validation-*.md"; then
+    test_pass
+else
+    test_fail "expected missing requested gate artifact to stop workflow; rc=${rc}; output=$(tail -40 "$run_dir/out.txt")"
+fi
+
+test_case "Gemini quota exhaustion degrades through fallback artifacts"
+run_dir="$(OCTOPUS_DEBATE_GATES=none OCTO_FAKE_GEMINI_QUOTA=true run_embrace_case gemini-quota)"
+rc="$(cat "$run_dir/rc.txt")"
+results="$run_dir/workspace/results"
+if [[ "$rc" == "0" ]] && \
+   assert_file_glob "$results/probe-synthesis-*.md" && \
+   assert_file_glob "$results/grasp-consensus-*.md" && \
+   assert_file_glob "$results/delivery-*.md" && \
+   grep -q "Auto-synthesis failed\\|Auto-consensus failed\\|raw findings" "$results"/probe-synthesis-*.md "$results"/grasp-consensus-*.md "$results"/delivery-*.md; then
+    test_pass
+else
+    test_fail "expected Gemini quota fallback artifacts; rc=${rc}; output=$(tail -40 "$run_dir/out.txt")"
+fi
+
+test_case "Codex stderr-only output is degraded usable output"
+run_dir="$(OCTOPUS_DEBATE_GATES=none OCTO_FAKE_CODEX_STDERR_ONLY=true run_embrace_case codex-stderr)"
+rc="$(cat "$run_dir/rc.txt")"
+results="$run_dir/workspace/results"
+if [[ "$rc" == "0" ]] && \
+   assert_file_glob "$results/tangle-validation-*.md" && \
+   grep -q "Status: SUCCESS (DEGRADED: Output captured on stderr)" "$results"/*codex*tangle-*.md; then
+    test_pass
+else
+    test_fail "expected Codex stderr-only output to count as degraded success; rc=${rc}; output=$(tail -40 "$run_dir/out.txt")"
+fi
+
+test_summary

--- a/tests/unit/test-embrace-command-contract.sh
+++ b/tests/unit/test-embrace-command-contract.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Static contract checks for /octo:embrace command.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "embrace command contract"
+
+COMMAND_FILE="$PROJECT_ROOT/.claude/commands/embrace.md"
+
+test_case "embrace command delegates to the single runner"
+content="$(cat "$COMMAND_FILE")"
+if [[ "$content" == *'bash scripts/orchestrate.sh embrace'* ]] && \
+   [[ "$content" == *'OCTOPUS_DEBATE_GATES='* ]]; then
+    test_pass
+else
+    test_fail "expected command to invoke scripts/orchestrate.sh embrace with debate gate env"
+fi
+
+test_case "embrace command does not instruct manual phase execution"
+if grep -qE 'scripts/orchestrate\.sh (probe|grasp|tangle|ink)' "$COMMAND_FILE"; then
+    test_fail "found direct phase execution instruction in embrace command"
+else
+    test_pass
+fi
+
+test_case "embrace command forbids local implementation fallback"
+if grep -qi 'must not execute phases manually' "$COMMAND_FILE" && \
+   grep -qi 'Do not continue manually' "$COMMAND_FILE"; then
+    test_pass
+else
+    test_fail "expected explicit prohibition against manual phase or implementation fallback"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary
- make /octo:embrace a thin runner-driven command instead of manual phase guidance
- enforce Embrace runner contracts for required artifacts, debate gates, and Tangle failure stops
- add tokenless conformance coverage with fake codex/gemini/claude providers

## Tests
- bash -n scripts/lib/agent-sync.sh scripts/lib/error-tracking.sh scripts/lib/testing.sh scripts/lib/workflows.sh tests/integration/test-embrace-conformance.sh tests/unit/test-embrace-command-contract.sh
- bash tests/unit/test-embrace-command-contract.sh
- bash tests/integration/test-embrace-conformance.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned `/octo:embrace` command with stricter workflow guardrails and improved runner-based orchestration
  * Added phase artifact validation and conformance gating layer to enforce workflow requirements

* **Chores**
  * Enhanced error detection and agent response handling
  * Improved artifact tracking across workflow phases

* **Tests**
  * Added conformance validation and command contract test suites

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->