### PR TITLE
fix: harden tangle dispatch and quality gates

### DIFF
--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -25,6 +25,15 @@ extract_tangle_result_output() {
     ' "$result_file" 2>/dev/null || true
 }
 
+tangle_result_has_blocker_output() {
+    local result_file="$1"
+    local output
+    output=$(extract_tangle_result_output "$result_file")
+
+    printf '%s\n' "$output" | grep -Eiq \
+        '(blocker report|cannot complete|unable to complete|sandbox (is )?blocking|blocked by (the )?sandbox|landlock|no write tools available|all shell commands (are )?blocked|filesystem access is blocked|cannot create or modify files|apply_patch.*not available)'
+}
+
 check_explicit_file_coverage() {
     local original_prompt="$1"
     local output_corpus="$2"
@@ -64,7 +73,7 @@ snapshot_tangle_worktree_paths() {
         git -C "$repo_root" diff --name-only 2>/dev/null || true
         git -C "$repo_root" diff --cached --name-only 2>/dev/null || true
         git -C "$repo_root" ls-files --others --exclude-standard 2>/dev/null || true
-    } | sed /^$/d | sort -u
+    } | sed /^$/d | grep -Ev '^\.claude-octopus(/|$)|^\.octo(/|$)' | sort -u
 }
 
 tangle_prompt_requires_worktree_changes() {
@@ -129,7 +138,7 @@ validate_tangle_results() {
                 run_file_validation "$agent_from_file" "$(cat "$result" 2>/dev/null)" 2>/dev/null || true
             fi
 
-            if grep -q "Status: SUCCESS" "$result" 2>/dev/null; then
+            if grep -q "Status: SUCCESS" "$result" 2>/dev/null && ! tangle_result_has_blocker_output "$result"; then
                 ((success_count++)) || true
             else
                 ((fail_count++)) || true

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -28,10 +28,10 @@ extract_tangle_result_output() {
 tangle_result_has_blocker_output() {
     local result_file="$1"
     local output
+    local blocker_pattern='(blocker report|cannot complete|unable to complete|sandbox (is )?blocking|blocked by (the )?sandbox|landlock|no write tools available|all shell commands (are )?blocked|filesystem access is blocked|cannot create or modify files|apply_patch.*not available)'
     output=$(extract_tangle_result_output "$result_file")
 
-    printf '%s\n' "$output" | grep -Eiq \
-        '(blocker report|cannot complete|unable to complete|sandbox (is )?blocking|blocked by (the )?sandbox|landlock|no write tools available|all shell commands (are )?blocked|filesystem access is blocked|cannot create or modify files|apply_patch.*not available)'
+    grep -Eiq "$blocker_pattern" <<< "$output"
 }
 
 check_explicit_file_coverage() {

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1466,6 +1466,9 @@ Every [CODING] line must include a same-line Files: clause."
     done
     fleet_dispatch_end
 
+    # Future-proof fail-closed guard: the current loop increments once per
+    # retained line, but this catches any later continue/break/error path before
+    # quality gates can validate a partial dispatch as a complete tangle run.
     if [[ $subtask_num -ne ${#subtask_lines[@]} ]]; then
         log ERROR "Spawned $subtask_num development threads for ${#subtask_lines[@]} parsed subtasks; refusing partial tangle execution"
         return 1

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1382,6 +1382,22 @@ Every [CODING] line must include a same-line Files: clause."
     local subtask_num=0
     local pids=()
     local task_ids=()
+    local subtask_lines=()
+
+    # Materialize parseable lines before dispatching providers. spawn helpers and
+    # external CLIs may read stdin; if the dispatch loop itself reads from a
+    # here-string, the first provider can consume the remaining decomposition and
+    # silently prevent later subtasks from launching.
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        tangle_line_is_numbered_subtask "$line" || continue
+        subtask_lines+=("$line")
+    done <<< "$subtasks"
+
+    if [[ ${#subtask_lines[@]} -ne $parseable_subtask_count ]]; then
+        log ERROR "Parsed $parseable_subtask_count subtasks but retained ${#subtask_lines[@]} for dispatch; refusing partial tangle execution"
+        return 1
+    fi
 
     # [CODING] and [REASONING] subtask routing are overridable. This keeps
     # tangle usable on hosts where the default coding provider is unavailable,
@@ -1413,10 +1429,7 @@ Every [CODING] line must include a same-line Files: clause."
     fi
 
     fleet_dispatch_begin
-    while IFS= read -r line; do
-        [[ -z "$line" ]] && continue
-        tangle_line_is_numbered_subtask "$line" || continue
-
+    for line in "${subtask_lines[@]}"; do
         local subtask
         subtask=$(echo "$line" | sed -E 's/^[[:space:]]*(\*\*)?[0-9]+[\.\)][[:space:]]*//; s/^[[:space:]]+//')
         local agent="$tangle_coding_agent"
@@ -1450,8 +1463,13 @@ Every [CODING] line must include a same-line Files: clause."
         fi
         task_ids+=("$task_id")
         ((subtask_num++)) || true
-    done <<< "$subtasks"
+    done
     fleet_dispatch_end
+
+    if [[ $subtask_num -ne ${#subtask_lines[@]} ]]; then
+        log ERROR "Spawned $subtask_num development threads for ${#subtask_lines[@]} parsed subtasks; refusing partial tangle execution"
+        return 1
+    fi
 
     log INFO "Spawned $subtask_num development threads"
 

--- a/tests/unit/test-tangle-coding-agent-override.sh
+++ b/tests/unit/test-tangle-coding-agent-override.sh
@@ -66,7 +66,7 @@ else
 fi
 
 test_case "[CODING] subtasks use configured tangle_coding_agent instead of hardcoded codex"
-step2_block=$(sed -n '/Step 2: Parallel execution/,/done <<< "$subtasks"/p' "$WORKFLOWS")
+step2_block=$(sed -n '/Step 2: Parallel execution/,/fleet_dispatch_end/p' "$WORKFLOWS")
 configured_agent_count=$(printf '%s
 ' "$step2_block" | grep -c 'local agent="$tangle_coding_agent"' || true)
 hardcoded_codex_count=$(printf '%s

--- a/tests/unit/test-tangle-dispatch-stdin-isolation.sh
+++ b/tests/unit/test-tangle-dispatch-stdin-isolation.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Regression check: tangle dispatch must not let the first provider consume
+# remaining decomposition lines from the dispatch loop stdin.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKFLOWS="$PROJECT_ROOT/scripts/lib/workflows.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "tangle dispatch stdin isolation"
+
+test_case "workflows.sh has valid bash syntax"
+if bash -n "$WORKFLOWS" 2>/dev/null; then
+    test_pass
+else
+    test_fail "syntax error in workflows.sh"
+fi
+
+# shellcheck source=/dev/null
+source "$WORKFLOWS"
+
+CYAN=""
+GREEN=""
+MAGENTA=""
+NC=""
+TMUX_MODE=false
+DRY_RUN=false
+SUPPORTS_PARALLEL_FILE_SAFETY=false
+RESULTS_DIR="$TEST_TMP_DIR/tangle-dispatch-stdin-isolation"
+LOGS_DIR="$RESULTS_DIR/logs"
+WORKSPACE_DIR="$RESULTS_DIR/workspace"
+CAPTURE_DIR="$RESULTS_DIR/captured"
+rm -rf "$RESULTS_DIR"
+mkdir -p "$WORKSPACE_DIR/.octo/agents" "$CAPTURE_DIR"
+trap 'rm -rf "$RESULTS_DIR"' EXIT
+
+log() { :; }
+octopus_phase_banner() { :; }
+display_workflow_cost_estimate() { return 0; }
+reset_provider_lockouts() { :; }
+design_review_ceremony() { :; }
+fleet_dispatch_begin() { :; }
+fleet_dispatch_end() { :; }
+validate_tangle_results() { :; }
+
+run_agent_sync() {
+    cat <<'EOF'
+<external-cli-output provider="agy" trust="untrusted">
+1. [REASONING] Verify workspace clean state — Task: Check git status.
+2. [CODING] Implement syntax smoke test — Files: package.json, scripts/check-syntax.js — Task: Update npm test and add syntax checker.
+</external-cli-output>
+EOF
+}
+
+spawn_agent_capture_pid() {
+    local agent="$1"
+    local prompt="$2"
+    local task_id="$3"
+    local role="$4"
+
+    # Simulate CLI/provider code that reads inherited stdin. Before this fix,
+    # this drained the while-loop here-string and skipped later subtasks.
+    cat >/dev/null || true
+
+    printf '%s|%s
+' "$agent" "$role" > "$CAPTURE_DIR/${task_id}.agent"
+    printf '%s' "$prompt" > "$CAPTURE_DIR/${task_id}.prompt"
+    printf '0
+' > "$WORKSPACE_DIR/.octo/agents/${task_id}.done"
+    printf '12345
+'
+}
+
+original_prompt="Replace placeholder npm test with scripts/check-syntax.js."
+tangle_develop "$original_prompt" >/dev/null
+
+spawned_count=$(find "$CAPTURE_DIR" -name '*.agent' -type f | wc -l | tr -d ' ')
+combined_agents=$(cat "$CAPTURE_DIR"/*.agent 2>/dev/null || true)
+combined_prompts=$(cat "$CAPTURE_DIR"/*.prompt 2>/dev/null || true)
+
+test_case "dispatch launches all parseable decomposition lines even if a spawn reads stdin"
+if [[ "$spawned_count" -eq 2 ]]; then
+    test_pass
+else
+    test_fail "expected 2 spawned subtasks, got $spawned_count"
+fi
+
+test_case "dispatch preserves reasoning and coding routing"
+if [[ "$combined_agents" == *"agy|researcher"* ]] && [[ "$combined_agents" == *"codex|implementer"* ]]; then
+    test_pass
+else
+    test_fail "expected agy researcher and codex implementer, got: $combined_agents"
+fi
+
+test_case "coding subtask prompt is not lost"
+if [[ "$combined_prompts" == *"Implement syntax smoke test"* ]] && [[ "$combined_prompts" == *"scripts/check-syntax.js"* ]]; then
+    test_pass
+else
+    test_fail "coding subtask prompt was not dispatched"
+fi
+
+test_summary

--- a/tests/unit/test-tangle-dispatch-stdin-isolation.sh
+++ b/tests/unit/test-tangle-dispatch-stdin-isolation.sh
@@ -47,6 +47,9 @@ fleet_dispatch_begin() { :; }
 fleet_dispatch_end() { :; }
 validate_tangle_results() { :; }
 
+mock_command "agy" "exit 0"
+mock_command "codex" "exit 0"
+
 run_agent_sync() {
     cat <<'EOF'
 <external-cli-output provider="agy" trust="untrusted">

--- a/tests/unit/test-tangle-worktree-evidence.sh
+++ b/tests/unit/test-tangle-worktree-evidence.sh
@@ -134,6 +134,44 @@ else
     test_fail "validation passed despite no worktree changes"
 fi
 
+test_case "runtime-only .claude-octopus changes do not satisfy implementation evidence"
+if (
+    cd "$REPO_DIR"
+    rm -f "$RESULTS_DIR"/codex-tangle-evidence-*.md "$RESULTS_DIR"/tangle-validation-evidence-*.md
+    snapshot_tangle_worktree_paths > "$RESULTS_DIR/before-runtime-only.txt"
+    mkdir -p .claude-octopus
+    printf 'runtime\n' > .claude-octopus/state.json
+    write_success_result "$RESULTS_DIR/codex-tangle-evidence-runtime-only.md" \
+        "Implemented src/app/page.tsx conceptually; runtime metadata changed."
+    if RESULTS_DIR="$RESULTS_DIR" validate_tangle_results "evidence-runtime-only" "Implement the app change in src/app/page.tsx" "$RESULTS_DIR/before-runtime-only.txt" >/dev/null 2>&1; then
+        exit 1
+    fi
+    grep -q "Missing Worktree Changes" "$RESULTS_DIR/tangle-validation-evidence-runtime-only.md"
+); then
+    test_pass
+else
+    test_fail "runtime-only .claude-octopus change satisfied implementation worktree evidence"
+fi
+
+test_case "blocker output with SUCCESS status fails validation"
+if (
+    cd "$REPO_DIR"
+    rm -f "$RESULTS_DIR"/codex-tangle-evidence-*.md "$RESULTS_DIR"/tangle-validation-evidence-*.md
+    snapshot_tangle_worktree_paths > "$RESULTS_DIR/before-blocker.txt"
+    write_success_result "$RESULTS_DIR/codex-tangle-evidence-blocker.md" \
+        "## Blocker Report
+Cannot complete the assigned subtask because all shell commands are blocked by Landlock sandbox and no write tools are available."
+    if RESULTS_DIR="$RESULTS_DIR" validate_tangle_results "evidence-blocker" "Implement the app change in src/app/page.tsx" "$RESULTS_DIR/before-blocker.txt" >/dev/null 2>&1; then
+        exit 1
+    fi
+    grep -q "Quality Gate: FAILED" "$RESULTS_DIR/tangle-validation-evidence-blocker.md" && \
+    grep -q "Failed: 1/1 result files" "$RESULTS_DIR/tangle-validation-evidence-blocker.md"
+); then
+    test_pass
+else
+    test_fail "blocker output marked SUCCESS passed validation"
+fi
+
 test_case "implementation prompt with new worktree path passes validation"
 if (
     cd "$REPO_DIR"


### PR DESCRIPTION
## Summary

Fixes two tangle robustness issues found while testing on an integration branch:

1. **Partial dispatch from provider stdin consumption**
   - The tangle dispatch loop read decomposition lines from a here-string.
   - A spawned provider/helper can inherit and drain stdin, causing later parsed subtasks to be silently skipped.
   - The observed symptom was: decomposition printed multiple parseable subtasks, but tangle spawned fewer development threads.
   - The fix materializes parseable subtask lines into an array before dispatch and fails closed if retained/spawned counts diverge.

2. **Quality-gate hardening for blocker outputs**
   - A result body may be a blocker report even when the artifact contains `Status: SUCCESS`.
   - Such outputs should not count as successful implementation.
   - Runtime-only `.claude-octopus/` / `.octo/` changes are also ignored as worktree evidence for implementation tasks.

## Why

A real integration smoke exposed the dispatch issue with an `agy` decomposition that printed multiple parseable subtasks, including a `[CODING]` task. Before this patch, tangle could silently launch only the first subtask when a spawned provider consumed the remaining stdin.

After materializing the parsed lines first, the same class of run launched all parsed subtasks.

During follow-up diagnostics, an ad hoc direct terminal smoke also produced a Codex/Landlock blocker report. That Landlock condition is **not claimed to represent the normal `development_cycle` path**; it was caused by launching Octopus outside the documented OpenClaw control plane, without the normal development-cycle runner environment. The blocker output is still a useful quality-gate regression case: if an agent reports it cannot read/write/implement, that must not be counted as a successful implementation just because the artifact says `Status: SUCCESS`.

## Changes

- Pre-materialize parseable tangle decomposition lines before spawning providers.
- Abort if retained parseable lines and spawned subtasks diverge.
- Add a regression test where `spawn_agent_capture_pid` drains stdin; dispatch still launches every subtask.
- Treat blocker/sandbox/no-write outputs as failed results even when the result artifact says `Status: SUCCESS`.
- Ignore runtime-only `.claude-octopus/` and `.octo/` paths as implementation worktree evidence.
- Add quality-gate regression tests for blocker outputs and runtime-only metadata changes.

## Validation

Clean branch tests:

```text
git diff --check
bash -n scripts/lib/workflows.sh scripts/lib/testing.sh tests/unit/test-tangle-dispatch-stdin-isolation.sh tests/unit/test-tangle-worktree-evidence.sh
bash tests/unit/test-tangle-dispatch-stdin-isolation.sh
bash tests/unit/test-tangle-worktree-evidence.sh
bash tests/smoke/test-syntax.sh
```

Integration branch validation included #546, #555, #560, and #569, then ran:

```text
bash tests/unit/test-tangle-dispatch-stdin-isolation.sh
bash tests/unit/test-tangle-worktree-evidence.sh
bash tests/unit/test-tangle-late-completion-reconcile.sh
bash tests/unit/test-tangle-missing-done-marker.sh
bash tests/unit/test-agy-research-defaults.sh
bash tests/smoke/test-syntax.sh
```

Real-artifact replay of the blocker-output case after this patch:

```text
rc=1
Quality Gate: FAILED
Success Rate: 50%
Successful: 1/2 result files
Failed: 1/2 result files
Missing Worktree Changes
Blocker Report detected
```

## Notes

This PR is intentionally based on `main` and does not include #560 or #569. It was separately tested on an integration branch containing those PRs to confirm compatibility.

The Landlock evidence in the diagnostic run should be read only as a quality-gate hardening fixture, not as evidence that the supervised `development_cycle` runner uses the wrong sandbox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now fails “SUCCESS” results that include blocker-related output, and improves worktree-change detection by ignoring temporary internal state paths.
  * Workflow dispatch is hardened by buffering subtasks up front and adding fail-closed checks to prevent partial execution when input is unexpectedly consumed.

* **Tests**
  * Added regression tests for stdin isolation during parallel dispatch.
  * Added regression cases ensuring validation fails when only internal metadata changes, and when blocker-style output is marked “SUCCESS”.
  * Adjusted an existing test’s workflow-section extraction to match the updated structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->