### PR TITLE
fix: honor tangle decompose routing for reformat retry

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1083,8 +1083,14 @@ Previous decomposition:
 ${previous_decomposition}
 "
 
-    run_agent_sync "agy" "$reformat_prompt" 120 "researcher" "tangle" || \
-    run_agent_sync "claude-sonnet" "$reformat_prompt" 120 "researcher" "tangle"
+    local tangle_decompose_agent="agy" tangle_decompose_fallback_agent="codex"
+    if declare -f octopus_agent_override >/dev/null 2>&1; then
+        tangle_decompose_agent=$(octopus_agent_override "tangle" "decompose" "agy")
+        tangle_decompose_fallback_agent=$(octopus_agent_override "tangle" "decompose_fallback" "codex")
+    fi
+
+    run_agent_sync "$tangle_decompose_agent" "$reformat_prompt" 120 "researcher" "tangle" || \
+    run_agent_sync "$tangle_decompose_fallback_agent" "$reformat_prompt" 120 "researcher" "tangle"
 }
 
 tangle_validate_parallel_write_scopes() {

--- a/tests/unit/test-tangle-reformat-agent-routing.sh
+++ b/tests/unit/test-tangle-reformat-agent-routing.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression checks for tangle decomposition reformat routing.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "tangle reformat agent routing"
+
+WORKFLOWS="$PROJECT_ROOT/scripts/lib/workflows.sh"
+AGENT_UTILS="$PROJECT_ROOT/scripts/lib/agent-utils.sh"
+CALL_LOG="$TEST_TMP_DIR/reformat-calls.log"
+mkdir -p "$TEST_TMP_DIR"
+
+PLUGIN_DIR="$PROJECT_ROOT"
+WORKSPACE_DIR="$TEST_TMP_DIR/workspace"
+RESULTS_DIR="$TEST_TMP_DIR/results"
+mkdir -p "$WORKSPACE_DIR" "$RESULTS_DIR"
+log() { :; }
+
+source "$AGENT_UTILS"
+source "$WORKFLOWS"
+
+run_agent_sync() {
+    local agent="$1"
+    local prompt="$2"
+    local timeout="$3"
+    local role="$4"
+    local phase="$5"
+    printf '%s|%s|%s|%s\n' "$agent" "$timeout" "$role" "$phase" >> "$CALL_LOG"
+    if [[ "$agent" == "gemini" || "$agent" == "agy" ]]; then
+        printf '1. [CODING] Reformatted task — Files: scripts/lib/workflows.sh — Task: use configured reformat route\n'
+        return 0
+    fi
+    return 1
+}
+
+test_case "reformat uses OCTOPUS_TANGLE_DECOMPOSE_AGENT before legacy defaults"
+if (
+    rm -f "$CALL_LOG"
+    export OCTOPUS_TANGLE_DECOMPOSE_AGENT="gemini"
+    export OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT="codex"
+    result=$(tangle_reformat_decomposition "task" "bad decomposition" "overlap" "")
+    [[ "$result" == *"Reformatted task"* ]] &&
+    [[ "$(sed -n '1p' "$CALL_LOG")" == "gemini|120|researcher|tangle" ]] &&
+    [[ "$(wc -l < "$CALL_LOG")" -eq 1 ]]
+); then
+    test_pass
+else
+    test_fail "reformat did not use OCTOPUS_TANGLE_DECOMPOSE_AGENT first"
+fi
+
+test_case "reformat falls back to OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT"
+if (
+    rm -f "$CALL_LOG"
+    export OCTOPUS_TANGLE_DECOMPOSE_AGENT="unavailable-agent"
+    export OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT="gemini"
+    result=$(tangle_reformat_decomposition "task" "bad decomposition" "overlap" "")
+    [[ "$result" == *"Reformatted task"* ]] &&
+    [[ "$(sed -n '1p' "$CALL_LOG")" == "unavailable-agent|120|researcher|tangle" ]] &&
+    [[ "$(sed -n '2p' "$CALL_LOG")" == "gemini|120|researcher|tangle" ]]
+); then
+    test_pass
+else
+    test_fail "reformat did not use OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT"
+fi
+
+
+test_case "reformat keeps legacy agy/codex compatibility when override helper is absent"
+if (
+    rm -f "$CALL_LOG"
+    unset -f octopus_agent_override
+    unset OCTOPUS_TANGLE_DECOMPOSE_AGENT
+    unset OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT
+    result=$(tangle_reformat_decomposition "task" "bad decomposition" "overlap" "")
+    [[ "$result" == *"Reformatted task"* ]] &&
+    [[ "$(sed -n '1p' "$CALL_LOG")" == "agy|120|researcher|tangle" ]] &&
+    [[ "$(wc -l < "$CALL_LOG")" -eq 1 ]]
+); then
+    test_pass
+else
+    test_fail "reformat did not preserve agy/codex compatibility without octopus_agent_override"
+fi
+
+test_case "reformat dispatch no longer hardcodes agy claude-sonnet chain"
+reformat_body=$(sed -n '/^tangle_reformat_decomposition()/,/^}/p' "$WORKFLOWS")
+if [[ "$(printf '%s\n' "$reformat_body" | grep -c 'run_agent_sync "agy"' || true)" -eq 0 ]] &&
+   [[ "$(printf '%s\n' "$reformat_body" | grep -c 'run_agent_sync "claude-sonnet"' || true)" -eq 0 ]]; then
+    test_pass
+else
+    test_fail "reformat still contains hardcoded agy/claude-sonnet dispatch"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

Makes `tangle_reformat_decomposition` honor the same decomposition routing overrides used by the initial decomposition pass.

The initial tangle decomposition already supports:

```bash
OCTOPUS_TANGLE_DECOMPOSE_AGENT
OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT
```

However, when decomposition validation failed and Octopus attempted the strict reformat retry, that retry still hardcoded:

```text
agy -> claude-sonnet
```

This meant a configured decomposer such as `gemini` could produce the initial decomposition, but the validation/reformat retry would ignore that routing and fail if `agy` was unavailable.

## Changes

- Resolve `tangle_decompose_agent` / `tangle_decompose_fallback_agent` inside `tangle_reformat_decomposition` with `octopus_agent_override`.
- Keep existing defaults as `agy` / `codex` when no override helper is available.
- Remove the hardcoded `agy -> claude-sonnet` reformat chain.
- Add focused tests for primary override, fallback override, and absence of the hardcoded chain.

## Validation

```bash
bash -n scripts/lib/workflows.sh tests/unit/test-tangle-reformat-agent-routing.sh
bash tests/unit/test-tangle-reformat-agent-routing.sh
bash tests/unit/test-tangle-write-scope-safety.sh
bash tests/unit/test-tangle-direct-fallback.sh
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reformat/decomposition workflows now use configurable primary and fallback agent selection, with optional overrides for both the main and fallback roles.
  * If the primary agent fails, the retry now uses the configured fallback agent (instead of a fixed default).

* **Tests**
  * Added a regression test suite to validate agent routing, fallback behavior when the primary is unavailable, legacy behavior when overrides aren’t present, and prevention of hardcoded agent dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->