### PR TITLE
fix: lower Gemini version floor to 0.45.0, honor OCTO_*_MIN_VERSION env overrides

### DIFF
--- a/scripts/lib/provider-versions.sh
+++ b/scripts/lib/provider-versions.sh
@@ -2,11 +2,11 @@
 # Provider CLI version floors — minimum versions for stable orchestration.
 # Source this file to access floor constants and octo_version_ok().
 
-OCTO_CODEX_MIN_VERSION="0.100.0"
-OCTO_GEMINI_MIN_VERSION="1.0.0"
-OCTO_QWEN_MIN_VERSION="9.10.0"
-OCTO_GH_MIN_VERSION="2.0.0"
-OCTO_OPENCODE_MIN_VERSION="0.1.0"
+OCTO_CODEX_MIN_VERSION="${OCTO_CODEX_MIN_VERSION:-0.100.0}"
+OCTO_GEMINI_MIN_VERSION="${OCTO_GEMINI_MIN_VERSION:-0.45.0}"
+OCTO_QWEN_MIN_VERSION="${OCTO_QWEN_MIN_VERSION:-9.10.0}"
+OCTO_GH_MIN_VERSION="${OCTO_GH_MIN_VERSION:-2.0.0}"
+OCTO_OPENCODE_MIN_VERSION="${OCTO_OPENCODE_MIN_VERSION:-0.1.0}"
 
 # Ollama model staleness threshold (days). Models older than this raise WARN.
 OCTO_OLLAMA_STALE_DAYS="${OCTO_OLLAMA_STALE_DAYS:-30}"


### PR DESCRIPTION
## Root cause

`scripts/lib/provider-versions.sh:6` unconditionally assigned `OCTO_GEMINI_MIN_VERSION="1.0.0"`. Two problems:

1. **Wrong floor value.** Gemini CLI has never shipped a 1.x release — npm `latest` is `0.46.0`, `preview`/`nightly` are `0.47.0-*`. Every Gemini user saw a false "outdated" warning from `doctor` on a fully up-to-date install.
2. **Clobbered env override.** The plain assignment wiped any pre-exported `OCTO_GEMINI_MIN_VERSION`, so the override knob documented in doctor output had no effect.

## Fix

Switch all five floor constants to `${VAR:-default}` form (matching `OCTO_OLLAMA_STALE_DAYS` on line 12, which already used this pattern). Lower the Gemini floor to `0.45.0` (one minor behind current stable, consistent with the intent of a minimum).

```diff
-OCTO_CODEX_MIN_VERSION="0.100.0"
-OCTO_GEMINI_MIN_VERSION="1.0.0"
-OCTO_QWEN_MIN_VERSION="9.10.0"
-OCTO_GH_MIN_VERSION="2.0.0"
-OCTO_OPENCODE_MIN_VERSION="0.1.0"
+OCTO_CODEX_MIN_VERSION="${OCTO_CODEX_MIN_VERSION:-0.100.0}"
+OCTO_GEMINI_MIN_VERSION="${OCTO_GEMINI_MIN_VERSION:-0.45.0}"
+OCTO_QWEN_MIN_VERSION="${OCTO_QWEN_MIN_VERSION:-9.10.0}"
+OCTO_GH_MIN_VERSION="${OCTO_GH_MIN_VERSION:-2.0.0}"
+OCTO_OPENCODE_MIN_VERSION="${OCTO_OPENCODE_MIN_VERSION:-0.1.0}"
```

## Tests

- `bash -n scripts/lib/provider-versions.sh` — syntax ok
- `bash -n scripts/*.sh scripts/lib/*.sh` — no errors across all scripts

Dispatch and credential checks are unaffected (`orchestrate.sh` / `_gemini_ok` never consults the floor). This is a `doctor` display-only fix.

Closes #473

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kpdzxg6cth5K4ZFHigprH5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Provider version requirements are now configurable via environment variables while maintaining default fallback values.
  * Adjusted minimum version support for Gemini provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->