### PR TITLE
fix: refresh Gemini text catalog to GA models; mark deprecated models (#493 partial)

### DIFF
--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -104,7 +104,7 @@ ensure_config() {
     }
   },
   "tiers": {
-    "budget": { "codex": "mini", "gemini": "flash", "opencode": "fast" },
+    "budget": { "codex": "mini", "gemini": "flash-lite", "opencode": "fast" },
     "standard": { "codex": "default", "gemini": "default", "opencode": "default" },
     "premium": { "codex": "default", "gemini": "default", "opencode": "default" }
   },

--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -73,8 +73,9 @@ ensure_config() {
     },
     "gemini": {
       "default": "gemini-3.1-pro-preview",
-      "fallback": "gemini-3-flash-preview",
-      "flash": "gemini-3-flash-preview",
+      "fallback": "gemini-3.5-flash",
+      "flash": "gemini-3.5-flash",
+      "flash-lite": "gemini-3.1-flash-lite",
       "image": "gemini-3-pro-image-preview"
     },
     "claude": {
@@ -522,8 +523,10 @@ cmd_models() {
         "o3|200|yes|no|yes|codex|premium|active"
         "o3-mini|200|yes|no|yes|codex|budget|active"
         "gemini-3.1-pro-preview|1000|yes|yes|no|gemini|premium|active"
-        "gemini-3-flash-preview|1000|yes|yes|no|gemini|budget|active"
-        "gemini-3-pro-image-preview|1000|yes|yes|no|gemini|premium|active"
+        "gemini-3.5-flash|1000|yes|no|no|gemini|standard|active"
+        "gemini-3.1-flash-lite|1000|yes|no|no|gemini|budget|active"
+        "gemini-3-flash-preview|1000|yes|no|no|gemini|budget|deprecated"
+        "gemini-3-pro-image-preview|1000|yes|yes|no|gemini|premium|deprecated"
         "claude-sonnet-4.6|200|yes|yes|no|claude|standard|active"
         "claude-opus-4.8|1000|yes|yes|yes|claude|premium|active"
         "claude-opus-4.7|1000|yes|yes|yes|claude|premium|legacy"

--- a/scripts/lib/auto-route.sh
+++ b/scripts/lib/auto-route.sh
@@ -722,7 +722,7 @@ Then provide specific optimization recommendations."
     case "$task_type" in
         image)
             echo -e "${YELLOW}Image Generation Task${NC}"
-            echo "  Using gemini-3-pro-image-preview for text-to-image generation."
+            echo "  Using gemini-image agent for text-to-image generation."
             echo "  Supports: text-to-image, image editing, multi-turn editing"
             echo "  Output: Up to 4K resolution images"
             echo ""

--- a/scripts/lib/cost.sh
+++ b/scripts/lib/cost.sh
@@ -849,10 +849,12 @@ get_model_pricing() {
         o3)                     echo "2.00:8.00" ;;
         o3-pro)                 echo "20.00:80.00" ;;  # v8.39.0: API-key only
         o3-mini)                echo "1.10:4.40" ;;    # v8.39.0: API-key only
-        # Google Gemini 3.0 models
+        # Google Gemini 3.x models
         gemini-3.1-pro-preview)   echo "2.50:10.00" ;;
-        gemini-3-flash-preview) echo "0.25:1.00" ;;
-        gemini-3-pro-image-preview) echo "5.00:20.00" ;;
+        gemini-3.5-flash)         echo "0.25:1.00" ;;   # GA fast default (replaces gemini-3-flash-preview)
+        gemini-3.1-flash-lite)    echo "0.10:0.40" ;;   # cheapest/fastest tier
+        gemini-3-flash-preview)   echo "0.25:1.00" ;;   # deprecated — migrate to gemini-3.5-flash
+        gemini-3-pro-image-preview) echo "5.00:20.00" ;; # deprecated — shut down 2026-06-25
         # Claude models
         claude-sonnet-4.5)      echo "3.00:15.00" ;;
         claude-sonnet-4.6)      echo "3.00:15.00" ;;   # v8.17: Sonnet 4.6 (same pricing as 4.5)

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -11,7 +11,7 @@
 #                    gpt-5.2-codex, gpt-5.4-mini (budget), gpt-5 (standard), gpt-5.2, gpt-5.1
 # - OpenAI Reasoning: o3, o3-pro (API-key only), o3 (API-key only), o3-mini (API-key only)
 # - OpenAI Large Context: gpt-4.1 (1M ctx, API-key only), gpt-5.4 (1M ctx, API-key only)
-# - Google Gemini 3.0: gemini-3.1-pro-preview, gemini-3-flash-preview, gemini-3-pro-image-preview
+# - Google Gemini 3.x: gemini-3.1-pro-preview, gemini-3.5-flash (GA), gemini-3.1-flash-lite (budget)
 # - Google Antigravity CLI: agy --print stdin dispatch, optional OCTOPUS_AGY_MODEL
 # Note: "API-key only" models require OPENAI_API_KEY; they are NOT available via ChatGPT subscription/OAuth.
 get_agent_command() {

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -617,7 +617,7 @@ find_capable_fallback() {
         codex)
             candidates=(gpt-5.4-mini gpt-5.2-codex gpt-5.3-codex gpt-5.4 gpt-5.4-pro o3) ;;
         gemini)
-            candidates=(gemini-3-flash-preview gemini-3.1-pro-preview) ;;
+            candidates=(gemini-3.5-flash gemini-3.1-flash-lite gemini-3.1-pro-preview) ;;
         agy)
             candidates=(default) ;;
         claude)

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -239,7 +239,7 @@ resolve_octopus_model() {
     if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
         case "$agent_type" in
             codex*)          resolved_model="gpt-5.5" ;;
-            gemini-fast|gemini-flash) resolved_model="gemini-3-flash-preview" ;;
+            gemini-fast|gemini-flash) resolved_model="gemini-3.5-flash" ;;
             gemini*)         resolved_model="gemini-3.1-pro-preview" ;;
             agy*|antigravity) resolved_model="default" ;;
             claude-opus-legacy*) resolved_model="claude-opus-4.6" ;;

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -33,8 +33,10 @@ get_model_catalog() {
         o3-mini)                echo "200|yes|no|yes|codex|budget|active" ;;
         # Gemini
         gemini-3.1-pro-preview)   echo "1000|yes|yes|no|gemini|premium|active" ;;
-        gemini-3-flash-preview) echo "1000|yes|no|no|gemini|budget|active" ;;
-        gemini-3-pro-image-preview) echo "1000|yes|yes|no|gemini|premium|active" ;;
+        gemini-3.5-flash)         echo "1000|yes|no|no|gemini|standard|active" ;;
+        gemini-3.1-flash-lite)    echo "1000|yes|no|no|gemini|budget|active" ;;
+        gemini-3-flash-preview)   echo "1000|yes|no|no|gemini|budget|deprecated" ;;
+        gemini-3-pro-image-preview) echo "1000|yes|yes|no|gemini|premium|deprecated" ;;
         # Antigravity CLI (agy routes to the user's configured Antigravity default)
         agy/default|default)       echo "1000|yes|yes|no|agy|standard|active" ;;
         # Claude
@@ -117,7 +119,8 @@ list_models() {
         gpt-5.5 gpt-5.5-pro gpt-5.4 gpt-5.4-pro gpt-5.3-codex gpt-5.2-codex
         gpt-5.4-mini gpt-5.1-codex-max
         o3 o3-pro o3-mini
-        gemini-3.1-pro-preview gemini-3-flash-preview gemini-3-pro-image-preview
+        gemini-3.1-pro-preview gemini-3.5-flash gemini-3.1-flash-lite
+        gemini-3-flash-preview gemini-3-pro-image-preview
         agy/default
         claude-sonnet-4.6 claude-fable-5 claude-opus-4.8 claude-opus-4.8-fast claude-opus-4.7 claude-opus-4.6 claude-opus-4.6-fast
         grok-4-20 grok-4-20-thinking composer-2-fast composer-2

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -251,7 +251,7 @@ migrate_provider_config() {
     }
   },
   "tiers": {
-    "budget": { "codex": "mini", "gemini": "flash" },
+    "budget": { "codex": "mini", "gemini": "flash-lite" },
     "standard": { "codex": "default", "gemini": "default" },
     "premium": { "codex": "default", "gemini": "default" }
   },
@@ -280,6 +280,7 @@ EOF
         '.providers.codex.fallback'
         '.providers.gemini.default'
         '.providers.gemini.fallback'
+        '.providers.gemini.flash'
         '.overrides.codex'
         '.overrides.gemini'
     )
@@ -384,7 +385,7 @@ set_provider_model() {
     }
   },
   "tiers": {
-    "budget": { "codex": "mini", "gemini": "flash" },
+    "budget": { "codex": "mini", "gemini": "flash-lite" },
     "standard": { "codex": "default", "gemini": "default" },
     "premium": { "codex": "default", "gemini": "default" }
   },

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -233,8 +233,9 @@ migrate_provider_config() {
     },
     "gemini": {
       "default": "$gemini_model",
-      "fallback": "gemini-3-flash-preview",
-      "flash": "gemini-3-flash-preview",
+      "fallback": "gemini-3.5-flash",
+      "flash": "gemini-3.5-flash",
+      "flash-lite": "gemini-3.1-flash-lite",
       "image": "gemini-3-pro-image-preview"
     }
   },
@@ -293,7 +294,9 @@ EOF
             claude-sonnet-4-5|claude-sonnet-4-5-20250514|claude-3-5-sonnet*|claude-sonnet-4*)
                 if [[ "$path" == *codex* ]]; then replacement="gpt-5.5"; fi ;;
             gemini-2.0-flash-thinking*|gemini-2.0-flash-exp*|gemini-exp-*)
-                replacement="gemini-3-flash-preview" ;;
+                replacement="gemini-3.5-flash" ;;
+            gemini-3-flash-preview)
+                replacement="gemini-3.5-flash" ;;
             gemini-2.0-pro*|gemini-1.5-pro*|gemini-pro)
                 replacement="gemini-3.1-pro-preview" ;;
             gpt-4o*|gpt-4-turbo*|gpt-4-*|o1-*|chatgpt-*)
@@ -366,8 +369,9 @@ set_provider_model() {
     },
     "gemini": {
       "default": "gemini-3.1-pro-preview",
-      "fallback": "gemini-3-flash-preview",
-      "flash": "gemini-3-flash-preview",
+      "fallback": "gemini-3.5-flash",
+      "flash": "gemini-3.5-flash",
+      "flash-lite": "gemini-3.1-flash-lite",
       "image": "gemini-3-pro-image-preview"
     }
   },

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -52,8 +52,8 @@ _claude_octopus() {
         'codex-mini:GPT-5.1-Codex-Mini (fast)'
         'codex-general:GPT-5.2'
         'gemini:Gemini-3-Pro'
-        'gemini-fast:Gemini-3-Flash'
-        'gemini-image:Gemini-3-Pro-Image'
+        'gemini-fast:Gemini-3.5-Flash (GA)'
+        'gemini-image:Gemini image generation (model TBD — see issue #493)'
         'codex-review:Code review mode'
     )
 

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -661,7 +661,7 @@ ${YELLOW}Available Agents:${NC}
   codex-standard  GPT-5.2-Codex       Standard tier
   codex-mini      GPT-5.1-Codex-Mini  Quick/cheap tasks
   gemini          Gemini-3-Pro        Deep analysis
-  gemini-fast     Gemini-3-Flash      Speed-critical
+  gemini-fast     Gemini-3.5-Flash (GA)  Speed-critical
 
 ${YELLOW}Common Options:${NC}
   -v, --verbose           Detailed output


### PR DESCRIPTION
## Root cause

Issue #493 calls out two problems:
1. `gemini-3-pro-image-preview` (and the flash preview) being shut down June 25 2026
2. Gemini text catalog still pointing at preview models after `gemini-3.5-flash` went GA

This PR addresses **part 2 fully** and **part 1 partially** (deprecation marking + removal of hardcoded model name from user-facing output). The image model migration (gemini-image → Nano Banana Pro/2) requires the exact Gemini CLI model IDs for the new image-generation models, which are not in the codebase — see the issue for follow-up.

## Changes

| File | What changed |
|---|---|
| `scripts/lib/models.sh` | Add `gemini-3.5-flash` (standard/active) and `gemini-3.1-flash-lite` (budget/active); mark `gemini-3-flash-preview` and `gemini-3-pro-image-preview` as `deprecated` |
| `scripts/lib/model-resolver.sh` | `gemini-fast` hardcoded fallback: `gemini-3-flash-preview` → `gemini-3.5-flash` |
| `scripts/lib/cost.sh` | Pricing entries for new GA models; deprecation comments on old ones |
| `scripts/helpers/octo-model-config.sh` | Default config template: `flash`/`fallback` → `gemini-3.5-flash`; add `flash-lite` tier; mark catalog entries deprecated |
| `scripts/lib/provider-routing.sh` | Both config templates updated; stale-model migration rule now forwards `gemini-3-flash-preview` → `gemini-3.5-flash` in providers.json |
| `scripts/lib/auto-route.sh` | Remove hardcoded `gemini-3-pro-image-preview` from user-facing message |
| `scripts/lib/dispatch.sh` | Update header comment |
| `scripts/lib/usage-help.sh` | Display names: `gemini-fast` → `Gemini-3.5-Flash (GA)` |

## Test results

- All 8 modified scripts pass `bash -n` syntax check
- Gemini provider unit tests: **52/52 pass** (`tests/unit/test-gemini-provider.sh`)
- `make test-unit`: 130/134 suites pass — the 4 failures are pre-existing (health-check grep matches function calls before definitions; synthesis-prompt quality tests) and unrelated to this change

## What's NOT in this PR

The gemini-image agent still routes to `gemini-3-pro-image-preview` in the config `"image"` key. That model is shut down June 25. To complete the migration, I need the exact Gemini CLI model ID(s) for the Nano Banana Pro / Nano Banana 2 image models (the ones that replace the preview). Once provided, the follow-up is a one-line change in `octo-model-config.sh`, `provider-routing.sh`, and the model catalog.

closes #493 (partial — text catalog refresh done; image model migration pending model IDs)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaBP9uniu4uGVk6Vk7LedV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added **Gemini-3.5-Flash (GA)** and **Gemini-3.1-Flash-Lite (budget)** to the available Gemini model catalog.

* **Chores**
  * Updated default Gemini fallback/flash behavior to prefer **Gemini-3.5-Flash (GA)** and route **budget** to **Gemini-3.1-Flash-Lite**.
  * Marked **Gemini-3-Flash-Preview** and **Gemini-3-Pro-Image-Preview** as deprecated and migrated existing configurations.
  * Refreshed Gemini pricing, routing/capability fallback preference, and updated usage/help text labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->