### PR TITLE
fix: close events.sh trim TOCTOU race (oco-7dk)

### DIFF
--- a/scripts/lib/events.sh
+++ b/scripts/lib/events.sh
@@ -63,6 +63,24 @@ PY
     printf '"%s"\n' "$out"
 }
 
+# Portable best-effort exclusive lock. flock is Linux-only; mkdir is atomic on
+# every POSIX filesystem. Bounded spin (~1s) so a dead lock holder degrades to a
+# lockless write rather than hanging the caller. Returns 0 if acquired, 1 if not.
+_octo_event_lock() {
+    local lockdir="$1.lock"
+    local tries=0
+    while ! mkdir "$lockdir" 2>/dev/null; do
+        tries=$((tries + 1))
+        [[ "$tries" -ge 50 ]] && return 1
+        sleep 0.02 2>/dev/null || return 1
+    done
+    return 0
+}
+
+_octo_event_unlock() {
+    rmdir "$1.lock" 2>/dev/null || true
+}
+
 _octo_event_trim() {
     local file="$1"
     local max_lines="${OCTO_EVENT_MAX_LINES:-1000}"
@@ -113,13 +131,27 @@ octo_event_emit() {
     dir="$(dirname "$log_file")"
     mkdir -p "$dir" 2>/dev/null || return 1
 
-    printf '{"timestamp":%s,"event":%s,"source":%s,"pid":%s,"session_id":%s,"attributes":{%s}}\n' \
+    local record
+    printf -v record '{"timestamp":%s,"event":%s,"source":%s,"pid":%s,"session_id":%s,"attributes":{%s}}\n' \
         "$(_octo_json_string "$timestamp")" \
         "$(_octo_json_string "$event")" \
         "$(_octo_json_string "${OCTO_EVENT_SOURCE:-octopus}")" \
         "$$" \
         "$(_octo_json_string "${OCTOPUS_SESSION_ID:-}")" \
-        "$attrs" >> "$log_file" || return 1
+        "$attrs"
 
-    _octo_event_trim "$log_file"
+    # Serialize append+trim under one lock so a concurrent emit can never have
+    # its just-appended line clobbered by another emit's trim (mv). If the lock
+    # can't be acquired (~1s spin), fall back to a lockless write — same
+    # best-effort behavior as before, and it never blocks the caller.
+    if _octo_event_lock "$log_file"; then
+        { printf '%s' "$record" >> "$log_file" && _octo_event_trim "$log_file"; } || {
+            _octo_event_unlock "$log_file"
+            return 1
+        }
+        _octo_event_unlock "$log_file"
+    else
+        printf '%s' "$record" >> "$log_file" || return 1
+        _octo_event_trim "$log_file"
+    fi
 }

--- a/tests/unit/test-octo-events.sh
+++ b/tests/unit/test-octo-events.sh
@@ -95,11 +95,49 @@ test_check_providers_event_hook() {
     fi
 }
 
+test_concurrent_emit_no_clobber() {
+    test_case "concurrent emits never tear lines or get clobbered by trim (oco-7dk)"
+    export OCTO_EVENT_LOG="$FIXTURE/concurrent.jsonl"
+    export OCTO_EVENT_MAX_LINES=50
+    : > "$OCTO_EVENT_LOG"
+    local p
+    for p in $(seq 1 12); do
+        ( for i in $(seq 1 60); do octo_event_emit "stress.test" proc="$p" seq="$i"; done ) &
+    done
+    wait
+    unset OCTO_EVENT_MAX_LINES
+
+    local lines
+    lines="$(wc -l < "$OCTO_EVENT_LOG" | tr -d ' ')"
+    if [[ "$lines" -gt 50 ]]; then
+        test_fail "trim under concurrency left $lines lines (> 50 cap)"
+        return
+    fi
+
+    # Every surviving line must be a complete, valid record — a torn line proves
+    # an append was clobbered mid-write by a concurrent trim.
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$OCTO_EVENT_LOG" <<'PY' || { test_fail "found torn/invalid JSON line under concurrency"; return; }
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    for line in fh:
+        if line.strip():
+            json.loads(line)
+PY
+    else
+        local bad
+        bad="$(grep -cvE '^\{.*\}$' "$OCTO_EVENT_LOG" || true)"
+        [[ "$bad" == "0" ]] || { test_fail "$bad torn lines under concurrency"; return; }
+    fi
+    test_pass
+}
+
 test_no_log_when_disabled
 test_emit_jsonl_event
 test_auto_log_path
 test_trim_event_log
 test_invalid_event_rejected
 test_check_providers_event_hook
+test_concurrent_emit_no_clobber
 
 test_summary


### PR DESCRIPTION
## What

`_octo_event_trim` read line count → `tail -n` → `mv`, which is not atomic against concurrent `>>` appends. Under parallel provider dispatch (octopus's core use case), an appended event could be clobbered by another emit's trim `mv`.

Fix: serialize append+trim under a portable `mkdir`-based lock (flock is Linux-only) with a bounded ~1s spin that degrades to a lockless write rather than hanging the caller. Never worse than today's behavior; correct when the lock is honored.

## Testing

- New 12-process concurrency regression test: asserts no torn/invalid JSON lines and the trim cap holds. Was reproducible before the fix.
- test-octo-events.sh → 7/7
- audit-provider-contracts.sh → 13/13

Closes oco-7dk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event logging reliability by preventing interference from concurrent event emissions and ensuring data integrity
  
* **Tests**
  * Added new test validating event system behavior and JSON integrity under concurrent access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->