### PR TITLE
fix: complete agy migration in parallel aggregator + probe/discover dispatch (#524 follow-up)

### DIFF
--- a/scripts/lib/embrace.sh
+++ b/scripts/lib/embrace.sh
@@ -24,10 +24,16 @@ get_dispatch_strategy() {
             local all_p="claude-sonnet"
             command -v codex >/dev/null 2>&1 && all_p="codex,${all_p}"
             command -v gemini >/dev/null 2>&1 && all_p="gemini,${all_p}"
-            echo "3:${all_p}:high"
+            # Antigravity (agy) is the Google seat since the Gemini CLI sunset (#524)
+            { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed agy; } \
+                && command -v agy >/dev/null 2>&1 && all_p="agy,${all_p}"
+            local _full_count; _full_count=$(awk -F, '{print NF}' <<< "$all_p")
+            echo "${_full_count}:${all_p}:high"
             return 0 ;;
         minimal)
-            if command -v gemini >/dev/null 2>&1; then echo "2:gemini,claude-sonnet:high"
+            # agy (Google seat) preferred over the sunset Gemini CLI (#524)
+            if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed agy; } && command -v agy >/dev/null 2>&1; then echo "2:agy,claude-sonnet:high"
+            elif command -v gemini >/dev/null 2>&1; then echo "2:gemini,claude-sonnet:high"
             elif command -v codex >/dev/null 2>&1; then echo "2:codex,claude-sonnet:high"
             else echo "1:claude-sonnet:high"; fi
             return 0 ;;
@@ -52,9 +58,15 @@ get_dispatch_strategy() {
     fi
 
     # v9.10.0: Detect all available providers for dispatch strategy
-    local has_codex=false has_gemini=false has_copilot=false has_qwen=false has_ollama=false has_cursor_agent=false
+    # v9.45.1: agy (Antigravity) added as the Google seat — the probe/discover
+    # fan-out never seated it before, so Antigravity-only setups fell back to
+    # Claude-only dispatch (Gemini CLI sunset 2026-06-18, #524).
+    local has_codex=false has_gemini=false has_copilot=false has_qwen=false has_ollama=false has_cursor_agent=false has_agy=false
     command -v codex >/dev/null 2>&1 && has_codex=true
     command -v gemini >/dev/null 2>&1 && has_gemini=true
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed agy; } && command -v agy >/dev/null 2>&1; then
+        has_agy=true
+    fi
     command -v copilot >/dev/null 2>&1 && has_copilot=true
     if declare -f qwen_is_usable >/dev/null 2>&1; then
         qwen_is_usable && has_qwen=true
@@ -74,6 +86,7 @@ get_dispatch_strategy() {
     local -a cli_providers=()
     [[ "$has_codex" == true ]] && cli_providers+=(codex)
     [[ "$has_gemini" == true ]] && cli_providers+=(gemini)
+    [[ "$has_agy" == true ]] && cli_providers+=(agy)
     [[ "$has_copilot" == true ]] && cli_providers+=(copilot)
     [[ "$has_qwen" == true ]] && cli_providers+=(qwen)
     [[ "$has_cursor_agent" == true ]] && cli_providers+=(cursor-agent)
@@ -82,12 +95,11 @@ get_dispatch_strategy() {
     case "$workflow" in
         review|security)
             # Each provider misses different bugs — more perspectives = better coverage
-            if [[ $cli_count -ge 3 ]]; then
+            if [[ $cli_count -ge 2 ]]; then
                 local providers_str
                 providers_str=$(IFS=,; echo "${cli_providers[*]}")
                 echo "$((cli_count + 1)):${providers_str},claude-sonnet:high"
-            elif [[ "$has_codex" == true && "$has_gemini" == true ]]; then
-                echo "3:codex,gemini,claude-sonnet:high"
+            elif [[ "$has_agy" == true ]]; then echo "2:agy,claude-sonnet:high"
             elif [[ "$has_codex" == true ]]; then echo "2:codex,claude-sonnet:high"
             elif [[ "$has_gemini" == true ]]; then echo "2:gemini,claude-sonnet:high"
             elif [[ "$has_qwen" == true ]]; then echo "2:qwen,claude-sonnet:medium"
@@ -107,6 +119,7 @@ get_dispatch_strategy() {
                 local providers_str
                 providers_str=$(IFS=,; echo "${cli_providers[*]}")
                 echo "$((cli_count + 1)):${providers_str},claude-sonnet:high"
+            elif [[ "$has_agy" == true ]]; then echo "2:agy,claude-sonnet:high"
             elif [[ "$has_gemini" == true ]]; then echo "2:gemini,claude-sonnet:high"
             elif [[ "$has_codex" == true ]]; then echo "2:codex,claude-sonnet:medium"
             elif [[ "$has_qwen" == true ]]; then echo "2:qwen,claude-sonnet:medium"

--- a/scripts/lib/embrace.sh
+++ b/scripts/lib/embrace.sh
@@ -14,6 +14,14 @@ if ! declare -f qwen_is_usable >/dev/null 2>&1; then
     source "${_embrace_lib_dir}/qwen.sh" 2>/dev/null || true
 fi
 
+# Provider allowlist gate used across get_dispatch_strategy. No-op (returns 0 /
+# allowed) when octo_provider_allowed is undefined or the allowlist is unset, so
+# default setups are unaffected; when an allowlist IS set every CLI seat — not
+# just agy — is filtered consistently so stale binaries can't bypass it (#524).
+_gds_provider_allowed() {
+    ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "$1"
+}
+
 get_dispatch_strategy() {
     local prompt="$1"
     local workflow="${2:-auto}"
@@ -22,19 +30,18 @@ get_dispatch_strategy() {
     case "$strategy" in
         full)
             local all_p="claude-sonnet"
-            command -v codex >/dev/null 2>&1 && all_p="codex,${all_p}"
-            command -v gemini >/dev/null 2>&1 && all_p="gemini,${all_p}"
+            _gds_provider_allowed codex && command -v codex >/dev/null 2>&1 && all_p="codex,${all_p}"
+            _gds_provider_allowed gemini && command -v gemini >/dev/null 2>&1 && all_p="gemini,${all_p}"
             # Antigravity (agy) is the Google seat since the Gemini CLI sunset (#524)
-            { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed agy; } \
-                && command -v agy >/dev/null 2>&1 && all_p="agy,${all_p}"
+            _gds_provider_allowed agy && command -v agy >/dev/null 2>&1 && all_p="agy,${all_p}"
             local _full_count; _full_count=$(awk -F, '{print NF}' <<< "$all_p")
             echo "${_full_count}:${all_p}:high"
             return 0 ;;
         minimal)
             # agy (Google seat) preferred over the sunset Gemini CLI (#524)
-            if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed agy; } && command -v agy >/dev/null 2>&1; then echo "2:agy,claude-sonnet:high"
-            elif command -v gemini >/dev/null 2>&1; then echo "2:gemini,claude-sonnet:high"
-            elif command -v codex >/dev/null 2>&1; then echo "2:codex,claude-sonnet:high"
+            if _gds_provider_allowed agy && command -v agy >/dev/null 2>&1; then echo "2:agy,claude-sonnet:high"
+            elif _gds_provider_allowed gemini && command -v gemini >/dev/null 2>&1; then echo "2:gemini,claude-sonnet:high"
+            elif _gds_provider_allowed codex && command -v codex >/dev/null 2>&1; then echo "2:codex,claude-sonnet:high"
             else echo "1:claude-sonnet:high"; fi
             return 0 ;;
     esac
@@ -62,23 +69,25 @@ get_dispatch_strategy() {
     # fan-out never seated it before, so Antigravity-only setups fell back to
     # Claude-only dispatch (Gemini CLI sunset 2026-06-18, #524).
     local has_codex=false has_gemini=false has_copilot=false has_qwen=false has_ollama=false has_cursor_agent=false has_agy=false
-    command -v codex >/dev/null 2>&1 && has_codex=true
-    command -v gemini >/dev/null 2>&1 && has_gemini=true
-    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed agy; } && command -v agy >/dev/null 2>&1; then
-        has_agy=true
+    _gds_provider_allowed codex  && command -v codex  >/dev/null 2>&1 && has_codex=true
+    _gds_provider_allowed gemini && command -v gemini >/dev/null 2>&1 && has_gemini=true
+    _gds_provider_allowed agy    && command -v agy    >/dev/null 2>&1 && has_agy=true
+    _gds_provider_allowed copilot && command -v copilot >/dev/null 2>&1 && has_copilot=true
+    if _gds_provider_allowed qwen; then
+        if declare -f qwen_is_usable >/dev/null 2>&1; then
+            qwen_is_usable && has_qwen=true
+        elif command -v qwen >/dev/null 2>&1; then
+            has_qwen=true
+        fi
     fi
-    command -v copilot >/dev/null 2>&1 && has_copilot=true
-    if declare -f qwen_is_usable >/dev/null 2>&1; then
-        qwen_is_usable && has_qwen=true
-    elif command -v qwen >/dev/null 2>&1; then
-        has_qwen=true
-    fi
-    command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags &>/dev/null && has_ollama=true
-    if declare -f cursor_agent_is_available >/dev/null 2>&1; then
-        cursor_agent_is_available && has_cursor_agent=true
-    elif declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
-        if [[ -n "${CURSOR_API_KEY:-}" ]] || grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; then
-            has_cursor_agent=true
+    _gds_provider_allowed ollama && command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags &>/dev/null && has_ollama=true
+    if _gds_provider_allowed cursor-agent; then
+        if declare -f cursor_agent_is_available >/dev/null 2>&1; then
+            cursor_agent_is_available && has_cursor_agent=true
+        elif declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
+            if [[ -n "${CURSOR_API_KEY:-}" ]] || grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; then
+                has_cursor_agent=true
+            fi
         fi
     fi
 

--- a/scripts/lib/heuristics.sh
+++ b/scripts/lib/heuristics.sh
@@ -338,7 +338,9 @@ $(<"$raw_concat")"
         if synthesis_result=$(run_agent_sync "$synth_agent" "$synthesis_prompt" "${TIMEOUT:-300}" "synthesizer" "aggregate" 2>/dev/null) \
             && [[ -n "$synthesis_result" ]]; then
             :  # primary synthesizer produced output
-        elif [[ "$synth_agent" != "claude-sonnet" ]] && command -v claude >/dev/null 2>&1 \
+        elif [[ "$synth_agent" != "claude-sonnet" ]] \
+            && { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed claude-sonnet; } \
+            && command -v claude >/dev/null 2>&1 \
             && synthesis_result=$(run_agent_sync "claude-sonnet" "$synthesis_prompt" "${TIMEOUT:-300}" "synthesizer" "aggregate" 2>/dev/null) \
             && [[ -n "$synthesis_result" ]]; then
             log WARN "Synthesizer '$synth_agent' failed — used claude-sonnet fallback"
@@ -473,13 +475,20 @@ $results"
 
     # Route probe synthesis through the Google seat (agy) with a claude-sonnet
     # retry, then the compact static fallback. (#524 — Gemini CLI sunset.)
+    # Keep an empty picker result authoritative — do NOT override it with
+    # claude-sonnet, which would bypass OCTO_ALLOWED_PROVIDERS and send probe
+    # context to a disabled provider. _aggregate_pick_synth_agent already returns
+    # claude-sonnet when (and only when) the allowlist permits it (#538).
     local synth_agent="" synthesis=""
     type _aggregate_pick_synth_agent >/dev/null 2>&1 && synth_agent=$(_aggregate_pick_synth_agent)
-    [[ -z "$synth_agent" ]] && synth_agent="claude-sonnet"
-    synthesis=$(run_agent_sync "$synth_agent" "$synthesis_prompt" "${TIMEOUT:-300}" "synthesizer" "probe") || synthesis=""
-    if [[ -z "$synthesis" && "$synth_agent" != "claude-sonnet" ]]; then
-        log WARN "Probe synthesis via '$synth_agent' failed — retrying with claude-sonnet"
-        synthesis=$(run_agent_sync "claude-sonnet" "$synthesis_prompt" "${TIMEOUT:-300}" "synthesizer" "probe") || synthesis=""
+    if [[ -n "$synth_agent" ]]; then
+        synthesis=$(run_agent_sync "$synth_agent" "$synthesis_prompt" "${TIMEOUT:-300}" "synthesizer" "probe") || synthesis=""
+        if [[ -z "$synthesis" && "$synth_agent" != "claude-sonnet" ]] \
+            && { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed claude-sonnet; } \
+            && command -v claude >/dev/null 2>&1; then
+            log WARN "Probe synthesis via '$synth_agent' failed — retrying with claude-sonnet"
+            synthesis=$(run_agent_sync "claude-sonnet" "$synthesis_prompt" "${TIMEOUT:-300}" "synthesizer" "probe") || synthesis=""
+        fi
     fi
     if [[ -z "$synthesis" ]]; then
         log WARN "Synthesis failed, using compact fallback"

--- a/scripts/lib/heuristics.sh
+++ b/scripts/lib/heuristics.sh
@@ -251,7 +251,7 @@ aggregate_results() {
     # Results are ordered best-first so the synthesis LLM sees highest-quality content first
     local result_count=0
     > "$raw_concat"
-    local ranked_files
+    local ranked_files=""
     if type agent_status_output_files >/dev/null 2>&1; then
         ranked_files=$(agent_status_output_files "$filter" 2>/dev/null || true)
     fi
@@ -290,9 +290,17 @@ aggregate_results() {
         ((result_count++)) || true
     done <<< "$ranked_files"
 
-    # Phase 2: Synthesize if we have a provider available and multiple results
-    if [[ $result_count -gt 1 ]] && command -v gemini &> /dev/null && [[ "$DRY_RUN" != "true" ]]; then
-        log INFO "Synthesizing $result_count results (ranked by quality, not just concatenating)..."
+    # Phase 2: Synthesize via the agy-capable run_agent_sync abstraction when we
+    # have a reachable provider and multiple results. (Gemini CLI sunset
+    # 2026-06-18 — agy is the default Google seat; claude-sonnet is the fallback;
+    # plain concatenation only when no provider is reachable.) The picker lives in
+    # parallel.sh, which orchestrate.sh sources before this lib.
+    local synth_agent="" synth_used=""
+    type _aggregate_pick_synth_agent >/dev/null 2>&1 && synth_agent=$(_aggregate_pick_synth_agent)
+    synth_used="$synth_agent"
+    if [[ $result_count -gt 1 ]] && [[ -n "$synth_agent" ]] \
+        && type run_agent_sync >/dev/null 2>&1 && [[ "$DRY_RUN" != "true" ]]; then
+        log INFO "Synthesizing $result_count results via $synth_agent (ranked by quality, not just concatenating)..."
 
         # v8.49.0: Enhanced synthesis prompt with relevance awareness and structured output
         local query_context=""
@@ -326,12 +334,25 @@ ${agent_summary:-No agent status ledger available}
 Subtask results:
 $(<"$raw_concat")"
 
-        local synthesis_result
-        if synthesis_result=$(printf '%s' "$synthesis_prompt" | run_with_timeout "$TIMEOUT" gemini 2>/dev/null) && [[ -n "$synthesis_result" ]]; then
+        local synthesis_result=""
+        if synthesis_result=$(run_agent_sync "$synth_agent" "$synthesis_prompt" "${TIMEOUT:-300}" "synthesizer" "aggregate" 2>/dev/null) \
+            && [[ -n "$synthesis_result" ]]; then
+            :  # primary synthesizer produced output
+        elif [[ "$synth_agent" != "claude-sonnet" ]] && command -v claude >/dev/null 2>&1 \
+            && synthesis_result=$(run_agent_sync "claude-sonnet" "$synthesis_prompt" "${TIMEOUT:-300}" "synthesizer" "aggregate" 2>/dev/null) \
+            && [[ -n "$synthesis_result" ]]; then
+            log WARN "Synthesizer '$synth_agent' failed — used claude-sonnet fallback"
+            synth_used="claude-sonnet"
+        else
+            synthesis_result=""
+        fi
+
+        if [[ -n "$synthesis_result" ]]; then
             echo "# Claude Octopus - Synthesized Results" > "$aggregate_file"
             echo "" >> "$aggregate_file"
             echo "Generated: $(date)" >> "$aggregate_file"
             echo "Sources: $result_count subtask outputs (ranked by quality)" >> "$aggregate_file"
+            echo "Synthesizer: $synth_used" >> "$aggregate_file"
             [[ -n "$user_query" ]] && echo "Query: $user_query" >> "$aggregate_file"
             if [[ -n "$agent_summary" ]]; then
                 echo "" >> "$aggregate_file"
@@ -340,7 +361,7 @@ $(<"$raw_concat")"
             echo "" >> "$aggregate_file"
             echo "$synthesis_result" >> "$aggregate_file"
             rm -f "$raw_concat"
-            log INFO "Synthesized $result_count results to: $aggregate_file"
+            log INFO "Synthesized $result_count results via $synth_used to: $aggregate_file"
             echo ""
             echo -e "${GREEN}✓${NC} Results synthesized to: $aggregate_file"
             guard_output "$(<"$aggregate_file")" "aggregate-synthesis"
@@ -422,7 +443,7 @@ synthesize_probe_results() {
         results="# Compact Probe Synthesis Context"$'\n\n'"No bounded probe excerpts could be collected. Inspect RESULTS_DIR for raw artifacts."
     fi
 
-    # Use Gemini for intelligent synthesis
+    # Use the Google seat (agy, post Gemini-CLI sunset #524) for intelligent synthesis
     # v8.49.0: Enhanced prompt with structured output, minority opinion preservation,
     # and relevance-aware weighting (inspired by Crawl4AI content filtering patterns)
     local synthesis_prompt="Synthesize these research findings into a coherent discovery summary.
@@ -450,11 +471,20 @@ Structure your synthesis as:
 Research findings:
 $results"
 
-    local synthesis
-    synthesis=$(run_agent_sync "gemini" "$synthesis_prompt" "${TIMEOUT:-300}") || {
+    # Route probe synthesis through the Google seat (agy) with a claude-sonnet
+    # retry, then the compact static fallback. (#524 — Gemini CLI sunset.)
+    local synth_agent="" synthesis=""
+    type _aggregate_pick_synth_agent >/dev/null 2>&1 && synth_agent=$(_aggregate_pick_synth_agent)
+    [[ -z "$synth_agent" ]] && synth_agent="claude-sonnet"
+    synthesis=$(run_agent_sync "$synth_agent" "$synthesis_prompt" "${TIMEOUT:-300}" "synthesizer" "probe") || synthesis=""
+    if [[ -z "$synthesis" && "$synth_agent" != "claude-sonnet" ]]; then
+        log WARN "Probe synthesis via '$synth_agent' failed — retrying with claude-sonnet"
+        synthesis=$(run_agent_sync "claude-sonnet" "$synthesis_prompt" "${TIMEOUT:-300}" "synthesizer" "probe") || synthesis=""
+    fi
+    if [[ -z "$synthesis" ]]; then
         log WARN "Synthesis failed, using compact fallback"
         synthesis=$(build_probe_fallback_synthesis "$original_prompt" "$result_count" "$usable_results" "$total_content_size" "$results")
-    }
+    fi
 
     cat > "$synthesis_file" << EOF
 # PROBE Phase Synthesis

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -318,6 +318,25 @@ Output as a simple numbered list. Task: $main_prompt"
     aggregate_results "$task_group"
 }
 
+# v9.45.1: Pick the synthesis provider for aggregate_results.
+# The Gemini CLI was sunset 2026-06-18; agy (Antigravity) is now the default
+# Google seat / synthesizer, mirroring the workflows.sh phase synthesizers
+# (#524). Preference order:
+#   1. agy           — Google seat, when the agy CLI is installed/allowed
+#   2. claude-sonnet — always available inside Claude Code
+# Echoes the chosen agent type, or empty when no synthesis provider is reachable
+# (the caller then falls back to plain concatenation).
+_aggregate_pick_synth_agent() {
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed agy; } \
+        && command -v agy >/dev/null 2>&1; then
+        echo "agy"; return 0
+    fi
+    if command -v claude >/dev/null 2>&1; then
+        echo "claude-sonnet"; return 0
+    fi
+    echo ""; return 1
+}
+
 aggregate_results() {
     local _ts; _ts=$(date +%s)
     local filter="${1:-}"
@@ -357,9 +376,16 @@ aggregate_results() {
         ((result_count++)) || true
     done <<< "$ranked_files"
 
-    # Phase 2: Synthesize if we have a provider available and multiple results
-    if [[ $result_count -gt 1 ]] && command -v gemini &> /dev/null && [[ "$DRY_RUN" != "true" ]]; then
-        log INFO "Synthesizing $result_count results (ranked by quality, not just concatenating)..."
+    # Phase 2: Synthesize via the agy-capable run_agent_sync abstraction when we
+    # have a reachable synthesis provider and multiple results. (Gemini CLI sunset
+    # 2026-06-18 — agy is the default Google seat; claude-sonnet is the fallback.
+    # Plain concatenation is used only when NO synthesis provider is available.)
+    local synth_agent synth_used
+    synth_agent=$(_aggregate_pick_synth_agent)
+    synth_used="$synth_agent"
+    if [[ $result_count -gt 1 ]] && [[ -n "$synth_agent" ]] \
+        && type run_agent_sync >/dev/null 2>&1 && [[ "$DRY_RUN" != "true" ]]; then
+        log INFO "Synthesizing $result_count results via $synth_agent (ranked by quality, not just concatenating)..."
 
         # v8.49.0: Enhanced synthesis prompt with relevance awareness and structured output
         local query_context=""
@@ -388,17 +414,30 @@ Structure the output as:
 Subtask results:
 $(<"$raw_concat")"
 
-        local synthesis_result
-        if synthesis_result=$(printf '%s' "$synthesis_prompt" | run_with_timeout "$TIMEOUT" gemini 2>/dev/null) && [[ -n "$synthesis_result" ]]; then
+        local synthesis_result=""
+        if synthesis_result=$(run_agent_sync "$synth_agent" "$synthesis_prompt" "$TIMEOUT" "synthesizer" "parallel" 2>/dev/null) \
+            && [[ -n "$synthesis_result" ]]; then
+            :  # primary synthesizer produced output
+        elif [[ "$synth_agent" != "claude-sonnet" ]] && command -v claude >/dev/null 2>&1 \
+            && synthesis_result=$(run_agent_sync "claude-sonnet" "$synthesis_prompt" "$TIMEOUT" "synthesizer" "parallel" 2>/dev/null) \
+            && [[ -n "$synthesis_result" ]]; then
+            log WARN "Synthesizer '$synth_agent' failed — used claude-sonnet fallback"
+            synth_used="claude-sonnet"
+        else
+            synthesis_result=""
+        fi
+
+        if [[ -n "$synthesis_result" ]]; then
             echo "# Claude Octopus - Synthesized Results" > "$aggregate_file"
             echo "" >> "$aggregate_file"
             echo "Generated: $(date)" >> "$aggregate_file"
             echo "Sources: $result_count subtask outputs (ranked by quality)" >> "$aggregate_file"
+            echo "Synthesizer: $synth_used" >> "$aggregate_file"
             [[ -n "$user_query" ]] && echo "Query: $user_query" >> "$aggregate_file"
             echo "" >> "$aggregate_file"
             echo "$synthesis_result" >> "$aggregate_file"
             rm -f "$raw_concat"
-            log INFO "Synthesized $result_count results to: $aggregate_file"
+            log INFO "Synthesized $result_count results via $synth_used to: $aggregate_file"
             echo ""
             echo -e "${GREEN}✓${NC} Results synthesized to: $aggregate_file"
             guard_output "$(<"$aggregate_file")" "aggregate-synthesis"

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -333,7 +333,10 @@ _aggregate_pick_synth_agent() {
         && command -v agy >/dev/null 2>&1; then
         echo "agy"; return 0
     fi
-    if command -v claude >/dev/null 2>&1; then
+    # claude-sonnet is the fallback only when the allowlist permits it — the
+    # picker is the single source of truth for synthesis authorization (#538).
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed claude-sonnet; } \
+        && command -v claude >/dev/null 2>&1; then
         echo "claude-sonnet"; return 0
     fi
     echo ""; return 0
@@ -420,7 +423,9 @@ $(<"$raw_concat")"
         if synthesis_result=$(run_agent_sync "$synth_agent" "$synthesis_prompt" "$TIMEOUT" "synthesizer" "parallel" 2>/dev/null) \
             && [[ -n "$synthesis_result" ]]; then
             :  # primary synthesizer produced output
-        elif [[ "$synth_agent" != "claude-sonnet" ]] && command -v claude >/dev/null 2>&1 \
+        elif [[ "$synth_agent" != "claude-sonnet" ]] \
+            && { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed claude-sonnet; } \
+            && command -v claude >/dev/null 2>&1 \
             && synthesis_result=$(run_agent_sync "claude-sonnet" "$synthesis_prompt" "$TIMEOUT" "synthesizer" "parallel" 2>/dev/null) \
             && [[ -n "$synthesis_result" ]]; then
             log WARN "Synthesizer '$synth_agent' failed — used claude-sonnet fallback"

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -325,7 +325,9 @@ Output as a simple numbered list. Task: $main_prompt"
 #   1. agy           — Google seat, when the agy CLI is installed/allowed
 #   2. claude-sonnet — always available inside Claude Code
 # Echoes the chosen agent type, or empty when no synthesis provider is reachable
-# (the caller then falls back to plain concatenation).
+# (the caller then falls back to plain concatenation). Always returns 0 — the
+# exit code is unused and the caller branches on the echoed value, so a non-zero
+# return would only misfire `set -e` in `synth_agent=$(...)` assignments.
 _aggregate_pick_synth_agent() {
     if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed agy; } \
         && command -v agy >/dev/null 2>&1; then
@@ -334,7 +336,7 @@ _aggregate_pick_synth_agent() {
     if command -v claude >/dev/null 2>&1; then
         echo "claude-sonnet"; return 0
     fi
-    echo ""; return 1
+    echo ""; return 0
 }
 
 aggregate_results() {

--- a/scripts/lib/provider-allowlist.sh
+++ b/scripts/lib/provider-allowlist.sh
@@ -113,9 +113,17 @@ octo_provider_allowed() {
                     codex|codex-*) return 0 ;;
                 esac
                 ;;
-            gemini|google)
+            gemini)
                 case "$provider" in
                     gemini|gemini-*) return 0 ;;
+                esac
+                ;;
+            # "google" is the Google-seat alias. Post Gemini-CLI sunset (#524) the
+            # seat is agy (Antigravity), so a legacy `google` allowlist must keep
+            # authorizing agy during/after migration — not just the Gemini CLI.
+            google)
+                case "$provider" in
+                    gemini|gemini-*|agy|agy-*|antigravity) return 0 ;;
                 esac
                 ;;
             agy|antigravity)

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -416,7 +416,7 @@ probe_discover() {
 
     if [[ "$DRY_RUN" == "true" ]]; then
         log INFO "[DRY-RUN] Would probe: $prompt"
-        log INFO "[DRY-RUN] Would spawn 5+ parallel research agents (Codex, Gemini, Sonnet 4.6, +codebase if in git repo, +Perplexity if API key set)"
+        log INFO "[DRY-RUN] Would spawn 5+ parallel research agents (Codex, Antigravity/agy, Sonnet 4.6, +codebase if in git repo, +Perplexity if API key set)"
         return 0
     fi
 
@@ -714,7 +714,7 @@ grasp_define() {
 
     if [[ "$DRY_RUN" == "true" ]]; then
         log INFO "[DRY-RUN] Would grasp: $prompt"
-        log INFO "[DRY-RUN] Would gather 4 perspectives (Codex, Gemini, Sonnet 4.6) and build consensus"
+        log INFO "[DRY-RUN] Would gather 4 perspectives (Codex, Antigravity/agy, Sonnet 4.6) and build consensus"
         return 0
     fi
 
@@ -743,8 +743,8 @@ grasp_define() {
         def1=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define the core problem statement in 2-3 sentences. What is the essential challenge?" 120 "backend-architect" "grasp") || true
     }
     def2=$(run_agent_sync "agy" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || {
-        log WARN "Gemini failed for success criteria, falling back to Claude"
-        echo -e " ${YELLOW}⚠${NC}  Gemini unavailable for success criteria — falling back to Claude"
+        log WARN "Antigravity (agy) failed for success criteria, falling back to Claude"
+        echo -e " ${YELLOW}⚠${NC}  Antigravity (agy) unavailable for success criteria — falling back to Claude"
         def2=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || true
     }
     def3=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define constraints and boundaries. What are we NOT solving? What are hard limits?" 120 "researcher" "grasp")
@@ -1976,8 +1976,8 @@ Return a concise gate review with:
 4. Concrete changes needed before the next phase
 5. Evidence from the context artifact"
 
-    local codex_view="" gemini_view="" claude_view="" synthesis=""
-    local codex_status="failed" gemini_status="failed" claude_status="failed"
+    local codex_view="" agy_view="" claude_view="" synthesis=""
+    local codex_status="failed" agy_status="failed" claude_status="failed"
     local successful=0
 
     if codex_view=$(run_agent_sync "codex" "$gate_prompt" 120 "code-reviewer" "embrace-gate" 2>/dev/null); then
@@ -1986,9 +1986,10 @@ Return a concise gate review with:
             successful=$((successful + 1))
         fi
     fi
-    if gemini_view=$(run_agent_sync "agy" "$gate_prompt" 120 "researcher" "embrace-gate" 2>/dev/null); then
-        if [[ -n "$gemini_view" ]]; then
-            gemini_status="ok"
+    # Antigravity (agy) is the Google seat since the Gemini CLI sunset (#524)
+    if agy_view=$(run_agent_sync "agy" "$gate_prompt" 120 "researcher" "embrace-gate" 2>/dev/null); then
+        if [[ -n "$agy_view" ]]; then
+            agy_status="ok"
             successful=$((successful + 1))
         fi
     fi
@@ -2009,13 +2010,13 @@ Return a concise gate review with:
 
 Task: ${prompt}
 Gate style: ${style}
-Provider statuses: codex=${codex_status}, gemini=${gemini_status}, claude=${claude_status}
+Provider statuses: codex=${codex_status}, agy=${agy_status}, claude=${claude_status}
 
 Codex:
 ${codex_view:-[no output]}
 
-Gemini:
-${gemini_view:-[no output]}
+Antigravity (agy):
+${agy_view:-[no output]}
 
 Claude:
 ${claude_view:-[no output]}
@@ -2039,7 +2040,7 @@ Return:
 **Task:** ${prompt}
 **Style:** ${style}
 **Context Artifact:** ${context_file}
-**Provider Statuses:** codex=${codex_status}, gemini=${gemini_status}, claude=${claude_status}
+**Provider Statuses:** codex=${codex_status}, agy=${agy_status}, claude=${claude_status}
 
 ---
 
@@ -2055,9 +2056,9 @@ ${synthesis}
 
 ${codex_view:-No output.}
 
-### Gemini (${gemini_status})
+### Antigravity / agy (${agy_status})
 
-${gemini_view:-No output.}
+${agy_view:-No output.}
 
 ### Claude (${claude_status})
 
@@ -2074,7 +2075,7 @@ EOF
             "Embrace debate gate completed: ${prompt:0:80}" \
             "" \
             "high" \
-            "Provider statuses: codex=${codex_status}, gemini=${gemini_status}, claude=${claude_status}" \
+            "Provider statuses: codex=${codex_status}, agy=${agy_status}, claude=${claude_status}" \
             "" 2>/dev/null || true
     fi
 

--- a/tests/unit/test-agy-heuristics-synthesis.sh
+++ b/tests/unit/test-agy-heuristics-synthesis.sh
@@ -75,7 +75,7 @@ _run_runtime_aggregate() {
     # checked first by the picker, so the choice is deterministic regardless of
     # whether the host has gemini.
     PROJECT_ROOT="$PROJECT_ROOT" WORKDIR="$workdir" HBIN="$hbin" MODE="$mode" bash -c '
-        set -uo pipefail
+        set -euo pipefail
         export PATH="$HBIN:$PATH"
         RESULTS_DIR="$WORKDIR/results"; DRY_RUN=false; TIMEOUT=30; GREEN=""; NC=""
         source "$PROJECT_ROOT/scripts/lib/parallel.sh"

--- a/tests/unit/test-agy-heuristics-synthesis.sh
+++ b/tests/unit/test-agy-heuristics-synthesis.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression tests for the RUNTIME-effective synthesis path.
+#
+# orchestrate.sh sources scripts/lib/parallel.sh and then scripts/lib/heuristics.sh,
+# and BOTH define aggregate_results(). Because heuristics.sh is sourced last, its
+# copy wins at runtime — so the parallel.sh agy fix (#538) was shadowed and the
+# probe/parallel synthesis still routed to the bare gemini CLI. These tests pin
+# the heuristics.sh copy (aggregate_results + synthesize_probe_results) to the
+# agy-capable run_agent_sync path and prove the runtime-effective routing.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "agy is the runtime synthesizer in heuristics.sh (parallel.sh aggregate_results is shadowed)"
+
+HEUR_LIB="$PROJECT_ROOT/scripts/lib/heuristics.sh"
+PARALLEL_LIB="$PROJECT_ROOT/scripts/lib/parallel.sh"
+ORCH="$PROJECT_ROOT/scripts/orchestrate.sh"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Static assertions
+# ─────────────────────────────────────────────────────────────────────────────
+
+test_heuristics_is_sourced_after_parallel() {
+    test_case "orchestrate.sh sources heuristics.sh after parallel.sh (heuristics aggregate_results wins)"
+    local p_line h_line
+    p_line=$(grep -n 'source .*lib/parallel\.sh' "$ORCH" | head -1 | cut -d: -f1)
+    h_line=$(grep -n 'source .*lib/heuristics\.sh' "$ORCH" | head -1 | cut -d: -f1)
+    if [[ -n "$p_line" && -n "$h_line" && "$h_line" -gt "$p_line" ]]; then
+        test_pass
+    else
+        test_fail "expected heuristics.sh sourced after parallel.sh (parallel=$p_line heuristics=$h_line)"
+    fi
+}
+
+test_heuristics_no_bare_gemini_synthesis() {
+    test_case "heuristics.sh aggregate_results/synthesize_probe_results no longer dispatch the bare gemini CLI"
+    if grep -Eq 'run_with_timeout +"\$TIMEOUT" +gemini|run_agent_sync +"gemini"' "$HEUR_LIB"; then
+        test_fail "stale gemini synthesis dispatch still present in heuristics.sh"
+    else
+        test_pass
+    fi
+}
+
+test_both_aggregate_results_route_agy() {
+    test_case "both aggregate_results copies route synthesis through run_agent_sync (shadow is harmless)"
+    # Whichever copy wins at runtime, neither may pipe synthesis to a bare gemini.
+    if grep -q 'run_agent_sync "\$synth_agent"' "$HEUR_LIB" \
+       && grep -q 'run_agent_sync "\$synth_agent"' "$PARALLEL_LIB"; then
+        test_pass
+    else
+        test_fail "one of the aggregate_results copies does not route through run_agent_sync"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Functional: source BOTH libs in runtime order, then drive aggregate_results.
+# The active definition is heuristics.sh's; _aggregate_pick_synth_agent comes
+# from parallel.sh (sourced first), exactly as at runtime.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_run_runtime_aggregate() {
+    # $1 = "agy" (fake agy present) or "none"
+    local mode="$1" workdir hbin
+    workdir=$(mktemp -d "${TEST_TMP_DIR}/wd.XXXXXX")
+    hbin="$workdir/hbin"; mkdir -p "$hbin" "$workdir/results"
+    [[ "$mode" == "agy" ]] && { printf '#!/bin/sh\necho agy\n' > "$hbin/agy"; chmod +x "$hbin/agy"; }
+    printf 'Result A\n' > "$workdir/results/codex-probe-1.md"
+    printf 'Result B\n' > "$workdir/results/agy-probe-2.md"
+
+    # Prepend the fake CLI dir; keep the real PATH so coreutils resolve. agy is
+    # checked first by the picker, so the choice is deterministic regardless of
+    # whether the host has gemini.
+    PROJECT_ROOT="$PROJECT_ROOT" WORKDIR="$workdir" HBIN="$hbin" MODE="$mode" bash -c '
+        set -uo pipefail
+        export PATH="$HBIN:$PATH"
+        RESULTS_DIR="$WORKDIR/results"; DRY_RUN=false; TIMEOUT=30; GREEN=""; NC=""
+        source "$PROJECT_ROOT/scripts/lib/parallel.sh"
+        source "$PROJECT_ROOT/scripts/lib/heuristics.sh"   # runtime order: this wins
+        # Stub deps after sourcing so our versions win (functions resolve at call time)
+        log() { :; }
+        guard_output() { :; }
+        probe_result_file_is_usable() { return 0; }
+        rank_results_by_signals() { printf "%s\n%s\n" "$RESULTS_DIR/codex-probe-1.md" "$RESULTS_DIR/agy-probe-2.md"; }
+        score_result_file() { echo 80; }
+        run_agent_sync() { echo "SYNTH_AGENT=$1" >> "$WORKDIR/agent.log"; echo "SYNTH BODY via $1"; }
+        aggregate_results >/dev/null 2>&1
+        echo "=== AGG ==="; cat "$RESULTS_DIR"/aggregate-*.md 2>/dev/null || true
+        echo "=== LOG ==="; cat "$WORKDIR/agent.log" 2>/dev/null || true
+    '
+    rm -rf "$workdir"
+}
+
+test_runtime_aggregate_synthesizes_via_agy() {
+    test_case "runtime aggregate_results (heuristics.sh) synthesizes via agy, not concatenation"
+    local out; out="$(_run_runtime_aggregate agy)"
+    if [[ "$out" == *"Synthesized Results"* ]] \
+       && [[ "$out" == *"Synthesizer: agy"* ]] \
+       && [[ "$out" == *"SYNTH_AGENT=agy"* ]] \
+       && [[ "$out" != *"Aggregated Results"* ]]; then
+        test_pass
+    else
+        test_fail "expected runtime synthesis via agy, got:\n$out"
+    fi
+}
+
+test_heuristics_is_sourced_after_parallel
+test_heuristics_no_bare_gemini_synthesis
+test_both_aggregate_results_route_agy
+test_runtime_aggregate_synthesizes_via_agy
+
+test_summary

--- a/tests/unit/test-agy-parallel-synthesis.sh
+++ b/tests/unit/test-agy-parallel-synthesis.sh
@@ -79,7 +79,11 @@ test_embrace_dispatch_seats_agy() {
 # ─────────────────────────────────────────────────────────────────────────────
 
 _run_aggregate_scenario() {
-    # $1 = "agy" to install a fake agy CLI, "none" to install none
+    # $1 = scenario:
+    #   "agy"       install a fake agy CLI (agy synthesizes)
+    #   "agy-fails" install fake agy + claude CLIs; the run_agent_sync stub fails
+    #              for agy so aggregate_results must retry via claude-sonnet
+    #   "none"      install neither (forces concatenation)
     local mode="$1"
     local workdir hbin
     workdir=$(mktemp -d "${TEST_TMP_DIR}/wd.XXXXXX")
@@ -90,15 +94,24 @@ _run_aggregate_scenario() {
     for b in date cat basename rm mkdir ln; do
         p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"
     done
-    if [[ "$mode" == "agy" ]]; then
+    if [[ "$mode" == "agy" || "$mode" == "agy-fails" ]]; then
         printf '#!/bin/sh\necho agy-output\n' > "$hbin/agy"
         chmod +x "$hbin/agy"
     fi
+    # The claude-sonnet retry branch gates on `command -v claude`; provide it so
+    # the agy-failure path can fall through to claude-sonnet.
+    if [[ "$mode" == "agy-fails" ]]; then
+        printf '#!/bin/sh\necho claude-output\n' > "$hbin/claude"
+        chmod +x "$hbin/claude"
+    fi
+    # Agent whose run_agent_sync stub should fail (empty/non-zero), or empty.
+    local fail_agent=""
+    [[ "$mode" == "agy-fails" ]] && fail_agent="agy"
 
     printf 'Result A: problem analysis content\n' > "$workdir/results/codex-probe-1.md"
     printf 'Result B: solution research content\n' > "$workdir/results/agy-probe-2.md"
 
-    PROJECT_ROOT="$PROJECT_ROOT" WORKDIR="$workdir" HBIN="$hbin" bash -c '
+    PROJECT_ROOT="$PROJECT_ROOT" WORKDIR="$workdir" HBIN="$hbin" FAIL_AGENT="$fail_agent" bash -c '
         set -euo pipefail
         export PATH="$HBIN"
         RESULTS_DIR="$WORKDIR/results"
@@ -114,6 +127,7 @@ _run_aggregate_scenario() {
         score_result_file() { echo 80; }
         run_agent_sync() {
             echo "SYNTH_AGENT=$1" >> "$WORKDIR/agent.log"
+            if [ -n "${FAIL_AGENT:-}" ] && [ "$1" = "$FAIL_AGENT" ]; then return 1; fi
             echo "SYNTHESIZED BODY via $1"
         }
         source "$PROJECT_ROOT/scripts/lib/parallel.sh"
@@ -153,11 +167,28 @@ test_aggregator_concatenates_when_no_provider() {
     fi
 }
 
+test_aggregator_retries_claude_sonnet_when_agy_fails() {
+    test_case "aggregate_results retries via claude-sonnet (not concatenation) when the agy synthesizer fails"
+    local out
+    out="$(_run_aggregate_scenario agy-fails)"
+    # agy must be attempted first, then claude-sonnet must produce the synthesis
+    if [[ "$out" == *"Synthesized Results"* ]] \
+       && [[ "$out" == *"Synthesizer: claude-sonnet"* ]] \
+       && [[ "$out" == *"SYNTH_AGENT=agy"* ]] \
+       && [[ "$out" == *"SYNTH_AGENT=claude-sonnet"* ]] \
+       && [[ "$out" != *"Aggregated Results"* ]]; then
+        test_pass
+    else
+        test_fail "expected claude-sonnet retry synthesis after agy failure, got:\n$out"
+    fi
+}
+
 test_no_bare_gemini_synthesis_in_parallel
 test_parallel_routes_through_run_agent_sync
 test_picker_prefers_agy
 test_embrace_dispatch_seats_agy
 test_aggregator_selects_agy_when_available
 test_aggregator_concatenates_when_no_provider
+test_aggregator_retries_claude_sonnet_when_agy_fails
 
 test_summary

--- a/tests/unit/test-agy-parallel-synthesis.sh
+++ b/tests/unit/test-agy-parallel-synthesis.sh
@@ -183,6 +183,41 @@ test_aggregator_retries_claude_sonnet_when_agy_fails() {
     fi
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Allowlist authorization — the picker must not fall back to claude-sonnet when
+# OCTO_ALLOWED_PROVIDERS excludes it (probe context must not reach a disabled
+# provider). Hermetic PATH: fake claude present, agy absent, no real PATH.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_pick_with_allowlist() {
+    # $1 = OCTO_ALLOWED_PROVIDERS value ("" = unset/allow-all)
+    local allow="$1" workdir hbin b p
+    workdir=$(mktemp -d "${TEST_TMP_DIR}/wd.XXXXXX"); hbin="$workdir/hbin"; mkdir -p "$hbin"
+    for b in tr sed cat basename; do p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"; done
+    printf '#!/bin/sh\necho claude\n' > "$hbin/claude"; chmod +x "$hbin/claude"  # claude present, agy absent
+    PROJECT_ROOT="$PROJECT_ROOT" HBIN="$hbin" ALLOW="$allow" bash -c '
+        set -uo pipefail
+        export PATH="$HBIN"                       # hermetic — agy deliberately absent
+        export OCTO_ALLOWED_PROVIDERS="$ALLOW"
+        source "$PROJECT_ROOT/scripts/lib/provider-allowlist.sh"
+        source "$PROJECT_ROOT/scripts/lib/parallel.sh"
+        _aggregate_pick_synth_agent
+    '
+    rm -rf "$workdir"
+}
+
+test_picker_withholds_claude_when_allowlist_excludes_it() {
+    test_case "_aggregate_pick_synth_agent returns empty (no claude-sonnet) when allowlist=agy and agy is unavailable"
+    local out; out="$(_pick_with_allowlist "agy")"
+    [[ -z "$out" ]] && test_pass || test_fail "expected empty pick (claude disallowed), got: '$out'"
+}
+
+test_picker_allows_claude_when_permitted() {
+    test_case "_aggregate_pick_synth_agent returns claude-sonnet when the allowlist permits claude"
+    local out; out="$(_pick_with_allowlist "claude")"
+    [[ "$out" == "claude-sonnet" ]] && test_pass || test_fail "expected claude-sonnet, got: '$out'"
+}
+
 test_no_bare_gemini_synthesis_in_parallel
 test_parallel_routes_through_run_agent_sync
 test_picker_prefers_agy
@@ -190,5 +225,7 @@ test_embrace_dispatch_seats_agy
 test_aggregator_selects_agy_when_available
 test_aggregator_concatenates_when_no_provider
 test_aggregator_retries_claude_sonnet_when_agy_fails
+test_picker_withholds_claude_when_allowlist_excludes_it
+test_picker_allows_claude_when_permitted
 
 test_summary

--- a/tests/unit/test-agy-parallel-synthesis.sh
+++ b/tests/unit/test-agy-parallel-synthesis.sh
@@ -196,7 +196,7 @@ _pick_with_allowlist() {
     for b in tr sed cat basename; do p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"; done
     printf '#!/bin/sh\necho claude\n' > "$hbin/claude"; chmod +x "$hbin/claude"  # claude present, agy absent
     PROJECT_ROOT="$PROJECT_ROOT" HBIN="$hbin" ALLOW="$allow" bash -c '
-        set -uo pipefail
+        set -euo pipefail
         export PATH="$HBIN"                       # hermetic — agy deliberately absent
         export OCTO_ALLOWED_PROVIDERS="$ALLOW"
         source "$PROJECT_ROOT/scripts/lib/provider-allowlist.sh"

--- a/tests/unit/test-agy-parallel-synthesis.sh
+++ b/tests/unit/test-agy-parallel-synthesis.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Regression tests for the agy migration in the parallel fan-out aggregator.
+#
+# The v9.45.0 agy migration (#524) updated the Double-Diamond phase synthesizers
+# in workflows.sh but missed scripts/lib/parallel.sh, which hard-coded synthesis
+# to the literal `gemini` CLI and degraded to plain concatenation whenever the
+# (now sunset, 2026-06-18) Gemini CLI was absent. These tests pin the fix:
+#   1. parallel.sh routes synthesis through the agy-capable run_agent_sync
+#      abstraction and SELECTS agy (not concatenation) when agy is available.
+#   2. embrace.sh get_dispatch_strategy seats agy in the probe/discover fan-out.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "agy is the synthesizer/Google seat in the parallel aggregator (Gemini CLI sunset 2026-06-18)"
+
+PARALLEL_LIB="$PROJECT_ROOT/scripts/lib/parallel.sh"
+EMBRACE_LIB="$PROJECT_ROOT/scripts/lib/embrace.sh"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Static assertions
+# ─────────────────────────────────────────────────────────────────────────────
+
+test_no_bare_gemini_synthesis_in_parallel() {
+    test_case "parallel.sh no longer pipes synthesis to the bare gemini CLI"
+    if grep -Eq 'run_with_timeout +"\$TIMEOUT" +gemini' "$PARALLEL_LIB"; then
+        test_fail "stale 'run_with_timeout \$TIMEOUT gemini' synthesis still present in parallel.sh"
+    else
+        test_pass
+    fi
+}
+
+test_parallel_routes_through_run_agent_sync() {
+    test_case "parallel.sh aggregate_results synthesizes via run_agent_sync + agy picker"
+    if grep -q '_aggregate_pick_synth_agent' "$PARALLEL_LIB" \
+       && grep -q 'run_agent_sync "\$synth_agent"' "$PARALLEL_LIB"; then
+        test_pass
+    else
+        test_fail "parallel.sh does not route synthesis through run_agent_sync/_aggregate_pick_synth_agent"
+    fi
+}
+
+test_picker_prefers_agy() {
+    test_case "_aggregate_pick_synth_agent prefers agy over the claude-sonnet fallback"
+    # agy listed before claude-sonnet in the picker body
+    local body
+    body=$(awk '/^_aggregate_pick_synth_agent\(\)/{f=1} f{print} /^}/{if(f)exit}' "$PARALLEL_LIB")
+    if [[ "$body" == *'echo "agy"'* && "$body" == *'echo "claude-sonnet"'* ]] \
+       && [[ "$(echo "$body" | grep -n 'echo "agy"' | head -1 | cut -d: -f1)" \
+             -lt "$(echo "$body" | grep -n 'echo "claude-sonnet"' | head -1 | cut -d: -f1)" ]]; then
+        test_pass
+    else
+        test_fail "picker does not prefer agy ahead of claude-sonnet"
+    fi
+}
+
+test_embrace_dispatch_seats_agy() {
+    test_case "embrace.sh get_dispatch_strategy detects and seats agy"
+    if grep -q 'has_agy=true' "$EMBRACE_LIB" \
+       && grep -q 'cli_providers+=(agy)' "$EMBRACE_LIB" \
+       && grep -q '"2:agy,claude-sonnet:high"' "$EMBRACE_LIB"; then
+        test_pass
+    else
+        test_fail "get_dispatch_strategy does not seat agy (probe/discover would still skip it)"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Functional assertion — drive aggregate_results in a hermetic env
+#
+# A fresh bash sources parallel.sh, stubs the surrounding lib helpers, and points
+# PATH at a temp dir holding ONLY coreutils plus (optionally) a fake `agy`. This
+# makes the gemini and claude CLIs deterministically absent regardless of the
+# host, so the picker's choice is unambiguous. run_agent_sync is stubbed to log
+# which agent synthesis used.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_run_aggregate_scenario() {
+    # $1 = "agy" to install a fake agy CLI, "none" to install none
+    local mode="$1"
+    local workdir hbin
+    workdir=$(mktemp -d)
+    hbin="$workdir/hbin"
+    mkdir -p "$hbin" "$workdir/results"
+
+    local b p
+    for b in date cat basename rm mkdir ln; do
+        p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"
+    done
+    if [[ "$mode" == "agy" ]]; then
+        printf '#!/bin/sh\necho agy-output\n' > "$hbin/agy"
+        chmod +x "$hbin/agy"
+    fi
+
+    printf 'Result A: problem analysis content\n' > "$workdir/results/codex-probe-1.md"
+    printf 'Result B: solution research content\n' > "$workdir/results/agy-probe-2.md"
+
+    PROJECT_ROOT="$PROJECT_ROOT" WORKDIR="$workdir" HBIN="$hbin" bash -c '
+        set -uo pipefail
+        export PATH="$HBIN"
+        RESULTS_DIR="$WORKDIR/results"
+        DRY_RUN=false
+        TIMEOUT=30
+        GREEN=""; NC=""
+        # Stubs for helpers that live in sibling libs (not sourced here)
+        log() { :; }
+        guard_output() { :; }
+        rank_results_by_signals() {
+            printf "%s\n%s\n" "$RESULTS_DIR/codex-probe-1.md" "$RESULTS_DIR/agy-probe-2.md"
+        }
+        score_result_file() { echo 80; }
+        run_agent_sync() {
+            echo "SYNTH_AGENT=$1" >> "$WORKDIR/agent.log"
+            echo "SYNTHESIZED BODY via $1"
+        }
+        source "$PROJECT_ROOT/scripts/lib/parallel.sh"
+        aggregate_results >/dev/null 2>&1
+        echo "=== AGGREGATE ==="
+        cat "$RESULTS_DIR"/aggregate-*.md 2>/dev/null || true
+        echo "=== AGENTLOG ==="
+        cat "$WORKDIR/agent.log" 2>/dev/null || true
+    '
+    rm -rf "$workdir"
+}
+
+test_aggregator_selects_agy_when_available() {
+    test_case "aggregate_results SYNTHESIZES via agy (not concatenation) when gemini is missing but agy is available"
+    local out
+    out="$(_run_aggregate_scenario agy)"
+    if [[ "$out" == *"Synthesized Results"* ]] \
+       && [[ "$out" == *"Synthesizer: agy"* ]] \
+       && [[ "$out" == *"SYNTH_AGENT=agy"* ]] \
+       && [[ "$out" != *"Aggregated Results"* ]]; then
+        test_pass
+    else
+        test_fail "expected agy-synthesized aggregate, got:\n$out"
+    fi
+}
+
+test_aggregator_concatenates_when_no_provider() {
+    test_case "aggregate_results falls back to concatenation when NO synthesis provider is reachable"
+    local out
+    out="$(_run_aggregate_scenario none)"
+    if [[ "$out" == *"Aggregated Results"* ]] \
+       && [[ "$out" != *"Synthesized Results"* ]] \
+       && [[ "$out" != *"SYNTH_AGENT="* ]]; then
+        test_pass
+    else
+        test_fail "expected plain concatenation with no provider, got:\n$out"
+    fi
+}
+
+test_no_bare_gemini_synthesis_in_parallel
+test_parallel_routes_through_run_agent_sync
+test_picker_prefers_agy
+test_embrace_dispatch_seats_agy
+test_aggregator_selects_agy_when_available
+test_aggregator_concatenates_when_no_provider
+
+test_summary

--- a/tests/unit/test-agy-parallel-synthesis.sh
+++ b/tests/unit/test-agy-parallel-synthesis.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 
 # Regression tests for the agy migration in the parallel fan-out aggregator.
 #
@@ -82,7 +82,7 @@ _run_aggregate_scenario() {
     # $1 = "agy" to install a fake agy CLI, "none" to install none
     local mode="$1"
     local workdir hbin
-    workdir=$(mktemp -d)
+    workdir=$(mktemp -d "${TEST_TMP_DIR}/wd.XXXXXX")
     hbin="$workdir/hbin"
     mkdir -p "$hbin" "$workdir/results"
 
@@ -99,7 +99,7 @@ _run_aggregate_scenario() {
     printf 'Result B: solution research content\n' > "$workdir/results/agy-probe-2.md"
 
     PROJECT_ROOT="$PROJECT_ROOT" WORKDIR="$workdir" HBIN="$hbin" bash -c '
-        set -uo pipefail
+        set -euo pipefail
         export PATH="$HBIN"
         RESULTS_DIR="$WORKDIR/results"
         DRY_RUN=false

--- a/tests/unit/test-provider-allowlist.sh
+++ b/tests/unit/test-provider-allowlist.sh
@@ -39,6 +39,26 @@ else
     test_fail "allowlist did not honor comma/space separated provider names"
 fi
 
+# #524: agy (Antigravity) is the Google seat after the Gemini CLI sunset. A legacy
+# "google" allowlist must keep authorizing agy during/after migration.
+test_case "legacy 'google' allowlist authorizes agy (Google seat) and gemini, not codex"
+if OCTO_ALLOWED_PROVIDERS="google" octo_provider_allowed agy &&
+   OCTO_ALLOWED_PROVIDERS="google" octo_provider_allowed agy-research &&
+   OCTO_ALLOWED_PROVIDERS="google" octo_provider_allowed gemini &&
+   ! OCTO_ALLOWED_PROVIDERS="google" octo_provider_allowed codex; then
+    test_pass
+else
+    test_fail "'google' alias should authorize agy + gemini (Google seat) but not codex"
+fi
+
+test_case "bare 'gemini' allowlist authorizes only the Gemini CLI, not agy"
+if OCTO_ALLOWED_PROVIDERS="gemini" octo_provider_allowed gemini &&
+   ! OCTO_ALLOWED_PROVIDERS="gemini" octo_provider_allowed agy; then
+    test_pass
+else
+    test_fail "'gemini' token must not authorize agy"
+fi
+
 session_config="$TEST_TMP_DIR/provider-allowlist-config"
 
 test_case "session allowlist file filters providers without env var"


### PR DESCRIPTION
## Summary

The v9.45.0 agy migration (#524, "agy = default Google seat across multi-LLM workflows, Gemini CLI sunset") updated the Double-Diamond **phase** synthesizers in `scripts/lib/workflows.sh`, but missed two other seats. This PR completes the migration.

### 1. `parallel.sh` synthesis now routes through the agy-capable abstraction
`aggregate_results()` hard-coded synthesis to the literal `gemini` CLI:
```bash
synthesis_result=$(printf '%s' "$synthesis_prompt" | run_with_timeout "$TIMEOUT" gemini 2>/dev/null)
```
When the Gemini CLI was absent this couldn't substitute agy — it degraded straight to plain concatenation. It now selects a synthesizer via a new `_aggregate_pick_synth_agent()` helper (**agy → claude-sonnet**) and runs through `run_agent_sync … "synthesizer" "parallel"`, mirroring the workflows.sh phase synthesizers. Plain concatenation is now the **final** fallback, used only when no synthesis provider is reachable. Output gains a `Synthesizer:` attribution line.

### 2. Probe/discover fan-out now seats agy
The probe/discover seats come from `get_dispatch_strategy()` in `scripts/lib/embrace.sh` (not `parallel.sh`'s `fan_out`). It detected codex/gemini/copilot/qwen/cursor-agent but **never agy**, so Antigravity-only setups fell back to Claude-only dispatch ("Antigravity works but the probe step doesn't route to it"). This adds `has_agy` detection (canonical `command -v agy` + `octo_provider_allowed` gate), seats agy in `cli_providers` and the single-provider fallbacks across the `full`/`minimal`/`review`/`security`/`research` strategies, and lowers the review/security multi-seat threshold from `>=3` to `>=2`.

Verified:
- `research` agy-only → `2:agy,claude-sonnet:high`
- `research` agy+codex → `3:codex,agy,claude-sonnet:high`

### 3. Stale gemini-era naming cleanup
In the embrace debate gate (`workflows.sh`): `gemini_view`/`gemini_status` (which held **agy** output after the #524 swap) → `agy_view`/`agy_status`, plus the `Gemini:` / `### Gemini` labels and the `write_structured_decision` status string. Also fixed a directly-mislabeled grasp warning ("Gemini failed…" → "Antigravity (agy) failed…") and two dry-run narration lines.

### 4. Test
New `tests/unit/test-agy-parallel-synthesis.sh` (6/6): static assertions (no bare-gemini synthesis remains; routes via `run_agent_sync`; picker prefers agy; embrace seats agy) **plus** a hermetic functional test driving `aggregate_results` with a fake `agy` on a controlled PATH — asserts it **synthesizes via agy, not concatenation** when gemini is missing but agy is available, and concatenates only when no provider is reachable.

## Verification
- `bash -n` clean on all three libs.
- New test 6/6. Existing suites pass: `test-agy-workflow-routing` (4/4), `test-agy-provider` (31/31), `test-fleet-diversity` (36/36), `test-routing-features-consumers` (15/15), `test-output-guard` (6/6), `test-fleet-dispatch-guard` (4/4).
- One pre-existing failure in `test-provider-activation.sh` (test 2.2, a brittle context-window grep) — confirmed it fails identically on `main`, **not** caused by this change.

## Notes for reviewers
- Out of scope (flagged as follow-up): `parallel.sh`'s `map_reduce()` decomposition (raw `gemini`) and the `fan_out`/`map_reduce` default `("codex" "gemini")` pairs are the same gemini-era class but a distinct concern (decomposition, not synthesis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded provider selection to prioritize Antigravity/agy across dispatch strategies and parallel result/probe synthesis.
  * Updated the “embrace” workflow’s logged perspectives and debate/probe artifacts to reflect agy instead of Gemini, including retry behavior with claude-sonnet when needed.

* **Bug Fixes**
  * Corrected dispatch threshold logic for review/security and added explicit agy-based fallback outputs when criteria aren’t met.
  * Improved provider allowlist handling so legacy “google” authorization continues to cover agy/antigravity and Gemini as intended.

* **Tests**
  * Added regression/unit coverage for agy synthesis routing and allowlist alias behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->