### PR TITLE
fix: make design review plan-aware and configurable

### DIFF
--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -463,6 +463,10 @@ Be concise and specific. This is a planning exercise, not implementation."
     local design_claude_agent="${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}"
     local design_synthesis_agent="${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}"
     local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-120}"
+    if [[ ! "$design_timeout" =~ ^[0-9]+$ ]] || [[ "$design_timeout" -le 0 ]]; then
+        log WARN "Invalid OCTOPUS_DESIGN_REVIEW_TIMEOUT='${design_timeout}', defaulting to 120s"
+        design_timeout=120
+    fi
 
     log INFO "Design review: gathering provider approaches..."
     log INFO "Design review agents: codex=${design_codex_agent}, gemini=${design_gemini_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${design_timeout}s"

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -455,18 +455,25 @@ State your HIGH-LEVEL approach in 3-5 bullet points:
 
 Be concise and specific. This is a planning exercise, not implementation."
 
-    # Gather approaches from available providers
+    # Gather approaches from available providers. Keep these configurable so
+    # operators can pick cheaper/faster review models without patching code.
     local codex_approach="" gemini_approach="" sonnet_approach=""
+    local design_codex_agent="${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-codex-mini}"
+    local design_gemini_agent="${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-gemini}"
+    local design_claude_agent="${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}"
+    local design_synthesis_agent="${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}"
+    local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-120}"
 
     log INFO "Design review: gathering provider approaches..."
+    log INFO "Design review agents: codex=${design_codex_agent}, gemini=${design_gemini_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${design_timeout}s"
 
-    codex_approach=$(run_agent_sync "codex" "$ceremony_prompt" 60 "implementer" "ceremony" 2>/dev/null) || true
-    gemini_approach=$(run_agent_sync "gemini" "$ceremony_prompt" 60 "researcher" "ceremony" 2>/dev/null) || true
-    sonnet_approach=$(run_agent_sync "claude-sonnet" "$ceremony_prompt" 60 "code-reviewer" "ceremony" 2>/dev/null) || true
+    codex_approach=$(run_agent_sync "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
+    gemini_approach=$(run_agent_sync "$design_gemini_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
+    sonnet_approach=$(run_agent_sync "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony" 2>/dev/null) || true
 
     # Synthesize conflicts and resolution
     local synthesis
-    synthesis=$(run_agent_sync "claude" "You are synthesizing a design review ceremony.
+    synthesis=$(run_agent_sync "$design_synthesis_agent" "You are synthesizing a design review ceremony.
 
 Three providers stated their approach to this task:
 
@@ -484,7 +491,7 @@ Identify:
 2. GAPS: What did everyone miss?
 3. RESOLUTION: The recommended unified approach (2-3 sentences)
 
-Be brief and actionable." 60 "synthesizer" "ceremony" 2>/dev/null) || true
+Be brief and actionable." "$design_timeout" "synthesizer" "ceremony" 2>/dev/null) || true
 
     if [[ -n "$synthesis" ]]; then
         echo -e "${GREEN}Design Review Summary:${NC}"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -978,8 +978,19 @@ tangle_develop() {
     done
     [[ "$noglob_was_set" == "false" ]] && set +f
     if [[ -n "$file_ref" && -f "$file_ref" ]]; then
+        local max_plan_bytes="${OCTOPUS_PLAN_INJECT_MAX_BYTES:-40000}"
+        [[ "$max_plan_bytes" =~ ^[0-9]+$ ]] || max_plan_bytes=40000
+        local file_size
+        file_size=$(wc -c < "$file_ref" 2>/dev/null || echo 0)
         local file_content
-        file_content=$(<"$file_ref")
+        if [[ "$file_size" -gt "$max_plan_bytes" ]]; then
+            file_content="$(head -c "$max_plan_bytes" "$file_ref" 2>/dev/null)"
+            file_content="${file_content}
+
+[... truncated from ${file_size} bytes to ${max_plan_bytes} bytes ...]"
+        else
+            file_content=$(<"$file_ref")
+        fi
         local plan_block="--- PLAN: ${file_ref} ---
 ${file_content}
 --- END PLAN ---"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -960,14 +960,9 @@ tangle_develop() {
         log INFO "Using grasp context from: $grasp_file"
     fi
 
-    # v8.18.0: Pre-work design review ceremony
-    design_review_ceremony "$prompt" "$context"
-
-    # Step 1: Decompose into validated subtasks
-    log INFO "Step 1: Task decomposition..."
-
-    # Resolve a referenced Markdown plan file without letting grep/head trip
-    # pipefail when the prompt has no file token.
+    # Resolve a referenced Markdown plan file before both design review and
+    # decomposition. Claude-based reviewers cannot read files outside the active
+    # worktree unless the content is injected into the prompt.
     local resolved_prompt="$prompt"
     local file_ref=""
     local raw_file_ref=""
@@ -1003,8 +998,15 @@ The following referenced plan file has been resolved. Use it as implementation c
 
 ${plan_block}"
         fi
-        log INFO "Resolved file reference: ${file_ref} - injecting content into decompose prompt"
+        log INFO "Resolved file reference: ${file_ref} - injecting content into workflow prompt"
     fi
+
+    # v8.18.0: Pre-work design review ceremony. Use resolved_prompt so reviewers
+    # receive plan content instead of an unreadable cross-workspace file path.
+    design_review_ceremony "$resolved_prompt" "$context"
+
+    # Step 1: Decompose into validated subtasks
+    log INFO "Step 1: Task decomposition..."
 
     local decompose_prompt="Decompose this task into subtasks that can be executed in parallel.
 Each subtask should be:


### PR DESCRIPTION
## Summary

Fix design review behavior for workflows that reference Markdown plan files and make the design-review provider choices configurable.

Before this change, `tangle_develop` ran `design_review_ceremony` before resolving a referenced `.md` plan file. Claude-based reviewers can be sandboxed to the active worktree, so a prompt that only contains an out-of-worktree plan path can fail even though the workflow later injects the same plan for decomposition.

This change:

- resolves/injects referenced Markdown plan content before the design review ceremony
- keeps decomposition using the same resolved prompt
- adds configurable design-review agents:
  - `OCTOPUS_DESIGN_REVIEW_CODEX_AGENT` default `codex-mini`
  - `OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT` default `gemini`
  - `OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT` default `claude-sonnet`
  - `OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT` default `claude-opus`
  - `OCTOPUS_DESIGN_REVIEW_TIMEOUT` default `120`

Rationale:

- prevents Claude/Sonnet reviewers from being asked to read plan files outside the active worktree
- avoids forcing slower/default Codex models into a short 60s design-review slot
- lets operators choose cheaper/faster or higher-quality review/synthesis agents without patching code

## Tests

- `bash -n scripts/lib/quality.sh scripts/lib/workflows.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Design review now supports configurable agent selection and a configurable timeout via environment variables, with input validation and sensible defaults.
  * Workflow now resolves and injects Markdown plan content before design review and task decomposition, logs when plan content is injected, and enforces a maximum injected size with truncation to prevent oversized prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->