### PR TITLE
fix(gemini-exec): fall back on quota exhaustion errors

### DIFF
--- a/scripts/helpers/gemini-exec.sh
+++ b/scripts/helpers/gemini-exec.sh
@@ -47,7 +47,7 @@ fi
 is_model_error() {
     (
         shopt -s nocasematch
-        local _re='model.*not (found|available|exist)|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404'
+        local _re='model.*not (found|available|exist)|does not exist|unknown model|invalid model|no such model|ModelNotFoundError|404|TerminalQuotaError|exhausted your (daily quota|capacity)|quota.*exceeded'
         [[ "$1" =~ $_re ]]
     )
 }


### PR DESCRIPTION
## Problem

`is_model_error` only matched model-not-found and 404 errors. Several quota exhaustion messages from the Gemini API weren't caught, so `gemini-exec` exited non-zero without triggering the fallback model chain.

Observed error that wasn't matched:
```
You have exhausted your capacity on this model. Your quota will reset after 1s.
```

This caused `gemini-2.5-pro` dispatch to fail silently instead of falling back to `OCTOPUS_GEMINI_FALLBACK_MODELS`.

## Fix

Extend the `is_model_error` regex to also match:
- `exhausted your capacity`
- `exhausted your daily quota`
- `quota.*exceeded`
- `TerminalQuotaError`

These are all transient quota states where the correct behaviour is to try the next model in the fallback chain, not abort.

## Test plan

- [ ] Trigger quota exhaustion on primary model — confirm fallback activates
- [ ] Existing model-not-found fallback still works

Related to the `gemini-exec` helper introduced in v9.38.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error detection for Gemini API interactions to recognize additional failure conditions including model unavailability, quota limitations, and daily capacity constraints. When these specific errors are identified, the system automatically activates alternative fallback models instead of terminating with an error, ensuring improved service reliability and continuity when primary AI services experience temporary issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->