### PR TITLE
fix: stop events.sh leaking set -e into sourcers

### DIFF
--- a/scripts/helpers/audit-provider-contracts.sh
+++ b/scripts/helpers/audit-provider-contracts.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 # Audit provider contracts that tend to drift as provider CLIs/plugins change.
+# NOTE: this is a source-text drift tripwire, not a behavioral test. It greps for
+# literal lines, so reformatting an audited line fails it even when behavior is
+# unchanged, and a behavior change that keeps the text passes. Treat green as
+# "the watched lines are intact", not "behavior verified".
 
 set -euo pipefail
 

--- a/scripts/lib/events.sh
+++ b/scripts/lib/events.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -eo pipefail
+# Source-safe: no shell options set at top. Setting `set -e`/`pipefail` here would
+# leak errexit into every sourcer (this lib is sourced, not executed). Helpers
+# guard their own return codes instead.
 
 # Claude Octopus event stream helpers.
 #


### PR DESCRIPTION
## What

`events.sh` is a source-safe lib (sourced, not executed) but had `set -eo pipefail` at the top, leaking errexit into every caller's shell. Removed it; the emit helpers already guard their own return codes.

Also documents `audit-provider-contracts.sh` as a source-text drift tripwire, not a behavioral test.

## Why

Only lib in `scripts/lib/` setting shell options at top. Harmless today (sole sourcer check-providers.sh already runs `set -euo`), but a silent footgun for any future sourcer of `octo_event_emit`.

## Testing

- audit-provider-contracts.sh -> 13/13
- test-octo-events.sh -> 6/6
- bash -n clean

## Follow-up

oco-7dk (P3): _octo_event_trim TOCTOU race under concurrent dispatch. Separate fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified audit methodology documentation to explain detection scope and behavior.

* **Chores**
  * Refined script initialization behavior to prevent shell configuration propagation to dependent processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->