### PR TITLE
fix(agy): seat agy as a first-class council provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **agy is now a first-class council provider.** `#524` seats agy only via the `backend-architect` persona; `council.sh`'s provider allow-list and org-diversity auto-expansion still omitted it, so `--providers=…agy…` was rejected and agy could never be explicitly selected or org-diversity-seated. Add agy to all 6 provider-list sites, the `cli_to_provider` mapping, and the usage docs. agy keeps its own `provider_org` (distinct from the sunset gemini/google seat), so `codex + agy` counts as two distinct providers for quorum.
+
 ## [9.47.1] - 2026-07-02
 
 ### Fixed

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -74,7 +74,7 @@ Options:
   --implement never|after-approval|plan-only
   --worktree auto|on|off
   --benchmark auto|on|off
-  --providers auto|claude,codex,gemini,qwen,opencode,openrouter
+  --providers auto|claude,codex,gemini,agy,qwen,opencode,openrouter
   --max-cost <usd>
   --simulate
   --single-model
@@ -175,7 +175,7 @@ council_validate_choice() {
 
 council_validate_provider_list() {
     local providers="$1"
-    local allowed="claude,codex,gemini,qwen,opencode,openrouter"
+    local allowed="claude,codex,gemini,agy,qwen,opencode,openrouter"
 
     if [[ "$providers" == "auto" ]]; then
         return 0
@@ -562,6 +562,7 @@ council_cli_to_provider() {
     case "$1" in
         claude*|opus*|sonnet*) echo "claude" ;;
         gemini*) echo "gemini" ;;
+        agy*) echo "agy" ;;
         opencode*) echo "opencode" ;;
         openrouter*) echo "openrouter" ;;
         codex*|gpt*) echo "codex" ;;
@@ -882,7 +883,7 @@ council_pick_provider() {
     fi
 
     local provider providers="$COUNCIL_PROVIDERS"
-    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,qwen,opencode,openrouter"
+    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,agy,qwen,opencode,openrouter"
     IFS=',' read -r -a provider_list <<< "$providers"
     for provider in "${provider_list[@]}"; do
         provider="${provider// /}"
@@ -982,7 +983,7 @@ council_candidate_personas() {
 
 council_available_provider_orgs_json() {
     local providers="$COUNCIL_PROVIDERS"
-    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,qwen,opencode,openrouter"
+    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,agy,qwen,opencode,openrouter"
 
     local json='[]' provider org
     IFS=',' read -r -a provider_list <<< "$providers"
@@ -998,7 +999,7 @@ council_available_provider_orgs_json() {
 council_provider_for_org() {
     local wanted_org="$1"
     local providers="$COUNCIL_PROVIDERS"
-    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,qwen,opencode,openrouter"
+    [[ "$providers" == "auto" ]] && providers="claude,codex,gemini,agy,qwen,opencode,openrouter"
 
     local provider
     IFS=',' read -r -a provider_list <<< "$providers"
@@ -1972,7 +1973,7 @@ council_start_implementation_handoff() {
 council_detect_providers() {
     local providers="$COUNCIL_PROVIDERS"
     if [[ "$providers" == "auto" ]]; then
-        providers="claude,codex,gemini,qwen,opencode,openrouter"
+        providers="claude,codex,gemini,agy,qwen,opencode,openrouter"
     fi
 
     local json='{}'

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -498,7 +498,7 @@ ${YELLOW}Options:${NC}
   --implement never|after-approval|plan-only
   --worktree auto|on|off
   --benchmark auto|on|off
-  --providers auto|claude,codex,gemini,qwen,opencode,openrouter
+  --providers auto|claude,codex,gemini,agy,qwen,opencode,openrouter
   --max-cost <usd>
   --dry-run
   --json

--- a/tests/unit/test-agy-council-provider.sh
+++ b/tests/unit/test-agy-council-provider.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# tests/unit/test-agy-council-provider.sh
+# Tests that agy is a seatable council provider org:
+#   - present in the council auto/allowed provider lists
+#   - cli_to_provider maps agy variants correctly
+#   - usage help documents it
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Agy council provider"
+
+COUNCIL="$PROJECT_ROOT/scripts/lib/council.sh"
+USAGE="$PROJECT_ROOT/scripts/lib/usage-help.sh"
+
+test_agy_in_auto_list() {
+    test_case "council auto provider list includes agy"
+
+    if grep -q 'gemini,agy,qwen,opencode' "$COUNCIL"; then
+        test_pass
+    else
+        test_fail "council.sh auto provider list should include agy"
+    fi
+}
+
+test_agy_no_stale_list() {
+    test_case "no stale agy-less provider list remains in council.sh"
+
+    if grep -q 'claude,codex,gemini,qwen,opencode,openrouter' "$COUNCIL"; then
+        test_fail "council.sh still contains a provider list without agy"
+    else
+        test_pass
+    fi
+}
+
+test_agy_validates() {
+    test_case "council_validate_provider_list accepts an explicit agy request"
+
+    if ( source "$COUNCIL" && council_validate_provider_list "claude,codex,agy" >/dev/null 2>&1 ); then
+        test_pass
+    else
+        test_fail "--providers claude,codex,agy should be accepted"
+    fi
+}
+
+test_agy_cli_to_provider() {
+    test_case "council_cli_to_provider maps agy variants to agy"
+
+    local result
+    result="$( source "$COUNCIL" && council_cli_to_provider "agy-turbo" )"
+    if [[ "$result" == "agy" ]]; then
+        test_pass
+    else
+        test_fail "council_cli_to_provider 'agy-turbo' returned '$result', expected 'agy'"
+    fi
+}
+
+test_agy_usage_doc() {
+    test_case "usage help lists agy as a --providers option"
+
+    if grep -q 'gemini,agy,qwen,opencode' "$USAGE"; then
+        test_pass
+    else
+        test_fail "usage-help.sh should document agy in the --providers list"
+    fi
+}
+
+test_agy_syntax() {
+    test_case "council.sh and usage-help.sh remain valid bash"
+
+    if bash -n "$COUNCIL" && bash -n "$USAGE"; then
+        test_pass
+    else
+        test_fail "edited scripts have syntax errors"
+    fi
+}
+
+test_agy_in_auto_list
+test_agy_no_stale_list
+test_agy_validates
+test_agy_cli_to_provider
+test_agy_usage_doc
+test_agy_syntax
+
+test_summary


### PR DESCRIPTION
## Summary

Follow-up to the council-wiring discussion on #501. When trimming #501, the `council.sh` agy changes were dropped as presumed-redundant with #513/#520. On closer inspection they are **not** redundant — agy is only half-wired on `main`, and this PR closes the gap in isolation (no adapter/session-dir changes; those stay in #501).

## The gap (reproducible on current `main`)

`#524` seats agy **only** via the `backend-architect` persona. But `council.sh`'s provider allow-list and org-diversity auto-expansion never learned about agy:

```bash
# on origin/main:
$ source scripts/lib/council.sh
$ council_validate_provider_list "codex,agy" && echo ok || echo REJECTED
REJECTED
```

Consequences on `main`:
- `--providers=…agy…` (explicit selection) is **rejected** by `council_validate_provider_list`.
- agy is **absent** from the `auto` org-diversity expansion (`claude,codex,gemini,qwen,opencode,openrouter`), so #513's "seat every available provider org" never considers it.
- Net: agy only ever appears as the one fixed `backend-architect` seat. With the gemini CLI sunset, a council that loses that seat (agy empty/unavailable) collapses to single-vendor.

## The fix

- Add agy to all 6 provider-list sites (allow-list, 4 `auto` expansions, implementation-handoff default) + usage docs.
- Map `agy*` → `agy` in `council_cli_to_provider`.
- agy keeps its **own** `provider_org` (distinct from the sunset gemini/google seat), so `codex + agy` = two distinct providers and the ≥2-distinct quorum guard passes.

After this PR, `council_validate_provider_list "codex,agy"` returns success and `--providers auto` includes agy as a seatable org.

## Test plan

- [x] `tests/unit/test-agy-council-provider.sh` — 6/6 pass
- [x] `bash -n scripts/lib/council.sh` / `scripts/lib/usage-help.sh` — clean
- [x] Verified `--providers=codex,agy` REJECTED on `origin/main`, ACCEPTED on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting `agy` as a first-class provider.
  * Updated provider selection so `agy` works with automatic provider choice and help text.

* **Bug Fixes**
  * Fixed provider validation and mapping so `agy` is accepted consistently.
  * Clarified quorum behavior: `codex` and `agy` are counted as separate providers.

* **Tests**
  * Added coverage for `agy` provider selection, mapping, and help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->