### PR TITLE
fix: honor tangle coding agent override

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1377,14 +1377,21 @@ Every [CODING] line must include a same-line Files: clause."
     local pids=()
     local task_ids=()
 
-    # [REASONING] subtask routing is overridable and falls back through available
-    # providers — mirrors the tangle_decompose_agent resolution above. Without
-    # this, users without agy get an unconditional exit 127 on every REASONING
-    # subtask even though the provider health check already flagged agy as absent.
+    # [CODING] and [REASONING] subtask routing are overridable. This keeps
+    # tangle usable on hosts where the default coding provider is unavailable,
+    # misconfigured, or unsuitable for implementation work. The lookup order is
+    # handled by octopus_agent_override(), e.g. OCTOPUS_TANGLE_CODING_AGENT,
+    # OCTOPUS_TANGLE_AGENT, then OCTOPUS_CODING_AGENT.
+    local tangle_coding_agent="codex"
     local tangle_reasoning_agent="agy"
     if declare -f octopus_agent_override >/dev/null 2>&1; then
+        tangle_coding_agent=$(octopus_agent_override "tangle" "coding" "codex")
         tangle_reasoning_agent=$(octopus_agent_override "tangle" "reasoning" "agy")
     fi
+
+    # [REASONING] falls back through available providers. Without this, users
+    # without agy get an unconditional exit 127 on every REASONING subtask even
+    # though the provider health check already flagged agy as absent.
     if ! command -v "$tangle_reasoning_agent" >/dev/null 2>&1; then
         local _tangle_reasoning_fb
         for _tangle_reasoning_fb in gemini codex; do
@@ -1406,7 +1413,7 @@ Every [CODING] line must include a same-line Files: clause."
 
         local subtask
         subtask=$(echo "$line" | sed -E 's/^[[:space:]]*(\*\*)?[0-9]+[\.\)][[:space:]]*//; s/^[[:space:]]+//')
-        local agent="codex"
+        local agent="$tangle_coding_agent"
         local role="implementer"
         local pane_icon="⚙️"
         if [[ "$subtask" =~ \[REASONING\] ]]; then
@@ -1420,10 +1427,10 @@ Every [CODING] line must include a same-line Files: clause."
         local subtask_prompt
         subtask_prompt=$(build_tangle_subtask_prompt "$resolved_prompt" "$subtask")
 
-        # Tangle currently routes only CLI-backed codex/gemini workers. Its
-        # completion watcher relies on .done markers written by the legacy
-        # spawn path; add equivalent hook markers before routing Claude Agent
-        # Teams into this loop.
+        # Tangle uses the legacy spawn path in this parallel loop so .done
+        # markers are written for the completion watcher. This also allows
+        # configurable CLI-backed coding/reasoning agents without requiring
+        # Claude Agent Teams hooks in the host process.
         if [[ "$TMUX_MODE" == "true" ]]; then
             # Use async+tmux spawning
             local pid

--- a/tests/unit/test-tangle-coding-agent-override.sh
+++ b/tests/unit/test-tangle-coding-agent-override.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Regression checks for tangle [CODING] agent override routing.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "tangle coding agent override"
+
+WORKFLOWS="$PROJECT_ROOT/scripts/lib/workflows.sh"
+AGENT_UTILS="$PROJECT_ROOT/scripts/lib/agent-utils.sh"
+
+# Minimal environment/helpers referenced while sourcing agent-utils.sh in this focused unit test.
+PLUGIN_DIR="$PROJECT_ROOT"
+WORKSPACE_DIR="$TEST_TMP_DIR"
+RESULTS_DIR="$WORKSPACE_DIR/results"
+mkdir -p "$RESULTS_DIR"
+log() { :; }
+
+source "$AGENT_UTILS"
+
+test_case "octopus_agent_override resolves tangle coding-specific env first"
+if (
+    export OCTOPUS_TANGLE_CODING_AGENT="gemini"
+    export OCTOPUS_TANGLE_AGENT="codex"
+    export OCTOPUS_CODING_AGENT="claude-sonnet"
+    [[ "$(octopus_agent_override tangle coding codex)" == "gemini" ]]
+); then
+    test_pass
+else
+    test_fail "OCTOPUS_TANGLE_CODING_AGENT was not preferred"
+fi
+
+test_case "octopus_agent_override falls back to phase-level tangle agent"
+if (
+    unset OCTOPUS_TANGLE_CODING_AGENT || true
+    export OCTOPUS_TANGLE_AGENT="gemini"
+    export OCTOPUS_CODING_AGENT="claude-sonnet"
+    [[ "$(octopus_agent_override tangle coding codex)" == "gemini" ]]
+); then
+    test_pass
+else
+    test_fail "OCTOPUS_TANGLE_AGENT was not used as coding fallback"
+fi
+
+test_case "octopus_agent_override falls back to role-level coding agent"
+if (
+    unset OCTOPUS_TANGLE_CODING_AGENT OCTOPUS_TANGLE_AGENT || true
+    export OCTOPUS_CODING_AGENT="claude-sonnet"
+    [[ "$(octopus_agent_override tangle coding codex)" == "claude-sonnet" ]]
+); then
+    test_pass
+else
+    test_fail "OCTOPUS_CODING_AGENT was not used as final coding fallback"
+fi
+
+test_case "tangle_develop resolves tangle_coding_agent through octopus_agent_override"
+resolver_count=$(grep -c 'tangle_coding_agent=$(octopus_agent_override "tangle" "coding" "codex")' "$WORKFLOWS" || true)
+if [[ "$resolver_count" -gt 0 ]]; then
+    test_pass
+else
+    test_fail "tangle_develop does not resolve OCTOPUS_TANGLE_CODING_AGENT"
+fi
+
+test_case "[CODING] subtasks use configured tangle_coding_agent instead of hardcoded codex"
+step2_block=$(sed -n '/Step 2: Parallel execution/,/done <<< "$subtasks"/p' "$WORKFLOWS")
+configured_agent_count=$(printf '%s
+' "$step2_block" | grep -c 'local agent="$tangle_coding_agent"' || true)
+hardcoded_codex_count=$(printf '%s
+' "$step2_block" | grep -c 'local agent="codex"' || true)
+if [[ "$configured_agent_count" -gt 0 ]] && [[ "$hardcoded_codex_count" -eq 0 ]]; then
+    test_pass
+else
+    test_fail "tangle coding loop still hardcodes codex"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

`tangle_develop` already has a generic `octopus_agent_override` helper whose documented lookup order includes coding-task overrides:

- `OCTOPUS_TANGLE_CODING_AGENT`
- `OCTOPUS_TANGLE_AGENT`
- `OCTOPUS_CODING_AGENT`

However, `[CODING]` subtasks in the tangle parallel execution loop were still hardcoded to `codex`. `[REASONING]` routing had already been made configurable/fallback-aware in #530, while coding routing still ignored the helper contract.

This PR makes `[CODING]` subtasks resolve their default agent through the existing helper. When no override is set, behavior is unchanged: coding still defaults to `codex`.

## Scope

This only selects the agent/provider used for `[CODING]` subtasks. It does not change model resolution, quality gates, decomposition fallback behavior, or the fail-closed contract introduced by the hardened tangle flow.

This is intended for providers compatible with the existing tangle legacy spawn / `.done` marker execution path.

## Validation

```bash
bash tests/unit/test-tangle-coding-agent-override.sh
bash tests/unit/test-tangle-worktree-evidence.sh
git diff --check HEAD~1..HEAD
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable support for selecting separate agents for coding and reasoning tasks, with a default coding agent.
  * Enhanced agent override handling, including environment-variable precedence for the coding agent and routing updates for both task types.
* **Bug Fixes**
  * Ensured parallel coding subtasks use the selected coding agent (instead of a fixed default).
  * Kept completion tracking working reliably for dispatched subtasks.
* **Tests**
  * Added a regression test validating coding-agent override precedence and workflow wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->