### PR TITLE
feat: emit agent lifecycle events

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -110,3 +110,36 @@ OCTOPUS_RELEASE_RUNTIME_SMOKE=1 bash scripts/validate-release.sh
 That mode creates a temporary plugin zip, loads it with `claude --plugin-dir <zip>`, serves it locally, then loads it with `claude --plugin-url http://127.0.0.1:<port>/octo-plugin.zip`. Both calls use stream-json with hook events enabled so `init.plugin_errors` surfaces plugin load failures in the release log.
 
 Use `OCTOPUS_RELEASE_SMOKE_MAX_BUDGET_USD` to lower or raise the Claude Code budget cap for the runtime smoke, and `OCTOPUS_RELEASE_SMOKE_PORT` if the default localhost port is busy.
+
+## Agent lifecycle events
+
+Octopus emits provider and dispatch telemetry to the JSONL event stream controlled by `OCTO_EVENT_LOG`. Agent spawn/completion events use the same surface:
+
+```bash
+export OCTO_EVENT_LOG=auto
+```
+
+Event names:
+
+```text
+agent.spawned
+agent.completed
+```
+
+Lifecycle event attributes include `provider`, `agent_type`, `task_id`, `role`, `phase`, `pid`, `result_file`, `results_dir`, `workspace_dir`, `exit_code`, `status`, `root_session_id`, and `parent_session_id`.
+
+External control planes that need an immediate callback instead of tailing the JSONL file can also set an optional best-effort hook:
+
+```bash
+export OCTOPUS_AGENT_LIFECYCLE_HOOK=/path/to/hook
+export OCTOPUS_AGENT_LIFECYCLE_HOOK_LOG=/tmp/octopus-agent-hook.log  # optional
+```
+
+The hook is invoked as:
+
+```bash
+$OCTOPUS_AGENT_LIFECYCLE_HOOK spawned
+$OCTOPUS_AGENT_LIFECYCLE_HOOK completed
+```
+
+The hook receives the same lifecycle metadata through `OCTOPUS_AGENT_*` environment variables. Hook stdout/stderr are redirected to the optional hook log or `/dev/null`; hook failures are ignored so observer outages never fail agent execution.

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -77,7 +77,27 @@ _octopus_agent_lifecycle_event() {
         elif command -v timeout >/dev/null 2>&1; then
             timeout "$hook_timeout" "$hook" "$event"
         else
-            "$hook" "$event"
+            # Built-in timeout fallback: run hook in background, wait with
+            # configured timeout, and kill if still running. Uses only bash
+            # built-ins so it works on systems without run_with_timeout or
+            # GNU timeout. See issue #511.
+            "$hook" "$event" &
+            local _hook_pid=$!
+            local _hook_waited=0
+            while [[ $_hook_waited -lt $hook_timeout ]]; do
+                if ! kill -0 "$_hook_pid" 2>/dev/null; then
+                    wait "$_hook_pid" 2>/dev/null || true
+                    break
+                fi
+                sleep 1
+                ((_hook_waited++)) || true
+            done
+            if kill -0 "$_hook_pid" 2>/dev/null; then
+                kill -TERM "$_hook_pid" 2>/dev/null || true
+                sleep 0.5 2>/dev/null || true
+                kill -KILL "$_hook_pid" 2>/dev/null || true
+                wait "$_hook_pid" 2>/dev/null || true
+            fi
         fi
     ) >>"$hook_log" 2>&1 || true
 }

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -14,6 +14,66 @@ quota_watcher_kill_spawn_children() {
     pkill -KILL -P "$spawn_pid" 2>/dev/null || true
 }
 
+
+# Emit agent lifecycle events to the Octopus JSONL event stream and, optionally,
+# to an external observer hook. The event stream is the primary integration
+# surface; OCTOPUS_AGENT_LIFECYCLE_HOOK is a best-effort bridge for local control
+# planes that need an immediate callback without tailing OCTO_EVENT_LOG.
+_octopus_agent_lifecycle_event() {
+    local event="$1"
+    local agent_type="$2"
+    local task_id="$3"
+    local role="${4:-}"
+    local phase="${5:-}"
+    local pid="${6:-}"
+    local result_file="${7:-}"
+    local exit_code="${8:-}"
+    local status="${9:-}"
+
+    local provider="${agent_type%%-*}"
+    local event_name="agent.${event}"
+
+    if declare -f octo_event_emit >/dev/null 2>&1; then
+        octo_event_emit "$event_name" \
+            provider="$provider" \
+            agent_type="$agent_type" \
+            task_id="$task_id" \
+            role="$role" \
+            phase="${phase:-unknown}" \
+            pid="$pid" \
+            result_file="$result_file" \
+            results_dir="${RESULTS_DIR:-}" \
+            workspace_dir="${WORKSPACE_DIR:-}" \
+            exit_code="$exit_code" \
+            status="$status" \
+            root_session_id="${CRABFLEET_ROOT_SESSION_ID:-${OCTOPUS_ROOT_SESSION_ID:-}}" \
+            parent_session_id="${CRABFLEET_PARENT_SESSION_ID:-${OCTOPUS_PARENT_SESSION_ID:-}}" || true
+    fi
+
+    local hook="${OCTOPUS_AGENT_LIFECYCLE_HOOK:-}"
+    [[ -n "$hook" && -x "$hook" ]] || return 0
+
+    local hook_log="${OCTOPUS_AGENT_LIFECYCLE_HOOK_LOG:-/dev/null}"
+    (
+        export OCTOPUS_AGENT_HOOK_EVENT="$event"
+        export OCTOPUS_AGENT_EVENT_NAME="$event_name"
+        export OCTOPUS_AGENT_PROVIDER="$provider"
+        export OCTOPUS_AGENT_TYPE="$agent_type"
+        export OCTOPUS_AGENT_TASK_ID="$task_id"
+        export OCTOPUS_AGENT_ROLE="$role"
+        export OCTOPUS_AGENT_PHASE="$phase"
+        export OCTOPUS_AGENT_PID="$pid"
+        export OCTOPUS_AGENT_RESULT_FILE="$result_file"
+        export OCTOPUS_AGENT_RESULTS_DIR="${RESULTS_DIR:-}"
+        export OCTOPUS_AGENT_WORKSPACE_DIR="${WORKSPACE_DIR:-}"
+        export OCTOPUS_AGENT_EXIT_CODE="$exit_code"
+        export OCTOPUS_AGENT_STATUS="$status"
+        export OCTOPUS_AGENT_ROOT_SESSION_ID="${CRABFLEET_ROOT_SESSION_ID:-${OCTOPUS_ROOT_SESSION_ID:-}}"
+        export OCTOPUS_AGENT_PARENT_SESSION_ID="${CRABFLEET_PARENT_SESSION_ID:-${OCTOPUS_PARENT_SESSION_ID:-}}"
+        "$hook" "$event"
+    ) >>"$hook_log" 2>&1 || true
+}
+
 spawn_agent() {
     local _ts; _ts=$(date +%s)
     local agent_type="$1"
@@ -942,11 +1002,25 @@ ${heuristic_ctx}"
             rm -f "$_done_tmp" 2>/dev/null || true
         fi
 
+        local _hook_final_status="failed"
+        if [[ "${_spawn_exit:-0}" -eq 0 ]]; then
+            if [[ "${_octo_success_status:-ok}" == "failed" ]]; then
+                _hook_final_status="failed"
+            else
+                _hook_final_status="completed"
+            fi
+        elif [[ "${_spawn_exit:-0}" -eq 124 || "${_spawn_exit:-0}" -eq 143 ]]; then
+            _hook_final_status="timeout"
+        fi
+        _octopus_agent_lifecycle_event "completed" "$agent_type" "$task_id" "$role" "$phase" "$BASHPID" "$result_file" "$_spawn_exit" "$_hook_final_status"
+
         # v8.19.0: Cleanup heartbeat (self-terminating monitor handles this too)
         cleanup_heartbeat "$$" 2>/dev/null || true
     ) &
 
     local pid=$!
+
+    _octopus_agent_lifecycle_event "spawned" "$agent_type" "$task_id" "$role" "$phase" "$pid" "$result_file" "" "running"
 
     # v8.19.0: Start heartbeat monitor for agent process
     start_heartbeat_monitor "$pid" "$task_id"

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -25,6 +25,7 @@ _octopus_agent_lifecycle_event() {
     local task_id="$3"
     local role="${4:-}"
     local phase="${5:-}"
+    local normalized_phase="${phase:-unknown}"
     local pid="${6:-}"
     local result_file="${7:-}"
     local exit_code="${8:-}"
@@ -39,7 +40,7 @@ _octopus_agent_lifecycle_event() {
             agent_type="$agent_type" \
             task_id="$task_id" \
             role="$role" \
-            phase="${phase:-unknown}" \
+            phase="$normalized_phase" \
             pid="$pid" \
             result_file="$result_file" \
             results_dir="${RESULTS_DIR:-}" \
@@ -61,7 +62,7 @@ _octopus_agent_lifecycle_event() {
         export OCTOPUS_AGENT_TYPE="$agent_type"
         export OCTOPUS_AGENT_TASK_ID="$task_id"
         export OCTOPUS_AGENT_ROLE="$role"
-        export OCTOPUS_AGENT_PHASE="$phase"
+        export OCTOPUS_AGENT_PHASE="$normalized_phase"
         export OCTOPUS_AGENT_PID="$pid"
         export OCTOPUS_AGENT_RESULT_FILE="$result_file"
         export OCTOPUS_AGENT_RESULTS_DIR="${RESULTS_DIR:-}"
@@ -70,7 +71,14 @@ _octopus_agent_lifecycle_event() {
         export OCTOPUS_AGENT_STATUS="$status"
         export OCTOPUS_AGENT_ROOT_SESSION_ID="${CRABFLEET_ROOT_SESSION_ID:-${OCTOPUS_ROOT_SESSION_ID:-}}"
         export OCTOPUS_AGENT_PARENT_SESSION_ID="${CRABFLEET_PARENT_SESSION_ID:-${OCTOPUS_PARENT_SESSION_ID:-}}"
-        "$hook" "$event"
+        local hook_timeout="${OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT:-3}"
+        if declare -f run_with_timeout >/dev/null 2>&1; then
+            run_with_timeout "$hook_timeout" "$hook" "$event"
+        elif command -v timeout >/dev/null 2>&1; then
+            timeout "$hook_timeout" "$hook" "$event"
+        else
+            "$hook" "$event"
+        fi
     ) >>"$hook_log" 2>&1 || true
 }
 
@@ -536,6 +544,7 @@ ${heuristic_ctx}"
         if [[ "$SUPPORTS_HOOK_LAST_MESSAGE" == "true" ]]; then
             log "DEBUG" "Result capture via SubagentStop hook (last_assistant_message)"
         fi
+        _octopus_agent_lifecycle_event "spawned" "$agent_type" "$task_id" "$role" "$phase" "" "$result_file" "" "running"
         return 0
     fi
 

--- a/tests/unit/test-agent-lifecycle-events.sh
+++ b/tests/unit/test-agent-lifecycle-events.sh
@@ -17,8 +17,10 @@ source "$PROJECT_ROOT/scripts/lib/spawn.sh"
 
 test_suite "agent lifecycle events"
 
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
+mkdir -p "$TEST_TMP_DIR"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
+TMP_DIR="$TEST_TMP_DIR"
 
 RESULTS_DIR="$TMP_DIR/results"
 WORKSPACE_DIR="$TMP_DIR/workspace"
@@ -80,6 +82,36 @@ if [[ -z "$stdout" ]] && \
 else
   test_fail "event log or hook metadata/output redirection did not match expectations"
 fi
+
+
+test_case "empty phase is normalized consistently for event stream and hook"
+: > "$OCTO_EVENT_LOG"
+: > "$HOOK_CAPTURE"
+_octopus_agent_lifecycle_event "spawned" "codex" "task-empty-phase" "developer" "" "444" "$RESULTS_DIR/codex-empty-phase.md" "" "running"
+if grep -q '"phase":"unknown"' "$OCTO_EVENT_LOG" && grep -q '^phase=unknown$' "$HOOK_CAPTURE"; then
+  test_pass
+else
+  test_fail "expected empty phase to normalize to unknown across event stream and hook"
+fi
+
+cat > "$TMP_DIR/slow-hook.sh" <<'HOOK'
+#!/usr/bin/env bash
+sleep 5
+HOOK
+chmod +x "$TMP_DIR/slow-hook.sh"
+
+test_case "lifecycle hook timeout prevents observer hangs"
+export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/slow-hook.sh"
+export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT=1
+start=$(date +%s)
+_octopus_agent_lifecycle_event "spawned" "codex" "task-slow-hook" "developer" "tangle" "555" "$RESULTS_DIR/codex-slow-hook.md" "" "running"
+elapsed=$(( $(date +%s) - start ))
+if [[ "$elapsed" -lt 4 ]]; then
+  test_pass
+else
+  test_fail "hook timeout did not return promptly"
+fi
+unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 
 test_case "completed lifecycle event carries exit status"
 _octopus_agent_lifecycle_event "completed" "gemini-fast" "task-2" "reviewer" "review" "222" "$RESULTS_DIR/gemini-task-2.md" "124" "timeout"

--- a/tests/unit/test-agent-lifecycle-events.sh
+++ b/tests/unit/test-agent-lifecycle-events.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Regression coverage for agent lifecycle events and optional observer hook.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+log() { :; }
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/events.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/spawn.sh"
+
+test_suite "agent lifecycle events"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+RESULTS_DIR="$TMP_DIR/results"
+WORKSPACE_DIR="$TMP_DIR/workspace"
+OCTO_EVENT_LOG="$TMP_DIR/events.jsonl"
+mkdir -p "$RESULTS_DIR" "$WORKSPACE_DIR"
+
+cat > "$TMP_DIR/hook.sh" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'argv=%s\n' "$1"
+  printf 'event=%s\n' "$OCTOPUS_AGENT_HOOK_EVENT"
+  printf 'event_name=%s\n' "$OCTOPUS_AGENT_EVENT_NAME"
+  printf 'provider=%s\n' "$OCTOPUS_AGENT_PROVIDER"
+  printf 'agent=%s\n' "$OCTOPUS_AGENT_TYPE"
+  printf 'task=%s\n' "$OCTOPUS_AGENT_TASK_ID"
+  printf 'role=%s\n' "$OCTOPUS_AGENT_ROLE"
+  printf 'phase=%s\n' "$OCTOPUS_AGENT_PHASE"
+  printf 'pid=%s\n' "$OCTOPUS_AGENT_PID"
+  printf 'result=%s\n' "$OCTOPUS_AGENT_RESULT_FILE"
+  printf 'results_dir=%s\n' "$OCTOPUS_AGENT_RESULTS_DIR"
+  printf 'workspace=%s\n' "$OCTOPUS_AGENT_WORKSPACE_DIR"
+  printf 'exit=%s\n' "$OCTOPUS_AGENT_EXIT_CODE"
+  printf 'status=%s\n' "$OCTOPUS_AGENT_STATUS"
+  printf 'root=%s\n' "$OCTOPUS_AGENT_ROOT_SESSION_ID"
+  printf 'parent=%s\n' "$OCTOPUS_AGENT_PARENT_SESSION_ID"
+} >> "$HOOK_CAPTURE"
+echo noisy stdout
+echo noisy stderr >&2
+HOOK
+chmod +x "$TMP_DIR/hook.sh"
+
+cat > "$TMP_DIR/fail-hook.sh" <<'HOOK'
+#!/usr/bin/env bash
+echo failing hook
+exit 42
+HOOK
+chmod +x "$TMP_DIR/fail-hook.sh"
+
+test_case "lifecycle event writes OCTO_EVENT_LOG and optional hook metadata"
+export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/hook.sh"
+export OCTOPUS_AGENT_LIFECYCLE_HOOK_LOG="$TMP_DIR/hook.log"
+export HOOK_CAPTURE="$TMP_DIR/capture.txt"
+export CRABFLEET_ROOT_SESSION_ID="IS-ROOT"
+export CRABFLEET_PARENT_SESSION_ID="IS-PARENT"
+stdout="$(_octopus_agent_lifecycle_event "spawned" "codex-standard" "task-1" "developer" "tangle" "12345" "$RESULTS_DIR/codex-task-1.md" "" "running")"
+if [[ -z "$stdout" ]] && \
+   grep -q '"event":"agent.spawned"' "$OCTO_EVENT_LOG" && \
+   grep -q '"agent_type":"codex-standard"' "$OCTO_EVENT_LOG" && \
+   grep -q '"provider":"codex"' "$OCTO_EVENT_LOG" && \
+   grep -q '^argv=spawned$' "$HOOK_CAPTURE" && \
+   grep -q '^event_name=agent.spawned$' "$HOOK_CAPTURE" && \
+   grep -q '^provider=codex$' "$HOOK_CAPTURE" && \
+   grep -q '^root=IS-ROOT$' "$HOOK_CAPTURE" && \
+   grep -q '^parent=IS-PARENT$' "$HOOK_CAPTURE" && \
+   grep -q 'noisy stdout' "$TMP_DIR/hook.log" && \
+   grep -q 'noisy stderr' "$TMP_DIR/hook.log"; then
+  test_pass
+else
+  test_fail "event log or hook metadata/output redirection did not match expectations"
+fi
+
+test_case "completed lifecycle event carries exit status"
+_octopus_agent_lifecycle_event "completed" "gemini-fast" "task-2" "reviewer" "review" "222" "$RESULTS_DIR/gemini-task-2.md" "124" "timeout"
+if grep -q '"event":"agent.completed"' "$OCTO_EVENT_LOG" && \
+   grep -q '"exit_code":"124"' "$OCTO_EVENT_LOG" && \
+   grep -q '"status":"timeout"' "$OCTO_EVENT_LOG"; then
+  test_pass
+else
+  test_fail "completed event missing exit/status attributes"
+fi
+
+test_case "hook failure is ignored"
+export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/fail-hook.sh"
+if _octopus_agent_lifecycle_event "completed" "gemini" "task-3" "reviewer" "review" "333" "$RESULTS_DIR/gemini-task-3.md" "1" "failed"; then
+  test_pass
+else
+  test_fail "hook failure should not fail agent lifecycle"
+fi
+
+test_case "missing hook is a no-op while event stream still works"
+unset OCTOPUS_AGENT_LIFECYCLE_HOOK
+before=$(wc -l < "$OCTO_EVENT_LOG")
+_octopus_agent_lifecycle_event "spawned" "codex" "task-4" "developer" "tangle" "444" "$RESULTS_DIR/codex-task-4.md" "" "running"
+after=$(wc -l < "$OCTO_EVENT_LOG")
+if [[ "$after" -eq $((before + 1)) ]]; then
+  test_pass
+else
+  test_fail "unset hook should not suppress event stream emission"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

Emit agent lifecycle events through the existing Octopus JSONL event stream and add an optional best-effort hook for external observers.

This keeps `OCTO_EVENT_LOG` as the primary integration surface and adds:

- `agent.spawned`
- `agent.completed`

Each lifecycle event includes provider, agent type, task id, role, phase, pid, result file, results/workspace dirs, exit code, status, and parent/root session ids.

For local control planes such as Crabfleet, `OCTOPUS_AGENT_LIFECYCLE_HOOK` can be set to an executable callback. The hook receives the same metadata via `OCTOPUS_AGENT_*` environment variables. Hook failures/timeouts are ignored so observability outages never fail agent execution.

## Why

Octopus now has `events.sh`, `OCTO_EVENT_LOG`, `octo-hud`, and provider lifecycle telemetry. Agent-level spawn/completion events make that stream useful to local control planes without requiring them to parse PID files or result markers.

The optional hook is intentionally secondary: it bridges live local observers, while the JSONL event stream remains the durable source of truth.

## Review follow-up

Addressed review feedback by:

- normalizing empty phase values to `unknown` consistently across JSONL and hook metadata;
- adding `OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT` with a default 3s timeout;
- emitting `agent.spawned` for the Agent Teams dispatch path;
- using the project standard `TEST_TMP_DIR` cleanup pattern.

## Validation

- `bash -n scripts/lib/spawn.sh scripts/lib/events.sh tests/unit/test-agent-lifecycle-events.sh`
- `bash tests/unit/test-agent-lifecycle-events.sh` — 6 passed / 0 failed
- `bash tests/unit/test-event-monitor.sh` — 4 passed / 0 failed
- `bash tests/unit/test-agent-command-validation.sh` — 6 passed / 0 failed
- `bash tests/unit/test-octo-events.sh` — 11 passed / 0 failed, duration 115s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent lifecycle events (`spawned`, `completed`) are now emitted to an event stream for monitoring and observability.
  * Optional observer hook support with timeout handling and graceful failure management.
  * Events include metadata such as PID, result files, exit codes, and execution status.

* **Documentation**
  * Added comprehensive guide for agent lifecycle events, stream configuration, and observer hook setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->