### PR TITLE
fix: ignore same-subtask tangle scope overlap (rebased #460)

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1137,6 +1137,7 @@ tangle_validate_parallel_write_scopes() {
             [[ -z "$scope" ]] && continue
             local i
             for i in "${!existing_scopes[@]}"; do
+                [[ "${existing_tasks[$i]}" == "$task_index" ]] && continue
                 if tangle_scopes_overlap "$scope" "${existing_scopes[$i]}"; then
                     echo "coding subtask ${task_index} effective write scope '${scope}' overlaps subtask ${existing_tasks[$i]} scope '${existing_scopes[$i]}'"
                     return 1

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1023,7 +1023,10 @@ tangle_scope_is_known_or_explicit_new_file() {
 tangle_line_is_numbered_subtask() {
     local line="$1"
     local numbered_subtask_pattern='^[[:space:]]*(\*\*)?[0-9]+[.)]'
-    [[ "$line" =~ $numbered_subtask_pattern ]]
+    if [[ "$line" =~ $numbered_subtask_pattern ]]; then
+        return 0
+    fi
+    return 1
 }
 
 tangle_parseable_subtask_count() {


### PR DESCRIPTION
Rebased #460 onto current main after the stacked #459 squash-merged (resolves the cascade conflict). Net change: 5-line same-subtask overlap guard in workflows.sh; the rest of the original PR was the inherited #459 stack now in main.

Original author: @Jhacarreiro (#460). Tangle write-scope + direct-fallback tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subtask processing to properly report success and failure outcomes.
  * Fixed parallel write-scope validation to correctly handle cases where multiple scopes belong to the same subtask, eliminating incorrect self-comparison checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->