### PR TITLE
fix: signal /octo:plan degradation when plan mode blocks artifact writes

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -19,6 +19,45 @@ aliases:
 
 ## 🤖 INSTRUCTIONS FOR CLAUDE
 
+### MANDATORY: Detect Plan Mode Write Conflict Before Starting
+
+**THIS CHECK RUNS FIRST — before intent capture, before any artifact write.**
+
+Native plan mode blocks all Write/Edit tool calls until `ExitPlanMode` is
+called. If you are currently in plan mode (you entered it earlier this session
+or the harness placed you in it), attempting to write `.claude/session-intent.md`
+or `.claude/session-plan.md` will silently fail, producing a degraded native
+plan instead of a full octo multi-provider plan.
+
+**If you are in plan mode when /octo:plan is invoked, you MUST:**
+
+1. Emit this exact warning as the very first output:
+
+   ```
+   ⚠️  OCTO PLAN DEGRADED — Plan Mode Write Conflict
+
+   Native plan mode is active. Octo cannot save its planning artifacts
+   (.claude/session-intent.md, .claude/session-plan.md) while plan mode
+   restricts writes. You are getting display-only output — this is NOT
+   a full octo multi-provider plan.
+
+   To get the full octo plan:
+     1. Exit or cancel native plan mode
+     2. Re-run /octo:plan
+
+   Continuing with plan visualization only (no artifacts saved)…
+   ```
+
+2. Skip Step 2 (Create Intent Contract) and Step 5 (Save the Plan) entirely.
+   Do not attempt these writes — they will silently fail.
+3. Complete Steps 1, 3, 4, and 6 so the user sees the visualization.
+4. Repeat the re-run reminder at the end of Step 6.
+
+**Do NOT silently fall through to generic native planning. The user invoked
+/octo:plan deliberately. A visible degradation warning is mandatory.**
+
+---
+
 ### MANDATORY COMPLIANCE — DO NOT SKIP
 
 **When the user explicitly invokes `/octo:plan`, you MUST execute the structured planning workflow below.** You are PROHIBITED from doing the task directly, skipping the intent capture questions, or deciding the task is "too simple" for structured planning. The user chose this command deliberately — respect that choice.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -33,7 +33,7 @@ plan instead of a full octo multi-provider plan.
 
 1. Emit this exact warning as the very first output:
 
-   ```
+   ```text
    ⚠️  OCTO PLAN DEGRADED — Plan Mode Write Conflict
 
    Native plan mode is active. Octo cannot save its planning artifacts

--- a/hooks/plan-mode-interceptor.sh
+++ b/hooks/plan-mode-interceptor.sh
@@ -55,6 +55,28 @@ Plans that contradict the intent contract are invalid.
 Do NOT plan to auto-invoke these skills — they require explicit user invocation:
 - skill-factory, skill-deep-research, skill-adversarial-security
 - flow-parallel, skill-ship
+
+### 5. Octo Plan Artifact Conflict — MANDATORY WARNING
+If the user invoked `/octo:plan` (or any octo planning workflow such as
+`/octo:embrace`) while plan mode is active, plan mode's write restriction
+BLOCKS octo from saving its planning artifacts:
+  - .claude/session-intent.md  (intent contract)
+  - .claude/session-plan.md    (weighted-phase plan)
+  - provider block and phase visualization files
+
+DO NOT silently fall through to generic native planning. You MUST:
+
+1. Emit this exact warning before any plan output:
+
+   ⚠️  OCTO PLAN DEGRADED — plan mode write conflict
+   Plan mode is active and blocking octo artifact writes.
+   The intent contract and session plan cannot be saved right now.
+   This is display-only output — NOT a full octo multi-provider plan.
+   To get the full octo plan: exit plan mode first, then re-run /octo:plan.
+
+2. Display the plan visualization so the user is not left with nothing.
+3. Skip Steps 2 and 5 of the /octo:plan workflow (artifact saves only).
+4. Remind the user at the end to re-run /octo:plan once plan mode exits.
 </PLAN-MODE-RULES>
 RULES
 

--- a/hooks/plan-mode-interceptor.sh
+++ b/hooks/plan-mode-interceptor.sh
@@ -66,17 +66,25 @@ BLOCKS octo from saving its planning artifacts:
 
 DO NOT silently fall through to generic native planning. You MUST:
 
-1. Emit this exact warning before any plan output:
+1. Emit this exact warning as the very first output:
 
-   ⚠️  OCTO PLAN DEGRADED — plan mode write conflict
-   Plan mode is active and blocking octo artifact writes.
-   The intent contract and session plan cannot be saved right now.
-   This is display-only output — NOT a full octo multi-provider plan.
-   To get the full octo plan: exit plan mode first, then re-run /octo:plan.
+   ⚠️  OCTO PLAN DEGRADED — Plan Mode Write Conflict
 
-2. Display the plan visualization so the user is not left with nothing.
-3. Skip Steps 2 and 5 of the /octo:plan workflow (artifact saves only).
-4. Remind the user at the end to re-run /octo:plan once plan mode exits.
+   Native plan mode is active. Octo cannot save its planning artifacts
+   (.claude/session-intent.md, .claude/session-plan.md) while plan mode
+   restricts writes. You are getting display-only output — this is NOT
+   a full octo multi-provider plan.
+
+   To get the full octo plan:
+     1. Exit or cancel native plan mode
+     2. Re-run /octo:plan
+
+   Continuing with plan visualization only (no artifacts saved)…
+
+2. Skip Step 2 (Create Intent Contract) and Step 5 (Save the Plan) entirely.
+   Do not attempt these writes — they will silently fail.
+3. Complete Steps 1, 3, 4, and 6 so the user sees the visualization.
+4. Repeat the re-run reminder at the end of Step 6.
 </PLAN-MODE-RULES>
 RULES
 


### PR DESCRIPTION
Fixes #514.

## Root cause

When native plan mode is active, Claude Code's `Write`/`Edit` tools are blocked until `ExitPlanMode`. The `/octo:plan` command tries to write `.claude/session-intent.md` and `.claude/session-plan.md` during its planning steps — exactly when writes are blocked. The result is silent: octo's artifacts are never saved and the user gets a generic native plan instead of the documented multi-provider octo plan, with no warning that degradation occurred.

`hooks/plan-mode-interceptor.sh` (PreToolUse: `EnterPlanMode`) was re-injecting planning enforcement rules but said nothing about octo artifact deferral, and nothing flagged the silent downgrade.

## Fix (option 3 from issue — signal the downgrade)

**`hooks/plan-mode-interceptor.sh`** — adds Rule 5 to the injected `PLAN-MODE-RULES` context block:
- Explicitly tells Claude that if `/octo:plan` is invoked while plan mode is active, it MUST emit a visible `⚠️ OCTO PLAN DEGRADED` warning
- Instructs Claude to skip the artifact-write steps (Steps 2 and 5) rather than silently falling through
- Requires a reminder at the end to re-run `/octo:plan` after exiting plan mode

**`.claude/commands/plan.md`** — adds a "Detect Plan Mode Write Conflict" section as the first instruction block:
- Covers the case where the user was already in plan mode before `/octo:plan` was invoked (the hook's `EnterPlanMode` matcher doesn't re-fire for pre-existing plan mode state)
- Belt-and-suspenders: the warning requirement is encoded in the command itself, not only in the hook context

## What this does NOT change

- No shell script logic changes (pure instruction/context additions)
- Does not defer or relocate artifact writes (options 1 and 2 from the issue) — those require deeper changes; this PR implements the minimum viable fix
- Does not affect any non-plan-mode workflow

## Tests

- `bash -n hooks/plan-mode-interceptor.sh` — syntax OK
- Both files contain the warning text (`grep -c "OCTO PLAN DEGRADED"` → 1 in each)
- Docs-only / instruction additions; no behavior change when plan mode is not active

https://claude.ai/code/session_01CFQNkBnfC2hbNbTFJQSFNe

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFQNkBnfC2hbNbTFJQSFNe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a mandatory pre-check to detect “plan mode write conflicts” when invoking planning commands while plan mode is already active.
  * System now emits an exact degradation warning as the first output (“⚠️ OCTO PLAN DEGRADED — Plan Mode Write Conflict”).
  * During the conflict, artifact saving is blocked while visualization output still completes, followed by a reminder to exit/cancel plan mode and re-run the planning command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->