### PR TITLE
fix: show accurate agy model in setup dashboard when OCTOPUS_AGY_MODEL unset (#527)

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -63,6 +63,10 @@ status_env() { [[ -n "${1:-}" ]] && echo "Configured ✓" || echo "Not set ✗";
 codex_status="$(status_installed codex)"
 gemini_status="$(status_installed gemini)"
 agy_status="$(status_installed agy)"
+agy_model_note=""
+if [[ "$agy_status" == "Installed ✓" ]]; then
+  agy_model_note=" (model: ${OCTOPUS_AGY_MODEL:-agy default})"
+fi
 perplexity_status="$(status_env "${PERPLEXITY_API_KEY:-}")"
 copilot_status="$(status_optional copilot)"
 qwen_status="$(status_optional qwen)"
@@ -75,7 +79,7 @@ cat <<BANNER
 Providers:
   🔴 Codex CLI:      ${codex_status}
   🟡 Gemini CLI:     ${gemini_status}
-  🧭 Antigravity:    ${agy_status} (model: ${OCTOPUS_AGY_MODEL:-agy default})
+  🧭 Antigravity:    ${agy_status}${agy_model_note}
   🟣 Perplexity:     ${perplexity_status}
   🟢 Copilot CLI:    ${copilot_status}
   🟠 Qwen CLI:       ${qwen_status}

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -28,7 +28,7 @@ printf "codex:%s\n" "$(command -v codex >/dev/null 2>&1 && echo installed || ech
 printf "codex_auth:%s\n" "$(codex --version >/dev/null 2>&1 && echo ok || echo none)"
 printf "gemini:%s\n" "$(command -v gemini >/dev/null 2>&1 && echo installed || echo missing)"
 printf "agy:%s\n" "$(command -v agy >/dev/null 2>&1 && echo installed || echo missing)"
-printf "agy_model:%s\n" "${OCTOPUS_AGY_MODEL:-Claude Sonnet 4.6 (Thinking)}"
+printf "agy_model:%s\n" "${OCTOPUS_AGY_MODEL:-}"
 printf "perplexity:%s\n" "$([ -n "${PERPLEXITY_API_KEY:-}" ] && echo configured || echo missing)"
 printf "copilot:%s\n" "$(command -v copilot >/dev/null 2>&1 && echo installed || echo missing)"
 printf "qwen:%s\n" "$(command -v qwen >/dev/null 2>&1 && echo installed || echo missing)"
@@ -75,7 +75,7 @@ cat <<BANNER
 Providers:
   🔴 Codex CLI:      ${codex_status}
   🟡 Gemini CLI:     ${gemini_status}
-  🧭 Antigravity:    ${agy_status} (model: ${OCTOPUS_AGY_MODEL:-default})
+  🧭 Antigravity:    ${agy_status} (model: ${OCTOPUS_AGY_MODEL:-agy default})
   🟣 Perplexity:     ${perplexity_status}
   🟢 Copilot CLI:    ${copilot_status}
   🟠 Qwen CLI:       ${qwen_status}
@@ -94,13 +94,13 @@ The rendered setup table must look like this shape, with ACTUAL statuses:
 Providers:
   🔴 Codex CLI:     [Installed ✓ / Missing ✗]
   🟡 Gemini CLI:    [Installed ✓ / Missing ✗]
-  🧭 Antigravity:   [Installed ✓ (model: OCTOPUS_AGY_MODEL/default) / Missing ✗]
+  🧭 Antigravity:   [Installed ✓ (model: OCTOPUS_AGY_MODEL/agy default) / Missing ✗]
   🟣 Perplexity:    [Configured ✓ / Not set ✗]
   🟢 Copilot CLI:   [Installed ✓ / Not installed]
   🟠 Qwen CLI:      [Installed ✓ / Not installed]
   🟤 OpenCode:      [Installed ✓ / Not installed]
   🔶 Vibe (Mistral): [Installed ✓ (auth: env-file/api-key/config) / Not installed]
-  ��� Ollama:        [Running ✓ / Installed / Not installed]
+  ⚫ Ollama:        [Running ✓ / Installed / Not installed]
   🔵 Claude:        Available ✓
 
 Token Optimization:
@@ -257,7 +257,7 @@ else
 fi
 ```
 
-If `agy` is not available yet, direct the user to install Google Antigravity CLI, then verify with `agy --version` and `agy models`. Octopus uses `OCTOPUS_AGY_MODEL` when set; otherwise it defaults to `Claude Sonnet 4.6 (Thinking)` for reliable non-interactive output.
+If `agy` is not available yet, direct the user to install Google Antigravity CLI, then verify with `agy --version` and `agy models`. Octopus uses `OCTOPUS_AGY_MODEL` when set; when unset, `agy` uses its own built-in default model.
 
 After install, offer auth:
 

--- a/.cursor-plugin/commands/octo-setup.md
+++ b/.cursor-plugin/commands/octo-setup.md
@@ -60,6 +60,10 @@ status_env() { [[ -n "${1:-}" ]] && echo "Configured ✓" || echo "Not set ✗";
 codex_status="$(status_installed codex)"
 gemini_status="$(status_installed gemini)"
 agy_status="$(status_installed agy)"
+agy_model_note=""
+if [[ "$agy_status" == "Installed ✓" ]]; then
+  agy_model_note=" (model: ${OCTOPUS_AGY_MODEL:-agy default})"
+fi
 perplexity_status="$(status_env "${PERPLEXITY_API_KEY:-}")"
 copilot_status="$(status_optional copilot)"
 qwen_status="$(status_optional qwen)"
@@ -72,7 +76,7 @@ cat <<BANNER
 Providers:
   🔴 Codex CLI:      ${codex_status}
   🟡 Gemini CLI:     ${gemini_status}
-  🧭 Antigravity:    ${agy_status} (model: ${OCTOPUS_AGY_MODEL:-agy default})
+  🧭 Antigravity:    ${agy_status}${agy_model_note}
   🟣 Perplexity:     ${perplexity_status}
   🟢 Copilot CLI:    ${copilot_status}
   🟠 Qwen CLI:       ${qwen_status}

--- a/.cursor-plugin/commands/octo-setup.md
+++ b/.cursor-plugin/commands/octo-setup.md
@@ -25,7 +25,7 @@ printf "codex:%s\n" "$(command -v codex >/dev/null 2>&1 && echo installed || ech
 printf "codex_auth:%s\n" "$(codex --version >/dev/null 2>&1 && echo ok || echo none)"
 printf "gemini:%s\n" "$(command -v gemini >/dev/null 2>&1 && echo installed || echo missing)"
 printf "agy:%s\n" "$(command -v agy >/dev/null 2>&1 && echo installed || echo missing)"
-printf "agy_model:%s\n" "${OCTOPUS_AGY_MODEL:-Claude Sonnet 4.6 (Thinking)}"
+printf "agy_model:%s\n" "${OCTOPUS_AGY_MODEL:-}"
 printf "perplexity:%s\n" "$([ -n "${PERPLEXITY_API_KEY:-}" ] && echo configured || echo missing)"
 printf "copilot:%s\n" "$(command -v copilot >/dev/null 2>&1 && echo installed || echo missing)"
 printf "qwen:%s\n" "$(command -v qwen >/dev/null 2>&1 && echo installed || echo missing)"
@@ -72,7 +72,7 @@ cat <<BANNER
 Providers:
   🔴 Codex CLI:      ${codex_status}
   🟡 Gemini CLI:     ${gemini_status}
-  🧭 Antigravity:    ${agy_status} (model: ${OCTOPUS_AGY_MODEL:-default})
+  🧭 Antigravity:    ${agy_status} (model: ${OCTOPUS_AGY_MODEL:-agy default})
   🟣 Perplexity:     ${perplexity_status}
   🟢 Copilot CLI:    ${copilot_status}
   🟠 Qwen CLI:       ${qwen_status}
@@ -91,13 +91,13 @@ The rendered setup table must look like this shape, with ACTUAL statuses:
 Providers:
   🔴 Codex CLI:     [Installed ✓ / Missing ✗]
   🟡 Gemini CLI:    [Installed ✓ / Missing ✗]
-  🧭 Antigravity:   [Installed ✓ (model: OCTOPUS_AGY_MODEL/default) / Missing ✗]
+  🧭 Antigravity:   [Installed ✓ (model: OCTOPUS_AGY_MODEL/agy default) / Missing ✗]
   🟣 Perplexity:    [Configured ✓ / Not set ✗]
   🟢 Copilot CLI:   [Installed ✓ / Not installed]
   🟠 Qwen CLI:      [Installed ✓ / Not installed]
   🟤 OpenCode:      [Installed ✓ / Not installed]
   🔶 Vibe (Mistral): [Installed ✓ (auth: env-file/api-key/config) / Not installed]
-  ��� Ollama:        [Running ✓ / Installed / Not installed]
+  ⚫ Ollama:        [Running ✓ / Installed / Not installed]
   🔵 Claude:        Available ✓
 
 Token Optimization:
@@ -254,7 +254,7 @@ else
 fi
 ```
 
-If `agy` is not available yet, direct the user to install Google Antigravity CLI, then verify with `agy --version` and `agy models`. Octopus uses `OCTOPUS_AGY_MODEL` when set; otherwise it defaults to `Claude Sonnet 4.6 (Thinking)` for reliable non-interactive output.
+If `agy` is not available yet, direct the user to install Google Antigravity CLI, then verify with `agy --version` and `agy models`. Octopus uses `OCTOPUS_AGY_MODEL` when set; when unset, `agy` uses its own built-in default model.
 
 After install, offer auth:
 

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -90,7 +90,7 @@ cmd_detect_providers() {
     if command -v agy &>/dev/null; then
         echo "AGY_STATUS=ok"
         echo "AGY_AUTH=cli"
-        echo "AGY_MODEL=${OCTOPUS_AGY_MODEL:-Claude Sonnet 4.6 (Thinking)}"
+        echo "AGY_MODEL=${OCTOPUS_AGY_MODEL:-}"
     else
         echo "AGY_STATUS=not-installed"
         echo "AGY_AUTH=none"
@@ -206,7 +206,7 @@ cmd_detect_providers() {
     local gemini_auth=$([[ -f "$HOME/.gemini/oauth_creds.json" ]] && echo "oauth" || [[ -n "${GEMINI_API_KEY:-}" ]] && echo "api-key" || echo "none")
     local agy_status=$(command -v agy &>/dev/null && echo "ok" || echo "not-installed")
     local agy_auth=$([[ "$agy_status" == "ok" ]] && echo "cli" || echo "none")
-    local agy_model="${OCTOPUS_AGY_MODEL:-Claude Sonnet 4.6 (Thinking)}"
+    local agy_model="${OCTOPUS_AGY_MODEL:-}"
     local perplexity_status=$([[ -n "${PERPLEXITY_API_KEY:-}" ]] && echo "ok" || echo "not-configured")
     local perplexity_auth=$([[ -n "${PERPLEXITY_API_KEY:-}" ]] && echo "api-key" || echo "none")
     local ollama_status=$(command -v ollama &>/dev/null && { curl -sf http://localhost:11434/api/tags &>/dev/null && echo "running" || echo "stopped"; } || echo "not-installed")
@@ -282,7 +282,7 @@ EOF
     fi
 
     if [[ "$agy_status" == "ok" ]]; then
-        echo "  ✓ Antigravity: Installed ($agy_model) — agy provider enabled"
+        echo "  ✓ Antigravity: Installed (model: ${agy_model:-agy default}) — agy provider enabled"
     else
         echo "  ○ Antigravity: Not installed (optional — install agy from Google Antigravity)"
     fi


### PR DESCRIPTION
## Root cause\n\n`agy-exec.sh` already does the right thing — it uses a `\"default\"` sentinel and only passes `--model` to `agy` when `OCTOPUS_AGY_MODEL` is explicitly set. But three display paths in the setup and detection code still had a hardcoded `:-Claude Sonnet 4.6 (Thinking)` fallback, so users saw that string in the dashboard even though `agy` was actually routing to its own built-in default (Gemini 3.5 Flash).\n\n## Changes\n\n| File | What changed |\n|------|--------------|\n| `.claude/commands/setup.md` | `printf \"agy_model:...\"` fallback: `:-Claude Sonnet 4.6 (Thinking)` → `:-` (empty); banner `:-default` → `:-agy default`; prose updated |\n| `.cursor-plugin/commands/octo-setup.md` | Same three changes (identical file structure) |\n| `scripts/lib/preflight.sh` | `echo \"AGY_MODEL=...\"` and `local agy_model=...` fallbacks cleared; summary display now shows `(model: ${agy_model:-agy default})` |\n\n`agy-exec.sh` execution logic is **not changed** — it was already correct.\n\n## Result after fix\n\nWhen `OCTOPUS_AGY_MODEL` is unset:\n- Setup banner shows: `🧭 Antigravity: Installed ✓ (model: agy default)`\n- `detect-providers` summary shows: `✓ Antigravity: Installed (model: agy default) — agy provider enabled`\n- Detection output emits: `agy_model:` (empty — no misleading model name)\n\nWhen `OCTOPUS_AGY_MODEL` is set: all three surfaces still show the configured value.\n\n## Testing\n\nDocs and shell display-only change, no behavior change to provider routing. Syntax-checked all modified bash blocks.\n\nCloses #527"

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAzNYDtpkbK39cWvnURzVa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the setup wizard guidance and examples to reflect the new Antigravity (`agy`) model default behavior, including the new `model: …` display format and conditional notes when `agy` is installed.
  * Revised provider install messaging to state that `agy` uses its own built-in default when `OCTOPUS_AGY_MODEL` is unset.

* **Configuration**
  * Adjusted provider detection to use `OCTOPUS_AGY_MODEL` (empty when unset) instead of a hardcoded fallback model.
  * Updated the Antigravity provider status output to show `model: …` with `agy default` when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->