### PR TITLE
feat: add session provider controls and codex icon

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.38.1"
+    "version": "9.39.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.38.1 - Multi-LLM orchestration for Claude Code with agent summaries, prompt-size preflight, research fanout, and Codex-compatible skills. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
-      "version": "9.38.1",
+      "description": "v9.39.0 - Multi-LLM orchestration for Claude Code with session provider controls, Codex marketplace icon, and OpenCode catalog maintenance. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
+      "version": "9.39.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.38.1",
-  "description": "v9.38.1 \u2014 Agent summaries, prompt-size preflight, research fanout, and Codex-compatible portable skills. Run /octo:setup.",
+  "version": "9.39.0",
+  "description": "v9.39.0 — Codex marketplace icon, session provider controls, and OpenCode catalog/logging maintenance. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude/commands/model-config.md
+++ b/.claude/commands/model-config.md
@@ -107,6 +107,7 @@ AskUserQuestion({
       {label: "Provider defaults", description: "Set default models for Codex, Gemini, OpenRouter, etc."},
       {label: "Phase routing", description: "Choose which model handles each workflow phase (discover, develop, review, etc.)"},
       {label: "Debate & multi-LLM", description: "Configure which providers participate in debates, parallel execution, and reviews"},
+      {label: "Session provider availability", description: "Temporarily enable or disable providers for this Claude Code session"},
       {label: "Cost mode", description: "Switch between budget, standard, and premium model tiers"},
       {label: "Reset to defaults", description: "Reset all or specific provider configuration"}
     ]
@@ -354,6 +355,54 @@ To make permanent: add to ~/.zshrc or ~/.bashrc
 
 Or offer to set it in the config file.
 
+### Route: Session Provider Availability
+
+Use this when the user wants to turn a provider off for the current session, for example when Codex quota is exhausted and they want Claude + Gemini only.
+
+First show the current allowlist:
+
+```bash
+${HOME}/.claude-octopus/plugin/scripts/helpers/octo-model-config.sh providers
+```
+
+Then ask which providers should be available:
+
+```
+AskUserQuestion({
+  questions: [{
+    question: "Which providers should Octopus use for this session?",
+    header: "Providers",
+    multiSelect: true,
+    options: [
+      {label: "Claude", description: "Built-in Claude providers"},
+      {label: "Codex", description: "OpenAI Codex CLI"},
+      {label: "Gemini", description: "Google Gemini CLI"},
+      {label: "Copilot", description: "GitHub Copilot CLI"},
+      {label: "Qwen", description: "Qwen Code CLI"},
+      {label: "OpenCode", description: "OpenCode multi-provider router"},
+      {label: "Perplexity", description: "Live web research via API key"},
+      {label: "OpenRouter", description: "OpenRouter API models"}
+    ]
+  }]
+})
+```
+
+Apply the selection as a session allowlist:
+
+```bash
+${HOME}/.claude-octopus/plugin/scripts/helpers/octo-model-config.sh allow <providers...> --session
+```
+
+Useful direct commands:
+
+```bash
+${HOME}/.claude-octopus/plugin/scripts/helpers/octo-model-config.sh disable codex --session
+${HOME}/.claude-octopus/plugin/scripts/helpers/octo-model-config.sh allow claude gemini --session
+${HOME}/.claude-octopus/plugin/scripts/helpers/octo-model-config.sh clear-allowlist --session
+```
+
+Explain that `OCTO_ALLOWED_PROVIDERS` still wins when it is set in the shell environment.
+
 ### Route: Reset
 
 ```
@@ -404,6 +453,11 @@ When invoked WITH arguments (e.g., `/octo:model-config codex gpt-5.4`), skip the
    - `<provider>.<capability> <model>` → Set capability-specific model
    - `<provider> <model> --session` → Set model (session only)
    - `phase <phase> <model>` → Set phase-specific model routing
+   - `providers` → Show current provider allowlist source and value
+   - `allow <providers...> --session` → Use only these providers for the current session
+   - `disable <providers...> --session` → Remove providers from the current session
+   - `enable <providers...> --session` → Add providers to the current session allowlist
+   - `clear-allowlist --session` → Restore default provider availability for the current session
    - `reset <provider|all>` → Reset to defaults
 
 2. **Set Model** (`<provider> <model>` or with `--session`):
@@ -427,6 +481,8 @@ When invoked WITH arguments (e.g., `/octo:model-config codex gpt-5.4`), skip the
    ```
 
 4. **Reset**: Use default values from the ensure_config block in `scripts/helpers/octo-model-config.sh`.
+
+5. **Provider Availability**: Use `scripts/helpers/octo-model-config.sh providers|allow|enable|disable|clear-allowlist`. These commands write to `~/.claude-octopus/config/provider-allowlist.<session>` by default. Global files are supported with `--global`, but prefer session scope unless the user explicitly asks for a persistent change.
 
 5. Always show confirmation and the updated value after any change.
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.38.1",
+  "version": "9.39.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"
@@ -31,8 +31,9 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Claude Octopus",
-    "shortDescription": "Multi-LLM orchestration \u2014 dispatch to 8 providers from one plugin.",
+    "shortDescription": "Multi-LLM orchestration — dispatch to 8 providers from one plugin.",
     "longDescription": "Claude Octopus orchestrates multiple AI providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) through structured Double Diamond workflows. 32 personas, 48 commands, 53 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch includes prompt-size preflight, agent summary tables, circuit breakers, cost tracking, and model routing.",
+    "composerIcon": "./assets/octopus-icon.svg",
     "developerName": "nyldn",
     "category": "Orchestration",
     "capabilities": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
-  "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.38.1",
+  "description": "Multi-LLM orchestration — up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
+  "version": "9.39.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.38.1"
+    "version": "9.39.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.38.1 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 48 commands, 53 skills. Run /octo:setup after install.",
-      "version": "9.38.1",
+      "description": "v9.39.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 48 commands, 53 skills. Run /octo:setup after install.",
+      "version": "9.39.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.38.1",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.38.1. 32 expert personas, 48 commands, 53 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.39.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.39.0. 32 expert personas, 48 commands, 53 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [9.39.0] - 2026-05-21
+
+### Added
+
+- Add Codex marketplace icon metadata and package the SVG asset for marketplace browsers (#385).
+- Add session-scoped provider availability controls to `/octo:model-config` so users can disable exhausted providers such as Codex without uninstalling them (#386).
+
+### Fixed
+
+- Surface the first provider stderr line in orchestrator logs when a provider command fails, while still preserving the full transcript in the result file (#404).
+- Align OpenCode model catalog metadata with the current `opencode/...` namespace (#404).
+- Replace low-risk `ls`/`read` shellcheck findings in `orchestrate.sh` with safer equivalents (#404).
+
 ## [9.38.1] - 2026-05-21
 
 Patch release covering the issue/PR triage queue after v9.38.0.
@@ -43,10 +56,6 @@ Patch release covering the issue/PR triage queue after v9.38.0.
 
 - Prevent the stable `~/.claude-octopus/plugin` self-heal path from recreating the plugin symlink as a self-referential loop (#371).
 - Update release validation to understand directory-based plugin skill registrations.
-
----
-
-## [Unreleased]
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.38.1-blue" alt="Version 9.38.1">
+  <img src="https://img.shields.io/badge/Version-9.39.0-blue" alt="Version 9.39.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -399,6 +399,8 @@ Everything except multi-AI features. You get all 32 personas, structured workflo
 **Data locations** — Results in `~/.claude-octopus/results/`, logs in `~/.claude-octopus/logs/`, project state in `.octo/`. Nothing hidden.
 
 **Provider transparency** — Every command shows a 🐙 activation indicator on launch. Colored dots (🔴 🟡 🟣 🔵) show exactly which providers are running and when external APIs are called. You always know what's happening.
+
+**Session provider controls** — Temporarily disable exhausted providers without uninstalling them. For example, `/octo:model-config disable codex --session` keeps Codex out of provider detection and multi-LLM fanout for the current session; `/octo:model-config clear-allowlist --session` restores the default.
 
 **Clean uninstall** — Run `claude plugin uninstall octo` from your terminal. If you see a scope error, add `--scope project`. No residual config changes.
 

--- a/assets/octopus-icon.svg
+++ b/assets/octopus-icon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Claude Octopus icon</title>
+  <desc id="desc">A stylized octopus mark for the Claude Octopus plugin.</desc>
+  <rect width="512" height="512" rx="108" fill="#111827"/>
+  <circle cx="256" cy="212" r="120" fill="#6366f1"/>
+  <circle cx="214" cy="200" r="18" fill="#ffffff"/>
+  <circle cx="298" cy="200" r="18" fill="#ffffff"/>
+  <circle cx="214" cy="200" r="8" fill="#111827"/>
+  <circle cx="298" cy="200" r="8" fill="#111827"/>
+  <path d="M176 274c18 22 45 35 80 35s62-13 80-35" fill="none" stroke="#ffffff" stroke-width="18" stroke-linecap="round"/>
+  <path d="M158 296c-41 8-71 32-78 68-4 24 8 44 31 52 25 9 53-2 70-28" fill="none" stroke="#6366f1" stroke-width="34" stroke-linecap="round"/>
+  <path d="M354 296c41 8 71 32 78 68 4 24-8 44-31 52-25 9-53-2-70-28" fill="none" stroke="#6366f1" stroke-width="34" stroke-linecap="round"/>
+  <path d="M210 318c-18 34-22 69-9 98 10 24 33 35 55 25 21-9 32-32 26-58" fill="none" stroke="#6366f1" stroke-width="34" stroke-linecap="round"/>
+  <path d="M302 318c18 34 22 69 9 98-10 24-33 35-55 25-21-9-32-32-26-58" fill="none" stroke="#6366f1" stroke-width="34" stroke-linecap="round"/>
+  <path d="M196 316c-31 20-50 48-50 80 0 25 17 43 41 43 23 0 43-17 50-43" fill="none" stroke="#818cf8" stroke-width="26" stroke-linecap="round"/>
+  <path d="M316 316c31 20 50 48 50 80 0 25-17 43-41 43-23 0-43-17-50-43" fill="none" stroke="#818cf8" stroke-width="26" stroke-linecap="round"/>
+  <path d="M132 130l34-34 34 34m112 0 34-34 34 34" fill="none" stroke="#22d3ee" stroke-width="22" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/COMMAND-REFERENCE.md
+++ b/docs/COMMAND-REFERENCE.md
@@ -276,6 +276,10 @@ Configure which AI models are used across Claude Octopus workflows.
 /octo:model-config codex gpt-5.4            # Set Codex model
 /octo:model-config codex gpt-5.4  # Fast Spark model
 /octo:model-config gemini gemini-3.1-pro-preview  # Set Gemini model
+/octo:model-config providers                 # Show provider allowlist
+/octo:model-config disable codex --session   # Stop using Codex in this session
+/octo:model-config allow claude gemini --session  # Use only Claude + Gemini in this session
+/octo:model-config clear-allowlist --session # Restore default provider availability
 /octo:model-config cost-mode budget         # Use cheaper models
 /octo:model-config cost-mode premium        # Use best models
 /octo:model-config trace                    # Debug model resolution

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.38.1",
+  "version": "9.39.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {
@@ -25,6 +25,7 @@
     ".mcp.json",
     "scripts/",
     "agents/",
+    "assets/",
     "bin/",
     "hooks/",
     "skills/",

--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -6,9 +6,11 @@ set -eo pipefail
 
 CONFIG_FILE="${HOME}/.claude-octopus/config/providers.json"
 CACHE_FILE="/tmp/octo-model-cache-${USER:-${USERNAME:-unknown}}-${CLAUDE_CODE_SESSION:-global}.json"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
 
 # Known providers and phases for validation
-KNOWN_PROVIDERS="codex gemini claude perplexity openrouter opencode copilot ollama qwen cursor-agent"
+KNOWN_PROVIDERS="codex gemini claude perplexity openrouter opencode copilot ollama qwen cursor-agent vibe"
 KNOWN_PHASES="discover define develop deliver quick debate review security research"
 
 # Colors
@@ -28,6 +30,11 @@ usage() {
     echo "  route <phase> <target>      Route a phase to a specific model/capability"
     echo "  reset [provider|all]        Reset configuration to defaults"
     echo "  models [filter]             List all known models with capabilities"
+    echo "  providers                   Show active provider allowlist"
+    echo "  allow <providers...>        Allow only these providers (session by default)"
+    echo "  enable <providers...>       Add providers to the active allowlist"
+    echo "  disable <providers...>      Remove providers from the active allowlist"
+    echo "  clear-allowlist             Clear the provider allowlist"
     echo "  verify                      Verify model accessibility"
     echo ""
     echo "Options:"
@@ -39,6 +46,7 @@ usage() {
     echo "  OCTOPUS_GEMINI_MODEL        Override gemini model"
     echo "  OCTOPUS_CURSOR_AGENT_MODEL  Override cursor-agent model"
     echo "  OCTOPUS_COST_MODE           Set cost tier: budget, standard, premium"
+    echo "  OCTO_ALLOWED_PROVIDERS      Override provider availability for this process"
     echo "  OCTOPUS_TRACE_MODELS=1      Debug model resolution precedence"
 }
 
@@ -121,6 +129,184 @@ validate_model() {
     return 0
 }
 
+canonical_provider() {
+    local provider
+    provider="$(octo_normalize_provider_name "${1:-}")"
+    case "$provider" in
+        anthropic|sonnet) echo "claude" ;;
+        openai) echo "codex" ;;
+        google) echo "gemini" ;;
+        cursor|xai) echo "cursor-agent" ;;
+        local) echo "ollama" ;;
+        *) echo "$provider" ;;
+    esac
+}
+
+provider_known() {
+    local provider="$1"
+    echo "$KNOWN_PROVIDERS" | grep -qw "$provider"
+}
+
+unique_provider_list() {
+    local seen="" out="" provider
+    for provider in "$@"; do
+        [[ -n "$provider" ]] || continue
+        if [[ " $seen " == *" $provider "* ]]; then
+            continue
+        fi
+        seen="${seen:+$seen }$provider"
+        out="${out:+$out }$provider"
+    done
+    printf '%s\n' "$out"
+}
+
+parse_provider_args() {
+    local providers=()
+    local arg provider
+    for arg in "$@"; do
+        case "$arg" in
+            --session|--global|--force) continue ;;
+        esac
+        provider="$(canonical_provider "$arg")"
+        if ! provider_known "$provider"; then
+            log_error "Unknown provider '$arg'. Valid: $KNOWN_PROVIDERS"
+            exit 1
+        fi
+        providers+=("$provider")
+    done
+
+    if [[ ${#providers[@]} -eq 0 ]]; then
+        log_error "At least one provider is required"
+        exit 1
+    fi
+
+    unique_provider_list "${providers[@]}"
+}
+
+current_provider_allowlist_or_all() {
+    local current
+    if declare -f octo_provider_allowlist_value >/dev/null 2>&1; then
+        current="$(octo_provider_allowlist_value)"
+    else
+        current="${OCTO_ALLOWED_PROVIDERS:-}"
+    fi
+    if [[ -z "$current" ]]; then
+        printf '%s\n' "$KNOWN_PROVIDERS"
+    else
+        local providers=() token
+        # shellcheck disable=SC2086 # Intentional word splitting: provider allowlist syntax.
+        for token in ${current//,/ }; do
+            providers+=("$(canonical_provider "$token")")
+        done
+        unique_provider_list "${providers[@]}"
+    fi
+}
+
+allowlist_target_file() {
+    local scope="$1"
+    case "$scope" in
+        global) octo_provider_allowlist_global_file ;;
+        *) octo_provider_allowlist_session_file ;;
+    esac
+}
+
+write_provider_allowlist() {
+    local scope="$1"
+    local providers="$2"
+    local file
+    file="$(allowlist_target_file "$scope")"
+    mkdir -p "$(dirname "$file")"
+    printf '%s\n' "$providers" > "$file"
+    clear_cache
+    log_info "Provider allowlist ($scope): ${providers:-none}"
+    echo "  File: $file"
+}
+
+cmd_provider_allowlist() {
+    local source="unset" value=""
+    if declare -f octo_provider_allowlist_source >/dev/null 2>&1; then
+        source="$(octo_provider_allowlist_source)"
+        value="$(octo_provider_allowlist_value)"
+    else
+        value="${OCTO_ALLOWED_PROVIDERS:-}"
+        [[ -n "$value" ]] && source="env:OCTO_ALLOWED_PROVIDERS"
+    fi
+
+    echo -e "${CYAN}Provider Allowlist${NC}"
+    echo "----------------------------------------"
+    echo "  Source: $source"
+    if [[ -z "$value" ]]; then
+        echo "  Allowed: all providers"
+    else
+        echo "  Allowed: $(unique_provider_list ${value//,/ })"
+    fi
+    echo ""
+    echo "  Session command examples:"
+    echo "    octo-model-config allow claude gemini --session"
+    echo "    octo-model-config disable codex --session"
+    echo "    octo-model-config clear-allowlist --session"
+}
+
+cmd_allow() {
+    local scope="session" arg
+    for arg in "$@"; do
+        [[ "$arg" == "--global" ]] && scope="global"
+    done
+    local providers
+    providers="$(parse_provider_args "$@")"
+    write_provider_allowlist "$scope" "$providers"
+}
+
+cmd_enable() {
+    local scope="session" arg
+    for arg in "$@"; do
+        [[ "$arg" == "--global" ]] && scope="global"
+    done
+    local existing add merged
+    existing="$(current_provider_allowlist_or_all)"
+    add="$(parse_provider_args "$@")"
+    merged="$(unique_provider_list $existing $add)"
+    write_provider_allowlist "$scope" "$merged"
+}
+
+cmd_disable() {
+    local scope="session" arg
+    for arg in "$@"; do
+        [[ "$arg" == "--global" ]] && scope="global"
+    done
+
+    local existing remove keep="" token blocked should_remove
+    existing="$(current_provider_allowlist_or_all)"
+    remove="$(parse_provider_args "$@")"
+
+    for token in $existing; do
+        should_remove=false
+        for blocked in $remove; do
+            if [[ "$token" == "$blocked" ]]; then
+                should_remove=true
+                break
+            fi
+        done
+        [[ "$should_remove" == "true" ]] && continue
+        keep="${keep:+$keep }$token"
+    done
+
+    write_provider_allowlist "$scope" "$keep"
+}
+
+cmd_clear_allowlist() {
+    local scope="session" arg
+    for arg in "$@"; do
+        [[ "$arg" == "--global" ]] && scope="global"
+    done
+    local file
+    file="$(allowlist_target_file "$scope")"
+    rm -f "$file"
+    clear_cache
+    log_info "Cleared provider allowlist ($scope)"
+    echo "  File: $file"
+}
+
 # v8.49.0: Invalidate model resolution cache after config changes
 clear_cache() {
     rm -f "$CACHE_FILE"
@@ -134,7 +320,7 @@ cmd_list() {
     # Environment overrides
     echo -e "\n${YELLOW}Environment Overrides:${NC}"
     local has_env=false
-    for var in OCTOPUS_CODEX_MODEL OCTOPUS_GEMINI_MODEL OCTOPUS_CURSOR_AGENT_MODEL OCTOPUS_PERPLEXITY_MODEL OCTOPUS_OPENCODE_MODEL OCTOPUS_COST_MODE OCTOPUS_TRACE_MODELS; do
+    for var in OCTOPUS_CODEX_MODEL OCTOPUS_GEMINI_MODEL OCTOPUS_CURSOR_AGENT_MODEL OCTOPUS_PERPLEXITY_MODEL OCTOPUS_OPENCODE_MODEL OCTOPUS_COST_MODE OCTO_ALLOWED_PROVIDERS OCTOPUS_TRACE_MODELS; do
         if [[ -n "${!var:-}" ]]; then
             echo "  $var=${!var}"
             has_env=true
@@ -161,6 +347,23 @@ cmd_list() {
     # Cost mode
     echo -e "\n${YELLOW}Cost Mode:${NC}"
     echo "  ${OCTOPUS_COST_MODE:-standard} (set via OCTOPUS_COST_MODE env var)"
+
+    # Provider allowlist
+    echo -e "\n${YELLOW}Provider Allowlist:${NC}"
+    local allowlist_source allowlist_value
+    if declare -f octo_provider_allowlist_source >/dev/null 2>&1; then
+        allowlist_source="$(octo_provider_allowlist_source)"
+        allowlist_value="$(octo_provider_allowlist_value)"
+    else
+        allowlist_source="env"
+        allowlist_value="${OCTO_ALLOWED_PROVIDERS:-}"
+    fi
+    echo "  Source: $allowlist_source"
+    if [[ -z "$allowlist_value" ]]; then
+        echo "  Allowed: all providers"
+    else
+        echo "  Allowed: $(unique_provider_list ${allowlist_value//,/ })"
+    fi
 
     # Session overrides
     echo -e "\n${YELLOW}Session Overrides:${NC}"
@@ -331,10 +534,10 @@ cmd_models() {
         "z-ai/glm-5|203|yes|no|no|openrouter|standard|active"
         "moonshotai/kimi-k2.5|262|yes|yes|no|openrouter|standard|active"
         "deepseek/deepseek-r1-0528|164|yes|no|yes|openrouter|standard|active"
-        "google/gemini-2.5-flash|1000|yes|no|no|opencode|budget|active"
-        "openai/gpt-5.4|400|yes|yes|no|opencode|premium|active"
-        "openai/gpt-5.4-mini|400|yes|no|no|opencode|budget|active"
-        "z-ai/glm-5.1|203|yes|no|no|opencode|standard|active"
+        "opencode/deepseek-v4-flash-free|128|yes|no|no|opencode|budget|active"
+        "opencode/gpt-5.4|400|yes|yes|no|opencode|premium|active"
+        "opencode/gpt-5.4-mini|400|yes|no|no|opencode|budget|active"
+        "opencode/glm-5.1|203|yes|no|no|opencode|standard|active"
     )
 
     for entry in "${models[@]}"; do
@@ -390,6 +593,11 @@ case "$COMMAND" in
     route) cmd_route "$@" ;;
     reset) cmd_reset "$@" ;;
     models) cmd_models "$@" ;;
+    providers|allowlist) cmd_provider_allowlist ;;
+    allow|set-allowlist) cmd_allow "$@" ;;
+    enable) cmd_enable "$@" ;;
+    disable|block) cmd_disable "$@" ;;
+    clear-allowlist|reset-allowlist) cmd_clear_allowlist "$@" ;;
     verify) cmd_verify ;;
     help|--help|-h) usage ;;
     *) usage; exit 1 ;;

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -48,10 +48,11 @@ get_model_catalog() {
         z-ai/glm-5)             echo "203|yes|no|no|openrouter|standard|active" ;;
         moonshotai/kimi-k2.5)   echo "262|yes|yes|no|openrouter|standard|active" ;;
         deepseek/deepseek-r1-0528) echo "164|yes|no|yes|openrouter|standard|active" ;;
-        # OpenCode (multi-provider router — models use provider/model format)
-        google/gemini-2.5-flash) echo "1000|yes|no|no|opencode|budget|active" ;;
-        openai/gpt-5.4)         echo "400|yes|yes|no|opencode|premium|active" ;;
-        openai/gpt-5.4-mini)    echo "400|yes|no|no|opencode|budget|active" ;;
+        # OpenCode (multi-provider router — models use opencode/<model> namespace)
+        opencode/deepseek-v4-flash-free) echo "128|yes|no|no|opencode|budget|active" ;;
+        opencode/gpt-5.4)       echo "400|yes|yes|no|opencode|premium|active" ;;
+        opencode/gpt-5.4-mini)  echo "400|yes|no|no|opencode|budget|active" ;;
+        opencode/glm-5.1)       echo "203|yes|no|no|opencode|standard|active" ;;
         # Perplexity
         sonar-pro)              echo "128|no|no|no|perplexity|standard|active" ;;
         sonar)                  echo "128|no|no|no|perplexity|budget|active" ;;
@@ -114,6 +115,7 @@ list_models() {
         claude-sonnet-4.6 claude-opus-4.7 claude-opus-4.6 claude-opus-4.6-fast
         grok-4-20 grok-4-20-thinking composer-2-fast composer-2
         z-ai/glm-5 moonshotai/kimi-k2.5 deepseek/deepseek-r1-0528
+        opencode/deepseek-v4-flash-free opencode/gpt-5.4 opencode/gpt-5.4-mini opencode/glm-5.1
         sonar-pro sonar
     )
 

--- a/scripts/lib/provider-allowlist.sh
+++ b/scripts/lib/provider-allowlist.sh
@@ -1,12 +1,83 @@
 #!/usr/bin/env bash
-# provider-allowlist.sh - Shared OCTO_ALLOWED_PROVIDERS helpers.
+# provider-allowlist.sh - Shared provider allowlist helpers.
 #
 # OCTO_ALLOWED_PROVIDERS is a space/comma separated list of provider names.
 # When unset, every detected provider is allowed. When set, scripts should
 # treat non-listed providers as unavailable even if their CLI/API key exists.
+#
+# Session commands can also write an allowlist under
+# ~/.claude-octopus/config/provider-allowlist.<session>. The env var wins when
+# present, then the session file, then the global config file.
 
 octo_normalize_provider_name() {
     printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ','
+}
+
+octo_provider_allowlist_config_dir() {
+    printf '%s\n' "${OCTOPUS_CONFIG_DIR:-${HOME}/.claude-octopus/config}"
+}
+
+octo_provider_allowlist_session_id() {
+    local raw
+    raw="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_CODE_SESSION:-${OCTOPUS_SESSION_ID:-${CLAUDE_SESSION_ID:-global}}}}"
+    raw="$(printf '%s' "$raw" | tr -c 'A-Za-z0-9_.-' '-' | sed 's/--*/-/g;s/^-//;s/-$//')"
+    printf '%s\n' "${raw:-global}"
+}
+
+octo_provider_allowlist_session_file() {
+    printf '%s/provider-allowlist.%s\n' "$(octo_provider_allowlist_config_dir)" "$(octo_provider_allowlist_session_id)"
+}
+
+octo_provider_allowlist_global_file() {
+    printf '%s/provider-allowlist\n' "$(octo_provider_allowlist_config_dir)"
+}
+
+octo_provider_allowlist_source() {
+    if [[ -n "${OCTO_ALLOWED_PROVIDERS:-}" ]]; then
+        printf 'env:OCTO_ALLOWED_PROVIDERS\n'
+        return 0
+    fi
+
+    local session_file
+    session_file="$(octo_provider_allowlist_session_file)"
+    if [[ -f "$session_file" ]]; then
+        printf 'session:%s\n' "$session_file"
+        return 0
+    fi
+
+    local global_file
+    global_file="$(octo_provider_allowlist_global_file)"
+    if [[ -f "$global_file" ]]; then
+        printf 'global:%s\n' "$global_file"
+        return 0
+    fi
+
+    printf 'unset\n'
+}
+
+octo_provider_allowlist_value() {
+    if [[ -n "${OCTO_ALLOWED_PROVIDERS:-}" ]]; then
+        printf '%s\n' "$OCTO_ALLOWED_PROVIDERS"
+        return 0
+    fi
+
+    local session_file
+    session_file="$(octo_provider_allowlist_session_file)"
+    if [[ -f "$session_file" ]]; then
+        tr '\n' ' ' < "$session_file"
+        printf '\n'
+        return 0
+    fi
+
+    local global_file
+    global_file="$(octo_provider_allowlist_global_file)"
+    if [[ -f "$global_file" ]]; then
+        tr '\n' ' ' < "$global_file"
+        printf '\n'
+        return 0
+    fi
+
+    printf '\n'
 }
 
 octo_provider_allowed() {
@@ -14,13 +85,15 @@ octo_provider_allowed() {
     provider="$(octo_normalize_provider_name "${1:-}")"
     [[ -n "$provider" ]] || return 1
 
-    if [[ -z "${OCTO_ALLOWED_PROVIDERS:-}" ]]; then
+    local allowed
+    allowed="$(octo_provider_allowlist_value)"
+    if [[ -z "$allowed" ]]; then
         return 0
     fi
 
     local token normalized
     # shellcheck disable=SC2086 # Intentional word splitting: space separated allowlist.
-    for token in ${OCTO_ALLOWED_PROVIDERS//,/ }; do
+    for token in ${allowed//,/ }; do
         normalized="$(octo_normalize_provider_name "$token")"
         [[ -n "$normalized" ]] || continue
 

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -7,10 +7,11 @@
 # Source-safe: no main execution block.
 # ═══════════════════════════════════════════════════════════════════════════════
 
+_providers_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if ! declare -f _is_cursor_agent_binary >/dev/null 2>&1; then
-    _providers_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     source "${_providers_lib_dir}/cursor-agent.sh" 2>/dev/null || true
 fi
+source "${_providers_lib_dir}/provider-allowlist.sh" 2>/dev/null || true
 
 # Version comparison utility
 version_compare() {
@@ -667,6 +668,11 @@ check_provider_health() {
     local provider="$1"
     local errors=0
 
+    if declare -f octo_provider_allowed >/dev/null 2>&1 && ! octo_provider_allowed "$provider"; then
+        echo "$provider: disabled by provider allowlist" >&2
+        return 1
+    fi
+
     case "$provider" in
         codex)
             if ! command -v codex &>/dev/null; then
@@ -934,7 +940,7 @@ detect_providers() {
     local result=""
 
     # Detect Codex CLI
-    if command -v codex &>/dev/null; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed codex; } && command -v codex &>/dev/null; then
         local codex_auth="none"
         if [[ -f "$HOME/.codex/auth.json" ]]; then
             codex_auth="oauth"
@@ -945,7 +951,7 @@ detect_providers() {
     fi
 
     # Detect Gemini CLI
-    if command -v gemini &>/dev/null; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed gemini; } && command -v gemini &>/dev/null; then
         local gemini_auth="none"
         if [[ -f "$HOME/.gemini/oauth_creds.json" ]]; then
             gemini_auth="oauth"
@@ -956,7 +962,7 @@ detect_providers() {
     fi
 
     # Detect Claude CLI (always available in Claude Code context)
-    if command -v claude &>/dev/null; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed claude; } && command -v claude &>/dev/null; then
         local claude_auth="oauth"
         # v8.8: Use claude auth status for reliable auth verification
         if [[ "$SUPPORTS_AUTH_CLI" == "true" ]]; then
@@ -971,17 +977,17 @@ detect_providers() {
     fi
 
     # Detect OpenRouter (API key only)
-    if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed openrouter; } && [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
         result="${result}openrouter:api-key "
     fi
 
     # Detect Perplexity (API key only)
-    if [[ -n "${PERPLEXITY_API_KEY:-}" ]]; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed perplexity; } && [[ -n "${PERPLEXITY_API_KEY:-}" ]]; then
         result="${result}perplexity:api-key "
     fi
 
     # Detect Ollama (CLI + server)
-    if command -v ollama &>/dev/null; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed ollama; } && command -v ollama &>/dev/null; then
         if curl -sf http://localhost:11434/api/tags &>/dev/null; then
             result="${result}ollama:running "
         else
@@ -990,7 +996,7 @@ detect_providers() {
     fi
 
     # Detect Copilot CLI (v9.9.0)
-    if command -v copilot &>/dev/null; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed copilot; } && command -v copilot &>/dev/null; then
         local copilot_auth="none"
         if [[ -n "${COPILOT_GITHUB_TOKEN:-}" ]]; then
             copilot_auth="pat"
@@ -1005,7 +1011,7 @@ detect_providers() {
     fi
 
     # Detect Qwen CLI (v9.10.0 — free tier)
-    if command -v qwen &>/dev/null; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed qwen; } && command -v qwen &>/dev/null; then
         local qwen_auth="none"
         if [[ -f "${HOME}/.qwen/oauth_creds.json" ]]; then
             qwen_auth="oauth"
@@ -1018,7 +1024,7 @@ detect_providers() {
     fi
 
     # Detect Cursor Agent CLI (Grok via Cursor subscription)
-    if declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed cursor-agent; } && declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
         local cursor_auth="none"
         if [[ -n "${CURSOR_API_KEY:-}" ]]; then
             cursor_auth="env:CURSOR_API_KEY"
@@ -1029,7 +1035,7 @@ detect_providers() {
     fi
 
     # Detect Vibe CLI (Mistral Vibe interactive CLI)
-    if command -v vibe &>/dev/null; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed vibe; } && command -v vibe &>/dev/null; then
         local vibe_auth="none"
         if [[ -f "${HOME}/.vibe/.env" ]] && grep -Eq '^[[:space:]]*MISTRAL_API_KEY=' "${HOME}/.vibe/.env" 2>/dev/null; then
             vibe_auth="env-file"
@@ -1042,7 +1048,7 @@ detect_providers() {
     fi
 
     # Detect OpenCode CLI (v9.11.0 — multi-provider router)
-    if command -v opencode &>/dev/null; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed opencode; } && command -v opencode &>/dev/null; then
         local opencode_auth="none"
         if [[ -f "${HOME}/.local/share/opencode/auth.json" ]]; then
             # Verify auth is actually valid via auth list (with timeout to prevent hang)

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -600,6 +600,14 @@ ${heuristic_ctx}"
             break
         done
 
+        if [[ $exit_code -ne 0 && -s "$temp_errors" ]]; then
+            local stderr_first_line=""
+            stderr_first_line=$(grep -m1 '[^[:space:]]' "$temp_errors" 2>/dev/null | head -c 240 || true)
+            if [[ -n "$stderr_first_line" ]]; then
+                log "ERROR" "[$agent_type] provider stderr: $stderr_first_line"
+            fi
+        fi
+
         # v8.16: Log auth retry metrics if retries occurred
         if [[ $auth_attempt -gt 0 ]]; then
             log "INFO" "Auth retries used: $auth_attempt/$max_auth_retries (backend=$OCTOPUS_BACKEND, exit=$exit_code)"

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -758,7 +758,7 @@ SKILLEOF
 
     # Max 20 skills: archive lowest-confidence when exceeded
     local skill_count
-    skill_count=$(ls -1 "$skills_dir"/*.md 2>/dev/null | wc -l | tr -d ' ')
+    skill_count=$(find "$skills_dir" -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
     if [[ "$skill_count" -gt 20 ]]; then
         # Find skill with lowest confidence (fewest occurrences)
         local lowest_file="" lowest_count=999
@@ -1521,7 +1521,7 @@ init_step_mode_selection() {
     echo -e "  ${DIM}Note: Both modes use Codex + Gemini - only personas differ${NC}"
     echo -e "  ${DIM}Switch anytime with /octo:dev or /octo:km${NC}"
     echo ""
-    read -p "  Choose mode [1-2] (default: 1): " mode_choice
+    read -r -p "  Choose mode [1-2] (default: 1): " mode_choice
 
     case "$mode_choice" in
         2)
@@ -1566,7 +1566,7 @@ init_step_intent() {
     echo ""
     echo -e "  ${GREEN}[0]${NC} General/All of above"
     echo ""
-    read -p "  Enter choices (e.g., '1,2,7' or '0' for all): " intent_choices
+    read -r -p "  Enter choices (e.g., '1,2,7' or '0' for all): " intent_choices
 
     # Parse choices
     intent_choices="${intent_choices:-0}"
@@ -1622,7 +1622,7 @@ init_step_resources() {
     echo ""
     echo -e "  ${GREEN}[5]${NC} Not sure / Skip        → Standard defaults"
     echo ""
-    read -p "  Select [1-5]: " tier_choice
+    read -r -p "  Select [1-5]: " tier_choice
 
     case "${tier_choice:-5}" in
         1) USER_RESOURCE_TIER="pro" ;;

--- a/tests/unit/test-codex-plugin-icon.sh
+++ b/tests/unit/test-codex-plugin-icon.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Tests for Codex marketplace icon metadata.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Codex plugin icon"
+
+PLUGIN_JSON="$PROJECT_ROOT/.codex-plugin/plugin.json"
+
+test_case "Codex plugin manifest has valid JSON"
+if jq empty "$PLUGIN_JSON"; then
+    test_pass
+else
+    test_fail ".codex-plugin/plugin.json is invalid JSON"
+fi
+
+test_case "composerIcon points to a packaged SVG asset"
+icon_path=$(jq -r '.interface.composerIcon // empty' "$PLUGIN_JSON")
+icon_file="$PROJECT_ROOT/${icon_path#./}"
+if [[ "$icon_path" == ./assets/*.svg ]] &&
+   [[ -f "$icon_file" ]] &&
+   grep -q '<svg' "$icon_file"; then
+    test_pass
+else
+    test_fail "composerIcon should point to an existing SVG under assets/"
+fi
+
+test_case "package includes assets directory"
+if jq -e '.files[] | select(. == "assets/")' "$PROJECT_ROOT/package.json" >/dev/null; then
+    test_pass
+else
+    test_fail "package.json files should include assets/"
+fi
+
+test_summary

--- a/tests/unit/test-opencode-model-defaults.sh
+++ b/tests/unit/test-opencode-model-defaults.sh
@@ -13,6 +13,8 @@ pass() { test_case "$1"; test_pass; }
 fail() { test_case "$1"; test_fail "${2:-$1}"; }
 
 MODEL_RESOLVER="$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+MODEL_CATALOG="$PROJECT_ROOT/scripts/lib/models.sh"
+MODEL_CONFIG="$PROJECT_ROOT/scripts/helpers/octo-model-config.sh"
 
 if bash -n "$MODEL_RESOLVER"; then
     pass "model resolver has valid bash syntax"
@@ -20,10 +22,17 @@ else
     fail "model resolver has valid bash syntax" "syntax error"
 fi
 
+if bash -n "$MODEL_CATALOG" "$MODEL_CONFIG"; then
+    pass "model catalog scripts have valid bash syntax"
+else
+    fail "model catalog scripts have valid bash syntax" "syntax error"
+fi
+
 TEST_HOME="$TEST_TMP_DIR/home"
 mkdir -p "$TEST_HOME"
 
 source "$MODEL_RESOLVER"
+source "$MODEL_CATALOG"
 
 test_case "opencode default uses opencode namespace"
 if [[ "$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="opencode-default" resolve_octopus_model opencode opencode 2>/dev/null)" == "opencode/deepseek-v4-flash-free" ]]; then
@@ -44,6 +53,24 @@ if [[ "$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="opencode-res
     test_pass
 else
     test_fail "expected opencode/glm-5.1"
+fi
+
+test_case "model catalog includes current opencode namespace"
+if is_known_model "opencode/deepseek-v4-flash-free" &&
+   is_known_model "opencode/glm-5.1" &&
+   [[ "$(get_model_capability "opencode/glm-5.1" provider)" == "opencode" ]]; then
+    test_pass
+else
+    test_fail "expected opencode namespaced models in catalog"
+fi
+
+test_case "model config catalog does not expose stale opencode metadata"
+catalog_output=$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="opencode-catalog" "$MODEL_CONFIG" models opencode 2>/dev/null)
+if assert_contains "$catalog_output" "opencode/deepseek-v4-flash-free" "opencode default should be listed" &&
+   assert_contains "$catalog_output" "opencode/glm-5.1" "opencode research model should be listed" &&
+   assert_not_contains "$catalog_output" "google/gemini-2.5-flash" "stale google model should not be listed as opencode" &&
+   assert_not_contains "$catalog_output" "z-ai/glm-5.1" "stale openrouter namespace should not be listed as opencode"; then
+    test_pass
 fi
 
 test_summary

--- a/tests/unit/test-provider-allowlist.sh
+++ b/tests/unit/test-provider-allowlist.sh
@@ -12,6 +12,7 @@ test_suite "Provider allowlist"
 ALLOWLIST_LIB="$PROJECT_ROOT/scripts/lib/provider-allowlist.sh"
 CHECK_PROVIDERS="$PROJECT_ROOT/scripts/helpers/check-providers.sh"
 BUILD_FLEET="$PROJECT_ROOT/scripts/helpers/build-fleet.sh"
+MODEL_CONFIG="$PROJECT_ROOT/scripts/helpers/octo-model-config.sh"
 
 test_case "allowlist helper has valid bash syntax"
 if bash -n "$ALLOWLIST_LIB"; then
@@ -36,6 +37,38 @@ if OCTO_ALLOWED_PROVIDERS="claude, gemini ollama" octo_provider_allowed gemini &
     test_pass
 else
     test_fail "allowlist did not honor comma/space separated provider names"
+fi
+
+session_config="$TEST_TMP_DIR/provider-allowlist-config"
+
+test_case "session allowlist file filters providers without env var"
+if unset OCTO_ALLOWED_PROVIDERS &&
+   OCTOPUS_CONFIG_DIR="$session_config" CLAUDE_CODE_SESSION_ID="session/one" "$MODEL_CONFIG" allow claude gemini --session >/dev/null &&
+   OCTOPUS_CONFIG_DIR="$session_config" CLAUDE_CODE_SESSION_ID="session/one" octo_provider_allowed claude-sonnet &&
+   OCTOPUS_CONFIG_DIR="$session_config" CLAUDE_CODE_SESSION_ID="session/one" octo_provider_allowed gemini &&
+   ! OCTOPUS_CONFIG_DIR="$session_config" CLAUDE_CODE_SESSION_ID="session/one" octo_provider_allowed codex; then
+    test_pass
+else
+    test_fail "session allowlist file should restrict providers"
+fi
+
+test_case "disable command removes one provider for current session"
+if unset OCTO_ALLOWED_PROVIDERS &&
+   OCTOPUS_CONFIG_DIR="$session_config" CLAUDE_CODE_SESSION_ID="session/two" "$MODEL_CONFIG" disable codex --session >/dev/null &&
+   ! OCTOPUS_CONFIG_DIR="$session_config" CLAUDE_CODE_SESSION_ID="session/two" octo_provider_allowed codex &&
+   OCTOPUS_CONFIG_DIR="$session_config" CLAUDE_CODE_SESSION_ID="session/two" octo_provider_allowed gemini; then
+    test_pass
+else
+    test_fail "disable should write a session allowlist excluding codex"
+fi
+
+test_case "clear-allowlist restores default provider availability"
+if unset OCTO_ALLOWED_PROVIDERS &&
+   OCTOPUS_CONFIG_DIR="$session_config" CLAUDE_CODE_SESSION_ID="session/two" "$MODEL_CONFIG" clear-allowlist --session >/dev/null &&
+   OCTOPUS_CONFIG_DIR="$session_config" CLAUDE_CODE_SESSION_ID="session/two" octo_provider_allowed codex; then
+    test_pass
+else
+    test_fail "clear-allowlist should restore default availability"
 fi
 
 mock_bin="$TEST_TMP_DIR/provider-allowlist-bin"


### PR DESCRIPTION
## Summary
- add a packaged Codex marketplace icon and wire `interface.composerIcon`
- add session/global provider allowlist controls to `/octo:model-config` so exhausted providers can be disabled without uninstalling
- refresh OpenCode catalog metadata, surface first stderr line on provider failures, and apply low-risk shellcheck cleanup from the maintainability triage
- bump release metadata to v9.39.0 and sync marketplace manifests

## Issue Coverage
- Closes #385
- Closes #386
- Closes #404

## Validation
- `make test-unit` (121 suites, 121 passed)
- `make test-smoke` (12 suites, 12 passed)
- `bash tests/unit/test-provider-allowlist.sh`
- `bash tests/unit/test-opencode-model-defaults.sh`
- `bash tests/unit/test-codex-plugin-icon.sh`
- `bash tests/unit/test-docs-sync.sh`
- `bash tests/unit/test-skill-templates.sh`
- `./scripts/build-codex-skills.sh --check`
- `./scripts/build-openclaw.sh --check`
- `./scripts/sync-marketplace.sh --check`
- `./scripts/validate-release.sh` (expected pre-merge warnings: tag/release not created yet)
- `jq empty` on public manifests
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v9.39.0

* **New Features**
  * Added session-scoped provider controls to temporarily disable or enable model providers for the current session
  * Added new OpenCode model options

* **Bug Fixes**
  * Improved error logging from model provider execution
  * Fixed provider namespace metadata alignment
  * Enhanced shell script robustness with safer input handling

* **Documentation**
  * Updated command reference with provider management examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->