### PR TITLE
feat: gate releases on provider contract audit

### DIFF
--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -143,6 +143,27 @@ fi
 echo ""
 
 # ============================================================================
+# 2b. PROVIDER CONTRACT AUDIT (release gate for provider drift)
+# ============================================================================
+echo "🔌 Running provider contract audit..."
+
+AUDIT_SCRIPT="$SCRIPT_DIR/helpers/audit-provider-contracts.sh"
+if [[ -x "$AUDIT_SCRIPT" ]]; then
+    if AUDIT_OUTPUT=$("$AUDIT_SCRIPT" 2>&1); then
+        echo -e "  ${GREEN}✓ $(echo "$AUDIT_OUTPUT" | grep '^SUMMARY' || echo 'provider contract audit passed')${NC}"
+    else
+        echo -e "  ${RED}ERROR: provider contract audit failed (provider auth/version/setup drift)${NC}"
+        echo "$AUDIT_OUTPUT" | grep '^FAIL' | sed 's/^/    /'
+        ((errors++)) || true
+    fi
+else
+    echo -e "  ${RED}ERROR: audit-provider-contracts.sh missing or not executable — provider contract is ungated${NC}"
+    ((errors++)) || true
+fi
+
+echo ""
+
+# ============================================================================
 # 3. CLAUDE PLUGIN VALIDATION
 # ============================================================================
 echo "🧪 Checking Claude plugin validation..."


### PR DESCRIPTION
## What

Wires `scripts/helpers/audit-provider-contracts.sh` into `validate-release.sh` as a release gate (new section 2b). Provider auth/version/setup drift now fails the release.

## Why

The audit shipped in #477 but **no release or CI path ever called it**, so the contract it defines (qwen fail-closed, version floors env-overridable, no retired-free-tier guidance, strict mode) was unenforced. A missing/non-executable audit script is now a hard error, not a silent skip.

This implements the Next-Minor item in `docs/roadmaps/2026-06-13-next-minor-major.md`.

## Testing

- `bash -n scripts/validate-release.sh` clean
- gate block run against current tree: `SUMMARY pass=13 fail=0` → PASS

## Follow-up

Roadmap also calls for including audit output in PR proof packets for provider-touching changes — separate CI work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added provider contract validation to the release process. The audit checks contract compliance before deployment and blocks releases that fail validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->