### PR TITLE
fix(council): distinct-approving-vendor quorum (substantive + verdict-gated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- **Council quorum now gates on distinct APPROVING vendors, not just distinct responders.** Each non-chair seat's response must end with `VERDICT: APPROVE|REVISE|BLOCK`; the runner reads the last such line (missing/ambiguous → REVISE, fail-safe). A vendor counts toward quorum only if it responded substantively **and** none of its seats dissented, so a split double-seated vendor (one seat APPROVE, one REVISE) can no longer cherry-pick its approving seat into a passing quorum. Standard/deep now require ≥2 distinct approving vendors; `summary.json` adds `distinct_approving_providers` + `approving_providers`. Fixes false `met:true` in the 2-vendor era (sail-cruisey #1992/#1994/#1983). Quick depth (required 1) is unchanged. Layers on the distinct-responder/substantive guard below.
+
 - **Council advice quorum now requires ≥2 DISTINCT providers with substantive responses.** Previously `quorum.met` for `standard`/`deep` depth was true as long as `received_non_chair >= required`, counting a seat on dispatch exit code alone — so a single-vendor result (e.g. 3× codex because agy/gemini returned empty) and even seats that exit 0 while reviewing nothing (the host self-dispatch stub, empty/~1B provider returns) all counted, producing false `met:true`. Now each responding seat's provider is recorded only when its response is non-empty **and** substantive (rejecting the host stub and short "cannot access the files" degenerate reviews, brevity-gated so long real reviews pass); gate-depth councils require ≥2 distinct providers, and `summary.json` reports `distinct_providers` + `responding_providers`. `quick` depth (required 1) is unchanged.
 
 ## [9.47.1] - 2026-07-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Council advice quorum now requires ≥2 DISTINCT providers with substantive responses.** Previously `quorum.met` for `standard`/`deep` depth was true as long as `received_non_chair >= required`, counting a seat on dispatch exit code alone — so a single-vendor result (e.g. 3× codex because agy/gemini returned empty) and even seats that exit 0 while reviewing nothing (the host self-dispatch stub, empty/~1B provider returns) all counted, producing false `met:true`. Now each responding seat's provider is recorded only when its response is non-empty **and** substantive (rejecting the host stub and short "cannot access the files" degenerate reviews, brevity-gated so long real reviews pass); gate-depth councils require ≥2 distinct providers, and `summary.json` reports `distinct_providers` + `responding_providers`. `quick` depth (required 1) is unchanged.
+
 ## [9.47.1] - 2026-07-02
 
 ### Fixed

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1594,8 +1594,9 @@ council_response_is_substantive() {
     local f="$1"
     [[ -f "$f" ]] || return 1
 
-    # 1) Host self-dispatch stub — runner-emitted, exact match.
-    if grep -qiE 'Subprocess dispatch is unavailable|active host runtime' "$f"; then
+    # 1) Host self-dispatch stub — runner-emitted, exact match. (grep -c … >/dev/null,
+    #    not -q: -q closes the pipe early and can SIGPIPE under set -eo pipefail.)
+    if grep -ciE 'Subprocess dispatch is unavailable|active host runtime' "$f" >/dev/null; then
         return 1
     fi
 
@@ -1603,7 +1604,7 @@ council_response_is_substantive() {
     #    gate (non-whitespace chars) keeps genuine, lengthy reviews safe.
     local nlen
     nlen="$(tr -d '[:space:]' < "$f" | wc -c | tr -d '[:space:]')"
-    if (( nlen < 1600 )) && grep -qiE "(cannot|could not|couldn'?t|unable to|can'?t)[[:space:]]+(access|read|open|locate|find|view|retrieve)[^.]{0,60}(file|plan|prd|diff|patch|artifact|document|spec)" "$f"; then
+    if (( nlen < 1600 )) && grep -ciE "(cannot|could not|couldn'?t|unable to|can'?t)[[:space:]]+(access|read|open|locate|find|view|retrieve)[^.]{0,60}(file|plan|prd|diff|patch|artifact|document|spec)" "$f" >/dev/null; then
         return 1
     fi
 
@@ -2268,7 +2269,7 @@ council_write_summary_json() {
         --arg responses_received "$COUNCIL_RESPONSES_RECEIVED" \
         --arg quorum_met "$COUNCIL_QUORUM_MET" \
         --arg distinct_providers "${COUNCIL_DISTINCT_PROVIDERS:-0}" \
-        --arg responding_providers "${COUNCIL_RESPONDING_PROVIDERS# }" \
+        --arg responding_providers "${COUNCIL_RESPONDING_PROVIDERS:+${COUNCIL_RESPONDING_PROVIDERS# }}" \
         --arg chair_received "$COUNCIL_CHAIR_RESPONSE_RECEIVED" \
         --arg chair_fallback_used "$COUNCIL_CHAIR_FALLBACK_USED" \
         --arg chair_fallback_persona "$COUNCIL_CHAIR_FALLBACK_PERSONA" \

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1351,6 +1351,12 @@ EOF
     cat << EOF
 
 Return concise Markdown with recommendation, assumptions, risks, implementation notes, and confidence.
+
+End your response with a single line, exactly one of:
+VERDICT: APPROVE
+VERDICT: REVISE
+VERDICT: BLOCK
+Use APPROVE only if you would ship the proposal as-is. Use REVISE if anything must change first, and BLOCK for a hard stop. This line is parsed mechanically — a missing or unclear verdict is treated as REVISE.
 EOF
 }
 
@@ -1405,6 +1411,15 @@ EOF
         return 0
     fi
 
+    # Fixture verdict: APPROVE by default; OCTOPUS_COUNCIL_FIXTURE_VERDICT overrides
+    # globally, and OCTOPUS_COUNCIL_FIXTURE_REVISE_PERSONAS (comma-separated) forces
+    # specific personas to REVISE — enough to simulate an all-approve pass, an
+    # all-revise fail, or a single-seat/split dissent in tests.
+    local fixture_verdict="${OCTOPUS_COUNCIL_FIXTURE_VERDICT:-APPROVE}"
+    if council_list_contains "${OCTOPUS_COUNCIL_FIXTURE_REVISE_PERSONAS:-}" "$persona"; then
+        fixture_verdict="REVISE"
+    fi
+
     cat << EOF
 ## Recommendation
 
@@ -1427,6 +1442,8 @@ $persona recommends a cautious, testable path for: $COUNCIL_TASK
 ## Confidence
 
 Medium
+
+VERDICT: ${fixture_verdict}
 EOF
 }
 
@@ -1611,12 +1628,52 @@ council_response_is_substantive() {
     return 0
 }
 
+council_response_verdict() {
+    # The seat's self-declared verdict, read from the LAST "VERDICT:" line. Fail
+    # safe: anything that is not a clean APPROVE (REVISE / BLOCK / missing /
+    # ambiguous) is reported as REVISE, so a seat that omits or hedges the line
+    # never counts as an approval toward quorum. Echoes APPROVE, REVISE, or BLOCK.
+    local f="$1" verdict
+    [[ -f "$f" ]] || { printf 'REVISE'; return 0; }
+    verdict="$(awk '
+        toupper($0) ~ /^[[:space:]]*VERDICT:/ { last = $0 }
+        END {
+            last = toupper(last)
+            sub(/^[[:space:]]*VERDICT:[[:space:]]*/, "", last)
+            sub(/[^A-Z].*$/, "", last)
+            print last
+        }' "$f")"
+    case "$verdict" in
+        APPROVE) printf 'APPROVE' ;;
+        BLOCK)   printf 'BLOCK' ;;
+        *)       printf 'REVISE' ;;
+    esac
+}
+
+council_compute_approving_providers() {
+    # Derive the APPROVING vendor set from the space-separated RESPONDING
+    # (substantive responders) and DISSENTING (any seat whose verdict != APPROVE)
+    # lists. A vendor is an approver only if it responded substantively AND none
+    # of its seats dissented — so a split double-seated vendor (one APPROVE, one
+    # REVISE) lands in DISSENTING and is NOT an approver. This is the fail-safe
+    # that stops a split vendor's yes-seat from being cherry-picked into a false
+    # quorum (sail-cruisey #1992/#1994/#1983). Echoes the deduped approver list.
+    local responding="$1" dissenting="$2"
+    local p approving=""
+    for p in $responding; do
+        case " $dissenting " in *" $p "*) continue ;; esac
+        case " $approving " in *" $p "*) ;; *) approving="${approving:+$approving }$p" ;; esac
+    done
+    printf '%s' "$approving"
+}
+
 council_run_advice_phase() {
     COUNCIL_RESPONSES_RECEIVED="0"
     COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
     COUNCIL_RESPONDING_PROVIDERS=""
+    local dissenting_providers=""
 
-    local index=0 member persona slug output_path seat mprovider
+    local index=0 member persona slug output_path seat mprovider verdict
     while IFS= read -r member; do
         persona="$(jq -r '.persona' <<< "$member")"
         seat="$(jq -r '.seat' <<< "$member")"
@@ -1628,15 +1685,19 @@ council_run_advice_phase() {
             if [[ "$seat" == "chair" ]]; then
                 COUNCIL_CHAIR_RESPONSE_RECEIVED="true"
             fi
-            # Count a provider toward the distinct-vendor quorum ONLY if the seat
-            # returned a non-empty, SUBSTANTIVE response. Exit code alone is not
-            # enough: the host self-dispatch stub and empty/degenerate returns exit
-            # 0 but review nothing, and previously inflated distinct_providers ->
-            # false met:true (sail-cruisey #2002/#2007/#2003). A single-vendor
-            # result (e.g. 3x codex, #1993) is still caught by the distinct guard
-            # below. Dedup happens downstream via sort -u.
+            # A provider counts toward quorum ONLY via a non-empty, SUBSTANTIVE
+            # response (exit 0 alone is not enough — the host self-dispatch stub and
+            # empty/degenerate returns review nothing; #2002/#2007/#2003). Record
+            # the vendor as a responder, then read its APPROVE/REVISE/BLOCK verdict:
+            # a non-APPROVE marks the vendor dissenting so its seat can't count as an
+            # approval, and a split double-seated vendor (one APPROVE, one REVISE)
+            # can't cherry-pick its yes-seat into the quorum (#1992/#1994/#1983).
             if council_response_nonempty "$output_path" && council_response_is_substantive "$output_path"; then
                 COUNCIL_RESPONDING_PROVIDERS="${COUNCIL_RESPONDING_PROVIDERS} ${mprovider}"
+                verdict="$(council_response_verdict "$output_path")"
+                if [[ "$verdict" != "APPROVE" ]]; then
+                    dissenting_providers="${dissenting_providers} ${mprovider}"
+                fi
             fi
         else
             rm -f "$output_path"
@@ -1652,24 +1713,30 @@ council_run_advice_phase() {
     required="$(council_required_non_chair)"
     received_non_chair="$(( COUNCIL_RESPONSES_RECEIVED > 0 ? COUNCIL_RESPONSES_RECEIVED - 1 : 0 ))"
 
-    # Distinct-vendor guard: a council where every responding seat is the SAME
-    # provider (e.g. 3 codex because agy/gemini returned empty) is NOT a valid
-    # consensus — one vendor can't catch its own blind spot. Count DISTINCT
-    # providers among seats that actually responded; gate-depth councils
-    # (required >= 2, i.e. standard/deep — the CP1/CP2 votes) need >= 2 distinct.
+    # Distinct-vendor quorum, in two layers:
+    #   distinct_providers  — vendors that returned a SUBSTANTIVE response.
+    #   approving_providers — vendors ALL of whose substantive seats cleanly
+    #                         APPROVED (any dissent drops the whole vendor).
+    # A cross-lab consensus requires >= `required` DISTINCT APPROVING vendors
+    # (2 for standard/deep, 1 for quick). Counting responders alone let a split
+    # double-seated vendor pass on its approving seat (#1992/#1994/#1983) and a
+    # single vendor stand in for consensus (#1993); gating on approvers closes both.
     COUNCIL_DISTINCT_PROVIDERS="$(printf '%s' "$COUNCIL_RESPONDING_PROVIDERS" | tr ' ' '\n' | sed '/^$/d' | sort -u | wc -l | tr -d '[:space:]')"
     [[ -z "$COUNCIL_DISTINCT_PROVIDERS" ]] && COUNCIL_DISTINCT_PROVIDERS=0
+    COUNCIL_APPROVING_PROVIDERS="$(council_compute_approving_providers "$COUNCIL_RESPONDING_PROVIDERS" "$dissenting_providers")"
+    COUNCIL_DISTINCT_APPROVING_PROVIDERS="$(printf '%s' "$COUNCIL_APPROVING_PROVIDERS" | tr ' ' '\n' | sed '/^$/d' | sort -u | wc -l | tr -d '[:space:]')"
+    [[ -z "$COUNCIL_DISTINCT_APPROVING_PROVIDERS" ]] && COUNCIL_DISTINCT_APPROVING_PROVIDERS=0
 
     if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" == "true" ]] && (( received_non_chair >= required )) \
-        && { (( required < 2 )) || (( COUNCIL_DISTINCT_PROVIDERS >= 2 )); }; then
+        && { (( required < 2 )) || (( COUNCIL_DISTINCT_APPROVING_PROVIDERS >= required )); }; then
         COUNCIL_QUORUM_MET="true"
     else
         COUNCIL_QUORUM_MET="false"
-        if (( required >= 2 )) && (( COUNCIL_DISTINCT_PROVIDERS < 2 )) && (( received_non_chair >= required )); then
+        if (( required >= 2 )) && (( COUNCIL_DISTINCT_APPROVING_PROVIDERS < required )) && (( received_non_chair >= required )); then
             # council.sh has no log() of its own (it lives in orchestrate.sh); emit
             # via the same stderr convention the rest of this file uses so the guard
             # never crashes when council is sourced standalone.
-            echo "Council warning: Quorum FAILED the distinct-vendor guard: ${received_non_chair} responses but only ${COUNCIL_DISTINCT_PROVIDERS} distinct provider(s) (${COUNCIL_RESPONDING_PROVIDERS# }). Single-vendor is not a valid consensus — restore a 2nd provider (§4) or surface the provider-shortage gate to the human." >&2
+            echo "Council warning: Quorum FAILED the distinct-approving-vendor guard: ${received_non_chair} responses, ${COUNCIL_DISTINCT_PROVIDERS} distinct provider(s) (${COUNCIL_RESPONDING_PROVIDERS# }), but only ${COUNCIL_DISTINCT_APPROVING_PROVIDERS} cleanly APPROVED (${COUNCIL_APPROVING_PROVIDERS:-none}). A single approving vendor — or a split double-seated vendor — is not a valid cross-lab consensus. Restore/await a 2nd approving provider (§4) or surface the provider-shortage gate to the human." >&2
         fi
     fi
 }
@@ -2270,6 +2337,8 @@ council_write_summary_json() {
         --arg quorum_met "$COUNCIL_QUORUM_MET" \
         --arg distinct_providers "${COUNCIL_DISTINCT_PROVIDERS:-0}" \
         --arg responding_providers "${COUNCIL_RESPONDING_PROVIDERS:+${COUNCIL_RESPONDING_PROVIDERS# }}" \
+        --arg distinct_approving_providers "${COUNCIL_DISTINCT_APPROVING_PROVIDERS:-0}" \
+        --arg approving_providers "${COUNCIL_APPROVING_PROVIDERS:-}" \
         --arg chair_received "$COUNCIL_CHAIR_RESPONSE_RECEIVED" \
         --arg chair_fallback_used "$COUNCIL_CHAIR_FALLBACK_USED" \
         --arg chair_fallback_persona "$COUNCIL_CHAIR_FALLBACK_PERSONA" \
@@ -2311,6 +2380,8 @@ council_write_summary_json() {
             chair_received: ($chair_received == "true"),
             distinct_providers: ($distinct_providers | tonumber),
             responding_providers: $responding_providers,
+            distinct_approving_providers: ($distinct_approving_providers | tonumber),
+            approving_providers: $approving_providers,
             met: ($quorum_met == "true")
           },
           providers: $providers,

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1571,20 +1571,71 @@ council_write_config_json() {
         }' > "$config_path"
 }
 
+council_response_nonempty() {
+    # True only if the file has at least one non-whitespace character. An empty
+    # or whitespace-only response (e.g. an agy seat that hit an exhausted quota
+    # group) is NOT a real response and must not count toward the quorum.
+    local f="$1"
+    [[ -s "$f" ]] || return 1
+    [[ -n "$(tr -d '[:space:]' < "$f")" ]]
+}
+
+council_response_is_substantive() {
+    # A non-empty response can still be DEGENERATE — it produced bytes but reviewed
+    # nothing — and such a seat must not count toward the distinct-provider quorum.
+    # Two known degenerate shapes:
+    #   1. The host self-dispatch stub (a fixed string the runner itself emits when
+    #      a seat's provider == the host CLI) — matched exactly, zero false positives.
+    #   2. An external seat that signalled it could not READ the artifact ("I cannot
+    #      access the plan/files…") — gated on brevity so a LONG real review that
+    #      merely quotes such a phrase is never rejected.
+    # (RATIONALE: sail-cruisey #1839 — agy's "I cannot access the implementation
+    # plan, PRD, or security audit files" REVISE was counted as the 2nd provider.)
+    local f="$1"
+    [[ -f "$f" ]] || return 1
+
+    # 1) Host self-dispatch stub — runner-emitted, exact match.
+    if grep -qiE 'Subprocess dispatch is unavailable|active host runtime' "$f"; then
+        return 1
+    fi
+
+    # 2) Short response that reports it could not reach the artifact. The brevity
+    #    gate (non-whitespace chars) keeps genuine, lengthy reviews safe.
+    local nlen
+    nlen="$(tr -d '[:space:]' < "$f" | wc -c | tr -d '[:space:]')"
+    if (( nlen < 1600 )) && grep -qiE "(cannot|could not|couldn'?t|unable to|can'?t)[[:space:]]+(access|read|open|locate|find|view|retrieve)[^.]{0,60}(file|plan|prd|diff|patch|artifact|document|spec)" "$f"; then
+        return 1
+    fi
+
+    return 0
+}
+
 council_run_advice_phase() {
     COUNCIL_RESPONSES_RECEIVED="0"
     COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
+    COUNCIL_RESPONDING_PROVIDERS=""
 
-    local index=0 member persona slug output_path seat
+    local index=0 member persona slug output_path seat mprovider
     while IFS= read -r member; do
         persona="$(jq -r '.persona' <<< "$member")"
         seat="$(jq -r '.seat' <<< "$member")"
+        mprovider="$(jq -r '.provider' <<< "$member")"
         slug="$(council_slug "$persona")"
         output_path="${COUNCIL_RUN_DIR}/responses/$(printf '%02d' "$index")-${slug}.md"
         if council_dispatch_member "$member" "independent-advice" > "$output_path"; then
             COUNCIL_RESPONSES_RECEIVED=$((COUNCIL_RESPONSES_RECEIVED + 1))
             if [[ "$seat" == "chair" ]]; then
                 COUNCIL_CHAIR_RESPONSE_RECEIVED="true"
+            fi
+            # Count a provider toward the distinct-vendor quorum ONLY if the seat
+            # returned a non-empty, SUBSTANTIVE response. Exit code alone is not
+            # enough: the host self-dispatch stub and empty/degenerate returns exit
+            # 0 but review nothing, and previously inflated distinct_providers ->
+            # false met:true (sail-cruisey #2002/#2007/#2003). A single-vendor
+            # result (e.g. 3x codex, #1993) is still caught by the distinct guard
+            # below. Dedup happens downstream via sort -u.
+            if council_response_nonempty "$output_path" && council_response_is_substantive "$output_path"; then
+                COUNCIL_RESPONDING_PROVIDERS="${COUNCIL_RESPONDING_PROVIDERS} ${mprovider}"
             fi
         else
             rm -f "$output_path"
@@ -1599,10 +1650,26 @@ council_run_advice_phase() {
     local required received_non_chair
     required="$(council_required_non_chair)"
     received_non_chair="$(( COUNCIL_RESPONSES_RECEIVED > 0 ? COUNCIL_RESPONSES_RECEIVED - 1 : 0 ))"
-    if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" == "true" ]] && (( received_non_chair >= required )); then
+
+    # Distinct-vendor guard: a council where every responding seat is the SAME
+    # provider (e.g. 3 codex because agy/gemini returned empty) is NOT a valid
+    # consensus — one vendor can't catch its own blind spot. Count DISTINCT
+    # providers among seats that actually responded; gate-depth councils
+    # (required >= 2, i.e. standard/deep — the CP1/CP2 votes) need >= 2 distinct.
+    COUNCIL_DISTINCT_PROVIDERS="$(printf '%s' "$COUNCIL_RESPONDING_PROVIDERS" | tr ' ' '\n' | sed '/^$/d' | sort -u | wc -l | tr -d '[:space:]')"
+    [[ -z "$COUNCIL_DISTINCT_PROVIDERS" ]] && COUNCIL_DISTINCT_PROVIDERS=0
+
+    if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" == "true" ]] && (( received_non_chair >= required )) \
+        && { (( required < 2 )) || (( COUNCIL_DISTINCT_PROVIDERS >= 2 )); }; then
         COUNCIL_QUORUM_MET="true"
     else
         COUNCIL_QUORUM_MET="false"
+        if (( required >= 2 )) && (( COUNCIL_DISTINCT_PROVIDERS < 2 )) && (( received_non_chair >= required )); then
+            # council.sh has no log() of its own (it lives in orchestrate.sh); emit
+            # via the same stderr convention the rest of this file uses so the guard
+            # never crashes when council is sourced standalone.
+            echo "Council warning: Quorum FAILED the distinct-vendor guard: ${received_non_chair} responses but only ${COUNCIL_DISTINCT_PROVIDERS} distinct provider(s) (${COUNCIL_RESPONDING_PROVIDERS# }). Single-vendor is not a valid consensus — restore a 2nd provider (§4) or surface the provider-shortage gate to the human." >&2
+        fi
     fi
 }
 
@@ -2200,6 +2267,8 @@ council_write_summary_json() {
         --argjson council_roster "$COUNCIL_ROSTER_JSON" \
         --arg responses_received "$COUNCIL_RESPONSES_RECEIVED" \
         --arg quorum_met "$COUNCIL_QUORUM_MET" \
+        --arg distinct_providers "${COUNCIL_DISTINCT_PROVIDERS:-0}" \
+        --arg responding_providers "${COUNCIL_RESPONDING_PROVIDERS# }" \
         --arg chair_received "$COUNCIL_CHAIR_RESPONSE_RECEIVED" \
         --arg chair_fallback_used "$COUNCIL_CHAIR_FALLBACK_USED" \
         --arg chair_fallback_persona "$COUNCIL_CHAIR_FALLBACK_PERSONA" \
@@ -2239,6 +2308,8 @@ council_write_summary_json() {
             required_non_chair: (if $depth == "quick" then 1 else 2 end),
             received_non_chair: (if ($responses_received | tonumber) > 0 then (($responses_received | tonumber) - 1) else 0 end),
             chair_received: ($chair_received == "true"),
+            distinct_providers: ($distinct_providers | tonumber),
+            responding_providers: $responding_providers,
             met: ($quorum_met == "true")
           },
           providers: $providers,

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1225,7 +1225,81 @@ test_council_live_response_host_native_fails_for_synthesis() {
     fi
 }
 
+test_council_verdict_parsing() {
+    test_case "council_response_verdict reads the last VERDICT line, fail-safe REVISE"
+    load_council_lib || return 1
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/verdict.XXXXXX")"
+    printf 'review\nVERDICT: APPROVE\n'                 > "$d/a.md"
+    printf 'review\nVERDICT: REVISE\n'                  > "$d/r.md"
+    printf 'review\nverdict: block now\n'               > "$d/b.md"
+    printf 'no verdict line at all here\n'              > "$d/none.md"
+    printf 'VERDICT: APPROVE\nmore\nVERDICT: REVISE\n'  > "$d/last.md"
+    if [[ "$(council_response_verdict "$d/a.md")"    == "APPROVE" ]] &&
+       [[ "$(council_response_verdict "$d/r.md")"    == "REVISE"  ]] &&
+       [[ "$(council_response_verdict "$d/b.md")"    == "BLOCK"   ]] &&
+       [[ "$(council_response_verdict "$d/none.md")" == "REVISE"  ]] &&
+       [[ "$(council_response_verdict "$d/last.md")" == "REVISE"  ]]; then
+        test_pass
+    else
+        test_fail "verdict parsing mismatch"
+        return 1
+    fi
+}
+
+test_council_approving_providers_failsafe() {
+    test_case "council_compute_approving_providers drops a split double-seated vendor"
+    load_council_lib || return 1
+    local split clean
+    split="$(council_compute_approving_providers "agy codex codex" "codex")"
+    clean="$(council_compute_approving_providers "agy codex codex" "")"
+    if [[ "$split" == "agy" ]] && [[ "$clean" == "agy codex" ]]; then
+        test_pass
+    else
+        test_fail "approver set wrong: split=[$split] clean=[$clean]"
+        return 1
+    fi
+}
+
+test_council_split_double_seat_fails_quorum() {
+    test_case "Council quorum fails when a double-seated vendor splits (sail-cruisey #1992)"
+    load_council_lib || return 1
+    local tmp_dir rd
+    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-split.XXXXXX")"
+    OCTOPUS_COUNCIL_FIXTURE=full-success \
+    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='codex:available,agy:available' \
+    OCTOPUS_COUNCIL_FIXTURE_REVISE_PERSONAS='code-reviewer' \
+        council_run --depth standard --output-dir "$tmp_dir" "Review X" >/dev/null 2>&1 || true
+    rd="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    if jq -e '.quorum.met == false and .quorum.distinct_approving_providers == 1 and .quorum.approving_providers == "agy"' "$rd/summary.json" >/dev/null; then
+        test_pass
+    else
+        test_fail "split double-seat did not fail quorum: $(jq -c .quorum "$rd/summary.json" 2>/dev/null)"
+        return 1
+    fi
+}
+
+test_council_all_approve_meets_quorum() {
+    test_case "Council quorum meets when >=2 distinct vendors cleanly APPROVE"
+    load_council_lib || return 1
+    local tmp_dir rd
+    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-approve.XXXXXX")"
+    OCTOPUS_COUNCIL_FIXTURE=full-success \
+    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='codex:available,agy:available' \
+        council_run --depth standard --output-dir "$tmp_dir" "Review X" >/dev/null 2>&1 || true
+    rd="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    if jq -e '.quorum.met == true and .quorum.distinct_approving_providers >= 2' "$rd/summary.json" >/dev/null; then
+        test_pass
+    else
+        test_fail "clean all-approve did not meet quorum: $(jq -c .quorum "$rd/summary.json" 2>/dev/null)"
+        return 1
+    fi
+}
+
 test_council_host_native_detection
 test_council_live_response_host_native_skips_subprocess
 test_council_live_response_host_native_fails_for_synthesis
+test_council_verdict_parsing
+test_council_approving_providers_failsafe
+test_council_split_double_seat_fails_quorum
+test_council_all_approve_meets_quorum
 test_summary


### PR DESCRIPTION
## Summary

The council advice-phase quorum has no distinct-vendor guard on `main` — `quorum.met` for `standard`/`deep` is true whenever `received_non_chair >= required`, and a seat is counted on **dispatch exit code alone**. Two failure modes slip through and were observed in production (sail-cruisey #2002/#2007/#2003, and the 3×-codex case #1993):

1. **Single-vendor "consensus."** Three codex seats (agy/gemini returned empty) all count → `met:true`, even though one vendor can't catch its own blind spot.
2. **Degenerate seats that exit 0 while reviewing nothing.** The host self-dispatch stub (`"active host runtime … subprocess dispatch is unavailable"`, ~604B) and empty/~1B provider returns are counted, producing false `met:true` with zero real reviews.

## Change

- Record a responding seat's provider only when its response is **non-empty** (`council_response_nonempty`) **and substantive** (`council_response_is_substantive` — rejects the host stub and short "cannot access the plan/files" degenerate reviews; brevity-gated at 1600 non-whitespace chars so a long, genuine review that merely quotes such a phrase still counts).
- Gate-depth councils (`required >= 2`, i.e. `standard`/`deep`) now require **≥2 distinct providers**; a single-vendor pass fails with a stderr warning to restore a 2nd provider or surface the provider-shortage gate.
- `summary.json` gains `distinct_providers` + `responding_providers` for transparency.
- `quick` depth (required 1) is unchanged.

The warning uses council.sh's own `>&2` convention (council.sh defines no `log()` of its own — that lives in `orchestrate.sh`), so the guard never crashes when the library is sourced standalone (e.g. under the unit tests).

## Reproduction (before this PR)

A `deep` run whose non-chair voting seats all return empty/stub content reports `quorum.met: true` with `distinct_providers` counting the degenerate seats. After this PR the same run reports `met: false` and names the shortage.

## Test plan

- [x] `tests/unit/test-council-command.sh` — **51/51 pass**
- [x] `bash -n scripts/lib/council.sh` — clean
- [x] Verified the content check excludes: empty, whitespace-only, the host self-dispatch stub, and short "cannot access the files" responses; and includes genuine long reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected council quorum “met” logic to count only **distinct approving vendors** using **substantive** seat verdicts with no dissent, with mixed/degenerate outputs handled more strictly.
  * Updated council advice quorum (standard/deep) to require **at least two distinct substantive providers** with non-empty responses; quick depth unchanged.
  * Expanded quorum reporting in `summary.json` with distinct **responding** and **approving** provider counts.
* **Tests**
  * Added unit tests covering verdict parsing, approving-provider failsafes, split double-seat quorum behavior, and the all-approve quorum case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->