### PR TITLE
fix: four Linux fresh-install bugs from #481

### DIFF
--- a/.claude/skills/skill-doctor/SKILL.md
+++ b/.claude/skills/skill-doctor/SKILL.md
@@ -73,7 +73,12 @@ if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" 
   exit 1
 fi
 mkdir -p "${HOME}/.claude-octopus"
-ln -sfn "$OCTO_PLUGIN_ROOT" "${HOME}/.claude-octopus/plugin" 2>/dev/null || true
+_octo_stable="${HOME}/.claude-octopus/plugin"
+if [[ ! -L "$_octo_stable" ]] || [[ "$(cd "$OCTO_PLUGIN_ROOT" 2>/dev/null && pwd -P)" != "$(cd "$_octo_stable" 2>/dev/null && pwd -P)" ]]; then
+  [[ -L "$_octo_stable" || -f "$_octo_stable" ]] && rm -f "$_octo_stable" 2>/dev/null || true
+  ln -s "$OCTO_PLUGIN_ROOT" "$_octo_stable" 2>/dev/null || true
+fi
+unset _octo_stable
 export OCTO_PLUGIN_ROOT
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor
 ```

--- a/.cursor-plugin/commands/octo-doctor.md
+++ b/.cursor-plugin/commands/octo-doctor.md
@@ -38,7 +38,12 @@ if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" 
   exit 1
 fi
 mkdir -p "${HOME}/.claude-octopus"
-ln -sfn "$OCTO_PLUGIN_ROOT" "${HOME}/.claude-octopus/plugin" 2>/dev/null || true
+_octo_stable="${HOME}/.claude-octopus/plugin"
+if [[ ! -L "$_octo_stable" ]] || [[ "$(cd "$OCTO_PLUGIN_ROOT" 2>/dev/null && pwd -P)" != "$(cd "$_octo_stable" 2>/dev/null && pwd -P)" ]]; then
+  [[ -L "$_octo_stable" || -f "$_octo_stable" ]] && rm -f "$_octo_stable" 2>/dev/null || true
+  ln -s "$OCTO_PLUGIN_ROOT" "$_octo_stable" 2>/dev/null || true
+fi
+unset _octo_stable
 export OCTO_PLUGIN_ROOT
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --verbose
 ```

--- a/scripts/helpers/check-ollama-models.sh
+++ b/scripts/helpers/check-ollama-models.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 #   OCTO_OLLAMA_API_URL   override Ollama endpoint (default: http://localhost:11434)
 #   OCTO_OLLAMA_STALE_DAYS override staleness threshold (default: 30)
 
-OCTO_ROOT="${OCTO_ROOT:-$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || echo "${HOME}/.claude-octopus/plugin")}"
+OCTO_ROOT="${OCTO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 OCTO_OLLAMA_API_URL="${OCTO_OLLAMA_API_URL:-http://localhost:11434}"
 
 # shellcheck source=scripts/lib/provider-versions.sh

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -253,6 +253,7 @@ ${provider_ctx}"
     local _dispatch_pid=""
 
     # Always init temp files so readers never fail on missing file.
+    mkdir -p "${RESULTS_DIR}" 2>/dev/null || true
     > "$temp_err"
     > "$temp_out"
 

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -174,7 +174,7 @@ doctor_check_providers() {
             stale_count=0
             local _check="${_octo_root}/scripts/helpers/check-ollama-models.sh"
             if [[ -r "$_check" ]]; then
-                stale_count=$(bash "$_check" --count-stale 2>/dev/null)
+                stale_count=$(bash "$_check" --count-stale 2>/dev/null || echo "0")
                 stale_count=$(printf '%s' "$stale_count" | grep -oE '^[0-9]+$' || echo "0")
                 stale_count="${stale_count:-0}"
             fi

--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -64,7 +64,12 @@ if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" 
   exit 1
 fi
 mkdir -p "${HOME}/.claude-octopus"
-ln -sfn "$OCTO_PLUGIN_ROOT" "${HOME}/.claude-octopus/plugin" 2>/dev/null || true
+_octo_stable="${HOME}/.claude-octopus/plugin"
+if [[ ! -L "$_octo_stable" ]] || [[ "$(cd "$OCTO_PLUGIN_ROOT" 2>/dev/null && pwd -P)" != "$(cd "$_octo_stable" 2>/dev/null && pwd -P)" ]]; then
+  [[ -L "$_octo_stable" || -f "$_octo_stable" ]] && rm -f "$_octo_stable" 2>/dev/null || true
+  ln -s "$OCTO_PLUGIN_ROOT" "$_octo_stable" 2>/dev/null || true
+fi
+unset _octo_stable
 export OCTO_PLUGIN_ROOT
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor
 ```


### PR DESCRIPTION
Fixes all four bugs reported in #481 by L3ulll on Fedora / 9.44.0.

## Root causes and fixes

**1. `scripts/helpers/check-ollama-models.sh:16` — OCTO_ROOT resolves CWD's git repo**

`git -C "$(pwd)" rev-parse --show-toplevel` looks up the *caller's* working directory. Run from inside any other git repo it pointed there, failed to find `provider-versions.sh`, and exited 1.

Fix: derive root from the script's own location via `BASH_SOURCE[0]`.

```diff
-OCTO_ROOT="${OCTO_ROOT:-$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || echo "${HOME}/.claude-octopus/plugin")}"
+OCTO_ROOT="${OCTO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
```

**2. `scripts/lib/doctor.sh:177` — stale_count unguarded under `set -eo pipefail`**

`stale_count=$(bash "$_check" --count-stale 2>/dev/null)` ran the helper that now exits 1 (bug #1), so the command substitution propagated that nonzero exit and aborted the entire `doctor` run before any report printed.

Fix: `|| echo "0"` (same pattern as the sanitize expression on the next line).

**3. `scripts/lib/agent-sync.sh` — no `mkdir -p` for `$RESULTS_DIR` in council path**

`debate.sh`, `research.sh`, and `spawn.sh` all call `mkdir -p "$RESULTS_DIR"` before their dispatch loops. The council dispatch path skips this, so every agent dies with "No such file or directory" on the `> "$temp_err"` / `> "$temp_out"` init and produces no report.

Fix: one `mkdir -p "${RESULTS_DIR}" 2>/dev/null || true` before the temp-file init block in `run_agent_sync`.

**4. Self-referential symlink in skill-doctor resolver**

`ln -sfn "$OCTO_PLUGIN_ROOT" "${HOME}/.claude-octopus/plugin"` was unconditional. When `$OCTO_PLUGIN_ROOT` resolved to the symlink path itself (e.g. `CLAUDE_PLUGIN_ROOT` set to `~/.claude-octopus/plugin`), it created a symlink pointing at itself → "Too many levels of symbolic links".

Fix: apply the same guard already present in `octo_ensure_stable_plugin_root` (plugin-root.sh lines 98–105) to the inline resolver blocks in `skills/skill-doctor/SKILL.md`, `.claude/skills/skill-doctor/SKILL.md`, and `.cursor-plugin/commands/octo-doctor.md`.

## Tests

- `bash -n` on all three shell scripts: clean
- Fixes are minimal one-liners / small guards; no logic changes beyond the specific failure mode

closes #481

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpyoAUTHPVQRSpDaV9vtDh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated setup instructions to improve reliability of plugin symlink management during initialization.

* **Bug Fixes**
  * Enhanced Ollama diagnostics to gracefully handle detection failures and continue health checks.
  * Fixed results directory initialization to prevent sync operation failures.
  * Improved repository root path detection for better script reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->