### PR TITLE
fix(providers): build provider env as an array, not a word-split string

### DIFF
--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -28,6 +28,15 @@
 build_provider_env() {
     local provider="$1"
 
+    # Return the env prefix as a global ARRAY (OCTO_PROVIDER_ENV), not a
+    # space-joined string. The string form was consumed via `read -ra`, which
+    # word-splits on spaces — so a PATH containing spaces (e.g. Windows
+    # "C:\Program Files\NVIDIA GPU Computing Toolkit\...") shattered and `env`
+    # tried to exec a fragment like 'Files/NVIDIA' (exit 127), silently failing
+    # every external provider. Array elements preserve spaces and quotes (this
+    # also removes the class of bug behind the literal-quote regression #117).
+    OCTO_PROVIDER_ENV=()
+
     if [[ "${OCTOPUS_SECURITY_V870:-true}" != "true" ]]; then
         return 0
     fi
@@ -36,16 +45,16 @@ build_provider_env() {
     case "$provider" in
         codex*)
             [[ -z "${OPENAI_API_KEY:-}" ]] && resolve_provider_env "OPENAI_API_KEY" 2>/dev/null
-            echo "env -i PATH=$PATH HOME=$HOME OPENAI_API_KEY=${OPENAI_API_KEY:-} TMPDIR=${TMPDIR:-/tmp}"
+            OCTO_PROVIDER_ENV=(env -i "PATH=$PATH" "HOME=$HOME" "OPENAI_API_KEY=${OPENAI_API_KEY:-}" "TMPDIR=${TMPDIR:-/tmp}")
             ;;
         gemini*)
             [[ -z "${GEMINI_API_KEY:-}" ]] && resolve_provider_env "GEMINI_API_KEY" 2>/dev/null
             [[ -z "${GOOGLE_API_KEY:-}" ]] && resolve_provider_env "GOOGLE_API_KEY" 2>/dev/null
-            echo "env -i PATH=$PATH HOME=$HOME GEMINI_API_KEY=${GEMINI_API_KEY:-} GOOGLE_API_KEY=${GOOGLE_API_KEY:-} NODE_NO_WARNINGS=1 TMPDIR=${TMPDIR:-/tmp}"
+            OCTO_PROVIDER_ENV=(env -i "PATH=$PATH" "HOME=$HOME" "GEMINI_API_KEY=${GEMINI_API_KEY:-}" "GOOGLE_API_KEY=${GOOGLE_API_KEY:-}" "NODE_NO_WARNINGS=1" "TMPDIR=${TMPDIR:-/tmp}")
             ;;
         perplexity*)
             [[ -z "${PERPLEXITY_API_KEY:-}" ]] && resolve_provider_env "PERPLEXITY_API_KEY" 2>/dev/null
-            echo "env -i PATH=$PATH HOME=$HOME PERPLEXITY_API_KEY=${PERPLEXITY_API_KEY:-} TMPDIR=${TMPDIR:-/tmp}"
+            OCTO_PROVIDER_ENV=(env -i "PATH=$PATH" "HOME=$HOME" "PERPLEXITY_API_KEY=${PERPLEXITY_API_KEY:-}" "TMPDIR=${TMPDIR:-/tmp}")
             ;;
         *)
             # Claude and other providers: no isolation needed

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -433,14 +433,18 @@ IMPORTANT: If you find yourself searching or grepping more than 3 times in a row
 
         # SECURITY: Use array-based execution to prevent word-splitting vulnerabilities
         # v8.32.0: Per-provider credential isolation — each agent only sees its own API key
-        local -a cmd_array
-        local env_prefix
-        env_prefix=$(build_provider_env "$agent_type")
-        if [[ -n "$env_prefix" ]]; then
-            read -ra cmd_array <<< "$env_prefix $cmd"
+        local -a cmd_array cmd_words
+        # Consume the env prefix as an ARRAY (global OCTO_PROVIDER_ENV set by
+        # build_provider_env) so a PATH containing spaces survives. The old
+        # `read -ra <<< "$env_prefix $cmd"` word-split the prefix and shattered
+        # a spaced PATH (env exit 127, all external providers silently failed).
+        build_provider_env "$agent_type"
+        read -ra cmd_words <<< "$cmd"
+        if [[ ${#OCTO_PROVIDER_ENV[@]} -gt 0 ]]; then
+            cmd_array=("${OCTO_PROVIDER_ENV[@]}" "${cmd_words[@]}")
             log "DEBUG" "Credential isolation active for $agent_type"
         else
-            read -ra cmd_array <<< "$cmd"
+            cmd_array=("${cmd_words[@]}")
         fi
 
         # IMPROVED: Use temp files for reliable output capture (v7.13.2 - Issue #10)

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -110,13 +110,15 @@ IMPORTANT: If you find yourself searching or grepping more than 3 times in a row
     local result_file="${RESULTS_DIR}/${agent_type}-${task_id}.md"
 
     # Build command array with credential isolation
-    local -a cmd_array
-    local env_prefix
-    env_prefix=$(build_provider_env "$agent_type")
-    if [[ -n "$env_prefix" ]]; then
-        read -ra cmd_array <<< "$env_prefix $cmd"
+    local -a cmd_array cmd_words
+    # Array-based env prefix (see provider-routing.sh) so a PATH with spaces
+    # survives instead of word-splitting under read -ra.
+    build_provider_env "$agent_type"
+    read -ra cmd_words <<< "$cmd"
+    if [[ ${#OCTO_PROVIDER_ENV[@]} -gt 0 ]]; then
+        cmd_array=("${OCTO_PROVIDER_ENV[@]}" "${cmd_words[@]}")
     else
-        read -ra cmd_array <<< "$cmd"
+        cmd_array=("${cmd_words[@]}")
     fi
 
     local temp_output="${RESULTS_DIR}/.tmp-${task_id}.out"


### PR DESCRIPTION
## Problem

`build_provider_env()` (scripts/lib/provider-routing.sh) returns the credential-isolation prefix as a **space-joined string**:

```sh
echo "env -i PATH=$PATH HOME=$HOME OPENAI_API_KEY=${OPENAI_API_KEY:-} TMPDIR=${TMPDIR:-/tmp}"
```

Both call sites (`spawn.sh`, `workflows.sh`) then consume it with:

```sh
read -ra cmd_array <<< "$env_prefix $cmd"
```

`read -ra` **word-splits on spaces**, so any env value containing a space breaks. The common trigger is `PATH` on Windows (Git Bash / WSL), where an entry like `C:\Program Files\NVIDIA GPU Computing Toolkit\...` shatters:

```
env: 'Files/NVIDIA': No such file or directory   # exit 127
```

Every external provider (codex / gemini / perplexity) then **silently fails**, while the run still reports (fabricated) cost/token estimates. This is the same class of bug as the literal-quote regression in #117 — a flat string simply can't carry values with spaces or quotes through `read -ra`.

### Repro
```sh
PATH_WS="/c/Program Files/NVIDIA GPU Computing Toolkit/bin:/usr/bin:/bin"
read -ra a <<< "env -i PATH=$PATH_WS HOME=/h OPENAI_API_KEY=x printenv PATH"
"${a[@]}"   # -> env: 'Files/NVIDIA': No such file or directory (127)
```

## Fix

Build the prefix as an **array** instead of a string:

- `build_provider_env()` populates a global `OCTO_PROVIDER_ENV=(env -i "PATH=$PATH" "HOME=$HOME" ...)` (one line per provider, so existing static-grep tests still match the `env -i …KEY…` line).
- `spawn.sh` / `workflows.sh` consume `"${OCTO_PROVIDER_ENV[@]}"`.

Array elements preserve spaces and quotes, so the spaced-PATH case works and the #117 literal-quote class is structurally avoided.

```sh
new=(env -i "PATH=$PATH_WS" "HOME=/h" "OPENAI_API_KEY=x" printenv PATH)
"${new[@]}"   # -> prints the full spaced PATH, exit 0
```

## Tests

`tests/test-credential-isolation.sh` → **19/19 passing** (the per-provider key scoping and the #117 "no escaped quotes" checks are preserved).

Found while wiring claude-octopus into an away-from-keyboard agent loop on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider execution failures caused by spaces in environment paths or configuration values. Enhanced the reliability of provider credential isolation and environment variable handling to ensure consistent performance across different system setups and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->