### PR TITLE
feat: agy is the default Google seat across multi-LLM workflows (Gemini CLI sunset)

### DIFF
--- a/scripts/lib/agents.sh
+++ b/scripts/lib/agents.sh
@@ -595,9 +595,9 @@ get_agent_for_task() {
         image) echo "gemini-image" ;;
         review) echo "codex-review" ;;
         coding) echo "codex" ;;
-        design) echo "gemini" ;;       # Gemini excels at reasoning about design
-        copywriting) echo "gemini" ;;  # Gemini strong at creative writing
-        research) echo "gemini" ;;     # Gemini good at analysis/synthesis
+        design) echo "agy" ;;          # Antigravity (Google seat) — Gemini CLI sunset 2026-06-18
+        copywriting) echo "agy" ;;     # Antigravity — creative writing
+        research) echo "agy" ;;        # Antigravity — analysis/synthesis
         general) echo "codex" ;;       # Default to codex for general tasks
         *) echo "codex" ;;
     esac
@@ -687,11 +687,9 @@ get_tiered_agent() {
             esac
             ;;
         design|copywriting|research)
-            # Gemini tasks: tier based on complexity
-            case "$adjusted_complexity" in
-                1) agent="gemini-fast" ;;     # Trivial → flash (cheaper)
-                *) agent="gemini" ;;          # Standard+ → pro
-            esac
+            # Antigravity (agy) is the Google seat (Gemini CLI sunset 2026-06-18).
+            # Model tier is selected via OCTOPUS_AGY_MODEL, not separate agents.
+            agent="agy"
             ;;
         diamond-*)
             # Double Diamond workflows: respect resource tier

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -398,9 +398,9 @@ get_fallback_agent() {
             ;;
         codex|codex-standard|codex-mini)
             # Codex unavailable, try gemini
-            if is_agent_available "gemini"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: $preferred -> gemini (no OpenAI)" || true
-                echo "gemini"
+            if is_agent_available "agy"; then
+                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: $preferred -> agy (no OpenAI)" || true
+                echo "agy"
             else
                 echo "$preferred"
             fi
@@ -410,9 +410,9 @@ get_fallback_agent() {
             if is_agent_available "codex"; then
                 [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-spark -> codex (spark unavailable)" || true
                 echo "codex"
-            elif is_agent_available "gemini"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-spark -> gemini (no OpenAI)" || true
-                echo "gemini"
+            elif is_agent_available "agy"; then
+                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-spark -> agy (no OpenAI)" || true
+                echo "agy"
             else
                 echo "$preferred"
             fi
@@ -422,9 +422,9 @@ get_fallback_agent() {
             if is_agent_available "codex"; then
                 [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-reasoning -> codex (reasoning unavailable)" || true
                 echo "codex"
-            elif is_agent_available "gemini"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-reasoning -> gemini (no OpenAI)" || true
-                echo "gemini"
+            elif is_agent_available "agy"; then
+                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-reasoning -> agy (no OpenAI)" || true
+                echo "agy"
             else
                 echo "$preferred"
             fi
@@ -434,9 +434,9 @@ get_fallback_agent() {
             if is_agent_available "codex"; then
                 [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-large-context -> codex (large-ctx unavailable)" || true
                 echo "codex"
-            elif is_agent_available "gemini"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-large-context -> gemini (no OpenAI)" || true
-                echo "gemini"
+            elif is_agent_available "agy"; then
+                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-large-context -> agy (no OpenAI)" || true
+                echo "agy"
             else
                 echo "$preferred"
             fi
@@ -449,9 +449,9 @@ get_fallback_agent() {
             elif is_agent_available "codex"; then
                 [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: $preferred -> codex (no OpenRouter)" || true
                 echo "codex"
-            elif is_agent_available "gemini"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: $preferred -> gemini (no OpenRouter/OpenAI)" || true
-                echo "gemini"
+            elif is_agent_available "agy"; then
+                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: $preferred -> agy (no OpenRouter/OpenAI)" || true
+                echo "agy"
             else
                 echo "$preferred"
             fi

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -248,15 +248,15 @@ get_alternate_provider() {
     local locked_provider="$1"
     case "$locked_provider" in
         codex|codex-fast|codex-mini)
-            if ! is_provider_locked "gemini"; then
-                echo "gemini"
+            if ! is_provider_locked "agy"; then
+                echo "agy"
             elif ! is_provider_locked "claude-sonnet"; then
                 echo "claude-sonnet"
             else
                 echo "$locked_provider"  # All locked, use original
             fi
             ;;
-        gemini|gemini-fast)
+        agy|agy-research|antigravity)
             if ! is_provider_locked "codex"; then
                 echo "codex"
             elif ! is_provider_locked "claude-sonnet"; then
@@ -268,8 +268,8 @@ get_alternate_provider() {
         claude-sonnet|claude*)
             if ! is_provider_locked "codex"; then
                 echo "codex"
-            elif ! is_provider_locked "gemini"; then
-                echo "gemini"
+            elif ! is_provider_locked "agy"; then
+                echo "agy"
             else
                 echo "$locked_provider"
             fi
@@ -459,7 +459,7 @@ Be concise and specific. This is a planning exercise, not implementation."
     # operators can pick cheaper/faster review models without patching code.
     local codex_approach="" gemini_approach="" sonnet_approach=""
     local design_codex_agent="${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-codex-mini}"
-    local design_gemini_agent="${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-gemini}"
+    local design_agy_agent="${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-agy}}"
     local design_claude_agent="${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}"
     local design_synthesis_agent="${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}"
     local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-120}"
@@ -474,10 +474,10 @@ Be concise and specific. This is a planning exercise, not implementation."
     fi
 
     log INFO "Design review: gathering provider approaches..."
-    log INFO "Design review agents: codex=${design_codex_agent}, gemini=${design_gemini_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${design_timeout}s, synth_timeout=${design_synth_timeout}s"
+    log INFO "Design review agents: codex=${design_codex_agent}, agy=${design_agy_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${design_timeout}s, synth_timeout=${design_synth_timeout}s"
 
     codex_approach=$(run_agent_sync "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
-    gemini_approach=$(run_agent_sync "$design_gemini_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
+    gemini_approach=$(run_agent_sync "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
     sonnet_approach=$(run_agent_sync "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony" 2>/dev/null) || true
 
     # Synthesize conflicts and resolution
@@ -941,8 +941,8 @@ get_cross_model_reviewer() {
     local author_provider="$1"
 
     case "$author_provider" in
-        codex*) echo "gemini" ;;
-        gemini*) echo "codex" ;;
+        codex*) echo "agy" ;;
+        agy*|antigravity) echo "codex" ;;
         claude*) echo "codex" ;;
         *) echo "codex" ;;
     esac

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -742,7 +742,7 @@ grasp_define() {
         echo -e " ${YELLOW}⚠${NC}  Codex unavailable for problem definition — falling back to Claude"
         def1=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define the core problem statement in 2-3 sentences. What is the essential challenge?" 120 "backend-architect" "grasp") || true
     }
-    def2=$(run_agent_sync "gemini" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || {
+    def2=$(run_agent_sync "agy" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || {
         log WARN "Gemini failed for success criteria, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Gemini unavailable for success criteria — falling back to Claude"
         def2=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || true
@@ -773,7 +773,7 @@ Output a single, clear problem definition document with:
 4. Recommended Approach"
 
     local consensus
-    consensus=$(run_agent_sync "gemini" "$consensus_prompt" 180 "synthesizer" "grasp") || {
+    consensus=$(run_agent_sync "agy" "$consensus_prompt" 180 "synthesizer" "grasp") || {
         consensus="[Auto-consensus failed - manual review required]\n\nProblem: $def1\n\nSuccess Criteria: $def2\n\nConstraints: $def3"
     }
 
@@ -1083,7 +1083,7 @@ Previous decomposition:
 ${previous_decomposition}
 "
 
-    run_agent_sync "gemini" "$reformat_prompt" 120 "researcher" "tangle" || \
+    run_agent_sync "agy" "$reformat_prompt" 120 "researcher" "tangle" || \
     run_agent_sync "claude-sonnet" "$reformat_prompt" 120 "researcher" "tangle"
 }
 
@@ -1306,9 +1306,9 @@ Every [CODING] line must include a same-line Files: clause."
     # Tangle decomposition agents are overridable (OCTOPUS_TANGLE_DECOMPOSE_AGENT,
     # OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT, OCTOPUS_TANGLE_AGENT). Override only
     # selects the dispatch agent; the fail-closed contract below is unchanged.
-    local tangle_decompose_agent="gemini" tangle_decompose_fallback_agent="codex"
+    local tangle_decompose_agent="agy" tangle_decompose_fallback_agent="codex"
     if declare -f octopus_agent_override >/dev/null 2>&1; then
-        tangle_decompose_agent=$(octopus_agent_override "tangle" "decompose" "gemini")
+        tangle_decompose_agent=$(octopus_agent_override "tangle" "decompose" "agy")
         tangle_decompose_fallback_agent=$(octopus_agent_override "tangle" "decompose_fallback" "codex")
     fi
 
@@ -1388,7 +1388,7 @@ Every [CODING] line must include a same-line Files: clause."
         local role="implementer"
         local pane_icon="⚙️"
         if [[ "$subtask" =~ \[REASONING\] ]]; then
-            agent="gemini"
+            agent="agy"
             role="researcher"
             pane_icon="🧠"
         fi
@@ -1788,7 +1788,7 @@ Compact source context to synthesize:
 $all_results"
 
     local delivery
-    delivery=$(run_agent_sync "gemini" "$synthesis_prompt" 180 "synthesizer" "ink") || {
+    delivery=$(run_agent_sync "agy" "$synthesis_prompt" 180 "synthesizer" "ink") || {
         delivery=$(build_ink_fallback_delivery "$prompt" "$sonnet_review" "$all_results")
     }
 
@@ -1964,7 +1964,7 @@ Return a concise gate review with:
             successful=$((successful + 1))
         fi
     fi
-    if gemini_view=$(run_agent_sync "gemini" "$gate_prompt" 120 "researcher" "embrace-gate" 2>/dev/null); then
+    if gemini_view=$(run_agent_sync "agy" "$gate_prompt" 120 "researcher" "embrace-gate" 2>/dev/null); then
         if [[ -n "$gemini_view" ]]; then
             gemini_status="ok"
             successful=$((successful + 1))

--- a/tests/unit/test-agy-workflow-routing.sh
+++ b/tests/unit/test-agy-workflow-routing.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "agy is the Google seat across workflows (Gemini CLI sunset 2026-06-18)"
+
+test_role_map_research_design_copywriting_is_agy() {
+    test_case "get_agent_for_task routes research/design/copywriting to agy"
+    local out
+    out="$(bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/agents.sh" 2>/dev/null
+        for r in research design copywriting; do get_agent_for_task "$r"; done')"
+    if [[ "$(echo "$out" | grep -c '^agy$')" == "3" ]]; then test_pass
+    else test_fail "expected 3x agy, got: $(echo "$out" | tr '\n' ' ')"; fi
+}
+
+test_fallback_chain_prefers_agy() {
+    test_case "get_fallback_agent falls back to agy (not gemini) when codex is down"
+    local out
+    out="$(bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+        is_agent_available(){ [[ "$1" == agy ]]; }
+        get_fallback_agent codex')"
+    [[ "$out" == "agy" ]] && test_pass || test_fail "expected agy, got: $out"
+}
+
+test_no_functional_gemini_dispatch() {
+    test_case "no functional gemini dispatch remains in the workflow libs"
+    local hits
+    hits=$(grep -nE 'run_agent_sync "gemini"|echo "gemini"|agent="gemini"' \
+        "$PROJECT_ROOT/scripts/lib/workflows.sh" \
+        "$PROJECT_ROOT/scripts/lib/agents.sh" \
+        "$PROJECT_ROOT/scripts/lib/quality.sh" \
+        "$PROJECT_ROOT/scripts/lib/model-resolver.sh" 2>/dev/null || true)
+    if [[ -z "$hits" ]]; then test_pass
+    else test_fail "stale gemini dispatch: $hits"; fi
+}
+
+test_tangle_decompose_default_is_agy() {
+    test_case "tangle decompose default agent is agy"
+    if grep -q 'tangle_decompose_agent="agy"' "$PROJECT_ROOT/scripts/lib/workflows.sh" && \
+       grep -q 'octopus_agent_override "tangle" "decompose" "agy"' "$PROJECT_ROOT/scripts/lib/workflows.sh"; then
+        test_pass
+    else test_fail "tangle decompose still defaults to gemini"; fi
+}
+
+test_role_map_research_design_copywriting_is_agy
+test_fallback_chain_prefers_agy
+test_no_functional_gemini_dispatch
+test_tangle_decompose_default_is_agy
+
+test_summary

--- a/tests/unit/test-cross-model-review.sh
+++ b/tests/unit/test-cross-model-review.sh
@@ -97,12 +97,14 @@ test_scorecard_format() {
 }
 
 test_cross_model_assignment() {
-    test_case "Cross-model reviewer assignment (codex->gemini, gemini->codex)"
+    test_case "Cross-model reviewer assignment (codex->agy, agy->codex)"
 
     local func_body
     func_body=$(sed -n '/^get_cross_model_reviewer()/,/^}/p' "$ALL_SRC")
 
-    if echo "$func_body" | grep -q 'codex.*gemini' && echo "$func_body" | grep -q 'gemini.*codex'; then
+    # Google seat is agy (Gemini CLI sunset 2026-06-18): codex author -> agy
+    # reviewer, agy author -> codex reviewer.
+    if echo "$func_body" | grep -q 'codex.*agy' && echo "$func_body" | grep -q 'agy.*codex'; then
         test_pass
     else
         test_fail "Cross-model assignment not correct"


### PR DESCRIPTION
Google sunset the Gemini CLI **2026-06-18**; Antigravity (`agy`) is the official replacement. Installed it + verified it works headless (`agy --print --dangerously-skip-permissions` → clean output; models: Gemini 3.5 Flash, 3.1 Pro, Claude Sonnet/Opus 4.6, GPT-OSS 120B).

## Repoints every functional gemini dispatch/routing site → agy
- **model-resolver.sh** `get_fallback_agent`: codex/openrouter fallbacks → agy (10 tokens)
- **agents.sh** `get_agent_for_task`: research/design/copywriting → agy; tier case → agy
- **workflows.sh**: grasp (def2, consensus), tangle (reformat, decompose default + override), ink (delivery), embrace-gate, probe fallback → agy (5 dispatches)
- **quality.sh**: design-ceremony agent, cross-model reviewer, alternate-provider → agy

## Measured migration, not removal
gemini-exec.sh + the gemini provider **stay** for explicit/paid-API-key use (paid Gemini CLI access persists past the sunset). The plugin's `agy-exec.sh` already matches the real CLI flags, so no exec rewrite. Full #522-style removal + cosmetic scrub is separate.

## Testing
agy role/fallback resolution verified; live agy dispatch end-to-end. New test-agy-workflow-routing.sh (4). Regression: gemini-provider 52/0, agy 31/0, fleet-diversity 36/0, resolve-model 9/0, audit 13/0, bash -n clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal agent routing so `design`, `copywriting`, and `research` tasks consistently use the **AGY** provider.
  * Adjusted multi-step provider fallback logic to prefer **AGY** over **Gemini** for Codex-related and locked-provider scenarios, and updated review/reviewer mappings accordingly.
  * Switched workflow “Gemini” dispatch phases to the **AGY** agent type.

* **Tests**
  * Added unit tests covering AGY routing, Codex fallback preference, and default `tangle_decompose` behavior.
  * Updated cross-model reviewer expectations to match the new AGY/Codex mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->