### PR TITLE
fix: allow vibe exec shim command validation

### DIFF
--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -166,6 +166,13 @@ sanitize_review_id() {
 # Only allows whitelisted command prefixes
 validate_agent_command() {
     local cmd="$1"
+    local cmd_executable="${cmd%%[[:space:]]*}"
+
+    # Allow the vibe shim only when it is the executable token, not when it
+    # appears later in the command string.
+    if [[ "$cmd_executable" == */vibe-exec.sh ]]; then
+        return 0
+    fi
 
     # Whitelist of allowed command prefixes (v7.19.0: tightened to exact patterns)
     case "$cmd" in

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+log() { :; }
+source "$PROJECT_ROOT/scripts/lib/utils.sh"
+
+test_suite "Agent Command Validation"
+
+test_case "validate_agent_command allows vibe-exec shim path"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/vibe-exec.sh --output text"; then
+    test_pass
+else
+    test_fail "expected vibe-exec shim path to be accepted"
+fi
+
+test_case "validate_agent_command allows vibe-exec shim path without args"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/vibe-exec.sh"; then
+    test_pass
+else
+    test_fail "expected bare vibe-exec shim path to be accepted"
+fi
+
+test_case "validate_agent_command rejects embedded vibe-exec shim path"
+if validate_agent_command "echo $PROJECT_ROOT/scripts/helpers/vibe-exec.sh --output text" >/dev/null 2>&1; then
+    test_fail "expected embedded vibe-exec shim path to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects unsafe command"
+if validate_agent_command "rm -rf /" >/dev/null 2>&1; then
+    test_fail "expected unsafe command to be rejected"
+else
+    test_pass
+fi
+
+test_summary


### PR DESCRIPTION
Fixes #451.

## Summary
- allow validate_agent_command to accept a vibe-exec.sh shim path when it is the command executable
- keep embedded shim references and unsafe shell commands rejected
- add focused unit coverage for shim path validation

## Verification
- bash tests/unit/test-agent-command-validation.sh
- bash tests/unit/test-vibe-provider.sh
- bash tests/smoke/test-fleet-dispatch-guard.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced command validation logic to explicitly validate executable tokens while maintaining existing allowlist behavior.

* **Tests**
  * Added comprehensive unit tests for command validation, covering valid executables, unsafe commands, and embedded command injection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->