### PR TITLE
fix: qwen/opencode dispatch gaps and missing agy smoke test

### DIFF
--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -207,7 +207,17 @@ get_agent_command() {
             # oco-dar: NO_BROWSER=1 stops a stale token from hijacking the user's
             # browser into the OAuth device-flow. Pre-flight (qwen_is_usable) should
             # already gate this out; this is defense-in-depth if dispatch is reached.
-            echo "env NODE_NO_WARNINGS=1 NO_BROWSER=1 qwen -o text --approval-mode yolo"
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
+            # OPENAI_COMPAT auth (OPENAI_API_KEY + OPENAI_BASE_URL) needs an explicit
+            # --auth-type: the qwen CLI does not auto-detect it from env vars alone
+            # in non-interactive mode (Issue #566).
+            local qwen_auth_flag=""
+            if declare -f qwen_auth_method >/dev/null 2>&1 && [[ "$(qwen_auth_method)" == "env:OPENAI_COMPAT" ]]; then
+                qwen_auth_flag="--auth-type openai"
+            fi
+            echo "env NODE_NO_WARNINGS=1 NO_BROWSER=1 qwen -o text --approval-mode yolo -m ${model} ${qwen_auth_flag}"
             ;;
         cursor-agent)  # v9.23.0: Cursor Agent CLI — Grok 4.20 via Cursor subscription
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
@@ -234,7 +244,12 @@ get_agent_command() {
             if [[ -n "$model" && "$model" != "default" ]]; then
                 oc_model_flag="-m ${model}"
             fi
-            echo "opencode run ${oc_model_flag}"
+            # --pure skips opencode's external-plugin auto-title path, which
+            # otherwise resolves an SDK handle for a hardcoded small model
+            # before the prompt is even sent — an unresolvable catalog/model
+            # there hangs `opencode run` indefinitely with no timeout or error
+            # (Issue #566).
+            echo "opencode run --pure ${oc_model_flag}"
             ;;
         *) return 1 ;;
     esac

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -248,8 +248,9 @@ get_agent_command() {
             # otherwise resolves an SDK handle for a hardcoded small model
             # before the prompt is even sent — an unresolvable catalog/model
             # there hangs `opencode run` indefinitely with no timeout or error
-            # (Issue #566).
-            echo "opencode run --pure ${oc_model_flag}"
+            # (Issue #566). It's a global flag, so it must precede the `run`
+            # subcommand or risk being ignored/rejected.
+            echo "opencode --pure run ${oc_model_flag}"
             ;;
         *) return 1 ;;
     esac

--- a/scripts/lib/qwen.sh
+++ b/scripts/lib/qwen.sh
@@ -76,11 +76,19 @@ qwen_execute() {
 
     [[ "${VERBOSE:-}" == "true" ]] && log DEBUG "qwen_execute: type=$agent_type, timeout=${timeout}s, auth=$(qwen_auth_method)" || true
 
+    # OPENAI_COMPAT auth (OPENAI_API_KEY + OPENAI_BASE_URL) needs an explicit
+    # --auth-type: the qwen CLI does not auto-detect it from env vars alone
+    # in non-interactive mode (Issue #566).
+    local qwen_auth_args=()
+    if [[ "$(qwen_auth_method)" == "env:OPENAI_COMPAT" ]]; then
+        qwen_auth_args=(--auth-type openai)
+    fi
+
     local response exit_code
     if declare -f run_with_timeout >/dev/null 2>&1; then
-        response=$(NO_BROWSER=1 NODE_NO_WARNINGS=1 run_with_timeout "$timeout" qwen -p "$prompt" --approval-mode yolo -o text 2>&1) && exit_code=0 || exit_code=$?
+        response=$(NO_BROWSER=1 NODE_NO_WARNINGS=1 run_with_timeout "$timeout" qwen -p "$prompt" --approval-mode yolo -o text "${qwen_auth_args[@]}" 2>&1) && exit_code=0 || exit_code=$?
     else
-        response=$(NO_BROWSER=1 NODE_NO_WARNINGS=1 timeout -k 10 "$timeout" qwen -p "$prompt" --approval-mode yolo -o text 2>&1) && exit_code=0 || exit_code=$?
+        response=$(NO_BROWSER=1 NODE_NO_WARNINGS=1 timeout -k 10 "$timeout" qwen -p "$prompt" --approval-mode yolo -o text "${qwen_auth_args[@]}" 2>&1) && exit_code=0 || exit_code=$?
     fi
 
     # Handle errors

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -1007,6 +1007,8 @@ _display_smoke_test_error() {
                 echo -e "    ${DIM}Fix: export OCTOPUS_CODEX_MODEL=gpt-5.5${NC}"
             elif [[ "$provider" == "cursor" || "$provider" == "cursor-agent" || "$provider" == "Cursor Agent" ]]; then
                 echo -e "    ${DIM}Fix: export OCTOPUS_CURSOR_AGENT_MODEL=grok-4-20${NC}"
+            elif [[ "$provider" == "agy" || "$provider" == "Antigravity" ]]; then
+                echo -e "    ${DIM}Fix: agy models  (pick a valid label)  OR  unset OCTOPUS_AGY_MODEL to use agy's default${NC}"
             else
                 echo -e "    ${DIM}Fix: export OCTOPUS_GEMINI_MODEL=gemini-3.1-pro-preview${NC}"
             fi
@@ -1017,6 +1019,8 @@ _display_smoke_test_error() {
                 echo -e "    ${DIM}Fix: codex login  OR  export OPENAI_API_KEY=\"sk-...\"${NC}"
             elif [[ "$provider" == "cursor" || "$provider" == "cursor-agent" || "$provider" == "Cursor Agent" ]]; then
                 echo -e "    ${DIM}Fix: agent login  OR  export CURSOR_API_KEY=\"...\"${NC}"
+            elif [[ "$provider" == "agy" || "$provider" == "Antigravity" ]]; then
+                echo -e "    ${DIM}Fix: agy login${NC}"
             else
                 echo -e "    ${DIM}Fix: gemini  (OAuth)  OR  export GEMINI_API_KEY=\"...\"${NC}"
             fi
@@ -1058,6 +1062,7 @@ _smoke_test_provider() {
         codex) agent_type="codex" ;;
         gemini) agent_type="gemini" ;;
         cursor-agent) agent_type="cursor-agent" ;;
+        agy) agent_type="agy" ;;
         *) echo "SKIP" > "$result_file"; return 0 ;;
     esac
 
@@ -1098,6 +1103,16 @@ _smoke_test_provider() {
         # --trust required for untrusted workspaces; matches cursor-agent.sh:143 dispatch path
         echo "Reply with exactly: ok" | run_with_timeout "$smoke_timeout" \
             $cmd_str -p "" --trust --output-format text \
+            >/dev/null 2>"$stderr_file" || smoke_exit=$?
+    elif [[ "$provider" == "agy" ]]; then
+        # agy-exec.sh is a stdin adapter that builds its own argv and execs agy
+        # directly — any argv appended here would be silently discarded, so the
+        # prompt must go via stdin (like codex/gemini above). Explicitly forbid
+        # tool use: a bare "ok" smoke prompt otherwise triggers agy's default
+        # web-search tool call, which hangs with no sandbox network permission.
+        echo "Reply with exactly: ok. Answer from your own knowledge only — do not use web search or any tools." \
+            | run_with_timeout "$smoke_timeout" \
+            $cmd_str \
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
     else
         run_with_timeout "$smoke_timeout" \
@@ -1147,24 +1162,26 @@ provider_smoke_test() {
     log INFO "Running provider smoke test... 🐙"
 
     # Determine which providers are available (from preflight state)
-    local has_codex=false has_gemini=false has_cursor_agent=false
+    local has_codex=false has_gemini=false has_cursor_agent=false has_agy=false
     command -v codex &>/dev/null && has_codex=true
     command -v gemini &>/dev/null && has_gemini=true
     if command -v agent &>/dev/null && _is_cursor_agent_binary && \
        { [[ -n "${CURSOR_API_KEY:-}" ]] || grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; }; then
         has_cursor_agent=true
     fi
+    command -v agy &>/dev/null && has_agy=true
 
-    if [[ "$has_codex" == "false" && "$has_gemini" == "false" && "$has_cursor_agent" == "false" ]]; then
+    if [[ "$has_codex" == "false" && "$has_gemini" == "false" && "$has_cursor_agent" == "false" && "$has_agy" == "false" ]]; then
         log WARN "Smoke test: no providers to test"
         return 0
     fi
 
     # Launch parallel smoke tests
-    local codex_result_file gemini_result_file cursor_agent_result_file
+    local codex_result_file gemini_result_file cursor_agent_result_file agy_result_file
     codex_result_file=$(secure_tempfile "smoke-codex")
     gemini_result_file=$(secure_tempfile "smoke-gemini")
     cursor_agent_result_file=$(secure_tempfile "smoke-cursor-agent")
+    agy_result_file=$(secure_tempfile "smoke-agy")
     local pids=()
 
     if [[ "$has_codex" == "true" ]]; then
@@ -1188,21 +1205,29 @@ provider_smoke_test() {
         echo "SKIP" > "$cursor_agent_result_file"
     fi
 
+    if [[ "$has_agy" == "true" ]]; then
+        _smoke_test_provider "agy" "${OCTOPUS_AGY_SMOKE_TIMEOUT:-45}" "$agy_result_file" &
+        pids+=($!)
+    else
+        echo "SKIP" > "$agy_result_file"
+    fi
+
     # Wait for all background tests
     for pid in "${pids[@]}"; do
         wait "$pid" 2>/dev/null || true
     done
 
     # Collect results
-    local codex_result gemini_result cursor_agent_result
+    local codex_result gemini_result cursor_agent_result agy_result
     codex_result=$(cat "$codex_result_file" 2>/dev/null || echo "SKIP")
     gemini_result=$(cat "$gemini_result_file" 2>/dev/null || echo "SKIP")
     cursor_agent_result=$(cat "$cursor_agent_result_file" 2>/dev/null || echo "SKIP")
-    rm -f "$codex_result_file" "$gemini_result_file" "$cursor_agent_result_file" 2>/dev/null
+    agy_result=$(cat "$agy_result_file" 2>/dev/null || echo "SKIP")
+    rm -f "$codex_result_file" "$gemini_result_file" "$cursor_agent_result_file" "$agy_result_file" 2>/dev/null
 
     local pass_count=0 fail_count=0 skip_count=0
 
-    for result in "$codex_result" "$gemini_result" "$cursor_agent_result"; do
+    for result in "$codex_result" "$gemini_result" "$cursor_agent_result" "$agy_result"; do
         case "${result%%:*}" in
             PASS) ((++pass_count)) ;;
             SKIP) ((++skip_count)) ;;
@@ -1227,6 +1252,11 @@ provider_smoke_test() {
             local cursor_agent_error="${cursor_agent_result%%:*}"
             local cursor_agent_model="${cursor_agent_result#*:}"
             _display_smoke_test_error "Cursor Agent" "$cursor_agent_error" "$cursor_agent_model"
+        fi
+        if [[ "$agy_result" != "PASS" && "$agy_result" != "SKIP" ]]; then
+            local agy_error="${agy_result%%:*}"
+            local agy_model="${agy_result#*:}"
+            _display_smoke_test_error "Antigravity" "$agy_error" "$agy_model"
         fi
         echo ""
     fi


### PR DESCRIPTION
## Description

Fixes the 4 provider-dispatch bugs reported in #566, found while running a fresh v9.47.1 install with only Agy/Qwen(OpenRouter)/OpenCode as live providers.

### 1. `scripts/lib/dispatch.sh` — qwen case never passed `--auth-type` or a model

The `qwen|qwen-research` case built `env NODE_NO_WARNINGS=1 NO_BROWSER=1 qwen -o text --approval-mode yolo` with no model resolution (unlike the `ollama`/`cursor-agent`/`opencode` cases immediately around it, which all call `get_agent_model`) and no `--auth-type`. With `OPENAI_API_KEY`+`OPENAI_BASE_URL` (OPENAI_COMPAT auth), the qwen CLI hard-errors in non-interactive mode without an explicit `--auth-type`, and falls back to its own default model (`qwen3.5-plus`), which 400s against OpenRouter.

### 2. `scripts/lib/qwen.sh` — same `--auth-type` gap in `qwen_execute()`

`qwen_auth_method()`/`qwen_is_usable()` already correctly detect the OPENAI_COMPAT path, but `qwen_execute()` never passed `--auth-type openai` to the actual `qwen` invocation, hitting the same non-interactive auth error even when `qwen_is_usable()` returned true.

### 3. `scripts/lib/dispatch.sh` — opencode case can hang forever without `--pure`

`opencode run ${oc_model_flag}` had no `--pure`. Without it, opencode's session-auto-title feature resolves an SDK handle for a hardcoded small model before the prompt is even sent — if that model isn't resolvable, the whole `opencode run` call hangs indefinitely with no timeout or error.

### 4. `scripts/lib/smoke.sh` — `provider_smoke_test()` only ever tested Codex/Gemini/Cursor Agent

Agy was migrated in as Gemini's replacement provider elsewhere in the plugin, but was never added as a smoke-test candidate. In an Agy/Qwen/OpenCode-only environment, the smoke test always reported "no providers responded successfully" even though Agy was fully healthy — it simply never tried it.

Two sub-issues fixed once Agy is added:
- `_smoke_test_provider`'s generic else-branch appends `-p "..."` as argv, but Agy's resolved command is `helpers/agy-exec.sh`, a stdin adapter that builds its own `agy --print ...` argv from scratch and `exec`s it — any caller-appended argv is silently discarded, so a bare `agy --print` hangs waiting on stdin that never arrives. Fixed by adding an Agy-specific branch that pipes the prompt via stdin, matching the existing codex/gemini/cursor-agent pattern.
- A bare `"Reply with exactly: ok"` smoke prompt causes `agy --print` to attempt a web-search tool call by default, which hangs with no sandbox network permission. The Agy smoke prompt now explicitly forbids tool use.

Also added Agy-specific fix hints in `_display_smoke_test_error` (MODEL_NOT_FOUND / AUTH_FAILURE) so a failing Agy smoke test doesn't show misleading Gemini-flavored advice.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check (dispatch.sh, qwen.sh, smoke.sh)
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync — not applicable, no skill/command changes
- [ ] New skills/commands registered — not applicable
- [ ] Version bump — not applicable, patch-level bug fix only
- [ ] Documentation updated — not applicable
- [ ] CHANGELOG.md updated — leaving to the release PR that bundles this fix, per repo convention

## Testing

No live qwen/opencode/agy CLIs are installed in this environment, so live end-to-end dispatch could not be re-verified the way the issue reporter did. What was verified:

```bash
bash -n scripts/lib/dispatch.sh scripts/lib/qwen.sh scripts/lib/smoke.sh   # clean
```

Functional check by sourcing the actual functions with minimal stubs (no live CLIs):
```
get_agent_command qwen (no auth)        -> env NODE_NO_WARNINGS=1 NO_BROWSER=1 qwen -o text --approval-mode yolo -m qwen3-coder
get_agent_command qwen (OPENAI_COMPAT)  -> ...  -m qwen3-coder --auth-type openai
get_agent_command opencode               -> opencode run --pure -m opencode/deepseek-v4-flash-free
_smoke_test_provider agy (agy binary absent) -> fails fast (UNKNOWN:default), confirmed NOT hanging via a 10s watchdog kill
```

Existing related suites, all passing:
```
tests/unit/test-agy-provider.sh              32/32
tests/unit/test-provider-allowlist.sh        10/10
tests/unit/test-provider-contract-audit.sh    4/4
tests/unit/test-qwen-council-provider.sh      6/6
tests/unit/test-opencode-model-defaults.sh   10/10
tests/smoke/test-fleet-dispatch-guard.sh      4/4
tests/smoke/test-dry-run-all.sh               6/6
tests/smoke/test-detect-providers.sh          2 passed, 1 skipped (no real providers installed here)
```

Given the live-CLI testing gap, please treat this as reviewed-and-syntax-verified rather than fully live-tested — happy to iterate if the original reporter (or anyone with a live qwen/opencode/agy setup) can confirm end-to-end.

## Related Issues
Closes #566


---
_Generated by [Claude Code](https://claude.ai/code/session_01P8Yo3mFM6dzvX9pBH3qbic)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Antigravity (agy) as a first-class participant in provider smoke testing, including parallel runs and tailored guidance on model/auth failures.

- **Bug Fixes**
  - Improved smoke test prompt handling for agy to reduce the chance of hanging.
  - Enhanced Qwen command construction by resolving the selected model and correctly applying OpenAI-compat authentication.
  - Updated opencode execution to use `--pure` for safer, more predictable runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->