### PR TITLE
fix(gemini-exec): catch exhausted capacity as quota error + misc fixes

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -18,6 +18,10 @@ Three review entry points coexist in Claude Code v2.1.111+ — pick the right on
 | Claude-native `/review` | Single-turn, current diff | Claude only | Ordinary review, one perspective suffices |
 | `/ultrareview` (CC v2.1.111+) | Cloud, parallel multi-agent | Claude parallelism | Pre-merge PR review without leaving CC |
 | `/octo:review` (this) | Multi-LLM, inline PR comments | Codex + Gemini + Claude | Provider diversity, adversarial cross-check, stricter escalation |
+| `/octo:review --deep` | Standard review + Opus second pass | Codex → Claude Opus 4.7 | Opt-in deeper analysis: logic gaps, intent drift, architectural issues |
+
+### `--deep` flag behaviour
+When `--deep` is passed, run the standard Codex review first, then send the full review output to **Claude Opus 4.7** with this prompt addition: *"You are a senior reviewer doing a second pass. The standard review is above. Identify: (1) logic gaps the first pass missed, (2) whether the solution matches the original intent, (3) architectural drift from the codebase's existing patterns. Be specific — only flag issues the standard review did not already catch."* Deliver both passes to the user, clearly labelled **Standard (Codex)** and **Deep (Opus)**.
 
 Use `/octo:review` when the user explicitly wants enhanced multi-LLM review, multiple model opinions, provider diversity, or stricter escalation workflows. If CC v2.1.111+ and the user just says "review this", prefer `/ultrareview` unless provider diversity is specifically requested.
 

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -258,25 +258,14 @@ AskUserQuestion({
 
 If Knowledge Work selected, offer to install document-skills plugin.
 
-## STEP 4b: Prompt Cache Optimization (Claude Code v2.1.108+)
+## STEP 4b: Prompt Cache Optimization
 
-Skip this step when `SUPPORTS_PROMPT_CACHE_1H=false`. Otherwise:
+> **Moved to `/octo:config cache`** — this is a preference question, not an activation requirement.
+> Surface it as a tip at the end of setup instead:
+>
+> "💡 Tip: run `/octo:config cache` to switch to a 1-hour prompt cache TTL (default is 5 min) — useful for long `/octo:embrace` or `/octo:loop` sessions."
 
-```javascript
-AskUserQuestion({
-  questions: [{
-    question: "Enable 1-hour prompt cache TTL? (Saves tokens on long /octo:embrace and /octo:loop sessions — the default is 5 minutes.)",
-    header: "Prompt Cache",
-    multiSelect: false,
-    options: [
-      {label: "Yes, enable 1-hour cache", description: "Adds ENABLE_PROMPT_CACHING_1H=1 to your shell profile — applies to Claude API/Bedrock/Vertex/Foundry."},
-      {label: "No, keep 5-minute default", description: "Simpler mental model; lower cost ceiling if you only run short sessions."}
-    ]
-  }]
-})
-```
-
-If "Yes", append `export ENABLE_PROMPT_CACHING_1H=1` to `~/.bashrc` (or `~/.zshrc` per `$SHELL`), only if not already present. Note to the user: this only affects Claude-to-Claude round-trips inside Claude Code. External CLI subshells (Codex, Gemini, Perplexity) are unaffected — their providers manage caching independently.
+Do NOT ask the cache TTL question during first-run setup. Default silently to 5-minute TTL. The user can opt in when they understand what it affects.
 
 ## STEP 4c: Project Tier Hint
 

--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,7 @@ coverage-report.html
 *.pem
 .tmp.*
 .claude/settings.local.json
+.claude/launch.json
+.claude/session-intent.md
+.claude/session-plan.md
+.claude/worktrees/

--- a/scripts/helpers/gemini-exec.sh
+++ b/scripts/helpers/gemini-exec.sh
@@ -47,7 +47,7 @@ fi
 is_model_error() {
     (
         shopt -s nocasematch
-        local _re='model.*not (found|available|exist)|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404'
+        local _re='model.*not (found|available|exist)|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404|TerminalQuotaError|exhausted your daily quota|quota.*exceeded'
         [[ "$1" =~ $_re ]]
     )
 }

--- a/scripts/helpers/gemini-exec.sh
+++ b/scripts/helpers/gemini-exec.sh
@@ -47,7 +47,7 @@ fi
 is_model_error() {
     (
         shopt -s nocasematch
-        local _re='model.*not (found|available|exist)|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404|TerminalQuotaError|exhausted your daily quota|quota.*exceeded'
+        local _re='model.*not (found|available|exist)|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404|TerminalQuotaError|exhausted your daily quota|exhausted your capacity|quota.*exceeded'
         [[ "$1" =~ $_re ]]
     )
 }


### PR DESCRIPTION
## Summary

- **fix(gemini-exec):** Add `exhausted your capacity` to `is_model_error` regex so Gemini quota failures on `gemini-2.5-pro` properly fall back to the configured fallback model instead of silently failing
- **refactor(setup):** Move cache TTL question out of first-run flow
- **feat(review):** Add opt-in `--deep` flag with Opus 4.7 second pass
- **chore:** Ignore Claude Code session files; update gemini-exec helper

## Root cause (gemini-exec fix)

The Gemini API returns `"You have exhausted your capacity on this model"` when hitting quota limits. This string matched none of the existing patterns in `is_model_error`, so quota exhaustion on the primary model did not trigger fallback — the agent just failed silently. Adding `exhausted your capacity` to the regex restores correct fallback behaviour.

## Test plan

- [ ] Run a probe with `gemini-2.5-pro` while quota is exhausted — confirm it falls back to `OCTOPUS_GEMINI_FALLBACK_MODELS` instead of failing
- [ ] Verify `gemini-exec.sh` unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/octo:review --deep` flag for enhanced two-pass code reviews that combine standard analysis with deeper issue detection.

* **Documentation**
  * Simplified setup process by making prompt cache configuration optional, now available as a post-setup tip instead of an interactive prompt.

* **Bug Fixes**
  * Enhanced model error detection to handle additional failure cases and enable better fallback to alternative models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->