### PR TITLE
fix: narrow quota-watcher to terminal-only errors, add 2-poll grace window

### DIFF
--- a/scripts/lib/quota-watcher.sh
+++ b/scripts/lib/quota-watcher.sh
@@ -2,7 +2,11 @@
 # Shared quota fast-fail watcher for provider CLIs that retry for a long time
 # after quota exhaustion instead of exiting promptly.
 
-OCTOPUS_QUOTA_PATTERN='QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|RetryableQuotaError|Attempt [0-9]+ failed.*exhausted|insufficient_quota|HTTP 401'
+# Terminal-only quota/auth errors — the provider CLI cannot recover from these on its own.
+# Excludes RetryableQuotaError and "Attempt N failed" retry log lines, which the Gemini CLI
+# emits during its own backoff/retry cycle. Matching those caused premature SIGTERM before the
+# CLI's retry landed, silently dropping reviewer roles (exit 143, empty output). (issue #516)
+OCTOPUS_QUOTA_PATTERN='QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|insufficient_quota|HTTP 401'
 
 # Session-scoped "this provider is quota/auth-dead" cache (oco-cbb). When a
 # terminal quota/auth error is seen at dispatch, the provider is marked here so
@@ -47,13 +51,22 @@ start_quota_watcher() {
     > "$temp_out"
 
     (
+        _consecutive=0
         while kill -0 "$target_pid" 2>/dev/null; do
             sleep 2
             if quota_watcher_has_match "$temp_err" "$temp_out"; then
-                log "WARN" "$warning_message"
-                octo_quota_mark_dead "$provider"
-                "$kill_callback" "$target_pid"
-                break
+                _consecutive=$((_consecutive + 1))
+                # Require the pattern to persist across two polls (~4 s) before killing.
+                # This lets provider CLIs with their own backoff (e.g. Gemini free-tier
+                # burst 429s) complete their retry before we act on the first match.
+                if [[ $_consecutive -ge 2 ]]; then
+                    log "WARN" "$warning_message"
+                    octo_quota_mark_dead "$provider"
+                    "$kill_callback" "$target_pid"
+                    break
+                fi
+            else
+                _consecutive=0
             fi
         done
     ) >/dev/null &


### PR DESCRIPTION
Fixes #516.\n\n## Root cause\n\n`scripts/lib/quota-watcher.sh:6` — `OCTOPUS_QUOTA_PATTERN` included two retryable markers:\n\n- `RetryableQuotaError` — Gemini's log for a transient 429 it will retry\n- `Attempt [0-9]+ failed.*exhausted` — the per-attempt retry log line\n\nThe watcher polls every 2 s. Gemini's own backoff/retry takes ~5 s. On a free-tier burst, Gemini logs one of these lines and starts retrying — the watcher fires before the retry lands and sends SIGTERM (exit 143). The role produces empty `## Output`, the orchestrator logs \"Round 1 complete.\", and coverage is silently dropped.\n\n## Fix\n\n**1. Narrow the terminal pattern** (`scripts/lib/quota-watcher.sh`)\n\nRemoved `RetryableQuotaError` and `Attempt [0-9]+ failed.*exhausted` from `OCTOPUS_QUOTA_PATTERN`. Remaining entries (`QUOTA_EXHAUSTED`, `TerminalQuotaError`, `exhausted your capacity`, `insufficient_quota`, `HTTP 401`) are all errors from which the provider CLI cannot recover on its own.\n\n**2. Add a 2-poll grace window** (`start_quota_watcher`)\n\nThe watcher now requires the terminal pattern to match on **two consecutive polls** (~4 s apart) before sending SIGTERM. This provides defence-in-depth against any terminal-looking log line that appears transiently at the start of a provider's own error-handling path, without meaningfully delaying the response to genuine terminal quota exhaustion.\n\nNo other callers or exported symbols changed.\n\n## Test results\n\n- `bash -n scripts/lib/quota-watcher.sh` — syntax OK\n- Pattern narrowing verified: `echo 'RetryableQuotaError' | grep -qE \"$OCTOPUS_QUOTA_PATTERN\"` → no match (correct)\n- Pattern still catches terminal: `echo 'TerminalQuotaError' | grep -qE \"$OCTOPUS_QUOTA_PATTERN\"` → match (correct)\n- `echo 'QUOTA_EXHAUSTED' | grep -qE \"$OCTOPUS_QUOTA_PATTERN\"` → match (correct)\n- `echo 'HTTP 401' | grep -qE \"$OCTOPUS_QUOTA_PATTERN\"` → match (correct)

---
_Generated by [Claude Code](https://claude.ai/code/session_016zNxewQxBpK9smEcUzfRyg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Refined quota and authentication error detection for provider CLIs to eliminate false positives from temporary errors.
- Quota warnings now trigger only when errors persist across consecutive monitoring intervals, improving detection reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->