### PR TITLE
fix: stale-lock recovery for atomic_json_update (closes #559)

### DIFF
--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -260,10 +260,55 @@ verify_result_integrity() {
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # Atomic JSON update with file locking (prevents race conditions)
+# #559: reclaim a mkdir-lock whose holder died before releasing it (SIGKILL,
+# crash, OOM, power loss all skip the EXIT trap, leaving the lock dir behind and
+# blocking every later caller until timeout). A lock is stale when its recorded
+# holder PID is no longer running, or it has outlived the age threshold.
+#
+# Reclaim is race-safe via grab-verify-restore: we atomically `mv` the lock
+# aside (only one contender can win that rename), then re-check the holder — if
+# it turns out to be alive (we grabbed a lock another reclaimer had just
+# re-created), we move it back untouched. Only a confirmed-dead holder is dropped.
+_atomic_reclaim_stale_lock() {
+    local lockfile="$1" stale_age="$2"
+    [[ -d "$lockfile" ]] || return 0
+
+    local pid ts now stale=0
+    pid=$(cat "$lockfile/pid" 2>/dev/null || true)
+    ts=$(cat "$lockfile/ts" 2>/dev/null || true)
+
+    if [[ "$pid" =~ ^[0-9]+$ ]]; then
+        kill -0 "$pid" 2>/dev/null || stale=1        # recorded holder is gone
+    fi
+    if [[ $stale -eq 0 && "$ts" =~ ^[0-9]+$ ]]; then
+        now=$(date +%s 2>/dev/null || echo 0)
+        [[ $((now - ts)) -ge "$stale_age" ]] && stale=1   # outlived threshold
+    fi
+    [[ $stale -eq 1 ]] || return 0
+
+    local stolen="${lockfile}.stale.${BASHPID:-$$}"
+    mv "$lockfile" "$stolen" 2>/dev/null || return 0   # lost the race to reclaim
+    # We exclusively hold the moved dir. Re-verify it was actually stale before
+    # dropping it, in case we grabbed a lock another process had just re-created.
+    local spid; spid=$(cat "$stolen/pid" 2>/dev/null || true)
+    if [[ "$spid" =~ ^[0-9]+$ ]] && kill -0 "$spid" 2>/dev/null; then
+        mv "$stolen" "$lockfile" 2>/dev/null || rm -rf "$stolen" 2>/dev/null || true
+    else
+        rm -rf "$stolen" 2>/dev/null || true
+    fi
+}
+
 atomic_json_update() {
     local json_file="$1"
     local jq_expression="$2"
     shift 2
+
+    # Guard an empty path so "${json_file}.lock" can never become a bare ".lock"
+    # that rm -rf would target in the CWD.
+    if [[ -z "$json_file" ]]; then
+        log WARN "atomic_json_update: empty json_file"
+        return 1
+    fi
 
     # mkdir is atomic on every POSIX filesystem, unlike a check-then-touch
     # lock: two concurrent callers can never both succeed at creating the
@@ -274,8 +319,12 @@ atomic_json_update() {
     local timeout=5
     local waited=0
     local max_waits=$((timeout * 10))
+    local stale_age="${OCTO_LOCK_STALE_SECS:-30}"
 
     while ! mkdir "$lockfile" 2>/dev/null; do
+        # #559: a leaked lock from a crashed holder would otherwise block forever.
+        _atomic_reclaim_stale_lock "$lockfile" "$stale_age"
+        mkdir "$lockfile" 2>/dev/null && break
         waited=$((waited + 1))
         if [[ $waited -ge $max_waits ]]; then
             log WARN "Timeout acquiring lock for $json_file"
@@ -284,6 +333,11 @@ atomic_json_update() {
         sleep 0.1
     done
 
+    # #559: record ownership so a later contender can tell a live holder from a
+    # crashed one. Best-effort — failure to write these never blocks the update.
+    printf '%s\n' "${BASHPID:-$$}" > "$lockfile/pid" 2>/dev/null || true
+    date +%s > "$lockfile/ts" 2>/dev/null || true
+
     # This function can run in the same shell as a caller's own long-lived
     # EXIT/INT/TERM traps (e.g. orchestrate.sh's temp-dir cleanup), so save
     # and restore them instead of clobbering them with `trap - EXIT`.
@@ -291,7 +345,8 @@ atomic_json_update() {
     prev_exit_trap=$(trap -p EXIT)
     prev_int_trap=$(trap -p INT)
     prev_term_trap=$(trap -p TERM)
-    trap 'rmdir "'"$lockfile"'" 2>/dev/null' EXIT INT TERM
+    # rm -rf (not rmdir): the lock dir now holds pid/ts ownership files (#559).
+    trap 'rm -rf "'"$lockfile"'" 2>/dev/null' EXIT INT TERM
 
     # BASHPID (not $$, which stays constant across every subshell spawned
     # from the same parent) keeps concurrent callers from colliding on one
@@ -301,7 +356,7 @@ atomic_json_update() {
     local result=$?
     [[ $result -ne 0 ]] && rm -f "$tmp_file"
 
-    rmdir "$lockfile" 2>/dev/null
+    rm -rf "$lockfile" 2>/dev/null
     eval "${prev_exit_trap:-trap - EXIT}"
     eval "${prev_int_trap:-trap - INT}"
     eval "${prev_term_trap:-trap - TERM}"

--- a/tests/unit/test-atomic-lock-recovery.sh
+++ b/tests/unit/test-atomic-lock-recovery.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# #559: stale-lock recovery for atomic_json_update. A holder killed before its
+# release trap runs leaves the mkdir lock dir behind, blocking every later
+# caller until timeout. These tests cover the reclaim (dead holder) vs respect
+# (live holder) behavior, plus the empty-path guard.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+log() { :; }
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/validation.sh"
+
+test_suite "atomic_json_update stale-lock recovery (#559)"
+
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT INT TERM
+
+# a PID that is guaranteed not running: spawn a trivial child and reap it
+dead_pid() { ( : ) & local p=$!; wait "$p" 2>/dev/null; echo "$p"; }
+
+test_empty_path_guard() {
+    test_case "atomic_json_update rejects an empty json_file"
+    if atomic_json_update "" '.x=1' 2>/dev/null; then
+        test_fail "empty path should return non-zero"
+    else
+        test_pass
+    fi
+}
+
+test_normal_update_no_lock_left() {
+    test_case "normal update applies jq and leaves no lock behind"
+    local f="$FIXTURE/a.json"; echo '{"n":1}' > "$f"
+    atomic_json_update "$f" '.n=2' && local ok=1 || local ok=0
+    local n; n=$(jq -r '.n' "$f" 2>/dev/null)
+    if [[ "$ok" == "1" && "$n" == "2" && ! -e "$f.lock" ]]; then test_pass
+    else test_fail "ok=$ok n=$n lock_exists=$([[ -e "$f.lock" ]] && echo yes || echo no)"; fi
+}
+
+test_reclaims_dead_holder_lock() {
+    test_case "a leaked lock from a dead holder is reclaimed (no timeout)"
+    local f="$FIXTURE/b.json"; echo '{"n":1}' > "$f"
+    # simulate a crashed holder: lock dir with a dead PID and fresh timestamp
+    mkdir -p "$f.lock"; echo "$(dead_pid)" > "$f.lock/pid"; date +%s > "$f.lock/ts"
+    local start end
+    start=$(date +%s)
+    atomic_json_update "$f" '.n=9' && local ok=1 || local ok=0
+    end=$(date +%s)
+    local n; n=$(jq -r '.n' "$f" 2>/dev/null)
+    # must succeed AND fast (well under the 5s timeout) — proves it reclaimed
+    if [[ "$ok" == "1" && "$n" == "9" && $((end - start)) -lt 4 && ! -e "$f.lock" ]]; then test_pass
+    else test_fail "ok=$ok n=$n elapsed=$((end-start))s lock=$([[ -e "$f.lock" ]] && echo left || echo clean)"; fi
+}
+
+test_respects_live_holder() {
+    test_case "a live holder's lock is NOT reclaimed"
+    local f="$FIXTURE/c.json"; echo '{"n":1}' > "$f"
+    sleep 20 & local live=$!
+    mkdir -p "$f.lock"; echo "$live" > "$f.lock/pid"; date +%s > "$f.lock/ts"
+    # reclaim helper must leave a live holder's lock intact
+    _atomic_reclaim_stale_lock "$f.lock" 30
+    local intact="no"; [[ -d "$f.lock" && "$(cat "$f.lock/pid" 2>/dev/null)" == "$live" ]] && intact="yes"
+    kill "$live" 2>/dev/null || true
+    rm -rf "$f.lock"
+    if [[ "$intact" == "yes" ]]; then test_pass; else test_fail "live holder's lock was reclaimed"; fi
+}
+
+test_reclaims_aged_out_lock() {
+    test_case "a lock older than the age threshold is reclaimed even if PID unknown"
+    local f="$FIXTURE/d.json"; echo '{"n":1}' > "$f"
+    mkdir -p "$f.lock"   # no pid/ts recorded, but force an old ts
+    echo $(( $(date +%s) - 120 )) > "$f.lock/ts"
+    _atomic_reclaim_stale_lock "$f.lock" 30
+    if [[ ! -e "$f.lock" ]]; then test_pass; else test_fail "aged lock not reclaimed"; fi
+}
+
+test_empty_path_guard
+test_normal_update_no_lock_left
+test_reclaims_dead_holder_lock
+test_respects_live_holder
+test_reclaims_aged_out_lock
+
+test_summary


### PR DESCRIPTION
Follow-up to #557/#558. `atomic_json_update()` locks via `mkdir "$json_file.lock"` and releases in an EXIT trap — a holder killed with SIGKILL (crash/OOM/power loss) skips the trap, leaving the lock dir behind permanently and blocking every later caller until timeout.

## Fix
- **Ownership**: after acquiring, write holder PID + acquisition timestamp into the lock dir.
- **Reclaim on contention**: stale = recorded PID not running, or lock older than `OCTO_LOCK_STALE_SECS` (default 30s). Reclaim is **race-safe via grab-verify-restore** — atomically `mv` the lock aside (only one contender wins the rename), re-check the holder, and move it back untouched if it's actually alive. Only a confirmed-dead holder is dropped; a live holder is always respected.
- Release uses `rm -rf` (lock dir now holds pid/ts); empty `json_file` guarded so `"${json_file}.lock"` can't become a bare `.lock`.

## Tests
`tests/unit/test-atomic-lock-recovery.sh` (5/5): empty-path guard, normal update leaves no lock, dead-holder lock reclaimed without timing out, **live holder respected**, aged-out lock reclaimed.

Closes #559.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from stale lock files so JSON updates can continue after a previous process leaves behind a lock.
  * Added safeguards to prevent unsafe behavior when the JSON file path is empty.
  * Locked updates now clean up reliably, including cases where lock metadata must be reclaimed or removed.  

* **Tests**
  * Added coverage for empty input handling, normal lock cleanup, stale lock recovery, live-lock protection, and aged-out lock removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->