### PR TITLE
[codex] Fix Codex plugin marketplace name mismatch

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-octopus",
+  "name": "octo",
   "version": "9.47.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {

--- a/scripts/test-codex-compat.sh
+++ b/scripts/test-codex-compat.sh
@@ -110,6 +110,10 @@ test_output "Codex manifest name matches marketplace selector" \
     "printf '%s:%s\n' \"\$(jq -r '.name' '$PLUGIN_ROOT/.codex-plugin/plugin.json')\" \"\$(jq -r '.plugins[] | select(.name == \"octo\") | .name' '$PLUGIN_ROOT/.claude-plugin/marketplace.json')\"" \
     "^octo:octo$"
 
+test_output "Release validation reports a missing Codex manifest clearly" \
+    "tmpdir=\$(mktemp -d); mkdir -p \"\$tmpdir/scripts\" \"\$tmpdir/.claude-plugin\"; cp '$SCRIPT_DIR/validate-release.sh' \"\$tmpdir/scripts/validate-release.sh\"; printf '%s\n' '{\"name\":\"octo\"}' > \"\$tmpdir/.claude-plugin/plugin.json\"; bash \"\$tmpdir/scripts/validate-release.sh\" 2>&1 || true; rm -rf \"\$tmpdir\"" \
+    "CRITICAL ERROR: Codex plugin manifest not found"
+
 test_output "Codex manifest points at portable root skills tree" \
     "jq -r '.skills' '$PLUGIN_ROOT/.codex-plugin/plugin.json'" \
     "^\\./skills/?$"

--- a/scripts/test-codex-compat.sh
+++ b/scripts/test-codex-compat.sh
@@ -106,6 +106,10 @@ echo "--- 2. Manifest + Output Structure (skills/) ---"
 test_cmd "Codex manifest is valid JSON" \
     "jq empty '$PLUGIN_ROOT/.codex-plugin/plugin.json'"
 
+test_output "Codex manifest name matches marketplace selector" \
+    "printf '%s:%s\n' \"\$(jq -r '.name' '$PLUGIN_ROOT/.codex-plugin/plugin.json')\" \"\$(jq -r '.plugins[] | select(.name == \"octo\") | .name' '$PLUGIN_ROOT/.claude-plugin/marketplace.json')\"" \
+    "^octo:octo$"
+
 test_output "Codex manifest points at portable root skills tree" \
     "jq -r '.skills' '$PLUGIN_ROOT/.codex-plugin/plugin.json'" \
     "^\\./skills/?$"

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -25,7 +25,12 @@ echo ""
 echo "🔒 Checking plugin names..."
 
 PLUGIN_NAME=$(grep '"name"' "$ROOT_DIR/.claude-plugin/plugin.json" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
-CODEX_PLUGIN_NAME=$(grep '"name"' "$ROOT_DIR/.codex-plugin/plugin.json" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
+CODEX_PLUGIN_JSON="$ROOT_DIR/.codex-plugin/plugin.json"
+if [[ ! -f "$CODEX_PLUGIN_JSON" ]]; then
+    echo -e "  ${RED}CRITICAL ERROR: Codex plugin manifest not found at $CODEX_PLUGIN_JSON${NC}"
+    exit 1
+fi
+CODEX_PLUGIN_NAME=$(grep '"name"' "$CODEX_PLUGIN_JSON" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
 MARKETPLACE_PLUGIN_NAME=$(sed -n '/"plugins"/,/]/p' "$ROOT_DIR/.claude-plugin/marketplace.json" | grep '"name"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
 
 if [[ "$PLUGIN_NAME" != "octo" ]]; then

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -25,6 +25,7 @@ echo ""
 echo "🔒 Checking plugin names..."
 
 PLUGIN_NAME=$(grep '"name"' "$ROOT_DIR/.claude-plugin/plugin.json" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
+CODEX_PLUGIN_NAME=$(grep '"name"' "$ROOT_DIR/.codex-plugin/plugin.json" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
 MARKETPLACE_PLUGIN_NAME=$(sed -n '/"plugins"/,/]/p' "$ROOT_DIR/.claude-plugin/marketplace.json" | grep '"name"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
 
 if [[ "$PLUGIN_NAME" != "octo" ]]; then
@@ -41,6 +42,14 @@ if [[ "$MARKETPLACE_PLUGIN_NAME" != "octo" ]]; then
     ((errors++)) || true
 else
     echo -e "  ${GREEN}✓ marketplace.json plugin name: octo (matches plugin.json for /plugin UI)${NC}"
+fi
+
+if [[ "$CODEX_PLUGIN_NAME" != "$MARKETPLACE_PLUGIN_NAME" ]]; then
+    echo -e "  ${RED}CRITICAL ERROR: Codex plugin name '$CODEX_PLUGIN_NAME' does not match marketplace name '$MARKETPLACE_PLUGIN_NAME'${NC}"
+    echo -e "  ${RED}Codex rejects installation when these names differ${NC}"
+    ((errors++)) || true
+else
+    echo -e "  ${GREEN}✓ Codex plugin name: $CODEX_PLUGIN_NAME (matches marketplace selector)${NC}"
 fi
 
 echo ""

--- a/tests/validate-plugin-name.sh
+++ b/tests/validate-plugin-name.sh
@@ -11,6 +11,7 @@ source "$SCRIPT_DIR/helpers/test-framework.sh"
 test_suite "Validate that plugin name remains "octo" in plugin.json"
 
 PLUGIN_JSON="$PROJECT_ROOT/.claude-plugin/plugin.json"
+CODEX_PLUGIN_JSON="$PROJECT_ROOT/.codex-plugin/plugin.json"
 
 
 echo "🔍 Validating plugin name..."
@@ -42,6 +43,25 @@ if [[ "$PLUGIN_NAME" != "$EXPECTED_NAME" ]]; then
     exit 1
 fi
 
+if [[ ! -f "$CODEX_PLUGIN_JSON" ]]; then
+    echo -e "${RED}❌ ERROR: Codex plugin.json not found at $CODEX_PLUGIN_JSON${NC}"
+    exit 1
+fi
+
+CODEX_PLUGIN_NAME=$(grep '"name"' "$CODEX_PLUGIN_JSON" | head -1 | sed 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+
+if [[ "$CODEX_PLUGIN_NAME" != "$EXPECTED_NAME" ]]; then
+    echo -e "${RED}❌ CRITICAL ERROR: Codex plugin name is incorrect!${NC}"
+    echo ""
+    echo -e "  Current:  ${YELLOW}\"$CODEX_PLUGIN_NAME\"${NC}"
+    echo -e "  Expected: ${GREEN}\"$EXPECTED_NAME\"${NC}"
+    echo ""
+    echo "The Codex manifest name MUST match the marketplace selector."
+    echo "Otherwise, 'codex plugin add octo@nyldn-plugins' rejects the plugin."
+    echo ""
+    exit 1
+fi
+
 # Also validate that package.json has correct name
 PACKAGE_JSON="$PROJECT_ROOT/package.json"
 if [[ -f "$PACKAGE_JSON" ]]; then
@@ -54,5 +74,6 @@ if [[ -f "$PACKAGE_JSON" ]]; then
 fi
 
 echo -e "${GREEN}✅ Plugin name is correct: \"$PLUGIN_NAME\"${NC}"
+echo -e "${GREEN}✅ Codex plugin name is correct: \"$CODEX_PLUGIN_NAME\"${NC}"
 echo "   Commands will work as: /octo:discover, /octo:debate, etc."
 test_summary


### PR DESCRIPTION
## What changed

- align `.codex-plugin/plugin.json` with the `octo` marketplace selector
- add a Codex compatibility regression assertion
- extend smoke and release validation so future releases reject mismatched names

## Root cause

The marketplace advertises `octo@nyldn-plugins`, while the Codex manifest declared `claude-octopus`. Codex validates that these identifiers match and rejected installation with:

```text
plugin.json name `claude-octopus` does not match marketplace plugin name `octo`
```

## Impact

After this change, `codex plugin add octo@nyldn-plugins` can resolve the plugin manifest instead of failing during package validation.

## Validation

- reproduced before the fix with Codex CLI 0.136.0
- compatibility suite before fix: 105 passed, 1 failed (the new name assertion)
- `tests/validate-plugin-name.sh`: passed after fix
- `scripts/validate-release.sh`: new plugin-name gate passed; the full script later hit existing Windows CRLF skill-index failures unrelated to this patch
- `scripts/validate-plugin-assembly.py --root .`: passed (`54 skills, 49 commands, 52 agents`)
- `bash -n` passed for all modified shell scripts
- `.codex-plugin/plugin.json` parsed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Codex plugin manifest’s displayed name to **“octo”**.
  * Added stricter validation to ensure the Codex plugin name and marketplace plugin name remain consistent.

* **Tests**
  * Added compatibility assertions that verify the Codex manifest name matches the marketplace entry for **octo**.
  * Added a release-validation case that fails when the Codex manifest is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->