### PR TITLE
feat: provider.selected + circuit-breaker lifecycle events (oco-aek, partial)

### DIFF
--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -306,6 +306,9 @@ ${heuristic_ctx}"
         return 1
     fi
 
+    # oco-aek: provider selected for dispatch (circuit closed). Opt-in event.
+    declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "provider.selected" provider="$provider_prefix" agent_type="$agent_type" phase="${phase:-unknown}" || true
+
     local cmd
     if ! cmd=$(get_agent_command "$agent_type" "${phase:-}" "${role:-}"); then
         log ERROR "Unknown agent type: $agent_type"

--- a/scripts/provider-router.sh
+++ b/scripts/provider-router.sh
@@ -10,6 +10,14 @@ OCTOPUS_ROUTING_MODE="${OCTOPUS_ROUTING_MODE:-round-robin}"
 _ROUTER_STATE_FILE="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.router-state"
 _ROUTER_STATS_FILE="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.provider-stats.json"
 
+# Opt-in lifecycle event stream (oco-aek) — no-op unless OCTO_EVENT_LOG is set.
+# Sourced guarded; emits below are also declare-f guarded.
+if ! declare -f octo_event_emit >/dev/null 2>&1; then
+    _octo_pr_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+    # shellcheck source=/dev/null
+    source "${_octo_pr_lib_dir}/lib/events.sh" 2>/dev/null || true
+fi
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Provider Reliability Layer (v9.8.0)
 # Error classification, circuit breaker, graduated backoff
@@ -107,6 +115,7 @@ record_provider_failure() {
             # Open the circuit breaker
             echo "$timestamp" > "${_PROVIDER_STATE_DIR}/${provider}.cooldown"
             log "WARN" "Circuit breaker OPEN for $provider — $recent_failures consecutive failures, cooling down ${OCTO_CB_COOLDOWN_SECS}s" 2>/dev/null || true
+            declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "circuit-breaker.open" provider="$provider" failures="$recent_failures" cooldown="$OCTO_CB_COOLDOWN_SECS" || true
         fi
     fi
 
@@ -119,8 +128,13 @@ record_provider_success() {
     local provider="$1"
 
     # Clear failure log and cooldown on success
+    local _was_open=0
+    [[ -f "${_PROVIDER_STATE_DIR}/${provider}.cooldown" ]] && _was_open=1
     rm -f "${_PROVIDER_STATE_DIR}/${provider}.failures" 2>/dev/null
     rm -f "${_PROVIDER_STATE_DIR}/${provider}.cooldown" 2>/dev/null
+    if [[ "$_was_open" == "1" ]] && declare -f octo_event_emit >/dev/null 2>&1; then
+        octo_event_emit "circuit-breaker.closed" provider="$provider" || true
+    fi
 }
 
 # Check if a provider is available (not in cooldown)
@@ -142,6 +156,7 @@ is_provider_available() {
         # Cooldown expired → half-open state (allow probe)
         rm -f "$cooldown_file"
         log "INFO" "Circuit breaker HALF-OPEN for $provider — allowing probe after ${elapsed}s cooldown" 2>/dev/null || true
+        declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "circuit-breaker.half-open" provider="$provider" cooldown_elapsed="$elapsed" || true
         return 0
     fi
 

--- a/tests/unit/test-octo-events.sh
+++ b/tests/unit/test-octo-events.sh
@@ -163,6 +163,37 @@ test_orchestrate_enables_telemetry_by_default() {
     fi
 }
 
+test_circuit_breaker_events() {
+    test_case "circuit-breaker open/closed/half-open lifecycle events emit (oco-aek)"
+    local home="$FIXTURE/cb-home"; mkdir -p "$home"
+    local log="$FIXTURE/cb.jsonl"
+    (
+        export HOME="$home" WORKSPACE_DIR="$home" OCTO_EVENT_LOG="$log"
+        # shellcheck disable=SC1091
+        source "$PROJECT_ROOT/scripts/lib/events.sh"
+        # shellcheck disable=SC1091
+        source "$PROJECT_ROOT/scripts/provider-router.sh" 2>/dev/null
+        mkdir -p "$_PROVIDER_STATE_DIR"
+        for _ in 1 2 3; do record_provider_failure cbtest "rate limit exceeded 429" >/dev/null 2>&1; done
+        record_provider_success cbtest >/dev/null 2>&1
+        echo "$(( $(date +%s) - 9999 ))" > "$_PROVIDER_STATE_DIR/cbtest.cooldown"
+        is_provider_available cbtest >/dev/null 2>&1
+    )
+    if grep -q '"event":"circuit-breaker.open"' "$log" 2>/dev/null && \
+       grep -q '"event":"circuit-breaker.closed"' "$log" 2>/dev/null && \
+       grep -q '"event":"circuit-breaker.half-open"' "$log" 2>/dev/null; then
+        test_pass
+    else
+        test_fail "missing circuit-breaker events: $(grep -oE '"event":"circuit-breaker[^"]*"' "$log" 2>/dev/null | tr '\n' ' ')"
+    fi
+}
+
+test_provider_selected_event_wired() {
+    test_case "spawn.sh emits provider.selected after the circuit check (oco-aek)"
+    grep -q 'octo_event_emit "provider.selected"' "$PROJECT_ROOT/scripts/lib/spawn.sh" \
+        && test_pass || test_fail "spawn.sh missing provider.selected emit"
+}
+
 test_no_log_when_disabled
 test_emit_jsonl_event
 test_auto_log_path
@@ -172,5 +203,8 @@ test_check_providers_event_hook
 test_concurrent_emit_no_clobber
 test_dispatch_lifecycle_events
 test_orchestrate_enables_telemetry_by_default
+
+test_circuit_breaker_events
+test_provider_selected_event_wired
 
 test_summary


### PR DESCRIPTION
Expands the JSONL lifecycle vocabulary for the planned control-plane HUD (PRD-1).

## Events added
- `provider.selected` — spawn.sh, after the circuit-breaker check passes (attrs: provider, agent_type, phase)
- `circuit-breaker.open` / `.closed` / `.half-open` — provider-router.sh, reusing the existing `record_provider_failure`/`record_provider_success`/`is_provider_available` state machine

## Safety
All emits `declare -f octo_event_emit`-guarded + `|| true` (no-op when the stream is off), same pattern as heartbeat.sh. provider-router.sh sources events.sh guarded so emits fire regardless of load order. No behavior change when telemetry is off.

## Scope (partial oco-aek)
`review.finding` and `synthesis.start/end` are **deferred** — they need structured-finding extraction and wrapping multi-line synthesis command-subs across review.sh/quality.sh. Tracked on the issue; the 4 events here are the clean, HUD-relevant ones.

## Testing
test-octo-events.sh 11/11 (new: circuit-breaker open/closed/half-open functional + provider.selected wiring). Audit gate 13/0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added telemetry event emissions for circuit breaker state transitions and provider selection tracking.

* **Tests**
  * Added test coverage for circuit breaker lifecycle events and provider selection event emissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->