### PR TITLE
fix: provider reliability bundle — gemini timeout, parallel fast-fail, quota-dead skip (oco-2kw/48z/cbb)

### DIFF
--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -24,6 +24,20 @@ source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/auth.sh" 2>/dev/null || true   # octo_oauth_token_valid (oco-dar)
 source "${SCRIPT_DIR}/../lib/qwen.sh" 2>/dev/null || true   # qwen_is_usable (oco-dar)
 source "${SCRIPT_DIR}/../lib/events.sh" 2>/dev/null || true  # opt-in JSONL lifecycle stream
+source "${SCRIPT_DIR}/../lib/quota-watcher.sh" 2>/dev/null || true  # octo_quota_is_dead (oco-cbb)
+
+# oco-cbb: report degraded when a key/binary-present provider was marked
+# quota/auth-dead earlier this session (perplexity 401, gemini exhausted), so it
+# is skipped instead of re-dispatched into the same failure + timeout.
+_octo_provider_state() {
+    local provider="$1" present_state="$2"
+    if [[ "$present_state" == "available" ]] && declare -f octo_quota_is_dead >/dev/null 2>&1 \
+       && octo_quota_is_dead "$provider"; then
+        echo "degraded"
+    else
+        echo "$present_state"
+    fi
+}
 
 provider_status() {
     local provider="$1"
@@ -46,9 +60,9 @@ fi
 
 echo "PROVIDER_CHECK_START"
 provider_status "codex" "$(command -v codex >/dev/null 2>&1 && echo available || echo missing)"
-provider_status "gemini" "$(command -v gemini >/dev/null 2>&1 && echo available || echo missing)"
+provider_status "gemini" "$(_octo_provider_state gemini "$(command -v gemini >/dev/null 2>&1 && echo available || echo missing)")"
 provider_status "agy" "$(command -v agy >/dev/null 2>&1 && echo available || echo missing)"
-provider_status "perplexity" "$([ -n "${PERPLEXITY_API_KEY:-}" ] && echo available || echo missing)"
+provider_status "perplexity" "$(_octo_provider_state perplexity "$([ -n "${PERPLEXITY_API_KEY:-}" ] && echo available || echo missing)")"
 provider_status "opencode" "$(command -v opencode >/dev/null 2>&1 && echo available || echo missing)"
 provider_status "copilot" "$(command -v copilot >/dev/null 2>&1 && echo available || echo missing)"
 # qwen: binary-only is not enough — an expired OAuth token (free tier EOL
@@ -66,5 +80,5 @@ fi
 provider_status "qwen" "$qwen_state"
 provider_status "cursor-agent" "$cursor_agent_status"
 provider_status "ollama" "$({ ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "ollama"; } && command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1 && echo available || echo missing)"
-provider_status "openrouter" "$([ -n "${OPENROUTER_API_KEY:-}" ] && echo available || echo missing)"
+provider_status "openrouter" "$(_octo_provider_state openrouter "$([ -n "${OPENROUTER_API_KEY:-}" ] && echo available || echo missing)")"
 echo "PROVIDER_CHECK_END"

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -314,6 +314,11 @@ is_agent_available_v2() {
     # Load config if needed
     [[ -z "$PROVIDER_CODEX_INSTALLED" ]] && load_providers_config
 
+    # oco-cbb: skip a provider marked quota/auth-dead earlier this session.
+    if declare -f octo_quota_is_dead >/dev/null 2>&1 && octo_quota_is_dead "${agent%%-*}"; then
+        return 1
+    fi
+
     if is_claude_agent_type "$agent"; then
         [[ "$PROVIDER_CLAUDE_INSTALLED" == "true" ]]
         return

--- a/scripts/lib/perplexity.sh
+++ b/scripts/lib/perplexity.sh
@@ -237,7 +237,17 @@ EOF
 
     if [[ -z "$content" ]]; then
         if [[ "$response" =~ \"error\":\{([^\}]*)\} ]]; then
-            log ERROR "Perplexity error: ${BASH_REMATCH[1]}"
+            local _ppx_err="${BASH_REMATCH[1]}"
+            # Terminal quota/auth (HTTP 401 insufficient_quota) returns faster than
+            # the 2s quota-watcher poll, so mark the provider dead directly here
+            # (oco-cbb) and emit a quota-watcher-matchable keyword (oco-48z) so
+            # preflight + is_agent_available skip perplexity for the rest of the run.
+            if [[ "$_ppx_err" == *insufficient_quota* || "$_ppx_err" == *'"code":401'* || "$_ppx_err" == *quota* ]]; then
+                log ERROR "Perplexity TerminalQuotaError (insufficient_quota / HTTP 401): ${_ppx_err}"
+                declare -f octo_quota_mark_dead >/dev/null 2>&1 && octo_quota_mark_dead "perplexity" || true
+                return 1
+            fi
+            log ERROR "Perplexity error: ${_ppx_err}"
             return 1
         fi
         # Content missing but no parseable error — surface the raw body and fail

--- a/scripts/lib/quota-watcher.sh
+++ b/scripts/lib/quota-watcher.sh
@@ -2,7 +2,30 @@
 # Shared quota fast-fail watcher for provider CLIs that retry for a long time
 # after quota exhaustion instead of exiting promptly.
 
-OCTOPUS_QUOTA_PATTERN='QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted'
+OCTOPUS_QUOTA_PATTERN='QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted|insufficient_quota|HTTP 401'
+
+# Session-scoped "this provider is quota/auth-dead" cache (oco-cbb). When a
+# terminal quota/auth error is seen at dispatch, the provider is marked here so
+# preflight (check-providers.sh) and is_agent_available skip it for the rest of
+# the run instead of re-dispatching into the same failure + timeout.
+octo_quota_dead_file() {
+    printf '%s\n' "${WORKSPACE_DIR:-$HOME/.claude-octopus}/state/.provider-quota-dead"
+}
+
+octo_quota_mark_dead() {
+    local provider="$1"
+    [[ -n "$provider" ]] || return 0
+    local f dir
+    f="$(octo_quota_dead_file)"; dir="$(dirname "$f")"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    grep -qxF "$provider" "$f" 2>/dev/null || printf '%s\n' "$provider" >> "$f"
+}
+
+octo_quota_is_dead() {
+    local provider="$1"
+    [[ -n "$provider" ]] || return 1
+    grep -qxF "$provider" "$(octo_quota_dead_file)" 2>/dev/null
+}
 
 quota_watcher_has_match() {
     local temp_err="$1"
@@ -18,6 +41,7 @@ start_quota_watcher() {
     local temp_out="$3"
     local kill_callback="$4"
     local warning_message="${5:-Quota exhaustion detected - fast-failing}"
+    local provider="${6:-}"   # optional: marked quota-dead for the session on match
 
     > "$temp_err"
     > "$temp_out"
@@ -27,6 +51,7 @@ start_quota_watcher() {
             sleep 2
             if quota_watcher_has_match "$temp_err" "$temp_out"; then
                 log "WARN" "$warning_message"
+                octo_quota_mark_dead "$provider"
                 "$kill_callback" "$target_pid"
                 break
             fi

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -567,26 +567,36 @@ ${heuristic_ctx}"
         while true; do
             exit_code=0
 
-            # Quota fast-fail watcher: detects quota exhaustion in stderr/stdout
-            # and kills the provider process early instead of waiting the full TIMEOUT.
-            # Applies to Gemini (free tier exhausts quota and retries for ~18h internally).
-            local _quota_watcher_pid=""
+            # oco-2kw: per-provider timeout. Gemini has no request timeout and its
+            # non-interactive maxSessionTurns default is unlimited, so a quota-loop
+            # or stall could burn the global TIMEOUT (~600s). Cap gemini separately;
+            # all others keep the global TIMEOUT. Plain scalar — bash 3.2 safe.
+            local _eff_timeout="$TIMEOUT"
             if [[ "$agent_type" == gemini* ]]; then
-                local _spawn_pid=$BASHPID
-                _quota_watcher_pid=$(start_quota_watcher \
-                    "$_spawn_pid" \
-                    "$temp_errors" \
-                    "$temp_output" \
-                    quota_watcher_kill_spawn_children \
-                    "[$agent_type] Quota exhaustion detected - fast-failing (saves ~${TIMEOUT}s wait)")
+                _eff_timeout="${OCTOPUS_GEMINI_TIMEOUT:-180}"
             fi
+
+            # oco-48z: quota/terminal-error fast-fail watcher for ALL providers (was
+            # gemini-only). Greps temp files every 2s; on match it kills the provider
+            # early and marks it quota-dead for the session (oco-cbb), so preflight and
+            # is_agent_available skip it instead of re-dispatching into the same failure.
+            local _quota_watcher_pid=""
+            local _spawn_pid=$BASHPID
+            local _provider_prefix="${agent_type%%-*}"
+            _quota_watcher_pid=$(start_quota_watcher \
+                "$_spawn_pid" \
+                "$temp_errors" \
+                "$temp_output" \
+                quota_watcher_kill_spawn_children \
+                "[$agent_type] Quota/terminal error detected - fast-failing (saves ~${_eff_timeout}s wait)" \
+                "$_provider_prefix")
 
             # v9.2.2: All agents use stdin-based prompt delivery to avoid ARG_MAX limits (Issue #173)
             # Previously only gemini used stdin; codex/claude passed prompt as CLI arg which fails on large diffs.
             if [[ "$agent_type" == agy* || "$agent_type" == "antigravity" ]]; then
-                printf '%s' "$enhanced_prompt" | run_with_timeout "$TIMEOUT" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"
+                printf '%s' "$enhanced_prompt" | run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"
                 exit_code=${PIPESTATUS[1]:-0}
-            elif printf '%s' "$enhanced_prompt" | run_with_timeout "$TIMEOUT" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then
+            elif printf '%s' "$enhanced_prompt" | run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then
                 exit_code=0
             else
                 exit_code=$?

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -1530,6 +1530,13 @@ is_agent_available() {
     # Load config if needed
     [[ -z "$USER_HAS_OPENAI" ]] && load_user_config
 
+    # oco-cbb: skip a provider marked quota/auth-dead earlier this session
+    # (perplexity 401, gemini exhausted) so it is not re-dispatched into the same
+    # terminal failure + timeout. Guarded; no-op if the helper is unavailable.
+    if declare -f octo_quota_is_dead >/dev/null 2>&1 && octo_quota_is_dead "${agent%%-*}"; then
+        return 1
+    fi
+
     case "$agent" in
         codex|codex-standard|codex-mini|codex-max)
             [[ "$USER_HAS_OPENAI" == "true" || -n "${OPENAI_API_KEY:-}" ]]

--- a/tests/unit/test-quota-fast-fail.sh
+++ b/tests/unit/test-quota-fast-fail.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Quota fast-fail + quota-dead cache (oco-2kw/48z/cbb)"
+
+# Isolate the session cache to a tmp workspace.
+FIXTURE="$(mktemp -d)"
+export WORKSPACE_DIR="$FIXTURE"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# shellcheck disable=SC1091
+source "$PROJECT_ROOT/scripts/lib/quota-watcher.sh"
+# stub log so the watcher subshell doesn't error when log is undefined
+log() { :; }
+
+test_quota_dead_cache_roundtrip() {
+    test_case "octo_quota_mark_dead / octo_quota_is_dead roundtrip"
+    if octo_quota_is_dead perplexity; then test_fail "dead before mark"; return; fi
+    octo_quota_mark_dead perplexity
+    if octo_quota_is_dead perplexity && ! octo_quota_is_dead gemini; then test_pass
+    else test_fail "mark/is_dead mismatch"; fi
+}
+
+test_quota_dead_cache_dedup() {
+    test_case "marking the same provider twice does not duplicate"
+    octo_quota_mark_dead codex; octo_quota_mark_dead codex
+    local n
+    n=$(grep -cxF codex "$(octo_quota_dead_file)" 2>/dev/null | tr -d ' ')
+    [[ "$n" == "1" ]] && test_pass || test_fail "expected 1 codex entry, got $n"
+}
+
+test_pattern_matches_terminal_errors() {
+    test_case "quota pattern matches 401 / insufficient_quota / exhausted"
+    local tmp_ok="$FIXTURE/m.txt" tmp_no="$FIXTURE/n.txt"
+    printf 'You exceeded your current quota insufficient_quota code 401\n' > "$tmp_ok"
+    printf 'all good, normal output\n' > "$tmp_no"
+    if quota_watcher_has_match "$tmp_ok" /dev/null && ! quota_watcher_has_match "$tmp_no" /dev/null; then
+        test_pass
+    else test_fail "pattern match incorrect"; fi
+}
+
+test_watcher_marks_dead_on_match() {
+    test_case "watcher marks a provider quota-dead when it sees a terminal error"
+    local errf="$FIXTURE/w-err.txt" outf="$FIXTURE/w-out.txt"
+    : > "$errf"; : > "$outf"
+    # Short-lived target we manage ourselves (no orphaned sleep, no self-kill race).
+    # Quota line is written AFTER the watcher starts (it truncates temp files on entry).
+    _noop_kill() { kill "$1" 2>/dev/null || true; }
+    ( sleep 1; echo "exhausted your capacity (insufficient_quota)" >> "$errf"; sleep 4 ) &
+    local target=$!
+    local wpid
+    wpid=$(start_quota_watcher "$target" "$errf" "$outf" _noop_kill "test" "fakeprov")
+    # Poll up to ~6s for the watcher to detect + mark.
+    local i marked=0
+    for i in $(seq 1 12); do
+        if octo_quota_is_dead fakeprov; then marked=1; break; fi
+        sleep 0.5
+    done
+    kill "$target" 2>/dev/null || true
+    wait "$target" 2>/dev/null || true
+    stop_quota_watcher "$wpid"
+    [[ "$marked" == "1" ]] && test_pass || test_fail "watcher did not mark fakeprov dead on quota match"
+}
+
+test_is_agent_available_skips_dead() {
+    test_case "is_agent_available returns false for a quota-dead provider"
+    octo_quota_mark_dead perplexity
+    # Minimal harness: define the guard exactly as orchestrate.sh uses it.
+    _is_avail() {
+        if declare -f octo_quota_is_dead >/dev/null 2>&1 && octo_quota_is_dead "${1%%-*}"; then
+            return 1
+        fi
+        return 0
+    }
+    if ! _is_avail perplexity && _is_avail copilot; then test_pass
+    else test_fail "quota-dead skip gate wrong"; fi
+}
+
+test_gemini_timeout_override_present() {
+    test_case "spawn.sh applies OCTOPUS_GEMINI_TIMEOUT to gemini dispatch (oco-2kw)"
+    if grep -q 'OCTOPUS_GEMINI_TIMEOUT' "$PROJECT_ROOT/scripts/lib/spawn.sh" && \
+       grep -q 'run_with_timeout "\$_eff_timeout"' "$PROJECT_ROOT/scripts/lib/spawn.sh"; then
+        test_pass
+    else test_fail "spawn.sh missing per-provider gemini timeout wiring"; fi
+}
+
+test_quota_dead_cache_roundtrip
+test_quota_dead_cache_dedup
+test_pattern_matches_terminal_errors
+test_watcher_marks_dead_on_match
+test_is_agent_available_skips_dead
+test_gemini_timeout_override_present
+
+test_summary


### PR DESCRIPTION
Fixes the three reliability bugs surfaced by today's research probes (gemini quota-looped to ~600s; perplexity 401 wasn't fast-failed).

## oco-2kw — gemini per-provider timeout
`spawn.sh` now caps gemini dispatch at `OCTOPUS_GEMINI_TIMEOUT` (default 180s) instead of the global ~600s, via the existing `run_with_timeout` (handles bash-3.2 + no-gtimeout). Sync path already capped gemini; this closes the parallel path.

## oco-48z — generalized fast-fail
The quota fast-fail watcher runs for **all** providers (was gemini-only). `perplexity_execute` classifies HTTP 401 / `insufficient_quota` as terminal — emits a watcher-matchable keyword and returns fast instead of dumping raw JSON.

## oco-cbb — quota-dead session cache
A terminal quota/auth error marks the provider dead for the session (`octo_quota_mark_dead`). `check-providers.sh` reports it `degraded`; `is_agent_available` / `is_agent_available_v2` skip it — no re-dispatch into the same failure. No always-on network probe (avoids per-run API cost).

## Reuse / safety
Reuses `run_with_timeout`, `start_quota_watcher`, and the qwen `degraded` pattern. All new code bash-3.2 safe (scalars, guarded helpers). 

## Testing
New `test-quota-fast-fail.sh` (6 cases): cache roundtrip/dedup, pattern match, watcher marks-dead, is_agent_available skip, gemini timeout wiring. Regression green: gemini-provider 52/0, cwd-routing 14/0, octo-events 9/0, contract-audit 4/0, audit gate 13/0.

Closes oco-2kw, oco-48z, oco-cbb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now detects and tracks provider quota exhaustion and authentication failures, enabling faster failover to alternative providers.

* **Bug Fixes**
  * Improved quota and authentication error detection to prevent unnecessary timeouts.
  * Provider availability checks now correctly skip quota-dead providers.

* **Tests**
  * Added comprehensive test suite for quota detection and fast-fail behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->