### PR TITLE
fix: honor quality retry env and support unlimited retries

### DIFF
--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -508,7 +508,11 @@ retry_failed_subtasks() {
     # Count tasks (newline-separated)
     local task_count
     task_count=$(echo "$FAILED_SUBTASKS" | grep -c .)
-    log INFO "Retrying $task_count failed subtasks (attempt $retry_count/${MAX_QUALITY_RETRIES})..."
+    local retry_limit_display="${MAX_QUALITY_RETRIES:-${CLAUDE_OCTOPUS_MAX_RETRIES:-3}}"
+    if declare -f quality_retry_limit >/dev/null 2>&1; then
+        retry_limit_display=$(quality_retry_limit)
+    fi
+    log INFO "Retrying $task_count failed subtasks (attempt $retry_count/${retry_limit_display})..."
 
     local pids=""
     local subtask_num=0

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -57,6 +57,37 @@ get_branch_display() {
     esac
 }
 
+quality_retries_unlimited() {
+    local retry_limit="${MAX_QUALITY_RETRIES:-3}"
+    retry_limit="$(printf '%s' "$retry_limit" | tr '[:upper:]' '[:lower:]')"
+    case "$retry_limit" in
+        unlimited|infinite|inf|forever|-1) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+quality_retry_limit() {
+    if quality_retries_unlimited; then
+        printf '∞\n'
+        return 0
+    fi
+    if [[ "${MAX_QUALITY_RETRIES:-}" =~ ^[0-9]+$ ]]; then
+        printf '%s\n' "$MAX_QUALITY_RETRIES"
+    else
+        printf '3\n'
+    fi
+}
+
+quality_retry_limit_reached() {
+    local retry_count="${1:-0}"
+    local retry_limit
+    if quality_retries_unlimited; then
+        return 1
+    fi
+    retry_limit=$(quality_retry_limit)
+    [[ "$retry_count" -ge "$retry_limit" ]]
+}
+
 # Evaluate next action based on quality gate outcome
 # Returns: proceed, proceed_warn, retry, escalate, abort
 evaluate_quality_branch() {
@@ -79,7 +110,7 @@ evaluate_quality_branch() {
         echo "proceed"  # Quality gate passed
     elif [[ $success_rate -ge $QUALITY_THRESHOLD ]]; then
         echo "proceed_warn"  # Passed with warning
-    elif [[ "$LOOP_UNTIL_APPROVED" == "true" && $retry_count -lt $MAX_QUALITY_RETRIES ]]; then
+    elif [[ "$LOOP_UNTIL_APPROVED" == "true" ]] && ! quality_retry_limit_reached "$retry_count"; then
         echo "retry"  # Auto-retry enabled
     elif [[ "$autonomy" == "supervised" ]]; then
         echo "escalate"  # Human decision required
@@ -110,7 +141,7 @@ execute_quality_branch() {
             return 0
             ;;
         retry)
-            log INFO "↻ Quality gate FAILED - retrying (attempt $((retry_count + 1))/$MAX_QUALITY_RETRIES)"
+            log INFO "↻ Quality gate FAILED - retrying (attempt $((retry_count + 1))/$(quality_retry_limit))"
             return 2  # Signal retry
             ;;
         escalate)
@@ -152,8 +183,8 @@ SKIP_SMOKE_TEST="${OCTOPUS_SKIP_SMOKE_TEST:-false}"
 # - loop-until-approved: Retry failed tasks until quality gate passes
 AUTONOMY_MODE="${CLAUDE_OCTOPUS_AUTONOMY:-semi-autonomous}"
 QUALITY_THRESHOLD="${CLAUDE_OCTOPUS_QUALITY_THRESHOLD:-75}"
-MAX_QUALITY_RETRIES="${CLAUDE_OCTOPUS_MAX_RETRIES:-3}"
-LOOP_UNTIL_APPROVED=false
+MAX_QUALITY_RETRIES="${MAX_QUALITY_RETRIES:-${CLAUDE_OCTOPUS_MAX_RETRIES:-3}}"
+LOOP_UNTIL_APPROVED="${LOOP_UNTIL_APPROVED:-false}"
 RESUME_SESSION=false
 
 # v3.1 Feature: Cost-Aware Routing

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -261,7 +261,7 @@ $challenge_result
 - Successful: ${success_count}/${total} result files
 - Failed: ${fail_count}/${total} result files
 - Decision Branch: ${quality_branch}
-- Retry Attempts: ${quality_retry_count}/${MAX_QUALITY_RETRIES}
+- Retry Attempts: ${quality_retry_count}/$(quality_retry_limit)
 
 ### Explicit File Coverage
 $(if [[ -n "$missing_explicit_files" ]]; then
@@ -294,11 +294,13 @@ EOF
                 ;;
             retry)
                 # Retry failed tasks
-                if [[ $quality_retry_count -lt $MAX_QUALITY_RETRIES ]]; then
+                if ! quality_retry_limit_reached "$quality_retry_count"; then
                     ((quality_retry_count++)) || true
+                    local retry_limit_display
+                    retry_limit_display=$(quality_retry_limit)
                     echo ""
                     echo -e "${YELLOW}${_BOX_TOP}${NC}"
-                    echo -e "${YELLOW}║  🐙 Branching: Retry Path (attempt $quality_retry_count/$MAX_QUALITY_RETRIES)                    ║${NC}"
+                    echo -e "${YELLOW}║  🐙 Branching: Retry Path (attempt $quality_retry_count/$retry_limit_display)                    ║${NC}"
                     echo -e "${YELLOW}${_BOX_BOT}${NC}"
                     log WARN "Quality gate at ${success_rate}%, below ${tangle_threshold}%. Retrying..."
                     # v8.18.0: Lock providers that failed quality gate
@@ -311,7 +313,7 @@ EOF
                     sleep 3
                     continue  # Re-validate
                 else
-                    log ERROR "Max retries ($MAX_QUALITY_RETRIES) exceeded. Proceeding with ${success_rate}%"
+                    log ERROR "Max retries ($(quality_retry_limit)) exceeded. Proceeding with ${success_rate}%"
                 fi
                 ;;
             escalate)

--- a/tests/unit/test-quality-retry-env-and-unlimited.sh
+++ b/tests/unit/test-quality-retry-env-and-unlimited.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Regression checks for quality retry environment overrides and unlimited retry mode.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "quality retry env and unlimited"
+
+prepare_quality_fixture() {
+    export WORKSPACE_DIR="$TEST_TMP_DIR/workspace"
+    export RESULTS_DIR="$TEST_TMP_DIR/results"
+    mkdir -p "$WORKSPACE_DIR" "$RESULTS_DIR"
+}
+
+test_case "quality.sh preserves LOOP_UNTIL_APPROVED and MAX_QUALITY_RETRIES from env"
+if (
+    prepare_quality_fixture
+    export LOOP_UNTIL_APPROVED=true
+    export MAX_QUALITY_RETRIES=unlimited
+    export CLAUDE_OCTOPUS_MAX_RETRIES=3
+    source "$PROJECT_ROOT/scripts/lib/quality.sh"
+    [[ "$LOOP_UNTIL_APPROVED" == "true" ]] && [[ "$MAX_QUALITY_RETRIES" == "unlimited" ]]
+); then
+    test_pass
+else
+    test_fail "quality.sh overwrote retry env overrides"
+fi
+
+test_case "unlimited retry mode keeps retrying regardless of retry count"
+if (
+    prepare_quality_fixture
+    export LOOP_UNTIL_APPROVED=true
+    source "$PROJECT_ROOT/scripts/lib/quality.sh"
+    for unlimited_alias in unlimited infinite inf forever -1 UNLIMITED; do
+        export MAX_QUALITY_RETRIES="$unlimited_alias"
+        [[ "$(evaluate_quality_branch 66 0)" == "retry" ]] || exit 1
+        [[ "$(evaluate_quality_branch 66 1000)" == "retry" ]] || exit 1
+        [[ "$(quality_retry_limit)" == "∞" ]] || exit 1
+    done
+); then
+    test_pass
+else
+    test_fail "unlimited retry mode did not keep retry branch open"
+fi
+
+test_case "finite retry mode still stops at configured limit"
+if (
+    prepare_quality_fixture
+    export LOOP_UNTIL_APPROVED=true
+    export MAX_QUALITY_RETRIES=2
+    source "$PROJECT_ROOT/scripts/lib/quality.sh"
+    [[ "$(evaluate_quality_branch 66 0)" == "retry" ]] &&
+    [[ "$(evaluate_quality_branch 66 1)" == "retry" ]] &&
+    [[ "$(evaluate_quality_branch 66 2)" == "abort" ]]
+); then
+    test_pass
+else
+    test_fail "finite retry limit no longer stops at configured max"
+fi
+
+test_case "CLAUDE_OCTOPUS_MAX_RETRIES remains fallback when MAX_QUALITY_RETRIES unset"
+if (
+    prepare_quality_fixture
+    unset MAX_QUALITY_RETRIES || true
+    export LOOP_UNTIL_APPROVED=true
+    export CLAUDE_OCTOPUS_MAX_RETRIES=5
+    source "$PROJECT_ROOT/scripts/lib/quality.sh"
+    [[ "$MAX_QUALITY_RETRIES" == "5" ]] &&
+    [[ "$(quality_retry_limit)" == "5" ]] &&
+    [[ "$(evaluate_quality_branch 66 4)" == "retry" ]] &&
+    [[ "$(evaluate_quality_branch 66 5)" == "abort" ]]
+); then
+    test_pass
+else
+    test_fail "CLAUDE_OCTOPUS_MAX_RETRIES fallback no longer works"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

Fixes the quality-gate retry configuration so environment overrides are honored and operators can request unlimited retry loops.

The previous defaults in `scripts/lib/quality.sh` overwrote environment values at source time:

```bash
MAX_QUALITY_RETRIES="${CLAUDE_OCTOPUS_MAX_RETRIES:-3}"
LOOP_UNTIL_APPROVED=false
```

That meant launching Octopus with `LOOP_UNTIL_APPROVED=true` or `MAX_QUALITY_RETRIES=...` could still produce an immediate abort path with `Retry Attempts: 0/3`.

## Changes

- Preserve existing `LOOP_UNTIL_APPROVED` from the environment.
- Preserve existing `MAX_QUALITY_RETRIES` from the environment, with `CLAUDE_OCTOPUS_MAX_RETRIES` as fallback.
- Add unlimited retry aliases:
  - `unlimited`
  - `infinite`
  - `inf`
  - `forever`
  - `-1`
- Replace numeric-only retry comparisons with helper functions.
- Display unlimited retry limits as `∞` in logs/reports.
- Keep finite retry behavior unchanged.

## Validation

```bash
bash tests/unit/test-quality-retry-env-and-unlimited.sh
bash tests/unit/test-error-learning.sh
bash -n scripts/lib/quality.sh scripts/lib/testing.sh scripts/lib/agent-utils.sh tests/unit/test-quality-retry-env-and-unlimited.sh
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quality-gate retry limiting is now centralized and dynamically driven by environment settings, including support for “unlimited”/infinite modes.
  * Retry/validation output now reports the effective retry limit (showing infinity when unlimited) and honors configured values.

* **Bug Fixes**
  * Retry/abort decisions now consistently enforce the effective configured limit, including correct “loop until approved” boundary behavior.

* **Tests**
  * Added regression coverage for environment overrides, unlimited aliases, finite limits, and fallback when limits are unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->