### PR TITLE
fix: make atomic_json_update actually atomic under concurrency

### DIFF
--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -283,7 +283,15 @@ atomic_json_update() {
         fi
         sleep 0.1
     done
-    trap 'rmdir "'"$lockfile"'" 2>/dev/null' EXIT
+
+    # This function can run in the same shell as a caller's own long-lived
+    # EXIT/INT/TERM traps (e.g. orchestrate.sh's temp-dir cleanup), so save
+    # and restore them instead of clobbering them with `trap - EXIT`.
+    local prev_exit_trap prev_int_trap prev_term_trap
+    prev_exit_trap=$(trap -p EXIT)
+    prev_int_trap=$(trap -p INT)
+    prev_term_trap=$(trap -p TERM)
+    trap 'rmdir "'"$lockfile"'" 2>/dev/null' EXIT INT TERM
 
     # BASHPID (not $$, which stays constant across every subshell spawned
     # from the same parent) keeps concurrent callers from colliding on one
@@ -294,7 +302,9 @@ atomic_json_update() {
     [[ $result -ne 0 ]] && rm -f "$tmp_file"
 
     rmdir "$lockfile" 2>/dev/null
-    trap - EXIT
+    eval "${prev_exit_trap:-trap - EXIT}"
+    eval "${prev_int_trap:-trap - INT}"
+    eval "${prev_term_trap:-trap - TERM}"
 
     return $result
 }

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -265,32 +265,35 @@ atomic_json_update() {
     local jq_expression="$2"
     shift 2
 
+    # mkdir is atomic on every POSIX filesystem, unlike a check-then-touch
+    # lock: two concurrent callers can never both succeed at creating the
+    # same directory, so this is a real mutex (see scripts/lib/events.sh
+    # _octo_event_lock for the same pattern). The lock is still a ".lock"
+    # path — it's just a directory now instead of a plain file.
     local lockfile="${json_file}.lock"
     local timeout=5
     local waited=0
+    local max_waits=$((timeout * 10))
 
-    # Wait for lock with timeout
-    while [[ -f "$lockfile" ]] && [[ $waited -lt $((timeout * 10)) ]]; do
-        sleep 0.1
+    while ! mkdir "$lockfile" 2>/dev/null; do
         waited=$((waited + 1))
+        if [[ $waited -ge $max_waits ]]; then
+            log WARN "Timeout acquiring lock for $json_file"
+            return 1
+        fi
+        sleep 0.1
     done
+    trap 'rmdir "'"$lockfile"'" 2>/dev/null' EXIT
 
-    if [[ -f "$lockfile" ]]; then
-        log WARN "Timeout acquiring lock for $json_file"
-        return 1
-    fi
-
-    # Acquire lock
-    touch "$lockfile"
-    trap 'rm -f "'"$lockfile"'"' EXIT
-
-    # Update atomically
-    local tmp_file="${json_file}.tmp.$$"
+    # BASHPID (not $$, which stays constant across every subshell spawned
+    # from the same parent) keeps concurrent callers from colliding on one
+    # temp file name.
+    local tmp_file="${json_file}.tmp.${BASHPID:-$$}"
     jq "$jq_expression" "$@" "$json_file" > "$tmp_file" && mv "$tmp_file" "$json_file"
     local result=$?
+    [[ $result -ne 0 ]] && rm -f "$tmp_file"
 
-    # Release lock
-    rm -f "$lockfile"
+    rmdir "$lockfile" 2>/dev/null
     trap - EXIT
 
     return $result


### PR DESCRIPTION
## Description
`atomic_json_update()` in `scripts/lib/validation.sh:263-297` isn't actually atomic under concurrency, which lets `/octo:review`'s concurrent reviewer-role writes to `progress.json` get dropped or corrupt the file entirely.

Three compounding bugs (root-caused in #557):
1. **TOCTOU lock**: `[[ -f "$lockfile" ]]` check followed by `touch "$lockfile"` isn't atomic — two callers can both observe the lock absent and both proceed.
2. **Colliding temp files**: the temp file was named `${json_file}.tmp.$$`, but `$$` is the *parent* shell PID and is identical across every `( ... ) &` subshell spawned from the same caller — concurrent roles wrote the same temp file and raced on `mv`.
3. Given 1 and 2, one caller's lock/temp-file cleanup could run out from under another caller mid-write, occasionally leaving `progress.json` malformed (stray trailing `]}`) and breaking every subsequent update for the rest of the run.

## Fix
- Replace the check-then-touch lock with `mkdir` (atomic on any POSIX filesystem — same pattern already used by `_octo_event_lock` in `scripts/lib/events.sh`).
- Name the temp file with `${BASHPID:-$$}` instead of `$$` so concurrent subshells never share a filename.
- Only remove the temp file on failure now that success always renames it away.

No callers changed — `atomic_json_update`'s signature and call sites (`scripts/lib/agents.sh`, `scripts/lib/provider-routing.sh`) are untouched.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (31/31)
- [ ] OpenClaw registry in sync — not applicable, no skill/command changes
- [ ] New skills/commands registered — not applicable
- [ ] Version bump — deferred to release PR if this merges
- [ ] Documentation updated — not applicable, internal helper function
- [ ] CHANGELOG.md updated — deferred to release PR

## Testing
Reproduced the issue's minimal repro against `origin/main` (unpatched): 30 concurrent `atomic_json_update` calls intermittently produced `mv: cannot stat ...tmp.<pid>` errors and left the JSON file malformed. Same repro against this branch: all 30 updates land, file stays well-formed, 100% reproducible across repeated runs.

```bash
bash -n scripts/lib/validation.sh          # syntax OK
bash tests/test-ux-features-v7.16.0.sh     # 52/52 pass (unchanged from baseline)
bash tests/test-model-config-v849.sh       # 72/88 pass — the 16 failures are pre-existing
                                            # on unpatched main (catalog/health-check/
                                            # synthesis-prompt checks unrelated to this fix)
bash tests/unit/test-openclaw-compat.sh    # 31/31 pass
```

`make test-unit` timed out in this environment (>3min) unrelated to this change; ran the directly affected + template-required test files individually instead, plus a targeted concurrency repro of the actual bug.

## Related Issues
Closes #557

---
_Generated by [Claude Code](https://claude.ai/code/session_01Axs8iL1V1jR6qKwjUfB72r)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of concurrent JSON updates by using a more robust, timeout-based lock mechanism with safer cleanup.
  * Reduced intermittent failures caused by temporary filename collisions during update writes.
  * Enhanced graceful handling of interrupted runs by preserving any existing interruption/exit behavior during the update process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->