### PR TITLE
fix: harden OpenAI-compatible agent transport

### DIFF
--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import argparse, json, os, subprocess, sys, time, urllib.request, urllib.error
+import argparse, json, os, subprocess, sys, time, urllib.parse, urllib.request, urllib.error
 from pathlib import Path
 
 PROVIDERS = {
@@ -54,11 +54,11 @@ def tool_exec(cwd: Path, name: str, args: dict) -> str:
             cmd = str(args.get("command", ""))
             if len(cmd) > 600: return "ERROR: command too long"
             timeout = env_float("OPENAI_COMPAT_COMMAND_TIMEOUT", 20.0)
-            r = subprocess.run(cmd, cwd=str(cwd), shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout)
+            r = subprocess.run(cmd, cwd=str(cwd), shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout, check=False)  # noqa: S602 - intentional shell-command tool
             return (f"exit={r.returncode}\n" + r.stdout)[-20000:]
         if name == "git_diff":
             timeout = env_float("OPENAI_COMPAT_COMMAND_TIMEOUT", 20.0)
-            r = subprocess.run("git diff -- .", cwd=str(cwd), shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout)
+            r = subprocess.run(["git", "diff", "--", "."], cwd=str(cwd), text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout, check=False)
             return (f"exit={r.returncode}\n" + r.stdout)[-30000:]
         return f"ERROR: unknown tool {name}"
     except Exception as e:
@@ -70,11 +70,15 @@ def api_call(base_url, key, model, headers_extra, messages, max_tokens=1400, req
         payload["max_tokens"] = max_tokens
     headers = {"Authorization": "Bearer " + key, "Content-Type": "application/json", **headers_extra}
     body = json.dumps(payload).encode()
+    endpoint = base_url.rstrip("/") + "/chat/completions"
+    scheme = urllib.parse.urlparse(endpoint).scheme
+    if scheme not in {"http", "https"}:
+        raise ValueError(f"unsupported OPENAI-compatible base URL scheme: {scheme or '<missing>'}")
     retry_statuses = {429, 502, 503, 504}
     last_error = None
     for attempt in range(1, max(1, max_retries) + 1):
         print(f"chat_start attempt={attempt}/{max(1, max_retries)} messages={len(messages)} bytes={len(body)} timeout={request_timeout} max_tokens={max_tokens if max_tokens > 0 else 'provider_default'}", file=sys.stderr)
-        req = urllib.request.Request(base_url.rstrip("/") + "/chat/completions", data=body, headers=headers, method="POST")
+        req = urllib.request.Request(endpoint, data=body, headers=headers, method="POST")
         started = time.time()
         try:
             with urllib.request.urlopen(req, timeout=request_timeout) as r:

--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -1,10 +1,33 @@
 #!/usr/bin/env python3
-import argparse, json, os, subprocess, sys, urllib.request, urllib.error
+import argparse, json, os, subprocess, sys, time, urllib.request, urllib.error
 from pathlib import Path
 
 PROVIDERS = {
     "generic": {"base_url": "", "api_key_env": "OPENAI_API_KEY", "model": "", "headers": {}},
 }
+
+
+def env_int(name: str, default: int, minimum: int = 0) -> int:
+    raw = os.environ.get(name, "")
+    if raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        print(f"WARN: invalid {name}={raw!r}; using {default}", file=sys.stderr)
+        return default
+    return max(minimum, value)
+
+def env_float(name: str, default: float, minimum: float = 0.1) -> float:
+    raw = os.environ.get(name, "")
+    if raw == "":
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        print(f"WARN: invalid {name}={raw!r}; using {default}", file=sys.stderr)
+        return default
+    return max(minimum, value)
 
 TOOLS = [
     {"type":"function","function":{"name":"read_file","description":"Read a UTF-8 file under cwd.","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}},
@@ -30,25 +53,47 @@ def tool_exec(cwd: Path, name: str, args: dict) -> str:
         if name == "run_command":
             cmd = str(args.get("command", ""))
             if len(cmd) > 600: return "ERROR: command too long"
-            r = subprocess.run(cmd, cwd=str(cwd), shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=20)
+            timeout = env_float("OPENAI_COMPAT_COMMAND_TIMEOUT", 20.0)
+            r = subprocess.run(cmd, cwd=str(cwd), shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout)
             return (f"exit={r.returncode}\n" + r.stdout)[-20000:]
         if name == "git_diff":
-            r = subprocess.run("git diff -- .", cwd=str(cwd), shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=20)
+            timeout = env_float("OPENAI_COMPAT_COMMAND_TIMEOUT", 20.0)
+            r = subprocess.run("git diff -- .", cwd=str(cwd), shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout)
             return (f"exit={r.returncode}\n" + r.stdout)[-30000:]
         return f"ERROR: unknown tool {name}"
     except Exception as e:
         return f"ERROR: {type(e).__name__}: {e}"
 
-def api_call(base_url, key, model, headers_extra, messages, max_tokens=1400):
-    payload = {"model": model, "messages": messages, "tools": TOOLS, "tool_choice": "auto", "temperature": 0, "max_tokens": max_tokens}
+def api_call(base_url, key, model, headers_extra, messages, max_tokens=1400, request_timeout=60.0, max_retries=3):
+    payload = {"model": model, "messages": messages, "tools": TOOLS, "tool_choice": "auto", "temperature": 0}
+    if max_tokens > 0:
+        payload["max_tokens"] = max_tokens
     headers = {"Authorization": "Bearer " + key, "Content-Type": "application/json", **headers_extra}
-    req = urllib.request.Request(base_url.rstrip("/") + "/chat/completions", data=json.dumps(payload).encode(), headers=headers, method="POST")
-    try:
-        with urllib.request.urlopen(req, timeout=60) as r:
-            return json.loads(r.read().decode())
-    except urllib.error.HTTPError as e:
-        body = e.read().decode(errors="replace")[:2000]
-        raise RuntimeError(f"HTTP {e.code}: {body}")
+    body = json.dumps(payload).encode()
+    retry_statuses = {429, 502, 503, 504}
+    last_error = None
+    for attempt in range(1, max(1, max_retries) + 1):
+        print(f"chat_start attempt={attempt}/{max(1, max_retries)} messages={len(messages)} bytes={len(body)} timeout={request_timeout} max_tokens={max_tokens if max_tokens > 0 else 'provider_default'}", file=sys.stderr)
+        req = urllib.request.Request(base_url.rstrip("/") + "/chat/completions", data=body, headers=headers, method="POST")
+        started = time.time()
+        try:
+            with urllib.request.urlopen(req, timeout=request_timeout) as r:
+                raw = r.read().decode()
+                print(f"chat_done attempt={attempt}/{max(1, max_retries)} status=200 elapsed={time.time() - started:.2f}s bytes={len(raw)}", file=sys.stderr)
+                return json.loads(raw)
+        except urllib.error.HTTPError as e:
+            body_text = e.read().decode(errors="replace")[:2000]
+            last_error = RuntimeError(f"HTTP {e.code}: {body_text}")
+            print(f"chat_error attempt={attempt}/{max(1, max_retries)} status={e.code} elapsed={time.time() - started:.2f}s", file=sys.stderr)
+            if e.code not in retry_statuses or attempt >= max(1, max_retries):
+                raise last_error
+        except Exception as e:
+            last_error = e
+            print(f"chat_error attempt={attempt}/{max(1, max_retries)} error={type(e).__name__}: {str(e)[:300]}", file=sys.stderr)
+            if attempt >= max(1, max_retries):
+                raise RuntimeError(f"request failed after {attempt} attempt(s): {e}") from e
+        time.sleep(min(float(attempt), 5.0))
+    raise RuntimeError(f"request failed after retries: {last_error}")
 
 def parse_args(raw: str) -> dict:
     try: return json.loads(raw or "{}")
@@ -58,7 +103,7 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--provider", choices=sorted(PROVIDERS), default="generic")
     ap.add_argument("--base-url"); ap.add_argument("--api-key-env"); ap.add_argument("--model")
-    ap.add_argument("--cwd", required=True); ap.add_argument("--max-turns", type=int, default=int(os.environ.get("OPENAI_COMPAT_MAX_TURNS", "20"))); ap.add_argument("--prompt")
+    ap.add_argument("--cwd", required=True); ap.add_argument("--max-turns", type=int, default=env_int("OPENAI_COMPAT_MAX_TURNS", 20, 1)); ap.add_argument("--prompt")
     args = ap.parse_args(); cfg = PROVIDERS[args.provider]
     base_url = args.base_url or os.environ.get("OPENAI_COMPAT_BASE_URL") or cfg["base_url"]
     key_env = args.api_key_env or os.environ.get("OPENAI_COMPAT_API_KEY_ENV") or cfg["api_key_env"]
@@ -70,6 +115,9 @@ def main() -> int:
     key = os.environ.get(key_env)
     if not key:
         print(f"ERROR: missing {key_env}", file=sys.stderr); return 2
+    max_tokens = env_int("OPENAI_COMPAT_MAX_TOKENS", 1400, 0)
+    request_timeout = env_float("OPENAI_COMPAT_REQUEST_TIMEOUT", 60.0)
+    max_retries = env_int("OPENAI_COMPAT_MAX_RETRIES", 3, 1)
     cwd = Path(args.cwd).resolve(); prompt = args.prompt if args.prompt is not None else sys.stdin.read()
     messages = [
         {"role":"system","content":"You are a coding agent. Use tools when needed. For implementation tasks, edit files, call git_diff before final, and do not stop after only reading files. Final answer must be visible text. If a verification command fails because a local dependency or tool is missing, stop retrying that same command, call git_diff if not already done, and give a final answer that reports the blocker and the worktree changes."},
@@ -77,7 +125,7 @@ def main() -> int:
     ]
     print(f"provider={args.provider} base_url={base_url} model={model} cwd={cwd}", file=sys.stderr)
     for turn in range(1, args.max_turns + 1):
-        d = api_call(base_url, key, model, cfg.get("headers", {}), messages)
+        d = api_call(base_url, key, model, cfg.get("headers", {}), messages, max_tokens=max_tokens, request_timeout=request_timeout, max_retries=max_retries)
         ch = d.get("choices", [{}])[0]; msg = ch.get("message", {})
         finish = ch.get("finish_reason")
         raw_content = msg.get("content")

--- a/tests/unit/test-openai-compatible-agent.sh
+++ b/tests/unit/test-openai-compatible-agent.sh
@@ -118,4 +118,25 @@ else
 fi
 
 
+test_case "openai-compatible-agent rejects non-http base URL schemes"
+if HELPER="$HELPER" python3 - <<'PYTEST'
+import importlib.util, os
+helper_path = os.environ["HELPER"]
+spec = importlib.util.spec_from_file_location("openai_compatible_agent", helper_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+try:
+    mod.api_call("file:///tmp/octopus", "key", "model", {}, [{"role":"user","content":"hi"}], max_tokens=0, request_timeout=1, max_retries=1)
+except ValueError as exc:
+    assert "unsupported OPENAI-compatible base URL scheme" in str(exc)
+else:
+    raise AssertionError("expected ValueError for file:// base URL")
+PYTEST
+then
+    test_pass
+else
+    test_fail "expected non-http base URL schemes to be rejected"
+fi
+
+
 test_summary

--- a/tests/unit/test-openai-compatible-agent.sh
+++ b/tests/unit/test-openai-compatible-agent.sh
@@ -60,4 +60,62 @@ if assert_contains "$cmd" "scripts/helpers/openai-compatible-agent.py" "helper p
     test_pass
 fi
 
+
+test_case "openai-compatible-agent omits max_tokens when configured as provider default"
+if HELPER="$HELPER" python3 - <<'PYTEST'
+import importlib.util, json, os
+helper_path = os.environ["HELPER"]
+spec = importlib.util.spec_from_file_location("openai_compatible_agent", helper_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+seen = []
+class Response:
+    def __enter__(self): return self
+    def __exit__(self, *args): return False
+    def read(self): return b'{"choices":[{"message":{"content":"ok"}}]}'
+def fake_urlopen(req, timeout):
+    seen.append(json.loads(req.data.decode()))
+    return Response()
+mod.urllib.request.urlopen = fake_urlopen
+mod.api_call("https://example.invalid/v1", "key", "model", {}, [{"role":"user","content":"hi"}], max_tokens=0, request_timeout=1, max_retries=1)
+assert "max_tokens" not in seen[-1], seen[-1]
+mod.api_call("https://example.invalid/v1", "key", "model", {}, [{"role":"user","content":"hi"}], max_tokens=123, request_timeout=1, max_retries=1)
+assert seen[-1]["max_tokens"] == 123, seen[-1]
+PYTEST
+then
+    test_pass
+else
+    test_fail "expected max_tokens=0 to omit max_tokens from request payload"
+fi
+
+test_case "openai-compatible-agent retries transient HTTP errors"
+if HELPER="$HELPER" python3 - <<'PYTEST'
+import importlib.util, io, os, urllib.error
+helper_path = os.environ["HELPER"]
+spec = importlib.util.spec_from_file_location("openai_compatible_agent", helper_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+mod.time.sleep = lambda _seconds: None
+calls = {"n": 0}
+class Response:
+    def __enter__(self): return self
+    def __exit__(self, *args): return False
+    def read(self): return b'{"choices":[{"message":{"content":"ok"}}]}'
+def fake_urlopen(req, timeout):
+    calls["n"] += 1
+    if calls["n"] == 1:
+        raise urllib.error.HTTPError(req.full_url, 503, "unavailable", {}, io.BytesIO(b'temporary'))
+    return Response()
+mod.urllib.request.urlopen = fake_urlopen
+result = mod.api_call("https://example.invalid/v1", "key", "model", {}, [{"role":"user","content":"hi"}], max_tokens=0, request_timeout=1, max_retries=2)
+assert calls["n"] == 2, calls
+assert result["choices"][0]["message"]["content"] == "ok"
+PYTEST
+then
+    test_pass
+else
+    test_fail "expected transient HTTP failure to be retried"
+fi
+
+
 test_summary


### PR DESCRIPTION
## Summary

Harden the generic OpenAI-compatible tool-loop agent transport without changing its provider interface.

This adds:

- `OPENAI_COMPAT_MAX_RETRIES` with retries for transient HTTP 429/502/503/504 responses;
- `OPENAI_COMPAT_REQUEST_TIMEOUT` for chat/completions requests;
- `OPENAI_COMPAT_COMMAND_TIMEOUT` for `run_command` and `git_diff` tools;
- `OPENAI_COMPAT_MAX_TOKENS=0` support, which omits `max_tokens` and lets the provider choose its default;
- stderr transport logs with attempt, response size, timeout, and provider-default max token visibility.

Default behavior remains conservative: max tokens still defaults to the existing 1400 unless explicitly set to `0`.

## Why

OpenAI-compatible endpoints can be gateway-backed and occasionally return transient 429/502/503/504 failures. This mirrors the resilience we validated in local OpenAI-compatible tool-loop runs: retry transient provider failures, make timeouts tunable, and allow provider-default token limits when requested.

## Validation

- `python3 -m py_compile scripts/helpers/openai-compatible-agent.py`
- `bash -n tests/unit/test-openai-compatible-agent.sh`
- `bash tests/unit/test-openai-compatible-agent.sh`
- `bash tests/unit/test-agent-command-validation.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment-configurable API request timeout and max-retry behavior for model calls
  * CLI defaults can now be set via environment variables for maximum turns/tokens
* **Bug Fixes**
  * Improved resilience by retrying transient HTTP failures (e.g., 429/502/503/504)
  * Better request validation and safer handling when `max_tokens` is set to 0
* **Tests**
  * Added unit coverage for request payload construction and retry/error handling behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->