### PR TITLE
docs: update v9.41.1 changelog after merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Fixed
 
 - Add the Gemini model flag to debate skill calls so selected Gemini models are honored (#422).
+- Add Cursor Agent trust and text-output flags to smoke checks so untrusted workspaces do not report false provider failures (#426, #427).
+- Accept directory-based skill entries in doctor skill checks so valid installs do not report false missing-skill failures (#428, #429).
 
 ### Changed
 


### PR DESCRIPTION
## Summary
- Add the post-release-PR bug fixes #427 and #429 to the v9.41.1 changelog entry.
- Keeps release notes aligned with the current merged main head before tagging v9.41.1.

## Verification
- bash tests/unit/test-docs-sync.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false provider failures during smoke checks in untrusted workspaces
  * Resolved false missing-skill errors in doctor checks for directory-based skill installations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyldn/claude-octopus/pull/431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->