### PR TITLE
fix: migrate gemini-image to Nano Banana Pro before 2026-06-25 shutdown

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
       "keywords": [
         "image-generation",
         "gpt-image-2",
-        "gemini-3.1-flash-image-preview",
+        "gemini-nano-banana-pro",
         "claude-code-plugin",
         "codex"
       ],

--- a/.claude/commands/model-config.md
+++ b/.claude/commands/model-config.md
@@ -175,7 +175,8 @@ AskUserQuestion({
     multiSelect: false,
     options: [
       {label: "gemini-3.1-pro-preview", description: "Premium — $2.50/$10 MTok, best research quality"},
-      {label: "gemini-3-flash-preview", description: "Fast — $0.25/$1 MTok, good for quick tasks"},
+      {label: "gemini-3.5-flash", description: "Fast — $0.25/$1 MTok, GA default for speed tasks"},
+      {label: "gemini-3.1-flash-lite", description: "Cheapest — $0.10/$0.40 MTok, highest throughput"},
       {label: "Custom", description: "Enter a custom model name"}
     ]
   }]

--- a/.claude/skills/skill-parallel-agents/SKILL.md
+++ b/.claude/skills/skill-parallel-agents/SKILL.md
@@ -623,8 +623,8 @@ The `tangle` phase enforces quality gates:
 | `codex-standard` | gpt-5.2-codex | Standard tier implementation |
 | `codex-mini` | gpt-5.4-mini | Quick fixes, simple tasks |
 | `gemini` | gemini-3-pro-preview | Deep analysis, 1M context |
-| `gemini-fast` | gemini-3-flash-preview | Speed-critical tasks |
-| `gemini-image` | gemini-3-pro-image-preview | Image generation |
+| `gemini-fast` | gemini-3.5-flash | Speed-critical tasks |
+| `gemini-image` | gemini-nano-banana-pro | Image generation |
 | `codex-review` | gpt-5.2-codex | Code review mode |
 | `openrouter` | Various | Universal fallback (400+ models) |
 

--- a/.cursor-plugin/commands/octo-model-config.md
+++ b/.cursor-plugin/commands/octo-model-config.md
@@ -169,7 +169,8 @@ AskUserQuestion({
     multiSelect: false,
     options: [
       {label: "gemini-3.1-pro-preview", description: "Premium — $2.50/$10 MTok, best research quality"},
-      {label: "gemini-3-flash-preview", description: "Fast — $0.25/$1 MTok, good for quick tasks"},
+      {label: "gemini-3.5-flash", description: "Fast — $0.25/$1 MTok, GA default for speed tasks"},
+      {label: "gemini-3.1-flash-lite", description: "Cheapest — $0.10/$0.40 MTok, highest throughput"},
       {label: "Custom", description: "Enter a custom model name"}
     ]
   }]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ Providers:
 
 Always be mindful that external CLIs cost money:
 - 🔴 Codex: ~$0.01-0.30 per query depending on model (GPT-5.5 $5/$30 MTok — premium default as of v9.44, GPT-5.4 $2.50/$15, GPT-5.3-Codex $1.75/$14, Mini $0.25/$2.00 MTok)
-- 🟡 Gemini: ~$0.01-0.03 per query (Gemini 3.1 Pro Preview $2.50/$10 MTok, 3 Flash Preview $0.25/$1)
+- 🟡 Gemini: ~$0.01-0.03 per query (3.1 Pro Preview $2.50/$10 MTok, 3.5 Flash $0.25/$1, 3.1 Flash Lite $0.10/$0.40, Nano Banana Pro image $5/$20)
 - 🧭 Antigravity CLI (`agy`): Included with the user's Antigravity access/subscription; backend cost depends on selected `OCTOPUS_AGY_MODEL`
 - 🟣 Perplexity: ~$0.01-0.05 per query (Sonar Pro $3/$15 MTok, Sonar $1/$1 MTok)
 - 🔵 Claude (Sonnet 4.6): Included with Claude Code subscription

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,7 +33,7 @@ Claude Octopus coordinates **nine AI providers** to give you multi-perspective a
 | Provider | CLI Tool | Underlying Model | Cost Source |
 |----------|----------|------------------|-------------|
 | **Codex CLI** | `codex exec --model gpt-5.4` | GPT-5.4 | Your `OPENAI_API_KEY` |
-| **Gemini CLI** | `gemini -y -m gemini-3.1-pro-preview` | Gemini 3.1 Pro Preview | Your `GEMINI_API_KEY` |
+| **Gemini CLI** | `gemini -y -m gemini-3.1-pro-preview` | Gemini 3.1 Pro Preview / 3.5 Flash / Nano Banana Pro (image) | Your `GEMINI_API_KEY` |
 | **Antigravity CLI** | `agy --print --sandbox` | Antigravity default model | Your Antigravity CLI auth |
 | **Claude** | Built-in | Claude Sonnet 4.6 / Opus 4.7 | Your Claude Code subscription |
 | **Perplexity** | API-only | Sonar Pro / Sonar | Your `PERPLEXITY_API_KEY` |
@@ -59,7 +59,7 @@ Role defaults refreshed based on April 2026 benchmark consensus. See [GPT-5.4 pr
 | `implementer`        | GPT-5.4               | Terminal-heavy execution, iterative patch/test loops                |
 | `implementer-heavy`  | Claude Opus 4.7       | Opt-in only; greenfield / large refactors / UI-heavy builds         |
 | `synthesizer`        | Claude Sonnet 4.6     | Best aggregator price/quality                                       |
-| `researcher`         | Gemini 3.1 Pro Preview| Broad research + synthesis                                          |
+| `researcher`         | Gemini 3.1 Pro Preview / 3.5 Flash | Broad research + synthesis                                |
 
 **Opt-out:** `OCTOPUS_LEGACY_ROLES=1` restores the v9.28 mapping (GPT-5.4 everywhere for architect/reviewer/implementer, Opus 4.6 for strategist).
 

--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -73,9 +73,11 @@ ensure_config() {
     },
     "gemini": {
       "default": "gemini-3.1-pro-preview",
-      "fallback": "gemini-3-flash-preview",
-      "flash": "gemini-3-flash-preview",
-      "image": "gemini-3-pro-image-preview"
+      "fallback": "gemini-3.5-flash",
+      "flash": "gemini-3.5-flash",
+      "flash-lite": "gemini-3.1-flash-lite",
+      "image": "gemini-nano-banana-pro",
+      "image-standard": "gemini-nano-banana-2"
     },
     "claude": {
       "default": "claude-sonnet-4.6",
@@ -522,8 +524,10 @@ cmd_models() {
         "o3|200|yes|no|yes|codex|premium|active"
         "o3-mini|200|yes|no|yes|codex|budget|active"
         "gemini-3.1-pro-preview|1000|yes|yes|no|gemini|premium|active"
-        "gemini-3-flash-preview|1000|yes|yes|no|gemini|budget|active"
-        "gemini-3-pro-image-preview|1000|yes|yes|no|gemini|premium|active"
+        "gemini-3.5-flash|1000|yes|no|no|gemini|standard|active"
+        "gemini-3.1-flash-lite|1000|yes|no|no|gemini|budget|active"
+        "gemini-nano-banana-pro|1000|yes|yes|no|gemini|premium|active"
+        "gemini-nano-banana-2|1000|yes|yes|no|gemini|standard|active"
         "claude-sonnet-4.6|200|yes|yes|no|claude|standard|active"
         "claude-opus-4.8|1000|yes|yes|yes|claude|premium|active"
         "claude-opus-4.7|1000|yes|yes|yes|claude|premium|legacy"

--- a/scripts/lib/auto-route.sh
+++ b/scripts/lib/auto-route.sh
@@ -722,7 +722,7 @@ Then provide specific optimization recommendations."
     case "$task_type" in
         image)
             echo -e "${YELLOW}Image Generation Task${NC}"
-            echo "  Using gemini-3-pro-image-preview for text-to-image generation."
+            echo "  Using gemini-nano-banana-pro for text-to-image generation."
             echo "  Supports: text-to-image, image editing, multi-turn editing"
             echo "  Output: Up to 4K resolution images"
             echo ""

--- a/scripts/lib/cost.sh
+++ b/scripts/lib/cost.sh
@@ -849,10 +849,16 @@ get_model_pricing() {
         o3)                     echo "2.00:8.00" ;;
         o3-pro)                 echo "20.00:80.00" ;;  # v8.39.0: API-key only
         o3-mini)                echo "1.10:4.40" ;;    # v8.39.0: API-key only
-        # Google Gemini 3.0 models
+        gpt-5.4)           echo "2.50:15.00" ;;
+        # Google Gemini models
         gemini-3.1-pro-preview)   echo "2.50:10.00" ;;
-        gemini-3-flash-preview) echo "0.25:1.00" ;;
-        gemini-3-pro-image-preview) echo "5.00:20.00" ;;
+        gemini-3.5-flash)         echo "0.25:1.00" ;;
+        gemini-3.1-flash-lite)    echo "0.10:0.40" ;;
+        gemini-nano-banana-pro)   echo "5.00:20.00" ;;
+        gemini-nano-banana-2)     echo "2.50:10.00" ;;
+        # Deprecated — shut down 2026-06-25
+        gemini-3-flash-preview)       echo "0.25:1.00" ;;
+        gemini-3-pro-image-preview)   echo "5.00:20.00" ;;
         # Claude models
         claude-sonnet-4.5)      echo "3.00:15.00" ;;
         claude-sonnet-4.6)      echo "3.00:15.00" ;;   # v8.17: Sonnet 4.6 (same pricing as 4.5)

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -11,7 +11,7 @@
 #                    gpt-5.2-codex, gpt-5.4-mini (budget), gpt-5 (standard), gpt-5.2, gpt-5.1
 # - OpenAI Reasoning: o3, o3-pro (API-key only), o3 (API-key only), o3-mini (API-key only)
 # - OpenAI Large Context: gpt-4.1 (1M ctx, API-key only), gpt-5.4 (1M ctx, API-key only)
-# - Google Gemini 3.0: gemini-3.1-pro-preview, gemini-3-flash-preview, gemini-3-pro-image-preview
+# - Google Gemini: gemini-3.1-pro-preview, gemini-3.5-flash (GA), gemini-3.1-flash-lite, gemini-nano-banana-pro/2 (image)
 # - Google Antigravity CLI: agy --print stdin dispatch, optional OCTOPUS_AGY_MODEL
 # Note: "API-key only" models require OPENAI_API_KEY; they are NOT available via ChatGPT subscription/OAuth.
 get_agent_command() {

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -617,7 +617,7 @@ find_capable_fallback() {
         codex)
             candidates=(gpt-5.4-mini gpt-5.2-codex gpt-5.3-codex gpt-5.4 gpt-5.4-pro o3) ;;
         gemini)
-            candidates=(gemini-3-flash-preview gemini-3.1-pro-preview) ;;
+            candidates=(gemini-3.1-flash-lite gemini-3.5-flash gemini-nano-banana-pro gemini-3.1-pro-preview) ;;
         agy)
             candidates=(default) ;;
         claude)

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -239,7 +239,8 @@ resolve_octopus_model() {
     if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
         case "$agent_type" in
             codex*)          resolved_model="gpt-5.5" ;;
-            gemini-fast|gemini-flash) resolved_model="gemini-3-flash-preview" ;;
+            gemini-image)    resolved_model="gemini-nano-banana-pro" ;;
+            gemini-fast|gemini-flash) resolved_model="gemini-3.5-flash" ;;
             gemini*)         resolved_model="gemini-3.1-pro-preview" ;;
             agy*|antigravity) resolved_model="default" ;;
             claude-opus-legacy*) resolved_model="claude-opus-4.6" ;;

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -33,10 +33,13 @@ get_model_catalog() {
         o3-mini)                echo "200|yes|no|yes|codex|budget|active" ;;
         # Gemini
         gemini-3.1-pro-preview)   echo "1000|yes|yes|no|gemini|premium|active" ;;
-        gemini-3.5-flash)       echo "1000|yes|no|no|gemini|budget|active" ;;   # GA fast (supersedes gemini-3-flash-preview)
-        gemini-3.1-flash-lite)  echo "1000|yes|no|no|gemini|budget|active" ;;   # fastest/cheapest tier
-        gemini-3-flash-preview) echo "1000|yes|no|no|gemini|budget|active" ;;
-        gemini-3-pro-image-preview) echo "1000|yes|yes|no|gemini|premium|active" ;;  # image: shutdown 2026-06-25 (oco-803), migrate to Nano Banana Pro
+        gemini-3.5-flash)         echo "1000|yes|no|no|gemini|standard|active" ;;
+        gemini-3.1-flash-lite)    echo "1000|yes|no|no|gemini|budget|active" ;;
+        gemini-nano-banana-pro)   echo "1000|yes|yes|no|gemini|premium|active" ;;
+        gemini-nano-banana-2)     echo "1000|yes|yes|no|gemini|standard|active" ;;
+        # Deprecated — shut down 2026-06-25; kept for migration diagnostics
+        gemini-3-flash-preview)       echo "1000|yes|no|no|gemini|budget|deprecated" ;;
+        gemini-3-pro-image-preview)   echo "1000|yes|yes|no|gemini|premium|deprecated" ;;
         # Antigravity CLI (agy routes to the user's configured Antigravity default)
         agy/default|default)       echo "1000|yes|yes|no|agy|standard|active" ;;
         # Claude
@@ -119,7 +122,8 @@ list_models() {
         gpt-5.5 gpt-5.5-pro gpt-5.4 gpt-5.4-pro gpt-5.3-codex gpt-5.2-codex
         gpt-5.4-mini gpt-5.1-codex-max
         o3 o3-pro o3-mini
-        gemini-3.1-pro-preview gemini-3.5-flash gemini-3.1-flash-lite gemini-3-flash-preview gemini-3-pro-image-preview
+        gemini-3.1-pro-preview gemini-3.5-flash gemini-3.1-flash-lite
+        gemini-nano-banana-pro gemini-nano-banana-2
         agy/default
         claude-sonnet-4.6 claude-fable-5 claude-opus-4.8 claude-opus-4.8-fast claude-opus-4.7 claude-opus-4.6 claude-opus-4.6-fast
         grok-4-20 grok-4-20-thinking composer-2-fast composer-2

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -302,7 +302,7 @@ EOF
                 replacement="gemini-3.5-flash" ;;
             gemini-2.0-pro*|gemini-1.5-pro*|gemini-pro)
                 replacement="gemini-3.1-pro-preview" ;;
-            gemini-3-pro-image-preview)
+            gemini-3-pro-image-preview|gemini-3.1-flash-image-preview)
                 replacement="gemini-nano-banana-pro" ;;
             gpt-4o*|gpt-4-turbo*|gpt-4-*|o1-*|chatgpt-*)
                 replacement="gpt-5.5" ;;

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -233,9 +233,11 @@ migrate_provider_config() {
     },
     "gemini": {
       "default": "$gemini_model",
-      "fallback": "gemini-3-flash-preview",
-      "flash": "gemini-3-flash-preview",
-      "image": "gemini-3-pro-image-preview"
+      "fallback": "gemini-3.5-flash",
+      "flash": "gemini-3.5-flash",
+      "flash-lite": "gemini-3.1-flash-lite",
+      "image": "gemini-nano-banana-pro",
+      "image-standard": "gemini-nano-banana-2"
     }
   },
   "routing": {
@@ -250,7 +252,7 @@ migrate_provider_config() {
     }
   },
   "tiers": {
-    "budget": { "codex": "mini", "gemini": "flash" },
+    "budget": { "codex": "mini", "gemini": "flash-lite" },
     "standard": { "codex": "default", "gemini": "default" },
     "premium": { "codex": "default", "gemini": "default" }
   },
@@ -279,6 +281,10 @@ EOF
         '.providers.codex.fallback'
         '.providers.gemini.default'
         '.providers.gemini.fallback'
+        '.providers.gemini.flash'
+        '.providers.gemini.flash-lite'
+        '.providers.gemini.image'
+        '.providers.gemini.image-standard'
         '.overrides.codex'
         '.overrides.gemini'
     )
@@ -292,10 +298,12 @@ EOF
         case "$current_val" in
             claude-sonnet-4-5|claude-sonnet-4-5-20250514|claude-3-5-sonnet*|claude-sonnet-4*)
                 if [[ "$path" == *codex* ]]; then replacement="gpt-5.5"; fi ;;
-            gemini-2.0-flash-thinking*|gemini-2.0-flash-exp*|gemini-exp-*)
-                replacement="gemini-3-flash-preview" ;;
+            gemini-2.0-flash-thinking*|gemini-2.0-flash-exp*|gemini-exp-*|gemini-3-flash-preview)
+                replacement="gemini-3.5-flash" ;;
             gemini-2.0-pro*|gemini-1.5-pro*|gemini-pro)
                 replacement="gemini-3.1-pro-preview" ;;
+            gemini-3-pro-image-preview)
+                replacement="gemini-nano-banana-pro" ;;
             gpt-4o*|gpt-4-turbo*|gpt-4-*|o1-*|chatgpt-*)
                 replacement="gpt-5.5" ;;
         esac
@@ -366,9 +374,11 @@ set_provider_model() {
     },
     "gemini": {
       "default": "gemini-3.1-pro-preview",
-      "fallback": "gemini-3-flash-preview",
-      "flash": "gemini-3-flash-preview",
-      "image": "gemini-3-pro-image-preview"
+      "fallback": "gemini-3.5-flash",
+      "flash": "gemini-3.5-flash",
+      "flash-lite": "gemini-3.1-flash-lite",
+      "image": "gemini-nano-banana-pro",
+      "image-standard": "gemini-nano-banana-2"
     }
   },
   "routing": {
@@ -380,7 +390,7 @@ set_provider_model() {
     }
   },
   "tiers": {
-    "budget": { "codex": "mini", "gemini": "flash" },
+    "budget": { "codex": "mini", "gemini": "flash-lite" },
     "standard": { "codex": "default", "gemini": "default" },
     "premium": { "codex": "default", "gemini": "default" }
   },

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -52,8 +52,8 @@ _claude_octopus() {
         'codex-mini:GPT-5.1-Codex-Mini (fast)'
         'codex-general:GPT-5.2'
         'gemini:Gemini-3-Pro'
-        'gemini-fast:Gemini-3-Flash'
-        'gemini-image:Gemini-3-Pro-Image'
+        'gemini-fast:Gemini-3.5-Flash'
+        'gemini-image:Gemini-Nano-Banana-Pro (image gen)'
         'codex-review:Code review mode'
     )
 

--- a/skills/skill-parallel-agents/SKILL.md
+++ b/skills/skill-parallel-agents/SKILL.md
@@ -598,8 +598,8 @@ The `tangle` phase enforces quality gates:
 | `codex-standard` | gpt-5.2-codex | Standard tier implementation |
 | `codex-mini` | gpt-5.4-mini | Quick fixes, simple tasks |
 | `gemini` | gemini-3-pro-preview | Deep analysis, 1M context |
-| `gemini-fast` | gemini-3-flash-preview | Speed-critical tasks |
-| `gemini-image` | gemini-3-pro-image-preview | Image generation |
+| `gemini-fast` | gemini-3.5-flash | Speed-critical tasks |
+| `gemini-image` | gemini-nano-banana-pro | Image generation |
 | `codex-review` | gpt-5.2-codex | Code review mode |
 | `openrouter` | Various | Universal fallback (400+ models) |
 


### PR DESCRIPTION
## Summary

`gemini-3-pro-image-preview` and `gemini-3.1-flash-image-preview` are shut down by Google on 2026-06-25 (~10 days). Without this fix, any call through the `gemini-image` agent will start returning model-not-found errors from that date.

Root cause: the model name was hardcoded in five places (provider-routing.sh JSON templates ×2, octo-model-config.sh, models.sh catalog, model-resolver.sh hardcoded fallback) with no stale-model migration entry to auto-heal user config files.

## Changes

| File | What changed |
|------|--------------|
| `scripts/lib/models.sh` | Add `gemini-nano-banana-pro`, `gemini-nano-banana-2`, `gemini-3.5-flash`, `gemini-3.1-flash-lite`; mark old preview models `deprecated` |
| `scripts/lib/cost.sh` | Add pricing for new models; retain deprecated entries for cost audit |
| `scripts/lib/provider-routing.sh` | Update both JSON config templates (`flash`→`3.5-flash`, `image`→`nano-banana-pro`); add stale-model migrations for `gemini-3-flash-preview` and `gemini-3-pro-image-preview` so existing user configs auto-heal on next run |
| `scripts/lib/model-resolver.sh` | Fix hardcoded fallback: `gemini-image` was falling through to `gemini-3.1-pro-preview` (wrong); now `gemini-nano-banana-pro`. Update `gemini-fast` fallback to `3.5-flash` |
| `scripts/helpers/octo-model-config.sh` | Update default JSON block and embedded catalog |
| `scripts/lib/auto-route.sh` | Update display text |
| `scripts/lib/usage-help.sh` | Update completion label |
| `skills/skill-parallel-agents/SKILL.md` + `.claude/skills/…` | Update agent→model table |
| `.claude/commands/model-config.md` + `.cursor-plugin/…` | Add 3.5-flash and 3.1-flash-lite as selectable options |
| `CLAUDE.md` | Update Gemini pricing table |
| `docs/ARCHITECTURE.md` | Update provider model column |
| `.claude-plugin/marketplace.json` | Update keyword |

## Test results

```
tests/unit/test-gemini-provider.sh: 52/52 PASS
bash -n on all 8 modified shell scripts: OK
jq empty on marketplace.json: OK
```

closes #493

https://claude.ai/code/session_013uGzkJRALdnKPW8PR7mFnu

---
_Generated by [Claude Code](https://claude.ai/code/session_013uGzkJRALdnKPW8PR7mFnu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Gemini model targets across the platform, replacing deprecated preview/image options with newer choices (Gemini 3.5 Flash, Gemini 3.1 Flash Lite, and Nano Banana Pro/2).
  * Refreshed defaults, routing/mapping, fallbacks, and image-generation messaging to align with the updated model catalog.
  * Updated Gemini cost guidance with a more granular per-query breakdown, including the newly supported variants.

* **Documentation**
  * Refreshed architecture and configuration references to reflect the current Gemini model catalog and default role/model mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->