### PR TITLE
fix: allow disabling provider history injection

### DIFF
--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -509,6 +509,10 @@ reset_provider_lockouts() {
 # Each provider accumulates project-specific knowledge in .octo/providers/{name}-history.md
 
 append_provider_history() {
+    case "${OCTOPUS_PROVIDER_HISTORY:-on}" in
+        off|false|0|no) return 0 ;;
+    esac
+
     local provider="$1"
     local phase="$2"
     local task_brief="$3"
@@ -546,6 +550,10 @@ HISTEOF
 }
 
 read_provider_history() {
+    case "${OCTOPUS_PROVIDER_HISTORY:-on}" in
+        off|false|0|no) return 0 ;;
+    esac
+
     local provider="$1"
     local history_file="${WORKSPACE_DIR}/.octo/providers/${provider}-history.md"
 

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -291,6 +291,10 @@ reset_provider_lockouts() {
 # Each provider accumulates project-specific knowledge in .octo/providers/{name}-history.md
 
 append_provider_history() {
+    case "${OCTOPUS_PROVIDER_HISTORY:-on}" in
+        off|false|0|no) return 0 ;;
+    esac
+
     local provider="$1"
     local phase="$2"
     local task_brief="$3"
@@ -328,6 +332,10 @@ HISTEOF
 }
 
 read_provider_history() {
+    case "${OCTOPUS_PROVIDER_HISTORY:-on}" in
+        off|false|0|no) return 0 ;;
+    esac
+
     local provider="$1"
     local history_file="${WORKSPACE_DIR}/.octo/providers/${provider}-history.md"
 

--- a/tests/unit/test-provider-history-toggle.sh
+++ b/tests/unit/test-provider-history-toggle.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Regression checks for disabling provider history read/write/injection.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "provider history toggle"
+
+WORKSPACE_DIR="$TEST_TMP_DIR/provider-history-toggle"
+RESULTS_DIR="$WORKSPACE_DIR/results"
+LOG_LEVEL="WARN"
+log() { :; }
+
+assert_provider_history_toggle_for_script() (
+    local script_path="$1"
+    rm -rf "$WORKSPACE_DIR"
+    mkdir -p "$WORKSPACE_DIR" "$RESULTS_DIR"
+    log() { :; }
+    source "$script_path"
+
+    export OCTOPUS_PROVIDER_HISTORY=off
+    append_provider_history codex tangle "task" "learned"
+    [[ ! -e "$WORKSPACE_DIR/.octo/providers/codex-history.md" ]] || return 1
+
+    mkdir -p "$WORKSPACE_DIR/.octo/providers"
+    cat > "$WORKSPACE_DIR/.octo/providers/codex-history.md" <<'EOF'
+### tangle | 2026-01-01T00:00:00Z
+**Task:** stale task
+**Learned:** stale learning
+---
+EOF
+    [[ -z "$(read_provider_history codex)" ]] || return 1
+    [[ -z "$(build_provider_context codex)" ]] || return 1
+
+    unset OCTOPUS_PROVIDER_HISTORY || true
+    rm -rf "$WORKSPACE_DIR"
+    mkdir -p "$WORKSPACE_DIR" "$RESULTS_DIR"
+    append_provider_history codex tangle "task" "learned"
+    local ctx
+    ctx="$(build_provider_context codex)"
+    [[ "$ctx" == *"Provider History (codex)"* ]] && [[ "$ctx" == *"learned"* ]]
+)
+
+test_case "provider-routing.sh honors OCTOPUS_PROVIDER_HISTORY"
+if assert_provider_history_toggle_for_script "$PROJECT_ROOT/scripts/lib/provider-routing.sh"; then
+    test_pass
+else
+    test_fail "provider-routing.sh provider history toggle behavior regressed"
+fi
+
+test_case "quality.sh honors OCTOPUS_PROVIDER_HISTORY"
+if assert_provider_history_toggle_for_script "$PROJECT_ROOT/scripts/lib/quality.sh"; then
+    test_pass
+else
+    test_fail "quality.sh provider history toggle behavior regressed"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

Adds an explicit runtime kill switch for provider history:

```bash
OCTOPUS_PROVIDER_HISTORY=off
```

When set to `off`, `false`, `0`, or `no`, provider history is not written, read, or injected into prompts.

## Why

Provider history can be useful during normal operation, but operators sometimes need a clean prompt path when local provider history is stale, noisy, or irrelevant to a run. There is already an `OCTOPUS_HEURISTIC_LEARNING=off` pattern for disabling heuristic learning. This adds the equivalent control for provider history.

Default behavior is unchanged: provider history remains enabled unless the environment variable disables it.

## Validation

```bash
bash tests/unit/test-provider-history-toggle.sh
bash tests/unit/test-provider-history.sh
git diff --check HEAD~1..HEAD
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an environment-controlled opt-out for provider history via `OCTOPUS_PROVIDER_HISTORY`. When set to `off|false|0|no`, provider history is no longer persisted or retrieved, preventing related provider context injection.
  * When `OCTOPUS_PROVIDER_HISTORY` is unset, existing provider history behavior remains unchanged.

* **Tests**
  * Added a regression test to verify provider history write/read behavior and the resulting provider context injection for both disabled (off) and default (unset) modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->