### PR TITLE
test: harden lifecycle hook timeout fallback

### DIFF
--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -72,32 +72,36 @@ _octopus_agent_lifecycle_event() {
         export OCTOPUS_AGENT_ROOT_SESSION_ID="${CRABFLEET_ROOT_SESSION_ID:-${OCTOPUS_ROOT_SESSION_ID:-}}"
         export OCTOPUS_AGENT_PARENT_SESSION_ID="${CRABFLEET_PARENT_SESSION_ID:-${OCTOPUS_PARENT_SESSION_ID:-}}"
         local hook_timeout="${OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT:-3}"
+        if [[ ! "$hook_timeout" =~ ^[0-9]+$ ]]; then
+            hook_timeout=3
+        else
+            hook_timeout=$((10#$hook_timeout))
+            [[ "$hook_timeout" -lt 1 ]] && hook_timeout=3
+        fi
         if declare -f run_with_timeout >/dev/null 2>&1; then
             run_with_timeout "$hook_timeout" "$hook" "$event"
         elif command -v timeout >/dev/null 2>&1; then
             timeout "$hook_timeout" "$hook" "$event"
         else
-            # Built-in timeout fallback: run hook in background, wait with
-            # configured timeout, and kill if still running. Uses only bash
-            # built-ins so it works on systems without run_with_timeout or
-            # GNU timeout. See issue #511.
+            # Built-in timeout fallback: run hook in background, wait with a
+            # SECONDS-based deadline, and kill if still running. Uses Bash plus
+            # the already-required sleep command, so systems without the Octopus
+            # run_with_timeout helper or GNU timeout do not execute hooks
+            # unbounded. See issue #511.
             "$hook" "$event" &
             local _hook_pid=$!
-            local _hook_waited=0
-            while [[ $_hook_waited -lt $hook_timeout ]]; do
-                if ! kill -0 "$_hook_pid" 2>/dev/null; then
-                    wait "$_hook_pid" 2>/dev/null || true
-                    break
-                fi
+            local _hook_deadline=$((SECONDS + hook_timeout))
+            while kill -0 "$_hook_pid" 2>/dev/null && [[ "$SECONDS" -lt "$_hook_deadline" ]]; do
                 sleep 1
-                ((_hook_waited++)) || true
             done
             if kill -0 "$_hook_pid" 2>/dev/null; then
                 kill -TERM "$_hook_pid" 2>/dev/null || true
-                sleep 0.5 2>/dev/null || true
+                pkill -TERM -P "$_hook_pid" 2>/dev/null || true
+                sleep 1
                 kill -KILL "$_hook_pid" 2>/dev/null || true
-                wait "$_hook_pid" 2>/dev/null || true
+                pkill -KILL -P "$_hook_pid" 2>/dev/null || true
             fi
+            wait "$_hook_pid" 2>/dev/null || true
         fi
     ) >>"$hook_log" 2>&1 || true
 }

--- a/tests/unit/test-agent-lifecycle-events.sh
+++ b/tests/unit/test-agent-lifecycle-events.sh
@@ -113,6 +113,47 @@ else
 fi
 unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 
+
+
+test_case "lifecycle hook timeout accepts zero-padded decimal values"
+export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/slow-hook.sh"
+export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT=08
+_octopus_agent_lifecycle_event "spawned" "codex" "task-zero-padded-timeout" "developer" "tangle" "557" "$RESULTS_DIR/codex-zero-padded-timeout.md" "" "running"
+if grep -q '"task_id":"task-zero-padded-timeout"' "$OCTO_EVENT_LOG" && ! grep -q 'value too great for base' "$TMP_DIR/hook.log"; then
+  test_pass
+else
+  test_fail "zero-padded hook timeout should be normalized as decimal"
+fi
+unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
+
+cat > "$TMP_DIR/slow-fallback-hook.sh" <<'HOOK'
+#!/usr/bin/env bash
+sleep 5
+HOOK
+chmod +x "$TMP_DIR/slow-fallback-hook.sh"
+
+test_case "lifecycle hook uses built-in timeout fallback when timeout commands are unavailable"
+no_timeout_bin="$TMP_DIR/no-timeout-bin"
+mkdir -p "$no_timeout_bin"
+ln -sf /bin/sleep "$no_timeout_bin/sleep"
+ln -sf /bin/bash "$no_timeout_bin/bash"
+ln -sf /bin/date "$no_timeout_bin/date"
+ln -sf /usr/bin/dirname "$no_timeout_bin/dirname"
+export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/slow-fallback-hook.sh"
+export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT=1
+saved_path="$PATH"
+start=$(date +%s)
+PATH="$no_timeout_bin"
+_octopus_agent_lifecycle_event "spawned" "codex" "task-fallback-timeout" "developer" "tangle" "556" "$RESULTS_DIR/codex-fallback-timeout.md" "" "running"
+PATH="$saved_path"
+elapsed=$(( $(date +%s) - start ))
+if [[ "$elapsed" -lt 4 ]]; then
+  test_pass
+else
+  test_fail "built-in timeout fallback did not return promptly"
+fi
+unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
+
 test_case "completed lifecycle event carries exit status"
 _octopus_agent_lifecycle_event "completed" "gemini-fast" "task-2" "reviewer" "review" "222" "$RESULTS_DIR/gemini-task-2.md" "124" "timeout"
 if grep -q '"event":"agent.completed"' "$OCTO_EVENT_LOG" && \


### PR DESCRIPTION
## Summary
- validate `OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT` before using it
- harden the built-in hook timeout fallback with a `SECONDS`-based deadline
- avoid fractional `sleep` in the fallback path
- add regression coverage that forces the built-in fallback path when `timeout` is unavailable

## Context
Draft follow-up stacked on top of #511. The #511 repair already makes the direct hook fallback bounded; this follow-up makes that path easier to reason about and adds explicit coverage for systems without `run_with_timeout` or GNU `timeout`.

This is intentionally draft while #511 is still open, because the comparison against `main` includes the #511 commits. Once #511 lands, this should reduce to the hardening commit only.

## Verification
- `bash -n scripts/lib/spawn.sh`
- `bash tests/unit/test-agent-lifecycle-events.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle hook timeout handling by sanitizing `OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT` to a valid positive decimal value (including zero-padded inputs) and defaulting to `3` when invalid.
  * Updated timeout fallback behavior to use a wall-clock deadline with `kill -0` polling, reliably terminating the hook and its child processes (TERM then KILL), followed by a best-effort wait.

* **Tests**
  * Added regression coverage for zero-padded timeout values and for prompt fallback behavior when external timeout utilities are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->