### PR TITLE
fix: dispatch providers from the user's project, stop provider-name model leaks

### DIFF
--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -30,8 +30,10 @@ When the user invokes this command (e.g., `/octo:discover <arguments>`):
 
 **✓ CORRECT - Run the orchestrated probe workflow:**
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh probe <user's arguments>
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" probe <user's arguments>
 ```
+
+Run this from the user's project directory — never `cd` into the plugin first. Dispatched providers sandbox file access to the invoking directory, so a plugin cwd makes the user's project files unreadable to every provider.
 
 **✗ INCORRECT:**
 ```
@@ -94,10 +96,10 @@ After receiving answers, incorporate them into the `orchestrate.sh probe` invoca
 ### Step 2: Run Discovery via orchestrate.sh
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh probe [intensity=quick|standard|deep] <user's arguments>
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" probe [intensity=quick|standard|deep] <user's arguments>
 ```
 
-Example: `cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh probe [intensity=standard] OAuth authentication patterns`
+Example: `bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" probe [intensity=standard] OAuth authentication patterns`
 
 ### Step 3: Post-Completion — Interactive Next Steps
 

--- a/.claude/commands/doctor.md
+++ b/.claude/commands/doctor.md
@@ -35,6 +35,6 @@ AskUserQuestion({
 Run the diagnostic script:
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/doctor.sh
+bash "${HOME}/.claude-octopus/plugin/scripts/doctor.sh"
 ```
 

--- a/.claude/commands/embrace.md
+++ b/.claude/commands/embrace.md
@@ -146,12 +146,14 @@ Scope: [answer]  Focus: [answer]  Autonomy: [answer]
 
 **CRITICAL: Each phase MUST run through `orchestrate.sh`. Do not invoke `/octo:discover`, `/octo:define`, `/octo:develop`, or `/octo:deliver` via Skill calls inside this command; direct phase dispatch prevents recursive command loading.**
 
+**CRITICAL: Run every orchestrate.sh command from the user's project directory. Do NOT `cd` into the plugin first — dispatched providers (codex workdir, gemini workspace) sandbox themselves to the invoking directory, and a plugin cwd makes every provider unable to read the user's project files. If the prompt references files outside the project (e.g. /tmp), pass `-d <dir>` or set `OCTOPUS_GEMINI_INCLUDE_DIRS`.**
+
 ### Phase 1 — Discover
 
 Run the Discover phase via orchestrate.sh:
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh probe <user's prompt>
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" probe <user's prompt>
 ```
 
 This will dispatch to Codex, Gemini, and other available providers. Results saved to `~/.claude-octopus/results/probe-synthesis-*.md`.
@@ -164,7 +166,7 @@ This will dispatch to Codex, Gemini, and other available providers. Results save
 Run the define phase via orchestrate.sh:
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh grasp <user's prompt>
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" grasp <user's prompt>
 ```
 
 This builds consensus across providers. Results saved to `~/.claude-octopus/results/grasp-consensus-*.md`.
@@ -179,7 +181,7 @@ If user selected debate gates at Define→Develop transition:
 
 ```bash
 latest_consensus="$(ls -t ~/.claude-octopus/results/grasp-consensus-*.md | head -1)"
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh embrace-gate define-develop "<user's prompt>" "$latest_consensus"
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" embrace-gate define-develop "<user's prompt>" "$latest_consensus"
 ```
 
 3. Verify `~/.claude-octopus/results/embrace-gate-define-develop-*.md` exists for this run before Phase 3. If the command fails or no artifact exists, STOP.
@@ -206,7 +208,7 @@ AskUserQuestion({
 Run the develop phase via orchestrate.sh:
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh tangle <user's prompt>
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" tangle <user's prompt>
 ```
 
 This dispatches implementation with quality gates. Results saved to `~/.claude-octopus/results/tangle-validation-*.md`.
@@ -217,7 +219,7 @@ If `DEBATE_GATES=both`, run this before Phase 4:
 
 ```bash
 latest_tangle="$(ls -t ~/.claude-octopus/results/tangle-validation-*.md | head -1)"
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh embrace-gate develop-deliver "<user's prompt>" "$latest_tangle"
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" embrace-gate develop-deliver "<user's prompt>" "$latest_tangle"
 ```
 
 Verify `~/.claude-octopus/results/embrace-gate-develop-deliver-*.md` exists for this run before Phase 4. If the command fails or no artifact exists, STOP. In autonomous mode, continue only after the gate artifact exists; do not silently skip this gate.
@@ -227,7 +229,7 @@ Verify `~/.claude-octopus/results/embrace-gate-develop-deliver-*.md` exists for 
 Run the deliver phase via orchestrate.sh:
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh ink <user's prompt>
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" ink <user's prompt>
 ```
 
 This runs multi-provider validation. Results saved to `~/.claude-octopus/results/delivery-*.md`.

--- a/.claude/skills/skill-doctor/SKILL.md
+++ b/.claude/skills/skill-doctor/SKILL.md
@@ -85,17 +85,17 @@ This runs all 11 check categories and displays a formatted report.
 If the user asks about a specific area, filter:
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor providers
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor auth
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor config
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor state
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor smoke
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor hooks
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor scheduler
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor skills
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor conflicts
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor agents
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor recurrence
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor providers
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor auth
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor config
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor state
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor smoke
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor hooks
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor scheduler
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor skills
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor conflicts
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor agents
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor recurrence
 ```
 
 ### Step 3: Check & Install Dependencies
@@ -118,13 +118,13 @@ This auto-installs: Codex CLI, Gemini CLI, jq, and the statusline resolver. For 
 
 ```bash
 # Detailed output for troubleshooting
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor --verbose
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor --verbose
 
 # Machine-readable output
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor --json
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor --json
 
 # Combine: specific category + verbose
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor auth --verbose
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor auth --verbose
 ```
 
 ### Step 5: Interactive Remediation (MANDATORY for fixable issues)

--- a/.claude/skills/skill-doctor/SKILL.md
+++ b/.claude/skills/skill-doctor/SKILL.md
@@ -75,7 +75,7 @@ fi
 mkdir -p "${HOME}/.claude-octopus"
 ln -sfn "$OCTO_PLUGIN_ROOT" "${HOME}/.claude-octopus/plugin" 2>/dev/null || true
 export OCTO_PLUGIN_ROOT
-cd "$OCTO_PLUGIN_ROOT" && bash scripts/orchestrate.sh doctor
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor
 ```
 
 This runs all 11 check categories and displays a formatted report.

--- a/.cursor-plugin/commands/octo-doctor.md
+++ b/.cursor-plugin/commands/octo-doctor.md
@@ -90,13 +90,13 @@ Execute each selected fix, verify it worked, report results.
 If the user asks about a specific area:
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor providers
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor auth
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor config
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor hooks
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor scheduler
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor skills
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor agents
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor providers
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor auth
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor config
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor hooks
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor scheduler
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor skills
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor agents
 ```
 
 ## Step 5: Token Optimization Report

--- a/.cursor-plugin/commands/octo-doctor.md
+++ b/.cursor-plugin/commands/octo-doctor.md
@@ -40,7 +40,7 @@ fi
 mkdir -p "${HOME}/.claude-octopus"
 ln -sfn "$OCTO_PLUGIN_ROOT" "${HOME}/.claude-octopus/plugin" 2>/dev/null || true
 export OCTO_PLUGIN_ROOT
-cd "$OCTO_PLUGIN_ROOT" && bash scripts/orchestrate.sh doctor --verbose
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --verbose
 ```
 
 ## Step 2: Run Dependency Check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Providers dispatched from the plugin directory instead of the user's project** (bug report 260609). Command docs instructed `cd "${HOME}/.claude-octopus/plugin"` before `orchestrate.sh`, so `PROJECT_ROOT=$PWD` pointed at the plugin checkout and every provider sandbox (codex workdir, gemini workspace, copilot, claude subagents) could not read project files. Docs now invoke `orchestrate.sh` by absolute path from the project directory; `orchestrate.sh` falls back to `CLAUDE_PROJECT_DIR` (or warns) when invoked from inside the plugin install; `OCTOPUS_PROJECT_DIR` added as an explicit override; `probe-single` now cds to `PROJECT_ROOT` before dispatch.
+- **Bare provider names in `routing.roles`/`routing.phases` leaked as model names.** `"researcher": "perplexity"` produced `codex exec --model perplexity` (400 on ChatGPT accounts) and a gemini model 404 plus fallback retry. The model resolver now treats bare provider names as provider routes and falls through to the provider's own default model.
+- **Spawned `claude --print` subagents could not Read files** ("Read is blocked in the current permission mode"). Claude dispatch commands now pre-approve `Read,Glob,Grep`; implementer/developer roles additionally run with `--permission-mode acceptEdits` and `Edit,Write`.
+- **`probe-synthesis-*.md` never written when a straggler stream blocked the wait loop.** `display_rich_progress` now has a watchdog (`TIMEOUT` + `OCTOPUS_PROGRESS_GRACE`, default 120s grace) that terminates stragglers and proceeds to synthesis with completed results.
+- **Perplexity failures were silent** (empty result file, "(no output captured)", no error). Curl failures, timeouts, and empty or contentless responses now log errors and fail the agent; the empty-output placeholder names the provider and points at `doctor`.
+
+### Added
+
+- `OCTOPUS_GEMINI_INCLUDE_DIRS` — comma-separated directories appended to gemini dispatch as `--include-directories`, for prompts referencing files outside `PROJECT_ROOT` (e.g. `/tmp` staging dirs).
+- `tests/unit/test-orchestrate-cwd-routing.sh` — behavioral coverage for cwd resolution, role-routing model leaks, claude permission flags, gemini include dirs, and the docs cd-pattern regression.
+
 ## [9.42.3] - 2026-06-03
 
 ### Changed

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -37,6 +37,18 @@ get_agent_command() {
 
     local sandbox_flag="--sandbox ${codex_sandbox}"
 
+    # Spawned `claude --print` subprocesses have no interactive approver, so any
+    # tool that would prompt is silently denied ("Read is blocked in the current
+    # permission mode"). Pre-approve read tools for every role; write-capable
+    # roles additionally accept edits (bug 260609). Comma-joined, no spaces —
+    # downstream `read -ra` word-splits the command string.
+    local claude_perm="--allowed-tools Read,Glob,Grep"
+    case "$role" in
+        implementer|developer)
+            claude_perm="--permission-mode acceptEdits --allowed-tools Read,Glob,Grep,Edit,Write"
+            ;;
+    esac
+
     case "$agent_type" in
         codex|codex-standard|codex-max|codex-mini|codex-general)
             model=$(get_agent_model "$agent_type" "$phase" "$role")
@@ -74,11 +86,17 @@ get_agent_command() {
             case "${OCTOPUS_GEMINI_SANDBOX:-headless}" in
                 interactive|prompt-mode) gemini_flags="" ;;
             esac
+            # Gemini confines reads to its cwd workspace; prompts that reference
+            # files outside PROJECT_ROOT (e.g. /tmp staging dirs) need those dirs
+            # whitelisted. Comma-separated, no spaces (read -ra word-splitting).
+            if [[ -n "${OCTOPUS_GEMINI_INCLUDE_DIRS:-}" ]]; then
+                gemini_flags="${gemini_flags} --include-directories ${OCTOPUS_GEMINI_INCLUDE_DIRS}"
+            fi
             echo "${gemini_env} ${gemini_exec} ${model} ${gemini_flags}"
             ;;
         codex-review) echo "codex exec --skip-git-repo-check review" ;; # Code review mode (no sandbox support)
-        claude) echo "claude${_BARE_OPT} --print" ;;                         # Claude Sonnet 4.6
-        claude-sonnet) echo "claude${_BARE_OPT} --print --model sonnet" ;;        # Claude Sonnet explicit
+        claude) echo "claude${_BARE_OPT} --print ${claude_perm}" ;;                         # Claude Sonnet 4.6
+        claude-sonnet) echo "claude${_BARE_OPT} --print --model sonnet ${claude_perm}" ;;        # Claude Sonnet explicit
         claude-opus)
             # v9.42: Opus alias — resolves to 4.8 on Claude Code v2.1.154+,
             # then 4.7/4.6 on older hosts or enterprise backends.
@@ -96,19 +114,19 @@ get_agent_command() {
                 opus_effort="$OCTOPUS_EFFORT_OVERRIDE"
             fi
             if [[ "${SUPPORTS_EFFORT_COMMAND:-false}" == "true" || "${SUPPORTS_XHIGH_EFFORT:-false}" == "true" ]]; then
-                echo "env CLAUDE_CODE_EFFORT_LEVEL=${opus_effort} claude${_BARE_OPT} --print --model opus"
+                echo "env CLAUDE_CODE_EFFORT_LEVEL=${opus_effort} claude${_BARE_OPT} --print --model opus ${claude_perm}"
             else
-                echo "claude${_BARE_OPT} --print --model opus"
+                echo "claude${_BARE_OPT} --print --model opus ${claude_perm}"
             fi
             ;;
         claude-opus-fast)
             if [[ "${SUPPORTS_OPUS_4_8:-false}" == "true" && "${OCTOPUS_OPUS_MODEL:-}" != "claude-opus-4.6" ]]; then
-                echo "claude${_BARE_OPT} --print --model claude-opus-4-8 --fast"
+                echo "claude${_BARE_OPT} --print --model claude-opus-4-8 --fast ${claude_perm}"
             else
-                echo "claude${_BARE_OPT} --print --model claude-opus-4-6 --fast"
+                echo "claude${_BARE_OPT} --print --model claude-opus-4-6 --fast ${claude_perm}"
             fi
             ;;
-        claude-opus-legacy) echo "claude${_BARE_OPT} --print --model claude-opus-4-6" ;; # v9.23: explicit 4.6 opt-in
+        claude-opus-legacy) echo "claude${_BARE_OPT} --print --model claude-opus-4-6 ${claude_perm}" ;; # v9.23: explicit 4.6 opt-in
         openrouter) echo "openrouter_execute" ;;                 # OpenRouter API (v4.8)
         openrouter-glm5) echo "openrouter_execute_model z-ai/glm-5" ;;           # v8.11.0: GLM-5 via OpenRouter
         openrouter-kimi) echo "openrouter_execute_model moonshotai/kimi-k2.5" ;; # v8.11.0: Kimi K2.5 via OpenRouter

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -140,7 +140,21 @@ resolve_octopus_model() {
                         resolved_model=$(resolve_octopus_model "$ref_provider" "$ref_type" "" "")
                     fi
                 else
-                    resolved_model="$routed"
+                    # Bare provider names in routing values are provider routes, not
+                    # model names. "researcher": "perplexity" means "route this role
+                    # to the perplexity provider" — it must never become
+                    # `codex exec --model perplexity` (bug 260609). Treat a bare
+                    # provider name like "provider:" with no model: skip for other
+                    # providers, fall through to lower tiers for the provider itself.
+                    case "$routed" in
+                        codex|gemini|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|cursor-agent|vibe)
+                            [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): SKIP (route '$routed' is a provider name, not a model — resolving for $provider)" >&2
+                            routed=""
+                            ;;
+                        *)
+                            resolved_model="$routed"
+                            ;;
+                    esac
                 fi
                 if [[ -n "$routed" ]]; then
                     [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): $resolved_model ← SELECTED (route: $routed)" >&2

--- a/scripts/lib/perplexity.sh
+++ b/scripts/lib/perplexity.sh
@@ -203,12 +203,24 @@ perplexity_execute() {
 EOF
 )
 
-    local response
-    response=$(curl -s -X POST "https://api.perplexity.ai/chat/completions" \
+    local response curl_exit=0
+    # -sS: silent progress but keep curl errors on stderr so the spawn error log
+    # captures them; --max-time bounds hung connections. A failed or empty
+    # request previously fell through silently and produced an empty result
+    # file with "(no output captured)" and no actionable error (bug 260609).
+    response=$(curl -sS --max-time "${OCTOPUS_PERPLEXITY_TIMEOUT:-120}" -X POST "https://api.perplexity.ai/chat/completions" \
         -H "Authorization: Bearer ${PERPLEXITY_API_KEY}" \
         -H "Content-Type: application/json" \
         -H "Connection: keep-alive" \
-        -d "$payload")
+        -d "$payload") || curl_exit=$?
+    if [[ $curl_exit -ne 0 ]]; then
+        log ERROR "Perplexity request failed (curl exit ${curl_exit}, model=$model)"
+        return 1
+    fi
+    if [[ -z "$response" ]]; then
+        log ERROR "Perplexity returned an empty response body (model=$model)"
+        return 1
+    fi
 
     # Extract content from OpenAI-compatible nested path .choices[0].message.content.
     # See openrouter_execute_model above — same bug, same fix (issue #307).
@@ -228,8 +240,11 @@ EOF
             log ERROR "Perplexity error: ${BASH_REMATCH[1]}"
             return 1
         fi
-        log WARN "Empty response from Perplexity ($model)"
+        # Content missing but no parseable error — surface the raw body and fail
+        # so the agent is marked FAILED instead of "succeeding" with JSON noise.
+        log ERROR "Perplexity response had no message content ($model)"
         echo "$response"
+        return 1
     else
         local result
         result=$(echo "$content" | sed 's/\\n/\n/g; s/\\t/\t/g; s/\\"/"/g')

--- a/scripts/lib/session.sh
+++ b/scripts/lib/session.sh
@@ -181,9 +181,25 @@ display_rich_progress() {
     # Progress bar function
     local bar_width=20
 
+    # Watchdog: every agent already runs under run_with_timeout, so the fleet
+    # should finish within TIMEOUT plus dispatch overhead. A straggler PID that
+    # never reaps (zombie, stuck watcher child) would otherwise block this loop
+    # forever and the synthesis step downstream would never run (bug 260609).
+    local watchdog_limit=$(( ${TIMEOUT:-300} + ${OCTOPUS_PROGRESS_GRACE:-120} ))
+
     while true; do
         local all_done=true
         local completed=0
+
+        if (( $(date +%s) - start_time > watchdog_limit )); then
+            echo ""
+            echo -e "${YELLOW}⚠ Progress watchdog: agents still reported running after ${watchdog_limit}s (timeout ${TIMEOUT:-300}s + grace). Terminating stragglers and continuing to synthesis with completed results.${NC}"
+            local straggler_pid
+            for straggler_pid in "${pids[@]}"; do
+                kill -0 "$straggler_pid" 2>/dev/null && kill -TERM "$straggler_pid" 2>/dev/null || true
+            done
+            break
+        fi
 
         # Clear previous output (move cursor up and clear)
         [[ $completed -gt 0 ]] && printf "\033[%dA" $((total_agents + 4))

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -832,7 +832,7 @@ ${heuristic_ctx}"
             elif [[ -s "$raw_output" ]]; then
                 cat "$raw_output" >> "$result_file"
             else
-                echo "(no output captured)" >> "$result_file"
+                echo "(no output captured — ${agent_type} produced no stdout; check provider auth/config with 'orchestrate.sh doctor')" >> "$result_file"
             fi
             echo '```' >> "$result_file"
             echo "" >> "$result_file"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -30,6 +30,13 @@ probe_single_agent() {
 
     mkdir -p "$RESULTS_DIR" "$LOGS_DIR"
 
+    # Dispatch from the user's project so provider sandboxes (codex workdir,
+    # gemini workspace) can read project files (bug 260609). probe-single runs
+    # in its own orchestrate.sh process, so cd here cannot leak to other work.
+    if [[ -n "${PROJECT_ROOT:-}" && -d "$PROJECT_ROOT" ]]; then
+        cd "$PROJECT_ROOT" || log "WARN" "probe_single_agent: cannot cd to PROJECT_ROOT=$PROJECT_ROOT"
+    fi
+
     # Determine role and phase
     local role="researcher"
     local phase="probe"

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -61,8 +61,28 @@ fi
 # Keep debug flag defined even when nounset is enabled by sourced scripts.
 OCTOPUS_DEBUG="${OCTOPUS_DEBUG:-false}"
 
-# Workspace location - uses home directory for global installation
+# Workspace location — the directory whose files dispatched providers must read.
+# Callers historically `cd` into the plugin install before invoking orchestrate.sh,
+# which sandboxed every provider (codex workdir, gemini workspace) to the plugin
+# checkout instead of the user's project, so no provider could read project files.
+# Resolution order: OCTOPUS_PROJECT_DIR > CLAUDE_PROJECT_DIR (when PWD is inside
+# the plugin install) > PWD. The -d/--dir flag still overrides at arg parse.
 PROJECT_ROOT="${PWD}"
+if [[ -n "${OCTOPUS_PROJECT_DIR:-}" ]]; then
+    PROJECT_ROOT="${OCTOPUS_PROJECT_DIR}"
+else
+    _octo_pwd_phys="$(pwd -P)"
+    if [[ "${_octo_pwd_phys}" == "${PLUGIN_DIR}" || "${_octo_pwd_phys}" == "${PLUGIN_DIR}/"* ]]; then
+        if [[ -n "${CLAUDE_PROJECT_DIR:-}" && -d "${CLAUDE_PROJECT_DIR}" ]]; then
+            PROJECT_ROOT="${CLAUDE_PROJECT_DIR}"
+        else
+            printf 'WARN: orchestrate.sh invoked from inside the plugin install (%s).\n' "${_octo_pwd_phys}" >&2
+            printf 'WARN: dispatched providers will be sandboxed here and cannot read your project files.\n' >&2
+            printf 'WARN: run from your project directory, or pass -d <project-dir> / set OCTOPUS_PROJECT_DIR.\n' >&2
+        fi
+    fi
+    unset _octo_pwd_phys
+fi
 
 # Source state manager utilities
 source "${SCRIPT_DIR}/state-manager.sh"

--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -76,17 +76,17 @@ This runs all 11 check categories and displays a formatted report.
 If the user asks about a specific area, filter:
 
 ```bash
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor providers
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor auth
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor config
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor state
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor smoke
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor hooks
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor scheduler
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor skills
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor conflicts
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor agents
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor recurrence
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor providers
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor auth
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor config
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor state
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor smoke
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor hooks
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor scheduler
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor skills
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor conflicts
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor agents
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor recurrence
 ```
 
 ### Step 3: Check & Install Dependencies
@@ -109,13 +109,13 @@ This auto-installs: Codex CLI, Gemini CLI, jq, and the statusline resolver. For 
 
 ```bash
 # Detailed output for troubleshooting
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor --verbose
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor --verbose
 
 # Machine-readable output
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor --json
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor --json
 
 # Combine: specific category + verbose
-cd "${HOME}/.claude-octopus/plugin" && bash scripts/orchestrate.sh doctor auth --verbose
+bash "${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" doctor auth --verbose
 ```
 
 ### Step 5: Interactive Remediation (MANDATORY for fixable issues)

--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -66,7 +66,7 @@ fi
 mkdir -p "${HOME}/.claude-octopus"
 ln -sfn "$OCTO_PLUGIN_ROOT" "${HOME}/.claude-octopus/plugin" 2>/dev/null || true
 export OCTO_PLUGIN_ROOT
-cd "$OCTO_PLUGIN_ROOT" && bash scripts/orchestrate.sh doctor
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor
 ```
 
 This runs all 11 check categories and displays a formatted report.

--- a/tests/unit/test-execution-mechanism.sh
+++ b/tests/unit/test-execution-mechanism.sh
@@ -99,7 +99,10 @@ EMBRACE="$PROJECT_ROOT/.claude/commands/embrace.md"
 if [[ -f "$EMBRACE" ]]; then
     missing_dispatches=()
     for workflow in probe grasp tangle ink; do
-        if ! grep -q "orchestrate.sh ${workflow}" "$EMBRACE" 2>/dev/null; then
+        # Accept both the legacy bare form (`orchestrate.sh probe`) and the
+        # quoted absolute-path form (`orchestrate.sh" probe`) introduced when
+        # the docs stopped cd-ing into the plugin (bug 260609).
+        if ! grep -qE "orchestrate\.sh\"? ${workflow}" "$EMBRACE" 2>/dev/null; then
             missing_dispatches+=("$workflow")
         fi
     done

--- a/tests/unit/test-orchestrate-cwd-routing.sh
+++ b/tests/unit/test-orchestrate-cwd-routing.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+set -euo pipefail
+
+# tests/unit/test-orchestrate-cwd-routing.sh
+# Behavioral coverage for the orchestrate.sh dispatch fixes (bug report 260609):
+#   1. Bare provider names in routing.roles/.phases must never be returned as a
+#      MODEL name for another provider (codex was dispatched --model perplexity).
+#   2. Spawned claude --print subprocesses must pre-approve read tools so Read
+#      is not denied in headless permission mode.
+#   3. PROJECT_ROOT falls back to CLAUDE_PROJECT_DIR (or warns) when callers
+#      invoke orchestrate.sh from inside the plugin install.
+#   4. Command docs no longer instruct `cd` into the plugin before dispatch.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Orchestrate cwd + model routing (bug 260609)"
+
+# dispatch.sh / model-resolver.sh call log() outside orchestrate.sh; stub it.
+log() { :; }
+export _BARE_OPT=""
+export OCTOPUS_PLATFORM="${OCTOPUS_PLATFORM:-Linux}"
+export PLUGIN_DIR="${PLUGIN_DIR:-$PROJECT_ROOT}"
+
+# shellcheck disable=SC1091
+source "$PROJECT_ROOT/scripts/lib/model-resolver.sh" 2>/dev/null || true
+# shellcheck disable=SC1091
+source "$PROJECT_ROOT/scripts/lib/dispatch.sh" 2>/dev/null || true
+
+if ! declare -f resolve_octopus_model >/dev/null 2>&1; then
+    test_case "resolve_octopus_model() is defined"
+    test_fail "resolve_octopus_model not sourced from model-resolver.sh"
+    test_summary
+    exit 1
+fi
+if ! declare -f get_agent_command >/dev/null 2>&1; then
+    test_case "get_agent_command() is defined"
+    test_fail "get_agent_command not sourced from dispatch.sh"
+    test_summary
+    exit 1
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Fixture: temp HOME with a providers.json whose role routing uses a bare
+# provider name — the exact config shape that produced `--model perplexity`.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+FIXTURE_HOME="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_HOME"' EXIT
+mkdir -p "$FIXTURE_HOME/.claude-octopus/config"
+cat > "$FIXTURE_HOME/.claude-octopus/config/providers.json" << 'EOF'
+{
+  "version": "3.0",
+  "providers": {},
+  "routing": {
+    "phases": {},
+    "roles": {
+      "researcher": "perplexity"
+    }
+  }
+}
+EOF
+
+# resolve_octopus_model reads ${HOME}/.claude-octopus/config/providers.json and
+# memoizes per cache_key; use a unique CLAUDE_CODE_SESSION per call so the
+# /tmp persistent cache never bleeds between assertions.
+resolve_with_fixture() {
+    local provider="$1" agent_type="$2" phase="$3" role="$4"
+    HOME="$FIXTURE_HOME" CLAUDE_CODE_SESSION="cwdtest-$$-$RANDOM" \
+        bash -c '
+            log() { :; }
+            export PLUGIN_DIR="'"$PROJECT_ROOT"'"
+            source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+            resolve_octopus_model "$@"
+        ' _ "$provider" "$agent_type" "$phase" "$role"
+}
+
+test_role_route_not_leaked_to_codex() {
+    test_case "routing.roles researcher=perplexity is not returned as a codex model"
+    local got
+    got="$(resolve_with_fixture codex codex probe researcher)"
+    if [[ "$got" != "perplexity" ]]; then
+        test_pass
+    else
+        test_fail "codex resolved model 'perplexity' — would dispatch 'codex exec --model perplexity'"
+    fi
+}
+
+test_role_route_not_leaked_to_gemini() {
+    test_case "routing.roles researcher=perplexity is not returned as a gemini model"
+    local got
+    got="$(resolve_with_fixture gemini gemini probe researcher)"
+    if [[ "$got" != "perplexity" ]]; then
+        test_pass
+    else
+        test_fail "gemini resolved model 'perplexity' — would 404 and burn a fallback retry"
+    fi
+}
+
+test_role_route_not_a_model_for_perplexity_itself() {
+    test_case "perplexity provider falls through to a real model, not the literal 'perplexity'"
+    local got
+    got="$(resolve_with_fixture perplexity perplexity probe researcher)"
+    if [[ -n "$got" && "$got" != "perplexity" ]]; then
+        test_pass
+    else
+        test_fail "expected a concrete model (e.g. sonar), got: '$got'"
+    fi
+}
+
+test_colon_route_still_resolves() {
+    test_case "provider:type routing (codex:mini) still resolves for the matching provider"
+    mkdir -p "$FIXTURE_HOME/.claude-octopus/config"
+    cat > "$FIXTURE_HOME/.claude-octopus/config/providers.json" << 'EOF'
+{
+  "version": "3.0",
+  "providers": {"codex": {"mini": "gpt-5.4-mini"}},
+  "routing": {"phases": {}, "roles": {"researcher": "codex:codex-mini"}}
+}
+EOF
+    local got
+    got="$(resolve_with_fixture codex codex probe researcher)"
+    if [[ -n "$got" && "$got" != "perplexity" ]]; then
+        test_pass
+    else
+        test_fail "colon-form route failed to resolve, got: '$got'"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Claude subprocess permission flags (Read blocked in headless --print mode)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_claude_grants_read_tools() {
+    test_case "get_agent_command claude → pre-approves Read,Glob,Grep"
+    local got; got="$(get_agent_command claude probe researcher)"
+    [[ "$got" == *"--allowed-tools Read,Glob,Grep"* ]] && test_pass || test_fail "missing --allowed-tools, got: $got"
+}
+
+test_claude_sonnet_grants_read_tools() {
+    test_case "get_agent_command claude-sonnet → pre-approves Read,Glob,Grep"
+    local got; got="$(get_agent_command claude-sonnet probe researcher)"
+    [[ "$got" == *"--allowed-tools Read,Glob,Grep"* ]] && test_pass || test_fail "missing --allowed-tools, got: $got"
+}
+
+test_claude_implementer_accepts_edits() {
+    test_case "get_agent_command claude (implementer) → acceptEdits + write tools"
+    local got; got="$(get_agent_command claude tangle implementer)"
+    if [[ "$got" == *"--permission-mode acceptEdits"* && "$got" == *"Edit,Write"* ]]; then
+        test_pass
+    else
+        test_fail "implementer role missing write grants, got: $got"
+    fi
+}
+
+test_claude_researcher_no_write_grant() {
+    test_case "get_agent_command claude (researcher) → no acceptEdits/write grant"
+    local got; got="$(get_agent_command claude probe researcher)"
+    if [[ "$got" != *"acceptEdits"* && "$got" != *"Edit,Write"* ]]; then
+        test_pass
+    else
+        test_fail "researcher role unexpectedly write-capable: $got"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Gemini external directory whitelisting
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_gemini_include_dirs_flag() {
+    test_case "OCTOPUS_GEMINI_INCLUDE_DIRS adds --include-directories to gemini dispatch"
+    # gemini branch calls get_agent_model → stub to avoid full resolver deps
+    local got
+    got="$(
+        get_agent_model() { echo "gemini-3-flash-preview"; }
+        OCTOPUS_GEMINI_INCLUDE_DIRS="/tmp/staging" get_agent_command gemini probe researcher
+    )"
+    [[ "$got" == *"--include-directories /tmp/staging"* ]] && test_pass || test_fail "flag missing, got: $got"
+}
+
+test_gemini_no_include_dirs_by_default() {
+    test_case "gemini dispatch has no --include-directories when env unset"
+    local got
+    got="$(
+        get_agent_model() { echo "gemini-3-flash-preview"; }
+        unset OCTOPUS_GEMINI_INCLUDE_DIRS
+        get_agent_command gemini probe researcher
+    )"
+    [[ "$got" != *"--include-directories"* ]] && test_pass || test_fail "unexpected flag: $got"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PROJECT_ROOT resolution when invoked from inside the plugin install
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_warns_when_cwd_is_plugin() {
+    test_case "orchestrate.sh warns when invoked from the plugin dir without CLAUDE_PROJECT_DIR"
+    local stderr_out
+    stderr_out="$(cd "$PROJECT_ROOT" && env -u CLAUDE_PROJECT_DIR -u OCTOPUS_PROJECT_DIR \
+        bash scripts/orchestrate.sh version 2>&1 >/dev/null || true)"
+    if [[ "$stderr_out" == *"invoked from inside the plugin install"* ]]; then
+        test_pass
+    else
+        test_fail "expected plugin-cwd warning on stderr"
+    fi
+}
+
+test_no_warn_with_claude_project_dir() {
+    test_case "orchestrate.sh silently redirects PROJECT_ROOT when CLAUDE_PROJECT_DIR is set"
+    local stderr_out
+    stderr_out="$(cd "$PROJECT_ROOT" && env -u OCTOPUS_PROJECT_DIR CLAUDE_PROJECT_DIR="$FIXTURE_HOME" \
+        bash scripts/orchestrate.sh version 2>&1 >/dev/null || true)"
+    if [[ "$stderr_out" != *"invoked from inside the plugin install"* ]]; then
+        test_pass
+    else
+        test_fail "warning fired despite CLAUDE_PROJECT_DIR fallback"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Docs regression: no `cd` into the plugin before orchestrate.sh
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_docs_do_not_cd_into_plugin() {
+    test_case "no tracked doc instructs 'cd .claude-octopus/plugin && bash scripts/'"
+    local hits
+    hits="$(cd "$PROJECT_ROOT" && git grep -l 'cd "\${HOME}/.claude-octopus/plugin" && bash scripts/' -- '*.md' 2>/dev/null || true)"
+    if [[ -z "$hits" ]]; then
+        test_pass
+    else
+        test_fail "cd-into-plugin pattern reintroduced in: $hits"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RUN
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_role_route_not_leaked_to_codex
+test_role_route_not_leaked_to_gemini
+test_role_route_not_a_model_for_perplexity_itself
+test_colon_route_still_resolves
+
+test_claude_grants_read_tools
+test_claude_sonnet_grants_read_tools
+test_claude_implementer_accepts_edits
+test_claude_researcher_no_write_grant
+
+test_gemini_include_dirs_flag
+test_gemini_no_include_dirs_by_default
+
+test_warns_when_cwd_is_plugin
+test_no_warn_with_claude_project_dir
+
+test_docs_do_not_cd_into_plugin
+
+test_summary

--- a/tests/unit/test-orchestrate-cwd-routing.sh
+++ b/tests/unit/test-orchestrate-cwd-routing.sh
@@ -47,8 +47,9 @@ fi
 # provider name — the exact config shape that produced `--model perplexity`.
 # ═══════════════════════════════════════════════════════════════════════════════
 
-FIXTURE_HOME="$(mktemp -d)"
-trap 'rm -rf "$FIXTURE_HOME"' EXIT
+# Use the framework's shared temp dir (created by test_suite, cleaned by its
+# EXIT trap) instead of a private mktemp + trap.
+FIXTURE_HOME="$TEST_TMP_DIR/fixture-home"
 mkdir -p "$FIXTURE_HOME/.claude-octopus/config"
 cat > "$FIXTURE_HOME/.claude-octopus/config/providers.json" << 'EOF'
 {
@@ -122,10 +123,10 @@ test_colon_route_still_resolves() {
 EOF
     local got
     got="$(resolve_with_fixture codex codex probe researcher)"
-    if [[ -n "$got" && "$got" != "perplexity" ]]; then
+    if [[ "$got" == "gpt-5.4-mini" ]]; then
         test_pass
     else
-        test_fail "colon-form route failed to resolve, got: '$got'"
+        test_fail "colon-form route should resolve to gpt-5.4-mini, got: '$got'"
     fi
 }
 

--- a/tests/unit/test-windows-doctor-compat.sh
+++ b/tests/unit/test-windows-doctor-compat.sh
@@ -23,7 +23,7 @@ fi
 test_case "doctor commands use portable plugin-root discovery"
 doctor_generated="$(< "$PROJECT_ROOT/.cursor-plugin/commands/octo-doctor.md")"
 if assert_contains "$doctor_generated" 'find "${HOME}/.claude/plugins"' "generated command searches Claude plugin installs" &&
-   assert_contains "$doctor_generated" 'cd "$OCTO_PLUGIN_ROOT" && bash scripts/orchestrate.sh doctor --verbose' "generated command runs doctor from resolved root"; then
+   assert_contains "$doctor_generated" 'bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --verbose' "generated command runs doctor from resolved root"; then
     test_pass
 fi
 


### PR DESCRIPTION
## Summary

Fixes bug report 260609: `orchestrate.sh probe` (via `/octo:embrace`) produced zero usable analysis — all seven provider streams failed to read project files, codex/gemini failed on model routing, and no `probe-synthesis-*.md` was written.

### Root causes and fixes

1. **Providers sandboxed to the plugin dir (root cause).** Command docs instructed `cd "${HOME}/.claude-octopus/plugin"` before `orchestrate.sh`, so `PROJECT_ROOT=$PWD` pointed at the plugin checkout. Docs now invoke `orchestrate.sh` by absolute path from the project directory; `orchestrate.sh` falls back to `CLAUDE_PROJECT_DIR` (or warns) when invoked from inside the plugin install; new `OCTOPUS_PROJECT_DIR` override; `probe-single` now cds to `PROJECT_ROOT` before dispatch.
2. **Bare provider names in `routing.roles` leaked as model names.** `"researcher": "perplexity"` produced `codex exec --model perplexity` (400 on ChatGPT accounts) and a gemini model 404. The resolver now treats bare provider names as provider routes.
3. **Spawned `claude --print` subagents could not Read files.** Dispatch now pre-approves `Read,Glob,Grep`; implementer/developer roles also get `--permission-mode acceptEdits` with `Edit,Write`.
4. **Straggler stream blocked synthesis forever.** `display_rich_progress` gained a watchdog (`TIMEOUT` + `OCTOPUS_PROGRESS_GRACE`).
5. **Perplexity failures were silent.** Curl failures, timeouts, and contentless responses now fail loudly; the "(no output captured)" placeholder names the provider.
6. New: `OCTOPUS_GEMINI_INCLUDE_DIRS` whitelists extra dirs for gemini reads.

### Tests

- New behavioral suite `tests/unit/test-orchestrate-cwd-routing.sh` (13 cases) reproduces the perplexity model leak against a fixture config and covers cwd warning/fallback, claude permission flags, gemini include dirs, and the docs cd-pattern regression.
- `test-execution-mechanism.sh` updated to accept the quoted absolute-path dispatch form.
- Full unit suite: 126/126 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider sandboxing by resolving project root and warning when providers can’t read project files.
  * Ensured Claude subprocesses get correct pre-approved permission flags (read vs edit/write).
  * Hardened Perplexity calls to fail on request/empty-response and added a watchdog to avoid synthesis hangs.
  * Clarified failure messages advising use of the diagnostic runner.

* **New Features**
  * Added OCTOPUS_GEMINI_INCLUDE_DIRS to grant Gemini include-directory access.

* **Documentation**
  * Updated command examples to invoke orchestration via absolute script paths and warn to run from the project directory.

* **Tests**
  * Added unit tests for cwd routing, permission flags, model routing, Gemini flags, and doc regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->