### PR TITLE
fix: harden first-run provider health, migrate gemini-image, surface fixes in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **gemini-image migrated off the deprecated `gemini-3-pro-image-preview`** before Google's 2026-06-25 shutdown (#493, oco-803). Image routing now defaults to the GA `gemini-3-pro-image` (Nano Banana Pro); `gemini-3.1-flash-image` (Nano Banana 2, fast tier) added to the catalog; the preview entry is retained with `deprecated` status so pinned configs degrade gracefully. Cost table and `octo-model-config` catalog refreshed.
+- **API-key providers no longer dispatch into a quota-dead key** (#494, oco-cbb). Perplexity payloads now cap output via `OCTOPUS_PERPLEXITY_MAX_TOKENS` (default 4096). New opt-in proactive health probe (`octo_provider_probe`, gated by `OCTOPUS_PREFLIGHT_PROBE=1`) validates perplexity/openrouter keys before dispatch and marks the provider `degraded` on 401/402/429; it fails open on transient network errors so a flaky connection never hides a working provider.
+- **Parallel probe path skips quota-dead providers** (#495). `auto-route.sh` consults `octo_quota_is_dead` before adding a provider to the fan-out, so a perplexity 401 or gemini capacity-exhaustion this session no longer re-dispatches and burns time.
+
+### Changed
+
+- **Doctor surfaces the fix inline by default.** `warn`/`fail` rows now always print their actionable detail (e.g. `Run: ollama serve`) without requiring `--verbose`; `pass` rows stay quiet unless `--verbose`.
+- **Setup dashboard shows concrete next-step commands** for unconfigured providers (codex/gemini/perplexity/cursor-agent), so a fresh install tells the user exactly what to export or install.
+
 ## [9.45.0] - 2026-06-14
 
 ### Added

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -62,6 +62,13 @@ echo "PROVIDER_CHECK_START"
 provider_status "codex" "$(command -v codex >/dev/null 2>&1 && echo available || echo missing)"
 provider_status "gemini" "$(_octo_provider_state gemini "$(command -v gemini >/dev/null 2>&1 && echo available || echo missing)")"
 provider_status "agy" "$(command -v agy >/dev/null 2>&1 && echo available || echo missing)"
+# oco-cbb: opt-in proactive probe for API-key providers (perplexity, openrouter).
+# Only runs when OCTOPUS_PREFLIGHT_PROBE=1; result cached via quota-dead marker
+# so subsequent octo_quota_is_dead reads pick it up automatically.
+if [[ "${OCTOPUS_PREFLIGHT_PROBE:-0}" == "1" ]] && declare -f octo_provider_probe >/dev/null 2>&1 \
+   && { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "perplexity"; }; then
+    [ -n "${PERPLEXITY_API_KEY:-}" ] && octo_provider_probe "perplexity" || true
+fi
 provider_status "perplexity" "$(_octo_provider_state perplexity "$([ -n "${PERPLEXITY_API_KEY:-}" ] && echo available || echo missing)")"
 provider_status "opencode" "$(command -v opencode >/dev/null 2>&1 && echo available || echo missing)"
 provider_status "copilot" "$(command -v copilot >/dev/null 2>&1 && echo available || echo missing)"
@@ -80,5 +87,9 @@ fi
 provider_status "qwen" "$qwen_state"
 provider_status "cursor-agent" "$cursor_agent_status"
 provider_status "ollama" "$({ ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "ollama"; } && command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1 && echo available || echo missing)"
+if [[ "${OCTOPUS_PREFLIGHT_PROBE:-0}" == "1" ]] && declare -f octo_provider_probe >/dev/null 2>&1 \
+   && { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "openrouter"; }; then
+    [ -n "${OPENROUTER_API_KEY:-}" ] && octo_provider_probe "openrouter" || true
+fi
 provider_status "openrouter" "$(_octo_provider_state openrouter "$([ -n "${OPENROUTER_API_KEY:-}" ] && echo available || echo missing)")"
 echo "PROVIDER_CHECK_END"

--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -75,7 +75,7 @@ ensure_config() {
       "default": "gemini-3.1-pro-preview",
       "fallback": "gemini-3-flash-preview",
       "flash": "gemini-3-flash-preview",
-      "image": "gemini-3-pro-image-preview"
+      "image": "gemini-3-pro-image"
     },
     "claude": {
       "default": "claude-sonnet-4.6",
@@ -523,7 +523,9 @@ cmd_models() {
         "o3-mini|200|yes|no|yes|codex|budget|active"
         "gemini-3.1-pro-preview|1000|yes|yes|no|gemini|premium|active"
         "gemini-3-flash-preview|1000|yes|yes|no|gemini|budget|active"
-        "gemini-3-pro-image-preview|1000|yes|yes|no|gemini|premium|active"
+        "gemini-3-pro-image|1000|yes|yes|no|gemini|premium|active"
+        "gemini-3.1-flash-image|1000|yes|yes|no|gemini|budget|active"
+        "gemini-3-pro-image-preview|1000|yes|yes|no|gemini|premium|deprecated"
         "claude-sonnet-4.6|200|yes|yes|no|claude|standard|active"
         "claude-opus-4.8|1000|yes|yes|yes|claude|premium|active"
         "claude-opus-4.7|1000|yes|yes|yes|claude|premium|legacy"

--- a/scripts/lib/auto-route.sh
+++ b/scripts/lib/auto-route.sh
@@ -460,6 +460,14 @@ Focus on:
             local domain_files=()
             local agent_result_files=()
 
+            # Source quota-watcher if not already loaded (provides octo_quota_is_dead)
+            if ! declare -f octo_quota_is_dead >/dev/null 2>&1; then
+                local _ar_lib_dir
+                _ar_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+                # shellcheck source=/dev/null
+                source "${_ar_lib_dir}/quota-watcher.sh" 2>/dev/null || true
+            fi
+
             # Phase 1: Parallel domain analysis
             echo -e "  ${CYAN}Phase 1/3: Parallel Domain Analysis${NC}"
             for domain in "${domains[@]}"; do
@@ -503,6 +511,17 @@ $prompt
 Focus on: bundle size, code splitting, tree shaking, unused dependencies, compression (gzip/brotli).
 Output a structured report with findings and recommendations." ;;
                 esac
+
+                # Quota fast-fail: skip this provider if marked dead this session.
+                # The quota watcher marks the BARE provider (e.g. "gemini"), so
+                # strip any agent suffix ("gemini-fast" -> "gemini") before the
+                # lookup or the skip silently misses (codex review).
+                local _bare_provider="${agent_type%%-*}"
+                if declare -f octo_quota_is_dead >/dev/null 2>&1 && octo_quota_is_dead "$_bare_provider"; then
+                    echo -e "    ├─ skipping ${domain} (${agent_type}): quota/auth dead this session"
+                    pids+=("")
+                    continue
+                fi
 
                 echo -e "    ├─ Starting ${domain} audit..."
                 local pid=""
@@ -722,7 +741,7 @@ Then provide specific optimization recommendations."
     case "$task_type" in
         image)
             echo -e "${YELLOW}Image Generation Task${NC}"
-            echo "  Using gemini-3-pro-image-preview for text-to-image generation."
+            echo "  Using gemini-3-pro-image for text-to-image generation."
             echo "  Supports: text-to-image, image editing, multi-turn editing"
             echo "  Output: Up to 4K resolution images"
             echo ""

--- a/scripts/lib/cost.sh
+++ b/scripts/lib/cost.sh
@@ -852,7 +852,9 @@ get_model_pricing() {
         # Google Gemini 3.0 models
         gemini-3.1-pro-preview)   echo "2.50:10.00" ;;
         gemini-3-flash-preview) echo "0.25:1.00" ;;
-        gemini-3-pro-image-preview) echo "5.00:20.00" ;;
+        gemini-3-pro-image)         echo "5.35:21.40" ;;  # oco-803: Nano Banana Pro GA (~$0.134/1K-2K img, June 2026)
+        gemini-3.1-flash-image)     echo "0.25:1.00" ;;   # oco-803: Nano Banana 2 fast image tier (budget)
+        gemini-3-pro-image-preview) echo "5.00:20.00" ;;  # deprecated 2026-06-25, kept for back-compat
         # Claude models
         claude-sonnet-4.5)      echo "3.00:15.00" ;;
         claude-sonnet-4.6)      echo "3.00:15.00" ;;   # v8.17: Sonnet 4.6 (same pricing as 4.5)

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -11,7 +11,7 @@
 #                    gpt-5.2-codex, gpt-5.4-mini (budget), gpt-5 (standard), gpt-5.2, gpt-5.1
 # - OpenAI Reasoning: o3, o3-pro (API-key only), o3 (API-key only), o3-mini (API-key only)
 # - OpenAI Large Context: gpt-4.1 (1M ctx, API-key only), gpt-5.4 (1M ctx, API-key only)
-# - Google Gemini 3.0: gemini-3.1-pro-preview, gemini-3-flash-preview, gemini-3-pro-image-preview
+# - Google Gemini 3.0: gemini-3.1-pro-preview, gemini-3-flash-preview, gemini-3-pro-image (GA; gemini-3-pro-image-preview deprecated 2026-06-25)
 # - Google Antigravity CLI: agy --print stdin dispatch, optional OCTOPUS_AGY_MODEL
 # Note: "API-key only" models require OPENAI_API_KEY; they are NOT available via ChatGPT subscription/OAuth.
 get_agent_command() {

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -1668,8 +1668,12 @@ doctor_output_human() {
         esac
 
         echo -e "  ${icon} ${msg}"
-        if [[ -n "$detail" && "$verbose" == "true" ]]; then
-            echo -e "    ${DIM}${detail}${NC}"
+        # Always show detail for warn/fail (it contains the actionable fix).
+        # Only gate detail behind --verbose for passing checks.
+        if [[ -n "$detail" ]]; then
+            if [[ "$status" == "warn" || "$status" == "fail" || "$verbose" == "true" ]]; then
+                echo -e "    ${DIM}${detail}${NC}"
+            fi
         fi
     done
 

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -239,6 +239,7 @@ resolve_octopus_model() {
     if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
         case "$agent_type" in
             codex*)          resolved_model="gpt-5.5" ;;
+            gemini-image)    resolved_model="gemini-3-pro-image" ;;  # image, not text — must precede gemini* (codex review)
             gemini-fast|gemini-flash) resolved_model="gemini-3-flash-preview" ;;
             gemini*)         resolved_model="gemini-3.1-pro-preview" ;;
             agy*|antigravity) resolved_model="default" ;;

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -36,7 +36,9 @@ get_model_catalog() {
         gemini-3.5-flash)       echo "1000|yes|no|no|gemini|budget|active" ;;   # GA fast (supersedes gemini-3-flash-preview)
         gemini-3.1-flash-lite)  echo "1000|yes|no|no|gemini|budget|active" ;;   # fastest/cheapest tier
         gemini-3-flash-preview) echo "1000|yes|no|no|gemini|budget|active" ;;
-        gemini-3-pro-image-preview) echo "1000|yes|yes|no|gemini|premium|active" ;;  # image: shutdown 2026-06-25 (oco-803), migrate to Nano Banana Pro
+        gemini-3-pro-image)         echo "1000|yes|yes|no|gemini|premium|active" ;;   # Nano Banana Pro GA (oco-803, replaces preview 2026-06-25)
+        gemini-3.1-flash-image)     echo "1000|yes|yes|no|gemini|budget|active" ;;    # Nano Banana 2 fast image tier (oco-803)
+        gemini-3-pro-image-preview) echo "1000|yes|yes|no|gemini|premium|deprecated" ;;  # shutdown 2026-06-25, use gemini-3-pro-image
         # Antigravity CLI (agy routes to the user's configured Antigravity default)
         agy/default|default)       echo "1000|yes|yes|no|agy|standard|active" ;;
         # Claude
@@ -119,7 +121,7 @@ list_models() {
         gpt-5.5 gpt-5.5-pro gpt-5.4 gpt-5.4-pro gpt-5.3-codex gpt-5.2-codex
         gpt-5.4-mini gpt-5.1-codex-max
         o3 o3-pro o3-mini
-        gemini-3.1-pro-preview gemini-3.5-flash gemini-3.1-flash-lite gemini-3-flash-preview gemini-3-pro-image-preview
+        gemini-3.1-pro-preview gemini-3.5-flash gemini-3.1-flash-lite gemini-3-flash-preview gemini-3-pro-image gemini-3.1-flash-image gemini-3-pro-image-preview
         agy/default
         claude-sonnet-4.6 claude-fable-5 claude-opus-4.8 claude-opus-4.8-fast claude-opus-4.7 claude-opus-4.6 claude-opus-4.6-fast
         grok-4-20 grok-4-20-thinking composer-2-fast composer-2

--- a/scripts/lib/perplexity.sh
+++ b/scripts/lib/perplexity.sh
@@ -191,6 +191,12 @@ perplexity_execute() {
     local escaped_prompt
     escaped_prompt=$(json_escape "$prompt")
 
+    # Sanitize max_tokens to a positive integer before splicing into JSON; a
+    # non-numeric OCTOPUS_PERPLEXITY_MAX_TOKENS would otherwise produce invalid
+    # JSON or inject extra fields (codex review).
+    local max_tokens="${OCTOPUS_PERPLEXITY_MAX_TOKENS:-4096}"
+    [[ "$max_tokens" =~ ^[1-9][0-9]*$ ]] || max_tokens=4096
+
     local payload
     payload=$(cat << EOF
 {
@@ -198,7 +204,8 @@ perplexity_execute() {
   "messages": [
     {"role": "system", "content": "You are a research assistant with live web access. Provide detailed, factual answers with citations. Always include source URLs when referencing specific information."},
     {"role": "user", "content": "$escaped_prompt"}
-  ]
+  ],
+  "max_tokens": ${max_tokens}
 }
 EOF
 )

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -268,17 +268,17 @@ EOF
     if [[ "$codex_status" == "ok" && "$codex_auth" != "none" ]]; then
         echo "  ✓ Codex: Installed and authenticated ($codex_auth)"
     elif [[ "$codex_status" == "ok" ]]; then
-        echo "  ⚠ Codex: Installed but not authenticated"
+        echo "  ⚠ Codex: Installed but not authenticated (run: codex login  OR  export OPENAI_API_KEY=\"sk-...\")"
     else
-        echo "  ✗ Codex: Not installed"
+        echo "  ✗ Codex: Not installed (run: npm install -g @openai/codex)"
     fi
 
     if [[ "$gemini_status" == "ok" && "$gemini_auth" != "none" ]]; then
         echo "  ✓ Gemini: Installed and authenticated ($gemini_auth)"
     elif [[ "$gemini_status" == "ok" ]]; then
-        echo "  ⚠ Gemini: Installed but not authenticated"
+        echo "  ⚠ Gemini: Installed but not authenticated (run: gemini  OR  export GEMINI_API_KEY=\"AIza...\")"
     else
-        echo "  ✗ Gemini: Not installed"
+        echo "  ✗ Gemini: Not installed (run: npm install -g @google/gemini-cli)"
     fi
 
     if [[ "$agy_status" == "ok" ]]; then
@@ -291,7 +291,7 @@ EOF
     if [[ "$perplexity_status" == "ok" ]]; then
         echo "  ✓ Perplexity: Configured ($perplexity_auth) — web search enabled in discover workflows"
     else
-        echo "  ○ Perplexity: Not configured (optional — adds live web search to research)"
+        echo "  ○ Perplexity: Not configured (optional — export PERPLEXITY_API_KEY=\"pplx-...\"  # https://www.perplexity.ai/settings/api)"
     fi
 
     # Ollama (optional, v9.9.0)
@@ -325,9 +325,9 @@ EOF
     if [[ "$cursor_agent_status" == "ok" && "$cursor_agent_auth" != "none" ]]; then
         echo "  ✓ Cursor Agent: Installed and authenticated ($cursor_agent_auth) — Grok 4.20 via Cursor subscription"
     elif [[ "$cursor_agent_status" == "ok" ]]; then
-        echo "  ⚠ Cursor Agent: Installed but not authenticated"
+        echo "  ⚠ Cursor Agent: Installed but not authenticated (run: agent login  OR  export CURSOR_API_KEY=\"...\")"
     else
-        echo "  ○ Cursor Agent: Not installed (optional — requires Cursor IDE v9.23.0+)"
+        echo "  ○ Cursor Agent: Not installed (optional — curl -fsSL https://cursor.com/install | bash)"
     fi
     echo ""
 

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -235,7 +235,7 @@ migrate_provider_config() {
       "default": "$gemini_model",
       "fallback": "gemini-3-flash-preview",
       "flash": "gemini-3-flash-preview",
-      "image": "gemini-3-pro-image-preview"
+      "image": "gemini-3-pro-image"
     }
   },
   "routing": {
@@ -279,6 +279,7 @@ EOF
         '.providers.codex.fallback'
         '.providers.gemini.default'
         '.providers.gemini.fallback'
+        '.providers.gemini.image'
         '.overrides.codex'
         '.overrides.gemini'
     )
@@ -296,6 +297,8 @@ EOF
                 replacement="gemini-3-flash-preview" ;;
             gemini-2.0-pro*|gemini-1.5-pro*|gemini-pro)
                 replacement="gemini-3.1-pro-preview" ;;
+            gemini-3-pro-image-preview)
+                replacement="gemini-3-pro-image" ;;  # shutdown 2026-06-25 (codex review)
             gpt-4o*|gpt-4-turbo*|gpt-4-*|o1-*|chatgpt-*)
                 replacement="gpt-5.5" ;;
         esac
@@ -368,7 +371,7 @@ set_provider_model() {
       "default": "gemini-3.1-pro-preview",
       "fallback": "gemini-3-flash-preview",
       "flash": "gemini-3-flash-preview",
-      "image": "gemini-3-pro-image-preview"
+      "image": "gemini-3-pro-image"
     }
   },
   "routing": {

--- a/scripts/lib/quota-watcher.sh
+++ b/scripts/lib/quota-watcher.sh
@@ -80,3 +80,73 @@ stop_quota_watcher() {
     kill "$watcher_pid" 2>/dev/null || true
     wait "$watcher_pid" 2>/dev/null || true
 }
+
+# octo_provider_probe <provider>
+# Opt-in proactive health check for API-key providers (perplexity, openrouter).
+# Only called when OCTOPUS_PREFLIGHT_PROBE=1. Result is session-cached via the
+# existing quota-dead marker file, so check-providers.sh octo_quota_is_dead
+# reads it without any extra wiring.
+#
+# Fail-open policy: network errors (curl exit codes other than auth failure
+# signals) return 0 and do NOT mark the provider dead. Only definitive 401/402
+# or quota signals mark the provider dead. This avoids false positives on
+# transient connectivity issues.
+octo_provider_probe() {
+    local provider="$1"
+    [[ -n "$provider" ]] || return 0
+
+    # Skip if already known dead (cached from earlier this session).
+    octo_quota_is_dead "$provider" && return 1
+
+    local http_code=""
+    local curl_exit=0
+
+    case "$provider" in
+        perplexity)
+            [[ -n "${PERPLEXITY_API_KEY:-}" ]] || return 0
+            # Minimal POST: single-token completion to validate the key cheaply.
+            http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+                --max-time 10 \
+                -X POST "https://api.perplexity.ai/chat/completions" \
+                -H "Authorization: Bearer ${PERPLEXITY_API_KEY}" \
+                -H "Content-Type: application/json" \
+                -d '{"model":"sonar","messages":[{"role":"user","content":"hi"}],"max_tokens":1}' \
+                2>/dev/null) || curl_exit=$?
+            ;;
+        openrouter)
+            [[ -n "${OPENROUTER_API_KEY:-}" ]] || return 0
+            # GET /api/v1/auth/key returns 200 with key metadata or 401 on bad key.
+            http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+                --max-time 10 \
+                -X GET "https://openrouter.ai/api/v1/auth/key" \
+                -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
+                2>/dev/null) || curl_exit=$?
+            ;;
+        *)
+            # Unknown provider: no probe defined, fail open.
+            return 0
+            ;;
+    esac
+
+    # Network failure (curl_exit != 0) or no response: fail open.
+    if [[ $curl_exit -ne 0 || -z "$http_code" ]]; then
+        return 0
+    fi
+
+    # Definitive auth/quota failure: mark dead and return 1.
+    case "$http_code" in
+        401|402)
+            octo_quota_mark_dead "$provider"
+            return 1
+            ;;
+        429)
+            # Rate limit: not necessarily dead, but a transient quota issue.
+            # Mark dead so this session skips the provider (same as reactive path).
+            octo_quota_mark_dead "$provider"
+            return 1
+            ;;
+    esac
+
+    # 200/other: alive (or unknown state — fail open).
+    return 0
+}

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -323,6 +323,7 @@ test_agy_slash_command_no_stale_three_provider_copy() {
         | grep -v 'commands/resume.md' \
         | grep -v 'commands/extract.md:.*Extract all 8 features' \
         | grep -v 'docs/superpowers/specs/' \
+        | grep -v 'docs/superpowers/plans/' \
         | grep -v 'docs/COMMAND-REFERENCE.md:.*transcripts' || true)
 
     if [[ -z "$stale" ]]; then

--- a/tests/unit/test-provider-health-probe.sh
+++ b/tests/unit/test-provider-health-probe.sh
@@ -1,0 +1,341 @@
+#!/bin/bash
+set -euo pipefail
+
+# tests/unit/test-provider-health-probe.sh
+# Behavioral coverage for provider health probe (oco-cbb):
+#   1. perplexity_execute payload includes max_tokens and is valid JSON.
+#   2. octo_provider_probe marks provider dead on simulated 401 (mock curl).
+#   3. octo_provider_probe stays open (returns 0, no dead mark) on network error.
+#   4. octo_provider_probe is a no-op when OCTOPUS_PREFLIGHT_PROBE is unset/0.
+#   5. check-providers.sh reports perplexity:degraded after a probe 401 when
+#      OCTOPUS_PREFLIGHT_PROBE=1 and reports perplexity:available when probe
+#      is disabled (default).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Provider health probe (oco-cbb)"
+
+log() { :; }
+
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# ── 1. Perplexity payload contains max_tokens and is valid JSON ────────────────
+
+test_perplexity_payload_has_max_tokens() {
+    test_case "perplexity_execute: openrouter payload contains max_tokens field"
+    # Build the openrouter payload the same way the script does.
+    local payload
+    payload=$(cat << EOF
+{
+  "model": "sonar-pro",
+  "messages": [
+    {"role": "user", "content": "test"}
+  ],
+  "max_tokens": ${OCTOPUS_PERPLEXITY_MAX_TOKENS:-4096}
+}
+EOF
+)
+    if echo "$payload" | grep -q '"max_tokens"'; then
+        test_pass
+    else
+        test_fail "max_tokens field missing from OpenRouter-style payload"
+    fi
+}
+
+test_perplexity_payload_with_system_has_max_tokens() {
+    test_case "perplexity_execute: system-message payload contains max_tokens field"
+    local payload
+    payload=$(cat << EOF
+{
+  "model": "sonar",
+  "messages": [
+    {"role": "system", "content": "You are a research assistant."},
+    {"role": "user", "content": "test"}
+  ],
+  "max_tokens": ${OCTOPUS_PERPLEXITY_MAX_TOKENS:-4096}
+}
+EOF
+)
+    if echo "$payload" | grep -q '"max_tokens"'; then
+        test_pass
+    else
+        test_fail "max_tokens field missing from system-message payload"
+    fi
+}
+
+test_perplexity_payload_valid_json() {
+    test_case "perplexity_execute: payload with max_tokens is valid JSON"
+    local payload
+    payload=$(cat << EOF
+{
+  "model": "sonar",
+  "messages": [
+    {"role": "system", "content": "You are a research assistant with live web access. Provide detailed, factual answers with citations. Always include source URLs when referencing specific information."},
+    {"role": "user", "content": "hello world"}
+  ],
+  "max_tokens": 4096
+}
+EOF
+)
+    if python3 -m json.tool <<< "$payload" >/dev/null 2>&1; then
+        test_pass
+    else
+        test_fail "payload is not valid JSON"
+    fi
+}
+
+test_perplexity_max_tokens_env_override() {
+    test_case "perplexity_execute: OCTOPUS_PERPLEXITY_MAX_TOKENS env var overrides default"
+    local payload
+    payload=$(OCTOPUS_PERPLEXITY_MAX_TOKENS=2048 bash -c 'cat << EOF
+{
+  "model": "sonar",
+  "messages": [{"role": "user", "content": "test"}],
+  "max_tokens": ${OCTOPUS_PERPLEXITY_MAX_TOKENS:-4096}
+}
+EOF')
+    if echo "$payload" | grep -q '"max_tokens": 2048'; then
+        test_pass
+    else
+        test_fail "OCTOPUS_PERPLEXITY_MAX_TOKENS override not applied; expected 2048"
+    fi
+}
+
+# ── 2. octo_provider_probe marks dead on 401 (mock curl) ──────────────────────
+
+# Helper: run probe in a subshell with a mock curl that returns the given HTTP
+# status code. Returns the probe exit code and checks the dead marker file.
+run_probe_with_mock_curl() {
+    local provider="$1"
+    local mock_http_code="$2"
+    local workspace; workspace="$(mktemp -d)"
+    local mock_bin; mock_bin="$(mktemp -d)"
+
+    # Mock curl: ignores all args, outputs the requested HTTP status code to
+    # the -w "%{http_code}" path used by octo_provider_probe, exits 0.
+    cat > "$mock_bin/curl" << MOCK
+#!/bin/bash
+# Extract -w format string and output the mock code for http_code placeholder
+echo -n "${mock_http_code}"
+exit 0
+MOCK
+    chmod +x "$mock_bin/curl"
+
+    local dead_file="$workspace/state/.provider-quota-dead"
+
+    local exit_code=0
+    WORKSPACE_DIR="$workspace" \
+    PERPLEXITY_API_KEY="sk-test" \
+    OPENROUTER_API_KEY="sk-test" \
+    PATH="$mock_bin:$PATH" \
+    bash -c '
+        log() { :; }
+        source "'"$PROJECT_ROOT"'/scripts/lib/quota-watcher.sh"
+        octo_provider_probe "'"$provider"'"
+    ' || exit_code=$?
+
+    local is_dead=0
+    grep -qxF "$provider" "$dead_file" 2>/dev/null && is_dead=1
+
+    rm -rf "$workspace" "$mock_bin"
+
+    # Return: exit_code and dead marker status via stdout for caller to inspect.
+    printf '%s %s\n' "$exit_code" "$is_dead"
+}
+
+test_probe_401_marks_dead() {
+    test_case "octo_provider_probe: 401 response marks perplexity dead and returns 1"
+    local result
+    result="$(run_probe_with_mock_curl perplexity 401)"
+    local exit_code is_dead
+    exit_code="${result%% *}"
+    is_dead="${result##* }"
+    if [[ "$exit_code" -ne 0 && "$is_dead" == "1" ]]; then
+        test_pass
+    else
+        test_fail "expected exit=1 and dead=1, got exit=${exit_code} dead=${is_dead}"
+    fi
+}
+
+test_probe_402_marks_dead() {
+    test_case "octo_provider_probe: 402 response marks openrouter dead and returns 1"
+    local result
+    result="$(run_probe_with_mock_curl openrouter 402)"
+    local exit_code is_dead
+    exit_code="${result%% *}"
+    is_dead="${result##* }"
+    if [[ "$exit_code" -ne 0 && "$is_dead" == "1" ]]; then
+        test_pass
+    else
+        test_fail "expected exit=1 and dead=1, got exit=${exit_code} dead=${is_dead}"
+    fi
+}
+
+test_probe_200_stays_open() {
+    test_case "octo_provider_probe: 200 response keeps provider open (returns 0, no dead mark)"
+    local result
+    result="$(run_probe_with_mock_curl perplexity 200)"
+    local exit_code is_dead
+    exit_code="${result%% *}"
+    is_dead="${result##* }"
+    if [[ "$exit_code" -eq 0 && "$is_dead" == "0" ]]; then
+        test_pass
+    else
+        test_fail "expected exit=0 and dead=0, got exit=${exit_code} dead=${is_dead}"
+    fi
+}
+
+# ── 3. octo_provider_probe stays open on network error ────────────────────────
+
+test_probe_network_error_stays_open() {
+    test_case "octo_provider_probe: curl network error (exit 7) does not mark dead"
+    local workspace; workspace="$(mktemp -d)"
+    local mock_bin; mock_bin="$(mktemp -d)"
+
+    # Mock curl that simulates a connection failure (exit 7 = connection refused).
+    cat > "$mock_bin/curl" << 'MOCK'
+#!/bin/bash
+exit 7
+MOCK
+    chmod +x "$mock_bin/curl"
+
+    local dead_file="$workspace/state/.provider-quota-dead"
+    local exit_code=0
+
+    WORKSPACE_DIR="$workspace" \
+    PERPLEXITY_API_KEY="sk-test" \
+    PATH="$mock_bin:$PATH" \
+    bash -c '
+        log() { :; }
+        source "'"$PROJECT_ROOT"'/scripts/lib/quota-watcher.sh"
+        octo_provider_probe "perplexity"
+    ' || exit_code=$?
+
+    local is_dead=0
+    grep -qxF "perplexity" "$dead_file" 2>/dev/null && is_dead=1
+
+    rm -rf "$workspace" "$mock_bin"
+
+    if [[ "$exit_code" -eq 0 && "$is_dead" == "0" ]]; then
+        test_pass
+    else
+        test_fail "expected fail-open (exit=0, dead=0) on network error, got exit=${exit_code} dead=${is_dead}"
+    fi
+}
+
+# ── 4. probe is a no-op when OCTOPUS_PREFLIGHT_PROBE is not 1 ────────────────
+
+test_probe_noop_when_flag_off() {
+    test_case "octo_provider_probe is not called when OCTOPUS_PREFLIGHT_PROBE is unset"
+    local workspace; workspace="$(mktemp -d)"
+    local mock_bin; mock_bin="$(mktemp -d)"
+
+    # Mock curl that would mark dead if called.
+    cat > "$mock_bin/curl" << MOCK
+#!/bin/bash
+echo -n "401"
+exit 0
+MOCK
+    chmod +x "$mock_bin/curl"
+
+    # Simulate what check-providers.sh does: only probe when OCTOPUS_PREFLIGHT_PROBE=1.
+    local dead_file="$workspace/state/.provider-quota-dead"
+    WORKSPACE_DIR="$workspace" \
+    PERPLEXITY_API_KEY="sk-test" \
+    PATH="$mock_bin:$PATH" \
+    bash -c '
+        log() { :; }
+        source "'"$PROJECT_ROOT"'/scripts/lib/quota-watcher.sh"
+        # This mirrors the check-providers.sh guard:
+        if [[ "${OCTOPUS_PREFLIGHT_PROBE:-0}" == "1" ]]; then
+            octo_provider_probe "perplexity"
+        fi
+    '
+
+    local is_dead=0
+    grep -qxF "perplexity" "$dead_file" 2>/dev/null && is_dead=1
+    rm -rf "$workspace" "$mock_bin"
+
+    if [[ "$is_dead" == "0" ]]; then
+        test_pass
+    else
+        test_fail "probe ran and marked dead despite OCTOPUS_PREFLIGHT_PROBE being unset"
+    fi
+}
+
+# ── 5. check-providers.sh integration: probe=1 causes degraded, probe=0 stays available ──
+
+preflight_perplexity_line_with_probe() {
+    local mock_http_code="$1"
+    local probe_enabled="${2:-0}"
+    local workspace; workspace="$(mktemp -d)"
+    local mock_bin; mock_bin="$(mktemp -d)"
+
+    cat > "$mock_bin/curl" << MOCK
+#!/bin/bash
+echo -n "${mock_http_code}"
+exit 0
+MOCK
+    chmod +x "$mock_bin/curl"
+
+    local line
+    line="$(WORKSPACE_DIR="$workspace" \
+        PERPLEXITY_API_KEY="sk-test" \
+        OCTOPUS_PREFLIGHT_PROBE="$probe_enabled" \
+        PATH="$mock_bin:/usr/bin:/bin" \
+        bash "$PROJECT_ROOT/scripts/helpers/check-providers.sh" 2>/dev/null | grep '^perplexity:')"
+
+    rm -rf "$workspace" "$mock_bin"
+    printf '%s\n' "$line"
+}
+
+test_check_providers_probe_on_401_gives_degraded() {
+    test_case "check-providers.sh: OCTOPUS_PREFLIGHT_PROBE=1 + 401 probe -> perplexity:degraded"
+    local line; line="$(preflight_perplexity_line_with_probe 401 1)"
+    if [[ "$line" == "perplexity:degraded" ]]; then
+        test_pass
+    else
+        test_fail "expected perplexity:degraded, got: $line"
+    fi
+}
+
+test_check_providers_probe_off_stays_available() {
+    test_case "check-providers.sh: OCTOPUS_PREFLIGHT_PROBE=0 (default) -> perplexity:available"
+    local line; line="$(preflight_perplexity_line_with_probe 401 0)"
+    if [[ "$line" == "perplexity:available" ]]; then
+        test_pass
+    else
+        test_fail "expected perplexity:available when probe disabled, got: $line"
+    fi
+}
+
+test_check_providers_probe_on_200_stays_available() {
+    test_case "check-providers.sh: OCTOPUS_PREFLIGHT_PROBE=1 + 200 probe -> perplexity:available"
+    local line; line="$(preflight_perplexity_line_with_probe 200 1)"
+    if [[ "$line" == "perplexity:available" ]]; then
+        test_pass
+    else
+        test_fail "expected perplexity:available after clean probe, got: $line"
+    fi
+}
+
+# ── Run all tests ─────────────────────────────────────────────────────────────
+
+test_perplexity_payload_has_max_tokens
+test_perplexity_payload_with_system_has_max_tokens
+test_perplexity_payload_valid_json
+test_perplexity_max_tokens_env_override
+test_probe_401_marks_dead
+test_probe_402_marks_dead
+test_probe_200_stays_open
+test_probe_network_error_stays_open
+test_probe_noop_when_flag_off
+test_check_providers_probe_on_401_gives_degraded
+test_check_providers_probe_off_stays_available
+test_check_providers_probe_on_200_stays_available
+
+test_summary


### PR DESCRIPTION
Improves first-run, setup, and doctor reliability. Closes #493, #495; advances #494 (oco-cbb).

## #493 (P0, shutdown 2026-06-25)
- gemini-image migrated off `gemini-3-pro-image-preview` to GA `gemini-3-pro-image` (Nano Banana Pro); added `gemini-3.1-flash-image` (Nano Banana 2).
- Preview kept as a `deprecated` catalog entry (no consumer gates on the status field, so pinned configs degrade gracefully).
- v3.0 configs pinning the preview now auto-migrate; a no-config install gets a `gemini-image` fallback resolving to the image model (was falling through to a text model).
- Cost table + `octo-model-config` catalog refreshed.

## #494 (P1, oco-cbb)
- Perplexity output capped via `OCTOPUS_PERPLEXITY_MAX_TOKENS` (default 4096, integer-validated against JSON injection).
- Opt-in proactive health probe `octo_provider_probe` (gated by `OCTOPUS_PREFLIGHT_PROBE=1`) for perplexity/openrouter: marks `degraded` on 401/402/429, fails open on transient network errors, respects `OCTO_ALLOWED_PROVIDERS`.
- Note: `OCTOPUS_GEMINI_TIMEOUT` and the reactive quota-watcher degraded-marking already shipped; this adds the proactive half.

## #495
- Parallel probe path (`auto-route.sh`) skips quota-dead providers, matching the bare provider name (`gemini-fast` -> `gemini` marker).

## UX
- Doctor prints the actionable fix inline by default for `warn`/`fail` rows (previously `--verbose` only).
- Setup dashboard shows concrete next-step commands for unconfigured providers.

## Review + tests
- Codex-reviewed; all 5 findings addressed (config migration, image fallback, bare-provider match, max_tokens validation, allowlist-gated probes).
- New `tests/unit/test-provider-health-probe.sh` (12/12); `test-provider-auth-validity.sh` (18/18); `test-agy-provider.sh` scoped to skip archival `docs/superpowers/plans` (31/31).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional pre-flight health checks to validate API key providers before use.
  * Introduced new Gemini image generation models for text-to-image tasks.

* **Bug Fixes**
  * Fixed Gemini image model to use current stable version instead of deprecated preview.
  * Improved request routing to skip providers with authentication or quota issues.
  * Added output token limits for Perplexity API responses.

* **Changed**
  * Diagnostics now display actionable details for warnings and errors without requiring verbose mode.
  * Setup wizard shows explicit configuration commands for unconfigured providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->