### PR TITLE
fix: add availability check + fallback to [REASONING] subtask routing in tangle_develop

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1377,6 +1377,22 @@ Every [CODING] line must include a same-line Files: clause."
     local pids=()
     local task_ids=()
 
+    # [REASONING] subtask routing is overridable and falls back through available
+    # providers — mirrors the tangle_decompose_agent resolution above. Without
+    # this, users without agy get an unconditional exit 127 on every REASONING
+    # subtask even though the provider health check already flagged agy as absent.
+    local tangle_reasoning_agent="agy"
+    if declare -f octopus_agent_override >/dev/null 2>&1; then
+        tangle_reasoning_agent=$(octopus_agent_override "tangle" "reasoning" "agy")
+    fi
+    if ! command -v "$tangle_reasoning_agent" >/dev/null 2>&1; then
+        local _tangle_reasoning_fb
+        for _tangle_reasoning_fb in gemini codex claude-sonnet; do
+            command -v "$_tangle_reasoning_fb" >/dev/null 2>&1 \
+                && tangle_reasoning_agent="$_tangle_reasoning_fb" && break
+        done
+    fi
+
     fleet_dispatch_begin
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
@@ -1388,7 +1404,7 @@ Every [CODING] line must include a same-line Files: clause."
         local role="implementer"
         local pane_icon="⚙️"
         if [[ "$subtask" =~ \[REASONING\] ]]; then
-            agent="agy"
+            agent="$tangle_reasoning_agent"
             role="researcher"
             pane_icon="🧠"
         fi

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1387,10 +1387,16 @@ Every [CODING] line must include a same-line Files: clause."
     fi
     if ! command -v "$tangle_reasoning_agent" >/dev/null 2>&1; then
         local _tangle_reasoning_fb
-        for _tangle_reasoning_fb in gemini codex claude-sonnet; do
+        for _tangle_reasoning_fb in gemini codex; do
             command -v "$_tangle_reasoning_fb" >/dev/null 2>&1 \
                 && tangle_reasoning_agent="$_tangle_reasoning_fb" && break
         done
+        # claude-sonnet is a type resolved by get_agent_command, not a bare
+        # executable — command -v never finds it. Fall back unconditionally
+        # since the claude binary (the host process) is always available.
+        if ! command -v "$tangle_reasoning_agent" >/dev/null 2>&1; then
+            tangle_reasoning_agent="claude-sonnet"
+        fi
     fi
 
     fleet_dispatch_begin


### PR DESCRIPTION
## Root cause

`tangle_develop()` in `scripts/lib/workflows.sh` (line 1391 on main) hardcoded `agent="agy"` unconditionally for every `[REASONING]` subtask in the parallel execution loop. No availability check, no fallback. Users without `agy` installed got `exit 127` on every REASONING subtask, dropping the quality-gate pass rate below the 75% threshold and aborting the workflow even though all `[CODING]` subtasks succeeded.

The decomposition step a few hundred lines earlier in the same function (`tangle_decompose_agent`) already handled this correctly — it uses `octopus_agent_override` for user override and chains a fallback agent. The parallel dispatch loop had no equivalent.

## Fix

Added a reasoning agent resolution block immediately before `fleet_dispatch_begin`, mirroring the `tangle_decompose_agent` pattern:

```bash
local tangle_reasoning_agent="agy"
if declare -f octopus_agent_override >/dev/null 2>&1; then
    tangle_reasoning_agent=$(octopus_agent_override "tangle" "reasoning" "agy")
fi
if ! command -v "$tangle_reasoning_agent" >/dev/null 2>&1; then
    local _tangle_reasoning_fb
    for _tangle_reasoning_fb in gemini codex claude-sonnet; do
        command -v "$_tangle_reasoning_fb" >/dev/null 2>&1 \
            && tangle_reasoning_agent="$_tangle_reasoning_fb" && break
    done
fi
```

Then replaced the hardcoded `agent="agy"` with `agent="$tangle_reasoning_agent"` in the `[REASONING]` branch.

The fallback chain (`gemini → codex → claude-sonnet`) matches what the issue reporter suggested. Users with `agy` see no behavior change.

## Tests

- `bash -n scripts/lib/workflows.sh` — syntax OK
- `bash -n scripts/*.sh scripts/lib/*.sh scripts/helpers/*.sh` — all syntax OK
- `test-tangle-write-scope-safety` — 12/12 pass
- `test-tangle-subtask-context` — 7/7 pass
- `test-tangle-direct-fallback` — 4/4 pass
- `test-tangle-file-coverage` — 4/4 pass

Closes #529.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5Ynm2YEy3RpRp4cw6Gz4H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Reasoning workflow now dynamically selects an available reasoning agent at runtime, using any configured override when present.
  * If the preferred agent isn’t available, it automatically falls back to other available options (when available) to keep reasoning subtasks running reliably.
  * Execution of reasoning-tagged subtasks now uses the selected agent instead of a single fixed default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->