### PR TITLE
fix: resolve tangle file scopes against repo context

### DIFF
--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -463,6 +463,10 @@ Be concise and specific. This is a planning exercise, not implementation."
     local design_claude_agent="${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}"
     local design_synthesis_agent="${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}"
     local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-120}"
+    if [[ ! "$design_timeout" =~ ^[0-9]+$ ]] || [[ "$design_timeout" -le 0 ]]; then
+        log WARN "Invalid OCTOPUS_DESIGN_REVIEW_TIMEOUT='${design_timeout}', defaulting to 120s"
+        design_timeout=120
+    fi
 
     log INFO "Design review: gathering provider approaches..."
     log INFO "Design review agents: codex=${design_codex_agent}, gemini=${design_gemini_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${design_timeout}s"

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -455,18 +455,25 @@ State your HIGH-LEVEL approach in 3-5 bullet points:
 
 Be concise and specific. This is a planning exercise, not implementation."
 
-    # Gather approaches from available providers
+    # Gather approaches from available providers. Keep these configurable so
+    # operators can pick cheaper/faster review models without patching code.
     local codex_approach="" gemini_approach="" sonnet_approach=""
+    local design_codex_agent="${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-codex-mini}"
+    local design_gemini_agent="${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-gemini}"
+    local design_claude_agent="${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}"
+    local design_synthesis_agent="${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}"
+    local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-120}"
 
     log INFO "Design review: gathering provider approaches..."
+    log INFO "Design review agents: codex=${design_codex_agent}, gemini=${design_gemini_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${design_timeout}s"
 
-    codex_approach=$(run_agent_sync "codex" "$ceremony_prompt" 60 "implementer" "ceremony" 2>/dev/null) || true
-    gemini_approach=$(run_agent_sync "gemini" "$ceremony_prompt" 60 "researcher" "ceremony" 2>/dev/null) || true
-    sonnet_approach=$(run_agent_sync "claude-sonnet" "$ceremony_prompt" 60 "code-reviewer" "ceremony" 2>/dev/null) || true
+    codex_approach=$(run_agent_sync "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
+    gemini_approach=$(run_agent_sync "$design_gemini_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
+    sonnet_approach=$(run_agent_sync "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony" 2>/dev/null) || true
 
     # Synthesize conflicts and resolution
     local synthesis
-    synthesis=$(run_agent_sync "claude" "You are synthesizing a design review ceremony.
+    synthesis=$(run_agent_sync "$design_synthesis_agent" "You are synthesizing a design review ceremony.
 
 Three providers stated their approach to this task:
 
@@ -484,7 +491,7 @@ Identify:
 2. GAPS: What did everyone miss?
 3. RESOLUTION: The recommended unified approach (2-3 sentences)
 
-Be brief and actionable." 60 "synthesizer" "ceremony" 2>/dev/null) || true
+Be brief and actionable." "$design_timeout" "synthesizer" "ceremony" 2>/dev/null) || true
 
     if [[ -n "$synthesis" ]]; then
         echo -e "${GREEN}Design Review Summary:${NC}"

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -463,13 +463,18 @@ Be concise and specific. This is a planning exercise, not implementation."
     local design_claude_agent="${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}"
     local design_synthesis_agent="${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}"
     local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-120}"
-    if [[ ! "$design_timeout" =~ ^[0-9]+$ ]] || [[ "$design_timeout" -le 0 ]]; then
+    local design_synth_timeout="${OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT:-120}"
+    if [[ ! "$design_timeout" =~ ^[0-9]+$ ]] || [[ "$design_timeout" -lt 120 ]]; then
         log WARN "Invalid OCTOPUS_DESIGN_REVIEW_TIMEOUT='${design_timeout}', defaulting to 120s"
         design_timeout=120
     fi
+    if [[ ! "$design_synth_timeout" =~ ^[0-9]+$ ]] || [[ "$design_synth_timeout" -lt 120 ]]; then
+        log WARN "Invalid OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT='${design_synth_timeout}', defaulting to 120s"
+        design_synth_timeout=120
+    fi
 
     log INFO "Design review: gathering provider approaches..."
-    log INFO "Design review agents: codex=${design_codex_agent}, gemini=${design_gemini_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${design_timeout}s"
+    log INFO "Design review agents: codex=${design_codex_agent}, gemini=${design_gemini_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${design_timeout}s, synth_timeout=${design_synth_timeout}s"
 
     codex_approach=$(run_agent_sync "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
     gemini_approach=$(run_agent_sync "$design_gemini_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
@@ -495,7 +500,7 @@ Identify:
 2. GAPS: What did everyone miss?
 3. RESOLUTION: The recommended unified approach (2-3 sentences)
 
-Be brief and actionable." "$design_timeout" "synthesizer" "ceremony" 2>/dev/null) || true
+Be brief and actionable." "$design_synth_timeout" "synthesizer" "ceremony" 2>/dev/null) || true
 
     if [[ -n "$synthesis" ]]; then
         echo -e "${GREEN}Design Review Summary:${NC}"

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -46,12 +46,19 @@ check_explicit_file_coverage() {
 }
 
 snapshot_tangle_worktree_paths() {
-    local repo_root="${PROJECT_ROOT:-$(pwd)}"
-    [[ -d "$repo_root" ]] || repo_root="$(pwd)"
-    if ! git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        repo_root="$(pwd)"
-        git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+    local repo_root=""
+
+    if [[ -n "${PROJECT_ROOT:-}" ]]; then
+        if [[ -d "$PROJECT_ROOT" ]]; then
+            repo_root=$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null || true)
+            [[ -n "$repo_root" ]] || return 0
+        else
+            repo_root=$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || true)
+        fi
+    else
+        repo_root=$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || true)
     fi
+    [[ -n "$repo_root" ]] || return 0
 
     {
         git -C "$repo_root" diff --name-only 2>/dev/null || true

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -46,13 +46,15 @@ check_explicit_file_coverage() {
 }
 
 snapshot_tangle_worktree_paths() {
-    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+    local repo_root="${PROJECT_ROOT:-$(pwd)}"
+    [[ -d "$repo_root" ]] || repo_root="$(pwd)"
+    git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
 
     {
-        git diff --name-only 2>/dev/null || true
-        git diff --cached --name-only 2>/dev/null || true
-        git ls-files --others --exclude-standard 2>/dev/null || true
-    } | sed '/^$/d' | sort -u
+        git -C "$repo_root" diff --name-only 2>/dev/null || true
+        git -C "$repo_root" diff --cached --name-only 2>/dev/null || true
+        git -C "$repo_root" ls-files --others --exclude-standard 2>/dev/null || true
+    } | sed /^$/d | sort -u
 }
 
 tangle_prompt_requires_worktree_changes() {

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -48,7 +48,10 @@ check_explicit_file_coverage() {
 snapshot_tangle_worktree_paths() {
     local repo_root="${PROJECT_ROOT:-$(pwd)}"
     [[ -d "$repo_root" ]] || repo_root="$(pwd)"
-    git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+    if ! git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        repo_root="$(pwd)"
+        git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+    fi
 
     {
         git -C "$repo_root" diff --name-only 2>/dev/null || true

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -978,8 +978,19 @@ tangle_develop() {
     done
     [[ "$noglob_was_set" == "false" ]] && set +f
     if [[ -n "$file_ref" && -f "$file_ref" ]]; then
+        local max_plan_bytes="${OCTOPUS_PLAN_INJECT_MAX_BYTES:-40000}"
+        [[ "$max_plan_bytes" =~ ^[0-9]+$ ]] || max_plan_bytes=40000
+        local file_size
+        file_size=$(wc -c < "$file_ref" 2>/dev/null || echo 0)
         local file_content
-        file_content=$(<"$file_ref")
+        if [[ "$file_size" -gt "$max_plan_bytes" ]]; then
+            file_content="$(head -c "$max_plan_bytes" "$file_ref" 2>/dev/null)"
+            file_content="${file_content}
+
+[... truncated from ${file_size} bytes to ${max_plan_bytes} bytes ...]"
+        else
+            file_content=$(<"$file_ref")
+        fi
         local plan_block="--- PLAN: ${file_ref} ---
 ${file_content}
 --- END PLAN ---"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -815,7 +815,7 @@ Execution instructions:
 - Treat the original task as authoritative for requirements, explicit file targets, acceptance criteria, and forbidden changes.
 - Complete the assigned subtask without dropping original constraints that apply to it.
 - For [CODING] work, edit the repository files directly in the current worktree. Do not only describe a plan or paste code snippets.
-- For [CODING] work, treat file paths/directories named in the assigned subtask as approximate scope intent. Use the resolved repository context files above as the concrete targets. Do not edit files clearly owned by another subtask; report a blocker if the required change crosses scopes.
+- For [CODING] work, treat file paths/directories named in the assigned subtask as approximate exclusive write scope intent. Use the resolved repository context files above as the concrete targets. Do not edit files clearly owned by another subtask; report a blocker if the required change crosses scopes.
 - If the subtask creates a new exported component, command, event type, route, hook, or helper, wire it into at least one production call site unless the original task explicitly asks for an isolated artifact.
 - Tests alone are not integration evidence. User-facing features must be reachable from the relevant user flow or the subtask must report a blocker.
 - In the final output, include "## Worktree Changes", "## Integration Evidence", and "## Verification" sections.
@@ -865,14 +865,34 @@ tangle_scopes_overlap() {
     return 1
 }
 
+tangle_resolve_repo_root() {
+    local repo_root
+    local resolved_root
+
+    if [[ -n "${PROJECT_ROOT:-}" ]]; then
+        if [[ -d "$PROJECT_ROOT" ]]; then
+            resolved_root=$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null || true)
+            [[ -n "$resolved_root" ]] || return 1
+            printf '%s\n' "$resolved_root"
+            return 0
+        fi
+        repo_root="$(pwd)"
+    else
+        repo_root="$(pwd)"
+    fi
+
+    resolved_root=$(git -C "$repo_root" rev-parse --show-toplevel 2>/dev/null || true)
+    [[ -n "$resolved_root" ]] || return 1
+    printf '%s\n' "$resolved_root"
+}
+
 tangle_resolve_repo_context_files() {
     local text="$1"
     local max_files="${OCTOPUS_TANGLE_CONTEXT_MAX_FILES:-16}"
     [[ "$max_files" =~ ^[0-9]+$ ]] || max_files=16
 
-    local repo_root="${PROJECT_ROOT:-$(pwd)}"
-    [[ -d "$repo_root" ]] || repo_root="$(pwd)"
-    git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1 || return 0
+    local repo_root
+    repo_root=$(tangle_resolve_repo_root) || return 0
 
     local files=()
     local token full basename
@@ -923,14 +943,14 @@ tangle_resolve_repo_context_files() {
         done
     fi
 
+    [[ ${#files[@]} -gt 0 ]] || return 0
     printf '%s\n' "${files[@]}" | sed '/^$/d' | awk '!seen[$0]++' | sed -n "1,${max_files}p"
 }
 
 tangle_build_repo_context_block() {
     local assigned_subtask="$1"
-    local repo_root="${PROJECT_ROOT:-$(pwd)}"
-    [[ -d "$repo_root" ]] || repo_root="$(pwd)"
-    git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1 || return 0
+    local repo_root
+    repo_root=$(tangle_resolve_repo_root) || return 0
     local resolved
     resolved=$(tangle_resolve_repo_context_files "$assigned_subtask")
     cat <<EOF
@@ -952,8 +972,14 @@ tangle_scope_is_known_or_explicit_new_file() {
     local normalized="${scope%/}"
     [[ -z "$normalized" ]] && return 1
 
-    local repo_root="${PROJECT_ROOT:-$(pwd)}"
-    [[ -d "$repo_root" ]] || repo_root="$(pwd)"
+    local repo_root
+    if ! repo_root=$(tangle_resolve_repo_root 2>/dev/null); then
+        if [[ -n "${PROJECT_ROOT:-}" && -d "$PROJECT_ROOT" ]]; then
+            repo_root="$PROJECT_ROOT"
+        else
+            repo_root=$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || pwd)
+        fi
+    fi
     if git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1; then
         if git -C "$repo_root" ls-files --error-unmatch "$normalized" >/dev/null 2>&1; then
             return 0
@@ -1114,7 +1140,12 @@ tangle_develop() {
     local noglob_was_set=false
     [[ "$-" == *f* ]] && noglob_was_set=true || set -f
     for token in $prompt; do
-        if [[ "$token" == plan:* || "$token" == plan=* || "$token" == *plan.md ]]; then
+        local candidate_ref="$token"
+        local candidate_basename
+        candidate_ref="${candidate_ref#plan:}"
+        candidate_ref="${candidate_ref#plan=}"
+        candidate_basename="${candidate_ref##*/}"
+        if [[ "$token" == plan:* || "$token" == plan=* || "$candidate_basename" == "plan.md" || "$candidate_basename" == *.plan.md || "$candidate_basename" == *-plan.md ]]; then
             raw_file_ref="$token"
             raw_file_ref="${raw_file_ref#plan:}"
             raw_file_ref="${raw_file_ref#plan=}"
@@ -1166,9 +1197,8 @@ ${plan_block}"
     log INFO "Step 1: Task decomposition..."
 
     local repo_file_map=""
-    local repo_root="${PROJECT_ROOT:-$(pwd)}"
-    [[ -d "$repo_root" ]] || repo_root="$(pwd)"
-    if git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1; then
+    local repo_root
+    if repo_root=$(tangle_resolve_repo_root 2>/dev/null); then
         repo_file_map="Repository files available for write scopes (from git ls-files, first 200):
 $(git -C "$repo_root" ls-files 2>/dev/null | sed -n 1,200p)
 "

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -960,14 +960,9 @@ tangle_develop() {
         log INFO "Using grasp context from: $grasp_file"
     fi
 
-    # v8.18.0: Pre-work design review ceremony
-    design_review_ceremony "$prompt" "$context"
-
-    # Step 1: Decompose into validated subtasks
-    log INFO "Step 1: Task decomposition..."
-
-    # Resolve a referenced Markdown plan file without letting grep/head trip
-    # pipefail when the prompt has no file token.
+    # Resolve a referenced Markdown plan file before both design review and
+    # decomposition. Claude-based reviewers cannot read files outside the active
+    # worktree unless the content is injected into the prompt.
     local resolved_prompt="$prompt"
     local file_ref=""
     local raw_file_ref=""
@@ -1003,8 +998,15 @@ The following referenced plan file has been resolved. Use it as implementation c
 
 ${plan_block}"
         fi
-        log INFO "Resolved file reference: ${file_ref} - injecting content into decompose prompt"
+        log INFO "Resolved file reference: ${file_ref} - injecting content into workflow prompt"
     fi
+
+    # v8.18.0: Pre-work design review ceremony. Use resolved_prompt so reviewers
+    # receive plan content instead of an unreadable cross-workspace file path.
+    design_review_ceremony "$resolved_prompt" "$context"
+
+    # Step 1: Decompose into validated subtasks
+    log INFO "Step 1: Task decomposition..."
 
     local decompose_prompt="Decompose this task into subtasks that can be executed in parallel.
 Each subtask should be:

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1166,9 +1166,11 @@ ${plan_block}"
     log INFO "Step 1: Task decomposition..."
 
     local repo_file_map=""
-    if git -C "$PROJECT_ROOT" rev-parse --show-toplevel >/dev/null 2>&1; then
+    local repo_root="${PROJECT_ROOT:-$(pwd)}"
+    [[ -d "$repo_root" ]] || repo_root="$(pwd)"
+    if git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1; then
         repo_file_map="Repository files available for write scopes (from git ls-files, first 200):
-$(git -C "$PROJECT_ROOT" ls-files 2>/dev/null | sed -n 1,200p)
+$(git -C "$repo_root" ls-files 2>/dev/null | sed -n 1,200p)
 "
     fi
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1019,6 +1019,13 @@ ${plan_block}"
     # Step 1: Decompose into validated subtasks
     log INFO "Step 1: Task decomposition..."
 
+    local repo_file_map=""
+    if git -C "$PROJECT_ROOT" rev-parse --show-toplevel >/dev/null 2>&1; then
+        repo_file_map="Repository files available for write scopes (from git ls-files, first 200):
+$(git -C "$PROJECT_ROOT" ls-files 2>/dev/null | sed -n 1,200p)
+"
+    fi
+
     local decompose_prompt="Decompose this task into subtasks that can be executed in parallel.
 Each subtask should be:
 - Self-contained and independently verifiable
@@ -1029,7 +1036,8 @@ Each subtask should be:
 
 **Cohesion rule:** If the task produces a single deliverable (one file, one script, one page, one config), keep it as ONE subtask — do not split it. Only decompose when subtasks are truly independent with no cross-file references between them. Aim for 2-6 subtasks; fewer is better when the work is tightly coupled.
 
-${context}Task: $resolved_prompt
+${context}${repo_file_map}
+Task: $resolved_prompt
 
 Output as numbered list with [CODING] or [REASONING] prefix for each subtask."
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -914,8 +914,8 @@ tangle_resolve_repo_context_files() {
 
     # Fallback: use grep over tracked text files for rare domain tokens.
     if [[ ${#files[@]} -lt 3 ]]; then
-        for token in runTerminalScript commands execute terminal swagger activity bounded timeout; do
-            if [[ "$lower" == *"${token,,}"* ]]; then
+        for token in runterminalscript commands execute terminal swagger activity bounded timeout; do
+            if [[ "$lower" == *"$token"* ]]; then
                 while IFS= read -r full; do
                     [[ -n "$full" ]] && files+=("$full")
                 done < <(git -C "$repo_root" grep -Il -m1 "$token" -- '*.js' '*.json' '*.md' 2>/dev/null | head -n 6)
@@ -958,7 +958,9 @@ tangle_scope_is_known_or_explicit_new_file() {
         if git -C "$repo_root" ls-files --error-unmatch "$normalized" >/dev/null 2>&1; then
             return 0
         fi
-        if git -C "$repo_root" ls-files "$normalized/" 2>/dev/null | grep -q .; then
+        local child_matches
+        child_matches=$(git -C "$repo_root" ls-files "$normalized/" 2>/dev/null || true)
+        if [[ -n "$child_matches" ]]; then
             return 0
         fi
     fi
@@ -969,8 +971,12 @@ tangle_scope_is_known_or_explicit_new_file() {
         local parent="${normalized%/*}"
         [[ "$parent" == "$normalized" ]] && return 0
         [[ -d "$repo_root/$parent" ]] && return 0
-        if git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1 && git -C "$repo_root" ls-files "$parent/" 2>/dev/null | grep -q .; then
-            return 0
+        if git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1; then
+            local parent_matches
+            parent_matches=$(git -C "$repo_root" ls-files "$parent/" 2>/dev/null || true)
+            if [[ -n "$parent_matches" ]]; then
+                return 0
+            fi
         fi
     fi
     return 1
@@ -1108,9 +1114,11 @@ tangle_develop() {
     local noglob_was_set=false
     [[ "$-" == *f* ]] && noglob_was_set=true || set -f
     for token in $prompt; do
-        if [[ "$token" == *.md ]]; then
+        if [[ "$token" == plan:* || "$token" == plan=* || "$token" == *.plan.md ]]; then
             raw_file_ref="$token"
-            file_ref="${token/#\~/$HOME}"
+            raw_file_ref="${raw_file_ref#plan:}"
+            raw_file_ref="${raw_file_ref#plan=}"
+            file_ref="${raw_file_ref/#\~/$HOME}"
             break
         fi
     done

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -799,6 +799,9 @@ build_tangle_subtask_prompt() {
         return 64
     fi
 
+    local repo_context
+    repo_context=$(tangle_build_repo_context_block "$assigned_subtask")
+
     cat <<EOF
 Original task context:
 ${original_task}
@@ -806,11 +809,13 @@ ${original_task}
 Assigned subtask:
 ${assigned_subtask}
 
+${repo_context}
+
 Execution instructions:
 - Treat the original task as authoritative for requirements, explicit file targets, acceptance criteria, and forbidden changes.
 - Complete the assigned subtask without dropping original constraints that apply to it.
 - For [CODING] work, edit the repository files directly in the current worktree. Do not only describe a plan or paste code snippets.
-- For [CODING] work, treat file paths/directories named in the assigned subtask as your exclusive write scope. Do not edit files owned by another subtask; report a blocker if the required change crosses scopes.
+- For [CODING] work, treat file paths/directories named in the assigned subtask as approximate scope intent. Use the resolved repository context files above as the concrete targets. Do not edit files clearly owned by another subtask; report a blocker if the required change crosses scopes.
 - If the subtask creates a new exported component, command, event type, route, hook, or helper, wire it into at least one production call site unless the original task explicitly asks for an isolated artifact.
 - Tests alone are not integration evidence. User-facing features must be reachable from the relevant user flow or the subtask must report a blocker.
 - In the final output, include "## Worktree Changes", "## Integration Evidence", and "## Verification" sections.
@@ -823,6 +828,7 @@ tangle_extract_write_scopes() {
     local files_text
 
     files_text=$(printf '%s\n' "$text" | sed -nE 's/.*Files:[[:space:]]*//p' | head -n 1)
+    files_text=$(printf '%s\n' "$files_text" | sed -E 's/[[:space:]]+[—-][[:space:]]+Task:.*$//; s/[[:space:]]+Task:.*$//')
     [[ -n "$files_text" ]] || return 0
 
     printf '%s\n' "$files_text" \
@@ -859,6 +865,117 @@ tangle_scopes_overlap() {
     return 1
 }
 
+tangle_resolve_repo_context_files() {
+    local text="$1"
+    local max_files="${OCTOPUS_TANGLE_CONTEXT_MAX_FILES:-16}"
+    [[ "$max_files" =~ ^[0-9]+$ ]] || max_files=16
+
+    local repo_root="${PROJECT_ROOT:-$(pwd)}"
+    [[ -d "$repo_root" ]] || repo_root="$(pwd)"
+    git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1 || return 0
+
+    local files=()
+    local token full basename
+
+    # Keep concrete existing files explicitly named by the decomposition.
+    while IFS= read -r token; do
+        [[ -z "$token" ]] && continue
+        token="${token#./}"
+        if [[ -f "$repo_root/$token" ]]; then
+            files+=("$token")
+        else
+            basename="${token##*/}"
+            if [[ "$basename" == *.* ]]; then
+                while IFS= read -r full; do
+                    [[ -n "$full" ]] && files+=("$full")
+                done < <(git -C "$repo_root" ls-files | awk -v b="$basename" 'BEGIN{n=0} {split($0,a,"/"); if (a[length(a)]==b && n<4) {print; n++}}')
+            fi
+        fi
+    done < <(printf '%s\n' "$text" | grep -Eo '[A-Za-z0-9_./-]+\.(js|ts|json|md|yml|yaml|toml|py|sh)' | sort -u)
+
+    # Add high-signal files by endpoint/domain terms.
+    local lower
+    lower=$(printf '%s' "$text" | tr '[:upper:]' '[:lower:]')
+    if [[ "$lower" == *"runterminalscript"* || "$lower" == *"commands/execute"* || "$lower" == *"script mode"* || "$lower" == *"bounded executor"* ]]; then
+        for full in api/terminal.js serverModules/apiRoutes.js serverModules/swaggerSetup.js api/activityLog.js package.json README.md SETUP.md; do
+            [[ -f "$repo_root/$full" ]] && files+=("$full")
+        done
+    fi
+    if [[ "$lower" == *"openapi"* || "$lower" == *"schema"* || "$lower" == *"readme"* || "$lower" == *"setup"* || "$lower" == *"documentation"* ]]; then
+        for full in serverModules/swaggerSetup.js README.md SETUP.md package.json; do
+            [[ -f "$repo_root/$full" ]] && files+=("$full")
+        done
+    fi
+    if [[ "$lower" == *"test"* || "$lower" == *"acceptance"* || "$lower" == *"smoke"* ]]; then
+        for full in package.json README.md SETUP.md; do
+            [[ -f "$repo_root/$full" ]] && files+=("$full")
+        done
+    fi
+
+    # Fallback: use grep over tracked text files for rare domain tokens.
+    if [[ ${#files[@]} -lt 3 ]]; then
+        for token in runTerminalScript commands execute terminal swagger activity bounded timeout; do
+            if [[ "$lower" == *"${token,,}"* ]]; then
+                while IFS= read -r full; do
+                    [[ -n "$full" ]] && files+=("$full")
+                done < <(git -C "$repo_root" grep -Il -m1 "$token" -- '*.js' '*.json' '*.md' 2>/dev/null | head -n 6)
+            fi
+        done
+    fi
+
+    printf '%s\n' "${files[@]}" | sed '/^$/d' | awk '!seen[$0]++' | sed -n "1,${max_files}p"
+}
+
+tangle_build_repo_context_block() {
+    local assigned_subtask="$1"
+    local repo_root="${PROJECT_ROOT:-$(pwd)}"
+    [[ -d "$repo_root" ]] || repo_root="$(pwd)"
+    git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1 || return 0
+    local resolved
+    resolved=$(tangle_resolve_repo_context_files "$assigned_subtask")
+    cat <<EOF
+Repository context for this subtask:
+- The worktree is the source of truth. Do not invent repository layout from generic names.
+- Treat the decomposer's Files clause as approximate intent. Prefer the resolved files below when they conflict with invented paths.
+- If none of the resolved files fit, inspect the tracked file list and report the blocker.
+
+Tracked files, first 200:
+$(git -C "$repo_root" ls-files 2>/dev/null | sed -n '1,200p')
+
+Resolved relevant files to inspect/edit for this subtask:
+${resolved:-<none resolved>}
+EOF
+}
+
+tangle_scope_is_known_or_explicit_new_file() {
+    local scope="$1"
+    local normalized="${scope%/}"
+    [[ -z "$normalized" ]] && return 1
+
+    local repo_root="${PROJECT_ROOT:-$(pwd)}"
+    [[ -d "$repo_root" ]] || repo_root="$(pwd)"
+    if git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1; then
+        if git -C "$repo_root" ls-files --error-unmatch "$normalized" >/dev/null 2>&1; then
+            return 0
+        fi
+        if git -C "$repo_root" ls-files "$normalized/" 2>/dev/null | grep -q .; then
+            return 0
+        fi
+    fi
+
+    [[ -e "$repo_root/$normalized" ]] && return 0
+
+    if [[ "$scope" != */ && "${normalized##*/}" == *.* ]]; then
+        local parent="${normalized%/*}"
+        [[ "$parent" == "$normalized" ]] && return 0
+        [[ -d "$repo_root/$parent" ]] && return 0
+        if git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1 && git -C "$repo_root" ls-files "$parent/" 2>/dev/null | grep -q .; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
 tangle_validate_parallel_write_scopes() {
     local subtasks="$1"
     local task_index=0
@@ -888,18 +1005,39 @@ tangle_validate_parallel_write_scopes() {
             return 1
         fi
 
+        local effective_scopes=""
+        while IFS= read -r scope; do
+            [[ -z "$scope" ]] && continue
+            if tangle_scope_is_known_or_explicit_new_file "$scope"; then
+                effective_scopes="${effective_scopes}${scope}
+"
+            else
+                local resolved_scopes
+                resolved_scopes=$(tangle_resolve_repo_context_files "$subtask")
+                if [[ -n "$resolved_scopes" ]]; then
+                    effective_scopes="${effective_scopes}${resolved_scopes}
+"
+                else
+                    effective_scopes="${effective_scopes}${scope}
+"
+                fi
+            fi
+        done <<< "$scopes"
+        effective_scopes=$(printf '%s
+' "$effective_scopes" | sed '/^$/d' | sort -u)
+
         while IFS= read -r scope; do
             [[ -z "$scope" ]] && continue
             local i
             for i in "${!existing_scopes[@]}"; do
                 if tangle_scopes_overlap "$scope" "${existing_scopes[$i]}"; then
-                    echo "coding subtask ${task_index} write scope '${scope}' overlaps subtask ${existing_tasks[$i]} scope '${existing_scopes[$i]}'"
+                    echo "coding subtask ${task_index} effective write scope '${scope}' overlaps subtask ${existing_tasks[$i]} scope '${existing_scopes[$i]}'"
                     return 1
                 fi
             done
             existing_scopes+=("$scope")
             existing_tasks+=("$task_index")
-        done <<< "$scopes"
+        done <<< "$effective_scopes"
     done <<< "$subtasks"
 
     [[ $coding_count -eq 0 ]] && return 0

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -872,7 +872,10 @@ tangle_resolve_repo_root() {
     if [[ -n "${PROJECT_ROOT:-}" ]]; then
         if [[ -d "$PROJECT_ROOT" ]]; then
             resolved_root=$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null || true)
-            [[ -n "$resolved_root" ]] || return 1
+            if [[ -z "$resolved_root" ]]; then
+                printf '%s\n' "$PROJECT_ROOT"
+                return 0
+            fi
             printf '%s\n' "$resolved_root"
             return 0
         fi
@@ -893,6 +896,7 @@ tangle_resolve_repo_context_files() {
 
     local repo_root
     repo_root=$(tangle_resolve_repo_root) || return 0
+    git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1 || return 0
 
     local files=()
     local token full basename

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1114,7 +1114,7 @@ tangle_develop() {
     local noglob_was_set=false
     [[ "$-" == *f* ]] && noglob_was_set=true || set -f
     for token in $prompt; do
-        if [[ "$token" == plan:* || "$token" == plan=* || "$token" == *.plan.md ]]; then
+        if [[ "$token" == plan:* || "$token" == plan=* || "$token" == *plan.md ]]; then
             raw_file_ref="$token"
             raw_file_ref="${raw_file_ref#plan:}"
             raw_file_ref="${raw_file_ref#plan=}"

--- a/tests/unit/test-develop-md-file-resolution.sh
+++ b/tests/unit/test-develop-md-file-resolution.sh
@@ -116,6 +116,29 @@ else
     test_fail "validate_tangle_results received raw prompt instead of resolved content"
 fi
 
+test_case "plan-prefixed Markdown references inject even without a plan-like filename"
+notes_file="$RESULTS_DIR/implementation-notes.md"
+printf '%s\n' "Fix scripts/lib/testing.sh fallback behavior." > "$notes_file"
+run_tangle_case "implement plan:$notes_file next"
+if [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"implement plan:$notes_file next"* ]] && \
+   [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"Fix scripts/lib/testing.sh fallback behavior."* ]]; then
+    test_pass
+else
+    test_fail "explicit plan: reference did not inject non-plan Markdown content"
+fi
+
+test_case "bare plan.md references inject content"
+bare_plan_dir="$RESULTS_DIR/bare-plan"
+mkdir -p "$bare_plan_dir"
+bare_plan_file="$bare_plan_dir/plan.md"
+printf '%s\n' "Apply the bare plan.md workflow fix." > "$bare_plan_file"
+run_tangle_case "implement $bare_plan_file"
+if [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"Apply the bare plan.md workflow fix."* ]]; then
+    test_pass
+else
+    test_fail "bare plan.md was not treated as an eligible plan file"
+fi
+
 test_case "wildcard-looking Markdown tokens are not glob-expanded"
 glob_dir="$RESULTS_DIR/glob-case"
 mkdir -p "$glob_dir"
@@ -126,6 +149,16 @@ printf '%s\n' "This file should not be injected from a wildcard prompt." > "$glo
 )
 if [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"This file should not be injected"* ]]; then
     test_fail "wildcard token was expanded and injected as a plan file"
+else
+    test_pass
+fi
+
+test_case "plain Markdown filenames ending in plan.md are not treated as plans unless deliberate"
+false_positive_file="$RESULTS_DIR/floorplan.md"
+printf '%s\n' "This floorplan note must not be injected automatically." > "$false_positive_file"
+run_tangle_case "review $false_positive_file for context"
+if [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"This floorplan note must not be injected automatically."* ]]; then
+    test_fail "non-deliberate floorplan.md content was injected as a plan"
 else
     test_pass
 fi

--- a/tests/unit/test-tangle-worktree-evidence.sh
+++ b/tests/unit/test-tangle-worktree-evidence.sh
@@ -74,6 +74,50 @@ printf 'base\n' > "$REPO_DIR/README.md"
 git -C "$REPO_DIR" add README.md
 git -C "$REPO_DIR" commit -q -m init
 
+test_case "snapshot worktree detection falls back to pwd when PROJECT_ROOT is invalid"
+if (
+    cd "$REPO_DIR"
+    touch fallback.txt
+    snapshot_output=$(PROJECT_ROOT="$TEST_TMP_DIR/missing-project-root" snapshot_tangle_worktree_paths)
+    rm -f fallback.txt
+    [[ "$snapshot_output" == *"fallback.txt"* ]]
+); then
+    test_pass
+else
+    test_fail "snapshot_tangle_worktree_paths ignored pwd fallback when PROJECT_ROOT was invalid"
+fi
+
+test_case "snapshot fallback resolves to git top-level from a subdirectory"
+if (
+    cd "$REPO_DIR"
+    mkdir -p src/app
+    touch root-only.txt
+    snapshot_output=$(
+        cd src/app
+        PROJECT_ROOT="$TEST_TMP_DIR/missing-project-root" snapshot_tangle_worktree_paths
+    )
+    rm -f root-only.txt
+    [[ "$snapshot_output" == *"root-only.txt"* ]]
+); then
+    test_pass
+else
+    test_fail "snapshot_tangle_worktree_paths did not resolve fallback to the git top-level"
+fi
+
+test_case "snapshot honors existing non-git PROJECT_ROOT instead of unrelated pwd repo"
+if (
+    cd "$REPO_DIR"
+    mkdir -p "$TEST_TMP_DIR/not-a-repo"
+    touch unrelated-repo-change.txt
+    snapshot_output=$(PROJECT_ROOT="$TEST_TMP_DIR/not-a-repo" snapshot_tangle_worktree_paths)
+    rm -f unrelated-repo-change.txt
+    [[ -z "$snapshot_output" ]]
+); then
+    test_pass
+else
+    test_fail "snapshot_tangle_worktree_paths used cwd repo despite explicit non-git PROJECT_ROOT"
+fi
+
 test_case "implementation prompt with no worktree change fails validation"
 if (
     cd "$REPO_DIR"

--- a/tests/unit/test-tangle-write-scope-safety.sh
+++ b/tests/unit/test-tangle-write-scope-safety.sh
@@ -103,6 +103,56 @@ else
     test_fail "write scope extraction rejected root-level filenames; got: $scopes"
 fi
 
+test_case "known scope lookup falls back to pwd when PROJECT_ROOT is invalid"
+real_project_root="$PROJECT_ROOT"
+if (
+    cd "$real_project_root"
+    PROJECT_ROOT="$TEST_TMP_DIR/missing-project-root"
+    tangle_scope_is_known_or_explicit_new_file "scripts/lib/workflows.sh"
+); then
+    test_pass
+else
+    test_fail "known scope lookup did not fall back when PROJECT_ROOT was invalid"
+fi
+
+test_case "repo context resolution falls back to pwd when PROJECT_ROOT is invalid"
+resolved_scopes=$(
+    cd "$real_project_root"
+    PROJECT_ROOT="$TEST_TMP_DIR/missing-project-root" \
+        tangle_resolve_repo_context_files "Update workflow safety. Files: scripts/lib/workflows.sh"
+)
+if [[ "$resolved_scopes" == *"scripts/lib/workflows.sh"* ]]; then
+    test_pass
+else
+    test_fail "repo context resolution did not fall back when PROJECT_ROOT was invalid: $resolved_scopes"
+fi
+
+test_case "existing non-git PROJECT_ROOT does not resolve scopes from unrelated pwd repo"
+resolved_scopes=$(
+    cd "$real_project_root"
+    mkdir -p "$TEST_TMP_DIR/not-a-repo"
+    PROJECT_ROOT="$TEST_TMP_DIR/not-a-repo" \
+        tangle_resolve_repo_context_files "Update workflow safety. Files: scripts/lib/workflows.sh"
+)
+if [[ -z "$resolved_scopes" ]]; then
+    test_pass
+else
+    test_fail "repo context resolution used cwd repo despite explicit non-git PROJECT_ROOT: $resolved_scopes"
+fi
+
+test_case "known scope lookup honors existing non-git PROJECT_ROOT files"
+if (
+    cd "$real_project_root"
+    mkdir -p "$TEST_TMP_DIR/not-a-repo/scripts/lib"
+    touch "$TEST_TMP_DIR/not-a-repo/scripts/lib/workflows.sh"
+    PROJECT_ROOT="$TEST_TMP_DIR/not-a-repo"
+    tangle_scope_is_known_or_explicit_new_file "scripts/lib/workflows.sh"
+); then
+    test_pass
+else
+    test_fail "known scope lookup ignored files under explicit non-git PROJECT_ROOT"
+fi
+
 original_prompt="Update src/lib/templates/NA02_REQUEST_REPORT.ts and src/lib/legal/legalReferenceCatalog.ts without producing duplicate subject prefixes."
 
 tangle_develop "$original_prompt" >/dev/null


### PR DESCRIPTION
## Problem

TANGLE requires coding subtasks to declare Files scopes so it can prevent unsafe parallel edits. In practice, model-generated scopes are often approximate: a basename, a generic path, or a file name from the task wording rather than the real path in the repository.

When that happens, Octopus can reject otherwise valid work or send the worker a scope that does not match the real worktree.

## Change

This treats Files values as scope intent and resolves them against the real repository before dispatch and validation.

It adds helpers that:
- keep exact existing file paths when they are valid;
- resolve basename-only references against tracked files;
- add relevant repository files from high-signal task terms;
- include resolved files in each subtask prompt;
- validate effective resolved scopes rather than only the model's raw path text.

## Why this is safe

The parallel-safety check remains in place. This only improves the file targets used by that check and by the worker prompt. If no concrete repository target can be resolved, the worker is told to inspect the tracked file list and report a blocker instead of inventing layout.

## Validation

- bash -n scripts/lib/workflows.sh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Design review: agent/provider selection is now configurable via environment variables; timeouts are validated/clamped and chosen agents/timeouts are logged.
  * Workflow engine: injects richer repository context into task prompts, resolves concrete file scopes, strips extraneous scope artifacts, enforces plan-file size caps, and tightens parallel-task conflict detection.
* **Tests**
  * Added regression tests for plan-file resolution, repo-root fallback behavior, and write-scope safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->