### PR TITLE
fix(opencode): correct hardcoded model namespace defaults

### DIFF
--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -77,9 +77,9 @@ ensure_config() {
       "fast": "sonar"
     },
     "opencode": {
-      "default": "google/gemini-2.5-flash",
-      "fast": "google/gemini-2.5-flash",
-      "research": "z-ai/glm-5.1"
+      "default": "opencode/deepseek-v4-flash-free",
+      "fast": "opencode/deepseek-v4-flash-free",
+      "research": "opencode/glm-5.1"
     }
   },
   "routing": {

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -211,9 +211,9 @@ resolve_octopus_model() {
             copilot*)        resolved_model="claude-sonnet-4.5" ;; # Copilot default; actual model selected by copilot CLI
             qwen*)           resolved_model="qwen3-coder" ;;
             cursor-agent*)   resolved_model="grok-4-20" ;;
-            opencode-research*) resolved_model="z-ai/glm-5.1" ;;
-            opencode-fast*)  resolved_model="google/gemini-2.5-flash" ;;
-            opencode*)       resolved_model="google/gemini-2.5-flash" ;;
+            opencode-research*) resolved_model="opencode/glm-5.1" ;;
+            opencode-fast*)  resolved_model="opencode/deepseek-v4-flash-free" ;;
+            opencode*)       resolved_model="opencode/deepseek-v4-flash-free" ;;
             *)              resolved_model="gpt-5.4" ;; # Safest universal fallback
         esac
         [[ -n "$_trace" ]] && echo "[model-trace] Tier 7 (hardcoded fallback): $resolved_model ← SELECTED" >&2

--- a/tests/unit/test-opencode-model-defaults.sh
+++ b/tests/unit/test-opencode-model-defaults.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Tests for OpenCode hardcoded model defaults.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "OpenCode model defaults"
+
+pass() { test_case "$1"; test_pass; }
+fail() { test_case "$1"; test_fail "${2:-$1}"; }
+
+MODEL_RESOLVER="$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+
+if bash -n "$MODEL_RESOLVER"; then
+    pass "model resolver has valid bash syntax"
+else
+    fail "model resolver has valid bash syntax" "syntax error"
+fi
+
+TEST_HOME="$TEST_TMP_DIR/home"
+mkdir -p "$TEST_HOME"
+
+source "$MODEL_RESOLVER"
+
+test_case "opencode default uses opencode namespace"
+if [[ "$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="opencode-default" resolve_octopus_model opencode opencode 2>/dev/null)" == "opencode/deepseek-v4-flash-free" ]]; then
+    test_pass
+else
+    test_fail "expected opencode/deepseek-v4-flash-free"
+fi
+
+test_case "opencode-fast default uses opencode namespace"
+if [[ "$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="opencode-fast" resolve_octopus_model opencode opencode-fast 2>/dev/null)" == "opencode/deepseek-v4-flash-free" ]]; then
+    test_pass
+else
+    test_fail "expected opencode/deepseek-v4-flash-free"
+fi
+
+test_case "opencode-research default uses opencode namespace"
+if [[ "$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="opencode-research" resolve_octopus_model opencode opencode-research 2>/dev/null)" == "opencode/glm-5.1" ]]; then
+    test_pass
+else
+    test_fail "expected opencode/glm-5.1"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

The Tier-7 hardcoded fallbacks for opencode agents in `scripts/lib/model-resolver.sh:214-216` emit `z-ai/glm-5.1` and `google/gemini-2.5-flash`, but **opencode no longer recognizes either name** — current valid names live under the `opencode/` namespace.

When a user has no per-agent model config and the orchestrator falls through to Tier 7, dispatch ends with one of:

- `Error: Model not found: z-ai/glm-5.1` — model name unknown to opencode
- `Error: Google Generative AI API key is missing. Pass it using the 'apiKey' parameter or the GOOGLE_GENERATIVE_AI_API_KEY environment variable.` — model name routes to an external provider that expects its own env var

…which leaves the agent looking like it "did nothing" from the user's perspective.

## Repro on a stock opencode install

```console
$ printf 'Reply ACK\n' | opencode run -m google/gemini-2.5-flash
Error: Google Generative AI API key is missing.

$ printf 'Reply ACK\n' | opencode run -m z-ai/glm-5.1
Error: Model not found: z-ai/glm-5.1
Try: `opencode models` to list available models

$ opencode models | grep -E '^opencode/' | head -3
opencode/big-pickle
opencode/claude-haiku-4-5
opencode/claude-opus-4-1
…
```

## Fix

| Agent | Before | After |
|-------|--------|-------|
| `opencode*` | `google/gemini-2.5-flash` | `opencode/deepseek-v4-flash-free` |
| `opencode-fast*` | `google/gemini-2.5-flash` | `opencode/deepseek-v4-flash-free` |
| `opencode-research*` | `z-ai/glm-5.1` | `opencode/glm-5.1` |

Rationale:

- `opencode/deepseek-v4-flash-free` works on the free OpenCode Zen tier — confirmed via test call below. Universal/fast routes pick it so first-run dispatches succeed without payment or extra env vars.
- `opencode/glm-5.1` requires payment, but `opencode-research` is an explicit opt-in — users who pick research-tier are signaling capability over cost.
- Same fix applied to `scripts/helpers/octo-model-config.sh` so `/octo:model-config` writes a working baseline JSON for new users.

## Out of scope (deliberately)

- `scripts/lib/models.sh:52` still references `google/gemini-2.5-flash` in a model-metadata row. Metadata is descriptive (cost/capability flags), not used for dispatch, so I left it untouched. Happy to follow up in a separate small PR if you'd prefer the metadata stay consistent.
- No changes to opencode dispatch logic in `dispatch.sh:119-127`; the empty-`oc_model_flag` path is no longer reachable when Tier-7 returns a valid name.

## Test plan

- [x] `printf 'Say ACK\n' | opencode run -m opencode/deepseek-v4-flash-free` returns `ACK` on a fresh install with only `opencode auth list` showing the OpenCode Zen credential.
- [x] `bash -n` passes on both touched files.
- [x] Verified the previous defaults fail with the exact error messages quoted above.

## Diff stat

```
 scripts/helpers/octo-model-config.sh | 6 +++---
 scripts/lib/model-resolver.sh        | 6 +++---
 2 files changed, 6 insertions(+), 6 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated opencode default model mappings: standard and fast modes now use a faster model for improved response speed; research mode now uses a model tuned for deeper analysis and higher-quality results.
* **Tests**
  * Added unit tests to validate the opencode model defaults and ensure consistent resolution across modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->