### PR TITLE
fix: validate agy model pins dynamically

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ Providers:
 Always be mindful that external CLIs cost money:
 - 🔴 Codex: ~$0.01-0.30 per query depending on model (GPT-5.5 $5/$30 MTok — premium default as of v9.44, GPT-5.4 $2.50/$15, GPT-5.3-Codex $1.75/$14, Mini $0.25/$2.00 MTok)
 - 🟡 Gemini: ~$0.01-0.03 per query (Gemini 3.1 Pro Preview $2.50/$10 MTok, 3 Flash Preview $0.25/$1)
-- 🧭 Antigravity CLI (`agy`): Included with the user's Antigravity access/subscription; backend cost depends on selected `OCTOPUS_AGY_MODEL`
+- 🧭 Antigravity CLI (`agy`): Included with the user's Antigravity access/subscription; backend cost depends on selected `OCTOPUS_AGY_MODEL`. Because Antigravity's model list is service-owned, explicit pins should use labels returned by `agy models` (for example `Gemini 3.5 Flash (Low)`) or `default`/`agy/default` to use the CLI default.
 - 🟣 Perplexity: ~$0.01-0.05 per query (Sonar Pro $3/$15 MTok, Sonar $1/$1 MTok)
 - 🔵 Claude (Sonnet 4.6): Included with Claude Code subscription
 - 🔵 Claude (Fable 5, Mythos-class, opt-in via `OCTOPUS_OPUS_MODEL=claude-fable-5`): **$10/$50 per MTok** — 2x Opus 4.8 cost. 1M context, 128K output. Never auto-selected. Note: Anthropic retains prompts/outputs up to 30 days for safety classifiers.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ Claude Octopus coordinates **nine AI providers** to give you multi-perspective a
 |----------|----------|------------------|-------------|
 | **Codex CLI** | `codex exec --model gpt-5.4` | GPT-5.4 | Your `OPENAI_API_KEY` |
 | **Gemini CLI** | `gemini -y -m gemini-3.1-pro-preview` | Gemini 3.1 Pro Preview | Your `GEMINI_API_KEY` |
-| **Antigravity CLI** | `agy --print --sandbox` | Antigravity default model | Your Antigravity CLI auth |
+| **Antigravity CLI** | `agy --print --sandbox` | `default`/`agy/default`, or an exact label from `agy models` | Your Antigravity CLI auth |
 | **Claude** | Built-in | Claude Sonnet 4.6 / Opus 4.7 | Your Claude Code subscription |
 | **Perplexity** | API-only | Sonar Pro / Sonar | Your `PERPLEXITY_API_KEY` |
 | **OpenRouter** | API-only | 100+ models (GLM-5, Kimi K2.5, DeepSeek R1, etc.) | Your `OPENROUTER_API_KEY` |

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -13,8 +13,12 @@ print_timeout="${OCTOPUS_AGY_PRINT_TIMEOUT:-5m0s}"
 # --dangerously-skip-permissions: auto-approve agy's folder-trust + tool prompts so
 # council seats don't block on a per-worktree trust prompt (already --sandbox'd).
 cmd=(agy --print --sandbox --dangerously-skip-permissions --print-timeout "$print_timeout")
-if [[ -n "$model" && "$model" != "default" ]]; then
-    cmd+=(--model "$model")
-fi
+case "$model" in
+    ""|default|agy/default)
+        ;;
+    *)
+        cmd+=(--model "$model")
+        ;;
+esac
 
 exec "${cmd[@]}"

--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -44,7 +44,7 @@ usage() {
     echo "Environment Variables:"
     echo "  OCTOPUS_CODEX_MODEL         Override codex model (highest priority)"
     echo "  OCTOPUS_GEMINI_MODEL        Override gemini model"
-    echo "  OCTOPUS_AGY_MODEL           Override Antigravity CLI model"
+    echo "  OCTOPUS_AGY_MODEL           Override Antigravity model (default, agy/default, or exact agy models label)"
     echo "  OCTOPUS_CURSOR_AGENT_MODEL  Override cursor-agent model"
     echo "  OCTOPUS_COST_MODE           Set cost tier: budget, standard, premium"
     echo "  OCTO_ALLOWED_PROVIDERS      Override provider availability for this process"

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -207,7 +207,7 @@ resolve_octopus_model() {
         config_data=$(<"$config_file")
 
         # Priority 1b: Session-only config overrides
-        resolved_model=$(echo "$config_data" | jq -r ".overrides.${canonical_provider} // empty" 2>/dev/null)
+        resolved_model=$(echo "$config_data" | jq -r --arg p "$canonical_provider" '.overrides[$p] // empty' 2>/dev/null)
         if [[ -n "$resolved_model" && "$resolved_model" != "null" ]]; then
             [[ -n "$_trace" ]] && echo "[model-trace] Tier 2 (session override): $resolved_model ← SELECTED" >&2
         else
@@ -218,10 +218,10 @@ resolve_octopus_model() {
         if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
             local routed=""
             if [[ -n "$phase" ]]; then
-                routed=$(echo "$config_data" | jq -r ".routing.phases.\"${phase}\" // empty" 2>/dev/null)
+                routed=$(echo "$config_data" | jq -r --arg phase "$phase" '.routing.phases[$phase] // empty' 2>/dev/null)
             fi
             if [[ -z "$routed" || "$routed" == "null" ]] && [[ -n "$role" ]]; then
-                routed=$(echo "$config_data" | jq -r ".routing.roles.\"${role}\" // empty" 2>/dev/null)
+                routed=$(echo "$config_data" | jq -r --arg role "$role" '.routing.roles[$role] // empty' 2>/dev/null)
             fi
 
             # Handle recursive reference (e.g. "codex:spark")
@@ -276,7 +276,7 @@ resolve_octopus_model() {
 
             if [[ -n "$capability" && "$capability" != "$canonical_provider" ]]; then
                 # Support both short capability (spark) and full model aliases (spark_model)
-                resolved_model=$(echo "$config_data" | jq -r ".providers."${canonical_provider}"."${capability}" // .providers."${canonical_provider}"."${capability}_model" // empty" 2>/dev/null)
+                resolved_model=$(echo "$config_data" | jq -r --arg p "$canonical_provider" --arg cap "$capability" '.providers[$p][$cap] // .providers[$p][($cap + "_model")] // empty' 2>/dev/null)
             fi
             if [[ -n "$resolved_model" && "$resolved_model" != "null" ]]; then
                 [[ -n "$_trace" ]] && echo "[model-trace] Tier 4 (capability map): $resolved_model ← SELECTED (cap: ${capability:-none})" >&2
@@ -288,11 +288,11 @@ resolve_octopus_model() {
         # 4. Tier Mapping
         if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
             if [[ -n "${OCTOPUS_COST_MODE:-}" && "${OCTOPUS_COST_MODE:-}" != "standard" ]]; then
-                resolved_model=$(echo "$config_data" | jq -r ".tiers."${OCTOPUS_COST_MODE}"."${canonical_provider}" // empty" 2>/dev/null)
+                resolved_model=$(echo "$config_data" | jq -r --arg mode "$OCTOPUS_COST_MODE" --arg p "$canonical_provider" '.tiers[$mode][$p] // empty' 2>/dev/null)
                 if [[ -n "$resolved_model" && "$resolved_model" =~ ^[a-z_]+$ ]]; then
                     # Capability ref in tier map
                     local tier_mapped_model
-                    tier_mapped_model=$(echo "$config_data" | jq -r ".providers."${canonical_provider}"."${resolved_model}" // .providers."${canonical_provider}"."${resolved_model}_model" // empty" 2>/dev/null)
+                    tier_mapped_model=$(echo "$config_data" | jq -r --arg p "$canonical_provider" --arg model "$resolved_model" '.providers[$p][$model] // .providers[$p][($model + "_model")] // empty' 2>/dev/null)
                     [[ -n "$tier_mapped_model" && "$tier_mapped_model" != "null" ]] && resolved_model="$tier_mapped_model"
                 fi
                 [[ -n "$_trace" ]] && echo "[model-trace] Tier 5 (cost mode ${OCTOPUS_COST_MODE}): ${resolved_model:-—}" >&2
@@ -301,7 +301,7 @@ resolve_octopus_model() {
 
         # 5. Global Defaults
         if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
-            resolved_model=$(echo "$config_data" | jq -r ".providers."${canonical_provider}".default // .providers."${canonical_provider}".model // empty" 2>/dev/null)
+            resolved_model=$(echo "$config_data" | jq -r --arg p "$canonical_provider" '.providers[$p].default // .providers[$p].model // empty' 2>/dev/null)
             if [[ -n "$resolved_model" && "$resolved_model" != "null" ]]; then
                 [[ -n "$_trace" ]] && echo "[model-trace] Tier 6 (config default): $resolved_model ← SELECTED" >&2
             else

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -94,7 +94,7 @@ validate_model_name_for_provider() {
     local model="$2"
 
     case "$provider" in
-        agy|antigravity)
+        agy|agy-research|antigravity)
             validate_agy_model_name "$model"
             ;;
         *)
@@ -116,7 +116,7 @@ resolve_octopus_model() {
     # session state and take precedence over any cached value.
     local canonical_provider="$provider"
     case "$canonical_provider" in
-        antigravity) canonical_provider="agy" ;;
+        antigravity|agy-research) canonical_provider="agy" ;;
     esac
     local env_var="OCTOPUS_$(echo "$canonical_provider" | tr '[:lower:]' '[:upper:]' | tr '-' '_')_MODEL"
     if [[ -n "${!env_var:-}" ]]; then
@@ -133,7 +133,7 @@ resolve_octopus_model() {
     local cache_key
     # v8.49.0: Field-delimited cache key prevents collisions
     # (e.g., provider="codex" + type="spark" must differ from type="codex-spark")
-    local safe_p="${provider//[^a-zA-Z0-9]/_}"
+    local safe_p="${canonical_provider//[^a-zA-Z0-9]/_}"
     local safe_a="${agent_type//[^a-zA-Z0-9]/_}"
     local safe_ph="${phase//[^a-zA-Z0-9]/_}"
     local safe_r="${role//[^a-zA-Z0-9]/_}"
@@ -207,7 +207,7 @@ resolve_octopus_model() {
         config_data=$(<"$config_file")
 
         # Priority 1b: Session-only config overrides
-        resolved_model=$(echo "$config_data" | jq -r ".overrides.${provider} // empty" 2>/dev/null)
+        resolved_model=$(echo "$config_data" | jq -r ".overrides.${canonical_provider} // empty" 2>/dev/null)
         if [[ -n "$resolved_model" && "$resolved_model" != "null" ]]; then
             [[ -n "$_trace" ]] && echo "[model-trace] Tier 2 (session override): $resolved_model ← SELECTED" >&2
         else

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -274,9 +274,9 @@ resolve_octopus_model() {
                 capability="$agent_type"
             fi
 
-            if [[ -n "$capability" && "$capability" != "$provider" ]]; then
+            if [[ -n "$capability" && "$capability" != "$canonical_provider" ]]; then
                 # Support both short capability (spark) and full model aliases (spark_model)
-                resolved_model=$(echo "$config_data" | jq -r ".providers.${provider}.\"${capability}\" // .providers.${provider}.\"${capability}_model\" // empty" 2>/dev/null)
+                resolved_model=$(echo "$config_data" | jq -r ".providers."${canonical_provider}"."${capability}" // .providers."${canonical_provider}"."${capability}_model" // empty" 2>/dev/null)
             fi
             if [[ -n "$resolved_model" && "$resolved_model" != "null" ]]; then
                 [[ -n "$_trace" ]] && echo "[model-trace] Tier 4 (capability map): $resolved_model ← SELECTED (cap: ${capability:-none})" >&2
@@ -288,11 +288,11 @@ resolve_octopus_model() {
         # 4. Tier Mapping
         if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
             if [[ -n "${OCTOPUS_COST_MODE:-}" && "${OCTOPUS_COST_MODE:-}" != "standard" ]]; then
-                resolved_model=$(echo "$config_data" | jq -r ".tiers.\"${OCTOPUS_COST_MODE}\".\"${provider}\" // empty" 2>/dev/null)
+                resolved_model=$(echo "$config_data" | jq -r ".tiers."${OCTOPUS_COST_MODE}"."${canonical_provider}" // empty" 2>/dev/null)
                 if [[ -n "$resolved_model" && "$resolved_model" =~ ^[a-z_]+$ ]]; then
                     # Capability ref in tier map
                     local tier_mapped_model
-                    tier_mapped_model=$(echo "$config_data" | jq -r ".providers.\"${provider}\".\"${resolved_model}\" // .providers.\"${provider}\".\"${resolved_model}_model\" // empty" 2>/dev/null)
+                    tier_mapped_model=$(echo "$config_data" | jq -r ".providers."${canonical_provider}"."${resolved_model}" // .providers."${canonical_provider}"."${resolved_model}_model" // empty" 2>/dev/null)
                     [[ -n "$tier_mapped_model" && "$tier_mapped_model" != "null" ]] && resolved_model="$tier_mapped_model"
                 fi
                 [[ -n "$_trace" ]] && echo "[model-trace] Tier 5 (cost mode ${OCTOPUS_COST_MODE}): ${resolved_model:-—}" >&2
@@ -301,7 +301,7 @@ resolve_octopus_model() {
 
         # 5. Global Defaults
         if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
-            resolved_model=$(echo "$config_data" | jq -r ".providers.${provider}.default // .providers.${provider}.model // empty" 2>/dev/null)
+            resolved_model=$(echo "$config_data" | jq -r ".providers."${canonical_provider}".default // .providers."${canonical_provider}".model // empty" 2>/dev/null)
             if [[ -n "$resolved_model" && "$resolved_model" != "null" ]]; then
                 [[ -n "$_trace" ]] && echo "[model-trace] Tier 6 (config default): $resolved_model ← SELECTED" >&2
             else

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -42,6 +42,52 @@ opus_default_model() {
     fi
 }
 
+# Validate Antigravity CLI model labels against the live CLI catalog.
+#
+# Antigravity's model selector is service-owned and changes outside Octopus
+# releases. Real labels include spaces and parentheses (for example,
+# "Gemini 3.5 Flash (Low)"), so the generic shell-token validator is too
+# strict for explicit agy model pins. Validate agy pins by exact membership in
+# `agy models` instead, while keeping the generic validator for all other
+# providers.
+validate_agy_model_name() {
+    local model="$1"
+
+    [[ -z "$model" ]] && return 1
+    [[ "$model" == *$'\n'* || "$model" == *$'\r'* ]] && return 1
+    case "$model" in
+        *\\*) return 1 ;;
+    esac
+
+    case "$model" in
+        default|agy/default)
+            return 0
+            ;;
+    esac
+
+    if ! command -v agy >/dev/null 2>&1; then
+        log ERROR "Cannot validate OCTOPUS_AGY_MODEL because agy CLI is not installed"
+        return 1
+    fi
+
+    local available_models=""
+    if ! available_models="$(agy models 2>/dev/null)" || [[ -z "$available_models" ]]; then
+        log ERROR "Cannot validate OCTOPUS_AGY_MODEL because 'agy models' returned no models"
+        return 1
+    fi
+
+    local line=""
+    while IFS= read -r line; do
+        line="${line%$'\r'}"
+        if [[ "$line" == "$model" ]]; then
+            return 0
+        fi
+    done <<< "$available_models"
+
+    log ERROR "Invalid OCTOPUS_AGY_MODEL: '$model'"
+    printf 'Available agy models:\n%s\n' "$available_models" >&2
+    return 1
+}
 # resolve_octopus_model <provider> <agent_type> <phase> <role>
 resolve_octopus_model() {
     local provider="$1"
@@ -60,7 +106,11 @@ resolve_octopus_model() {
     esac
     local env_var="OCTOPUS_$(echo "$canonical_provider" | tr '[:lower:]' '[:upper:]' | tr '-' '_')_MODEL"
     if [[ -n "${!env_var:-}" ]]; then
-        if ! validate_model_name "${!env_var}"; then
+        if [[ "$canonical_provider" == "agy" ]]; then
+            if ! validate_agy_model_name "${!env_var}"; then
+                return 1
+            fi
+        elif ! validate_model_name "${!env_var}"; then
             log ERROR "Invalid model name in $env_var"
             return 1
         fi
@@ -316,7 +366,9 @@ validate_model_name() {
     # Reject empty names
     [[ -z "$model" ]] && return 1
     [[ "$model" == *$'\n'* || "$model" == *$'\r'* ]] && return 1
-    [[ "$model" == *"\\"* ]] && return 1
+    case "$model" in
+        *\\*) return 1 ;;
+    esac
 
     # Reject shell metacharacters and whitespace (v8.50.0 Security hardening).
     case "$model" in

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -88,6 +88,20 @@ validate_agy_model_name() {
     printf 'Available agy models:\n%s\n' "$available_models" >&2
     return 1
 }
+
+validate_model_name_for_provider() {
+    local provider="$1"
+    local model="$2"
+
+    case "$provider" in
+        agy|antigravity)
+            validate_agy_model_name "$model"
+            ;;
+        *)
+            validate_model_name "$model"
+            ;;
+    esac
+}
 # resolve_octopus_model <provider> <agent_type> <phase> <role>
 resolve_octopus_model() {
     local provider="$1"
@@ -106,11 +120,7 @@ resolve_octopus_model() {
     esac
     local env_var="OCTOPUS_$(echo "$canonical_provider" | tr '[:lower:]' '[:upper:]' | tr '-' '_')_MODEL"
     if [[ -n "${!env_var:-}" ]]; then
-        if [[ "$canonical_provider" == "agy" ]]; then
-            if ! validate_agy_model_name "${!env_var}"; then
-                return 1
-            fi
-        elif ! validate_model_name "${!env_var}"; then
+        if ! validate_model_name_for_provider "$canonical_provider" "${!env_var}"; then
             log ERROR "Invalid model name in $env_var"
             return 1
         fi
@@ -136,7 +146,7 @@ resolve_octopus_model() {
     local cached_val
     eval "cached_val=\"\${_OCTO_MODEL_CACHE_${cache_key}:-}\""
     if [[ -n "$cached_val" ]]; then
-        if validate_model_name "$cached_val"; then
+        if validate_model_name_for_provider "$canonical_provider" "$cached_val"; then
             echo "$cached_val"
             return 0
         fi
@@ -162,7 +172,7 @@ resolve_octopus_model() {
         if [[ -n "$cached_val" && "$cached_val" != "null" ]]; then
             # Reject invalid cached model names instead of mutating them into a
             # different model string before eval.
-            if validate_model_name "$cached_val"; then
+            if validate_model_name_for_provider "$canonical_provider" "$cached_val"; then
                 eval "_OCTO_MODEL_CACHE_${cache_key}=\"\$cached_val\""
                 echo "$cached_val"
                 return 0
@@ -333,7 +343,7 @@ resolve_octopus_model() {
 
     # Validate before eval/cache. Dispatch also validates before command
     # construction, but the resolver cache itself must not eval unsafe values.
-    if ! validate_model_name "$resolved_model"; then
+    if ! validate_model_name_for_provider "$canonical_provider" "$resolved_model"; then
         log ERROR "Invalid resolved model name for $provider/$agent_type"
         return 1
     fi

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -65,13 +65,26 @@ MOCK_AGY
     chmod +x "$tmp_bin/agy"
 
     local old_path="$PATH"
+    local old_home="$HOME"
+    local had_log=0
     PATH="$tmp_bin:$PATH"
     AGY_ARG_CAPTURE="$capture"
     export AGY_ARG_CAPTURE
 
+    if declare -F log >/dev/null 2>&1; then
+        had_log=1
+        eval "$(declare -f log | sed '1s/^log/__octo_saved_log/')"
+    fi
+
     restore_agy_dynamic_model_env() {
         PATH="$old_path"
+        HOME="$old_home"
         unset AGY_ARG_CAPTURE
+        unset -f log 2>/dev/null || true
+        if [[ "$had_log" == "1" ]] && declare -F __octo_saved_log >/dev/null 2>&1; then
+            eval "$(declare -f __octo_saved_log | sed '1s/^__octo_saved_log/log/')"
+            unset -f __octo_saved_log 2>/dev/null || true
+        fi
     }
 
     log() { :; }
@@ -103,15 +116,26 @@ MOCK_AGY
         return
     fi
 
+    OCTOPUS_AGY_MODEL='Gemini 3.5 Flash (Low)'
+    resolved="$(resolve_octopus_model agy-research agy tangle decomposer)"
+    unset OCTOPUS_AGY_MODEL
+    if [[ "$resolved" != 'Gemini 3.5 Flash (Low)' ]]; then
+        restore_agy_dynamic_model_env
+        test_fail "agy-research should use agy-specific env validation"
+        return
+    fi
+
     local config_dir="$TEST_TMP_DIR/agy-config-home"
     mkdir -p "$config_dir/.claude-octopus/config"
     cat > "$config_dir/.claude-octopus/config/providers.json" <<'JSON'
 {"overrides":{"agy":"Gemini 3.5 Flash (Medium)"}}
 JSON
-    HOME="$config_dir" resolved="$(HOME="$config_dir" resolve_octopus_model agy agy tangle decomposer)"
+    HOME="$config_dir"
+    resolved="$(resolve_octopus_model agy-research agy tangle decomposer)"
+    HOME="$old_home"
     if [[ "$resolved" != 'Gemini 3.5 Flash (Medium)' ]]; then
         restore_agy_dynamic_model_env
-        test_fail "config-resolved agy labels should use agy-specific validation"
+        test_fail "config-resolved agy-research labels should use agy-specific validation"
         return
     fi
 

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -43,6 +43,78 @@ test_agy_dispatch_native_flags() {
     fi
 }
 
+
+test_agy_dynamic_model_validation() {
+    test_case "explicit agy model pins validate against agy models"
+
+    local tmp_bin="$TEST_TMP_DIR/agy-dynamic-model-bin"
+    local capture="$TEST_TMP_DIR/agy-argv.txt"
+    mkdir -p "$tmp_bin"
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "models" ]]; then
+    printf '%s\n' \
+        'Gemini 3.5 Flash (Low)' \
+        'Gemini 3.5 Flash (Medium)' \
+        'Claude Sonnet 4.6 (Thinking)'
+    exit 0
+fi
+printf '%s\n' "$@" > "${AGY_ARG_CAPTURE:?}"
+exit 0
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+
+    local old_path="$PATH"
+    PATH="$tmp_bin:$PATH"
+    AGY_ARG_CAPTURE="$capture"
+    export AGY_ARG_CAPTURE
+
+    log() { :; }
+    source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+
+    if ! validate_agy_model_name 'Gemini 3.5 Flash (Low)'; then
+        PATH="$old_path"
+        test_fail "real agy labels from agy models should be accepted"
+        return
+    fi
+    if validate_model_name 'Gemini 3.5 Flash (Low)'; then
+        PATH="$old_path"
+        test_fail "generic model validator should remain strict for shell-token providers"
+        return
+    fi
+    if validate_agy_model_name 'Gemini 9 Unknown (Low)' >/dev/null 2>&1; then
+        PATH="$old_path"
+        test_fail "agy labels absent from agy models should be rejected"
+        return
+    fi
+
+    local resolved=""
+    OCTOPUS_AGY_MODEL='Gemini 3.5 Flash (Low)'
+    resolved="$(resolve_octopus_model agy agy tangle decomposer)"
+    unset OCTOPUS_AGY_MODEL
+    if [[ "$resolved" != 'Gemini 3.5 Flash (Low)' ]]; then
+        PATH="$old_path"
+        test_fail "resolver should return explicit agy labels validated from agy models"
+        return
+    fi
+
+    OCTOPUS_AGY_MODEL='agy/default' bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" </dev/null
+    if grep -q -- '--model' "$capture"; then
+        PATH="$old_path"
+        test_fail "agy/default should not be passed to agy --model"
+        return
+    fi
+
+    OCTOPUS_AGY_MODEL='Gemini 3.5 Flash (Low)' bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" </dev/null
+    if grep -Fxq -- '--model' "$capture" && grep -Fxq -- 'Gemini 3.5 Flash (Low)' "$capture"; then
+        PATH="$old_path"
+        test_pass
+    else
+        PATH="$old_path"
+        test_fail "explicit agy model labels should be passed as one --model argument"
+    fi
+}
+
 test_agy_command_validation() {
     test_case "command validator allows agy dispatch"
 
@@ -515,6 +587,7 @@ test_provider_workflow_review_regressions() {
 test_agy_config_exists
 test_agy_available_agent
 test_agy_dispatch_native_flags
+test_agy_dynamic_model_validation
 test_agy_command_validation
 test_agy_dispatch_not_gemini_wrapper
 test_agy_provider_detection

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -108,7 +108,12 @@ MOCK_AGY
 
     local resolved=""
     OCTOPUS_AGY_MODEL='Gemini 3.5 Flash (Low)'
-    resolved="$(resolve_octopus_model agy agy tangle decomposer)"
+    if ! resolved="$(resolve_octopus_model agy agy tangle decomposer)"; then
+        unset OCTOPUS_AGY_MODEL
+        restore_agy_dynamic_model_env
+        test_fail "resolver failed for explicit agy label"
+        return
+    fi
     unset OCTOPUS_AGY_MODEL
     if [[ "$resolved" != 'Gemini 3.5 Flash (Low)' ]]; then
         restore_agy_dynamic_model_env
@@ -117,7 +122,12 @@ MOCK_AGY
     fi
 
     OCTOPUS_AGY_MODEL='Gemini 3.5 Flash (Low)'
-    resolved="$(resolve_octopus_model agy-research agy tangle decomposer)"
+    if ! resolved="$(resolve_octopus_model agy-research agy tangle decomposer)"; then
+        unset OCTOPUS_AGY_MODEL
+        restore_agy_dynamic_model_env
+        test_fail "resolver failed for explicit agy-research label"
+        return
+    fi
     unset OCTOPUS_AGY_MODEL
     if [[ "$resolved" != 'Gemini 3.5 Flash (Low)' ]]; then
         restore_agy_dynamic_model_env
@@ -128,14 +138,19 @@ MOCK_AGY
     local config_dir="$TEST_TMP_DIR/agy-config-home"
     mkdir -p "$config_dir/.claude-octopus/config"
     cat > "$config_dir/.claude-octopus/config/providers.json" <<'JSON'
-{"overrides":{"agy":"Gemini 3.5 Flash (Medium)"}}
+{"providers":{"agy":{"default":"Gemini 3.5 Flash (Medium)"}}}
 JSON
     HOME="$config_dir"
-    resolved="$(resolve_octopus_model agy-research agy tangle decomposer)"
+    if ! resolved="$(resolve_octopus_model agy-research agy tangle decomposer)"; then
+        HOME="$old_home"
+        restore_agy_dynamic_model_env
+        test_fail "resolver failed for config-resolved agy-research label"
+        return
+    fi
     HOME="$old_home"
     if [[ "$resolved" != 'Gemini 3.5 Flash (Medium)' ]]; then
         restore_agy_dynamic_model_env
-        test_fail "config-resolved agy-research labels should use agy-specific validation"
+        test_fail "config-resolved agy-research labels should use agy-specific provider lookups"
         return
     fi
 

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -69,21 +69,26 @@ MOCK_AGY
     AGY_ARG_CAPTURE="$capture"
     export AGY_ARG_CAPTURE
 
+    restore_agy_dynamic_model_env() {
+        PATH="$old_path"
+        unset AGY_ARG_CAPTURE
+    }
+
     log() { :; }
     source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
 
     if ! validate_agy_model_name 'Gemini 3.5 Flash (Low)'; then
-        PATH="$old_path"
+        restore_agy_dynamic_model_env
         test_fail "real agy labels from agy models should be accepted"
         return
     fi
     if validate_model_name 'Gemini 3.5 Flash (Low)'; then
-        PATH="$old_path"
+        restore_agy_dynamic_model_env
         test_fail "generic model validator should remain strict for shell-token providers"
         return
     fi
     if validate_agy_model_name 'Gemini 9 Unknown (Low)' >/dev/null 2>&1; then
-        PATH="$old_path"
+        restore_agy_dynamic_model_env
         test_fail "agy labels absent from agy models should be rejected"
         return
     fi
@@ -93,28 +98,39 @@ MOCK_AGY
     resolved="$(resolve_octopus_model agy agy tangle decomposer)"
     unset OCTOPUS_AGY_MODEL
     if [[ "$resolved" != 'Gemini 3.5 Flash (Low)' ]]; then
-        PATH="$old_path"
+        restore_agy_dynamic_model_env
         test_fail "resolver should return explicit agy labels validated from agy models"
+        return
+    fi
+
+    local config_dir="$TEST_TMP_DIR/agy-config-home"
+    mkdir -p "$config_dir/.claude-octopus/config"
+    cat > "$config_dir/.claude-octopus/config/providers.json" <<'JSON'
+{"overrides":{"agy":"Gemini 3.5 Flash (Medium)"}}
+JSON
+    HOME="$config_dir" resolved="$(HOME="$config_dir" resolve_octopus_model agy agy tangle decomposer)"
+    if [[ "$resolved" != 'Gemini 3.5 Flash (Medium)' ]]; then
+        restore_agy_dynamic_model_env
+        test_fail "config-resolved agy labels should use agy-specific validation"
         return
     fi
 
     OCTOPUS_AGY_MODEL='agy/default' bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" </dev/null
     if grep -q -- '--model' "$capture"; then
-        PATH="$old_path"
+        restore_agy_dynamic_model_env
         test_fail "agy/default should not be passed to agy --model"
         return
     fi
 
     OCTOPUS_AGY_MODEL='Gemini 3.5 Flash (Low)' bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" </dev/null
     if grep -Fxq -- '--model' "$capture" && grep -Fxq -- 'Gemini 3.5 Flash (Low)' "$capture"; then
-        PATH="$old_path"
+        restore_agy_dynamic_model_env
         test_pass
     else
-        PATH="$old_path"
+        restore_agy_dynamic_model_env
         test_fail "explicit agy model labels should be passed as one --model argument"
     fi
 }
-
 test_agy_command_validation() {
     test_case "command validator allows agy dispatch"
 


### PR DESCRIPTION
## Summary

This PR makes explicit Antigravity (`agy`) model pins validate against the live Antigravity CLI catalog instead of Octopus' generic shell-token model validator.

The current system has a fragile gap:

- Octopus exposes `OCTOPUS_AGY_MODEL` as the control for Antigravity model selection.
- Real `agy models` labels include spaces and parentheses, for example `Gemini 3.5 Flash (Low)`.
- The generic `validate_model_name` rejects whitespace and parentheses by design, so a valid Antigravity model label is rejected before it reaches the `agy` CLI.
- The only reliable workaround is to avoid `OCTOPUS_AGY_MODEL` and let the account-level Antigravity default decide the model.
- That fallback is operationally weak: changing the model in the Antigravity UI/TUI can silently affect every Octopus run without a config diff, run log pin, or reproducible model declaration.
- Antigravity's model list is service-owned and can change independently of Octopus releases, so hardcoding aliases in Octopus would become stale quickly.

This PR uses the opportunity to make Antigravity model selection explicit and dynamic: if `OCTOPUS_AGY_MODEL` is set for provider `agy`, Octopus validates it by exact membership in `agy models`.

## Changes

- Adds `validate_agy_model_name()` to `scripts/lib/model-resolver.sh`.
  - Accepts `default` and `agy/default` without calling the CLI.
  - For explicit pins, calls `agy models` and requires an exact label match.
  - Keeps the generic strict shell-token validator for all other providers.
- Updates resolver env override handling so `OCTOPUS_AGY_MODEL='Gemini 3.5 Flash (Low)'` can resolve for `agy`.
- Updates `scripts/helpers/agy-exec.sh` so both `default` and `agy/default` mean "do not pass `--model`".
- Adds a focused unit test covering:
  - exact `agy models` label acceptance;
  - generic validator remaining strict;
  - invalid `agy` labels rejected;
  - resolver returning explicit labels with spaces/parentheses;
  - helper not passing `--model` for `agy/default`;
  - helper passing explicit labels as a single `--model` argument.
- Updates docs/help text to describe `OCTOPUS_AGY_MODEL` as `default`, `agy/default`, or an exact label from `agy models`.

## Validation

Passed:

```text
git diff --check
bash -n scripts/lib/model-resolver.sh scripts/helpers/agy-exec.sh scripts/helpers/octo-model-config.sh tests/unit/test-agy-provider.sh
bash tests/unit/test-agy-provider.sh
bash tests/test-resolve-model.sh
bash tests/test-model-config-simple.sh
bash tests/smoke/test-syntax.sh
```

Also validated with a live authenticated `agy` CLI without generation:

```text
OCTOPUS_AGY_MODEL="Gemini 3.5 Flash (Low)" resolve_octopus_model agy agy tangle decomposer
→ Gemini 3.5 Flash (Low)
```

Noted but not caused by this patch:

```text
bash tests/test-model-config-v849.sh
→ failed in existing model-catalog/probe-ranking expectations unrelated to agy dynamic validation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-aware validation for Antigravity model pins, ensuring only labels returned from the available model list are accepted.
  * Improved model resolution by canonicalizing Antigravity-related providers and consistently honoring model override behavior.
* **Bug Fixes**
  * Avoided redundant `--model` arguments for `agy/default`.
  * Hardened model-name validation and normalized override handling for Antigravity providers.
* **Documentation**
  * Updated architecture mapping, CLI help text for `OCTOPUS_AGY_MODEL`, and expanded cost guidance with pinning examples.
* **Tests**
  * Added unit tests for Antigravity label validation, override resolution, and `--model` argument construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->