### PR TITLE
fix: honor OCTOPUS_AGENT_TIMEOUT unconditionally; skip-not-fail on oversize rejections

### DIFF
--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -84,8 +84,13 @@ run_agent_sync() {
     local role="${4:-}"   # Optional role override
     local phase="${5:-}"  # Optional phase context
 
-    # v8.19.0: Dynamic timeout calculation (when caller uses default 120)
-    if [[ "$timeout_secs" -eq 120 ]]; then
+    # OCTOPUS_AGENT_TIMEOUT env var overrides all caller-hardcoded values.
+    # Without this, callers passing explicit values (e.g. 300, 600) bypass the
+    # dynamic path and the env var has no effect — making it dead code (#410).
+    if [[ -n "${OCTOPUS_AGENT_TIMEOUT:-}" && "${OCTOPUS_AGENT_TIMEOUT}" =~ ^[0-9]+$ ]]; then
+        timeout_secs="$OCTOPUS_AGENT_TIMEOUT"
+    elif [[ "$timeout_secs" -eq 120 ]]; then
+        # v8.19.0: Dynamic timeout calculation (when caller uses default 120)
         local task_type_for_timeout
         task_type_for_timeout=$(classify_task "$prompt" 2>/dev/null) || task_type_for_timeout="standard"
         timeout_secs=$(compute_dynamic_timeout "$task_type_for_timeout" "$prompt")
@@ -360,6 +365,16 @@ ${provider_ctx}"
         _sync_status="${_classification%%:*}"
         _sync_reason="${_classification#*:}"
         if [[ "$_sync_status" == "failed" ]]; then
+            # Oversize rejections are a provider-input-size mismatch, not a hard
+            # run failure. Return 0 with empty output so multi-provider dispatch
+            # loops continue to gather perspectives from remaining providers (#410).
+            if [[ "$_sync_reason" == *"oversize"* || "$_sync_reason" == *"Prompt rejected by provider"* ]]; then
+                log WARN "Agent $agent_type prompt rejected as oversized — skipping provider (reduce session context or lower OCTOPUS_CONTEXT_BUDGET)"
+                type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "skipped" "$tokens_in" 0 "Prompt rejected by provider (oversize)" "$_elapsed_ms" "" "$role" || true
+                rm -f "$temp_err" "$temp_out"
+                echo ""
+                return 0
+            fi
             log ERROR "Agent $agent_type returned unusable output: $_sync_reason"
             type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "failed" "$tokens_in" "$(octo_estimate_tokens_for_file "$temp_out" 2>/dev/null || echo 0)" "$_sync_reason" "$_elapsed_ms" "" "$role" || true
             rm -f "$temp_err" "$temp_out"


### PR DESCRIPTION
## Root cause

Two related issues in `run_agent_sync` (`scripts/lib/agent-sync.sh`):

**1. `OCTOPUS_AGENT_TIMEOUT` env var was dead code (#410 observation)**

The dynamic-timeout path only fired when callers used the default `120`. Callers that pass an explicit value (e.g. `300`, `600`, `1200`) bypassed the env var entirely. Setting `OCTOPUS_AGENT_TIMEOUT=1200` therefore had zero effect on dispatch agents — confirmed by the reporter who observed 19-minute runs ignoring the override.

**2. Oversize rejection caused exit-on-first-failure across all providers (#410 main bug)**

When `classify_agent_output` detected `"Prompt rejected by provider (oversize)"` in the agent's output, `run_agent_sync` logged an ERROR and returned 1. The calling dispatch loop treated this as a hard run failure, aborting before remaining providers (gemini, ollama) could be queried. Zero synthesis artifacts were produced.

An oversize rejection is a provider/input-size mismatch — not a run-level failure. The correct behavior is to skip that provider and continue.

## Fix

**Fix 1 — `OCTOPUS_AGENT_TIMEOUT` wins unconditionally:**
```bash
if [[ -n "${OCTOPUS_AGENT_TIMEOUT:-}" && "${OCTOPUS_AGENT_TIMEOUT}" =~ ^[0-9]+$ ]]; then
    timeout_secs="$OCTOPUS_AGENT_TIMEOUT"
elif [[ "$timeout_secs" -eq 120 ]]; then
    # dynamic path (unchanged)
fi
```

**Fix 2 — Oversize rejections log WARN and return 0 with empty output:**
- Status written as `"skipped"` (not `"failed"`) so dashboards reflect the skip correctly
- Returning 0 allows multi-provider dispatch loops to continue to the next provider
- Callers already guard against empty results (`[[ -n "$result" ]]` patterns)

## Files changed

- `scripts/lib/agent-sync.sh` — 17 lines (+15 / -2)

## Tests

- `bash -n scripts/lib/*.sh`: all pass
- `make test-unit`: 118/121 pass. The 3 failures (`test-github-work-queue-hook.sh`, `test-hud-smart-mode.sh`, `test-tangle-worktree-evidence.sh`) are pre-existing on `origin/main` — confirmed by running the test suite against the unmodified tree.

closes #410

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwBuV2mvTohSEZGooVZRa8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `OCTOPUS_AGENT_TIMEOUT` environment variable to configure timeout behavior.

* **Bug Fixes**
  * Improved handling of oversized prompt rejections—system now logs warnings and continues processing instead of failing completely.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->