### PR TITLE
fix(agy): record agy's actual selected model instead of "default"

### DIFF
--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -917,6 +917,12 @@ council_roster_entry_json() {
     [[ -n "$provider" ]] || provider="$(council_pick_provider "$preferred_provider")"
     provider_org="$(council_provider_org "$provider")"
     model="$(council_persona_model "$persona")"
+    # agy ignores the per-persona model (agy-exec runs `--model default`), so record
+    # the model agy will ACTUALLY use — resolved from its own settings — instead of
+    # the placeholder, so the seat's cross-lab lineage is verifiable from the artifact.
+    if [[ "$provider" == "agy" ]] && declare -f agy_current_model >/dev/null 2>&1; then
+        model="$(agy_current_model)"
+    fi
     seat="$(council_persona_seat "$persona")"
     family="$(council_persona_family "$persona")"
     permission_mode="$(council_agent_config_value "$persona" "permissionMode" | tr -d '"')"

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -90,7 +90,11 @@ cmd_detect_providers() {
     if command -v agy &>/dev/null; then
         echo "AGY_STATUS=ok"
         echo "AGY_AUTH=cli"
-        echo "AGY_MODEL=${OCTOPUS_AGY_MODEL:-}"
+        if declare -f agy_current_model >/dev/null 2>&1; then
+            echo "AGY_MODEL=$(agy_current_model)"
+        else
+            echo "AGY_MODEL=${OCTOPUS_AGY_MODEL:-}"
+        fi
     else
         echo "AGY_STATUS=not-installed"
         echo "AGY_AUTH=none"
@@ -207,6 +211,9 @@ cmd_detect_providers() {
     local agy_status=$(command -v agy &>/dev/null && echo "ok" || echo "not-installed")
     local agy_auth=$([[ "$agy_status" == "ok" ]] && echo "cli" || echo "none")
     local agy_model="${OCTOPUS_AGY_MODEL:-}"
+    if [[ "$agy_status" == "ok" ]] && declare -f agy_current_model >/dev/null 2>&1; then
+        agy_model="$(agy_current_model)"
+    fi
     local perplexity_status=$([[ -n "${PERPLEXITY_API_KEY:-}" ]] && echo "ok" || echo "not-configured")
     local perplexity_auth=$([[ -n "${PERPLEXITY_API_KEY:-}" ]] && echo "api-key" || echo "none")
     local ollama_status=$(command -v ollama &>/dev/null && { curl -sf http://localhost:11434/api/tags &>/dev/null && echo "running" || echo "stopped"; } || echo "not-installed")

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -977,6 +977,33 @@ EOF
     fi
 }
 
+# ── agy_current_model: resolve the model the Antigravity CLI will actually use ──
+# agy-exec.sh runs `agy --print` with `--model default` (no --model flag) unless
+# OCTOPUS_AGY_MODEL is set, so agy uses whatever is selected in its own /model UI —
+# persisted to ~/.gemini/antigravity-cli/settings.json. Resolve that here so the
+# council roster artifact and the activation banner record the REAL model
+# (e.g. "Gemini 3.1 Pro (Low)") instead of the opaque "default", which is what makes
+# a Codex+agy panel's cross-lab-vs-same-lineage status verifiable from the artifact.
+# Fail-safe: purely diagnostic, never gate logic — echo "default (unresolved)" if the
+# selection can't be read, and never abort a run.
+agy_current_model() {
+    local override="${OCTOPUS_AGY_MODEL:-}"
+    if [[ -n "$override" && "$override" != "default" ]]; then
+        printf '%s\n' "$override"
+        return 0
+    fi
+    local settings="${HOME}/.gemini/antigravity-cli/settings.json"
+    if [[ -f "$settings" ]] && command -v jq >/dev/null 2>&1; then
+        local m
+        m="$(jq -r '.model // empty' "$settings" 2>/dev/null)"
+        if [[ -n "$m" ]]; then
+            printf '%s\n' "$m"
+            return 0
+        fi
+    fi
+    printf '%s\n' "default (unresolved)"
+}
+
 # ── detect_providers: multi-CLI + auth detection (moved from orchestrate.sh v9.22.1) ──
 detect_providers() {
     local result=""


### PR DESCRIPTION
## Problem

`agy-exec.sh` runs `agy --print` with `--model default` (no `--model` flag) unless `OCTOPUS_AGY_MODEL` is set — so agy uses whatever model is selected in its own `/model` UI. As a result, the council roster artifact (`summary.json`) and the preflight banner record the opaque string **`"default"`** for the agy seat.

That makes a `Codex + agy` panel's **cross-lab-vs-same-lineage** status unverifiable from the artifact: whether agy ran a Gemini model (cross-lab with Codex), a Claude model, or GPT-OSS (same-lineage as Codex) can't be told from `model: "default"` — you have to know agy's current selection out-of-band.

## Fix

Add `agy_current_model()` to `lib/providers.sh` (sourced before `preflight.sh` and `council.sh` by `orchestrate.sh`). Resolution mirrors `agy-exec`:

1. `OCTOPUS_AGY_MODEL` if set and not `default`, else
2. read `.model` from `~/.gemini/antigravity-cli/settings.json` (where the CLI persists the `/model` selection), else
3. fail-safe `"default (unresolved)"`.

Wired into two places (both guarded with `declare -f` so standalone runs fall back to prior behavior — purely diagnostic, never gate logic):

- **`council.sh` `council_roster_entry_json`** — the agy seat records its real model (e.g. `Gemini 3.1 Pro (Low)`) in `summary.json`.
- **`preflight.sh`** — the provider-cache `AGY_MODEL` and the activation banner show the real model instead of empty / "agy default".

## Verification

- `bash -n` clean on all three files.
- Happy path → `Gemini 3.1 Pro (Low)`; `OCTOPUS_AGY_MODEL` override → wins; missing `settings.json` → `default (unresolved)`.
- Source order `providers.sh → council.sh` keeps the helper defined.

3 files, +41/−1. No behavior change to dispatch — only what gets recorded/displayed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model detection for the Antigravity provider so the active model is now shown more accurately in generated roster and cache data.
  * Added a fallback when the model can’t be determined, helping keep output readable instead of incomplete.

* **Bug Fixes**
  * Fixed cases where a default or placeholder model could be used instead of the currently selected model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->