### PR TITLE
fix: pass GOOGLE_CLOUD_PROJECT vars through Gemini env isolation

### DIFF
--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -64,7 +64,7 @@ build_provider_env() {
             if [[ -z "${GOOGLE_API_KEY:-}" ]]; then
                 resolve_provider_env "GOOGLE_API_KEY" 2>/dev/null || true
             fi
-            PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "GEMINI_API_KEY=${GEMINI_API_KEY:-}" "GOOGLE_API_KEY=${GOOGLE_API_KEY:-}" "NODE_NO_WARNINGS=1" "TMPDIR=${TMPDIR:-/tmp}" "GEMINI_CLI_TRUST_WORKSPACE=${GEMINI_CLI_TRUST_WORKSPACE:-true}")
+            PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "GEMINI_API_KEY=${GEMINI_API_KEY:-}" "GOOGLE_API_KEY=${GOOGLE_API_KEY:-}" "GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-}" "GOOGLE_CLOUD_PROJECT_ID=${GOOGLE_CLOUD_PROJECT_ID:-}" "NODE_NO_WARNINGS=1" "TMPDIR=${TMPDIR:-/tmp}" "GEMINI_CLI_TRUST_WORKSPACE=${GEMINI_CLI_TRUST_WORKSPACE:-true}")
             if [[ ${#_trace_env[@]} -gt 0 ]]; then
                 PROVIDER_ENV_ARRAY+=("${_trace_env[@]}")
             fi

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -606,10 +606,10 @@ ${heuristic_ctx}"
         done
 
         if [[ $exit_code -ne 0 && -s "$temp_errors" ]]; then
-            local stderr_first_line=""
-            stderr_first_line=$(grep -m1 '[^[:space:]]' "$temp_errors" 2>/dev/null | head -c 240 || true)
-            if [[ -n "$stderr_first_line" ]]; then
-                log "ERROR" "[$agent_type] provider stderr: $stderr_first_line"
+            local stderr_excerpt=""
+            stderr_excerpt=$(grep -m5 '[^[:space:]]' "$temp_errors" 2>/dev/null | tr '\n' ' ' | head -c 600 || true)
+            if [[ -n "$stderr_excerpt" ]]; then
+                log "ERROR" "[$agent_type] provider stderr: $stderr_excerpt"
             fi
         fi
 


### PR DESCRIPTION
## Root cause

`build_provider_env` in `scripts/lib/provider-routing.sh:67` wraps every Gemini agent invocation in `env -i` with a fixed allowlist. The list omitted `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_PROJECT_ID`, which the Gemini CLI requires when authenticated via Workspace/GCA OAuth (`~/.gemini/oauth_creds.json`). Every orchestrated Gemini agent failed immediately with `ProjectIdRequiredError` while direct `gemini` invocations (no `env -i`) worked fine — making the failure invisible to `/octo:preflight`.

## Fix

**`scripts/lib/provider-routing.sh`** — add both vars to the gemini allowlist:
```
"GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-}" \
"GOOGLE_CLOUD_PROJECT_ID=${GOOGLE_CLOUD_PROJECT_ID:-}"
```
These identify a GCP project, not a credential. Passing them does not weaken the isolation model.

**`scripts/lib/spawn.sh`** — expand the provider stderr log from 1 line (240 chars) to 5 lines (600 chars), so cosmetic leading warnings (`Warning: 256-color support not detected`) no longer hide the real error in orchestrator output.

## Test results

- `bash -n scripts/lib/provider-routing.sh scripts/lib/spawn.sh` — clean
- `bash -n scripts/lib/*.sh` — clean (all lib scripts)
- `tests/unit/test-gemini-provider.sh` — 52/52 passed
- `tests/unit/test-provider-allowlist.sh` — 8/8 passed

Closes #471

---
_Generated by [Claude Code](https://claude.ai/code/session_01UF8pULgkRDDuDtaJ37MxJm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error diagnostics with more detailed information captured and displayed when provider failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->