### PR TITLE
feat: emit review.finding + synthesis lifecycle events (#498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`review.finding` and `synthesis` lifecycle events** complete the #498 event vocabulary (the other two, `provider.selected` and `circuit-breaker.*`, shipped in 9.46.0). `review.finding` fires once per Round 1 code-review finding with `provider`, `severity`, `message`, and `round` attributes, capturing per-provider attribution before findings are merged and de-duplicated. `synthesis` fires when a synthesis artifact is produced (attributes `phase`, `provider`, `count`), wired into the review/deliver workflow (`review.sh`, success branch only) and the parallel aggregator (`parallel.sh`, attributing the provider that actually produced the artifact). `octo-hud` renders both, coloring `review.finding` by severity. Council and debate synthesis sites are a documented follow-up (their multi-branch fallbacks need per-site attribution care). (#498)
+
 ## [9.46.0] - 2026-07-01
 
 ### Added

--- a/scripts/lib/event-monitor.sh
+++ b/scripts/lib/event-monitor.sh
@@ -30,7 +30,7 @@ octo_hud_format_line() {
     local line="$1"
     [[ -n "${line// /}" ]] || return 1
 
-    local event ts provider outcome status command exit_code
+    local event ts provider outcome status command exit_code severity message findings
     event="$(octo_hud_field "$line" event)"
     [[ -n "$event" ]] || return 1   # not a recognizable event record
 
@@ -40,6 +40,9 @@ octo_hud_format_line() {
     status="$(octo_hud_field "$line" status)"
     command="$(octo_hud_field "$line" command)"
     exit_code="$(octo_hud_field "$line" exit_code)"
+    severity="$(octo_hud_field "$line" severity)"   # #498: review.finding
+    message="$(octo_hud_field "$line" message)"     # #498: review.finding
+    findings="$(octo_hud_field "$line" count)"      # #498: synthesis tally
 
     # Color by event family (guard colors so non-TTY/no-tput still works).
     local c_reset c_dim c_evt
@@ -49,15 +52,22 @@ octo_hud_format_line() {
         dispatch.end)
             if [[ "$outcome" == "error" ]]; then c_evt=$'\033[31m'; else c_evt=$'\033[32m'; fi ;;
         circuit-breaker.closed|circuit-breaker.half-open|provider.selected) c_evt=$'\033[36m' ;; # cyan
+        review.finding)                                                     # #498
+            case "$severity" in normal|critical|high) c_evt=$'\033[31m' ;;  # red for real bugs
+                                *) c_evt=$'\033[33m' ;; esac ;;             # yellow for nit/other
+        synthesis) c_evt=$'\033[32m' ;;                                     # #498: green
         *) c_evt=$'\033[0m' ;;
     esac
 
     local detail=""
     [[ -n "$provider" ]]  && detail="${detail} provider=${provider}"
+    [[ -n "$severity" ]]  && detail="${detail} severity=${severity}"
     [[ -n "$status" ]]    && detail="${detail} status=${status}"
     [[ -n "$command" ]]   && detail="${detail} cmd=${command}"
     [[ -n "$outcome" ]]   && detail="${detail} outcome=${outcome}"
+    [[ -n "$findings" ]]  && detail="${detail} count=${findings}"
     [[ -n "$exit_code" ]] && detail="${detail} exit=${exit_code}"
+    [[ -n "$message" ]]   && detail="${detail} msg=${message}"
 
     printf '%s%s%s  %s%-22s%s%s\n' \
         "$c_dim" "${ts:-now}" "$c_reset" "$c_evt" "$event" "$c_reset" "$detail"

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -485,6 +485,10 @@ $(<"$raw_concat")"
             echo "$synthesis_result" >> "$aggregate_file"
             rm -f "$raw_concat"
             log INFO "Synthesized $result_count results via $synth_used to: $aggregate_file"
+            # #498: emit a synthesis lifecycle event on the success path, attributing
+            # the provider that actually produced the artifact ($synth_used, which
+            # reflects the claude-sonnet fallback above).
+            declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "synthesis" phase="parallel" provider="$synth_used" count="$result_count" || true
             echo ""
             echo -e "${GREEN}✓${NC} Results synthesized to: $aggregate_file"
             guard_output "$(<"$aggregate_file")" "aggregate-synthesis"

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -568,6 +568,15 @@ ${agent_prompt_base}"
         # v9.3.1: Write provider status for Round 1 agents (#187)
         local atype="${round1_agent_types[$idx]}"
         local provider_key="${atype%%[-_]*}"
+        # #498: emit one review.finding lifecycle event per Round 1 finding, while
+        # per-provider attribution is still in scope (it is dropped after the merge
+        # above). round="1" lets consumers filter pre-verification noise.
+        if [[ "$agent_findings" != "[]" ]] && declare -f octo_event_emit >/dev/null 2>&1; then
+            while IFS=$'\t' read -r _rf_sev _rf_title; do
+                [[ -z "${_rf_sev}${_rf_title}" ]] && continue
+                octo_event_emit "review.finding" provider="$provider_key" severity="${_rf_sev:-unknown}" message="${_rf_title:-}" round="1" || true
+            done < <(printf '%s' "$agent_findings" | jq -r '.[]? | [(.severity // "unknown"), (.title // .message // "")] | @tsv' 2>/dev/null)
+        fi
         if [[ $(grep -c "Status: FAILED" "$f" 2>/dev/null || true) -gt 0 ]]; then
             echo "${provider_key}|fallback|Round 1 agent failed" >> "$provider_status_file"
         elif [[ "$agent_findings" != "[]" ]]; then
@@ -685,8 +694,9 @@ Findings: $(echo "$confirmed_findings" | jq -c '.')
 
 Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
 
-    local final_json
+    local final_json synth_ok="true"
     final_json=$(run_agent_sync "claude-sonnet" "$synthesis_prompt" 120 "code-reviewer" "review") || {
+        synth_ok="false"
         log WARN "review_run: synthesis failed, using confirmed findings sorted as-is"
         final_json="{\"findings\":$(echo "$confirmed_findings" | jq -c 'sort_by(.severity)' 2>/dev/null || echo "[]")}"
     }
@@ -697,6 +707,15 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
     # Write findings file
     echo "$final_json" > "$findings_file"
     log INFO "review_run: findings saved to $findings_file"
+
+    # #498: emit a synthesis lifecycle event when Round 3 synthesis succeeds.
+    # Only on the success branch — the fallback above reassigns the provider, so
+    # attribution would be wrong there (per design-review verification).
+    if [[ "$synth_ok" == "true" ]] && declare -f octo_event_emit >/dev/null 2>&1; then
+        local _synth_count
+        _synth_count=$(printf '%s' "$final_json" | jq '.findings | length' 2>/dev/null || echo 0)
+        octo_event_emit "synthesis" phase="review" provider="claude-sonnet" count="${_synth_count:-0}" || true
+    fi
 
     if [[ -n "$proof_dir" ]]; then
         octo_proof_artifact "$proof_dir" "review-findings" "$findings_file" "final review findings"

--- a/tests/unit/test-lifecycle-events-498.sh
+++ b/tests/unit/test-lifecycle-events-498.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# #498: coverage for the review.finding + synthesis lifecycle events —
+# event contract (emit shape) + HUD rendering (no write-only telemetry) +
+# the jq extraction review.sh uses to derive per-finding attributes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+log() { :; }
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/events.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/event-monitor.sh"
+
+test_suite "lifecycle events: review.finding + synthesis (#498)"
+
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT INT TERM
+
+# ── review.finding event shape ────────────────────────────────────────────
+test_review_finding_shape() {
+    test_case "review.finding emits provider/severity/message/round attributes"
+    export OCTO_EVENT_LOG="$FIXTURE/rf.jsonl"
+    : > "$OCTO_EVENT_LOG"
+    octo_event_emit "review.finding" provider=codex severity=normal message="null deref in auth" round=1
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$OCTO_EVENT_LOG" <<'PY' || { test_fail "review.finding JSON invalid"; return; }
+import json, sys
+row = json.loads(open(sys.argv[1]).readline())
+a = row["attributes"]
+assert row["event"] == "review.finding", row["event"]
+assert a["provider"] == "codex"
+assert a["severity"] == "normal"
+assert a["message"] == "null deref in auth"
+assert a["round"] == "1"
+PY
+    else
+        grep -q '"event":"review.finding"' "$OCTO_EVENT_LOG" || { test_fail "event name missing"; return; }
+    fi
+    test_pass
+}
+
+# ── synthesis event shape ───────────────────────────────────────────────────
+test_synthesis_shape() {
+    test_case "synthesis emits phase/provider/count attributes"
+    export OCTO_EVENT_LOG="$FIXTURE/syn.jsonl"
+    : > "$OCTO_EVENT_LOG"
+    octo_event_emit "synthesis" phase=review provider=claude-sonnet count=7
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$OCTO_EVENT_LOG" <<'PY' || { test_fail "synthesis JSON invalid"; return; }
+import json, sys
+row = json.loads(open(sys.argv[1]).readline())
+a = row["attributes"]
+assert row["event"] == "synthesis", row["event"]
+assert a["phase"] == "review"
+assert a["provider"] == "claude-sonnet"
+assert a["count"] == "7"
+PY
+    else
+        grep -q '"event":"synthesis"' "$OCTO_EVENT_LOG" || { test_fail "event name missing"; return; }
+    fi
+    test_pass
+}
+
+# ── HUD renders the new events (no write-only telemetry) ─────────────────────
+test_hud_renders_review_finding() {
+    test_case "HUD formatter surfaces review.finding severity + message"
+    local line out
+    line='{"timestamp":"2026-07-01T00:00:00Z","event":"review.finding","source":"octopus","pid":1,"session_id":"s","attributes":{"provider":"codex","severity":"normal","message":"boom","round":"1"}}'
+    out="$(octo_hud_format_line "$line")" || { test_fail "formatter returned non-zero"; return; }
+    assert_contains "$out" "review.finding"
+    assert_contains "$out" "provider=codex"
+    assert_contains "$out" "severity=normal"
+    assert_contains "$out" "msg=boom"
+    test_pass
+}
+
+test_hud_renders_synthesis() {
+    test_case "HUD formatter surfaces synthesis count"
+    local line out
+    line='{"timestamp":"2026-07-01T00:00:00Z","event":"synthesis","source":"octopus","pid":1,"session_id":"s","attributes":{"phase":"parallel","provider":"agy","count":"5"}}'
+    out="$(octo_hud_format_line "$line")" || { test_fail "formatter returned non-zero"; return; }
+    assert_contains "$out" "synthesis"
+    assert_contains "$out" "provider=agy"
+    assert_contains "$out" "count=5"
+    test_pass
+}
+
+# ── the jq extraction review.sh uses to derive per-finding attributes ────────
+test_review_finding_extraction() {
+    test_case "review.sh jq extraction yields severity<TAB>title per finding"
+    local findings tsv
+    findings='[{"severity":"normal","title":"A","file":"x"},{"title":"B"},{"severity":"nit"}]'
+    tsv="$(printf '%s' "$findings" | jq -r '.[]? | [(.severity // "unknown"), (.title // .message // "")] | @tsv' 2>/dev/null)"
+    # 3 findings → 3 lines; missing severity → "unknown"; missing title → ""
+    assert_equals "3" "$(printf '%s\n' "$tsv" | grep -c .)"
+    assert_contains "$tsv" "normal	A"
+    assert_contains "$tsv" "unknown	B"
+    assert_contains "$tsv" "nit	"
+    test_pass
+}
+
+test_review_finding_shape
+test_synthesis_shape
+test_hud_renders_review_finding
+test_hud_renders_synthesis
+test_review_finding_extraction
+
+test_summary


### PR DESCRIPTION
Completes the **#498** lifecycle-event vocabulary. `provider.selected` and `circuit-breaker.*` shipped in v9.46.0; this adds the two remaining events.

## What

- **`review.finding`** — emitted once per Round 1 code-review finding in `review.sh`, inside the collection loop where per-provider attribution is still in scope (attribution is dropped once agent findings are merged). Attributes: `provider`, `severity`, `message`, `round`. `round="1"` lets consumers filter pre-verification noise.
- **`synthesis`** — emitted when a synthesis artifact is produced. Wired into:
  - `review.sh` Round 3 — **success branch only** (the fallback reassigns the provider, so attribution would be wrong there)
  - `parallel.sh` aggregator — attributes `$synth_used`, which reflects the claude-sonnet fallback
  - Attributes: `phase`, `provider`, `count`
- **`event-monitor.sh` / octo-hud** renders both (review.finding colored by severity, synthesis green), surfacing `severity`/`message`/`count` so the events are not write-only telemetry.

Attribute contract held across sites: `review.finding = {provider, severity, message, round}`, `synthesis = {phase, provider, count}`.

## How it was designed

Ran a multi-provider `/octo:develop` design-review ceremony (codex/agy/claude). It verified the binding constraint (provider attribution only survives inside the review.sh Round 1 loop) and flagged two risks this PR addresses: double-emission across `review.sh`/`workflows.sh` (resolved by emitting only in `review.sh`), and write-only telemetry (resolved by the HUD rendering). The ceremony's own code-gen step failed on provider errors, so the implementation is hand-written from the verified design.

## Follow-up (intentionally out of scope)
Council and debate synthesis sites. Their multi-branch fallbacks (quorum vs moderator; multi-phase state machine) need per-site attribution care to avoid double-emission — noted in the CHANGELOG.

## Tests
`tests/unit/test-lifecycle-events-498.sh` (5 cases): both event shapes, HUD rendering of each, and the jq extraction `review.sh` uses to derive per-finding attributes. Local: new test 5/5; `test-octo-events` 11/0, `test-event-monitor` 4/0, `test-agent-lifecycle-events` 6/0, `test-hud-smart-mode` 31/0 — no regressions.

Partially addresses #498 (completes its two remaining events).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle event tracking for review findings and synthesis results.
  * Improved HUD output to show event severity, messages, and result counts, with clearer color-coded highlighting.

* **Bug Fixes**
  * Ensured synthesis events are only shown when synthesis succeeds.
  * Added support for missing field defaults so event output stays readable and consistent.

* **Tests**
  * Added coverage for event payloads and HUD rendering to verify the new event details display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->