### PR TITLE
release: v9.47.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.47.1"
+    "version": "9.47.2"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.47.1 - reliability fixes: atomic_json_update is now race-safe under concurrent agent status writes, agy model pins validate dynamically, and late tangle completions retry with feedback. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.47.1",
+      "description": "v9.47.2 - dispatch and tangle reliability: Qwen/OpenCode dispatch gaps fixed, Copilot routed through a stdin-to-arg shim, tangle dispatch and hard-gate retries hardened, council distinct-vendor quorum, agy research defaults, and a safer session-end cleanup guard. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.47.2",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.47.1",
+  "version": "9.47.2",
   "description": "v9.44.1 \u2014 Patch release for Gemini environment/version detection and qwen auth gating. Run /octo:setup.",
   "author": {
     "name": "nyldn",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.47.1",
+  "version": "9.47.2",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.47.1",
+  "version": "9.47.2",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.47.1"
+    "version": "9.47.2"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.47.1 - reliability fixes: atomic_json_update is now race-safe under concurrent agent status writes, agy model pins validate dynamically, and late tangle completions retry with feedback. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.47.1",
+      "description": "v9.47.2 - dispatch and tangle reliability: Qwen/OpenCode dispatch gaps fixed, Copilot routed through a stdin-to-arg shim, tangle dispatch and hard-gate retries hardened, council distinct-vendor quorum, agy research defaults, and a safer session-end cleanup guard. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.47.2",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.47.1",
+  "version": "9.47.2",
   "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## [Unreleased]
 
+## [9.47.2] - 2026-07-06
+
 ### Fixed
 
+- **Qwen/OpenCode/Agy dispatch gaps closed** (#566, #568). Qwen dispatch now passes the required `--auth-type`, OpenCode model resolution is wired up (no more hang), and the provider smoke test actually exercises Agy.
+- **`agy` is the research-phase default** (#569). Research routing now selects agy (the Google seat) where it previously fell through, aligning research with the rest of the workflow routing.
+- **Codex plugin marketplace name mismatch fixed** (#570). The `.codex-plugin` manifest name now matches what the release/validation scripts expect, so plugin-name validation passes.
+- **Tangle dispatch and quality gates hardened** (#571) and **hard-gate failures now retry** (#572). Tangle dispatch runs with stdin isolation and the quality gates retry transient hard-gate failures instead of aborting the run.
+- **`session-end.sh` sentinel cleanup guarded against empty-match CWD deletion** (#567). A cleanup glob that could match nothing and delete the working directory is now guarded, preventing accidental repo-root deletion.
 - **Council quorum now gates on distinct APPROVING vendors, not just distinct responders.** Each non-chair seat's response must end with `VERDICT: APPROVE|REVISE|BLOCK`; the runner reads the last such line (missing/ambiguous → REVISE, fail-safe). A vendor counts toward quorum only if it responded substantively **and** none of its seats dissented, so a split double-seated vendor (one seat APPROVE, one REVISE) can no longer cherry-pick its approving seat into a passing quorum. Standard/deep now require ≥2 distinct approving vendors; `summary.json` adds `distinct_approving_providers` + `approving_providers`. Fixes false `met:true` in the 2-vendor era (sail-cruisey #1992/#1994/#1983). Quick depth (required 1) is unchanged. Layers on the distinct-responder/substantive guard below.
 
 - **Council advice quorum now requires ≥2 DISTINCT providers with substantive responses.** Previously `quorum.met` for `standard`/`deep` depth was true as long as `received_non_chair >= required`, counting a seat on dispatch exit code alone — so a single-vendor result (e.g. 3× codex because agy/gemini returned empty) and even seats that exit 0 while reviewing nothing (the host self-dispatch stub, empty/~1B provider returns) all counted, producing false `met:true`. Now each responding seat's provider is recorded only when its response is non-empty **and** substantive (rejecting the host stub and short "cannot access the files" degenerate reviews, brevity-gated so long real reviews pass); gate-depth councils require ≥2 distinct providers, and `summary.json` reports `distinct_providers` + `responding_providers`. `quick` depth (required 1) is unchanged.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.47.1-blue" alt="Version 9.47.1">
+  <img src="https://img.shields.io/badge/Version-9.47.2-blue" alt="Version 9.47.2">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.47.1",
+  "version": "9.47.2",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## v9.47.2

Patch release from the 8 fixes landed since v9.47.1.

### Fixed
- Qwen/OpenCode/Agy dispatch gaps + agy smoke test (closes #566) — #568
- agy is the research-phase default — #569
- Codex plugin marketplace name mismatch — #570
- Harden tangle dispatch + quality gates (#571), retry hard-gate failures (#572)
- Guard `session-end.sh` sentinel cleanup vs empty-match CWD deletion — #567
- Council quorum gates on distinct approving vendors — #577

Version bumped to 9.47.2 across manifests, package.json, README. Verified: full suite **176/176 green** on merged main (covers the 3 fork PRs whose per-branch CI didn't run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the product to version **9.47.2** across manifests, marketplace listings, and the README badge.

* **Bug Fixes**
  * Improved dispatch reliability and retry behavior for hard failures.
  * Fixed an issue that could cause marketplace validation mismatches.
  * Added safer cleanup handling to avoid accidental deletions when no files match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->