### PR TITLE
release: v9.41.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.41.0"
+    "version": "9.41.1"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.41.0 - /octo:council promoted to first-class workflow: structured 3/5/7-persona deliberation across Claude, Codex, Gemini, OpenCode with goal modes, adversarial styles, benchmark-aware routing, quorum/veto gates, and gated implementation handoff. 32 personas, 48 commands, 54 skills. Run /octo:setup.",
-      "version": "9.41.0",
+      "description": "v9.41.1 - Patch release for debate Gemini CLI model selection and provider version-floor/onboarding hardening. 32 personas, 48 commands, 54 skills. Run /octo:setup.",
+      "version": "9.41.1",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.41.0",
-  "description": "v9.41.0 \u2014 /octo:council promoted to first-class workflow: structured 3/5/7-persona deliberation across Claude, Codex, Gemini, OpenCode with goal modes, adversarial styles, benchmark-aware routing, quorum/veto gates, and gated implementation handoff. Run /octo:setup.",
+  "version": "9.41.1",
+  "description": "v9.41.1 \u2014 Patch release for debate Gemini CLI model selection and provider version-floor/onboarding hardening. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.41.0",
+  "version": "9.41.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.41.0",
+  "version": "9.41.1",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.41.0"
+    "version": "9.41.1"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.41.0 - Multi-AI orchestration with Double Diamond workflow and first-class council routing. 32 personas, 48 commands, 54 skills. Run /octo:setup after install.",
-      "version": "9.41.0",
+      "description": "v9.41.1 - Patch release for debate Gemini CLI model selection and provider version-floor/onboarding hardening. 32 personas, 48 commands, 54 skills. Run /octo:setup after install.",
+      "version": "9.41.1",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.41.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.41.0. 32 expert personas, 48 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.41.1",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.41.1. 32 expert personas, 48 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [9.41.1] - 2026-05-27
+
+### Fixed
+
+- Add the Gemini model flag to debate skill calls so selected Gemini models are honored (#422).
+
+### Changed
+
+- Include provider CLI version-floor enforcement and onboarding preflight/setup helpers merged after v9.41.0 (#419, #420).
+
 ## [9.41.0] - 2026-05-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.41.0-blue" alt="Version 9.41.0">
+  <img src="https://img.shields.io/badge/Version-9.41.1-blue" alt="Version 9.41.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/openclaw/src/tools/index.ts
+++ b/openclaw/src/tools/index.ts
@@ -102,6 +102,7 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "plan", description: "Intelligent plan builder - creates strategic execution plans (doesn't execute). Use /octo:embrace to execute plans.", type: "command", file: "plan.md" },
   { name: "prd-score", description: "Score an existing PRD against the 100-point AI-optimization framework", type: "command", file: "prd-score.md" },
   { name: "prd", description: "Write an AI-optimized PRD using multi-AI orchestration and 100-point scoring framework", type: "command", file: "prd.md" },
+  { name: "preflight", description: "Check provider health before running multi-LLM workflows", type: "command", file: "preflight.md" },
   { name: "quick", description: "Quick execution mode for ad-hoc tasks without full workflow overhead", type: "command", file: "quick.md" },
   { name: "research", description: "Deep research with multi-source synthesis and comprehensive analysis", type: "command", file: "research.md" },
   { name: "resume", description: "[advanced] Resume a previous agent by ID — continue an interrupted task where it left off", type: "command", file: "resume.md" },
@@ -118,4 +119,4 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "unfreeze", description: "[advanced] Remove freeze mode edit restriction", type: "command", file: "unfreeze.md" },
 ];
 
-export const REGISTRY_COUNT = 101;
+export const REGISTRY_COUNT = 102;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.41.0",
+  "version": "9.41.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Changelog

### Fixed

- Add the Gemini model flag to debate skill calls so selected Gemini models are honored (#422).

### Changed

- Include provider CLI version-floor enforcement and onboarding preflight/setup helpers merged after v9.41.0 (#419, #420).
- Sync the OpenClaw registry so the preflight command is included in generated tool metadata.

## Verification

- jq empty package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json .factory-plugin/marketplace.json
- bash tests/unit/test-docs-sync.sh
- bash tests/unit/test-openclaw-compat.sh
- make test-unit
- make test-integration

Release PR only. No tag will be cut until this PR is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where selected Gemini models were not being properly applied to debate skill calls.

* **New Features**
  * Added preflight command for provider health verification across multi-LLM workflows.

* **Changes**
  * Updated provider CLI version-floor enforcement and enhanced onboarding setup verification helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->