### PR TITLE
council: make qwen a seatable provider org

### DIFF
--- a/agents/config.yaml
+++ b/agents/config.yaml
@@ -182,8 +182,9 @@ agents:
 
   python-pro:
     file: personas/python-pro.md
-    cli: codex
-    model: gpt-5.3-codex
+    cli: qwen                      # qwen cross-lab council seat (mirrors backend-architect=agy); falls back to codex when the qwen CLI is unavailable
+    fallback_cli: codex
+    model: qwen3-coder-plus
     phases: [tangle]
     tier: premium
     expertise: [python, fastapi, django, async]

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -74,7 +74,7 @@ Options:
   --implement never|after-approval|plan-only
   --worktree auto|on|off
   --benchmark auto|on|off
-  --providers auto|claude,codex,gemini,opencode,openrouter
+  --providers auto|claude,codex,gemini,qwen,opencode,openrouter
   --max-cost <usd>
   --simulate
   --single-model
@@ -175,7 +175,7 @@ council_validate_choice() {
 
 council_validate_provider_list() {
     local providers="$1"
-    local allowed="claude,codex,gemini,opencode,openrouter"
+    local allowed="claude,codex,gemini,qwen,opencode,openrouter"
 
     if [[ "$providers" == "auto" ]]; then
         return 0
@@ -882,7 +882,7 @@ council_pick_provider() {
     fi
 
     local provider providers="$COUNCIL_PROVIDERS"
-    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,opencode,openrouter"
+    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,qwen,opencode,openrouter"
     IFS=',' read -r -a provider_list <<< "$providers"
     for provider in "${provider_list[@]}"; do
         provider="${provider// /}"
@@ -982,7 +982,7 @@ council_candidate_personas() {
 
 council_available_provider_orgs_json() {
     local providers="$COUNCIL_PROVIDERS"
-    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,opencode,openrouter"
+    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,qwen,opencode,openrouter"
 
     local json='[]' provider org
     IFS=',' read -r -a provider_list <<< "$providers"
@@ -998,7 +998,7 @@ council_available_provider_orgs_json() {
 council_provider_for_org() {
     local wanted_org="$1"
     local providers="$COUNCIL_PROVIDERS"
-    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,opencode,openrouter"
+    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,qwen,opencode,openrouter"
 
     local provider
     IFS=',' read -r -a provider_list <<< "$providers"
@@ -1950,7 +1950,7 @@ council_start_implementation_handoff() {
 council_detect_providers() {
     local providers="$COUNCIL_PROVIDERS"
     if [[ "$providers" == "auto" ]]; then
-        providers="claude,codex,gemini,opencode,openrouter"
+        providers="claude,codex,gemini,qwen,opencode,openrouter"
     fi
 
     local json='{}'

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -498,7 +498,7 @@ ${YELLOW}Options:${NC}
   --implement never|after-approval|plan-only
   --worktree auto|on|off
   --benchmark auto|on|off
-  --providers auto|claude,codex,gemini,opencode,openrouter
+  --providers auto|claude,codex,gemini,qwen,opencode,openrouter
   --max-cost <usd>
   --dry-run
   --json

--- a/tests/unit/test-qwen-council-provider.sh
+++ b/tests/unit/test-qwen-council-provider.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# tests/unit/test-qwen-council-provider.sh
+# Tests that Qwen is a seatable council provider org:
+#   - present in the council auto/allowed provider lists
+#   - representable by a persona so council diversity/scoring can seat it
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Qwen council provider"
+
+COUNCIL="$PROJECT_ROOT/scripts/lib/council.sh"
+CONFIG="$PROJECT_ROOT/agents/config.yaml"
+USAGE="$PROJECT_ROOT/scripts/lib/usage-help.sh"
+
+test_qwen_in_auto_list() {
+    test_case "council auto provider list includes qwen"
+
+    if grep -q 'claude,codex,gemini,qwen,opencode,openrouter' "$COUNCIL"; then
+        test_pass
+    else
+        test_fail "council.sh auto provider list should include qwen"
+    fi
+}
+
+test_qwen_no_stale_list() {
+    test_case "no stale qwen-less provider list remains in council.sh"
+
+    if grep -q 'claude,codex,gemini,opencode,openrouter' "$COUNCIL"; then
+        test_fail "council.sh still contains a provider list without qwen"
+    else
+        test_pass
+    fi
+}
+
+test_qwen_validates() {
+    test_case "council_validate_provider_list accepts an explicit qwen request"
+
+    # council.sh is source-safe (function definitions only); validate is pure.
+    if ( source "$COUNCIL" && council_validate_provider_list "claude,codex,qwen" >/dev/null 2>&1 ); then
+        test_pass
+    else
+        test_fail "--providers claude,codex,qwen should be accepted"
+    fi
+}
+
+test_qwen_persona_seat() {
+    test_case "config.yaml gives the qwen org a council persona with codex fallback"
+
+    local block
+    block="$(awk '/^  python-pro:/{f=1} f{print} f&&/^  [a-z].*:/&&!/^  python-pro:/{exit}' "$CONFIG")"
+    if [[ "$block" == *"cli: qwen"* ]] && [[ "$block" == *"fallback_cli: codex"* ]]; then
+        test_pass
+    else
+        test_fail "a persona should default to cli: qwen with fallback_cli: codex"
+    fi
+}
+
+test_qwen_usage_doc() {
+    test_case "usage help lists qwen as a --providers option"
+
+    if grep -q 'claude,codex,gemini,qwen,opencode,openrouter' "$USAGE"; then
+        test_pass
+    else
+        test_fail "usage-help.sh should document qwen in the --providers list"
+    fi
+}
+
+test_qwen_syntax() {
+    test_case "council.sh and usage-help.sh remain valid bash"
+
+    if bash -n "$COUNCIL" && bash -n "$USAGE"; then
+        test_pass
+    else
+        test_fail "edited scripts have syntax errors"
+    fi
+}
+
+test_qwen_in_auto_list
+test_qwen_no_stale_list
+test_qwen_validates
+test_qwen_persona_seat
+test_qwen_usage_doc
+test_qwen_syntax
+
+test_summary


### PR DESCRIPTION
## Problem

Qwen ships with full dispatch support in this repo — `scripts/lib/qwen.sh`, provider detection in `providers.sh`, and `check-providers` reports `qwen:available` — yet it can **never participate in a council**:

1. **Rejected on request.** `qwen` is absent from the council provider lists, so `council_validate_provider_list` rejects `--providers …,qwen` with `unknown provider 'qwen'`.
2. **Unrepresentable for auto/diversity.** No persona's default provider resolves to the `qwen` org, so `council_candidate_for_provider_org` returns nothing and the diversity pass logs *"available provider diversity could not be represented by configured personas"* — qwen is silently dropped even when installed and available.

Net effect: an installed, authenticated qwen CLI shows as available in the banner but is excluded from every council.

## Fix

- Add `qwen` to the council **auto** and **allowed** provider lists (`scripts/lib/council.sh`, `scripts/lib/usage-help.sh`).
- Give the `qwen` org a council seat via the `python-pro` persona (`cli: qwen`, `fallback_cli: codex`, `model: qwen3-coder-plus`), mirroring the existing `backend-architect: cli: agy` cross-lab seat pattern.

With this, qwen seats through roster scoring exactly like `agy` does today, and `--providers …,qwen` is accepted. Combined with #513 (*seat every available provider org*) it is also auto-seated on `--providers auto`. The `fallback_cli: codex` keeps behavior unchanged when the qwen CLI isn't installed.

## Tests

New `tests/unit/test-qwen-council-provider.sh` (6 cases): qwen in the auto/allowed lists, no stale qwen-less list remains, `council_validate_provider_list` accepts an explicit qwen request, a persona represents the qwen org with codex fallback, usage-help documents it, and the edited scripts stay valid bash.

Verified locally on top of `main`:
- new test: 6/6 pass
- `tests/unit/test-council-command.sh`: 51/51 pass
- `tests/unit/test-persona-packs.sh`: 13/13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Qwen provider in council provider selection.
  * Updated the `python-pro` agent to use the Qwen CLI (`qwen3-coder-plus`) when available, with automatic fallback to Codex.

* **Documentation**
  * Expanded `council` command help so `--providers` includes Qwen.

* **Tests**
  * Added unit coverage to verify Qwen is supported end-to-end (provider validation, configuration, and shell syntax).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->