### PR TITLE
feat: octo-hud — local event-stream monitor (oco-8gw)

### DIFF
--- a/bin/octo-hud
+++ b/bin/octo-hud
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# octo-hud — local HUD over the Octopus JSONL event stream (oco-8gw).
+#
+# Usage:
+#   octo-hud [events.jsonl]
+#
+# Reads $OCTO_EVENT_LOG when no path is given. Run in a second terminal beside a
+# workflow to watch provider/dispatch/circuit lifecycle events live. No-op when
+# stdout is not a TTY.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/scripts/lib/event-monitor.sh"
+
+octo_hud_run "${1:-}"

--- a/scripts/lib/event-monitor.sh
+++ b/scripts/lib/event-monitor.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# event-monitor.sh — local HUD over the Octopus JSONL event stream (oco-8gw).
+#
+# A passive observer (like claude-hud): tails OCTO_EVENT_LOG and renders a live,
+# colorized one-line feed of provider/dispatch/circuit lifecycle events. Run it
+# in a second terminal alongside a workflow:
+#
+#   bin/octo-hud                       # reads $OCTO_EVENT_LOG
+#   bin/octo-hud /path/to/events.jsonl
+#
+# Degrades to a no-op when stdout is not a TTY (CI/headless), so piping is safe.
+# Source-safe: no main execution block. bash 3.2 compatible (no assoc arrays).
+
+# Extract a value from one JSONL event record. Looks in attributes.<key> first,
+# then top-level <key>. Uses jq when available, else a tolerant sed fallback.
+octo_hud_field() {
+    local line="$1" key="$2"
+    if command -v jq >/dev/null 2>&1; then
+        printf '%s' "$line" \
+            | jq -r --arg k "$key" '(.attributes[$k]? // .[$k]? // "") | tostring' 2>/dev/null
+        return 0
+    fi
+    # Fallback: match "key":"value" or "key":value anywhere in the line.
+    printf '%s' "$line" | sed -n "s/.*\"$key\":\"\\([^\"]*\\)\".*/\\1/p" | head -1
+}
+
+# Format one event record into a colorized HUD line. Returns non-zero (and emits
+# nothing) for blank/malformed input so the caller can skip it safely.
+octo_hud_format_line() {
+    local line="$1"
+    [[ -n "${line// /}" ]] || return 1
+
+    local event ts provider outcome status command exit_code
+    event="$(octo_hud_field "$line" event)"
+    [[ -n "$event" ]] || return 1   # not a recognizable event record
+
+    ts="$(octo_hud_field "$line" timestamp)"; ts="${ts##*T}"; ts="${ts%Z}"
+    provider="$(octo_hud_field "$line" provider)"
+    outcome="$(octo_hud_field "$line" outcome)"
+    status="$(octo_hud_field "$line" status)"
+    command="$(octo_hud_field "$line" command)"
+    exit_code="$(octo_hud_field "$line" exit_code)"
+
+    # Color by event family (guard colors so non-TTY/no-tput still works).
+    local c_reset c_dim c_evt
+    c_reset=$'\033[0m'; c_dim=$'\033[2m'
+    case "$event" in
+        *timeout|circuit-breaker.open|provider.status) c_evt=$'\033[31m' ;;   # red
+        dispatch.end)
+            if [[ "$outcome" == "error" ]]; then c_evt=$'\033[31m'; else c_evt=$'\033[32m'; fi ;;
+        circuit-breaker.closed|circuit-breaker.half-open|provider.selected) c_evt=$'\033[36m' ;; # cyan
+        *) c_evt=$'\033[0m' ;;
+    esac
+
+    local detail=""
+    [[ -n "$provider" ]]  && detail="${detail} provider=${provider}"
+    [[ -n "$status" ]]    && detail="${detail} status=${status}"
+    [[ -n "$command" ]]   && detail="${detail} cmd=${command}"
+    [[ -n "$outcome" ]]   && detail="${detail} outcome=${outcome}"
+    [[ -n "$exit_code" ]] && detail="${detail} exit=${exit_code}"
+
+    printf '%s%s%s  %s%-22s%s%s\n' \
+        "$c_dim" "${ts:-now}" "$c_reset" "$c_evt" "$event" "$c_reset" "$detail"
+}
+
+# Tail the event log and render the live feed. No-op when stdout is not a TTY.
+octo_hud_run() {
+    local log="${1:-${OCTO_EVENT_LOG:-}}"
+    if [[ ! -t 1 ]]; then
+        return 0   # headless/piped — render nothing
+    fi
+    if [[ -z "$log" || "$log" == "off" ]]; then
+        echo "octo-hud: no event log (set OCTO_EVENT_LOG or pass a path)" >&2
+        return 1
+    fi
+    # Wait briefly for the log to appear (a run may not have emitted yet).
+    local _w=0
+    while [[ ! -f "$log" && $_w -lt 30 ]]; do sleep 0.5; _w=$((_w + 1)); done
+    [[ -f "$log" ]] || { echo "octo-hud: event log not found: $log" >&2; return 1; }
+
+    printf '\033[2J\033[H'   # clear screen
+    printf '🐙 Octopus HUD — %s  (Ctrl-C to exit)\n' "$log"
+    printf '%s\n' "------------------------------------------------------------"
+    # -n +1: include existing lines; -F: keep following across rotation/trim.
+    tail -n +1 -F "$log" 2>/dev/null | while IFS= read -r _line; do
+        octo_hud_format_line "$_line" || true
+    done
+}

--- a/tests/unit/test-event-monitor.sh
+++ b/tests/unit/test-event-monitor.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Event monitor HUD (oco-8gw)"
+
+# shellcheck disable=SC1091
+source "$PROJECT_ROOT/scripts/lib/event-monitor.sh"
+
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+_dispatch_end='{"timestamp":"2026-06-15T01:00:00Z","event":"dispatch.end","attributes":{"command":"codex","outcome":"ok","exit_code":"0"}}'
+_provider_status='{"timestamp":"2026-06-15T01:00:01Z","event":"provider.status","attributes":{"provider":"gemini","status":"degraded"}}'
+
+test_format_parses_event() {
+    test_case "octo_hud_format_line renders event name + key attributes"
+    local out
+    out="$(octo_hud_format_line "$_dispatch_end")"
+    if [[ "$out" == *dispatch.end* && "$out" == *codex* && "$out" == *outcome=ok* ]]; then
+        test_pass
+    else test_fail "unexpected format: $out"; fi
+}
+
+test_format_provider_status() {
+    test_case "octo_hud_format_line surfaces provider + status"
+    local out
+    out="$(octo_hud_format_line "$_provider_status")"
+    if [[ "$out" == *provider=gemini* && "$out" == *status=degraded* ]]; then
+        test_pass
+    else test_fail "unexpected: $out"; fi
+}
+
+test_malformed_skipped() {
+    test_case "malformed / blank input is skipped without error"
+    local rc1=0 rc2=0 rc3=0
+    octo_hud_format_line "not json at all" >/dev/null 2>&1 || rc1=$?
+    octo_hud_format_line "" >/dev/null 2>&1 || rc2=$?
+    octo_hud_format_line "{}" >/dev/null 2>&1 || rc3=$?
+    # All should return non-zero (nothing rendered) and not crash the caller.
+    if [[ "$rc1" -ne 0 && "$rc2" -ne 0 && "$rc3" -ne 0 ]]; then test_pass
+    else test_fail "expected non-zero for malformed (got $rc1/$rc2/$rc3)"; fi
+}
+
+test_degrades_when_not_tty() {
+    test_case "octo_hud_run is a no-op when stdout is not a TTY"
+    local f="$FIXTURE/ev.jsonl"; printf '%s\n' "$_dispatch_end" > "$f"
+    # stdout is captured (a pipe, not a TTY) → expect no output, clean exit.
+    local out rc
+    out="$(octo_hud_run "$f" 2>/dev/null)"; rc=$?
+    if [[ -z "$out" && "$rc" -eq 0 ]]; then test_pass
+    else test_fail "expected no output + rc=0 in non-TTY (rc=$rc, out='${out:0:40}')"; fi
+}
+
+test_format_parses_event
+test_format_provider_status
+test_malformed_skipped
+test_degrades_when_not_tty
+
+test_summary


### PR DESCRIPTION
A passive HUD over the JSONL event stream (the claude-hud-style observer the PRD-0 brief identified as the control-plane wedge).

## What
- `scripts/lib/event-monitor.sh`: `octo_hud_format_line` (pure, testable) + `octo_hud_run` (tail -F loop) rendering a live colorized feed of provider/dispatch/circuit lifecycle events.
- `bin/octo-hud [events.jsonl]` — reads `$OCTO_EVENT_LOG` by default.

## Design
v1 is a **standalone observer** run in a second terminal — it does NOT auto-launch inside orchestrate.sh (that would clobber the live progress display). In-run auto-launch is a follow-up. **No-op when stdout is not a TTY** (CI/headless safe). bash 3.2 compatible (no assoc arrays); jq with sed fallback.

## Testing
test-event-monitor.sh (4): format rendering, provider.status surfacing, malformed/blank skip, non-TTY degrade. Audit gate 13/0; events suite 11/0.

Pairs with #509 (the events it renders). Closes oco-8gw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `octo-hud` command to display Octopus event logs as a live, colorized stream in the terminal.

* **Tests**
  * Added comprehensive unit tests for event monitoring functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->