### PR TITLE
fix: add agy/agy-research/antigravity to bare-provider skip-list in resolve_octopus_model

### DIFF
--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -173,7 +173,7 @@ resolve_octopus_model() {
                     # provider name like "provider:" with no model: skip for other
                     # providers, fall through to lower tiers for the provider itself.
                     case "$routed" in
-                        codex|gemini|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|cursor-agent|vibe)
+                        codex|gemini|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|cursor-agent|vibe|agy|agy-research|antigravity)
                             [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): SKIP (route '$routed' is a provider name, not a model — resolving for $provider)" >&2
                             routed=""
                             ;;


### PR DESCRIPTION
## Root cause

`resolve_octopus_model()` in `scripts/lib/model-resolver.sh` has a skip-list (Tier 3 phase/role routing) that recognises bare provider names in `routing.roles` / `routing.phases` config and skips them rather than interpreting them as literal model names. The list covered `codex|gemini|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|cursor-agent|vibe` but was never extended to include `agy`, `agy-research`, or `antigravity` — identifiers introduced by #524 when the Google seat moved from `gemini` → `agy`.

A user with a config like:
```json
"routing": { "roles": { "researcher": "agy" }, "phases": { "research": "agy" } }
```
hit Tier 3's default (`*`) branch, which set `resolved_model="agy"` on whatever provider was currently resolving — including the `claude-sonnet` researcher fallback in `workflows.sh`. That fallback then dispatched with an invalid model name.

## Fix

One-line change to `scripts/lib/model-resolver.sh` line 176:

```diff
-  codex|gemini|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|cursor-agent|vibe)
+  codex|gemini|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|cursor-agent|vibe|agy|agy-research|antigravity)
```

## Tests

All directly-affected tests pass locally:

| Suite | Passed | Failed |
|---|---|---|
| `test-resolve-model` | 9 | 0 |
| `test-agy-provider` | 31 | 0 |
| `test-agy-workflow-routing` | 4 | 0 |
| `test-routing-features-consumers` | 15 | 0 |
| `test-debate-routing` | 9 | 0 (+1 skip, submodule not initialised — expected) |

All shell scripts pass `bash -n` syntax check.

Closes #525.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JY4YumbH2FjvgHXTpisVQK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved routing issues for additional model providers, ensuring they are recognized and handled consistently with other supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->