### PR TITLE
fix: honor --timeout for synthesis stages (closes #408)

### DIFF
--- a/scripts/lib/factory-spec.sh
+++ b/scripts/lib/factory-spec.sh
@@ -203,7 +203,7 @@ ${supplemental}"
     # Fallback to Claude if both external providers failed
     if [[ -z "$scenarios" ]]; then
         log WARN "External providers unavailable for scenario generation, using Claude"
-        scenarios=$(run_agent_sync "claude" "$scenario_prompt" 180 "qa-engineer" "factory" 2>/dev/null) || true
+        scenarios=$(run_agent_sync "claude" "$scenario_prompt" "${TIMEOUT:-300}" "qa-engineer" "factory" 2>/dev/null) || true
     fi
 
     if [[ -z "$scenarios" ]]; then

--- a/scripts/lib/factory.sh
+++ b/scripts/lib/factory.sh
@@ -164,14 +164,14 @@ After all scenarios, output:
 
     # Cross-model holdout evaluation for objectivity
     local eval_result
-    eval_result=$(run_agent_sync "gemini" "$holdout_prompt" 180 "qa-reviewer" "factory" 2>/dev/null) || true
+    eval_result=$(run_agent_sync "gemini" "$holdout_prompt" "${TIMEOUT:-300}" "qa-reviewer" "factory" 2>/dev/null) || true
 
     if [[ -z "$eval_result" ]]; then
-        eval_result=$(run_agent_sync "codex" "$holdout_prompt" 180 "qa-reviewer" "factory" 2>/dev/null) || true
+        eval_result=$(run_agent_sync "codex" "$holdout_prompt" "${TIMEOUT:-300}" "qa-reviewer" "factory" 2>/dev/null) || true
     fi
 
     if [[ -z "$eval_result" ]]; then
-        eval_result=$(run_agent_sync "claude" "$holdout_prompt" 180 "qa-reviewer" "factory" 2>/dev/null) || true
+        eval_result=$(run_agent_sync "claude" "$holdout_prompt" "${TIMEOUT:-300}" "qa-reviewer" "factory" 2>/dev/null) || true
     fi
 
     if [[ -z "$eval_result" ]]; then

--- a/scripts/lib/heuristics.sh
+++ b/scripts/lib/heuristics.sh
@@ -455,7 +455,7 @@ Research findings:
 $results"
 
     local synthesis
-    synthesis=$(run_agent_sync "gemini" "$synthesis_prompt" 180) || {
+    synthesis=$(run_agent_sync "gemini" "$synthesis_prompt" "${TIMEOUT:-300}") || {
         log WARN "Synthesis failed, using compact fallback"
         synthesis=$(build_probe_fallback_synthesis "$original_prompt" "$result_count" "$usable_results" "$total_content_size" "$results")
     }

--- a/scripts/lib/research.sh
+++ b/scripts/lib/research.sh
@@ -38,10 +38,10 @@ Analyze the research context and provide:
 3. Unmet needs and opportunities
 4. Behavioral themes across user segments
 
-Format as a structured research synthesis." 180 "ux-researcher" "empathize") || {
+Format as a structured research synthesis." "${TIMEOUT:-300}" "ux-researcher" "empathize") || {
         log WARN "Gemini failed for research synthesis, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Gemini unavailable — falling back to Claude"
-        synthesis=$(run_agent_sync "claude-sonnet" "You are a UX researcher. Synthesize user research for: $prompt. Provide: key insights, pain points, unmet needs, behavioral themes." 180 "ux-researcher" "empathize") || true
+        synthesis=$(run_agent_sync "claude-sonnet" "You are a UX researcher. Synthesize user research for: $prompt. Provide: key insights, pain points, unmet needs, behavioral themes." "${TIMEOUT:-300}" "ux-researcher" "empathize") || true
     }
 
     echo -e "${CYAN}🦑 Phase 2/4: Creating personas and journey maps...${NC}"
@@ -54,10 +54,10 @@ Create:
 2. A current-state journey map for the primary persona
 3. Key moments of truth and emotional highs/lows
 
-Use evidence-based persona development." 180 "ux-researcher" "empathize") || {
+Use evidence-based persona development." "${TIMEOUT:-300}" "ux-researcher" "empathize") || {
         log WARN "Gemini failed for personas, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Gemini unavailable — falling back to Claude"
-        personas=$(run_agent_sync "claude-sonnet" "Based on this research: $synthesis. Create 2-3 user personas and a journey map for the primary persona." 180 "ux-researcher" "empathize") || true
+        personas=$(run_agent_sync "claude-sonnet" "Based on this research: $synthesis. Create 2-3 user personas and a journey map for the primary persona." "${TIMEOUT:-300}" "ux-researcher" "empathize") || true
     }
 
     echo -e "${CYAN}🦑 Phase 3/4: Defining product requirements...${NC}"
@@ -76,10 +76,10 @@ Create product requirements:
 3. Success metrics tied to user outcomes
 4. Prioritized backlog recommendations
 
-Original context: $prompt" 180 "product-writer" "empathize") || {
+Original context: $prompt" "${TIMEOUT:-300}" "product-writer" "empathize") || {
         log WARN "Codex failed for requirements, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Codex unavailable — falling back to Claude"
-        requirements=$(run_agent_sync "claude-sonnet" "Based on research: $synthesis and personas: $personas. Create: user stories, acceptance criteria, success metrics, prioritized backlog. Context: $prompt" 180 "product-writer" "empathize") || true
+        requirements=$(run_agent_sync "claude-sonnet" "Based on research: $synthesis and personas: $personas. Create: user stories, acceptance criteria, success metrics, prioritized backlog. Context: $prompt" "${TIMEOUT:-300}" "product-writer" "empathize") || true
     }
 
     echo -e "${CYAN}🦑 Phase 4/4: Validating through adversarial review...${NC}"
@@ -176,10 +176,10 @@ Provide:
 3. Seminal works and key researchers in the field
 4. Taxonomy for organizing the literature
 
-Create a structure for systematic review." 180 "research-synthesizer" "synthesize") || {
+Create a structure for systematic review." "${TIMEOUT:-300}" "research-synthesizer" "synthesize") || {
         log WARN "Gemini failed for literature gathering, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Gemini unavailable — falling back to Claude"
-        gathering=$(run_agent_sync "claude-sonnet" "You are a research synthesizer. For: $prompt. Provide: key research areas, theoretical frameworks, seminal works, taxonomy for systematic review." 180 "research-synthesizer" "synthesize") || true
+        gathering=$(run_agent_sync "claude-sonnet" "You are a research synthesizer. For: $prompt. Provide: key research areas, theoretical frameworks, seminal works, taxonomy for systematic review." "${TIMEOUT:-300}" "research-synthesizer" "synthesize") || true
     }
 
     echo -e "${CYAN}🦑 Phase 2/4: Conducting thematic analysis...${NC}"
@@ -193,10 +193,10 @@ Conduct thematic analysis:
 3. Identify conflicting findings and their sources
 4. Trace the evolution of thinking on this topic
 
-Topic: $prompt" 180 "research-synthesizer" "synthesize") || {
+Topic: $prompt" "${TIMEOUT:-300}" "research-synthesizer" "synthesize") || {
         log WARN "Gemini failed for thematic analysis, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Gemini unavailable — falling back to Claude"
-        themes=$(run_agent_sync "claude-sonnet" "Based on: $gathering. Identify 4-6 themes, consensus points, conflicts, and evolution of thinking. Topic: $prompt" 180 "research-synthesizer" "synthesize") || true
+        themes=$(run_agent_sync "claude-sonnet" "Based on: $gathering. Identify 4-6 themes, consensus points, conflicts, and evolution of thinking. Topic: $prompt" "${TIMEOUT:-300}" "research-synthesizer" "synthesize") || true
     }
 
     echo -e "${CYAN}🦑 Phase 3/4: Identifying gaps and future directions...${NC}"
@@ -213,10 +213,10 @@ Identify:
 4. Practical implications needing research
 5. Priority research questions for the field
 
-Original topic: $prompt" 180 "research-synthesizer" "synthesize") || {
+Original topic: $prompt" "${TIMEOUT:-300}" "research-synthesizer" "synthesize") || {
         log WARN "Codex failed for gap identification, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Codex unavailable — falling back to Claude"
-        gaps=$(run_agent_sync "claude-sonnet" "Based on structure: $gathering and themes: $themes. Identify: research gaps, methodological limitations, theoretical gaps, practical implications, priority questions. Topic: $prompt" 180 "research-synthesizer" "synthesize") || true
+        gaps=$(run_agent_sync "claude-sonnet" "Based on structure: $gathering and themes: $themes. Identify: research gaps, methodological limitations, theoretical gaps, practical implications, priority questions. Topic: $prompt" "${TIMEOUT:-300}" "research-synthesizer" "synthesize") || true
     }
 
     echo -e "${CYAN}🦑 Phase 4/4: Drafting synthesis narrative...${NC}"
@@ -234,10 +234,10 @@ Create:
 3. Critical synthesis connecting themes
 4. Conclusion with gaps and future directions
 
-Use academic writing conventions." 180 "academic-writer" "synthesize") || {
+Use academic writing conventions." "${TIMEOUT:-300}" "academic-writer" "synthesize") || {
         log WARN "Gemini failed for synthesis narrative, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Gemini unavailable — falling back to Claude"
-        narrative=$(run_agent_sync "claude-sonnet" "Write a literature review for: $prompt. Structure: $gathering. Themes: $themes. Gaps: $gaps. Use academic writing conventions, organize by themes." 180 "academic-writer" "synthesize") || true
+        narrative=$(run_agent_sync "claude-sonnet" "Write a literature review for: $prompt. Structure: $gathering. Themes: $themes. Gaps: $gaps. Use academic writing conventions, organize by themes." "${TIMEOUT:-300}" "academic-writer" "synthesize") || true
     }
 
     local result_file="$RESULTS_DIR/synthesize-${task_group}.md"

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -620,13 +620,13 @@ $(echo "$all_findings" | jq -c '.')
 Return ONLY valid JSON with 'findings' array including verdict field."
 
     local verified_findings
-    verified_findings=$(run_agent_sync "codex" "$verifier_prompt" 180 "code-reviewer" "review") && {
+    verified_findings=$(run_agent_sync "codex" "$verifier_prompt" "${TIMEOUT:-300}" "code-reviewer" "review") && {
         echo "codex|ok|Round 2 verification" >> "$provider_status_file"
     } || {
         log WARN "review_run: codex verifier failed, falling back to claude-sonnet"
         log "USER" "⚠ Round 2: Codex unavailable → claude-sonnet (fallback). Codex API usage will NOT change."
         echo "codex|fallback|Round 2 → claude-sonnet" >> "$provider_status_file"
-        verified_findings=$(run_agent_sync "claude-sonnet" "$verifier_prompt" 180 "code-reviewer" "review") || {
+        verified_findings=$(run_agent_sync "claude-sonnet" "$verifier_prompt" "${TIMEOUT:-300}" "code-reviewer" "review") || {
             log WARN "review_run: verification failed entirely, using all findings as confirmed"
             verified_findings="{\"findings\":$(echo "$all_findings" | \
                 jq 'map(. + {"verdict":"confirmed"})' 2>/dev/null || echo "[]")}"

--- a/scripts/lib/sentinel.sh
+++ b/scripts/lib/sentinel.sh
@@ -170,10 +170,10 @@ Provide:
 3. Key industry trends and disruption factors
 4. PESTLE factors affecting the decision
 
-Be specific with data where possible, noting assumptions." 180 "strategy-analyst" "advise") || {
+Be specific with data where possible, noting assumptions." "${TIMEOUT:-300}" "strategy-analyst" "advise") || {
         log WARN "Gemini failed for market analysis, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Gemini unavailable — falling back to Claude"
-        analysis=$(run_agent_sync "claude-sonnet" "You are a strategy analyst. Analyze the strategic context for: $prompt. Provide: market sizing, competitive landscape, industry trends, PESTLE factors." 180 "strategy-analyst" "advise") || true
+        analysis=$(run_agent_sync "claude-sonnet" "You are a strategy analyst. Analyze the strategic context for: $prompt. Provide: market sizing, competitive landscape, industry trends, PESTLE factors." "${TIMEOUT:-300}" "strategy-analyst" "advise") || true
     }
 
     echo -e "${CYAN}🦑 Phase 2/4: Applying strategic frameworks...${NC}"
@@ -186,10 +186,10 @@ Apply relevant strategic frameworks:
 2. Porter's Five Forces (if industry analysis is relevant)
 3. Strategic options matrix with trade-offs
 
-Context: $prompt" 180 "strategy-analyst" "advise") || {
+Context: $prompt" "${TIMEOUT:-300}" "strategy-analyst" "advise") || {
         log WARN "Gemini failed for strategic frameworks, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Gemini unavailable — falling back to Claude"
-        frameworks=$(run_agent_sync "claude-sonnet" "Based on this analysis: $analysis. Apply SWOT, Porter's Five Forces, and strategic options matrix. Context: $prompt" 180 "strategy-analyst" "advise") || true
+        frameworks=$(run_agent_sync "claude-sonnet" "Based on this analysis: $analysis. Apply SWOT, Porter's Five Forces, and strategic options matrix. Context: $prompt" "${TIMEOUT:-300}" "strategy-analyst" "advise") || true
     }
 
     echo -e "${CYAN}🦑 Phase 3/4: Building business case and recommendations...${NC}"
@@ -209,10 +209,10 @@ Develop:
 4. Success metrics and KPIs
 5. 90-day action plan
 
-Original question: $prompt" 180 "strategy-analyst" "advise") || {
+Original question: $prompt" "${TIMEOUT:-300}" "strategy-analyst" "advise") || {
         log WARN "Codex failed for recommendations, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Codex unavailable — falling back to Claude"
-        recommendations=$(run_agent_sync "claude-sonnet" "Based on analysis: $analysis and frameworks: $frameworks. Develop: strategic options, recommendation, risks, KPIs, 90-day plan. Question: $prompt" 180 "strategy-analyst" "advise") || true
+        recommendations=$(run_agent_sync "claude-sonnet" "Based on analysis: $analysis and frameworks: $frameworks. Develop: strategic options, recommendation, risks, KPIs, 90-day plan. Question: $prompt" "${TIMEOUT:-300}" "strategy-analyst" "advise") || true
     }
 
     echo -e "${CYAN}🦑 Phase 4/4: Crafting executive communication...${NC}"


### PR DESCRIPTION
## Root cause

All `run_agent_sync` synthesis call sites across 6 lib files were passing a literal `180` as the timeout argument. This had two consequences:

1. It bypassed `run_agent_sync`'s dynamic-timeout logic, which only activates when the default of `120` is used.
2. It ignored the `$TIMEOUT` variable set by `--timeout N` on the orchestrate.sh CLI — so the documented workaround (`--timeout 600`) had no effect on synthesis, as confirmed empirically in #408.

The inconsistency was already visible in the codebase: `heuristics.sh:328` (parallel-aggregation path) correctly used `run_with_timeout "$TIMEOUT"`, while the probe-synthesis path at `heuristics.sh:458` hardcoded `180`. This fix makes all synthesis call sites consistent.

## Fix

Replace all 27 hardcoded `180` occurrences with `"${TIMEOUT:-300}"` across:

- `scripts/lib/heuristics.sh` — probe synthesis (1 site)
- `scripts/lib/research.sh` — UX/literature review stage synthesis (14 sites across 7 primary+fallback pairs)
- `scripts/lib/sentinel.sh` — strategy-analyst stages (6 sites)
- `scripts/lib/review.sh` — code-review verifier (2 sites)
- `scripts/lib/factory.sh` — QA holdout evaluation (3 sites)
- `scripts/lib/factory-spec.sh` — scenario generation fallback (1 site)

The `${TIMEOUT:-300}` form:
- Raises the default from 180s → 300s (matching the existing fallback in `agents.sh:115` and consistent with the issue's recommendation)
- Lets `--timeout N` actually control synthesis as documented

## Tests

- `bash -n` on all 6 modified files: pass
- `tests/unit/test-probe-compact-synthesis.sh`: 3/3 pass
- `tests/unit/test-sentinel.sh`: 6/6 pass
- `tests/unit/test-review-run.sh`: 21/21 pass
- `tests/unit/test-research-fanout-static.sh`: 3/3 pass

closes #408

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZZHJfXp3LYQUuR3gNNcRf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script timeout configuration to use a configurable environment variable (`TIMEOUT`) instead of hardcoded values across factory, heuristics, research, review, and sentinel workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->