### PR TITLE
fix: pass GOOGLE_CLOUD_PROJECT vars to Gemini env for Workspace OAuth

### DIFF
--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -64,7 +64,7 @@ build_provider_env() {
             if [[ -z "${GOOGLE_API_KEY:-}" ]]; then
                 resolve_provider_env "GOOGLE_API_KEY" 2>/dev/null || true
             fi
-            PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "GEMINI_API_KEY=${GEMINI_API_KEY:-}" "GOOGLE_API_KEY=${GOOGLE_API_KEY:-}" "NODE_NO_WARNINGS=1" "TMPDIR=${TMPDIR:-/tmp}" "GEMINI_CLI_TRUST_WORKSPACE=${GEMINI_CLI_TRUST_WORKSPACE:-true}")
+            PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "GEMINI_API_KEY=${GEMINI_API_KEY:-}" "GOOGLE_API_KEY=${GOOGLE_API_KEY:-}" "GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-}" "GOOGLE_CLOUD_PROJECT_ID=${GOOGLE_CLOUD_PROJECT_ID:-}" "NODE_NO_WARNINGS=1" "TMPDIR=${TMPDIR:-/tmp}" "GEMINI_CLI_TRUST_WORKSPACE=${GEMINI_CLI_TRUST_WORKSPACE:-true}")
             if [[ ${#_trace_env[@]} -gt 0 ]]; then
                 PROVIDER_ENV_ARRAY+=("${_trace_env[@]}")
             fi


### PR DESCRIPTION
## Description

Adds GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_PROJECT_ID to the Gemini provider environment allowlist in build_provider_env. Workspace/GCA OAuth users require one of these variables; the env -i isolation was stripping them, causing every orchestrated Gemini agent to fail with ProjectIdRequiredError while direct gemini CLI invocations worked fine.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes bash -n scripts/orchestrate.sh
- [x] Shell scripts pass bash -n syntax check

## Testing

Both variables are added with an empty-string fallback so they pass through when set and remain harmless when absent. Verified locally against v9.39.0: the same env -i invocation that previously failed with ProjectIdRequiredError succeeds after the change.

## Related Issues
Closes #471