### PR TITLE
feat: emit dispatch lifecycle events from run_with_timeout

### DIFF
--- a/docs/roadmaps/2026-06-13-next-minor-major.md
+++ b/docs/roadmaps/2026-06-13-next-minor-major.md
@@ -82,6 +82,14 @@ Ship the provider contract audit as part of the release gate:
 - include the audit output in proof packets for PRs that touch provider auth,
   versions, docs, or setup help.
 
+### Major Groundwork: Dispatch Lifecycle Events
+
+`run_with_timeout` (the universal provider-execution chokepoint) now emits
+opt-in `dispatch.start`, `dispatch.end` (with exit code and outcome), and
+`dispatch.timeout` events when `OCTO_EVENT_LOG` is set. Every provider funnels
+through this path, so the event stream now carries real dispatch lifecycle
+signal, not just `provider.status`. No behavior change when the stream is off.
+
 ## Next Major
 
 Build an Octopus control plane around the event stream:

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -4,6 +4,12 @@
 # Extracted from orchestrate.sh (v8.19.0 heartbeat + v7.16.0 timeout)
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# Opt-in lifecycle event stream — no-op unless OCTO_EVENT_LOG is set. Sourced
+# guarded so heartbeat stays usable even if events.sh is absent.
+_octo_heartbeat_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=/dev/null
+source "${_octo_heartbeat_lib_dir}/events.sh" 2>/dev/null || true
+
 start_heartbeat_monitor() {
     local pid="$1"
     local task_id="$2"
@@ -134,6 +140,11 @@ run_with_timeout() {
     shift
 
     local exit_code
+    local _octo_cmd_label="${1:-unknown}"
+
+    if declare -f octo_event_emit >/dev/null 2>&1; then
+        octo_event_emit "dispatch.start" command="$_octo_cmd_label" timeout="$timeout_secs" || true
+    fi
 
     # v9.20.1: Detect if command is a shell function (e.g. perplexity_execute,
     # openrouter_execute). External timeout/gtimeout can only exec binaries —
@@ -209,7 +220,16 @@ run_with_timeout() {
         echo "   3. Check provider API status for slowness" >&2
         echo "" >&2
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" >&2
+        if declare -f octo_event_emit >/dev/null 2>&1; then
+            octo_event_emit "dispatch.timeout" command="$_octo_cmd_label" timeout="$timeout_secs" exit_code="$exit_code" || true
+        fi
         return 124
+    fi
+
+    if declare -f octo_event_emit >/dev/null 2>&1; then
+        local _octo_outcome="ok"
+        [[ $exit_code -eq 0 ]] || _octo_outcome="error"
+        octo_event_emit "dispatch.end" command="$_octo_cmd_label" exit_code="$exit_code" outcome="$_octo_outcome" || true
     fi
 
     return $exit_code

--- a/tests/unit/test-octo-events.sh
+++ b/tests/unit/test-octo-events.sh
@@ -132,6 +132,26 @@ PY
     test_pass
 }
 
+test_dispatch_lifecycle_events() {
+    test_case "run_with_timeout emits dispatch.start/end/timeout lifecycle events"
+    export OCTO_EVENT_LOG="$FIXTURE/lifecycle.jsonl"
+    : > "$OCTO_EVENT_LOG"
+    (
+        log() { :; }  # heartbeat.sh logs on timeout; stub it for the unit test
+        # shellcheck disable=SC1091
+        source "$PROJECT_ROOT/scripts/lib/heartbeat.sh"
+        run_with_timeout 5 true >/dev/null 2>&1 || true
+        run_with_timeout 1 sleep 5 >/dev/null 2>&1 || true
+    )
+    if grep -q '"event":"dispatch.start"' "$OCTO_EVENT_LOG" && \
+       grep -q '"event":"dispatch.end"' "$OCTO_EVENT_LOG" && \
+       grep -q '"event":"dispatch.timeout"' "$OCTO_EVENT_LOG"; then
+        test_pass
+    else
+        test_fail "missing one of dispatch.start/end/timeout in $(grep -oE '"event":"[^"]*"' "$OCTO_EVENT_LOG" | tr '\n' ' ')"
+    fi
+}
+
 test_no_log_when_disabled
 test_emit_jsonl_event
 test_auto_log_path
@@ -139,5 +159,6 @@ test_trim_event_log
 test_invalid_event_rejected
 test_check_providers_event_hook
 test_concurrent_emit_no_clobber
+test_dispatch_lifecycle_events
 
 test_summary


### PR DESCRIPTION
## What

First Next-Major control-plane increment. `run_with_timeout` (heartbeat.sh) is the universal provider-execution chokepoint — every provider funnels through it. It now emits opt-in `dispatch.start`, `dispatch.end` (exit_code + outcome), and `dispatch.timeout` events when `OCTO_EVENT_LOG` is set.

The event stream now carries real dispatch lifecycle signal, not just `provider.status`.

## Safety

Opt-in and double-guarded: no-op unless `OCTO_EVENT_LOG` is set AND `octo_event_emit` is defined. Zero behavior change when the stream is off.

## Testing

- New lifecycle regression test (start/end/timeout all fire): test-octo-events.sh → 8/8
- bash -n clean

## Follow-up

- oco-8gw: local monitor/HUD reading the stream
- oco-aek: provider.selected / circuit-breaker / review.finding / synthesis events
- oco-fgg: control-plane major bets (backprop, semantic adapters, lock-aware scheduling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dispatch lifecycle events are now optionally emitted as JSONL logs, including start, end (with exit codes and outcomes), and timeout notifications. Environment-controlled with no impact when disabled.

* **Documentation**
  * Updated roadmap documentation for dispatch lifecycle events.

* **Tests**
  * Added comprehensive test coverage for dispatch lifecycle events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->