### PR TITLE
fix: recover tangle tasks missing done markers

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1450,25 +1450,51 @@ Every [CODING] line must include a same-line Files: clause."
     local _deadline=$(( $(date +%s) + _tangle_max_wait ))
     local completed=0
     local _failed_tasks=()
+    local _terminal_task_ids=""
     while [[ $completed -lt ${#task_ids[@]} ]]; do
         completed=0
         for i in "${!task_ids[@]}"; do
             local _done_file="${_done_dir}/${task_ids[$i]}.done"
             if [[ -f "$_done_file" ]]; then
                 ((completed++)) || true
-            elif (( $(date +%s) > _deadline )); then
-                log WARN "Thread ${task_ids[$i]} deadline exceeded — killing and marking timeout"
+            elif [[ " $_terminal_task_ids " == *" ${task_ids[$i]} "* ]]; then
+                ((completed++)) || true
+            else
                 local _wrapper_pid="${pids[$i]:-}"
-                if [[ -n "$_wrapper_pid" ]]; then
-                    pkill -TERM -P "$_wrapper_pid" 2>/dev/null || true
-                    kill -TERM "$_wrapper_pid" 2>/dev/null || true
-                    sleep 1
-                    pkill -KILL -P "$_wrapper_pid" 2>/dev/null || true
-                    kill -KILL "$_wrapper_pid" 2>/dev/null || true
-                fi
-                mkdir -p "$_done_dir" 2>/dev/null || true
-                if [[ ! -f "$_done_file" ]] && ! echo "timeout" > "$_done_file" 2>/dev/null; then
-                    log WARN "Failed to write timeout marker for ${task_ids[$i]} at $_done_file"
+                if (( $(date +%s) > _deadline )); then
+                    log WARN "Thread ${task_ids[$i]} deadline exceeded — killing and marking timeout"
+                    if [[ -n "$_wrapper_pid" ]]; then
+                        pkill -TERM -P "$_wrapper_pid" 2>/dev/null || true
+                        kill -TERM "$_wrapper_pid" 2>/dev/null || true
+                        sleep 1
+                        pkill -KILL -P "$_wrapper_pid" 2>/dev/null || true
+                        kill -KILL "$_wrapper_pid" 2>/dev/null || true
+                    fi
+                    mkdir -p "$_done_dir" 2>/dev/null || true
+                    if [[ ! -f "$_done_file" ]] && ! echo "timeout" > "$_done_file" 2>/dev/null; then
+                        log WARN "Failed to write timeout marker for ${task_ids[$i]} at $_done_file"
+                    fi
+                    [[ " $_terminal_task_ids " == *" ${task_ids[$i]} "* ]] || _terminal_task_ids="${_terminal_task_ids:+$_terminal_task_ids }${task_ids[$i]}"
+                elif [[ -n "$_wrapper_pid" ]] && ! kill -0 "$_wrapper_pid" 2>/dev/null; then
+                    log WARN "Thread ${task_ids[$i]} exited without writing completion marker — marking failed"
+                    mkdir -p "$_done_dir" 2>/dev/null || true
+                    if [[ ! -f "$_done_file" ]] && ! echo "missing-done-marker" > "$_done_file" 2>/dev/null; then
+                        log WARN "Failed to write missing-done marker for ${task_ids[$i]} at $_done_file"
+                    fi
+                    [[ " $_terminal_task_ids " == *" ${task_ids[$i]} "* ]] || _terminal_task_ids="${_terminal_task_ids:+$_terminal_task_ids }${task_ids[$i]}"
+                    local _result_file
+                    _result_file=$(find "${RESULTS_DIR:-${HOME}/.claude-octopus/results}" -maxdepth 1 -type f -name "*-${task_ids[$i]}.md" 2>/dev/null | head -1 || true)
+                    if [[ -n "$_result_file" ]]; then
+                        local _status_count
+                        _status_count=$(grep -c '^## Status:' "$_result_file" 2>/dev/null || true)
+                        if [[ "${_status_count:-0}" -eq 0 ]]; then
+                            {
+                                echo ""
+                                echo "## Status: FAILED (Missing completion marker)"
+                                echo "# Completed: $(date)"
+                            } >> "$_result_file" 2>/dev/null || true
+                        fi
+                    fi
                 fi
             fi
         done

--- a/tests/unit/test-tangle-missing-done-marker.sh
+++ b/tests/unit/test-tangle-missing-done-marker.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Regression checks for tangle wait loop recovery when a wrapper exits without a .done marker.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "tangle missing done marker recovery"
+
+WORKFLOWS="$PROJECT_ROOT/scripts/lib/workflows.sh"
+TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
+rm -rf "$TEST_TMP_DIR"
+mkdir -p "$TEST_TMP_DIR"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
+
+source "$WORKFLOWS"
+
+CYAN=""
+MAGENTA=""
+GREEN=""
+YELLOW=""
+RED=""
+NC=""
+TMUX_MODE=false
+DRY_RUN=false
+SUPPORTS_PARALLEL_FILE_SAFETY=false
+RESULTS_DIR="$TEST_TMP_DIR/results"
+WORKSPACE_DIR="$TEST_TMP_DIR/workspace"
+LOG_CAPTURE_FILE="$TEST_TMP_DIR/tangle.log"
+DATE_COUNTER_FILE="$TEST_TMP_DIR/date-counter"
+SLEEP_COUNTER_FILE="$TEST_TMP_DIR/sleep-counter"
+mkdir -p "$RESULTS_DIR" "$WORKSPACE_DIR/.octo/agents"
+
+log() {
+    printf '%s %s\n' "${1:-}" "${2:-}" >> "$LOG_CAPTURE_FILE"
+}
+octopus_phase_banner() { :; }
+design_review_ceremony() { :; }
+display_workflow_cost_estimate() { return 0; }
+reset_provider_lockouts() { :; }
+fleet_dispatch_begin() { :; }
+fleet_dispatch_end() { :; }
+validate_tangle_results() { :; }
+run_agent_sync() {
+    printf '%s\n' "1. [CODING] failed marker task. Files: scripts/lib/workflows.sh"
+}
+spawn_agent_capture_pid() {
+    local task_id="$3"
+    cat > "$RESULTS_DIR/codex-${task_id}.md" <<EOF
+# Agent: codex
+# Task ID: $task_id
+# Role: implementer
+# Prompt: failed marker task
+# Started: test
+
+## Output
+EOF
+    ( : ) &
+    local dead_pid="$!"
+    wait "$dead_pid" 2>/dev/null || true
+    printf '%s\n' "$dead_pid"
+}
+sleep() {
+    local count
+    mkdir -p "$(dirname "$SLEEP_COUNTER_FILE")"
+    [[ -f "$SLEEP_COUNTER_FILE" ]] || printf '0' > "$SLEEP_COUNTER_FILE"
+    count=$(<"$SLEEP_COUNTER_FILE")
+    count=$((count + 1))
+    printf '%s' "$count" > "$SLEEP_COUNTER_FILE"
+    if [[ $count -gt 5 ]]; then
+        # Do not let a regression hang CI forever. Force a completion marker so
+        # tangle_develop can return; the assertions below fail via the counter.
+        rm -f "$WORKSPACE_DIR/.octo/agents" 2>/dev/null || true
+        mkdir -p "$WORKSPACE_DIR/.octo/agents"
+        printf '0' > "$WORKSPACE_DIR/.octo/agents/tangle-100-0.done"
+    fi
+}
+date() {
+    if [[ "${1:-}" == "+%s" ]]; then
+        local count
+        mkdir -p "$(dirname "$DATE_COUNTER_FILE")"
+        [[ -f "$DATE_COUNTER_FILE" ]] || printf '0' > "$DATE_COUNTER_FILE"
+        count=$(<"$DATE_COUNTER_FILE")
+        count=$((count + 1))
+        printf '%s' "$count" > "$DATE_COUNTER_FILE"
+        printf '%s\n' "100"
+        return 0
+    fi
+    command date "$@"
+}
+
+reset_fixture() {
+    rm -rf "$RESULTS_DIR" "$WORKSPACE_DIR" "$LOG_CAPTURE_FILE"
+    mkdir -p "$RESULTS_DIR" "$WORKSPACE_DIR/.octo/agents"
+    printf '0' > "$DATE_COUNTER_FILE"
+    printf '0' > "$SLEEP_COUNTER_FILE"
+}
+
+test_case "dead wrapper writes missing-done-marker and failed status before deadline"
+reset_fixture
+if tangle_develop "missing marker task" >/dev/null 2>&1; then
+    result_file=$(find "$RESULTS_DIR" -maxdepth 1 -type f -name 'codex-tangle-*.md' 2>/dev/null | head -1 || true)
+    if [[ "$(grep -c 'finished with status: missing-done-marker' "$LOG_CAPTURE_FILE" || true)" -eq 1 ]] && \
+       [[ -n "$result_file" ]] && [[ "$(grep -c '^## Status: FAILED (Missing completion marker)' "$result_file" || true)" -eq 1 ]]; then
+        test_pass
+    else
+        test_fail "dead wrapper did not produce missing-done marker log and failed result status"
+    fi
+else
+    test_fail "tangle_develop failed while handling dead wrapper"
+fi
+
+test_case "wait loop records terminal task even when marker write fails"
+reset_fixture
+rm -rf "$WORKSPACE_DIR/.octo/agents"
+printf 'not a directory' > "$WORKSPACE_DIR/.octo/agents"
+if tangle_develop "unwritable marker task" >/dev/null 2>&1 && \
+   [[ "$(<"$SLEEP_COUNTER_FILE")" -le 2 ]] && \
+   [[ "$(grep -c 'Failed to write missing-done marker' "$LOG_CAPTURE_FILE" || true)" -ge 1 ]]; then
+    test_pass
+else
+    test_fail "wait loop did not terminate when marker write failed"
+fi
+
+unset -f date
+unset -f sleep
+
+test_summary


### PR DESCRIPTION
## Summary

Extends the tangle `.done` marker watchdog to handle one more failure mode: a wrapper process exits before writing its completion marker, while the global tangle deadline has not yet elapsed.

Today, tangle waits for `.done` files. If the wrapper has already exited and no provider child is still running, there is no future writer for that marker. The loop can then sit at partial progress until the global deadline.

This PR detects that condition and marks the subtask as `missing-done-marker` instead of waiting for the global deadline.

## Relationship to existing timeout behavior

The existing deadline timeout path remains authoritative. If `OCTOPUS_TANGLE_DEADLINE` has elapsed, tangle still marks the task as `timeout` and uses the existing TERM/KILL cleanup path.

The new `missing-done-marker` path only applies before the deadline when the wrapper PID is already gone and the marker is absent.

## Validation

```bash
bash tests/unit/test-tangle-missing-done-marker.sh
bash tests/unit/test-develop-md-file-resolution.sh
git diff --check HEAD~1..HEAD
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subtask wait-loop handling so subtasks can be marked terminal even when completion markers aren’t written.
  * On deadline expiry, the wrapper process is terminated, a timeout marker is written (when missing), and terminal state is recorded.
  * If the wrapper exits early without a marker, a “missing-done” marker is saved and failure status is added when status info is absent.

* **Tests**
  * Added a deterministic regression test for missing/invalid completion marker scenarios, asserting logs/output and ensuring bounded CI runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->