### PR TITLE
feat: OCTOPUS_CLAUDE_BIN override + nested-session env strip for claude provider

### DIFF
--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -18,6 +18,10 @@ get_agent_command() {
     local phase="${2:-}"
     local role="${3:-}"
     local model=""
+    # Allow swapping the claude binary (e.g. clarp = subscription-billed drop-in
+    # for `claude -p`, instead of metered API). Default unchanged. May include
+    # args (word-split downstream by read -ra), e.g. "clarp --strict-mcp-config".
+    local _claude_bin="${OCTOPUS_CLAUDE_BIN:-claude}"
 
     # Configurable sandbox mode (v7.13.1 - Issue #9)
     # Priority: OCTOPUS_CODEX_SANDBOX env var > default (workspace-write)
@@ -95,8 +99,8 @@ get_agent_command() {
             echo "${gemini_env} ${gemini_exec} ${model} ${gemini_flags}"
             ;;
         codex-review) echo "codex exec --skip-git-repo-check review" ;; # Code review mode (no sandbox support)
-        claude) echo "claude${_BARE_OPT} --print ${claude_perm}" ;;                         # Claude Sonnet 4.6
-        claude-sonnet) echo "claude${_BARE_OPT} --print --model sonnet ${claude_perm}" ;;        # Claude Sonnet explicit
+        claude) echo "${_claude_bin}${_BARE_OPT} --print ${claude_perm}" ;;                         # Claude Sonnet 4.6
+        claude-sonnet) echo "${_claude_bin}${_BARE_OPT} --print --model sonnet ${claude_perm}" ;;        # Claude Sonnet explicit
         claude-opus)
             # v9.42: Opus alias — resolves to 4.8 on Claude Code v2.1.154+,
             # then 4.7/4.6 on older hosts or enterprise backends.
@@ -114,19 +118,19 @@ get_agent_command() {
                 opus_effort="$OCTOPUS_EFFORT_OVERRIDE"
             fi
             if [[ "${SUPPORTS_EFFORT_COMMAND:-false}" == "true" || "${SUPPORTS_XHIGH_EFFORT:-false}" == "true" ]]; then
-                echo "env CLAUDE_CODE_EFFORT_LEVEL=${opus_effort} claude${_BARE_OPT} --print --model opus ${claude_perm}"
+                echo "env CLAUDE_CODE_EFFORT_LEVEL=${opus_effort} ${_claude_bin}${_BARE_OPT} --print --model opus ${claude_perm}"
             else
-                echo "claude${_BARE_OPT} --print --model opus ${claude_perm}"
+                echo "${_claude_bin}${_BARE_OPT} --print --model opus ${claude_perm}"
             fi
             ;;
         claude-opus-fast)
             if [[ "${SUPPORTS_OPUS_4_8:-false}" == "true" && "${OCTOPUS_OPUS_MODEL:-}" != "claude-opus-4.6" ]]; then
-                echo "claude${_BARE_OPT} --print --model claude-opus-4-8 --fast ${claude_perm}"
+                echo "${_claude_bin}${_BARE_OPT} --print --model claude-opus-4-8 --fast ${claude_perm}"
             else
-                echo "claude${_BARE_OPT} --print --model claude-opus-4-6 --fast ${claude_perm}"
+                echo "${_claude_bin}${_BARE_OPT} --print --model claude-opus-4-6 --fast ${claude_perm}"
             fi
             ;;
-        claude-opus-legacy) echo "claude${_BARE_OPT} --print --model claude-opus-4-6 ${claude_perm}" ;; # v9.23: explicit 4.6 opt-in
+        claude-opus-legacy) echo "${_claude_bin}${_BARE_OPT} --print --model claude-opus-4-6 ${claude_perm}" ;; # v9.23: explicit 4.6 opt-in
         openrouter) echo "openrouter_execute" ;;                 # OpenRouter API (v4.8)
         openrouter-glm5) echo "openrouter_execute_model z-ai/glm-5" ;;           # v8.11.0: GLM-5 via OpenRouter
         openrouter-kimi) echo "openrouter_execute_model moonshotai/kimi-k2.5" ;; # v8.11.0: Kimi K2.5 via OpenRouter

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -83,8 +83,18 @@ build_provider_env() {
             fi
             return 0
             ;;
+        claude*)
+            # A headless claude (or clarp wrapping it) must NOT inherit the parent
+            # Claude Code session markers, or the inner `claude` hangs thinking it
+            # is a nested child (council/agent-sync seat stalls at 0 bytes until
+            # timeout). Strip them; keep the rest of the env (PATH/HOME/auth).
+            PROVIDER_ENV_ARRAY=(env -u CLAUDECODE -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_SESSION_ID -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_EXECPATH)
+            if [[ ${#_trace_env[@]} -gt 0 ]]; then
+                PROVIDER_ENV_ARRAY+=("${_trace_env[@]}")
+            fi
+            ;;
         *)
-            # Claude and other providers: no isolation needed
+            # Other providers: no isolation needed
             return 0
             ;;
     esac


### PR DESCRIPTION
# PR draft — `OCTOPUS_CLAUDE_BIN`: allow swapping the Claude provider binary (enables clarp / subscription-billed headless Claude)

**Repo:** `nyldn/plugins` (octo plugin) · **Suggested branch:** `feat/octopus-claude-bin-override`
**Plugin version observed:** 9.44.0

---

## Motivation

The `claude` provider is hard-coded to invoke the `claude` binary (`scripts/lib/dispatch.sh`).
Two problems for anyone running Octopus **from inside a Claude Code session**:

1. **No way to redirect the binary.** Users on a Claude *subscription* (Max/Pro) who want
   headless Claude seats billed to the subscription rather than metered API have no hook to
   point the provider at a wrapper such as [`clarp`](https://github.com/dn00/clarp) (a drop-in
   for `claude -p` that runs the real `claude` in a PTY on the subscription). Every other
   provider is effectively swappable; `claude` is not.

2. **Nested-session hang.** A headless `claude` (or any wrapper that spawns it) launched as a
   subprocess of an active Claude Code session inherits `CLAUDECODE` / `CLAUDE_CODE_*` markers.
   The inner `claude` then detects itself as a nested child and **hangs indefinitely** — the
   council/`agent-sync` seat sits at 0 bytes until the timeout. `build_provider_env()` isolates
   `codex`/`gemini` envs but leaves `claude` to inherit everything.

## Changes

### 1. `scripts/lib/dispatch.sh` — `OCTOPUS_CLAUDE_BIN` override

```diff
 get_agent_command() {
     local agent_type="$1"
     local phase="${2:-}"
     local role="${3:-}"
     local model=""
+    # Allow swapping the claude binary (e.g. clarp = subscription-billed drop-in
+    # for `claude -p`, instead of metered API). Default unchanged.
+    local _claude_bin="${OCTOPUS_CLAUDE_BIN:-claude}"
```

…and in every `claude*` branch, `claude${_BARE_OPT}` → `${_claude_bin}${_BARE_OPT}`
(`claude`, `claude-sonnet`, `claude-opus`, `claude-opus-fast`, `claude-opus-legacy`).
Default `OCTOPUS_CLAUDE_BIN=claude` → **zero behaviour change** when unset.

`OCTOPUS_CLAUDE_BIN` may include args (it is word-split by the existing `read -ra`), e.g.
`OCTOPUS_CLAUDE_BIN="clarp --strict-mcp-config"`.

### 2. `scripts/lib/provider-routing.sh` — strip nested-session env for the claude provider

```diff
             ;;
+        claude*)
+            # A headless claude (or clarp wrapping it) must NOT inherit the parent
+            # Claude Code session markers, or the inner `claude` hangs thinking it is
+            # a nested child. Strip them; keep the rest of the env (PATH/HOME/auth).
+            PROVIDER_ENV_ARRAY=(env -u CLAUDECODE -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_SESSION_ID -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_EXECPATH)
+            if [[ ${#_trace_env[@]} -gt 0 ]]; then
+                PROVIDER_ENV_ARRAY+=("${_trace_env[@]}")
+            fi
+            ;;
         *)
-            # Claude and other providers: no isolation needed
+            # Other providers: no isolation needed
             return 0
             ;;
     esac
```

This is safe for plain `claude --print` too (it does not need the nested markers), and is the
fix that makes any headless-claude seat work from inside Claude Code.

## Testing

- `OCTOPUS_CLAUDE_BIN` unset → identical command strings (regression-free).
- `OCTOPUS_CLAUDE_BIN="clarp --strict-mcp-config"` + a 2-seat council (claude chair + codex):
  the clarp claude seat produced a full response and the synthesis completed — previously the
  claude seat hung at 0 bytes.

## Docs

Add to the providers/config reference:

> `OCTOPUS_CLAUDE_BIN` — override the binary used for `claude` seats (default `claude`). Set to
> `clarp --strict-mcp-config` to bill headless Claude to a Claude Code subscription via
> [clarp](https://github.com/dn00/clarp). Headless/wrapped Claude requires the nested-session
> env strip added in `provider-routing.sh`.

---

## Appendix — four independent fresh-install bugs (separate PR(s) recommended)

Found while bringing 9.44.0 up on Fedora; each is a one-liner and unrelated to the feature above:

1. **`scripts/helpers/check-ollama-models.sh:16`** — resolves `OCTO_ROOT` via
   `git -C "$(pwd)" rev-parse --show-toplevel`, i.e. the **CWD's** repo. Run from inside any
   other git repo it points there, can't find `provider-versions.sh`, and exits 1. Fix: derive
   from the script's own location — `$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)`.

2. **`scripts/lib/doctor.sh:177`** — `stale_count=$(bash "$_check" --count-stale 2>/dev/null)`
   is unguarded; under `set -eo pipefail` the helper's nonzero exit (see #1) aborts the **entire**
   `doctor` run before any report prints. Fix: `… || echo "0"` (matches the sanitize on the next
   line).

3. **`scripts/lib/agent-sync.sh`** — temp files `${RESULTS_DIR}/.tmp-agent-*` are written without
   ensuring `$RESULTS_DIR` exists. `debate.sh`/`research.sh`/`spawn.sh` `mkdir -p` it; the
   **council** path does not, so every agent dies exit-1 ("No such file or directory") and no
   report is produced. Fix: `mkdir -p "$RESULTS_DIR" 2>/dev/null || true` before the temp-file init.

4. **Self-referential symlink** at `~/.claude-octopus/plugin` (→ itself) produced by the
   skill-doctor resolver when the symlink pre-exists — "Too many levels of symbolic links".
   Worth a guard in the resolver that refuses to `ln -s` a path onto itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the Claude CLI executable via environment variable, allowing selection of different Claude model variants.

* **Bug Fixes**
  * Improved Claude provider environment isolation to prevent session conflicts by properly isolating session-specific variables while maintaining essential system, authentication, and tracing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->