### PR TITLE
release: v9.46.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.45.0"
+    "version": "9.46.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.45.0 - Add Antigravity CLI (agy) provider, generic OpenAI-compatible agent, and tangle routing overrides. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.45.0",
+      "description": "v9.46.0 - agy is now the default Google seat (Gemini CLI sunset); agent lifecycle events, octo-hud event-stream monitor, and multi-provider council seating; plus provider-reliability and tangle-workflow fixes. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.46.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.45.0",
+  "version": "9.46.0",
   "description": "v9.44.1 \u2014 Patch release for Gemini environment/version detection and qwen auth gating. Run /octo:setup.",
   "author": {
     "name": "nyldn",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.45.0",
+  "version": "9.46.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.45.0",
+  "version": "9.46.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.45.0"
+    "version": "9.46.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.45.0 - Add Antigravity CLI (agy) provider, generic OpenAI-compatible agent, and tangle routing overrides. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.45.0",
+      "description": "v9.46.0 - agy is now the default Google seat (Gemini CLI sunset); agent lifecycle events, octo-hud event-stream monitor, and multi-provider council seating; plus provider-reliability and tangle-workflow fixes. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.46.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.45.0",
+  "version": "9.46.0",
   "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,34 @@
 
 ## [Unreleased]
 
-### Fixed
+## [9.46.0] - 2026-07-01
 
-- **gemini-image migrated off the deprecated `gemini-3-pro-image-preview`** before Google's 2026-06-25 shutdown (#493, oco-803). Image routing now defaults to the GA `gemini-3-pro-image` (Nano Banana Pro); `gemini-3.1-flash-image` (Nano Banana 2, fast tier) added to the catalog; the preview entry is retained with `deprecated` status so pinned configs degrade gracefully. Cost table and `octo-model-config` catalog refreshed.
-- **API-key providers no longer dispatch into a quota-dead key** (#494, oco-cbb). Perplexity payloads now cap output via `OCTOPUS_PERPLEXITY_MAX_TOKENS` (default 4096). New opt-in proactive health probe (`octo_provider_probe`, gated by `OCTOPUS_PREFLIGHT_PROBE=1`) validates perplexity/openrouter keys before dispatch and marks the provider `degraded` on 401/402/429; it fails open on transient network errors so a flaky connection never hides a working provider.
-- **Parallel probe path skips quota-dead providers** (#495). `auto-route.sh` consults `octo_quota_is_dead` before adding a provider to the fan-out, so a perplexity 401 or gemini capacity-exhaustion this session no longer re-dispatches and burns time.
+### Added
+
+- **Antigravity CLI (`agy`) is now the default Google seat** across all multi-LLM workflows, replacing the sunset Gemini CLI (#524). Probe, discover, define, develop, deliver, parallel map/reduce, and Double-Diamond synthesis paths now route Google work to `agy`.
+- **Agent lifecycle events** emitted across dispatch for observability (#511), plus `provider.selected` and circuit-breaker lifecycle events. `OCTO_EVENT_LOG` telemetry is enabled by default in `orchestrate.sh`.
+- **`octo-hud` local event-stream monitor** renders the `OCTO_EVENT_LOG` stream without scraping the terminal (#510).
+- **Council seats every available provider org** rather than just two (#513), and **qwen is now a seatable council provider org** (#520).
+- **GA `gemini-3.5-flash` and `gemini-3.1-flash-lite`** added to the model catalog.
 
 ### Changed
 
 - **Doctor surfaces the fix inline by default.** `warn`/`fail` rows now always print their actionable detail (e.g. `Run: ollama serve`) without requiring `--verbose`; `pass` rows stay quiet unless `--verbose`.
 - **Setup dashboard shows concrete next-step commands** for unconfigured providers (codex/gemini/perplexity/cursor-agent), so a fresh install tells the user exactly what to export or install.
+
+### Fixed
+
+- **gemini-image migrated off the deprecated `gemini-3-pro-image-preview`** before Google's 2026-06-25 shutdown (#493, oco-803). Image routing now defaults to the GA `gemini-3-pro-image` (Nano Banana Pro); `gemini-3.1-flash-image` (Nano Banana 2, fast tier) added to the catalog; the preview entry is retained with `deprecated` status so pinned configs degrade gracefully. Cost table and `octo-model-config` catalog refreshed.
+- **API-key providers no longer dispatch into a quota-dead key** (#494, oco-cbb). Perplexity payloads now cap output via `OCTOPUS_PERPLEXITY_MAX_TOKENS` (default 4096). New opt-in proactive health probe (`octo_provider_probe`, gated by `OCTOPUS_PREFLIGHT_PROBE=1`) validates perplexity/openrouter keys before dispatch and marks the provider `degraded` on 401/402/429; it fails open on transient network errors so a flaky connection never hides a working provider.
+- **Parallel probe path skips quota-dead providers** (#495). `auto-route.sh` consults `octo_quota_is_dead` before adding a provider to the fan-out, so a perplexity 401 or gemini capacity-exhaustion this session no longer re-dispatches and burns time.
+- **Provider reliability bundle**: Gemini research-phase timeout controls, parallel probe fast-fail on quota and terminal errors, plus related hardening (#496).
+- **Quota watcher narrowed to terminal-only errors** with a two-poll grace window (#516, #517); **Gemini retryable-throttle lines are excluded from quota fast-fail** (#536, #537).
+- **First-run provider health hardened**; setup dashboard shows the accurate `agy` model when `OCTOPUS_AGY_MODEL` is set; `agy`/`agy-research`/`antigravity` added to the bare-provider skip-list in routing.
+- **Tangle workflow hardening**: honor the coding-agent override (#543), recover tasks missing done markers (#545), honor decompose routing on reformat retry (#547), and retry output failures with feedback.
+- **Quality retry honors env configuration and supports unlimited retries** (#548); **provider history injection can now be disabled** (#544).
+- **agy migration completed** in the parallel aggregator and probe/discover dispatch (#538) and in `parallel.sh` `map_reduce`/`fan_out` (#539).
+- **Hardened OpenAI-compatible agent** dispatch args (#535) and transport (#512); `octo_write_stable_script_shim` refuses self-targeting writes; `[REASONING]` subtask routing gains an availability check and fallback.
+- **Docs**: fixed stale `tests/run-pre-push.sh` references in CONTRIBUTING and the PR template (#505, #541); corrected the README version badge.
 
 ## [9.45.0] - 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.45.0-blue" alt="Version 9.45.0">
+  <img src="https://img.shields.io/badge/Version-9.46.0-blue" alt="Version 9.46.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.45.0",
+  "version": "9.46.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## v9.46.0

Cuts v9.46.0 from the 28 commits landed since the `v9.45.0` tag. Minor bump (features present), not the patch that stale #519 assumed — those feature commits landed after #519 was opened.

### Added
- **agy is the default Google seat** across all workflows (Gemini CLI sunset, #524)
- **Agent lifecycle events** + `provider.selected`/circuit-breaker events; `OCTO_EVENT_LOG` on by default (#511)
- **`octo-hud`** local event-stream monitor (#510)
- **Council seats every available provider org**; qwen seatable (#513, #520)
- GA `gemini-3.5-flash` + `gemini-3.1-flash-lite` in the catalog

### Fixed
- Provider-reliability bundle: quota fast-fail, gemini timeout, health probes (#494, #495, #496, #516, #517, #536, #537)
- Tangle-workflow + quality-retry hardening (#543, #544, #545, #547, #548)
- agy migration completed in parallel aggregator + probe/discover dispatch (#535, #538, #539)
- Docs: stale `tests/run-pre-push.sh` refs (#505, #541)

Full detail in CHANGELOG.md.

### Verification
Local `smoke + unit + integration` suites: **172/172 green** on the merged main + release edits.

### Closes
Closes #494, closes #495, closes #496, closes #505, closes #536.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for new model options and expanded provider coverage.
  - Improved setup guidance with clearer next-step commands for unconfigured providers.

- **Bug Fixes**
  - Fixed routing, provider health checks, and quota-related issues to make connections more reliable.
  - Improved workflow handling and retry behavior for smoother runs.
  - Updated agent and event behavior for better telemetry and monitoring.

- **Documentation**
  - Updated the changelog and version references across project docs and plugin listings to **9.46.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->