### PR TITLE
release: v9.47.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.47.0"
+    "version": "9.47.1"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.47.0 - completes the #498 lifecycle-event vocabulary (review.finding + synthesis across review, parallel, council, and debate), all rendered by octo-hud; plus a /octo:plan plan-mode degradation signal and CI updates. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.47.0",
+      "description": "v9.47.1 - patch release fixing a concurrency race in progress-file updates (#557) and validating Antigravity model pins dynamically against the live agy catalog (#555). 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.47.1",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.47.0",
+  "version": "9.47.1",
   "description": "v9.44.1 \u2014 Patch release for Gemini environment/version detection and qwen auth gating. Run /octo:setup.",
   "author": {
     "name": "nyldn",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.47.0",
+  "version": "9.47.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.47.0",
+  "version": "9.47.1",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.47.0"
+    "version": "9.47.1"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.47.0 - completes the #498 lifecycle-event vocabulary (review.finding + synthesis across review, parallel, council, and debate), all rendered by octo-hud; plus a /octo:plan plan-mode degradation signal and CI updates. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.47.0",
+      "description": "v9.47.1 - patch release fixing a concurrency race in progress-file updates (#557) and validating Antigravity model pins dynamically against the live agy catalog (#555). 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.47.1",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.47.0",
+  "version": "9.47.1",
   "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [9.47.1] - 2026-07-02
+
+### Fixed
+
+- **`atomic_json_update()` is now actually atomic under concurrency** (#557, #558). The lock was a check-then-`touch` race (two callers could both observe it absent and proceed) and the temp file was named with `$$`, which is constant across every `( ... ) &` subshell spawned from the same parent — concurrent `/octo:review` reviewer roles could collide, drop updates, or leave `progress.json` malformed. Replaced with an `mkdir`-based mutex (same pattern as `_octo_event_lock` in `scripts/lib/events.sh`) and `BASHPID`-based temp file naming; also fixed the function clobbering a caller's own `EXIT`/`INT`/`TERM` traps (e.g. `orchestrate.sh`'s temp-dir cleanup) by saving and restoring them instead of unconditionally clearing them.
+- **Antigravity (`agy`) explicit model pins now validate against the live `agy models` catalog** instead of the generic shell-token validator, which rejected valid labels containing spaces or parentheses (e.g. `Gemini 3.5 Flash (Low)`) (#555). `OCTOPUS_AGY_MODEL` now accepts `default`, `agy/default`, or an exact label from `agy models`.
+
 ## [9.47.0] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.47.0-blue" alt="Version 9.47.0">
+  <img src="https://img.shields.io/badge/Version-9.47.1-blue" alt="Version 9.47.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.47.0",
+  "version": "9.47.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Description
Patch release (9.47.0 → 9.47.1) bundling two bug fixes merged to `main` since the last release tag:

- **#558** — `atomic_json_update()` concurrency race fixed (closes #557). The lock was a non-atomic check-then-`touch` pattern and the temp file name collided across subshells, letting concurrent `/octo:review` reviewer roles drop updates or corrupt `progress.json`.
- **#555** — Antigravity (`agy`) explicit model pins now validate dynamically against the live `agy models` catalog instead of the generic shell-token validator, which rejected valid labels containing spaces/parentheses (e.g. `Gemini 3.5 Flash (Low)`).

## Changes
- Version bump `9.47.0` → `9.47.1` across `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.factory-plugin/plugin.json`, `.factory-plugin/marketplace.json`, and the README version badge.
- Updated the `octo` plugin description in both marketplace manifests to summarize this patch (was still describing 9.47.0's changes).
- `CHANGELOG.md` entry for 9.47.1.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (describe): Release / version bump

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync — not applicable, no skill/command changes
- [ ] New skills/commands registered — not applicable
- [x] Version bump: package.json + plugin/marketplace manifests + public adapter manifests + README.md + CHANGELOG.md
- [ ] Documentation updated — not applicable
- [x] CHANGELOG.md updated

## Testing
```bash
jq empty package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json \
  .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json \
  .factory-plugin/marketplace.json                  # all valid
bash tests/unit/test-docs-sync.sh                    # 134/134 pass
bash -n scripts/orchestrate.sh                        # syntax OK
```

**`make test-unit` was intentionally not run against this working tree for this PR.** While preparing this release I discovered `tests/unit/test-hook-err-traps.sh` can intermittently delete tracked root-level files (`Makefile`, `LICENSE`, `GOALS.md`, `PRODUCT.md` — reproduced on a fresh clone, 2 of ~5 attempts) when the full unit suite runs — filed as **#563** with repro steps and bisection notes. This release only touches version strings and docs/changelog (no script logic), so I validated it with JSON-schema/docs-sync checks plus a targeted, known-safe test file instead of risking the working tree by re-running the full suite. Recommend prioritizing #563 before the next code-bearing release.

## Related Issues
Bundles #557 (via #558) and includes #555.
Files: #563 (new, found while preparing this release — not part of the version bump)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Axs8iL1V1jR6qKwjUfB72r)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updates happen at the same time, reducing the chance of conflicting save operations.
  * Strengthened model selection checks so supported options are validated more accurately against the available list.

* **Chores**
  * Bumped the release version across the app, plugin manifests, package metadata, and documentation.
  * Updated the changelog and version badge to reflect the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->