### PR TITLE
feat: allow tangle agent routing overrides (rebased #462)

### DIFF
--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -11,6 +11,49 @@
 
 # ═══════════════════════════════════════════════════════════════════════════════
 
+
+# Resolve phase/role-specific agent/provider overrides while preserving existing defaults.
+#
+# This selects only the agent/provider name used for dispatch. Model selection is
+# still handled later by resolve_octopus_model() in scripts/lib/model-resolver.sh.
+# That resolver may return values from /tmp/octo-model-cache-*.json before reading
+# model environment overrides; clear that cache to force-refresh model selection.
+#
+# Lookup order for phase="tangle", role="coding":
+#   OCTOPUS_TANGLE_CODING_AGENT
+#   OCTOPUS_TANGLE_AGENT
+#   OCTOPUS_CODING_AGENT
+#   <default passed by caller>
+octopus_agent_override() {
+    local phase="$1"
+    local role="$2"
+    local default_agent="$3"
+    local phase_key role_key env_name value
+
+    phase_key=$(printf '%s' "$phase" | tr '[:lower:]-' '[:upper:]_' | sed -E 's/[^A-Z0-9_]+/_/g; s/^_+//; s/_+$//')
+    role_key=$(printf '%s' "$role" | tr '[:lower:]-' '[:upper:]_' | sed -E 's/[^A-Z0-9_]+/_/g; s/^_+//; s/_+$//')
+
+    if [[ -n "$phase_key" && -n "$role_key" ]]; then
+        env_name="OCTOPUS_${phase_key}_${role_key}_AGENT"
+        value="${!env_name:-}"
+        [[ -n "$value" ]] && { echo "$value"; return 0; }
+    fi
+
+    if [[ -n "$phase_key" ]]; then
+        env_name="OCTOPUS_${phase_key}_AGENT"
+        value="${!env_name:-}"
+        [[ -n "$value" ]] && { echo "$value"; return 0; }
+    fi
+
+    if [[ -n "$role_key" ]]; then
+        env_name="OCTOPUS_${role_key}_AGENT"
+        value="${!env_name:-}"
+        [[ -n "$value" ]] && { echo "$value"; return 0; }
+    fi
+
+    echo "$default_agent"
+}
+
 # v9.19.0: Safe default for --bare flag (set by providers.sh, but guard for standalone sourcing)
 _BARE_OPT="${_BARE_OPT:-}"
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1302,9 +1302,18 @@ Required format:
 2. [REASONING] Short title — Task: specific reasoning work
 Every [CODING] line must include a same-line Files: clause."
 
+    # Tangle decomposition agents are overridable (OCTOPUS_TANGLE_DECOMPOSE_AGENT,
+    # OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT, OCTOPUS_TANGLE_AGENT). Override only
+    # selects the dispatch agent; the fail-closed contract below is unchanged.
+    local tangle_decompose_agent="gemini" tangle_decompose_fallback_agent="codex"
+    if declare -f octopus_agent_override >/dev/null 2>&1; then
+        tangle_decompose_agent=$(octopus_agent_override "tangle" "decompose" "gemini")
+        tangle_decompose_fallback_agent=$(octopus_agent_override "tangle" "decompose_fallback" "codex")
+    fi
+
     local subtasks
-    subtasks=$(run_agent_sync "gemini" "$decompose_prompt" 120 "researcher" "tangle") || \
-    subtasks=$(run_agent_sync "codex" "$decompose_prompt" 120 "researcher" "tangle") || {
+    subtasks=$(run_agent_sync "$tangle_decompose_agent" "$decompose_prompt" 120 "researcher" "tangle") || \
+    subtasks=$(run_agent_sync "$tangle_decompose_fallback_agent" "$decompose_prompt" 120 "researcher" "tangle") || {
         log ERROR "Decomposition failed with all providers; refusing monolithic direct fallback"
         return 1
     }


### PR DESCRIPTION
Re-implements #462 against current main (original conflicted on the hardened tangle flow).

Adds `octopus_agent_override` and makes the tangle decompose + fallback dispatch agents overridable via `OCTOPUS_TANGLE_DECOMPOSE_AGENT` / `OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT` / `OCTOPUS_TANGLE_AGENT`.

**Resolution note:** the original PR predated #459/#460 and reintroduced the monolithic direct-fallback those PRs deliberately removed. This redo does NOT restore that fallback — main's fail-closed contract (gemini → codex → refuse) is preserved; the override only selects which agent dispatches.

Verified: override precedence (default → specific → fallback → phase-level) under bash; tangle write-scope + direct-fallback tests pass.

Original author: @Jhacarreiro (#462).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable decomposition agent selection, allowing overrides via environment variables.
  * When set, the workflow will use the overridden agent provider for the decomposition attempts while preserving the existing fail-closed fallback behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->