### PR TITLE
release: v9.48.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.47.2"
+    "version": "9.48.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.47.2 - dispatch and tangle reliability: Qwen/OpenCode dispatch gaps fixed, Copilot routed through a stdin-to-arg shim, tangle dispatch and hard-gate retries hardened, council distinct-vendor quorum, agy research defaults, and a safer session-end cleanup guard. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.47.2",
+      "description": "v9.48.0 - adds the xAI Grok CLI as a first-class provider; plus reliability fixes: crash-safe stale-lock recovery for atomic_json_update, hardened hook-test isolation (no more deleting tracked repo files), and late-tangle-completion reconciliation. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.48.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.47.2",
+  "version": "9.48.0",
   "description": "v9.44.1 \u2014 Patch release for Gemini environment/version detection and qwen auth gating. Run /octo:setup.",
   "author": {
     "name": "nyldn",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.47.2",
+  "version": "9.48.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.47.2",
+  "version": "9.48.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.47.2"
+    "version": "9.48.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.47.2 - dispatch and tangle reliability: Qwen/OpenCode dispatch gaps fixed, Copilot routed through a stdin-to-arg shim, tangle dispatch and hard-gate retries hardened, council distinct-vendor quorum, agy research defaults, and a safer session-end cleanup guard. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.47.2",
+      "description": "v9.48.0 - adds the xAI Grok CLI as a first-class provider; plus reliability fixes: crash-safe stale-lock recovery for atomic_json_update, hardened hook-test isolation (no more deleting tracked repo files), and late-tangle-completion reconciliation. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.48.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.47.2",
+  "version": "9.48.0",
   "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [9.48.0] - 2026-07-06
+
+### Added
+
+- **xAI Grok CLI as a first-class provider** (#542). New `grok` provider (`xai` family): stdin dispatch via `scripts/helpers/grok-exec.sh`, `scripts/lib/grok.sh`, detection, routing, doctor checks, fleet inclusion in `build-fleet.sh`, and model-config catalog entries. Available in debate/brainstorm alongside the other providers.
+
+### Fixed
+
+- **`atomic_json_update` recovers from a crashed lock holder** (#557, #559). The `mkdir`-based lock now records the holder PID + acquisition timestamp; a contender reclaims a lock whose holder is gone (dead PID) or that has outlived `OCTO_LOCK_STALE_SECS` (default 30s), via a race-safe grab-verify-restore that always respects a live holder. Previously a SIGKILL/crash left the lock dir behind and blocked every later caller until timeout.
+- **Running the unit suite no longer deletes tracked repo files** (#563). `test-hook-err-traps.sh` invoked every hook with `CLAUDE_PLUGIN_ROOT` and CWD pointed at the live checkout, so a hook resolving a path/glob from either (e.g. `session-end.sh`'s CWD-scan memory-dir fallback) could delete `Makefile`/`LICENSE`/`GOALS.md`/`PRODUCT.md`. Hooks now run against a disposable tree copy with a throwaway CWD and `CLAUDE_PROJECT_DIR`; a sentinel fails the suite if a tracked file ever disappears.
+- **Late tangle completions are reconciled on their final status** (#560). Success detection now reads the latest `## Status:` line (so a task that completes late and appends a newer status is judged on its final state, not an earlier SUCCESS) while keeping the blocker-output guard.
+- **Corrected a stale cache-key sanitization test assertion** (#583) that reported a false failure after the resolver moved to sanitizing the canonical provider name.
+
 ## [9.47.2] - 2026-07-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.47.2-blue" alt="Version 9.47.2">
+  <img src="https://img.shields.io/badge/Version-9.48.0-blue" alt="Version 9.48.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.47.2",
+  "version": "9.48.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## v9.48.0

Minor release (new provider) from the 5 changes landed since v9.47.2.

### Added
- **xAI Grok CLI as a first-class provider** (#542) — grok-exec dispatch, detection, routing, doctor, fleet inclusion, model catalog

### Fixed
- **`atomic_json_update` crash-safe stale-lock recovery** (#557, #559) — reclaims locks from dead holders, always respects live ones
- **Unit suite no longer deletes tracked repo files** (#563) — hook-test isolation via disposable tree + throwaway CWD/CLAUDE_PROJECT_DIR + a sentinel
- **Late tangle completions reconciled on final status** (#560)
- **Stale cache-key sanitization test assertion corrected** (#583)

Version bumped to 9.48.0 across manifests, package.json, README. Verified: full suite **178/178 green** on merged main; expert-review gate 50/50.