### PR TITLE
council: seat every available provider org, not just two

### DIFF
--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1032,43 +1032,56 @@ council_candidate_for_provider_org() {
 }
 
 council_enforce_provider_diversity() {
-    [[ "$COUNCIL_DEPTH" == "quick" ]] && return 0
-
-    local available_orgs available_count roster_count missing_org replacement provider candidate entry replace_index
+    # Represent every AVAILABLE provider org on the council (the requested provider
+    # list, or the auto list, filtered by availability), bounded by the number of
+    # non-chair seats. The previous implementation only guaranteed >=2 orgs and
+    # bailed at quick depth, so a low-scoring-but-available provider (e.g. gemini,
+    # whose personas score below codex's) could be seated 0 times even when the
+    # user explicitly passed `--providers claude,codex,gemini` — chair(claude)+codex
+    # already satisfied the 2-org floor. Only duplicate-org seats are replaced
+    # (never displace a seat that is the sole representative of a needed org, so the
+    # loop can't thrash when more orgs are available than seats), the chair seat is
+    # never touched, and the replaced seat keeps its label.
+    local available_orgs available_count
     available_orgs="$(council_available_provider_orgs_json)"
     available_count="$(jq 'length' <<< "$available_orgs")"
     (( available_count >= 2 )) || return 0
 
-    roster_count="$(jq '[.[].provider_org] | unique | length' <<< "$COUNCIL_ROSTER_JSON")"
-    (( roster_count >= 2 )) && return 0
+    local guard=0
+    while (( guard++ < 12 )); do
+        local roster_count
+        roster_count="$(jq '[.[].provider_org] | unique | length' <<< "$COUNCIL_ROSTER_JSON")"
+        (( roster_count >= available_count )) && break
 
-    missing_org="$(jq -r --argjson roster "$COUNCIL_ROSTER_JSON" '.[] as $org | select(($roster | map(.provider_org) | index($org)) | not) | $org' <<< "$available_orgs" | head -1)"
-    if [[ -z "$missing_org" ]]; then
-        return 0
-    fi
+        local missing_org
+        missing_org="$(jq -r --argjson roster "$COUNCIL_ROSTER_JSON" '.[] as $org | select(($roster | map(.provider_org) | index($org)) | not) | $org' <<< "$available_orgs" | head -1)"
+        [[ -z "$missing_org" ]] && break
 
-    replacement="$(council_candidate_for_provider_org "$missing_org" || true)"
-    if [[ -z "$replacement" ]]; then
-        COUNCIL_DIVERSITY_WARNING="available provider diversity could not be represented by configured personas"
-        return 0
-    fi
+        local replacement
+        replacement="$(council_candidate_for_provider_org "$missing_org" || true)"
+        if [[ -z "$replacement" ]]; then
+            COUNCIL_DIVERSITY_WARNING="available provider diversity could not be represented by configured personas"
+            break
+        fi
+        local candidate="${replacement%%|*}" provider="${replacement#*|}" entry
+        entry="$(council_roster_entry_json "$candidate" "$provider")"
 
-    candidate="${replacement%%|*}"
-    provider="${replacement#*|}"
-    entry="$(council_roster_entry_json "$candidate" "$provider")"
+        # Replace the lowest-scoring non-chair seat whose org is duplicated (safe to
+        # drop without losing coverage). If none exists, stop — never displace a
+        # unique-org seat.
+        local replace_index
+        replace_index="$(jq -r '
+            ([.[].provider_org] | group_by(.) | map(select(length>1)[0])) as $dups
+            | [ to_entries[] | select(.value.seat != "chair") | select(.value.provider_org as $o | $dups | index($o)) ]
+            | if length == 0 then empty else (min_by(.value.score) | .key) end
+        ' <<< "$COUNCIL_ROSTER_JSON")"
+        [[ -z "$replace_index" ]] && break
 
-    replace_index="$(jq -r '
-        [to_entries[] | select(.value.seat != "chair")] |
-        if length == 0 then empty else min_by(.value.score).key end
-    ' <<< "$COUNCIL_ROSTER_JSON")"
-
-    if [[ -z "$replace_index" ]]; then
-        COUNCIL_DIVERSITY_WARNING="provider diversity required but no replaceable non-chair seat was available"
-        return 0
-    fi
-
-    COUNCIL_ROSTER_JSON="$(jq -c --argjson entry "$entry" --argjson index "$replace_index" '.[$index] = $entry' <<< "$COUNCIL_ROSTER_JSON")"
-    COUNCIL_DIVERSITY_REPLACED="true"
+        # Preserve the replaced seat's label so a chair-type persona swapped in for
+        # diversity does not create a second "chair" seat.
+        COUNCIL_ROSTER_JSON="$(jq -c --argjson entry "$entry" --argjson index "$replace_index" '.[$index] = ($entry + {seat: .[$index].seat})' <<< "$COUNCIL_ROSTER_JSON")"
+        COUNCIL_DIVERSITY_REPLACED="true"
+    done
 }
 
 council_build_roster() {


### PR DESCRIPTION
## Problem

`council_enforce_provider_diversity` (scripts/lib/council.sh) only guaranteed **≥2 provider orgs** and **returned early at `--depth quick`**. Because the chair is `strategy-analyst` (claude) and the next-highest-scoring personas are codex-mapped (`backend-architect`, `security-auditor`), a `claude + codex` roster already satisfies the 2-org floor — so an available provider whose personas score lower (notably **gemini** via `research-synthesizer`/`business-analyst`) gets **seated zero times**, even when the user explicitly asks for it.

### Repro
```
orchestrate.sh council "<q>" --depth quick --members 3 --providers claude,codex,gemini
```
`summary.json` → seats are `chair=claude, advisor=codex, skeptic=codex`. **No gemini**, despite `provider_status.gemini == "available"` and an explicit `--providers …,gemini`. Same on `--providers auto`.

## Fix

Represent **every available provider org** (the requested list, or the auto list, filtered by availability), bounded by the number of non-chair seats, at any depth. Implementation notes:
- Loops until all available orgs are represented (or no replaceable seat remains).
- **Only duplicate-org seats are replaced** — never displaces the sole representative of a still-needed org, so the loop can't thrash when more orgs are available than there are seats.
- The **chair seat is never touched**.
- The **replaced seat keeps its label**, so a chair-type persona swapped in for diversity (e.g. `business-analyst`) no longer creates a second `"chair"` seat.

## Validation

- Live councils (auto and explicit) now seat `claude / codex / gemini`, single chair, quorum met, `diversity_replaced=true`.
- Standalone logic tests (7 cases): seats the missing org; chair protected; seat label preserved; no thrash when available orgs > seats; no-op when already diverse; no-op when <2 orgs available.
- `tests/test-fleet-diversity.sh` still passes 36/36. (The pre-existing timeout in `tests/unit/test-council-command.sh` is the live "fixture run" dispatch case and reproduces on clean `main` — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider representation logic to more robustly ensure all available providers are appropriately represented, preventing displacement of sole representatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->