### PR TITLE
fix: use agy for research defaults

### DIFF
--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -77,6 +77,11 @@ ensure_config() {
       "flash": "gemini-3-flash-preview",
       "image": "gemini-3-pro-image"
     },
+    "agy": {
+      "default": "Gemini 3.1 Pro (High)",
+      "fallback": "Gemini 3.5 Flash (High)",
+      "flash": "Gemini 3.5 Flash (Low)"
+    },
     "claude": {
       "default": "claude-sonnet-4.6",
       "opus": "claude-opus-4.8"
@@ -96,7 +101,7 @@ ensure_config() {
       "deliver": "codex:default",
       "review": "codex:default",
       "security": "codex:reasoning",
-      "research": "gemini:default"
+      "research": "agy"
     },
     "roles": {
       "researcher": "perplexity"
@@ -396,7 +401,7 @@ cmd_show_phases() {
             case "$phase" in
                 deliver|review|quick) default_target="codex:spark" ;;
                 security) default_target="codex:reasoning" ;;
-                research) default_target="gemini:default" ;;
+                research) default_target="agy" ;;
             esac
             printf "  %-12s %-25s %s\n" "$phase" "$default_target" "(default)"
         fi

--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -85,7 +85,7 @@ get_role_mapping() {
 
     case "$role" in
         architect)         echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-4.7)" ;;  # Planning, UI/UX, architecture
-        researcher)        echo "gemini:gemini-3.1-pro-preview" ;;                                          # Deep investigation
+        researcher)        echo "agy:Gemini 3.1 Pro (High)" ;;                                             # Deep investigation via Antigravity (Google seat)
         reviewer|code-reviewer) echo "codex-review:gpt-5.5" ;;                                              # Code review, edge cases; `reviewer` = alias
         security-reviewer) echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-4.7)" ;;  # Adversarial reasoning
         implementer)       echo "codex:gpt-5.5" ;;                                                          # Default code generation; terminal-heavy

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -74,7 +74,7 @@ Options:
   --implement never|after-approval|plan-only
   --worktree auto|on|off
   --benchmark auto|on|off
-  --providers auto|claude,codex,gemini,qwen,opencode,openrouter
+  --providers auto|claude,codex,agy,gemini,qwen,opencode,openrouter
   --max-cost <usd>
   --simulate
   --single-model
@@ -175,7 +175,7 @@ council_validate_choice() {
 
 council_validate_provider_list() {
     local providers="$1"
-    local allowed="claude,codex,gemini,qwen,opencode,openrouter"
+    local allowed="claude,codex,agy,gemini,qwen,opencode,openrouter"
 
     if [[ "$providers" == "auto" ]]; then
         return 0
@@ -518,6 +518,7 @@ council_provider_command() {
         claude) echo "claude" ;;
         codex) echo "codex" ;;
         gemini) echo "gemini" ;;
+        agy) echo "agy" ;;
         opencode) echo "opencode" ;;
         openrouter) echo "openrouter" ;;
         *) echo "$1" ;;
@@ -528,7 +529,7 @@ council_provider_org() {
     case "$1" in
         claude) echo "anthropic" ;;
         codex) echo "openai" ;;
-        gemini) echo "google" ;;
+        gemini|agy) echo "google" ;;
         opencode) echo "opencode" ;;
         openrouter) echo "openrouter" ;;
         *) echo "$1" ;;
@@ -562,6 +563,7 @@ council_cli_to_provider() {
     case "$1" in
         claude*|opus*|sonnet*) echo "claude" ;;
         gemini*) echo "gemini" ;;
+        agy*) echo "agy" ;;
         opencode*) echo "opencode" ;;
         openrouter*) echo "openrouter" ;;
         codex*|gpt*) echo "codex" ;;
@@ -882,7 +884,7 @@ council_pick_provider() {
     fi
 
     local provider providers="$COUNCIL_PROVIDERS"
-    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,qwen,opencode,openrouter"
+    [[ "$providers" == "auto" ]] && providers="claude,codex,agy,gemini,qwen,opencode,openrouter"
     IFS=',' read -r -a provider_list <<< "$providers"
     for provider in "${provider_list[@]}"; do
         provider="${provider// /}"
@@ -982,7 +984,7 @@ council_candidate_personas() {
 
 council_available_provider_orgs_json() {
     local providers="$COUNCIL_PROVIDERS"
-    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,qwen,opencode,openrouter"
+    [[ "$providers" == "auto" ]] && providers="claude,codex,agy,gemini,qwen,opencode,openrouter"
 
     local json='[]' provider org
     IFS=',' read -r -a provider_list <<< "$providers"
@@ -998,7 +1000,7 @@ council_available_provider_orgs_json() {
 council_provider_for_org() {
     local wanted_org="$1"
     local providers="$COUNCIL_PROVIDERS"
-    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,qwen,opencode,openrouter"
+    [[ "$providers" == "auto" ]] && providers="claude,codex,agy,gemini,qwen,opencode,openrouter"
 
     local provider
     IFS=',' read -r -a provider_list <<< "$providers"
@@ -1972,7 +1974,7 @@ council_start_implementation_handoff() {
 council_detect_providers() {
     local providers="$COUNCIL_PROVIDERS"
     if [[ "$providers" == "auto" ]]; then
-        providers="claude,codex,gemini,qwen,opencode,openrouter"
+        providers="claude,codex,agy,gemini,qwen,opencode,openrouter"
     fi
 
     local json='{}'

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -579,7 +579,7 @@ council_persona_default_provider() {
 
     case "$1" in
         strategy-analyst|exec-communicator) echo "claude" ;;
-        research-synthesizer|business-analyst|finance-analyst|academic-writer|ux-researcher) echo "gemini" ;;
+        research-synthesizer|business-analyst|finance-analyst|academic-writer|ux-researcher) echo "agy" ;;
         *) echo "codex" ;;
     esac
 }
@@ -594,7 +594,7 @@ council_persona_model() {
 
     case "$1" in
         strategy-analyst|exec-communicator) echo "anthropic/claude-sonnet-4.6" ;;
-        research-synthesizer|business-analyst|finance-analyst|academic-writer|ux-researcher) echo "gemini-3-pro-preview" ;;
+        research-synthesizer|business-analyst|finance-analyst|academic-writer|ux-researcher) echo "Gemini 3.1 Pro (High)" ;;
         code-reviewer) echo "gpt-5.3-codex-spark" ;;
         *) echo "gpt-5.3-codex" ;;
     esac

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -236,6 +236,11 @@ migrate_provider_config() {
       "fallback": "gemini-3-flash-preview",
       "flash": "gemini-3-flash-preview",
       "image": "gemini-3-pro-image"
+    },
+    "agy": {
+      "default": "Gemini 3.1 Pro (High)",
+      "fallback": "Gemini 3.5 Flash (High)",
+      "flash": "Gemini 3.5 Flash (Low)"
     }
   },
   "routing": {
@@ -243,7 +248,7 @@ migrate_provider_config() {
       "deliver": "codex:default",
       "review": "codex:default",
       "security": "codex:reasoning",
-      "research": "gemini:default"
+      "research": "agy"
     },
     "roles": {
       "researcher": "perplexity"
@@ -372,6 +377,11 @@ set_provider_model() {
       "fallback": "gemini-3-flash-preview",
       "flash": "gemini-3-flash-preview",
       "image": "gemini-3-pro-image"
+    },
+    "agy": {
+      "default": "Gemini 3.1 Pro (High)",
+      "fallback": "Gemini 3.5 Flash (High)",
+      "flash": "Gemini 3.5 Flash (Low)"
     }
   },
   "routing": {
@@ -379,7 +389,7 @@ set_provider_model() {
       "deliver": "codex:default",
       "review": "codex:default",
       "security": "codex:reasoning",
-      "research": "gemini:default"
+      "research": "agy"
     }
   },
   "tiers": {

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -498,7 +498,7 @@ ${YELLOW}Options:${NC}
   --implement never|after-approval|plan-only
   --worktree auto|on|off
   --benchmark auto|on|off
-  --providers auto|claude,codex,gemini,qwen,opencode,openrouter
+  --providers auto|claude,codex,agy,gemini,qwen,opencode,openrouter
   --max-cost <usd>
   --dry-run
   --json

--- a/tests/unit/test-agy-research-defaults.sh
+++ b/tests/unit/test-agy-research-defaults.sh
@@ -17,23 +17,28 @@ fi
 
 test_case "legacy researcher mapping is preserved"
 legacy_mapping="$(bash -c 'export OCTOPUS_LEGACY_ROLES=1; source "$1/scripts/lib/agent-utils.sh" 2>/dev/null; get_role_mapping researcher' bash "$PROJECT_ROOT")"
-if [[ "$legacy_mapping" == "gemini:gemini-3.1-pro-preview" ]]; then
+if [[ "$legacy_mapping" == gemini:gemini-* ]]; then
     test_pass
 else
-    test_fail "expected legacy gemini mapping, got: $legacy_mapping"
+    test_fail "expected legacy gemini provider mapping, got: $legacy_mapping"
 fi
 
 test_case "new model config routes research phase to agy"
 config_hits="$(grep -R '"research": "gemini:default"' "$PROJECT_ROOT/scripts/helpers/octo-model-config.sh" "$PROJECT_ROOT/scripts/lib/provider-routing.sh" 2>/dev/null || true)"
+phase_fallback_out="$({
+    tmp_home="$(mktemp -d)"
+    trap 'rm -rf "$tmp_home"' EXIT
+    HOME="$tmp_home" "$PROJECT_ROOT/scripts/helpers/octo-model-config.sh" show phases
+} 2>/dev/null)"
 if [[ -z "$config_hits" ]] && \
    grep -q '"research": "agy"' "$PROJECT_ROOT/scripts/helpers/octo-model-config.sh" && \
    grep -q '"research": "agy"' "$PROJECT_ROOT/scripts/lib/provider-routing.sh" && \
    grep -q '"default": "Gemini 3.1 Pro (High)"' "$PROJECT_ROOT/scripts/helpers/octo-model-config.sh" && \
    grep -q '"default": "Gemini 3.1 Pro (High)"' "$PROJECT_ROOT/scripts/lib/provider-routing.sh" && \
-   grep -q 'research) default_target="agy" ;;' "$PROJECT_ROOT/scripts/helpers/octo-model-config.sh"; then
+   [[ "$phase_fallback_out" == *"research"*"agy"* ]]; then
     test_pass
 else
-    test_fail "research config defaults are not consistently agy; stale hits: $config_hits"
+    test_fail "research config defaults are not consistently agy; stale hits: $config_hits; phases: $phase_fallback_out"
 fi
 
 test_case "research phase resolves to explicit agy Pro label"
@@ -67,6 +72,26 @@ if [[ "$resolve_out" == "Gemini 3.1 Pro (High)" ]]; then
     test_pass
 else
     test_fail "expected Gemini 3.1 Pro (High), got: $resolve_out"
+fi
+
+
+
+test_case "council accepts and detects agy provider"
+council_detect_out="$({
+    tmp_bin="$(mktemp -d)"
+    cleanup_council_agy_tmp() { rm -rf "$tmp_bin"; }
+    trap cleanup_council_agy_tmp EXIT
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+exit 0
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+    PATH="$tmp_bin:$PATH" bash -c 'source "$1/scripts/lib/council.sh" 2>/dev/null; COUNCIL_PROVIDERS=auto; council_validate_provider_list agy && council_detect_providers && jq -r ".agy // empty" <<< "$COUNCIL_PROVIDER_STATUS_JSON"' bash "$PROJECT_ROOT"
+} 2>/dev/null)"
+if [[ "$council_detect_out" == "available" ]]; then
+    test_pass
+else
+    test_fail "expected council to accept and detect agy provider, got: $council_detect_out"
 fi
 
 test_case "council research fallback defaults to agy"

--- a/tests/unit/test-agy-research-defaults.sh
+++ b/tests/unit/test-agy-research-defaults.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "research defaults use Antigravity instead of Gemini API"
+
+test_case "default researcher role maps to agy"
+role_mapping="$(bash -c 'source "$1/scripts/lib/agent-utils.sh" 2>/dev/null; get_role_mapping researcher' bash "$PROJECT_ROOT")"
+if [[ "$role_mapping" == "agy:Gemini 3.1 Pro (High)" ]]; then
+    test_pass
+else
+    test_fail "expected agy:Gemini 3.1 Pro (High), got: $role_mapping"
+fi
+
+test_case "legacy researcher mapping is preserved"
+legacy_mapping="$(bash -c 'export OCTOPUS_LEGACY_ROLES=1; source "$1/scripts/lib/agent-utils.sh" 2>/dev/null; get_role_mapping researcher' bash "$PROJECT_ROOT")"
+if [[ "$legacy_mapping" == "gemini:gemini-3.1-pro-preview" ]]; then
+    test_pass
+else
+    test_fail "expected legacy gemini mapping, got: $legacy_mapping"
+fi
+
+test_case "new model config routes research phase to agy"
+config_hits="$(grep -R '"research": "gemini:default"' "$PROJECT_ROOT/scripts/helpers/octo-model-config.sh" "$PROJECT_ROOT/scripts/lib/provider-routing.sh" 2>/dev/null || true)"
+if [[ -z "$config_hits" ]] && \
+   grep -q '"research": "agy"' "$PROJECT_ROOT/scripts/helpers/octo-model-config.sh" && \
+   grep -q '"research": "agy"' "$PROJECT_ROOT/scripts/lib/provider-routing.sh" && \
+   grep -q '"default": "Gemini 3.1 Pro (High)"' "$PROJECT_ROOT/scripts/helpers/octo-model-config.sh" && \
+   grep -q '"default": "Gemini 3.1 Pro (High)"' "$PROJECT_ROOT/scripts/lib/provider-routing.sh" && \
+   grep -q 'research) default_target="agy" ;;' "$PROJECT_ROOT/scripts/helpers/octo-model-config.sh"; then
+    test_pass
+else
+    test_fail "research config defaults are not consistently agy; stale hits: $config_hits"
+fi
+
+test_case "research phase resolves to explicit agy Pro label"
+resolve_out="$({
+    tmp_home=""
+    tmp_bin=""
+    cleanup_research_defaults_tmp() {
+        rm -rf "$tmp_home" "$tmp_bin"
+    }
+    trap cleanup_research_defaults_tmp EXIT
+
+    tmp_home="$(mktemp -d)"
+    tmp_bin="$(mktemp -d)"
+    mkdir -p "$tmp_home/.claude-octopus/config"
+    cat > "$tmp_home/.claude-octopus/config/providers.json" <<'JSON'
+{"providers":{"agy":{"default":"Gemini 3.1 Pro (High)"}},"routing":{"phases":{"research":"agy"}}}
+JSON
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "models" ]]; then
+    printf '%s
+' 'Gemini 3.1 Pro (High)' 'Gemini 3.5 Flash (High)' 'Gemini 3.5 Flash (Low)'
+    exit 0
+fi
+exit 0
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+    HOME="$tmp_home" PATH="$tmp_bin:$PATH" bash -c 'log(){ :; }; source "$1/scripts/lib/model-resolver.sh"; resolve_octopus_model agy agy research researcher' bash "$PROJECT_ROOT"
+} 2>/dev/null)"
+if [[ "$resolve_out" == "Gemini 3.1 Pro (High)" ]]; then
+    test_pass
+else
+    test_fail "expected Gemini 3.1 Pro (High), got: $resolve_out"
+fi
+
+test_case "council research fallback defaults to agy"
+council_out="$(bash -c 'source "$1/scripts/lib/council.sh" 2>/dev/null; council_agent_config_value(){ return 0; }; council_persona_default_provider research-synthesizer; council_persona_model research-synthesizer' bash "$PROJECT_ROOT")"
+if [[ "$council_out" == $'agy\nGemini 3.1 Pro (High)' ]]; then
+    test_pass
+else
+    test_fail "expected agy/Gemini 3.1 Pro (High), got: $(printf '%s' "$council_out" | tr '\n' '/')"
+fi
+
+test_summary

--- a/tests/unit/test-qwen-council-provider.sh
+++ b/tests/unit/test-qwen-council-provider.sh
@@ -19,7 +19,7 @@ USAGE="$PROJECT_ROOT/scripts/lib/usage-help.sh"
 test_qwen_in_auto_list() {
     test_case "council auto provider list includes qwen"
 
-    if grep -q 'claude,codex,gemini,qwen,opencode,openrouter' "$COUNCIL"; then
+    if grep -Eq 'claude,codex,.*qwen,.*opencode,openrouter' "$COUNCIL"; then
         test_pass
     else
         test_fail "council.sh auto provider list should include qwen"
@@ -62,7 +62,7 @@ test_qwen_persona_seat() {
 test_qwen_usage_doc() {
     test_case "usage help lists qwen as a --providers option"
 
-    if grep -q 'claude,codex,gemini,qwen,opencode,openrouter' "$USAGE"; then
+    if grep -Eq 'claude,codex,.*qwen,.*opencode,openrouter' "$USAGE"; then
         test_pass
     else
         test_fail "usage-help.sh should document qwen in the --providers list"


### PR DESCRIPTION
## Summary

This is the small, surgical alternative to broad Gemini removal work.

It keeps Gemini as an explicit provider, but stops default research paths from selecting the Gemini API. Research defaults now route to `agy` / Antigravity while preserving the intended Gemini Pro-class model by pinning the explicit Antigravity label `Gemini 3.1 Pro (High)`.

## Changes

- Default `researcher` role mapping: `gemini:gemini-3.1-pro-preview` → `agy:Gemini 3.1 Pro (High)`.
- Default `research` phase routing in new/generated provider configs: `gemini:default` → `agy`.
- Add explicit `providers.agy.default = "Gemini 3.1 Pro (High)"` in generated/default model config templates.
- Council research persona fallback provider/model: `gemini` / `gemini-3-pro-preview` → `agy` / `Gemini 3.1 Pro (High)`.
- Preserve `OCTOPUS_LEGACY_ROLES=1` behavior unchanged.
- Add a focused unit test covering the explicit agy model default, runtime model resolution, and the legacy exception.

## Non-goals

- Does not remove the Gemini provider.
- Does not change Codex, Claude, Opus, OpenRouter, or other non-research model defaults.
- Does not alter explicit user selections of `gemini:*`.
- Does not rely on `agy/default`; the agy research model is explicit.

## Validation

```text
git diff --check
bash -n scripts/lib/agent-utils.sh scripts/lib/provider-routing.sh scripts/helpers/octo-model-config.sh scripts/lib/council.sh tests/unit/test-agy-research-defaults.sh
bash tests/unit/test-agy-research-defaults.sh
bash tests/unit/test-agy-workflow-routing.sh
bash tests/unit/test-agy-provider.sh
bash tests/smoke/test-syntax.sh
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Research-related routing now defaults to the new `agy` provider instead of the previous default.
  * Role and persona fallbacks now resolve to the updated `agy` model for research-focused workflows.

* **Bug Fixes**
  * Improved consistency between generated configuration, routing defaults, and displayed phase information.

* **Tests**
  * Added coverage for default research routing, legacy role behavior, model resolution, and fallback persona mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->