### PR TITLE
fix: let role model routes override phase routes

### DIFF
--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -102,6 +102,15 @@ validate_model_name_for_provider() {
             ;;
     esac
 }
+
+_octo_is_known_provider_name() {
+    case "$1" in
+        codex|gemini|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|cursor-agent|vibe|agy|agy-research|antigravity)
+            return 0 ;;
+        *)
+            return 1 ;;
+    esac
+}
 # resolve_octopus_model <provider> <agent_type> <phase> <role>
 resolve_octopus_model() {
     local provider="$1"
@@ -220,11 +229,28 @@ resolve_octopus_model() {
         # `review` phase route points at the default coding provider/model.
         if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
             local routed=""
+            local phase_routed=""
+            [[ -n "$phase" ]] && phase_routed=$(echo "$config_data" | jq -r --arg phase "$phase" '.routing.phases[$phase] // empty' 2>/dev/null)
             if [[ -n "$role" ]]; then
                 routed=$(echo "$config_data" | jq -r --arg role "$role" '.routing.roles[$role] // empty' 2>/dev/null)
+                if [[ -n "$routed" && "$routed" != "null" ]]; then
+                    local role_route_provider=""
+                    if [[ "$routed" == *:* ]]; then
+                        role_route_provider="${routed%%:*}"
+                    elif _octo_is_known_provider_name "$routed"; then
+                        role_route_provider="$routed"
+                    fi
+                    if [[ -n "$role_route_provider" && "$role_route_provider" != "$provider" ]]; then
+                        [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (role routing): SKIP (role route $routed targets $role_route_provider, resolving for $provider); checking phase route" >&2
+                        routed=""
+                    elif [[ -z "$role_route_provider" && -n "$phase_routed" && "$phase_routed" != "null" ]]; then
+                        [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (role routing): SKIP (bare role route $routed is unscoped and phase route exists); checking phase route" >&2
+                        routed=""
+                    fi
+                fi
             fi
-            if [[ -z "$routed" || "$routed" == "null" ]] && [[ -n "$phase" ]]; then
-                routed=$(echo "$config_data" | jq -r --arg phase "$phase" '.routing.phases[$phase] // empty' 2>/dev/null)
+            if [[ -z "$routed" || "$routed" == "null" ]] && [[ -n "$phase_routed" && "$phase_routed" != "null" ]]; then
+                routed="$phase_routed"
             fi
 
             # Handle recursive reference (e.g. "codex:spark")
@@ -250,15 +276,12 @@ resolve_octopus_model() {
                     # `codex exec --model perplexity` (bug 260609). Treat a bare
                     # provider name like "provider:" with no model: skip for other
                     # providers, fall through to lower tiers for the provider itself.
-                    case "$routed" in
-                        codex|gemini|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|cursor-agent|vibe|agy|agy-research|antigravity)
-                            [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): SKIP (route '$routed' is a provider name, not a model — resolving for $provider)" >&2
-                            routed=""
-                            ;;
-                        *)
-                            resolved_model="$routed"
-                            ;;
-                    esac
+                    if _octo_is_known_provider_name "$routed"; then
+                        [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): SKIP (route '$routed' is a provider name, not a model — resolving for $provider)" >&2
+                        routed=""
+                    else
+                        resolved_model="$routed"
+                    fi
                 fi
                 if [[ -n "$routed" ]]; then
                     [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): $resolved_model ← SELECTED (route: $routed)" >&2

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -214,14 +214,17 @@ resolve_octopus_model() {
             [[ -n "$_trace" ]] && echo "[model-trace] Tier 2 (session override): —" >&2
         fi
 
-        # 2. Phase/Role Routing
+        # 2. Role/Phase Routing
+        # Role routes are more specific than phase routes. In review fleets this
+        # lets `logic-reviewer` use an independent model even when the broad
+        # `review` phase route points at the default coding provider/model.
         if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
             local routed=""
-            if [[ -n "$phase" ]]; then
-                routed=$(echo "$config_data" | jq -r --arg phase "$phase" '.routing.phases[$phase] // empty' 2>/dev/null)
-            fi
-            if [[ -z "$routed" || "$routed" == "null" ]] && [[ -n "$role" ]]; then
+            if [[ -n "$role" ]]; then
                 routed=$(echo "$config_data" | jq -r --arg role "$role" '.routing.roles[$role] // empty' 2>/dev/null)
+            fi
+            if [[ -z "$routed" || "$routed" == "null" ]] && [[ -n "$phase" ]]; then
+                routed=$(echo "$config_data" | jq -r --arg phase "$phase" '.routing.phases[$phase] // empty' 2>/dev/null)
             fi
 
             # Handle recursive reference (e.g. "codex:spark")

--- a/tests/test-resolve-model.sh
+++ b/tests/test-resolve-model.sh
@@ -148,7 +148,25 @@ export OCTOPUS_COST_MODE="budget"
 assert_eq "$(resolve_octopus_model "codex" "codex")" "config-mini" "Tier mapping (budget)"
 unset OCTOPUS_COST_MODE
 
-# Test 8: Session override
+# Test 8: Role routing wins over phase routing
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": {
+    "codex": { "default": "deepseek-ai/DeepSeek-V4-Pro" }
+  },
+  "routing": {
+    "phases": { "review": "codex:default" },
+    "roles": { "logic-reviewer": "gpt-5.5" }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "codex" "codex" "review" "logic-reviewer")" "gpt-5.5" "Role routing overrides review phase routing"
+clear_model_cache
+assert_eq "$(resolve_octopus_model "codex" "codex" "review" "arch-reviewer")" "deepseek-ai/DeepSeek-V4-Pro" "Review phase routing still applies without role override"
+
+# Test 9: Session override
 clear_model_cache
 cat > "$CONFIG_FILE" << EOF
 {

--- a/tests/test-resolve-model.sh
+++ b/tests/test-resolve-model.sh
@@ -148,23 +148,45 @@ export OCTOPUS_COST_MODE="budget"
 assert_eq "$(resolve_octopus_model "codex" "codex")" "config-mini" "Tier mapping (budget)"
 unset OCTOPUS_COST_MODE
 
-# Test 8: Role routing wins over phase routing
+# Test 8: Provider-scoped role routing wins over phase routing
 clear_model_cache
 cat > "$CONFIG_FILE" << EOF
 {
   "version": "3.0",
   "providers": {
-    "codex": { "default": "deepseek-ai/DeepSeek-V4-Pro" }
+    "codex": { "default": "deepseek-ai/DeepSeek-V4-Pro", "logic_review": "gpt-5.5" },
+    "claude": { "default": "claude-sonnet-4.6", "review": "claude-review-phase" },
+    "gemini": { "default": "gemini-3.1-pro-preview" }
   },
   "routing": {
-    "phases": { "review": "codex:default" },
+    "phases": { "review": "claude:review" },
+    "roles": { "logic-reviewer": "codex:logic_review" }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "codex" "codex" "review" "logic-reviewer")" "gpt-5.5" "Provider-scoped role routing overrides review phase routing for matching provider"
+clear_model_cache
+assert_eq "$(resolve_octopus_model "claude" "claude-sonnet" "review" "logic-reviewer")" "claude-review-phase" "Cross-provider role routing falls back to matching phase routing for claude"
+clear_model_cache
+assert_eq "$(resolve_octopus_model "gemini" "gemini" "review" "logic-reviewer")" "gemini-3.1-pro-preview" "Provider-scoped role routing does not leak codex or claude models to gemini"
+clear_model_cache
+assert_eq "$(resolve_octopus_model "codex" "codex" "review" "arch-reviewer")" "deepseek-ai/DeepSeek-V4-Pro" "Cross-provider phase routing does not leak claude model to codex"
+
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": {
+    "codex": { "default": "deepseek-ai/DeepSeek-V4-Pro" },
+    "claude": { "default": "claude-sonnet-4.6", "review": "claude-review-phase" }
+  },
+  "routing": {
+    "phases": { "review": "claude:review" },
     "roles": { "logic-reviewer": "gpt-5.5" }
   }
 }
 EOF
-assert_eq "$(resolve_octopus_model "codex" "codex" "review" "logic-reviewer")" "gpt-5.5" "Role routing overrides review phase routing"
-clear_model_cache
-assert_eq "$(resolve_octopus_model "codex" "codex" "review" "arch-reviewer")" "deepseek-ai/DeepSeek-V4-Pro" "Review phase routing still applies without role override"
+assert_eq "$(resolve_octopus_model "claude" "claude-sonnet" "review" "logic-reviewer")" "claude-review-phase" "Bare role model invalid for provider falls back to matching phase routing"
 
 # Test 9: Session override
 clear_model_cache


### PR DESCRIPTION
## Summary

Fix model routing precedence so role-specific routes are applied before broad phase routes.

This matters for review fleets: a broad `review -> codex:default` phase route currently prevents a more specific role route such as `logic-reviewer -> codex:logic_review` from taking effect. The result is that specialist reviewer roles silently inherit the phase default model.

## Changes

- Prefer `routing.roles[$role]` before `routing.phases[$phase]` in `resolve_octopus_model`.
- Keep the existing fallback behavior: if no role route exists, phase routing still applies.
- Add regression tests showing:
  - role routing overrides review phase routing for the matching provider;
  - provider-scoped role routes do not leak Codex models into Claude/Gemini fallback reviewers;
  - review phase routing continues to apply when no role override exists.

## Tests

```bash
bash -n scripts/lib/model-resolver.sh
bash tests/test-resolve-model.sh
bash tests/unit/test-orchestrate-cwd-routing.sh
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model routing so provider-scoped role overrides take priority over phase-based routing when resolving an unset model.
  * Added safer fallback behavior when a role override targets a different provider, preventing cross-provider routing leakage.
* **Tests**
  * Added new assertions covering role-vs-phase routing priority and provider isolation, including cases where role overrides aren’t valid for the current provider.
  * Renumbered the existing session override test header for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->