### PR TITLE
fix: refuse self-targeting writes in octo_write_stable_script_shim

### DIFF
--- a/scripts/lib/plugin-root.sh
+++ b/scripts/lib/plugin-root.sh
@@ -30,13 +30,12 @@ octo_write_stable_script_shim() {
 
     # Refuse to write a shim that resolves to its own source file. If
     # stable_root's children are symlinks into the live plugin cache (rather
-    # than stable_root itself being a single symlink), dst can physically
-    # resolve to src, and writing the exec stub there corrupts the live
-    # script into a self-referential exec loop. See #521.
-    local rsrc rdst
-    rsrc="$(cd "$(dirname "$src")" 2>/dev/null && pwd -P)/$(basename "$src")"
-    rdst="$(cd "$(dirname "$dst")" 2>/dev/null && pwd -P)/$(basename "$dst")"
-    [[ -n "$rsrc" && "$rsrc" == "$rdst" ]] && return 0
+    # than stable_root itself being a single symlink), or dst is itself a
+    # symlink aliasing src, writing the exec stub there corrupts the live
+    # script into a self-referential exec loop. -ef compares device+inode so
+    # it catches aliasing via either a symlinked parent dir or dst itself
+    # being a symlink to src. See #521.
+    [[ -e "$dst" && "$src" -ef "$dst" ]] && return 0
 
     local quoted_src
     printf -v quoted_src '%q' "$src"

--- a/scripts/lib/plugin-root.sh
+++ b/scripts/lib/plugin-root.sh
@@ -28,6 +28,16 @@ octo_write_stable_script_shim() {
 
     [[ -f "$src" ]] || return 0
 
+    # Refuse to write a shim that resolves to its own source file. If
+    # stable_root's children are symlinks into the live plugin cache (rather
+    # than stable_root itself being a single symlink), dst can physically
+    # resolve to src, and writing the exec stub there corrupts the live
+    # script into a self-referential exec loop. See #521.
+    local rsrc rdst
+    rsrc="$(cd "$(dirname "$src")" 2>/dev/null && pwd -P)/$(basename "$src")"
+    rdst="$(cd "$(dirname "$dst")" 2>/dev/null && pwd -P)/$(basename "$dst")"
+    [[ -n "$rsrc" && "$rsrc" == "$rdst" ]] && return 0
+
     local quoted_src
     printf -v quoted_src '%q' "$src"
     mkdir -p "$(dirname "$dst")"

--- a/tests/unit/test-plugin-root-shim.sh
+++ b/tests/unit/test-plugin-root-shim.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/lib/plugin-root.sh — octo_write_stable_script_shim
+# self-targeting guard. See #521.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/scripts/lib/plugin-root.sh"
+
+# shellcheck disable=SC1090
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Plugin Root Shim Self-Targeting Guard (#521)"
+
+test_lib_sourceable() {
+    test_case "plugin-root.sh is readable and syntactically valid"
+    [[ -r "$LIB" ]] && bash -n "$LIB" && test_pass || test_fail "lib missing or has syntax errors"
+}
+
+# Reproduces #521: stable_root/scripts is a symlink into the live plugin
+# cache, so dst physically resolves to src. The shim must refuse to write
+# and leave the live script untouched, instead of corrupting it into a
+# self-referential exec stub.
+test_refuses_self_targeting_write() {
+    test_case "octo_write_stable_script_shim does not overwrite src when dst resolves to src"
+    local work
+    work=$(mktemp -d)
+    mkdir -p "$work/cache/9.45.0/scripts"
+    cat > "$work/cache/9.45.0/scripts/orchestrate.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "real orchestrate.sh"
+EOF
+    chmod +x "$work/cache/9.45.0/scripts/orchestrate.sh"
+    mkdir -p "$work/stable"
+    ln -s "$work/cache/9.45.0/scripts" "$work/stable/scripts"
+
+    bash -c "source '$LIB'; octo_write_stable_script_shim '$work/cache/9.45.0' '$work/stable' 'scripts/orchestrate.sh'"
+
+    local contents
+    contents="$(cat "$work/cache/9.45.0/scripts/orchestrate.sh")"
+    rm -rf "$work"
+
+    if [[ "$contents" == *"real orchestrate.sh"* && "$contents" != *"exec "* ]]; then
+        test_pass
+    else
+        test_fail "live script was overwritten with a shim: $contents"
+    fi
+}
+
+# Normal case: stable_root is a plain directory (e.g. Windows Git Bash
+# fallback) whose children are NOT symlinks into the cache. The shim should
+# still write the wrapper as before.
+test_writes_shim_when_not_self_targeting() {
+    test_case "octo_write_stable_script_shim still writes a wrapper for a genuinely separate dst"
+    local work
+    work=$(mktemp -d)
+    mkdir -p "$work/cache/9.45.0/scripts"
+    cat > "$work/cache/9.45.0/scripts/orchestrate.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "real orchestrate.sh"
+EOF
+    chmod +x "$work/cache/9.45.0/scripts/orchestrate.sh"
+    mkdir -p "$work/stable"
+
+    bash -c "source '$LIB'; octo_write_stable_script_shim '$work/cache/9.45.0' '$work/stable' 'scripts/orchestrate.sh'"
+
+    local contents
+    contents="$(cat "$work/stable/scripts/orchestrate.sh" 2>/dev/null || echo MISSING)"
+    rm -rf "$work"
+
+    [[ "$contents" == *"exec "* ]] && test_pass || test_fail "expected an exec wrapper, got: $contents"
+}
+
+test_lib_sourceable
+test_refuses_self_targeting_write
+test_writes_shim_when_not_self_targeting
+
+test_summary

--- a/tests/unit/test-plugin-root-shim.sh
+++ b/tests/unit/test-plugin-root-shim.sh
@@ -24,8 +24,7 @@ test_lib_sourceable() {
 # self-referential exec stub.
 test_refuses_self_targeting_write() {
     test_case "octo_write_stable_script_shim does not overwrite src when dst resolves to src"
-    local work
-    work=$(mktemp -d)
+    local work="$TEST_TMP_DIR/refuses-self-targeting"
     mkdir -p "$work/cache/9.45.0/scripts"
     cat > "$work/cache/9.45.0/scripts/orchestrate.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -39,7 +38,6 @@ EOF
 
     local contents
     contents="$(cat "$work/cache/9.45.0/scripts/orchestrate.sh")"
-    rm -rf "$work"
 
     if [[ "$contents" == *"real orchestrate.sh"* && "$contents" != *"exec "* ]]; then
         test_pass
@@ -53,8 +51,7 @@ EOF
 # still write the wrapper as before.
 test_writes_shim_when_not_self_targeting() {
     test_case "octo_write_stable_script_shim still writes a wrapper for a genuinely separate dst"
-    local work
-    work=$(mktemp -d)
+    local work="$TEST_TMP_DIR/writes-shim"
     mkdir -p "$work/cache/9.45.0/scripts"
     cat > "$work/cache/9.45.0/scripts/orchestrate.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -67,13 +64,40 @@ EOF
 
     local contents
     contents="$(cat "$work/stable/scripts/orchestrate.sh" 2>/dev/null || echo MISSING)"
-    rm -rf "$work"
 
     [[ "$contents" == *"exec "* ]] && test_pass || test_fail "expected an exec wrapper, got: $contents"
+}
+
+# dst itself (not a parent directory) is a symlink aliasing src, with no
+# symlink in dst's parent chain. A guard that only canonicalizes dst's parent
+# directory misses this; -ef catches it because it compares device+inode.
+test_refuses_self_targeting_write_via_dst_symlink() {
+    test_case "octo_write_stable_script_shim does not overwrite src when dst itself symlinks to src"
+    local work="$TEST_TMP_DIR/refuses-self-targeting-dst-symlink"
+    mkdir -p "$work/cache/9.45.0/scripts"
+    cat > "$work/cache/9.45.0/scripts/orchestrate.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "real orchestrate.sh"
+EOF
+    chmod +x "$work/cache/9.45.0/scripts/orchestrate.sh"
+    mkdir -p "$work/stable/scripts"
+    ln -s "$work/cache/9.45.0/scripts/orchestrate.sh" "$work/stable/scripts/orchestrate.sh"
+
+    bash -c "source '$LIB'; octo_write_stable_script_shim '$work/cache/9.45.0' '$work/stable' 'scripts/orchestrate.sh'"
+
+    local contents
+    contents="$(cat "$work/cache/9.45.0/scripts/orchestrate.sh")"
+
+    if [[ "$contents" == *"real orchestrate.sh"* && "$contents" != *"exec "* ]]; then
+        test_pass
+    else
+        test_fail "live script was overwritten with a shim: $contents"
+    fi
 }
 
 test_lib_sourceable
 test_refuses_self_targeting_write
 test_writes_shim_when_not_self_targeting
+test_refuses_self_targeting_write_via_dst_symlink
 
 test_summary


### PR DESCRIPTION
Fixes #521.

## Root cause

`octo_ensure_stable_plugin_root` falls back to writing per-script exec shims (`scripts/lib/plugin-root.sh:22-44`, ~10 entry points) when `~/.claude-octopus/plugin` exists as a plain directory rather than a single symlink — e.g. on the reporter's setup where `~/.claude-octopus/plugin` was a directory whose children (`scripts`, etc.) were themselves symlinks into the live version cache.

In that layout, `octo_write_stable_script_shim`'s `dst` (`${stable_root}/${rel_path}`) physically resolves to the same file as `src` (`${plugin_root}/${rel_path}`) once the intermediate symlink is followed. The function had no check for this and unconditionally wrote:

```sh
exec <src> "$@"
```

into `dst` — which is `src` itself — turning the real script into a self-referential `exec` loop. Every subsequent invocation of e.g. `orchestrate.sh` hangs forever, and the corruption is self-perpetuating (each run rewrites the stub).

## Fix

Resolve both `src` and `dst` to their physical paths using the `cd ... && pwd -P` pattern already established in this file for the same class of problem (`#371`'s same-physical-dir guard), and skip the write when they match (`scripts/lib/plugin-root.sh:31-39`). This is the "highest-value guard" suggested in the issue — `readlink -f` was avoided since it's a GNU extension not available on the reporter's platform (macOS/BSD `readlink`).

## Tests

- New `tests/unit/test-plugin-root-shim.sh`: reproduces the exact symlink layout from the issue and asserts the live script is left untouched, plus a control case confirming the shim is still written when `dst` is a genuinely separate path (the Windows Git Bash fallback case this function exists for).
- Manually reproduced the corruption against the pre-fix code (confirmed `orchestrate.sh` gets overwritten with an `exec` stub) and confirmed the patched code leaves it intact and runnable.
- `bash -n scripts/lib/plugin-root.sh` — syntax OK.
- `make test-unit`: 133/137 suites pass; the 4 failures (`test-github-work-queue-hook`, `test-hud-smart-mode`, `test-shared-marketplace-sync`, `test-tangle-worktree-evidence`) are pre-existing environment limitations of this sandbox (missing `gh` CLI, and a commit-signing proxy that rejects throwaway git fixture commits) — none reference `plugin-root.sh`.
- `make test-integration`: 7/7 suites pass.

https://claude.ai/code/session_01VDS9NqFH96CvCPMYCcRMy2


---
_Generated by [Claude Code](https://claude.ai/code/session_01VDS9NqFH96CvCPMYCcRMy2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented plugin script shims from being written in cases where the destination resolves to the same live script, avoiding self-referential execution loops.

* **Tests**
  * Added unit tests covering symlink/self-aliasing scenarios to ensure the live script is preserved, plus a normal case validating shim replacement in separate directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->