### PR TITLE
fix: add -m flag to Gemini CLI calls in debate skill

### DIFF
--- a/skills/skill-debate/SKILL.md
+++ b/skills/skill-debate/SKILL.md
@@ -52,6 +52,7 @@ YOUR PROMPT HERE"
 ```bash
 printf '%s' "YOUR PROMPT HERE" | gemini -m "${OCTOPUS_GEMINI_MODEL:-gemini-2.5-flash}" -p "" -o text --approval-mode yolo
 ```
+
 - MUST use `-p ""` to trigger headless mode
 - MUST pipe prompt via stdin (avoids OS arg length limits)
 - MUST use `-m` to specify the model — omitting it falls back to the Gemini CLI's own default (`gemini-2.5-pro`) instead of the plugin-configured model

--- a/skills/skill-debate/SKILL.md
+++ b/skills/skill-debate/SKILL.md
@@ -50,10 +50,11 @@ YOUR PROMPT HERE"
 
 **Gemini CLI** (non-interactive headless mode):
 ```bash
-printf '%s' "YOUR PROMPT HERE" | gemini -p "" -o text --approval-mode yolo
+printf '%s' "YOUR PROMPT HERE" | gemini -m "${OCTOPUS_GEMINI_MODEL:-gemini-2.5-flash}" -p "" -o text --approval-mode yolo
 ```
 - MUST use `-p ""` to trigger headless mode
 - MUST pipe prompt via stdin (avoids OS arg length limits)
+- MUST use `-m` to specify the model — omitting it falls back to the Gemini CLI's own default (`gemini-2.5-pro`) instead of the plugin-configured model
 - Do NOT use `-y` (deprecated, replaced by `--approval-mode yolo`)
 
 **Flags that DO NOT EXIST (will cause errors):**
@@ -403,7 +404,7 @@ For each round:
 
 #### 5.1: Consult Gemini
 ```bash
-printf '%s' "${QUESTION}" | gemini -p "" -o text --approval-mode yolo > "${DEBATE_DIR}/rounds/r001_gemini.md"
+printf '%s' "${QUESTION}" | gemini -m "${OCTOPUS_GEMINI_MODEL:-gemini-2.5-flash}" -p "" -o text --approval-mode yolo > "${DEBATE_DIR}/rounds/r001_gemini.md"
 ```
 
 #### 5.2: Consult Codex
@@ -563,7 +564,7 @@ Claude:
 2. Writes context.md with question
 3. Round 1:
    - Launches Sonnet via Agent(model: sonnet, background execution: true) — pragmatic implementer
-   - Calls printf '%s' "Should we use Redis..." | gemini -p "" -o text --approval-mode yolo
+   - Calls printf '%s' "Should we use Redis..." | gemini -m "${OCTOPUS_GEMINI_MODEL:-gemini-2.5-flash}" -p "" -o text --approval-mode yolo
    - Calls codex exec --skip-git-repo-check "Should we use Redis or in-memory cache?"
    - Waits for Sonnet completion
    - Writes own analysis (Opus) considering all three advisor perspectives


### PR DESCRIPTION
## Root cause

`skills/skill-debate/SKILL.md` contained three `gemini` CLI invocations with no `-m` model flag:

- Line 53 (authoritative syntax example)
- Line 407 (Step 5.1 execution template — the live call site)
- Line 567 (worked example trace)

When `-m` is absent the Gemini CLI falls back to its own built-in default (`gemini-2.5-pro`) instead of the plugin-configured model (`OCTOPUS_GEMINI_MODEL`, defaulting to `gemini-2.5-flash` per `gemini-exec.sh`).

## Fix

Added `-m "${OCTOPUS_GEMINI_MODEL:-gemini-2.5-flash}"` to all three call sites:

```bash
printf '%s' "${QUESTION}" | gemini -m "${OCTOPUS_GEMINI_MODEL:-gemini-2.5-flash}" -p "" -o text --approval-mode yolo
```

This matches the env-var pattern used elsewhere in the plugin and lets users override via `export OCTOPUS_GEMINI_MODEL=<model>`.

## Tests

- `bash -n scripts/lib/debate.sh scripts/helpers/gemini-exec.sh scripts/helpers/build-fleet.sh` — syntax clean
- All three call sites confirmed via `grep -n "gemini -" skills/skill-debate/SKILL.md`

Closes #421

---
_Generated by [Claude Code](https://claude.ai/code/session_013pCWcEw7JFMgRTbuvedLQH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated skill documentation with clearer Gemini CLI examples: commands now explicitly show model selection and preserve headless prompt piping and approval-mode usage, improving guidance for configuring and running debate/quick-debate workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->