### PR TITLE
release: v9.39.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.39.0"
+    "version": "9.39.1"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.39.0 - Multi-LLM orchestration for Claude Code with session provider controls, Codex marketplace icon, and OpenCode catalog maintenance. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
-      "version": "9.39.0",
+      "description": "v9.39.1 - Multi-LLM orchestration for Claude Code. Fixes synthesis stage timeouts (--timeout now honored) and agent dispatch oversize handling. 32 personas, 48 commands, 52 skills. Run /octo:setup.",
+      "version": "9.39.1",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.39.0",
+  "version": "9.39.1",
   "description": "v9.39.0 — Codex marketplace icon, session provider controls, and OpenCode catalog/logging maintenance. Run /octo:setup.",
   "author": {
     "name": "nyldn",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.39.0",
+  "version": "9.39.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.39.0"
+    "version": "9.39.1"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
       "description": "v9.39.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 48 commands, 53 skills. Run /octo:setup after install.",
-      "version": "9.39.0",
+      "version": "9.39.1",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.39.0",
+  "version": "9.39.1",
   "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.39.0. 32 expert personas, 48 commands, 53 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [9.39.1] - 2026-05-22
+
+Patch release covering two synthesis/dispatch timeout bugs caught during daily triage.
+
+### Fixed
+
+- Replace hardcoded `180s` synthesis timeouts with `${TIMEOUT:-300}` across all `run_agent_sync` synthesis call sites in `heuristics.sh`, `research.sh`, `sentinel.sh`, `review.sh`, `factory.sh`, and `factory-spec.sh`. The `--timeout N` CLI flag now correctly controls synthesis stages as documented; default raised from 180s to 300s (#408, #409).
+- Honor `OCTOPUS_AGENT_TIMEOUT` unconditionally; treat oversize agent rejections as skip, not failure, to avoid aborting the whole workflow (#410, #411).
+
 ## [9.39.0] - 2026-05-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.39.0-blue" alt="Version 9.39.0">
+  <img src="https://img.shields.io/badge/Version-9.39.1-blue" alt="Version 9.39.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.39.0",
+  "version": "9.39.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## v9.39.1 — Patch release

Bundles two timeout/dispatch bug fixes caught during daily triage (2026-05-22).

### Fixes included

**#408 / PR #409 — Synthesis stage timeouts now respect `--timeout N`**
- 27 hardcoded `180`-second `run_agent_sync` synthesis call sites across `heuristics.sh`, `research.sh`, `sentinel.sh`, `review.sh`, `factory.sh`, `factory-spec.sh` replaced with `${TIMEOUT:-300}`
- Default raised from 180s → 300s; `--timeout N` now actually controls synthesis as documented

**#410 / PR #411 — `OCTOPUS_AGENT_TIMEOUT` dead code; oversize exit-on-first-failure**
- `OCTOPUS_AGENT_TIMEOUT` env var now honored unconditionally in `run_agent_sync` — previously ignored by callers passing explicit timeout values
- "Prompt rejected by provider (oversize)" now logs WARN + skips that provider instead of aborting the entire multi-provider dispatch run

### Version bumps

- `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.factory-plugin/plugin.json`, `.factory-plugin/marketplace.json`: `9.39.0` → `9.39.1`
- `README.md` version badge updated
- `CHANGELOG.md` entry added

### Tests

- All JSON manifests valid (`jq empty`)
- `tests/unit/test-docs-sync.sh`: 133/133 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwBuV2mvTohSEZGooVZRa8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synthesis and dispatch timeout handling with configurable defaults and CLI flag control
  * Enhanced environment variable support for timeout configuration
  * Updated error handling to gracefully skip agent rejection scenarios instead of failing workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->