### PR TITLE
feat: add GA gemini-3.5-flash + gemini-3.1-flash-lite to model catalog (oco-803)

### DIFF
--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -33,8 +33,10 @@ get_model_catalog() {
         o3-mini)                echo "200|yes|no|yes|codex|budget|active" ;;
         # Gemini
         gemini-3.1-pro-preview)   echo "1000|yes|yes|no|gemini|premium|active" ;;
+        gemini-3.5-flash)       echo "1000|yes|no|no|gemini|budget|active" ;;   # GA fast (supersedes gemini-3-flash-preview)
+        gemini-3.1-flash-lite)  echo "1000|yes|no|no|gemini|budget|active" ;;   # fastest/cheapest tier
         gemini-3-flash-preview) echo "1000|yes|no|no|gemini|budget|active" ;;
-        gemini-3-pro-image-preview) echo "1000|yes|yes|no|gemini|premium|active" ;;
+        gemini-3-pro-image-preview) echo "1000|yes|yes|no|gemini|premium|active" ;;  # image: shutdown 2026-06-25 (oco-803), migrate to Nano Banana Pro
         # Antigravity CLI (agy routes to the user's configured Antigravity default)
         agy/default|default)       echo "1000|yes|yes|no|agy|standard|active" ;;
         # Claude
@@ -117,7 +119,7 @@ list_models() {
         gpt-5.5 gpt-5.5-pro gpt-5.4 gpt-5.4-pro gpt-5.3-codex gpt-5.2-codex
         gpt-5.4-mini gpt-5.1-codex-max
         o3 o3-pro o3-mini
-        gemini-3.1-pro-preview gemini-3-flash-preview gemini-3-pro-image-preview
+        gemini-3.1-pro-preview gemini-3.5-flash gemini-3.1-flash-lite gemini-3-flash-preview gemini-3-pro-image-preview
         agy/default
         claude-sonnet-4.6 claude-fable-5 claude-opus-4.8 claude-opus-4.8-fast claude-opus-4.7 claude-opus-4.6 claude-opus-4.6-fast
         grok-4-20 grok-4-20-thinking composer-2-fast composer-2


### PR DESCRIPTION
## What

Adds the now-GA fast Gemini models to `get_model_catalog` + the validation list so they're selectable (e.g. `OCTOPUS_GEMINI_MODEL=gemini-3.5-flash`):
- `gemini-3.5-flash` — GA, supersedes `gemini-3-flash-preview`
- `gemini-3.1-flash-lite` — fastest/cheapest tier

Additive only — no routing/default change (that's oco-2kw). Annotates `gemini-3-pro-image-preview` with its 2026-06-25 shutdown.

## Scope note

This is the **confirmed-safe text half of oco-803**. The image-model migration stays blocked: sources conflict on the authoritative Nano Banana Pro GA id and the API is quota-dead, so I won't guess a model id for a public plugin.

## Testing

- New models resolve via get_model_catalog (budget/active).
- test-gemini-provider 52/0, test-orchestrate-cwd-routing 14/0, provider audit 13/0, bash -n clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new Gemini AI models: gemini-3.5-flash and gemini-3.1-flash-lite
  * Updated Gemini model catalog with enhanced metadata
  * Improved model discoverability through expanded catalog capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->