### PR TITLE
fix: enable OCTO_EVENT_LOG telemetry by default (oco-7db)

### DIFF
--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -501,6 +501,16 @@ TASKS_FILE="${WORKSPACE_DIR}/tasks.json"
 RESULTS_DIR="$SESSION_RESULTS_DIR"
 LOGS_DIR="$SESSION_LOGS_DIR"
 PID_FILE="${WORKSPACE_DIR}/pids"
+
+# Telemetry: enable the opt-in JSONL event stream by default for every run so
+# provider.status + dispatch lifecycle events are captured (usage data + the
+# basis for a control-plane HUD). Stdout is unchanged (events.sh appends to the
+# log only). Opt out with OCTO_EVENT_LOG=off; override the path by setting it.
+if [[ -z "${OCTO_EVENT_LOG:-}" ]]; then
+    export OCTO_EVENT_LOG="${RESULTS_DIR}/events.jsonl"
+elif [[ "${OCTO_EVENT_LOG}" == "off" ]]; then
+    unset OCTO_EVENT_LOG
+fi
 ANALYTICS_DIR="${WORKSPACE_DIR}/analytics"
 
 # Secure temporary directory (cleaned up on exit)

--- a/tests/unit/test-octo-events.sh
+++ b/tests/unit/test-octo-events.sh
@@ -152,6 +152,17 @@ test_dispatch_lifecycle_events() {
     fi
 }
 
+test_orchestrate_enables_telemetry_by_default() {
+    test_case "orchestrate.sh enables OCTO_EVENT_LOG by default with an opt-out (oco-7db)"
+    local orch="$PROJECT_ROOT/scripts/orchestrate.sh"
+    if grep -q 'export OCTO_EVENT_LOG=.*RESULTS_DIR.*events.jsonl' "$orch" && \
+       grep -q 'OCTO_EVENT_LOG.* == .off.' "$orch"; then
+        test_pass
+    else
+        test_fail "orchestrate.sh must default OCTO_EVENT_LOG to RESULTS_DIR/events.jsonl and honor OCTO_EVENT_LOG=off"
+    fi
+}
+
 test_no_log_when_disabled
 test_emit_jsonl_event
 test_auto_log_path
@@ -160,5 +171,6 @@ test_invalid_event_rejected
 test_check_providers_event_hook
 test_concurrent_emit_no_clobber
 test_dispatch_lifecycle_events
+test_orchestrate_enables_telemetry_by_default
 
 test_summary


### PR DESCRIPTION
## What

orchestrate.sh now defaults `OCTO_EVENT_LOG` to `RESULTS_DIR/events.jsonl` per run, so `provider.status` + dispatch lifecycle events are captured for every run. Stdout unchanged (events.sh appends to the log only). Opt out with `OCTO_EVENT_LOG=off`.

## Why

The event substrate shipped in v9.45 but nothing enabled it — every run emitted zero telemetry. This is why the PRD-0 research pass had no usage data, and the planned control-plane HUD had nothing to read.

## Testing

- Functional: check-providers under a set `OCTO_EVENT_LOG` emits 10 provider.status lines.
- New regression test in test-octo-events.sh; suite green.
- bash -n clean.

Closes oco-7db. Filed oco-48z separately for the parallel-path quota/terminal fast-fail gap (failed providers burning the full ~600s timeout).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry data collection is now enabled automatically on every run.
  * Users can disable telemetry collection if preferred; normal output remains unchanged.

* **Tests**
  * Added test coverage for default telemetry behavior and opt-out functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->