### PR TITLE
feat: allow code-review contract context

### DIFF
--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -326,14 +326,17 @@ review_run() {
     local profile_json="${1:-"{}"}"
 
     # Parse profile fields (with defaults)
-    local target focus provenance autonomy publish debate history
-    target=$(echo "$profile_json"     | jq -r '.target     // "staged"')
-    focus=$(echo "$profile_json"      | jq -r '.focus      // ["correctness","security","architecture","tdd"]  | join(",")')
-    provenance=$(echo "$profile_json" | jq -r '.provenance // "unknown"')
-    autonomy=$(echo "$profile_json"   | jq -r '.autonomy   // "supervised"')
-    publish=$(echo "$profile_json"    | jq -r '.publish    // "ask"')
-    debate=$(echo "$profile_json"     | jq -r '.debate     // "auto"')
-    history=$(echo "$profile_json"    | jq -r '.history    // "auto"')
+    local target focus provenance autonomy publish debate history context_file context_text context_label
+    target=$(echo "$profile_json"       | jq -r '.target       // "staged"')
+    focus=$(echo "$profile_json"        | jq -r '.focus        // ["correctness","security","architecture","tdd"]  | join(",")')
+    provenance=$(echo "$profile_json"   | jq -r '.provenance   // "unknown"')
+    autonomy=$(echo "$profile_json"     | jq -r '.autonomy     // "supervised"')
+    publish=$(echo "$profile_json"      | jq -r '.publish      // "ask"')
+    debate=$(echo "$profile_json"       | jq -r '.debate       // "auto"')
+    history=$(echo "$profile_json"      | jq -r '.history      // "auto"')
+    context_file=$(echo "$profile_json" | jq -r '.contextFile  // .context_file  // empty')
+    context_text=$(echo "$profile_json" | jq -r '.contextText  // .context_text  // empty')
+    context_label=$(echo "$profile_json"| jq -r '.contextLabel // .context_label // "Review context / task contract"')
     if [[ "$target" == "fresh" ]]; then
         target="working-tree"
         history="fresh"
@@ -366,7 +369,74 @@ review_run() {
         proof_dir=$(octo_proof_init "review" "target=${target} focus=${focus}" "$profile_json" 2>/dev/null || true)
     fi
 
-    log INFO "review_run: target=$target focus=$focus provenance=$provenance autonomy=$autonomy history=$history"
+    local review_contract_context=""
+    local review_context_chars="${OCTOPUS_REVIEW_CONTEXT_CHARS:-20000}"
+    [[ "$review_context_chars" =~ ^[0-9]+$ ]] || review_context_chars=20000
+    review_context_chars=$((10#$review_context_chars))
+    [[ "$review_context_chars" -lt 1000 ]] && review_context_chars=1000
+
+    local context_truncated="false"
+    if [[ -n "$context_file" ]]; then
+        local review_root=""
+        local context_file_resolved=""
+        review_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)
+        review_root=$(cd "$review_root" 2>/dev/null && pwd -P || printf '%s' "$review_root")
+        context_file_resolved=$(realpath "$context_file" 2>/dev/null || true)
+        if [[ -z "$context_file_resolved" || ! -r "$context_file_resolved" ]]; then
+            log ERROR "review_run: contextFile is not readable: $context_file"
+            echo '{"findings":[],"warning":"contextFile is not readable"}' > "$findings_file"
+            if [[ -n "$proof_dir" ]]; then
+                octo_proof_artifact "$proof_dir" "review-findings" "$findings_file" "contextFile not readable"
+                octo_proof_capture_provider_status "$proof_dir" "$provider_status_file"
+                octo_proof_finalize "$proof_dir" "fail" "contextFile is not readable: $context_file"
+            fi
+            rm -f "$provider_status_file"
+            render_terminal_report "$findings_file"
+            return 1
+        fi
+        case "$context_file_resolved" in
+            "$review_root"|"$review_root"/*) ;;
+            *)
+                log ERROR "review_run: contextFile escapes workspace root: $context_file"
+                echo '{"findings":[],"warning":"contextFile escapes workspace root"}' > "$findings_file"
+                if [[ -n "$proof_dir" ]]; then
+                    octo_proof_artifact "$proof_dir" "review-findings" "$findings_file" "contextFile escapes workspace root"
+                    octo_proof_capture_provider_status "$proof_dir" "$provider_status_file"
+                    octo_proof_finalize "$proof_dir" "fail" "contextFile escapes workspace root: $context_file"
+                fi
+                rm -f "$provider_status_file"
+                render_terminal_report "$findings_file"
+                return 1
+                ;;
+        esac
+        context_file="$context_file_resolved"
+        local context_file_bytes="0"
+        context_file_bytes=$(wc -c < "$context_file" 2>/dev/null | tr -d '[:space:]' || echo 0)
+        context_text=$(head -c "$review_context_chars" "$context_file" 2>/dev/null || true)
+        if [[ "$context_file_bytes" =~ ^[0-9]+$ && "$context_file_bytes" -gt "$review_context_chars" ]]; then
+            context_truncated="true"
+        fi
+    elif [[ -n "$context_text" ]]; then
+        if [[ ${#context_text} -gt $review_context_chars ]]; then
+            context_truncated="true"
+        fi
+        context_text=$(printf '%s' "$context_text" | head -c "$review_context_chars")
+    fi
+    if [[ "$context_truncated" == "true" ]]; then
+        context_text="${context_text}
+...[truncated]"
+    fi
+
+    if [[ -n "$context_text" ]]; then
+        review_contract_context="Additional review context / task contract (${context_label}):
+\`\`\`
+${context_text}
+\`\`\`
+
+Use this context as the requested behavior and constraints. Flag severity=normal when the diff is plausible code but fails the supplied task contract, misses acceptance criteria, violates constraints, changes unrelated areas, or omits required work."
+    fi
+
+    log INFO "review_run: target=$target focus=$focus provenance=$provenance autonomy=$autonomy history=$history context=$([[ -n "$review_contract_context" ]] && echo supplied || echo none)"
 
     # ── REVIEW.md ────────────────────────────────────────────────────────────
     parse_review_md
@@ -470,8 +540,11 @@ review_run() {
             --arg publish "$publish" \
             --arg debate "$debate" \
             --arg history "$history" \
+            --arg contextFile "$context_file" \
+            --arg contextLabel "$context_label" \
+            --argjson contextSupplied "$([[ -n "$review_contract_context" ]] && echo true || echo false)" \
             --argjson diff_lines "$diff_lines" \
-            '{target:$target, focus:$focus, provenance:$provenance, autonomy:$autonomy, publish:$publish, debate:$debate, history:$history, diff_lines:$diff_lines}')"
+            '{target:$target, focus:$focus, provenance:$provenance, autonomy:$autonomy, publish:$publish, debate:$debate, history:$history, contextFile:$contextFile, contextLabel:$contextLabel, contextSupplied:$contextSupplied, diff_lines:$diff_lines}')"
     fi
 
     # ── ROUND 1: Parallel agent fleet ────────────────────────────────────────
@@ -494,6 +567,7 @@ Severity guide:
 - pre-existing: bug not introduced by this PR (purple)
 
 ${review_context}
+${review_contract_context}
 ${review_history_context}
 ${graphify_context}
 
@@ -617,6 +691,8 @@ ${agent_prompt_base}"
 
 Return ONLY JSON: same findings array with an added 'verdict' field: confirmed|false-positive|needs-debate.
 Also add 'pre_existing_newly_reachable': true if a pre-existing finding becomes reachable via this PR changes.
+
+${review_contract_context}
 
 Diff:
 \`\`\`

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -2380,8 +2380,9 @@ case "$COMMAND" in
         # Multi-LLM code review pipeline — competitor to CC Code Review
         if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
             echo "Usage: $(basename "$0") code-review '<json-profile>'"
-            echo "Profile fields: target, focus, provenance, autonomy, publish, debate"
+            echo "Profile fields: target, focus, provenance, autonomy, publish, debate, contextFile, contextText, contextLabel"
             echo "Example: $(basename "$0") code-review '{\"target\":\"staged\",\"publish\":\"ask\"}'"
+            echo "Example with contract: $(basename "$0") code-review '{\"target\":\"working-tree\",\"contextFile\":\"./PLAN.md\",\"focus\":[\"correctness\",\"plan-conformance\"]}'"
             exit 0
         fi
         review_run "${1:-"{}"}"

--- a/tests/unit/test-review-context-profile.sh
+++ b/tests/unit/test-review-context-profile.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Tests for code-review JSON profile contract context support.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "code-review context profile"
+
+REVIEW_SH="$PROJECT_ROOT/scripts/lib/review.sh"
+ORCH="$PROJECT_ROOT/scripts/orchestrate.sh"
+
+assert_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    test_case "$label"
+    if grep -qF "$pattern" "$file"; then
+        test_pass
+    else
+        test_fail "missing pattern: $pattern"
+    fi
+}
+
+assert_contains "$REVIEW_SH" "contextFile" "review profile accepts contextFile"
+assert_contains "$REVIEW_SH" "contextText" "review profile accepts contextText"
+assert_contains "$REVIEW_SH" "contextLabel" "review profile accepts contextLabel"
+assert_contains "$REVIEW_SH" "OCTOPUS_REVIEW_CONTEXT_CHARS" "review context has bounded size"
+assert_contains "$REVIEW_SH" "fails the supplied task contract" "review prompt checks task contract conformance"
+assert_contains "$REVIEW_SH" "contextFile is not readable" "missing contextFile fails clearly"
+assert_contains "$REVIEW_SH" "contextFile escapes workspace root" "contextFile is restricted to workspace root"
+assert_contains "$REVIEW_SH" "context_file_resolved" "contextFile is resolved before reading"
+assert_contains "$REVIEW_SH" "octo_proof_finalize" "unreadable contextFile finalizes proof packet"
+assert_contains "$REVIEW_SH" "provider_status_file" "unreadable contextFile cleans up provider status"
+assert_contains "$REVIEW_SH" "...[truncated]" "truncated review context is marked"
+assert_contains "$ORCH" "contextFile, contextText, contextLabel" "code-review help documents context fields"
+assert_contains "$ORCH" "plan-conformance" "code-review help shows plan-conformance example"
+
+test_summary


### PR DESCRIPTION
## Summary

Adds optional task-contract context to the `code-review` JSON profile:

- `contextFile` / `context_file`
- `contextText` / `context_text`
- `contextLabel` / `context_label`

When context is supplied, `/octo:review` includes it in the reviewer and verifier prompts and asks reviewers to flag `severity=normal` when a diff is plausible code but fails the supplied task contract, misses acceptance criteria, violates constraints, changes unrelated areas, or omits required work.

## Why

Today code review primarily evaluates the diff itself. Autonomous or multi-agent development also needs conformance review: does this diff actually implement the requested plan/spec/prompt/decomposition?

This PR is intentionally small and does not change default review behavior when no context is supplied.

## Validation

- `bash -n scripts/lib/review.sh`
- `bash -n scripts/orchestrate.sh`
- `bash tests/unit/test-review-context-profile.sh`
- `./scripts/orchestrate.sh code-review --help | grep -E "contextFile|plan-conformance"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review runs can now include optional “review contract” context from the profile, using inline text or a file source (customizable label; accepts camelCase or snake_case fields).
  * Contract context is injected into both reviewer rounds for more consistent findings and verdicts.
  * The review command help now documents added profile fields and includes a context-aware example.
* **Bug Fixes**
  * If a configured context file can’t be read or is outside the workspace, the run emits a warning findings artifact and fails early.
  * Context size is validated and bounded; oversized content is truncated with an explicit `...[truncated]` marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->