### PR TITLE
fix: replace stale tests/run-pre-push.sh refs with tests/run-all-tests.sh

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ How was this tested? Which test suites were run?
 
 ```bash
 # Run pre-push suite
-bash tests/run-pre-push.sh
+bash tests/run-all-tests.sh
 
 # Run specific test
 bash tests/unit/test-<name>.sh

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,5 +23,5 @@ structured Double Diamond workflows.
 
 ## Testing
 
-Run the pre-push test suite: `bash tests/run-pre-push.sh`
+Run the pre-push test suite: `bash tests/run-all-tests.sh`
 Run a single test: `bash tests/unit/test-<name>.sh`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,7 +44,7 @@ bash tests/unit/test-adapter-flags.sh
 scripts/build-openclaw.sh --check
 
 # Run full pre-push suite
-bash tests/run-pre-push.sh
+bash tests/run-all-tests.sh
 ```
 
 ## Making Changes
@@ -89,7 +89,7 @@ Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
 ### PR Checklist
 
 - [ ] Shell scripts pass `bash -n` check
-- [ ] Tests pass: `bash tests/run-pre-push.sh`
+- [ ] Tests pass: `bash tests/run-all-tests.sh`
 - [ ] Generated plugin-root skills/commands refreshed and `claude plugin validate .claude-plugin/plugin.json` passes
 - [ ] Documentation updated (if applicable)
 - [ ] CHANGELOG.md updated (for features/fixes)


### PR DESCRIPTION
## Root cause

`tests/run-pre-push.sh` was referenced in contributor docs and templates but has never existed in the repo. The actual main test entry point is `tests/run-all-tests.sh` (self-described as such in its header comment). Contributors following `docs/CONTRIBUTING.md` step-by-step hit a hard stop with `bash: tests/run-pre-push.sh: No such file or directory`.

## Fix

Four references across three files updated to point at the correct script:

| File | Location |
|------|----------|
| `docs/CONTRIBUTING.md` | "Run full pre-push suite" code block (line 47) |
| `docs/CONTRIBUTING.md` | PR checklist item (line 92) |
| `.github/PULL_REQUEST_TEMPLATE.md` | Testing section (line 26) |
| `.github/copilot-instructions.md` | Testing section (line 26) |

No logic changes. Docs-only fix.

## Verification

```
grep -rn "run-pre-push" . --include="*.md" --include="*.sh"
# (no output — all references removed)
```

Closes #505

---
_Generated by [Claude Code](https://claude.ai/code/session_01McXHijZ4DQkZDAw7z3aE7m)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and pull request guidance to reference the full test suite for pre-push and PR verification.
  * Aligned checklist and instructional text so the same test command is used throughout.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->