### PR TITLE
fix: migrate parallel.sh map_reduce/fan_out off the sunset Gemini CLI (#524 follow-up)

### DIFF
--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -33,6 +33,22 @@ _fan_out_agents_from_config() {
     ' "$config_file" 2>/dev/null || true
 }
 
+# Resolve the preferred non-Codex dispatch seat for fan-out / map-reduce.
+# The Gemini CLI was sunset 2026-06-18; agy (Antigravity) is the default Google
+# seat (#524). Order: agy → gemini (legacy, only when still installed, to
+# preserve behavior for existing setups) → claude-sonnet (always available in
+# Claude Code). Always echoes a usable agent.
+_parallel_google_seat() {
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed agy; } \
+        && command -v agy >/dev/null 2>&1; then
+        echo "agy"; return 0
+    fi
+    if command -v gemini >/dev/null 2>&1; then
+        echo "gemini"; return 0
+    fi
+    echo "claude-sonnet"; return 0
+}
+
 fan_out() {
     local prompt="$1"
     local agents=()
@@ -55,8 +71,9 @@ fan_out() {
         done <<< "$_configured"
     fi
 
-    # Fallback to original default pair when config absent or all entries invalid
-    [[ ${#agents[@]} -eq 0 ]] && agents=("codex" "gemini")
+    # Fallback to default pair when config absent or all entries invalid.
+    # Second seat prefers agy (Google seat) over the sunset Gemini CLI (#524).
+    [[ ${#agents[@]} -eq 0 ]] && agents=("codex" "$(_parallel_google_seat)")
 
     log INFO "Fan-out: Sending prompt to ${#agents[@]} agents (${agents[*]})"
     echo ""
@@ -255,7 +272,7 @@ map_reduce() {
 
     log INFO "Map-Reduce: Decomposing task and distributing to agents"
 
-    log INFO "Phase 1: Task decomposition with Gemini"
+    log INFO "Phase 1: Task decomposition"
     local decompose_prompt="Analyze this task and break it into subtasks that can be executed in parallel.
 If the task produces a single deliverable (one file, one script, one page, one config), keep it as ONE subtask — do not split it. Only decompose when subtasks are truly independent with no cross-file references. Aim for 2-5 subtasks; fewer is better when the work is tightly coupled.
 Output as a simple numbered list. Task: $main_prompt"
@@ -267,11 +284,32 @@ Output as a simple numbered list. Task: $main_prompt"
         return 0
     fi
 
-    gemini "$decompose_prompt" > "$decompose_result" 2>&1 || {
-        log WARN "Decomposition failed, falling back to fan-out"
+    # Route decomposition through the agy-capable run_agent_sync abstraction
+    # (Gemini CLI sunset 2026-06-18; agy is the Google seat, #524), mirroring
+    # aggregate_results' synthesis path. claude-sonnet is the fallback; a plain
+    # fan-out is the last resort when no decomposition agent succeeds.
+    if type run_agent_sync >/dev/null 2>&1; then
+        local decompose_agent decompose_output=""
+        decompose_agent=$(_parallel_google_seat)
+        log INFO "Decomposing with $decompose_agent"
+        if decompose_output=$(run_agent_sync "$decompose_agent" "$decompose_prompt" "${TIMEOUT:-120}" "decompose" "parallel" 2>/dev/null) \
+            && [[ -n "$decompose_output" ]]; then
+            printf '%s\n' "$decompose_output" > "$decompose_result"
+        elif [[ "$decompose_agent" != "claude-sonnet" ]] \
+            && decompose_output=$(run_agent_sync "claude-sonnet" "$decompose_prompt" "${TIMEOUT:-120}" "decompose" "parallel" 2>/dev/null) \
+            && [[ -n "$decompose_output" ]]; then
+            log WARN "Decomposition via '$decompose_agent' failed — used claude-sonnet fallback"
+            printf '%s\n' "$decompose_output" > "$decompose_result"
+        else
+            log WARN "Decomposition failed, falling back to fan-out"
+            fan_out "$main_prompt"
+            return
+        fi
+    else
+        log WARN "run_agent_sync unavailable, falling back to fan-out"
         fan_out "$main_prompt"
         return
-    }
+    fi
 
     log INFO "Decomposition complete. Subtasks:"
     cat "$decompose_result"
@@ -279,7 +317,8 @@ Output as a simple numbered list. Task: $main_prompt"
 
     log INFO "Phase 2: Mapping subtasks to agents"
     local subtask_num=0
-    local agents=("codex" "gemini")
+    # Second seat prefers agy (Google seat) over the sunset Gemini CLI (#524)
+    local agents=("codex" "$(_parallel_google_seat)")
     local pids=()
 
     while IFS= read -r line; do

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -43,7 +43,8 @@ _parallel_google_seat() {
         && command -v agy >/dev/null 2>&1; then
         echo "agy"; return 0
     fi
-    if command -v gemini >/dev/null 2>&1; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed gemini; } \
+        && command -v gemini >/dev/null 2>&1; then
         echo "gemini"; return 0
     fi
     echo "claude-sonnet"; return 0

--- a/tests/unit/test-agy-parallel-decompose.sh
+++ b/tests/unit/test-agy-parallel-decompose.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Regression tests for the agy migration of parallel.sh map_reduce/fan_out.
+#
+# The v9.45.0 agy migration (#524, Gemini CLI sunset 2026-06-18) left Gemini-CLI
+# dispatch in the parallel primitives: map_reduce() decomposed tasks with the
+# bare `gemini` binary and both fan_out()/map_reduce() defaulted their second
+# dispatch seat to `gemini`. When the (sunset) Gemini CLI is absent these paths
+# break or skip agy. These tests pin the fix:
+#   1. _parallel_google_seat() prefers agy, keeps gemini when still installed,
+#      and falls back to claude-sonnet.
+#   2. map_reduce() decomposition routes through run_agent_sync (agy), not the
+#      bare gemini CLI.
+#   3. fan_out()/map_reduce() default pairs prefer agy over gemini.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "agy is the Google seat in parallel.sh map_reduce/fan_out (Gemini CLI sunset 2026-06-18)"
+
+PARALLEL_LIB="$PROJECT_ROOT/scripts/lib/parallel.sh"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Static assertions
+# ─────────────────────────────────────────────────────────────────────────────
+
+test_no_bare_gemini_decompose() {
+    test_case "map_reduce no longer decomposes with the bare gemini CLI"
+    if grep -Eq 'gemini +"\$decompose_prompt"' "$PARALLEL_LIB"; then
+        test_fail "stale 'gemini \$decompose_prompt' decomposition still present"
+    else
+        test_pass
+    fi
+}
+
+test_decompose_routes_run_agent_sync() {
+    test_case "map_reduce decomposition routes through run_agent_sync + _parallel_google_seat"
+    if grep -q '_parallel_google_seat' "$PARALLEL_LIB" \
+       && grep -q 'run_agent_sync "\$decompose_agent"' "$PARALLEL_LIB"; then
+        test_pass
+    else
+        test_fail "decomposition does not route through run_agent_sync/_parallel_google_seat"
+    fi
+}
+
+test_default_pairs_use_google_seat() {
+    test_case "fan_out and map_reduce default pairs use _parallel_google_seat (not hard-coded gemini)"
+    local hits
+    hits=$(grep -c 'agents=("codex" "\$(_parallel_google_seat)")' "$PARALLEL_LIB")
+    if [[ "$hits" -ge 2 ]] && ! grep -q 'agents=("codex" "gemini")' "$PARALLEL_LIB"; then
+        test_pass
+    else
+        test_fail "expected 2 google-seat default pairs and no hard-coded codex/gemini pair (found $hits)"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unit: _parallel_google_seat preference order (hermetic PATH)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_seat_with_clis() {
+    # $@ = CLI names to install as fakes on a hermetic PATH; echoes the seat
+    local workdir hbin b p cli
+    workdir=$(mktemp -d); hbin="$workdir/hbin"; mkdir -p "$hbin"
+    for b in cat basename; do p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"; done
+    for cli in "$@"; do printf '#!/bin/sh\necho ok\n' > "$hbin/$cli"; chmod +x "$hbin/$cli"; done
+    PROJECT_ROOT="$PROJECT_ROOT" HBIN="$hbin" bash -c '
+        set -uo pipefail
+        export PATH="$HBIN"
+        source "$PROJECT_ROOT/scripts/lib/parallel.sh"
+        _parallel_google_seat
+    '
+    rm -rf "$workdir"
+}
+
+test_seat_prefers_agy() {
+    test_case "_parallel_google_seat returns agy when agy is available"
+    local out; out="$(_seat_with_clis agy gemini)"
+    [[ "$out" == "agy" ]] && test_pass || test_fail "expected agy, got: $out"
+}
+
+test_seat_keeps_gemini_when_no_agy() {
+    test_case "_parallel_google_seat keeps gemini when agy absent but gemini still installed"
+    local out; out="$(_seat_with_clis gemini)"
+    [[ "$out" == "gemini" ]] && test_pass || test_fail "expected gemini, got: $out"
+}
+
+test_seat_claude_fallback() {
+    test_case "_parallel_google_seat falls back to claude-sonnet when neither agy nor gemini present"
+    local out; out="$(_seat_with_clis)"
+    [[ "$out" == "claude-sonnet" ]] && test_pass || test_fail "expected claude-sonnet, got: $out"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Functional: drive map_reduce / fan_out in a hermetic env with a fake agy.
+# run_agent_sync and spawn_agent_capture_pid are stubbed to record which agent
+# each path selected; the bare gemini CLI is deliberately absent from PATH.
+# ─────────────────────────────────────────────────────────────────────────────
+
+test_mapreduce_decomposes_via_agy() {
+    test_case "map_reduce decomposes via run_agent_sync(agy) and seats agy in the subtask rotation"
+    local workdir hbin b p out
+    workdir=$(mktemp -d); hbin="$workdir/hbin"; mkdir -p "$hbin" "$workdir/results"
+    for b in date cat basename rm mkdir sed; do p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"; done
+    printf '#!/bin/sh\necho ok\n' > "$hbin/agy"; chmod +x "$hbin/agy"   # agy present, gemini absent
+
+    out="$(PROJECT_ROOT="$PROJECT_ROOT" WORKDIR="$workdir" HBIN="$hbin" bash -c '
+        set -uo pipefail
+        export PATH="$HBIN"
+        RESULTS_DIR="$WORKDIR/results"; DRY_RUN=false; TIMEOUT=30; CYAN=""; NC=""
+        # Source FIRST, then override parallel.sh-defined functions (aggregate_results)
+        # plus the cross-lib helpers (log/run_agent_sync/spawn_agent_capture_pid).
+        source "$PROJECT_ROOT/scripts/lib/parallel.sh"
+        log() { :; }
+        aggregate_results() { :; }
+        run_agent_sync() { echo "DECOMPOSE_AGENT=$1" >> "$WORKDIR/ras.log"; printf "1. alpha subtask\n2. beta subtask\n"; }
+        spawn_agent_capture_pid() { echo "$1" >> "$WORKDIR/spawn.log"; echo 2147480000; }
+        map_reduce "build a thing" >/dev/null 2>&1
+        echo "=== RAS ==="; cat "$WORKDIR/ras.log" 2>/dev/null || true
+        echo "=== SPAWN ==="; cat "$WORKDIR/spawn.log" 2>/dev/null || true
+    ')"
+    rm -rf "$workdir"
+
+    if [[ "$out" == *"DECOMPOSE_AGENT=agy"* ]] \
+       && [[ "$out" != *"DECOMPOSE_AGENT=gemini"* ]] \
+       && [[ "$out" == *"codex"* ]] && [[ "$out" == *"agy"* ]]; then
+        test_pass
+    else
+        test_fail "expected decomposition via agy + agy in subtask rotation, got:\n$out"
+    fi
+}
+
+test_fanout_default_pair_prefers_agy() {
+    test_case "fan_out default pair is (codex, agy) when no wizard config and agy is available"
+    local workdir hbin b p out
+    workdir=$(mktemp -d); hbin="$workdir/hbin"; mkdir -p "$hbin" "$workdir/results"
+    for b in date cat basename rm mkdir tr; do p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"; done
+    printf '#!/bin/sh\necho ok\n' > "$hbin/agy"; chmod +x "$hbin/agy"   # agy present, gemini absent
+
+    out="$(PROJECT_ROOT="$PROJECT_ROOT" WORKDIR="$workdir" HBIN="$hbin" bash -c '
+        set -uo pipefail
+        export PATH="$HBIN"
+        RESULTS_DIR="$WORKDIR/results"; DRY_RUN=false; CYAN=""; NC=""
+        # Source FIRST, then override _fan_out_agents_from_config (defined in
+        # parallel.sh) to force the default-pair path, plus cross-lib stubs.
+        source "$PROJECT_ROOT/scripts/lib/parallel.sh"
+        log() { :; }
+        _fan_out_agents_from_config() { :; }   # force the default-pair path
+        spawn_agent_capture_pid() { echo "$1" >> "$WORKDIR/spawn.log"; echo 2147480000; }
+        fan_out "do work" >/dev/null 2>&1
+        cat "$WORKDIR/spawn.log" 2>/dev/null | tr "\n" " "
+    ')"
+    rm -rf "$workdir"
+
+    if [[ "$out" == *"codex"* ]] && [[ "$out" == *"agy"* ]] && [[ "$out" != *"gemini"* ]]; then
+        test_pass
+    else
+        test_fail "expected fan_out to spawn (codex, agy), got: $out"
+    fi
+}
+
+test_no_bare_gemini_decompose
+test_decompose_routes_run_agent_sync
+test_default_pairs_use_google_seat
+test_seat_prefers_agy
+test_seat_keeps_gemini_when_no_agy
+test_seat_claude_fallback
+test_mapreduce_decomposes_via_agy
+test_fanout_default_pair_prefers_agy
+
+test_summary

--- a/tests/unit/test-agy-parallel-decompose.sh
+++ b/tests/unit/test-agy-parallel-decompose.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 
 # Regression tests for the agy migration of parallel.sh map_reduce/fan_out.
 #
@@ -63,11 +63,11 @@ test_default_pairs_use_google_seat() {
 _seat_with_clis() {
     # $@ = CLI names to install as fakes on a hermetic PATH; echoes the seat
     local workdir hbin b p cli
-    workdir=$(mktemp -d); hbin="$workdir/hbin"; mkdir -p "$hbin"
+    workdir=$(mktemp -d "${TEST_TMP_DIR}/wd.XXXXXX"); hbin="$workdir/hbin"; mkdir -p "$hbin"
     for b in cat basename; do p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"; done
     for cli in "$@"; do printf '#!/bin/sh\necho ok\n' > "$hbin/$cli"; chmod +x "$hbin/$cli"; done
     PROJECT_ROOT="$PROJECT_ROOT" HBIN="$hbin" bash -c '
-        set -uo pipefail
+        set -euo pipefail
         export PATH="$HBIN"
         source "$PROJECT_ROOT/scripts/lib/parallel.sh"
         _parallel_google_seat
@@ -102,12 +102,12 @@ test_seat_claude_fallback() {
 test_mapreduce_decomposes_via_agy() {
     test_case "map_reduce decomposes via run_agent_sync(agy) and seats agy in the subtask rotation"
     local workdir hbin b p out
-    workdir=$(mktemp -d); hbin="$workdir/hbin"; mkdir -p "$hbin" "$workdir/results"
-    for b in date cat basename rm mkdir sed; do p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"; done
+    workdir=$(mktemp -d "${TEST_TMP_DIR}/wd.XXXXXX"); hbin="$workdir/hbin"; mkdir -p "$hbin" "$workdir/results"
+    for b in date cat basename rm mkdir sed sleep; do p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"; done
     printf '#!/bin/sh\necho ok\n' > "$hbin/agy"; chmod +x "$hbin/agy"   # agy present, gemini absent
 
     out="$(PROJECT_ROOT="$PROJECT_ROOT" WORKDIR="$workdir" HBIN="$hbin" bash -c '
-        set -uo pipefail
+        set -euo pipefail
         export PATH="$HBIN"
         RESULTS_DIR="$WORKDIR/results"; DRY_RUN=false; TIMEOUT=30; CYAN=""; NC=""
         # Source FIRST, then override parallel.sh-defined functions (aggregate_results)
@@ -123,9 +123,14 @@ test_mapreduce_decomposes_via_agy() {
     ')"
     rm -rf "$workdir"
 
+    # Scope the rotation assertion to the SPAWN section only — otherwise the
+    # DECOMPOSE_AGENT=agy line in the RAS section would satisfy *"agy"* even if a
+    # regression dropped agy from the spawned subtask pair (CodeRabbit, #539).
+    local spawn_section="${out##*=== SPAWN ===}"
     if [[ "$out" == *"DECOMPOSE_AGENT=agy"* ]] \
        && [[ "$out" != *"DECOMPOSE_AGENT=gemini"* ]] \
-       && [[ "$out" == *"codex"* ]] && [[ "$out" == *"agy"* ]]; then
+       && [[ "$spawn_section" == *"codex"* ]] && [[ "$spawn_section" == *"agy"* ]] \
+       && [[ "$spawn_section" != *"gemini"* ]]; then
         test_pass
     else
         test_fail "expected decomposition via agy + agy in subtask rotation, got:\n$out"
@@ -135,12 +140,12 @@ test_mapreduce_decomposes_via_agy() {
 test_fanout_default_pair_prefers_agy() {
     test_case "fan_out default pair is (codex, agy) when no wizard config and agy is available"
     local workdir hbin b p out
-    workdir=$(mktemp -d); hbin="$workdir/hbin"; mkdir -p "$hbin" "$workdir/results"
-    for b in date cat basename rm mkdir tr; do p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"; done
+    workdir=$(mktemp -d "${TEST_TMP_DIR}/wd.XXXXXX"); hbin="$workdir/hbin"; mkdir -p "$hbin" "$workdir/results"
+    for b in date cat basename rm mkdir tr sleep; do p=$(command -v "$b" 2>/dev/null) && ln -sf "$p" "$hbin/$b"; done
     printf '#!/bin/sh\necho ok\n' > "$hbin/agy"; chmod +x "$hbin/agy"   # agy present, gemini absent
 
     out="$(PROJECT_ROOT="$PROJECT_ROOT" WORKDIR="$workdir" HBIN="$hbin" bash -c '
-        set -uo pipefail
+        set -euo pipefail
         export PATH="$HBIN"
         RESULTS_DIR="$WORKDIR/results"; DRY_RUN=false; CYAN=""; NC=""
         # Source FIRST, then override _fan_out_agents_from_config (defined in


### PR DESCRIPTION
## Summary

Completes the agy migration (#524, "agy = default Google seat", Gemini CLI sunset 2026-06-18) in the parallel primitives. Three Gemini-CLI-era dispatch points remained in `scripts/lib/parallel.sh` that break or skip agy when the gemini binary is absent:

1. **`map_reduce()` decomposition** hard-coded `gemini "$decompose_prompt" > "$decompose_result"` — when gemini isn't installed this failed outright and degraded to a plain `fan_out`.
2. **`fan_out()`** defaulted its second dispatch seat to `gemini` (`agents=("codex" "gemini")`).
3. **`map_reduce()`** rotated subtasks over the same hard-coded `("codex" "gemini")` pair.

## Changes

- **New `_parallel_google_seat()` resolver** — `agy → gemini (legacy, only when still installed) → claude-sonnet`. This *prefers agy* (the Google seat) while *preserving behavior for setups that still have the Gemini CLI*, with a guaranteed claude-sonnet fallback.
- **Decomposition** now routes through the agy-capable `run_agent_sync … "decompose" "parallel"` abstraction (agy → claude-sonnet fallback → `fan_out` as last resort), mirroring how the synthesis path is being migrated. Guarded on `type run_agent_sync`; "Phase 1 … with Gemini" log relabeled.
- **Default pairs** in `fan_out()` and `map_reduce()` now use `("codex" "$(_parallel_google_seat)")`.

## Test — `tests/unit/test-agy-parallel-decompose.sh` (8/8)

Static assertions (no bare `gemini "$decompose_prompt"` remains; routes via `run_agent_sync` + `_parallel_google_seat`; default pairs use the resolver) **plus** hermetic functional tests:
- seat preference order: agy preferred; gemini kept when agy absent; claude-sonnet when neither;
- `map_reduce` decomposes via `run_agent_sync(agy)` **not** the bare gemini CLI, and seats agy in the subtask rotation;
- `fan_out`'s default pair resolves to `(codex, agy)` when agy is available and gemini is absent.

## Verification

- `bash -n` clean; new test 8/8.
- Regression: `test-routing-features-consumers` (15/15), `test-output-guard` (6/6), `test-agy-provider` (31/31), `test-agy-workflow-routing` (4/4).

## Notes for reviewers

- Scoped to decomposition + default dispatch pairs. The `aggregate_results()` **synthesis** path is migrated separately in #538; this branch is cut from `main`, so the two touch disjoint functions/lines and won't conflict. On this branch the synthesis path still shows the old gemini call (that's #538's fix).
- `_parallel_google_seat` is intentionally distinct from #538's `_aggregate_pick_synth_agent` (this resolver keeps gemini when still installed; the synthesis picker drops it). The two can be unified once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced task dispatch for fan-out and map-reduce to prefer a newer Google dispatch seat when available, with automatic fallback to the best remaining option.

* **Bug Fixes**
  * Improved decomposition routing to avoid Gemini-only fallback behavior and ensure more reliable agent selection when certain tools are missing.

* **Tests**
  * Added regression tests to verify seat-precedence rules and confirm decomposition uses the expected agent path, plus coverage for fan-out and map-reduce defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->