### PR TITLE
release: v9.44.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.44.0"
+    "version": "9.44.1"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.44.0 - Fix cursor-agent smoke test in untrusted workspaces. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.44.0",
+      "description": "v9.44.1 - Fix Gemini env/version handling and qwen auth gating. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.44.1",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.44.0",
-  "description": "v9.44.0 \u2014 Patch release for cursor-agent smoke checks in untrusted workspaces. Run /octo:setup.",
+  "version": "9.44.1",
+  "description": "v9.44.1 \u2014 Patch release for Gemini environment/version detection and qwen auth gating. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.44.0",
+  "version": "9.44.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.44.0",
+  "version": "9.44.1",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.44.0"
+    "version": "9.44.1"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.44.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 49 commands, 54 skills. Run /octo:setup after install.",
-      "version": "9.44.0",
+      "description": "v9.44.1 - Fix Gemini env/version handling and qwen auth gating. 32 personas, 49 commands, 54 skills. Run /octo:setup after install.",
+      "version": "9.44.1",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.44.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.0. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.44.1",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [9.44.1] - 2026-06-14
+
 ### Added
 
 - `scripts/helpers/audit-provider-contracts.sh` release-gate audit for provider drift: provider states must stay `available|missing|degraded`, qwen auth must fail closed when OAuth cannot be validated, stale free-tier setup guidance must not reappear, and provider version floors must remain env-overridable.
@@ -10,7 +12,10 @@
 
 ### Fixed
 
+- Pass `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, and `CLOUDSDK_CORE_PROJECT` through Gemini environment isolation so Vertex-backed Gemini auth keeps its project context (#472).
+- Lower the Gemini CLI version floor to `0.45.0` and honor `OCTO_*_MIN_VERSION` overrides for provider checks (#475).
 - `detect_providers` no longer treats a bare qwen OAuth file as dispatchable when the qwen auth validator is unavailable; it reports `oauth-unvalidated` instead. Setup guidance now points users at `QWEN_API_KEY` or Coding-Plan auth rather than the retired free tier.
+- `scripts/lib/events.sh` no longer sets shell options at the top, so sourcing it no longer leaks `set -e`/`pipefail` into the calling shell (#479).
 
 ## [9.44.0] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to eight of them on every
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.44.0-blue" alt="Version 9.44.0">
+  <img src="https://img.shields.io/badge/Version-9.44.1-blue" alt="Version 9.44.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.44.0",
+  "version": "9.44.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Release v9.44.1

Patch release for merged fixes after v9.44.0.

### Included fixes
- #472 pass GOOGLE_CLOUD_PROJECT, GCLOUD_PROJECT, and CLOUDSDK_CORE_PROJECT through Gemini env isolation
- #475 lower Gemini CLI version floor to 0.45.0 and honor OCTO_*_MIN_VERSION overrides
- #476 harden qwen auth gating so bare OAuth files without validation report degraded instead of dispatchable

### Other included changes
- #477 provider contract audit and event stream groundwork

### Verification
- jq empty package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json .factory-plugin/marketplace.json
- bash tests/unit/test-docs-sync.sh
- make test-unit (first run: 129/130, rerun: 130/130 passed)
- make test-integration (7/7 passed)

No tag published; tag only after release PR merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini environment isolation by preserving Google Cloud project context variables.
  * Lowered the Gemini CLI minimum version floor while still honoring `OCTO_*_MIN_VERSION` overrides.
  * Updated provider detection to report unvalidated Qwen OAuth instead of dispatching it when validation isn’t available.
  * Prevented event-script shell option settings from leaking into shells that source it.
* **Documentation**
  * Updated the README version badge to 9.44.1.
* **Chores**
  * Released version **9.44.1** across all plugin and package manifests/configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->