### PR TITLE
release: v9.45.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.45.0"
+    "version": "9.45.1"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.45.0 - Add Antigravity CLI (agy) provider, generic OpenAI-compatible agent, and tangle routing overrides. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.45.0",
+      "description": "v9.45.1 - Add Antigravity CLI (agy) provider, generic OpenAI-compatible agent, and tangle routing overrides. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.45.1",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.45.0",
-  "description": "v9.44.1 \u2014 Patch release for Gemini environment/version detection and qwen auth gating. Run /octo:setup.",
+  "version": "9.45.1",
+  "description": "v9.45.1 \u2014 Patch release for provider reliability and event telemetry. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.45.0",
+  "version": "9.45.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.45.0",
+  "version": "9.45.1",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.45.0"
+    "version": "9.45.1"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.45.0 - Add Antigravity CLI (agy) provider, generic OpenAI-compatible agent, and tangle routing overrides. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.45.0",
+      "description": "v9.45.1 - Add Antigravity CLI (agy) provider, generic OpenAI-compatible agent, and tangle routing overrides. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.45.1",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.45.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.45.1",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.45.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [9.45.1] - 2026-06-16
+
+### Added
+
+- `bin/octo-hud` local event-stream monitor for `OCTO_EVENT_LOG`, rendering provider, dispatch, and circuit-breaker lifecycle state without a server dependency (#510).
+- Provider lifecycle telemetry for `provider.selected` plus circuit-breaker open, half-open, and closed events under the existing opt-in event log guard (#509).
+- GA Gemini text catalog entries for `gemini-3.5-flash` and `gemini-3.1-flash-lite` (#502).
+
+### Fixed
+
+- Provider reliability bundle: adds Gemini per-provider timeout handling, parallel-path quota and terminal fast-fail coverage, and a quota-dead session cache that degrades or skips dead providers instead of dispatching into known failures (#508).
+- `OCTO_EVENT_LOG` telemetry is enabled by default from `orchestrate.sh` so event-enabled workflows can observe dispatch state without extra setup (#491).
+
 ## [9.45.0] - 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.45.0-blue" alt="Version 9.44.1">
+  <img src="https://img.shields.io/badge/Version-9.45.1-blue" alt="Version 9.45.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.45.0",
+  "version": "9.45.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Summary

Patch release for merged fixes since v9.45.0.

### Changelog excerpt

#### Added

- `bin/octo-hud` local event-stream monitor for `OCTO_EVENT_LOG`, rendering provider, dispatch, and circuit-breaker lifecycle state without a server dependency (#510).
- Provider lifecycle telemetry for `provider.selected` plus circuit-breaker open, half-open, and closed events under the existing opt-in event log guard (#509).
- GA Gemini text catalog entries for `gemini-3.5-flash` and `gemini-3.1-flash-lite` (#502).

#### Fixed

- Provider reliability bundle: adds Gemini per-provider timeout handling, parallel-path quota and terminal fast-fail coverage, and a quota-dead session cache that degrades or skips dead providers instead of dispatching into known failures (#508).
- `OCTO_EVENT_LOG` telemetry is enabled by default from `orchestrate.sh` so event-enabled workflows can observe dispatch state without extra setup (#491).

## Verification

- `jq empty package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json .factory-plugin/marketplace.json`
- `bash tests/unit/test-docs-sync.sh`
- `make test-unit` (136/136 suites passed)
- `make test-integration` (7/7 suites passed)

## Notes

Release PR only. Do not tag until this PR is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 9.45.1

* **New Features**
  * Added local event-stream monitoring capability
  * Added provider lifecycle telemetry tracking
  * GA support for Gemini flash model variants

* **Bug Fixes**
  * Improved provider reliability with enhanced timeout handling and fast-fail coverage
  * Event telemetry enabled by default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->