### PR TITLE
fix: doctor skill-existence check handles directory-based skills

### DIFF
--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -837,7 +837,7 @@ doctor_check_skills() {
         skill_path=$(jq -r ".skills[$i]" "$plugin_json" 2>/dev/null)
         # Resolve relative paths from plugin dir
         local resolved="${PLUGIN_DIR}/${skill_path#./}"
-        if [[ ! -f "$resolved" ]]; then
+        if [[ ! -f "$resolved" ]] && [[ ! -f "$resolved/SKILL.md" ]]; then
             doctor_add "skill-missing-$(basename "$skill_path")" "skills" "fail" \
                 "Skill file missing: $(basename "$skill_path")" "$resolved"
             ((skill_missing++)) || true


### PR DESCRIPTION
## Root cause

In v9.39.1 each skill is a folder containing `SKILL.md` rather than a flat `.md` file. The doctor check in `scripts/lib/doctor.sh:840` tested `[[ ! -f "$resolved" ]]` against the directory path, which always evaluates true for a directory — producing 53 false "Skill file missing" failures for every skill on the user's system.

## Fix

One-line change: treat a path as present if it is either a regular file **or** a directory containing `SKILL.md`:

```bash
# before
if [[ ! -f "$resolved" ]]; then

# after
if [[ ! -f "$resolved" ]] && [[ ! -f "$resolved/SKILL.md" ]]; then
```

This handles both the old flat-file layout (for any legacy paths) and the v9.39.1 directory layout. No other paths were affected — the commands check (line 860) only ever has flat `.md` files so it is unchanged.

## Tests

- `bash -n scripts/lib/*.sh` — syntax OK
- `bash -n scripts/*.sh` — syntax OK  
- `make test-unit` — 118/121 pass. The 3 failing tests (`test-github-work-queue-hook.sh`, `test-hud-smart-mode.sh`, `test-tangle-worktree-evidence.sh`) are pre-existing failures unrelated to this change (verified by running them against unmodified `origin/main`). The worktree failure is an environment-level git signing issue.

Closes #414

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3qN5KQxWrg5ySVzkLaVYL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill validation so the system now recognizes both single-file and directory-based skill layouts (directories containing the expected skill marker). This prevents incorrect "missing" reports, reduces false alerts during health checks, and improves reliability when detecting installed skills.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->