### PR TITLE
fix: harden OpenAI-compatible agent dispatch args

### DIFF
--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -14,6 +14,20 @@
 # - Google Gemini 3.0: gemini-3.1-pro-preview, gemini-3-flash-preview, gemini-3-pro-image (GA; gemini-3-pro-image-preview deprecated 2026-06-25)
 # - Google Antigravity CLI: agy --print stdin dispatch, optional OCTOPUS_AGY_MODEL
 # Note: "API-key only" models require OPENAI_API_KEY; they are NOT available via ChatGPT subscription/OAuth.
+
+_octopus_is_safe_openai_compatible_dispatch_value() {
+    local value="$1"
+    [[ -z "$value" ]] && return 1
+    [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]] && return 1
+    [[ "$value" == *"\\"* ]] && return 1
+    case "$value" in
+        *[[:space:]]*|*\*|*";"*|*"|"*|*"&"*|*'$'*|*'`'*|*"'"*|*'"'*|*"("*|*")"*|*"<"*|*">"*|*"!"*|*"*"*|*"?"*|*"["*|*"]"*|*"{"*|*"}"*)
+            return 1
+            ;;
+    esac
+    return 0
+}
+
 get_agent_command() {
     local agent_type="$1"
     local phase="${2:-}"
@@ -66,23 +80,34 @@ get_agent_command() {
 
     case "$agent_type" in
         codex|codex-standard|codex-max|codex-mini|codex-general)
-            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
             echo "${codex_bin} exec --skip-git-repo-check --model ${model} ${sandbox_flag} -"
             ;;
         codex-spark)  # v8.9.0: Ultra-fast Spark model (1000+ tok/s)
-            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
             echo "${codex_bin} exec --skip-git-repo-check --model ${model} ${sandbox_flag} -"
             ;;
         codex-reasoning)  # v8.9.0: Reasoning models (o3, o3)
-            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
             echo "${codex_bin} exec --skip-git-repo-check --model ${model} ${sandbox_flag} -"
             ;;
         codex-large-context)  # v8.9.0: 1M context models (gpt-4.1)
-            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
             echo "${codex_bin} exec --skip-git-repo-check --model ${model} ${sandbox_flag} -"
             ;;
         gemini|gemini-fast|gemini-image)
-            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            local gemini_flags="-o text --approval-mode yolo"
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
             # v8.10.0: Fixed headless mode (Issue #25)
             # Prompt delivered via stdin by callers (avoids OS arg limits)
             # Callers add -p "" for headless mode trigger
@@ -97,7 +122,6 @@ get_agent_command() {
                 gemini_env="env NODE_NO_WARNINGS=1 GEMINI_FORCE_FILE_STORAGE=true"
             fi
             local gemini_exec="${PLUGIN_DIR}/scripts/helpers/gemini-exec.sh"
-            local gemini_flags="-o text --approval-mode yolo"
             case "${OCTOPUS_GEMINI_SANDBOX:-headless}" in
                 interactive|prompt-mode) gemini_flags="" ;;
             esac
@@ -150,11 +174,23 @@ get_agent_command() {
         openrouter-kimi) echo "openrouter_execute_model moonshotai/kimi-k2.5" ;; # v8.11.0: Kimi K2.5 via OpenRouter
         openrouter-deepseek) echo "openrouter_execute_model deepseek/deepseek-r1-0528" ;; # v8.11.0: DeepSeek R1 via OpenRouter
         openai-compatible-agent)  # Generic OpenAI-compatible tool-loop agent
-            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
+            if ! validate_model_name "$model"; then
+                log ERROR "Invalid OpenAI-compatible model name: ${model}"
+                return 1
+            fi
+            if ! _octopus_is_safe_openai_compatible_dispatch_value "${PWD}"; then
+                log ERROR "Invalid OpenAI-compatible cwd: ${PWD}"
+                return 1
+            fi
             echo "${PLUGIN_DIR}/scripts/helpers/openai-compatible-agent.py --provider generic --model ${model} --cwd ${PWD}"
             ;;
         perplexity|perplexity-fast)  # v8.24.0: Perplexity Sonar — web-grounded research (Issue #22)
-            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
             echo "perplexity_execute $model"
             ;;
         copilot|copilot-research)  # v9.9.0: GitHub Copilot CLI — copilot -p (Issue #198)
@@ -162,7 +198,9 @@ get_agent_command() {
             echo "copilot --no-ask-user -s --disable-builtin-mcps"
             ;;
         ollama|ollama-*)  # v9.9.0: Ollama local LLM — ollama run
-            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
             echo "ollama run $model"
             ;;
         qwen|qwen-research)  # v9.10.0: Qwen CLI — fork of Gemini CLI
@@ -172,7 +210,9 @@ get_agent_command() {
             echo "env NODE_NO_WARNINGS=1 NO_BROWSER=1 qwen -o text --approval-mode yolo"
             ;;
         cursor-agent)  # v9.23.0: Cursor Agent CLI — Grok 4.20 via Cursor subscription
-            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
             # NOTE: bare ${model} (no quotes) — downstream uses `read -ra` which
             # does NOT interpret quotes; literal " would be passed to --model.
             echo "agent --trust --output-format text --model ${model}"
@@ -185,7 +225,9 @@ get_agent_command() {
             echo "${PLUGIN_DIR}/scripts/helpers/vibe-exec.sh --output text"
             ;;
         opencode|opencode-fast|opencode-research)  # v9.11.0: OpenCode CLI — multi-provider router
-            model=$(get_agent_model "$agent_type" "$phase" "$role")
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
             # Uses default text output (ANSI stripped by caller) — consistent with other providers
             # --model flag uses provider/model format; we store bare name and map here
             local oc_model_flag=""
@@ -415,13 +457,19 @@ get_agent_model() {
     esac
 
     local resolved_model
-    resolved_model=$(resolve_octopus_model "$provider" "$agent_type" "$phase" "$role")
+    if ! resolved_model=$(resolve_octopus_model "$provider" "$agent_type" "$phase" "$role"); then
+        return 1
+    fi
 
     # v8.31.0: Apply model restriction service if configured
     if [[ -n "$provider" ]]; then
         local fallback
         fallback=$(validate_model_allowed "$provider" "$resolved_model")
         if [[ $? -ne 0 && -n "$fallback" ]]; then
+            if ! validate_model_name "$fallback"; then
+                log ERROR "Invalid fallback model name for $provider"
+                return 1
+            fi
             echo "$fallback"
             return 0
         fi

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -60,6 +60,10 @@ resolve_octopus_model() {
     esac
     local env_var="OCTOPUS_$(echo "$canonical_provider" | tr '[:lower:]' '[:upper:]' | tr '-' '_')_MODEL"
     if [[ -n "${!env_var:-}" ]]; then
+        if ! validate_model_name "${!env_var}"; then
+            log ERROR "Invalid model name in $env_var"
+            return 1
+        fi
         echo "${!env_var}"
         return 0
     fi
@@ -82,8 +86,13 @@ resolve_octopus_model() {
     local cached_val
     eval "cached_val=\"\${_OCTO_MODEL_CACHE_${cache_key}:-}\""
     if [[ -n "$cached_val" ]]; then
-        echo "$cached_val"
-        return 0
+        if validate_model_name "$cached_val"; then
+            echo "$cached_val"
+            return 0
+        fi
+        log ERROR "Invalid model name in memory cache for $provider/$agent_type"
+        eval "unset _OCTO_MODEL_CACHE_${cache_key}"
+        cached_val=""
     fi
 
     # Persistent File Cache (optional, for parallel execution speed)
@@ -101,11 +110,15 @@ resolve_octopus_model() {
     if [[ -n "$persistent_cache" && -f "$persistent_cache" ]] && command -v jq &>/dev/null; then
         cached_val=$(jq -r ".\"$cache_key\" // empty" "$persistent_cache" 2>/dev/null)
         if [[ -n "$cached_val" && "$cached_val" != "null" ]]; then
-            # Sanitize before eval: strip shell metacharacters (model names are alphanumeric + .:/-_)
-            cached_val="${cached_val//[^a-zA-Z0-9._:\/\-]/}"
-            eval "_OCTO_MODEL_CACHE_${cache_key}=\"\$cached_val\""
-            echo "$cached_val"
-            return 0
+            # Reject invalid cached model names instead of mutating them into a
+            # different model string before eval.
+            if validate_model_name "$cached_val"; then
+                eval "_OCTO_MODEL_CACHE_${cache_key}=\"\$cached_val\""
+                echo "$cached_val"
+                return 0
+            fi
+            rm -f "$persistent_cache" 2>/dev/null || true
+            cached_val=""
         fi
     fi
 
@@ -163,7 +176,9 @@ resolve_octopus_model() {
                         [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): SKIP (route $routed targets $ref_provider, resolving for $provider)" >&2
                         routed=""
                     else
-                        resolved_model=$(resolve_octopus_model "$ref_provider" "$ref_type" "" "")
+                        if ! resolved_model=$(resolve_octopus_model "$ref_provider" "$ref_type" "" ""); then
+                            return 1
+                        fi
                     fi
                 else
                     # Bare provider names in routing values are provider routes, not
@@ -266,8 +281,15 @@ resolve_octopus_model() {
 
     [[ -n "$_trace" ]] && echo "[model-trace] ► Result: $resolved_model" >&2
 
+    # Validate before eval/cache. Dispatch also validates before command
+    # construction, but the resolver cache itself must not eval unsafe values.
+    if ! validate_model_name "$resolved_model"; then
+        log ERROR "Invalid resolved model name for $provider/$agent_type"
+        return 1
+    fi
+
     # Update memory and persistent cache
-    # Use \$var to prevent double-expansion; resolved_model is internally computed but defensive quoting is cheap
+    # Use \$var to prevent double-expansion; resolved_model is validated above and internally computed.
     eval "_OCTO_MODEL_CACHE_${cache_key}=\"\$resolved_model\""
     if [[ -n "$persistent_cache" ]] && command -v jq &>/dev/null; then
         local cache_json="{}"
@@ -290,20 +312,24 @@ resolve_octopus_model() {
 # Validate model name to prevent shell injection and other malformed inputs
 validate_model_name() {
     local model="$1"
-    
+
     # Reject empty names
     [[ -z "$model" ]] && return 1
-    
-    # Reject names with shell meta-characters (v8.50.0 Security hardening)
-    if [[ "$model" =~ [[:space:]\;\|\&\$\`\'\"()\<\>\!*?\[\]\{\}$'\n'$'\r'] ]]; then
-        return 1
-    fi
-    
+    [[ "$model" == *$'\n'* || "$model" == *$'\r'* ]] && return 1
+    [[ "$model" == *"\\"* ]] && return 1
+
+    # Reject shell metacharacters and whitespace (v8.50.0 Security hardening).
+    case "$model" in
+        *[[:space:]]*|*\*|*";"*|*"|"*|*"&"*|*'$'*|*'`'*|*"'"*|*'"'*|*"("*|*")"*|*"<"*|*">"*|*"!"*|*"*"*|*"?"*|*"["*|*"]"*|*"{"*|*"}"*)
+            return 1
+            ;;
+    esac
+
     # Reject names that look like absolute paths
     if [[ "$model" == /* ]]; then
         return 1
     fi
-    
+
     return 0
 }
 

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -162,6 +162,37 @@ sanitize_review_id() {
     return 0
 }
 
+_octopus_is_safe_openai_compatible_value() {
+    local value="$1"
+    [[ -z "$value" ]] && return 1
+    [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]] && return 1
+    [[ "$value" == *"\\"* ]] && return 1
+    case "$value" in
+        *[[:space:]]*|*\*|*";"*|*"|"*|*"&"*|*'$'*|*'`'*|*"'"*|*'"'*|*"("*|*")"*|*"<"*|*">"*|*"!"*|*"*"*|*"?"*|*"["*|*"]"*|*"{"*|*"}"*)
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+_validate_openai_compatible_agent_command() {
+    local cmd="$1"
+    local -a parts
+    # Preserve backslashes while splitting the generated helper command into
+    # tokens; unsafe backslashes are rejected by the per-token validators below.
+    read -r -a parts <<< "$cmd"
+
+    [[ "${#parts[@]}" -eq 7 ]] || return 1
+    [[ "${parts[0]}" == */scripts/helpers/openai-compatible-agent.py ]] || return 1
+    [[ "${parts[1]}" == "--provider" && "${parts[2]}" == "generic" ]] || return 1
+    [[ "${parts[3]}" == "--model" ]] || return 1
+    _octopus_is_safe_openai_compatible_value "${parts[4]}" || return 1
+    [[ "${parts[4]}" != /* ]] || return 1
+    [[ "${parts[5]}" == "--cwd" ]] || return 1
+    _octopus_is_safe_openai_compatible_value "${parts[6]}" || return 1
+    return 0
+}
+
 # Validate agent command to prevent command injection
 # Only allows whitelisted command prefixes
 validate_agent_command() {
@@ -169,8 +200,14 @@ validate_agent_command() {
     local cmd_executable="${cmd%%[[:space:]]*}"
 
     # Allow helper shims only when they are the executable token, not when they
-    # appear later in the command string.
-    if [[ "$cmd_executable" == */vibe-exec.sh || "$cmd_executable" == */openai-compatible-agent.py ]]; then
+    # appear later in the command string. OpenAI-compatible helper arguments are
+    # validated strictly because model and cwd values are interpolated into the
+    # command returned by dispatch.
+    if [[ "$cmd_executable" == */scripts/helpers/openai-compatible-agent.py ]]; then
+        _validate_openai_compatible_agent_command "$cmd"
+        return $?
+    fi
+    if [[ "$cmd_executable" == */vibe-exec.sh ]]; then
         return 0
     fi
 

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -41,6 +41,48 @@ else
     test_fail "expected openai-compatible helper path to be accepted"
 fi
 
+test_case "validate_agent_command rejects non-project openai-compatible helper path"
+if validate_agent_command "/tmp/openai-compatible-agent.py --provider generic --model minimax/minimax-m3 --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected non-project openai-compatible helper path to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects openai-compatible helper model metacharacters"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --model bad;touch --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected openai-compatible helper model metacharacters to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects openai-compatible helper absolute model path"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --model /tmp/model --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected openai-compatible helper absolute model path to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects openai-compatible helper extra args"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --model minimax/minimax-m3 --cwd /tmp/test --unexpected flag" >/dev/null 2>&1; then
+    test_fail "expected openai-compatible helper extra args to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects openai-compatible helper backslash model"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --model bad\ --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected openai-compatible helper backslash model to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects openai-compatible helper in-token backslash model"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --model bad\\model --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected openai-compatible helper in-token backslash model to be rejected"
+else
+    test_pass
+fi
+
 test_case "validate_agent_command rejects embedded openai-compatible helper path"
 if validate_agent_command "echo $PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic" >/dev/null 2>&1; then
     test_fail "expected embedded openai-compatible helper path to be rejected"

--- a/tests/unit/test-openai-compatible-agent.sh
+++ b/tests/unit/test-openai-compatible-agent.sh
@@ -61,6 +61,70 @@ if assert_contains "$cmd" "scripts/helpers/openai-compatible-agent.py" "helper p
 fi
 
 
+test_case "openai-compatible-agent rejects unsafe model names before dispatch"
+if HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-cmd-unsafe" PWD="/tmp/octo-cwd" OPENAI_COMPAT_MODEL="bad;touch" get_agent_command openai-compatible-agent unsafe-phase >/dev/null 2>&1; then
+    test_fail "expected unsafe OPENAI_COMPAT_MODEL to be rejected"
+else
+    test_pass
+fi
+
+
+test_case "openai-compatible-agent rejects unsafe cwd before dispatch"
+if HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-cwd-unsafe" PWD="/tmp/octo cwd" OPENAI_COMPAT_MODEL="vendor/model-fast" get_agent_command openai-compatible-agent cwd-phase >/dev/null 2>&1; then
+    test_fail "expected unsafe PWD to be rejected"
+else
+    test_pass
+fi
+
+
+test_case "openai-compatible-agent rejects model env override metacharacters"
+if HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-env-unsafe" OCTOPUS_OPENAI_COMPATIBLE_AGENT_MODEL="bad;touch" get_agent_model openai-compatible-agent env-phase >/dev/null 2>&1; then
+    test_fail "expected unsafe OCTOPUS_OPENAI_COMPATIBLE_AGENT_MODEL to be rejected"
+else
+    test_pass
+fi
+
+
+test_case "openai-compatible-agent rejects invalid allowlist fallback model"
+if HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-fallback-unsafe" OPENAI_COMPAT_MODEL="vendor/model-fast" OPENAI_COMPAT_ALLOWED_MODELS="/tmp/model" get_agent_model openai-compatible-agent fallback-phase >/dev/null 2>&1; then
+    test_fail "expected invalid allowlist fallback model to be rejected"
+else
+    test_pass
+fi
+
+
+test_case "openai-compatible-agent reads valid memory cache and replaces unsafe entries"
+cache_key="MC_openai_compatible_agent_A_openai_compatible_agent_P_memcache_R__C_no_config"
+cache_var="_OCTO_MODEL_CACHE_${cache_key}"
+out_file="$TEST_TMP_DIR/openai-compatible-memory-cache-model.out"
+printf -v "$cache_var" "%s" "vendor/model-fast"
+if ! HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-memcache" resolve_octopus_model openai-compatible-agent openai-compatible-agent memcache "" >"$out_file" 2>/dev/null; then
+    test_fail "expected resolver to read valid memory cache entry"
+elif [[ "$(cat "$out_file")" != "vendor/model-fast" ]]; then
+    test_fail "expected resolver to return the seeded valid memory cache entry"
+else
+    printf -v "$cache_var" "%s" "bad;touch"
+    if ! HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-memcache" resolve_octopus_model openai-compatible-agent openai-compatible-agent memcache "" >"$out_file" 2>/dev/null; then
+        test_fail "expected resolver to self-heal unsafe memory cache entry"
+    elif [[ "$(cat "$out_file")" == "bad;touch" ]]; then
+        test_fail "expected unsafe memory cache model not to be returned"
+    elif [[ "${!cache_var:-}" == "bad;touch" ]]; then
+        test_fail "expected unsafe memory cache entry to be replaced after being read"
+    else
+        test_pass
+    fi
+fi
+unset "$cache_var" 2>/dev/null || true
+
+
+test_case "openai-compatible-agent rejects model names with backslashes"
+if HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-backslash" PWD="/tmp/octo-cwd" OPENAI_COMPAT_MODEL='vendor/model\' get_agent_command openai-compatible-agent backslash-phase >/dev/null 2>&1; then
+    test_fail "expected model ending in backslash to be rejected"
+else
+    test_pass
+fi
+
+
 test_case "openai-compatible-agent omits max_tokens when configured as provider default"
 if HELPER="$HELPER" python3 - <<'PYTEST'
 import importlib.util, json, os

--- a/tests/unit/test-orchestrate-cwd-routing.sh
+++ b/tests/unit/test-orchestrate-cwd-routing.sh
@@ -130,6 +130,24 @@ EOF
     fi
 }
 
+test_invalid_nested_route_fails_closed() {
+    test_case "invalid provider:type routing fails closed instead of falling back"
+    mkdir -p "$FIXTURE_HOME/.claude-octopus/config"
+    cat > "$FIXTURE_HOME/.claude-octopus/config/providers.json" << 'EOF'
+{
+  "version": "3.0",
+  "providers": {"codex": {"unsafe": "bad;touch"}},
+  "routing": {"phases": {}, "roles": {"researcher": "codex:codex-unsafe"}}
+}
+EOF
+    local got=""
+    if got="$(resolve_with_fixture codex codex probe researcher 2>/dev/null)"; then
+        test_fail "expected invalid nested route to fail, got fallback/model: '$got'"
+    else
+        test_pass
+    fi
+}
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Claude subprocess permission flags (Read blocked in headless --print mode)
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -254,6 +272,7 @@ test_role_route_not_leaked_to_codex
 test_role_route_not_leaked_to_gemini
 test_role_route_not_a_model_for_perplexity_itself
 test_colon_route_still_resolves
+test_invalid_nested_route_fails_closed
 
 test_claude_grants_read_tools
 test_claude_sonnet_grants_read_tools


### PR DESCRIPTION
## Summary

Hardens OpenAI-compatible agent dispatch/model handling.

This PR keeps the scope narrow:

- validates model names before the resolver stores them in memory/persistent cache;
- rejects invalid cached model names instead of mutating them into a different model string;
- validates the `openai-compatible-agent.py` helper command shape and arguments in `validate_agent_command`;
- validates the resolved OpenAI-compatible model before command construction;
- adds regression tests for model metacharacters and unexpected helper args.

## Why

The OpenAI-compatible helper path interpolates the resolved model into a command string before callers split it into argv. The command path does not use `eval`, but model values containing shell metacharacters should still be rejected before they reach dispatch, command validation, or resolver cache/eval paths.

During local validation, an unsafe value such as `bad;touch` showed that the existing regex-based model validator did not reject `;`. This PR replaces that check with explicit shell-pattern guards and ensures unsafe values are rejected before eval/cache.

## Scope

Changed files:

- `scripts/lib/model-resolver.sh`
- `scripts/lib/dispatch.sh`
- `scripts/lib/utils.sh`
- `tests/unit/test-agent-command-validation.sh`
- `tests/unit/test-openai-compatible-agent.sh`

## Validation

Ran focused and adjacent tests locally from a clean worktree based on `origin/main`:

```bash
tests/unit/test-agent-command-validation.sh
tests/unit/test-openai-compatible-agent.sh
tests/unit/test-agent-lifecycle-events.sh
tests/unit/test-codex-bin-override.sh
tests/unit/test-codex-sandbox-mode.sh
tests/unit/test-opencode-model-defaults.sh
tests/unit/test-role-mapping-v929.sh
tests/unit/test-gemini-provider.sh
tests/unit/test-agent-predicates.sh
tests/unit/test-agy-workflow-routing.sh
tests/unit/test-compound-init.sh
tests/unit/test-opus-48-routing.sh
tests/unit/test-orchestrate-cwd-routing.sh
tests/unit/test-probe-single.sh
git diff --check
```

All listed tests passed; `git diff --check` reported no issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened validation for compatible-agent invocations and model names, rejecting empty values, newline/carriage returns, backslashes, absolute-path-like values, and shell metacharacters/whitespace-like patterns.
  * Improved safety for dispatch and command generation by failing fast on unresolved models, validating resolved model and working directory, and preventing unsafe caching (including replacing/clearing invalid cache entries).
  * Added fail-closed behavior for invalid nested provider routing.
* **Tests**
  * Expanded unit coverage with new negative cases for invalid command layouts, unsafe environment inputs, cache safety/replacement, and routing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->