### PR TITLE
fix(agy): harden adapter + ensure session dirs exist (trimmed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Antigravity adapter (`agy-exec.sh`) hardened**: `OCTOPUS_AGY_SANDBOX=off` drops the `--sandbox` restriction, `OCTOPUS_AGY_INCLUDE_DIRS` (comma-separated) whitelists extra read dirs via `--add-dir`, and a single replay-from-stdin retry recovers a silent-empty success (opt out with `OCTOPUS_AGY_NO_RETRY=1`). The adapter stays a thin, env-driven wrapper — no model-fallback chain or error classifier.
+
 ### Fixed
 
+- **Session `results`/`logs`/`plans` dirs are now created early** in `orchestrate.sh`, before any subcommand dispatches provider seats. Codex/agy seats write into `RESULTS_DIR` during dispatch and previously crashed when it was missing. The `mkdir -p` is cheap and idempotent.
 - **Ollama and Codex OSS models can no longer trigger an unbounded auto-pull on fallback.** Both `ollama run <model>` and the Codex CLI's built-in OSS/local-model handling silently download a missing model, so a provider-failure cascade could kick off an unbounded multi-GB pull with no human in the loop (observed: a ~42 GB pull). All Ollama dispatch now routes through a fail-closed shim (`scripts/helpers/ollama-run.sh`), and Codex dispatch for OSS models (e.g. `gpt-oss:*`) routes through `scripts/helpers/codex-run.sh`; both share the guard in `scripts/helpers/ollama-pull-guard.lib.sh` and refuse to pull an absent model unless `OCTOPUS_OLLAMA_ALLOW_PULL=true`, capping an allowed pull at `OCTOPUS_OLLAMA_MAX_PULL_GB` (default 20). Cloud Codex models (e.g. `gpt-5.x`, `o3`, `gpt-4.1`, `gpt-5.2-codex`) are unaffected and bypass the guard.
 - **The agy council seat now records its real model instead of `"default"`.** `agy-exec` runs `agy --print` with `--model default` (agy uses whatever is picked in its own `/model` UI), so the roster artifact and preflight banner logged the opaque string `default` for the agy seat — making a Codex+agy panel's cross-lab-vs-same-lineage status unverifiable from `summary.json`. New `agy_current_model()` (`lib/providers.sh`) honors `OCTOPUS_AGY_MODEL`, else resolves the selection from `~/.gemini/antigravity-cli/settings.json`, else fails safe to `default (unresolved)`; it's wired into `council_roster_entry_json` and the preflight banner. Purely diagnostic — never gates logic, and guarded with `declare -f` so standalone runs fall back to prior behavior.
 

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 # Antigravity CLI stdin adapter.
+#
+# This intentionally stays a thin, env-driven adapter. It does NOT implement a
+# model-fallback chain or an error classifier the way the Gemini adapter does:
+# agy's model catalog and error strings are not verified here (agy may be
+# unauthenticated on a given box), and forcing a specific --model pushes agy onto
+# an exhaustible quota group. The only added robustness is provider-agnostic — a
+# single replay-from-cached-stdin retry on a silent-empty success.
 set -euo pipefail
 
 # Default to "default" → don't pass --model, so agy uses the model you picked in
@@ -12,7 +19,13 @@ print_timeout="${OCTOPUS_AGY_PRINT_TIMEOUT:-5m0s}"
 
 # --dangerously-skip-permissions: auto-approve agy's folder-trust + tool prompts so
 # council seats don't block on a per-worktree trust prompt (already --sandbox'd).
+# OCTOPUS_AGY_SANDBOX=off drops the sandbox restriction; the default keeps it on.
 cmd=(agy --print --sandbox --dangerously-skip-permissions --print-timeout "$print_timeout")
+if [[ "${OCTOPUS_AGY_SANDBOX:-on}" == "off" ]]; then
+    cmd=(agy --print --dangerously-skip-permissions --print-timeout "$print_timeout")
+fi
+
+# Model-pin guard adopted from #555: query-free, treats agy/default as "no pin".
 case "$model" in
     ""|default|agy/default)
         ;;
@@ -21,4 +34,49 @@ case "$model" in
         ;;
 esac
 
-exec "${cmd[@]}"
+# agy confines reads to its workspace; whitelist extra dirs (e.g. a /tmp staging
+# dir) the prompt references. Comma-separated.
+if [[ -n "${OCTOPUS_AGY_INCLUDE_DIRS:-}" ]]; then
+    IFS=',' read -r -a _agy_dirs <<< "$OCTOPUS_AGY_INCLUDE_DIRS"
+    for _d in "${_agy_dirs[@]}"; do
+        [[ -n "$_d" ]] && cmd+=(--add-dir "$_d")
+    done
+fi
+
+# agy --print reads the prompt from stdin; cache it so a retry can replay it
+# (stdin is consumed once). Buffer stdout to a file to preserve output fidelity.
+prompt_file=""
+stdout_file=$(mktemp -t "octo-agy-stdout.XXXXXX")
+trap 'rm -f "${prompt_file:-}" "${stdout_file:-}"' EXIT
+# INT/TERM must actually terminate (bash otherwise resumes after the handler);
+# the EXIT trap still runs the cleanup on the way out.
+trap 'exit 130' INT
+trap 'exit 143' TERM
+if [[ ! -t 0 ]]; then
+    prompt_file=$(mktemp -t "octo-agy-prompt.XXXXXX")
+    cat > "$prompt_file"
+fi
+
+run_agy() {
+    : > "$stdout_file"
+    if [[ -n "$prompt_file" ]]; then
+        "${cmd[@]}" < "$prompt_file" > "$stdout_file"
+    else
+        "${cmd[@]}" > "$stdout_file"
+    fi
+}
+
+set +e
+run_agy
+rc=$?
+# Retry once on a silent-empty success (a documented agy failure mode), replaying
+# the cached prompt. Keyed on emptiness, not on any provider error string.
+content=$(<"$stdout_file")
+if [[ $rc -eq 0 && -z "${content//[$' \t\r\n']/}" && -n "$prompt_file" && "${OCTOPUS_AGY_NO_RETRY:-}" != "1" ]]; then
+    run_agy
+    rc=$?
+fi
+set -e
+
+cat "$stdout_file"
+exit "$rc"

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -515,6 +515,11 @@ elif [[ "${OCTO_EVENT_LOG}" == "off" ]]; then
 fi
 ANALYTICS_DIR="${WORKSPACE_DIR}/analytics"
 
+# Ensure the per-session results/logs/plans dirs exist EARLY — before any
+# subcommand (council, debate, …) dispatches provider seats. Codex/agy seats
+# write into RESULTS_DIR and crash if it's missing. Cheap, idempotent.
+mkdir -p "$RESULTS_DIR" "$LOGS_DIR" "$PLANS_DIR" 2>/dev/null || true
+
 # Secure temporary directory (cleaned up on exit)
 OCTOPUS_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/claude-octopus.XXXXXX")
 trap 'rm -rf "$OCTOPUS_TMP_DIR"' EXIT INT TERM


### PR DESCRIPTION
## Summary

Rebased onto current `main` and **trimmed to only the pieces still additive** after v9.46.0/#513/#520/#524.

The original PR's council allow-list wiring is now **redundant**: #513 seats every available provider org, #520 made qwen seatable, and #524 made agy the default Google seat (it already seats via the `backend-architect` persona, `cli: agy`). So the `council.sh` / `usage-help.sh` / `test-agy-council-provider.sh` changes have been dropped.

What remains — the two pieces genuinely net-new over `main`:

- **`orchestrate.sh`** — pre-create the per-session `results`/`logs`/`plans` dirs early, before any subcommand dispatches provider seats. Codex/agy seats write into `RESULTS_DIR` during dispatch and crashed when it was missing. Cheap and idempotent. *(the maintainer's called-out additive piece)*
- **`agy-exec.sh`** — adapter hardening, orthogonal to council seating and not on `main`: `OCTOPUS_AGY_SANDBOX=off` drops `--sandbox`, `OCTOPUS_AGY_INCLUDE_DIRS` (comma-separated) whitelists extra read dirs via `--add-dir`, and a single replay-from-stdin retry recovers a silent-empty success (`OCTOPUS_AGY_NO_RETRY=1` to opt out).

## Diff

```
 CHANGELOG.md                |  8 ++++++
 scripts/helpers/agy-exec.sh | 59 ++++++++++++++++++++-
 scripts/orchestrate.sh      |  5 ++++
 3 files changed, 71 insertions(+), 1 deletion(-)
```

## Test plan

- [x] `bash -n scripts/orchestrate.sh` — clean
- [x] `bash -n scripts/helpers/agy-exec.sh` — clean
- [x] `git diff main -- scripts/lib/council.sh scripts/lib/usage-help.sh` → empty (council seating fully dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)