### PR TITLE
test: fix stale cache-key sanitization assertion (false failure)

### DIFF
--- a/tests/test-model-config-v849.sh
+++ b/tests/test-model-config-v849.sh
@@ -49,8 +49,10 @@ else
     pass "Old CACHE_ collision-prone pattern removed"
 fi
 
-# Verify per-field sanitization variables exist
-if grep -q 'safe_p="\${provider//\[^a-zA-Z0-9\]/_}"' "$_ORCH_ALL_TMP"; then
+# Verify per-field sanitization variables exist. The provider field is sanitized
+# from its canonical form (alias-resolved), so accept both `provider` and
+# `canonical_provider` — the resolver keys the cache on the canonical name.
+if grep -qE 'safe_p="\$\{(canonical_)?provider//\[\^a-zA-Z0-9\]/_\}"' "$_ORCH_ALL_TMP"; then
     pass "Per-field sanitization for cache keys present"
 else
     fail "Missing per-field sanitization for cache keys"


### PR DESCRIPTION
`tests/test-model-config-v849.sh` reported a false `Missing per-field sanitization for cache keys` failure on `main`.

The resolver correctly sanitizes the **canonical** provider name — `safe_p="${canonical_provider//[^a-zA-Z0-9]/_}"` (model-resolver.sh:136) — but the test still grepped for the pre-refactor `${provider//...}`. The sanitization is present and correct; the assertion was stale.

Fix matches both `provider` and `canonical_provider`. Root-level suite: 87/1 → **88/0**. No code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated cache-key collision checks to match the current provider sanitization behavior.
  * The test now accepts either provider field format when validating safe cache key generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->