### PR TITLE
feat: add provider contract audit and event stream groundwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- `scripts/helpers/audit-provider-contracts.sh` release-gate audit for provider drift: provider states must stay `available|missing|degraded`, qwen auth must fail closed when OAuth cannot be validated, stale free-tier setup guidance must not reappear, and provider version floors must remain env-overridable.
+- `scripts/lib/events.sh` opt-in JSONL event emitter plus `check-providers.sh` `provider.status` events when `OCTO_EVENT_LOG` is set. Normal provider-check stdout is unchanged.
+- `docs/roadmaps/2026-06-13-next-minor-major.md` captures the June 2026 Claude Code plugin research and maps it into the next minor and major Octopus direction.
+
+### Fixed
+
+- `detect_providers` no longer treats a bare qwen OAuth file as dispatchable when the qwen auth validator is unavailable; it reports `oauth-unvalidated` instead. Setup guidance now points users at `QWEN_API_KEY` or Coding-Plan auth rather than the retired free tier.
+
 ## [9.44.0] - 2026-06-10
 
 

--- a/docs/COMMAND-REFERENCE.md
+++ b/docs/COMMAND-REFERENCE.md
@@ -258,6 +258,23 @@ Run environment diagnostics across 9 check categories.
 
 These are advisory unless they identify a concrete misconfiguration. For example, `gateway-model-discovery` warns only when `ANTHROPIC_BASE_URL` is set without `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, and `mcp-workspace-reserved` warns only when a settings file defines `mcpServers.workspace`.
 
+**Provider contract audit:**
+
+```bash
+bash scripts/helpers/audit-provider-contracts.sh
+```
+
+Use this release gate when provider auth, setup guidance, version floors, or provider docs change. It checks that provider states remain `available|missing|degraded`, qwen OAuth validation fails closed, stale free-tier guidance does not reappear, and provider checks can emit opt-in lifecycle events.
+
+**Opt-in event stream:**
+
+```bash
+OCTO_EVENT_LOG=auto bash scripts/helpers/check-providers.sh
+OCTO_EVENT_LOG=/tmp/octo-events.jsonl bash scripts/helpers/check-providers.sh
+```
+
+When enabled, provider checks append JSONL `provider.status` records without changing stdout. Leave `OCTO_EVENT_LOG` unset for normal behavior.
+
 **Flags:**
 
 | Flag | Description |

--- a/docs/roadmaps/2026-06-13-next-minor-major.md
+++ b/docs/roadmaps/2026-06-13-next-minor-major.md
@@ -1,0 +1,99 @@
+# Next Minor and Major Direction - June 2026
+
+This research pass looked at current Claude Code plugin and agent tooling on
+June 13, 2026, then converted the strongest patterns into scoped Octopus work.
+
+## Signals
+
+- [Claude Code plugin docs](https://code.claude.com/docs/en/discover-plugins)
+  emphasize marketplaces, component inventories, plugin load errors, token cost,
+  and trust review before installation.
+- [Plugins reference](https://code.claude.com/docs/en/plugins-reference) defines
+  plugins as bundled skills, agents, hooks, MCP servers, LSP servers, and
+  monitors.
+- [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official)
+  was the highest-signal official source: curated marketplace structure plus a
+  strong warning that third-party plugins can bring their own files, MCP
+  servers, and runtime behavior.
+- [wshobson/agents](https://github.com/wshobson/agents) showed the most mature
+  cross-harness pattern: one catalog of agents and skills emitted into Claude
+  Code, Codex CLI, Cursor, OpenCode, Copilot, and Gemini.
+- [jarrodwatts/claude-hud](https://github.com/jarrodwatts/claude-hud),
+  [disler/claude-code-hooks-multi-agent-observability](https://github.com/disler/claude-code-hooks-multi-agent-observability),
+  and [patoles/agent-flow](https://github.com/patoles/agent-flow) all point in
+  the same direction: agent systems need ambient observability, not only final
+  summaries.
+- [zilliztech/claude-context](https://github.com/zilliztech/claude-context)
+  reinforced that semantic code context is becoming a plugin-level primitive.
+- [JuliusBrussee/cavekit](https://github.com/JuliusBrussee/cavekit) showed a
+  useful spec-driven loop: failures and review findings should backpropagate
+  into durable invariants, not only patch the immediate bug.
+- [hamelsmu/claude-review-loop](https://github.com/hamelsmu/claude-review-loop)
+  and [ReflexioAI/claude-smart](https://github.com/ReflexioAI/claude-smart)
+  make the same point for review and correction loops: agent systems should
+  learn from repeated corrections.
+
+Live GitHub star counts at research time put these in the high-signal cluster:
+`wshobson/agents` around 36.7k, `anthropics/claude-plugins-official` around
+30.1k, `jarrodwatts/claude-hud` around 25.1k, `zilliztech/claude-context`
+around 11.8k, `disler/claude-code-hooks-multi-agent-observability` around
+1.5k, `JuliusBrussee/cavekit` around 1.0k, `patoles/agent-flow` around 970,
+and `Dicklesworthstone/claude_code_agent_farm` around 840.
+
+## Implemented Now
+
+### Minor: Provider Contract Audit
+
+The qwen auth regression was a concrete version of a broader marketplace
+problem: provider assumptions drift faster than docs, setup guidance, and
+dispatch gates. Octopus now has `scripts/helpers/audit-provider-contracts.sh`
+to enforce the provider contract that matters before release:
+
+- `check-providers.sh` must use strict mode and document `available`,
+  `missing`, and `degraded`.
+- qwen must fail closed when OAuth is expired or cannot be validated.
+- qwen setup guidance must point at API-key or Coding-Plan auth, not the retired
+  free OAuth tier.
+- provider version floors must stay env-overridable and match provider CLI
+  version schemes.
+- OAuth expiry parsing must avoid brittle regex extraction.
+- provider checks can emit opt-in `provider.status` events.
+
+### Major Groundwork: Local Event Stream
+
+Octopus now has `scripts/lib/events.sh`, an opt-in JSONL event emitter:
+
+```bash
+OCTO_EVENT_LOG=auto bash scripts/helpers/check-providers.sh
+OCTO_EVENT_LOG=/tmp/octo-events.jsonl bash scripts/helpers/check-providers.sh
+```
+
+When enabled, `check-providers.sh` appends `provider.status` events without
+changing normal stdout. This is intentionally small: it gives future HUD,
+dashboard, monitor, and agent-flow work a shared event substrate without adding
+a server dependency or changing the CLI contract.
+
+## Next Minor
+
+Ship the provider contract audit as part of the release gate:
+
+- call `scripts/helpers/audit-provider-contracts.sh` from release validation;
+- add contract checks for new providers before they can be marked dispatchable;
+- include the audit output in proof packets for PRs that touch provider auth,
+  versions, docs, or setup help.
+
+## Next Major
+
+Build an Octopus control plane around the event stream:
+
+- structured lifecycle events for provider selection, dispatch start/end,
+  timeout, circuit breaker, review finding, and synthesis;
+- a local monitor/HUD that can render events without scraping terminal output;
+- invariant backprop from repeated review findings into durable specs;
+- optional semantic context adapters so large-codebase discovery is explicit and
+  measurable;
+- lock-aware parallel agent scheduling with leases and recovery reports.
+
+The control-plane version should preserve Octopus' current advantage: local
+multi-provider orchestration with explicit safety gates. The new capability is
+visibility and durable learning, not a hosted service dependency.

--- a/scripts/helpers/audit-provider-contracts.sh
+++ b/scripts/helpers/audit-provider-contracts.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Audit provider contracts that tend to drift as provider CLIs/plugins change.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
+
+PASS=0
+FAIL=0
+
+pass() {
+    PASS=$((PASS + 1))
+    printf 'PASS %s\n' "$1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s\n' "$1"
+}
+
+contains() {
+    local file="$1" pattern="$2" label="$3"
+    if grep -Eq "$pattern" "$file" 2>/dev/null; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+not_contains() {
+    local file="$1" pattern="$2" label="$3"
+    if grep -Eq "$pattern" "$file" 2>/dev/null; then
+        fail "$label"
+    else
+        pass "$label"
+    fi
+}
+
+contains "${ROOT}/scripts/helpers/check-providers.sh" '^set -euo pipefail$' \
+    "check-providers uses strict mode"
+contains "${ROOT}/scripts/helpers/check-providers.sh" 'name:degraded' \
+    "provider status contract documents degraded"
+contains "${ROOT}/scripts/helpers/check-providers.sh" 'qwen_state="degraded"' \
+    "qwen binary-with-bad-auth fails closed in provider banner"
+contains "${ROOT}/scripts/helpers/check-providers.sh" 'octo_event_emit "provider\.status"' \
+    "provider banner can emit opt-in lifecycle events"
+
+contains "${ROOT}/scripts/lib/qwen.sh" 'oauth-unvalidated' \
+    "qwen OAuth without validator is a non-dispatchable state"
+contains "${ROOT}/scripts/lib/providers.sh" 'oauth-unvalidated' \
+    "provider detection preserves unvalidated qwen OAuth state"
+contains "${ROOT}/scripts/lib/providers.sh" 'configure Coding-Plan' \
+    "qwen setup guidance points at API key or Coding-Plan auth"
+not_contains "${ROOT}/scripts/lib/providers.sh" 'Qwen:.*free tier' \
+    "qwen setup guidance does not advertise the retired free tier"
+
+contains "${ROOT}/scripts/lib/provider-versions.sh" 'OCTO_GEMINI_MIN_VERSION="\$\{OCTO_GEMINI_MIN_VERSION:-0\.45\.0\}"' \
+    "gemini version floor is current and env-overridable"
+contains "${ROOT}/scripts/lib/provider-versions.sh" 'OCTO_QWEN_MIN_VERSION="\$\{OCTO_QWEN_MIN_VERSION:-0\.14\.0\}"' \
+    "qwen version floor is current and env-overridable"
+not_contains "${ROOT}/scripts/lib/auth.sh" 'grep -oE.*expiry_date' \
+    "OAuth expiry parsing avoids brittle regex fallback"
+
+if [[ -f "${ROOT}/scripts/lib/events.sh" ]] && bash -n "${ROOT}/scripts/lib/events.sh"; then
+    pass "event stream helper exists and has valid syntax"
+else
+    fail "event stream helper exists and has valid syntax"
+fi
+
+if bash -n "${ROOT}/scripts/helpers/check-providers.sh" "${ROOT}/scripts/helpers/audit-provider-contracts.sh"; then
+    pass "provider helper scripts have valid shell syntax"
+else
+    fail "provider helper scripts have valid shell syntax"
+fi
+
+printf 'SUMMARY pass=%s fail=%s\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/helpers/audit-provider-contracts.sh
+++ b/scripts/helpers/audit-provider-contracts.sh
@@ -68,7 +68,14 @@ else
     fail "event stream helper exists and has valid syntax"
 fi
 
-if bash -n "${ROOT}/scripts/helpers/check-providers.sh" "${ROOT}/scripts/helpers/audit-provider-contracts.sh"; then
+syntax_ok=1
+for script in \
+    "${ROOT}/scripts/helpers/check-providers.sh" \
+    "${ROOT}/scripts/helpers/audit-provider-contracts.sh"; do
+    bash -n "$script" || syntax_ok=0
+done
+
+if [[ "$syntax_ok" -eq 1 ]]; then
     pass "provider helper scripts have valid shell syntax"
 else
     fail "provider helper scripts have valid shell syntax"

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -23,6 +23,7 @@ source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/auth.sh" 2>/dev/null || true   # octo_oauth_token_valid (oco-dar)
 source "${SCRIPT_DIR}/../lib/qwen.sh" 2>/dev/null || true   # qwen_is_usable (oco-dar)
+source "${SCRIPT_DIR}/../lib/events.sh" 2>/dev/null || true  # opt-in JSONL lifecycle stream
 
 provider_status() {
     local provider="$1"
@@ -31,6 +32,9 @@ provider_status() {
         status="missing"
     fi
     printf "%s:%s\n" "$provider" "$status"
+    if declare -f octo_event_emit >/dev/null 2>&1; then
+        octo_event_emit "provider.status" provider="$provider" status="$status" source="check-providers" || true
+    fi
 }
 
 cursor_agent_status="missing"

--- a/scripts/lib/events.sh
+++ b/scripts/lib/events.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Claude Octopus event stream helpers.
+#
+# The event stream is opt-in. Set OCTO_EVENT_LOG to a JSONL file path, or to
+# "auto" to write ${WORKSPACE_DIR:-$PWD}/.octo/events.jsonl.
+# Normal command output is unchanged when OCTO_EVENT_LOG is unset.
+
+octo_event_log_path() {
+    case "${OCTO_EVENT_LOG:-}" in
+        "") return 1 ;;
+        auto) printf '%s\n' "${WORKSPACE_DIR:-$PWD}/.octo/events.jsonl" ;;
+        *) printf '%s\n' "$OCTO_EVENT_LOG" ;;
+    esac
+}
+
+octo_event_enabled() {
+    octo_event_log_path >/dev/null 2>&1
+}
+
+_octo_json_string() {
+    local value="$1"
+
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$value" <<'PY' 2>/dev/null && return 0
+import json
+import sys
+
+print(json.dumps(sys.argv[1]))
+PY
+    fi
+
+    if command -v jq >/dev/null 2>&1; then
+        jq -Rn --arg value "$value" '$value' 2>/dev/null && return 0
+    fi
+
+    value=${value//\\/\\\\}
+    value=${value//\"/\\\"}
+    value=${value//$'\n'/\\n}
+    value=${value//$'\r'/\\r}
+    value=${value//$'\t'/\\t}
+    printf '"%s"\n' "$value"
+}
+
+_octo_event_trim() {
+    local file="$1"
+    local max_lines="${OCTO_EVENT_MAX_LINES:-1000}"
+
+    [[ "$max_lines" =~ ^[0-9]+$ ]] || max_lines=1000
+    [[ "$max_lines" -gt 0 ]] || return 0
+    [[ -f "$file" ]] || return 0
+
+    local count
+    count=$(wc -l < "$file" 2>/dev/null | tr -d ' ')
+    [[ "$count" =~ ^[0-9]+$ ]] || return 0
+    [[ "$count" -le "$max_lines" ]] && return 0
+
+    local tmp="${file}.tmp.$$"
+    tail -n "$max_lines" "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
+# octo_event_emit EVENT [key=value ...]
+# Appends one JSON object to OCTO_EVENT_LOG. Attribute values are strings by
+# design; callers that need richer data can link records by run_id/session_id.
+octo_event_emit() {
+    local event="${1:-}"
+    shift || true
+
+    local log_file
+    log_file=$(octo_event_log_path 2>/dev/null) || return 0
+
+    [[ "$event" =~ ^[A-Za-z0-9_.:-]+$ ]] || return 2
+
+    local attrs="" sep=""
+    local pair key value
+    for pair in "$@"; do
+        key="${pair%%=*}"
+        value="${pair#*=}"
+        [[ "$pair" == *=* ]] || return 2
+        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_.:-]*$ ]] || return 2
+        attrs="${attrs}${sep}$(_octo_json_string "$key"):$(_octo_json_string "$value")"
+        sep=","
+    done
+
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date +%s)
+
+    local dir
+    dir="$(dirname "$log_file")"
+    mkdir -p "$dir" 2>/dev/null || return 1
+
+    printf '{"timestamp":%s,"event":%s,"source":%s,"pid":%s,"session_id":%s,"attributes":{%s}}\n' \
+        "$(_octo_json_string "$timestamp")" \
+        "$(_octo_json_string "$event")" \
+        "$(_octo_json_string "${OCTO_EVENT_SOURCE:-octopus}")" \
+        "$$" \
+        "$(_octo_json_string "${OCTOPUS_SESSION_ID:-}")" \
+        "$attrs" >> "$log_file" || return 1
+
+    _octo_event_trim "$log_file"
+}

--- a/scripts/lib/events.sh
+++ b/scripts/lib/events.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -eo pipefail
+
 # Claude Octopus event stream helpers.
 #
 # The event stream is opt-in. Set OCTO_EVENT_LOG to a JSONL file path, or to
@@ -33,12 +35,30 @@ PY
         jq -Rn --arg value "$value" '$value' 2>/dev/null && return 0
     fi
 
+    local out="" ch ord esc
+    local i
     value=${value//\\/\\\\}
     value=${value//\"/\\\"}
-    value=${value//$'\n'/\\n}
-    value=${value//$'\r'/\\r}
-    value=${value//$'\t'/\\t}
-    printf '"%s"\n' "$value"
+    for ((i = 0; i < ${#value}; i++)); do
+        ch="${value:i:1}"
+        case "$ch" in
+            $'\b') out="${out}\\b" ;;
+            $'\f') out="${out}\\f" ;;
+            $'\n') out="${out}\\n" ;;
+            $'\r') out="${out}\\r" ;;
+            $'\t') out="${out}\\t" ;;
+            *)
+                LC_ALL=C printf -v ord '%d' "'$ch"
+                if (( ord < 32 )); then
+                    printf -v esc '\\u%04x' "$ord"
+                    out="${out}${esc}"
+                else
+                    out="${out}${ch}"
+                fi
+                ;;
+        esac
+    done
+    printf '"%s"\n' "$out"
 }
 
 _octo_event_trim() {
@@ -55,7 +75,10 @@ _octo_event_trim() {
     [[ "$count" -le "$max_lines" ]] && return 0
 
     local tmp="${file}.tmp.$$"
-    tail -n "$max_lines" "$file" > "$tmp" && mv "$tmp" "$file"
+    tail -n "$max_lines" "$file" > "$tmp" && mv "$tmp" "$file" || {
+        rm -f "$tmp"
+        return 1
+    }
 }
 
 # octo_event_emit EVENT [key=value ...]

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -1055,6 +1055,7 @@ detect_providers() {
                 env:QWEN_API_KEY) qwen_auth="api-key" ;;
                 env:OPENAI_COMPAT) qwen_auth="openai-compatible" ;;
                 oauth)            qwen_auth="oauth" ;;
+                oauth-unvalidated) qwen_auth="oauth-unvalidated" ;;
                 oauth-expired)    qwen_auth="oauth-expired" ;;
                 config)           qwen_auth="config" ;;
                 *)                qwen_auth="none" ;;

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -12,6 +12,8 @@ if ! declare -f _is_cursor_agent_binary >/dev/null 2>&1; then
     source "${_providers_lib_dir}/cursor-agent.sh" 2>/dev/null || true
 fi
 source "${_providers_lib_dir}/provider-allowlist.sh" 2>/dev/null || true
+source "${_providers_lib_dir}/auth.sh" 2>/dev/null || true
+source "${_providers_lib_dir}/qwen.sh" 2>/dev/null || true
 
 # Version comparison utility
 version_compare() {
@@ -799,10 +801,11 @@ check_provider_health() {
                         return 1
                         ;;
                 esac
-            elif [[ ! -f "${HOME}/.qwen/oauth_creds.json" ]] && \
-                 [[ ! -f "${HOME}/.qwen/config.json" ]] && \
-                 [[ -z "${QWEN_API_KEY:-}" ]] && \
-                 ! [[ -n "${OPENAI_API_KEY:-}" && -n "${OPENAI_BASE_URL:-}" ]]; then
+            elif [[ -n "${QWEN_API_KEY:-}" ]] || \
+                 [[ -n "${OPENAI_API_KEY:-}" && -n "${OPENAI_BASE_URL:-}" ]] || \
+                 [[ -f "${HOME}/.qwen/config.json" ]]; then
+                :
+            else
                 echo "qwen: not authenticated (set QWEN_API_KEY or configure Coding-Plan)" >&2
                 return 1
             fi
@@ -1057,7 +1060,7 @@ detect_providers() {
                 *)                qwen_auth="none" ;;
             esac
         elif [[ -f "${HOME}/.qwen/oauth_creds.json" ]]; then
-            qwen_auth="oauth"
+            qwen_auth="oauth-unvalidated"
         elif [[ -f "${HOME}/.qwen/config.json" ]]; then
             qwen_auth="config"
         elif [[ -n "${QWEN_API_KEY:-}" ]]; then
@@ -1115,7 +1118,7 @@ detect_providers() {
         log WARN "  - OpenRouter: Set OPENROUTER_API_KEY environment variable"
         log WARN "  - Copilot: brew install copilot-cli (zero additional cost)"
         log WARN "  - Ollama: brew install ollama (free local LLM)"
-        log WARN "  - Qwen: npm i -g @qwen-code/qwen-code (free tier)"
+        log WARN "  - Qwen: npm i -g @qwen-code/qwen-code; set QWEN_API_KEY or configure Coding-Plan"
         log WARN "  - OpenCode: npm i -g opencode (multi-provider router)"
         echo "none:unavailable"
         return 1

--- a/tests/unit/test-octo-events.sh
+++ b/tests/unit/test-octo-events.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Octopus event stream helpers"
+
+# shellcheck disable=SC1091
+source "$PROJECT_ROOT/scripts/lib/events.sh"
+
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+test_no_log_when_disabled() {
+    test_case "octo_event_emit is a no-op when OCTO_EVENT_LOG is unset"
+    unset OCTO_EVENT_LOG
+    octo_event_emit "provider.status" provider=qwen status=degraded
+    if [[ ! -e "$FIXTURE/events.jsonl" ]]; then test_pass
+    else test_fail "event log was created while disabled"; fi
+}
+
+test_emit_jsonl_event() {
+    test_case "octo_event_emit writes JSONL with string attributes"
+    export OCTO_EVENT_LOG="$FIXTURE/events.jsonl"
+    export OCTO_EVENT_SOURCE="unit-test"
+    export OCTOPUS_SESSION_ID="session-1"
+    octo_event_emit "provider.status" provider=qwen status=degraded detail='quote " and slash \'
+
+    if [[ ! -s "$OCTO_EVENT_LOG" ]]; then
+        test_fail "event log was not written"
+        return
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$OCTO_EVENT_LOG" <<'PY' || { test_fail "event JSON did not parse"; return; }
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    row = json.loads(fh.readline())
+
+assert row["event"] == "provider.status"
+assert row["source"] == "unit-test"
+assert row["session_id"] == "session-1"
+assert row["attributes"]["provider"] == "qwen"
+assert row["attributes"]["status"] == "degraded"
+PY
+    else
+        grep -q '"event":"provider.status"' "$OCTO_EVENT_LOG" || { test_fail "event name missing"; return; }
+    fi
+    test_pass
+}
+
+test_auto_log_path() {
+    test_case "OCTO_EVENT_LOG=auto writes under WORKSPACE_DIR/.octo"
+    export WORKSPACE_DIR="$FIXTURE/workspace"
+    export OCTO_EVENT_LOG="auto"
+    octo_event_emit "octo.audit" result=pass
+    if [[ -s "$WORKSPACE_DIR/.octo/events.jsonl" ]]; then test_pass
+    else test_fail "auto event log was not written"; fi
+}
+
+test_trim_event_log() {
+    test_case "octo_event_emit trims to OCTO_EVENT_MAX_LINES"
+    export OCTO_EVENT_LOG="$FIXTURE/trim.jsonl"
+    export OCTO_EVENT_MAX_LINES=2
+    octo_event_emit "octo.test" n=1
+    octo_event_emit "octo.test" n=2
+    octo_event_emit "octo.test" n=3
+    local lines
+    lines="$(wc -l < "$OCTO_EVENT_LOG" | tr -d ' ')"
+    unset OCTO_EVENT_MAX_LINES
+    if [[ "$lines" == "2" ]]; then test_pass
+    else test_fail "expected 2 lines after trim, got $lines"; fi
+}
+
+test_invalid_event_rejected() {
+    test_case "octo_event_emit rejects invalid event names"
+    export OCTO_EVENT_LOG="$FIXTURE/invalid.jsonl"
+    if ! octo_event_emit "provider status" provider=qwen; then test_pass
+    else test_fail "invalid event name accepted"; fi
+}
+
+test_check_providers_event_hook() {
+    test_case "check-providers emits provider.status events when enabled"
+    export OCTO_EVENT_LOG="$FIXTURE/providers.jsonl"
+    bash "$PROJECT_ROOT/scripts/helpers/check-providers.sh" >/dev/null
+    if grep -q '"event":"provider.status"' "$OCTO_EVENT_LOG" && \
+       grep -q '"provider"' "$OCTO_EVENT_LOG"; then
+        test_pass
+    else
+        test_fail "provider.status event not found"
+    fi
+}
+
+test_no_log_when_disabled
+test_emit_jsonl_event
+test_auto_log_path
+test_trim_event_log
+test_invalid_event_rejected
+test_check_providers_event_hook
+
+test_summary

--- a/tests/unit/test-octo-events.sh
+++ b/tests/unit/test-octo-events.sh
@@ -17,8 +17,8 @@ test_no_log_when_disabled() {
     test_case "octo_event_emit is a no-op when OCTO_EVENT_LOG is unset"
     unset OCTO_EVENT_LOG
     octo_event_emit "provider.status" provider=qwen status=degraded
-    if [[ ! -e "$FIXTURE/events.jsonl" ]]; then test_pass
-    else test_fail "event log was created while disabled"; fi
+    if [[ -z "$(find "$FIXTURE" -mindepth 1 -print -quit)" ]]; then test_pass
+    else test_fail "event log created files while disabled"; fi
 }
 
 test_emit_jsonl_event() {

--- a/tests/unit/test-provider-contract-audit.sh
+++ b/tests/unit/test-provider-contract-audit.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Provider contract audit"
+
+AUDIT="$PROJECT_ROOT/scripts/helpers/audit-provider-contracts.sh"
+
+test_audit_script_syntax() {
+    test_case "audit-provider-contracts.sh has valid syntax"
+    if bash -n "$AUDIT"; then test_pass
+    else test_fail "syntax check failed"; fi
+}
+
+test_audit_passes_current_tree() {
+    test_case "provider contract audit passes current tree"
+    local output
+    if output="$(bash "$AUDIT" 2>&1)"; then
+        if printf '%s\n' "$output" | grep -q 'SUMMARY .*fail=0'; then test_pass
+        else test_fail "missing fail=0 summary: $output"; fi
+    else
+        test_fail "$output"
+    fi
+}
+
+test_audit_guards_qwen_free_tier_guidance() {
+    test_case "audit guards against stale qwen free-tier setup guidance"
+    if grep -q 'Qwen:.*free tier' "$AUDIT"; then test_pass
+    else test_fail "audit does not check stale qwen guidance"; fi
+}
+
+test_audit_guards_event_stream_contract() {
+    test_case "audit guards provider.status event hook"
+    if grep -q 'provider\\.status' "$AUDIT"; then test_pass
+    else test_fail "audit does not check provider.status hook"; fi
+}
+
+test_audit_script_syntax
+test_audit_passes_current_tree
+test_audit_guards_qwen_free_tier_guidance
+test_audit_guards_event_stream_contract
+
+test_summary


### PR DESCRIPTION
## Summary
- add a provider contract audit helper for drift-prone provider auth/version/setup guidance
- add an opt-in JSONL event emitter and provider.status events from check-providers.sh
- document the June 2026 Claude Code plugin research and next minor/major Octopus direction
- tighten qwen detect_providers fallback so unvalidated OAuth is not treated as dispatchable guidance

## Research inputs
- Anthropic Claude Code plugin docs: https://code.claude.com/docs/en/discover-plugins
- Anthropic plugins reference: https://code.claude.com/docs/en/plugins-reference
- Official plugins marketplace: https://github.com/anthropics/claude-plugins-official
- Cross-harness agent catalog: https://github.com/wshobson/agents
- HUD/observability references: https://github.com/jarrodwatts/claude-hud, https://github.com/disler/claude-code-hooks-multi-agent-observability, https://github.com/patoles/agent-flow
- Semantic context/spec-loop references: https://github.com/zilliztech/claude-context, https://github.com/JuliusBrussee/cavekit

## Validation
- bash scripts/helpers/audit-provider-contracts.sh
- bash tests/unit/test-octo-events.sh
- bash tests/unit/test-provider-contract-audit.sh
- bash tests/unit/test-provider-auth-validity.sh
- bash tests/test-fleet-diversity.sh
- git diff --check upstream/main...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider contract auditing to validate provider configurations
  * Opt-in JSONL event logging for provider.status observability

* **Bug Fixes**
  * Improved Qwen OAuth handling to surface an unvalidated state and remove retired free‑tier guidance

* **Documentation**
  * Updated command reference with audit and event‑stream modes
  * Added June 2026 roadmap

* **Tests**
  * Added unit tests for event logging and provider audit behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->