### PR TITLE
release: v9.47.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.46.0"
+    "version": "9.47.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.46.0 - agy is now the default Google seat (Gemini CLI sunset); agent lifecycle events, octo-hud event-stream monitor, and multi-provider council seating; plus provider-reliability and tangle-workflow fixes. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.46.0",
+      "description": "v9.47.0 - completes the #498 lifecycle-event vocabulary (review.finding + synthesis across review, parallel, council, and debate), all rendered by octo-hud; plus a /octo:plan plan-mode degradation signal and CI updates. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.47.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.46.0",
+  "version": "9.47.0",
   "description": "v9.44.1 \u2014 Patch release for Gemini environment/version detection and qwen auth gating. Run /octo:setup.",
   "author": {
     "name": "nyldn",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.46.0",
+  "version": "9.47.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.46.0",
+  "version": "9.47.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.46.0"
+    "version": "9.47.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.46.0 - agy is now the default Google seat (Gemini CLI sunset); agent lifecycle events, octo-hud event-stream monitor, and multi-provider council seating; plus provider-reliability and tangle-workflow fixes. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.46.0",
+      "description": "v9.47.0 - completes the #498 lifecycle-event vocabulary (review.finding + synthesis across review, parallel, council, and debate), all rendered by octo-hud; plus a /octo:plan plan-mode degradation signal and CI updates. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.47.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.46.0",
+  "version": "9.47.0",
   "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 ## [Unreleased]
 
+## [9.47.0] - 2026-07-01
+
 ### Added
 
 - **`review.finding` and `synthesis` lifecycle events** complete the #498 event vocabulary (the other two, `provider.selected` and `circuit-breaker.*`, shipped in 9.46.0). `review.finding` fires once per Round 1 code-review finding with `provider`, `severity`, `message`, and `round` attributes, capturing per-provider attribution before findings are merged and de-duplicated. `synthesis` fires when a synthesis artifact is produced (attributes `phase`, `provider`, `count`), wired into the review/deliver workflow (`review.sh`, success branch only) and the parallel aggregator (`parallel.sh`, attributing the provider that actually produced the artifact). `octo-hud` renders both, coloring `review.finding` by severity. The `synthesis` event also fires from the council chair-synthesis success path (`council.sh`, attributing the chair member's provider) and the debate final synthesis (`debate.sh`, attributing the moderator or quorum path), each guarded against the fallback branches so attribution is never wrong. This fully closes #498. (#498)
+
+### Fixed
+
+- **`/octo:plan` now signals degradation when native plan mode blocks artifact writes** (#514, #515). When plan mode restricts Write/Edit, `/octo:plan` emits a visible "OCTO PLAN DEGRADED" warning and skips the intent-contract and plan-save steps (which would silently fail) instead of falling through to generic native planning. The command's `plan.md` and the `plan-mode-interceptor.sh` hook now prescribe verbatim-matching warning text.
+
+### Changed
+
+- **CI: bump `actions/checkout` from 6 to 7** (#531).
 
 ## [9.46.0] - 2026-07-01
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.46.0-blue" alt="Version 9.46.0">
+  <img src="https://img.shields.io/badge/Version-9.47.0-blue" alt="Version 9.47.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.46.0",
+  "version": "9.47.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## v9.47.0

Cuts v9.47.0 from the 4 commits landed since v9.46.0.

### Added
- **Completes the #498 lifecycle-event vocabulary** — `review.finding` + `synthesis` now emit across `review.sh`, `parallel.sh`, `council.sh`, and `debate.sh`, each guarded against fallback branches so provider attribution is never wrong; all rendered by octo-hud (#553, #554)

### Fixed
- **`/octo:plan` signals degradation** when native plan mode blocks artifact writes, instead of silently falling through to generic native planning (#515, closes #514)

### Changed
- CI: bump `actions/checkout` 6 → 7 (#531)

Full detail in CHANGELOG.md. Version bumped to 9.47.0 across plugin/marketplace manifests, package.json, README badge.

Verified: expert-review gate 50/50 (version consistency + CHANGELOG mention).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new lifecycle events and updated release content for the latest version.
* **Bug Fixes**
  * Improved planning feedback by showing a clearer degraded-mode warning and avoiding steps that can’t complete in that mode.
* **Documentation**
  * Updated the changelog and README to reflect version 9.47.0.
* **Chores**
  * Bumped package and plugin metadata to 9.47.0 across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->