### PR TITLE
fix: guard session-end.sh sentinel cleanup against empty-match CWD deletion

### DIFF
--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -203,8 +203,15 @@ rm -f "${HOME}/.claude-octopus/.reload-signal" 2>/dev/null || true
 
 # Clean up session title sentinel files (from user-prompt-submit.sh auto-titling)
 # Keep last 20 (by mtime), remove the rest to prevent accumulation
-find "${HOME}/.claude-octopus/" -maxdepth 1 -name ".session-titled-*" -type f 2>/dev/null \
-    | xargs ls -t 2>/dev/null | tail -n +21 | xargs rm -f 2>/dev/null || true
+# Guard on a nonzero match count first: when find matches nothing, `xargs ls -t`
+# still runs `ls -t` with no arguments (xargs' default on empty input), which
+# lists CWD instead of "${HOME}/.claude-octopus/" and can delete unrelated
+# files ranked oldest-by-mtime there. See #563.
+SESSION_TITLE_COUNT=$(find "${HOME}/.claude-octopus/" -maxdepth 1 -name ".session-titled-*" -type f 2>/dev/null | wc -l | tr -d ' ') || true
+if [[ "$SESSION_TITLE_COUNT" -gt 20 ]]; then
+    find "${HOME}/.claude-octopus/" -maxdepth 1 -name ".session-titled-*" -type f 2>/dev/null \
+        | xargs ls -t 2>/dev/null | tail -n +21 | xargs rm -f 2>/dev/null || true
+fi
 
 # Session manager cleanup: retain 10 most recent sessions
 if [[ -x "${CLAUDE_PLUGIN_ROOT:-}/scripts/session-manager.sh" ]]; then

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -207,9 +207,10 @@ rm -f "${HOME}/.claude-octopus/.reload-signal" 2>/dev/null || true
 # still runs `ls -t` with no arguments (xargs' default on empty input), which
 # lists CWD instead of "${HOME}/.claude-octopus/" and can delete unrelated
 # files ranked oldest-by-mtime there. See #563.
-SESSION_TITLE_COUNT=$(find "${HOME}/.claude-octopus/" -maxdepth 1 -name ".session-titled-*" -type f 2>/dev/null | wc -l | tr -d ' ') || true
+SESSION_TITLE_FILES=$(find "${HOME}/.claude-octopus/" -maxdepth 1 -name ".session-titled-*" -type f 2>/dev/null) || true
+SESSION_TITLE_COUNT=$(printf '%s\n' "$SESSION_TITLE_FILES" | grep -c . 2>/dev/null) || true
 if [[ "$SESSION_TITLE_COUNT" -gt 20 ]]; then
-    find "${HOME}/.claude-octopus/" -maxdepth 1 -name ".session-titled-*" -type f 2>/dev/null \
+    printf '%s\n' "$SESSION_TITLE_FILES" \
         | xargs ls -t 2>/dev/null | tail -n +21 | xargs rm -f 2>/dev/null || true
 fi
 


### PR DESCRIPTION
## Description

Root cause for #563 (`test-hook-err-traps.sh` intermittently deleting tracked root-level files like `Makefile`, `LICENSE`, `GOALS.md`, `PRODUCT.md`, `SECURITY.md`).

`hooks/session-end.sh:206-207` had:

```bash
find "${HOME}/.claude-octopus/" -maxdepth 1 -name ".session-titled-*" -type f 2>/dev/null \
    | xargs ls -t 2>/dev/null | tail -n +21 | xargs rm -f 2>/dev/null || true
```

When `find` matches nothing (a fresh `$HOME`, as the test harness always uses), `xargs` still invokes `ls -t` once with **zero arguments** — that's `xargs`'s documented default behavior on empty stdin (both GNU and BSD run the command anyway unless `-r`/`--no-run-if-empty` is passed). `ls -t` with no arguments lists the **current working directory** instead of the intended sentinel-file directory. Since the test spawns each hook via `subprocess.run` without setting `cwd`, the child inherits the test runner's CWD — the live repo root. `tail -n +21` then keeps everything ranked 21st-oldest-or-later by mtime, and `xargs rm -f` deletes it. Root-level docs/config files (`Makefile`, `LICENSE`, etc.) rarely change, so they naturally sort to the bottom of `ls -t` and get caught.

### Repro (confirmed via strace)

```bash
git worktree add --detach /tmp/repro origin/main
cd /tmp/repro
strace -f -e trace=unlink,unlinkat -o /tmp/strace.log bash tests/unit/test-hook-err-traps.sh
grep -n "Makefile\|LICENSE" /tmp/strace.log
# 5568  unlinkat(AT_FDCWD, "LICENSE", 0)  = 0
# 5568  unlinkat(AT_FDCWD, "Makefile", 0) = 0
# 5568  unlinkat(AT_FDCWD, "PRODUCT.md", 0) = 0
# 5568  unlinkat(AT_FDCWD, "SECURITY.md", 0) = 0
```
Reproduced on the very first attempt against a pristine `origin/main` worktree.

## Fix

Count matches with `find | wc -l` first (mirroring the guard the file already uses one block down for `octopus-learnings.md` pruning), and only run the `xargs ls -t | tail -n +21 | xargs rm -f` pipeline when there are actually more than 20 candidates. When the count is 0 (or ≤20), the risky pipeline never executes at all.

```bash
SESSION_TITLE_COUNT=$(find "${HOME}/.claude-octopus/" -maxdepth 1 -name ".session-titled-*" -type f 2>/dev/null | wc -l | tr -d ' ') || true
if [[ "$SESSION_TITLE_COUNT" -gt 20 ]]; then
    find "${HOME}/.claude-octopus/" -maxdepth 1 -name ".session-titled-*" -type f 2>/dev/null \
        | xargs ls -t 2>/dev/null | tail -n +21 | xargs rm -f 2>/dev/null || true
fi
```

(The `|| true` on the count assignment is needed because `find` on a not-yet-created `$HOME/.claude-octopus/` returns nonzero even with stderr suppressed, and under `set -e -o pipefail` that would otherwise abort the whole hook.)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (31/31)
- [ ] OpenClaw registry in sync — not applicable, no skill/command changes
- [ ] New skills/commands registered — not applicable
- [ ] Version bump — not applicable, patch-level bug fix only
- [ ] Documentation updated — not applicable
- [ ] CHANGELOG.md updated — leaving to the release PR that bundles this fix, per repo convention

## Testing

```bash
bash -n hooks/session-end.sh                          # syntax OK
bash tests/unit/test-hook-err-traps.sh                 # 7/7 pass
```

- Reproduced the deletion on a clean `origin/main` git worktree, traced it with `strace -f -e trace=unlink,unlinkat` to the exact `unlinkat()` calls and PID, and correlated that PID back to this code block.
- Applied the fix in the same worktree and re-ran `tests/unit/test-hook-err-traps.sh` **10 times** — zero working-tree changes each time (previously reproduced on attempt 1 of 1 unpatched).
- Re-ran the same test **6 more times** against this actual checkout post-fix — clean every time, 7/7 passing.
- Positive-path check: seeded 25 fake `.session-titled-*` sentinel files in a fake `$HOME`, ran the hook, confirmed exactly 20 remain (oldest 5 pruned) — the intended cleanup behavior still works, this isn't a no-op fix.
- Ran `make test-unit` against the real checkout; it made it through ~30+ test files with 0 failures before hitting my shell's 150s timeout (the full suite legitimately runs longer than that) — working tree stayed clean throughout except two benign `chmod +x` mode-bit touches from the test runner on unrelated files, which I reverted.

## Related Issues
Closes #563


---
_Generated by [Claude Code](https://claude.ai/code/session_01P8Yo3mFM6dzvX9pBH3qbic)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cleanup to avoid deleting unrelated files when no matching temporary files are found.
  * Added a safety check so cleanup only runs when there are enough matching files to prune, reducing the risk of accidental removals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->