### PR TITLE
fix: exclude Gemini retryable-throttle lines from quota fast-fail (closes #536)

### DIFF
--- a/scripts/lib/quota-watcher.sh
+++ b/scripts/lib/quota-watcher.sh
@@ -6,7 +6,8 @@
 # Excludes RetryableQuotaError and "Attempt N failed" retry log lines, which the Gemini CLI
 # emits during its own backoff/retry cycle. Matching those caused premature SIGTERM before the
 # CLI's retry landed, silently dropping reviewer roles (exit 143, empty output). (issue #516)
-OCTOPUS_QUOTA_PATTERN='QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|insufficient_quota|HTTP 401'
+# Overridable via env var so operators can narrow the pattern without patching. (issue #536)
+OCTOPUS_QUOTA_PATTERN=${OCTOPUS_QUOTA_PATTERN:-'QUOTA_EXHAUSTED|TerminalQuotaError|exhausted your capacity|insufficient_quota|HTTP 401'}
 
 # Session-scoped "this provider is quota/auth-dead" cache (oco-cbb). When a
 # terminal quota/auth error is seen at dispatch, the provider is marked here so
@@ -34,9 +35,18 @@ octo_quota_is_dead() {
 quota_watcher_has_match() {
     local temp_err="$1"
     local temp_out="$2"
+    local _matches
 
-    grep -qE "$OCTOPUS_QUOTA_PATTERN" "$temp_err" 2>/dev/null || \
-        grep -qE "$OCTOPUS_QUOTA_PATTERN" "$temp_out" 2>/dev/null
+    # Exclude lines that contain "Retrying after" — those are provider-internal
+    # retry progress messages (e.g. Gemini burst-throttle 429s) that contain
+    # "exhausted your capacity" but recover on their own. Matching them as
+    # terminal errors caused SIGTERM mid-retry, dropping reviewer roles with
+    # exit 143 and empty output. (issue #536)
+    for f in "$temp_err" "$temp_out"; do
+        _matches=$(grep -E "$OCTOPUS_QUOTA_PATTERN" "$f" 2>/dev/null | grep -vE "Retrying after") || true
+        [[ -n "$_matches" ]] && return 0
+    done
+    return 1
 }
 
 start_quota_watcher() {


### PR DESCRIPTION
## Root cause

`quota_watcher_has_match` (`scripts/lib/quota-watcher.sh:34`) ran the terminal quota pattern against every line in the captured stderr/stdout without filtering. Gemini's burst-throttle 429 retry progress message:

```
Attempt 1 failed: You have exhausted your capacity on this model. Your quota will reset after 1s.. Retrying after 5162ms...
```

matched via the `exhausted your capacity` phrase in `OCTOPUS_QUOTA_PATTERN`. This caused `start_quota_watcher` to issue SIGTERM before Gemini's internal retry could land — dropping the reviewer role with exit 143 and empty output while the orchestrator logged "Round 1 complete."

## Fix

Two changes in `scripts/lib/quota-watcher.sh`:

1. **`quota_watcher_has_match`**: pipe the pattern-matched lines through `grep -vE "Retrying after"` before the match check. Lines containing `Retrying after` are provider-internal retry progress — they contain quota phrasing but the provider is self-recovering and should not be killed. Terminal error lines (`QUOTA_EXHAUSTED`, `TerminalQuotaError`, `insufficient_quota`, `HTTP 401`) do not contain `Retrying after`, so they still trigger fast-fail correctly.

2. **`OCTOPUS_QUOTA_PATTERN`**: changed from a bare assignment to `${OCTOPUS_QUOTA_PATTERN:-'...'}` so operators can narrow the pattern via env var without patching (regression in 9.45.0 noted in the issue).

## Test results

```
tests/unit/test-quota-watcher.sh    — 2/2 pass
tests/unit/test-quota-fast-fail.sh  — 6/6 pass
bash -n scripts/lib/quota-watcher.sh — syntax ok
```

Manual verification:
- Retryable line → `would not kill` ✓
- `QUOTA_EXHAUSTED` → `WOULD KILL` ✓
- `TerminalQuotaError` → `WOULD KILL` ✓
- `insufficient_quota` → `WOULD KILL` ✓
- `HTTP 401` → `WOULD KILL` ✓

closes #536

---
_Generated by [Claude Code](https://claude.ai/code/session_011Pwd7sWy2Nm8dwKZb9gXFC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota/error detection to reduce false fast-fail terminations during retry and backoff handling.
  * Matching now checks both standard output and error output, making detection more reliable.
* **Chores**
  * Added support for configuring the quota/error match pattern through an environment variable, allowing easier customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->