### PR TITLE
fix: migrate gemini image models before 2026-06-25 deprecation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
       "keywords": [
         "image-generation",
         "gpt-image-2",
-        "gemini-3.1-flash-image-preview",
+        "gemini-nano-banana-2",
         "claude-code-plugin",
         "codex"
       ],

--- a/.claude/commands/model-config.md
+++ b/.claude/commands/model-config.md
@@ -175,7 +175,7 @@ AskUserQuestion({
     multiSelect: false,
     options: [
       {label: "gemini-3.1-pro-preview", description: "Premium — $2.50/$10 MTok, best research quality"},
-      {label: "gemini-3-flash-preview", description: "Fast — $0.25/$1 MTok, good for quick tasks"},
+      {label: "gemini-3.5-flash", description: "Fast (GA) — $0.25/$1 MTok, good for quick tasks"},
       {label: "Custom", description: "Enter a custom model name"}
     ]
   }]

--- a/.claude/skills/skill-parallel-agents/SKILL.md
+++ b/.claude/skills/skill-parallel-agents/SKILL.md
@@ -623,8 +623,8 @@ The `tangle` phase enforces quality gates:
 | `codex-standard` | gpt-5.2-codex | Standard tier implementation |
 | `codex-mini` | gpt-5.4-mini | Quick fixes, simple tasks |
 | `gemini` | gemini-3-pro-preview | Deep analysis, 1M context |
-| `gemini-fast` | gemini-3-flash-preview | Speed-critical tasks |
-| `gemini-image` | gemini-3-pro-image-preview | Image generation |
+| `gemini-fast` | gemini-3.5-flash | Speed-critical tasks |
+| `gemini-image` | gemini-nano-banana-pro | Image generation |
 | `codex-review` | gpt-5.2-codex | Code review mode |
 | `openrouter` | Various | Universal fallback (400+ models) |
 

--- a/.cursor-plugin/commands/octo-model-config.md
+++ b/.cursor-plugin/commands/octo-model-config.md
@@ -169,7 +169,7 @@ AskUserQuestion({
     multiSelect: false,
     options: [
       {label: "gemini-3.1-pro-preview", description: "Premium — $2.50/$10 MTok, best research quality"},
-      {label: "gemini-3-flash-preview", description: "Fast — $0.25/$1 MTok, good for quick tasks"},
+      {label: "gemini-3.5-flash", description: "Fast (GA) — $0.25/$1 MTok, good for quick tasks"},
       {label: "Custom", description: "Enter a custom model name"}
     ]
   }]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ Providers:
 
 Always be mindful that external CLIs cost money:
 - 🔴 Codex: ~$0.01-0.30 per query depending on model (GPT-5.5 $5/$30 MTok — premium default as of v9.44, GPT-5.4 $2.50/$15, GPT-5.3-Codex $1.75/$14, Mini $0.25/$2.00 MTok)
-- 🟡 Gemini: ~$0.01-0.03 per query (Gemini 3.1 Pro Preview $2.50/$10 MTok, 3 Flash Preview $0.25/$1)
+- 🟡 Gemini: ~$0.01-0.03 per query (Gemini 3.1 Pro Preview $2.50/$10 MTok, 3.5 Flash GA $0.25/$1, 3.1 Flash Lite $0.10/$0.40, Nano Banana Pro image $5/$20 MTok)
 - 🧭 Antigravity CLI (`agy`): Included with the user's Antigravity access/subscription; backend cost depends on selected `OCTOPUS_AGY_MODEL`
 - 🟣 Perplexity: ~$0.01-0.05 per query (Sonar Pro $3/$15 MTok, Sonar $1/$1 MTok)
 - 🔵 Claude (Sonnet 4.6): Included with Claude Code subscription

--- a/agents/config.yaml
+++ b/agents/config.yaml
@@ -397,7 +397,7 @@ agents:
   context-manager:
     file: personas/context-manager.md
     cli: gemini-fast
-    model: gemini-3-flash-preview
+    model: gemini-3.5-flash
     phases: [probe, grasp, tangle, ink]
     background: true
     tier: standard
@@ -445,7 +445,7 @@ agents:
   mermaid-expert:
     file: personas/mermaid-expert.md
     cli: gemini-fast
-    model: gemini-3-flash-preview
+    model: gemini-3.5-flash
     phases: [grasp, ink]
     tier: trivial
     expertise: [diagrams, flowcharts, sequence-diagrams]

--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -73,9 +73,11 @@ ensure_config() {
     },
     "gemini": {
       "default": "gemini-3.1-pro-preview",
-      "fallback": "gemini-3-flash-preview",
-      "flash": "gemini-3-flash-preview",
-      "image": "gemini-3-pro-image-preview"
+      "fallback": "gemini-3.5-flash",
+      "flash": "gemini-3.5-flash",
+      "lite": "gemini-3.1-flash-lite",
+      "image": "gemini-nano-banana-pro",
+      "image-lite": "gemini-nano-banana-2"
     },
     "claude": {
       "default": "claude-sonnet-4.6",
@@ -522,8 +524,10 @@ cmd_models() {
         "o3|200|yes|no|yes|codex|premium|active"
         "o3-mini|200|yes|no|yes|codex|budget|active"
         "gemini-3.1-pro-preview|1000|yes|yes|no|gemini|premium|active"
-        "gemini-3-flash-preview|1000|yes|yes|no|gemini|budget|active"
-        "gemini-3-pro-image-preview|1000|yes|yes|no|gemini|premium|active"
+        "gemini-3.5-flash|1000|yes|no|no|gemini|budget|active"
+        "gemini-3.1-flash-lite|1000|yes|no|no|gemini|budget|active"
+        "gemini-nano-banana-pro|1000|yes|yes|no|gemini|premium|active"
+        "gemini-nano-banana-2|1000|yes|yes|no|gemini|standard|active"
         "claude-sonnet-4.6|200|yes|yes|no|claude|standard|active"
         "claude-opus-4.8|1000|yes|yes|yes|claude|premium|active"
         "claude-opus-4.7|1000|yes|yes|yes|claude|premium|legacy"

--- a/scripts/lib/auto-route.sh
+++ b/scripts/lib/auto-route.sh
@@ -722,7 +722,7 @@ Then provide specific optimization recommendations."
     case "$task_type" in
         image)
             echo -e "${YELLOW}Image Generation Task${NC}"
-            echo "  Using gemini-3-pro-image-preview for text-to-image generation."
+            echo "  Using gemini-nano-banana-pro for text-to-image generation."
             echo "  Supports: text-to-image, image editing, multi-turn editing"
             echo "  Output: Up to 4K resolution images"
             echo ""

--- a/scripts/lib/cost.sh
+++ b/scripts/lib/cost.sh
@@ -849,9 +849,14 @@ get_model_pricing() {
         o3)                     echo "2.00:8.00" ;;
         o3-pro)                 echo "20.00:80.00" ;;  # v8.39.0: API-key only
         o3-mini)                echo "1.10:4.40" ;;    # v8.39.0: API-key only
-        # Google Gemini 3.0 models
+        # Google Gemini models (v9.46: refreshed catalog)
         gemini-3.1-pro-preview)   echo "2.50:10.00" ;;
-        gemini-3-flash-preview) echo "0.25:1.00" ;;
+        gemini-3.5-flash)         echo "0.25:1.00" ;;   # GA fast default (was gemini-3-flash-preview)
+        gemini-3.1-flash-lite)    echo "0.10:0.40" ;;   # fastest/cheapest tier
+        gemini-nano-banana-pro)   echo "5.00:20.00" ;;  # image gen premium (replaces gemini-3-pro-image-preview)
+        gemini-nano-banana-2)     echo "2.50:10.00" ;;  # image gen standard
+        # deprecated 2026-06-25 — kept for cost-reporting continuity
+        gemini-3-flash-preview)   echo "0.25:1.00" ;;
         gemini-3-pro-image-preview) echo "5.00:20.00" ;;
         # Claude models
         claude-sonnet-4.5)      echo "3.00:15.00" ;;

--- a/scripts/lib/cost.sh
+++ b/scripts/lib/cost.sh
@@ -856,8 +856,9 @@ get_model_pricing() {
         gemini-nano-banana-pro)   echo "5.00:20.00" ;;  # image gen premium (replaces gemini-3-pro-image-preview)
         gemini-nano-banana-2)     echo "2.50:10.00" ;;  # image gen standard
         # deprecated 2026-06-25 — kept for cost-reporting continuity
-        gemini-3-flash-preview)   echo "0.25:1.00" ;;
-        gemini-3-pro-image-preview) echo "5.00:20.00" ;;
+        gemini-3-flash-preview)         echo "0.25:1.00" ;;
+        gemini-3-pro-image-preview)     echo "5.00:20.00" ;;
+        gemini-3.1-flash-image-preview) echo "2.50:10.00" ;;
         # Claude models
         claude-sonnet-4.5)      echo "3.00:15.00" ;;
         claude-sonnet-4.6)      echo "3.00:15.00" ;;   # v8.17: Sonnet 4.6 (same pricing as 4.5)

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -11,7 +11,7 @@
 #                    gpt-5.2-codex, gpt-5.4-mini (budget), gpt-5 (standard), gpt-5.2, gpt-5.1
 # - OpenAI Reasoning: o3, o3-pro (API-key only), o3 (API-key only), o3-mini (API-key only)
 # - OpenAI Large Context: gpt-4.1 (1M ctx, API-key only), gpt-5.4 (1M ctx, API-key only)
-# - Google Gemini 3.0: gemini-3.1-pro-preview, gemini-3-flash-preview, gemini-3-pro-image-preview
+# - Google Gemini 3.x: gemini-3.1-pro-preview, gemini-3.5-flash (GA), gemini-3.1-flash-lite, gemini-nano-banana-pro/2 (image)
 # - Google Antigravity CLI: agy --print stdin dispatch, optional OCTOPUS_AGY_MODEL
 # Note: "API-key only" models require OPENAI_API_KEY; they are NOT available via ChatGPT subscription/OAuth.
 get_agent_command() {
@@ -617,7 +617,7 @@ find_capable_fallback() {
         codex)
             candidates=(gpt-5.4-mini gpt-5.2-codex gpt-5.3-codex gpt-5.4 gpt-5.4-pro o3) ;;
         gemini)
-            candidates=(gemini-3-flash-preview gemini-3.1-pro-preview) ;;
+            candidates=(gemini-3.5-flash gemini-3.1-pro-preview) ;;
         agy)
             candidates=(default) ;;
         claude)

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -617,7 +617,7 @@ find_capable_fallback() {
         codex)
             candidates=(gpt-5.4-mini gpt-5.2-codex gpt-5.3-codex gpt-5.4 gpt-5.4-pro o3) ;;
         gemini)
-            candidates=(gemini-3.5-flash gemini-3.1-pro-preview) ;;
+            candidates=(gemini-3.1-flash-lite gemini-3.5-flash gemini-3.1-pro-preview gemini-nano-banana-2 gemini-nano-banana-pro) ;;
         agy)
             candidates=(default) ;;
         claude)

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -239,7 +239,8 @@ resolve_octopus_model() {
     if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
         case "$agent_type" in
             codex*)          resolved_model="gpt-5.5" ;;
-            gemini-fast|gemini-flash) resolved_model="gemini-3-flash-preview" ;;
+            gemini-fast|gemini-flash) resolved_model="gemini-3.5-flash" ;;
+            gemini-image)    resolved_model="gemini-nano-banana-pro" ;;
             gemini*)         resolved_model="gemini-3.1-pro-preview" ;;
             agy*|antigravity) resolved_model="default" ;;
             claude-opus-legacy*) resolved_model="claude-opus-4.6" ;;

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -38,8 +38,9 @@ get_model_catalog() {
         gemini-nano-banana-pro)   echo "1000|yes|yes|no|gemini|premium|active" ;;
         gemini-nano-banana-2)     echo "1000|yes|yes|no|gemini|standard|active" ;;
         # deprecated 2026-06-25 — kept for migration warnings only
-        gemini-3-flash-preview)   echo "1000|yes|no|no|gemini|budget|deprecated" ;;
-        gemini-3-pro-image-preview) echo "1000|yes|yes|no|gemini|premium|deprecated" ;;
+        gemini-3-flash-preview)        echo "1000|yes|no|no|gemini|budget|deprecated" ;;
+        gemini-3-pro-image-preview)    echo "1000|yes|yes|no|gemini|premium|deprecated" ;;
+        gemini-3.1-flash-image-preview) echo "1000|yes|yes|no|gemini|standard|deprecated" ;;
         # Antigravity CLI (agy routes to the user's configured Antigravity default)
         agy/default|default)       echo "1000|yes|yes|no|agy|standard|active" ;;
         # Claude

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -31,10 +31,15 @@ get_model_catalog() {
         o3)                     echo "200|yes|no|yes|codex|premium|active" ;;
         o3-pro)                 echo "200|yes|no|yes|codex|premium|active" ;;
         o3-mini)                echo "200|yes|no|yes|codex|budget|active" ;;
-        # Gemini
+        # Gemini (v9.46: refreshed catalog — gemini-3.5-flash GA, nano-banana image models)
         gemini-3.1-pro-preview)   echo "1000|yes|yes|no|gemini|premium|active" ;;
-        gemini-3-flash-preview) echo "1000|yes|no|no|gemini|budget|active" ;;
-        gemini-3-pro-image-preview) echo "1000|yes|yes|no|gemini|premium|active" ;;
+        gemini-3.5-flash)         echo "1000|yes|no|no|gemini|budget|active" ;;
+        gemini-3.1-flash-lite)    echo "1000|yes|no|no|gemini|budget|active" ;;
+        gemini-nano-banana-pro)   echo "1000|yes|yes|no|gemini|premium|active" ;;
+        gemini-nano-banana-2)     echo "1000|yes|yes|no|gemini|standard|active" ;;
+        # deprecated 2026-06-25 — kept for migration warnings only
+        gemini-3-flash-preview)   echo "1000|yes|no|no|gemini|budget|deprecated" ;;
+        gemini-3-pro-image-preview) echo "1000|yes|yes|no|gemini|premium|deprecated" ;;
         # Antigravity CLI (agy routes to the user's configured Antigravity default)
         agy/default|default)       echo "1000|yes|yes|no|agy|standard|active" ;;
         # Claude
@@ -117,7 +122,8 @@ list_models() {
         gpt-5.5 gpt-5.5-pro gpt-5.4 gpt-5.4-pro gpt-5.3-codex gpt-5.2-codex
         gpt-5.4-mini gpt-5.1-codex-max
         o3 o3-pro o3-mini
-        gemini-3.1-pro-preview gemini-3-flash-preview gemini-3-pro-image-preview
+        gemini-3.1-pro-preview gemini-3.5-flash gemini-3.1-flash-lite
+        gemini-nano-banana-pro gemini-nano-banana-2
         agy/default
         claude-sonnet-4.6 claude-fable-5 claude-opus-4.8 claude-opus-4.8-fast claude-opus-4.7 claude-opus-4.6 claude-opus-4.6-fast
         grok-4-20 grok-4-20-thinking composer-2-fast composer-2

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -233,9 +233,11 @@ migrate_provider_config() {
     },
     "gemini": {
       "default": "$gemini_model",
-      "fallback": "gemini-3-flash-preview",
-      "flash": "gemini-3-flash-preview",
-      "image": "gemini-3-pro-image-preview"
+      "fallback": "gemini-3.5-flash",
+      "flash": "gemini-3.5-flash",
+      "lite": "gemini-3.1-flash-lite",
+      "image": "gemini-nano-banana-pro",
+      "image-lite": "gemini-nano-banana-2"
     }
   },
   "routing": {
@@ -292,8 +294,10 @@ EOF
         case "$current_val" in
             claude-sonnet-4-5|claude-sonnet-4-5-20250514|claude-3-5-sonnet*|claude-sonnet-4*)
                 if [[ "$path" == *codex* ]]; then replacement="gpt-5.5"; fi ;;
-            gemini-2.0-flash-thinking*|gemini-2.0-flash-exp*|gemini-exp-*)
-                replacement="gemini-3-flash-preview" ;;
+            gemini-2.0-flash-thinking*|gemini-2.0-flash-exp*|gemini-exp-*|gemini-3-flash-preview)
+                replacement="gemini-3.5-flash" ;;
+            gemini-3-pro-image-preview|gemini-3\.1-flash-image-preview)
+                replacement="gemini-nano-banana-pro" ;;
             gemini-2.0-pro*|gemini-1.5-pro*|gemini-pro)
                 replacement="gemini-3.1-pro-preview" ;;
             gpt-4o*|gpt-4-turbo*|gpt-4-*|o1-*|chatgpt-*)
@@ -366,9 +370,11 @@ set_provider_model() {
     },
     "gemini": {
       "default": "gemini-3.1-pro-preview",
-      "fallback": "gemini-3-flash-preview",
-      "flash": "gemini-3-flash-preview",
-      "image": "gemini-3-pro-image-preview"
+      "fallback": "gemini-3.5-flash",
+      "flash": "gemini-3.5-flash",
+      "lite": "gemini-3.1-flash-lite",
+      "image": "gemini-nano-banana-pro",
+      "image-lite": "gemini-nano-banana-2"
     }
   },
   "routing": {

--- a/skills/skill-parallel-agents/SKILL.md
+++ b/skills/skill-parallel-agents/SKILL.md
@@ -598,8 +598,8 @@ The `tangle` phase enforces quality gates:
 | `codex-standard` | gpt-5.2-codex | Standard tier implementation |
 | `codex-mini` | gpt-5.4-mini | Quick fixes, simple tasks |
 | `gemini` | gemini-3-pro-preview | Deep analysis, 1M context |
-| `gemini-fast` | gemini-3-flash-preview | Speed-critical tasks |
-| `gemini-image` | gemini-3-pro-image-preview | Image generation |
+| `gemini-fast` | gemini-3.5-flash | Speed-critical tasks |
+| `gemini-image` | gemini-nano-banana-pro | Image generation |
 | `codex-review` | gpt-5.2-codex | Code review mode |
 | `openrouter` | Various | Universal fallback (400+ models) |
 

--- a/tests/unit/test-orchestrate-cwd-routing.sh
+++ b/tests/unit/test-orchestrate-cwd-routing.sh
@@ -186,7 +186,7 @@ test_gemini_include_dirs_flag() {
     # gemini branch calls get_agent_model → stub to avoid full resolver deps
     local got
     got="$(
-        get_agent_model() { echo "gemini-3-flash-preview"; }
+        get_agent_model() { echo "gemini-3.5-flash"; }
         OCTOPUS_GEMINI_INCLUDE_DIRS="/tmp/staging" get_agent_command gemini probe researcher
     )"
     [[ "$got" == *"--include-directories /tmp/staging"* ]] && test_pass || test_fail "flag missing, got: $got"
@@ -196,7 +196,7 @@ test_gemini_no_include_dirs_by_default() {
     test_case "gemini dispatch has no --include-directories when env unset"
     local got
     got="$(
-        get_agent_model() { echo "gemini-3-flash-preview"; }
+        get_agent_model() { echo "gemini-3.5-flash"; }
         unset OCTOPUS_GEMINI_INCLUDE_DIRS
         get_agent_command gemini probe researcher
     )"


### PR DESCRIPTION
## Summary

- **P0 deadline**: `gemini-3-pro-image-preview` and `gemini-3.1-flash-image-preview` are shut down by Google on 2026-06-25 (~10 days). Without this fix the `gemini-image` agent breaks hard on that date.
- **Image model migration**: both deprecated model IDs replaced with `gemini-nano-banana-pro` (premium) and `gemini-nano-banana-2` (standard) across the full stack.
- **Text catalog refresh**: `gemini-3.5-flash` (now GA) replaces `gemini-3-flash-preview` as the fast default everywhere; `gemini-3.1-flash-lite` added as cheapest tier.

## Root cause

`gemini-3-pro-image-preview` was hard-coded in `models.sh`, `model-resolver.sh`, `provider-routing.sh`, `octo-model-config.sh`, and `agents/config.yaml`. No migration path existed for stale user configs containing the old name.

## Files changed

| File | Change |
|------|--------|
| `scripts/lib/models.sh` | Add `gemini-nano-banana-pro/2`, `gemini-3.5-flash`, `gemini-3.1-flash-lite`; mark old preview names `deprecated` |
| `scripts/lib/cost.sh` | Pricing for new models; deprecated entries kept for cost-log continuity |
| `scripts/lib/model-resolver.sh` | `gemini-image` default → `gemini-nano-banana-pro`; `gemini-fast` → `gemini-3.5-flash` |
| `scripts/lib/dispatch.sh` | Header comment + fallback candidate list |
| `scripts/lib/provider-routing.sh` | Config defaults; migration case added for old image model names in stale user configs |
| `scripts/lib/auto-route.sh` | Image agent log string |
| `scripts/helpers/octo-model-config.sh` | Config generation defaults + model table |
| `agents/config.yaml` | `context-manager` and `mermaid-expert` agents → `gemini-3.5-flash` |
| `CLAUDE.md` | Pricing table |
| `skills/`, `.claude/skills/`, `.cursor-plugin/`, `.claude/commands/` | Docs/labels |
| `tests/unit/test-orchestrate-cwd-routing.sh` | Mock stubs updated |

## Test results

```
tests/unit/test-orchestrate-cwd-routing.sh — 14/14 PASS
bash -n scripts/lib/*.sh scripts/helpers/octo-model-config.sh — OK
```

Closes #493

---
_Generated by [Claude Code](https://claude.ai/code/session_01HReQ7fq736gen7s7uUhqdj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default Gemini models to newer GA options (notably `gemini-3.5-flash`) across agent configurations and routing, including image-related models (`gemini-nano-banana-*`).
  * Refreshed model catalogs to mark prior preview/image variants as deprecated while adding new flash-lite/nano-banana variants.
  * Updated fallback and stale-model migration targets to prefer the newer model set.
* **Documentation**
  * Updated interactive model selection text, agent selection tables, and displayed Gemini pricing/cost guidance to match the new model lineup.
* **Tests**
  * Adjusted Gemini routing unit test expectations to use the new default model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->