### PR TITLE
fix(agy): record agy's real model in the council seat, not "default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **The agy council seat now records its real model instead of `"default"`.** `agy-exec` runs `agy --print` with `--model default` (agy uses whatever is picked in its own `/model` UI), so the roster artifact and preflight banner logged the opaque string `default` for the agy seat — making a Codex+agy panel's cross-lab-vs-same-lineage status unverifiable from `summary.json`. New `agy_current_model()` (`lib/providers.sh`) honors `OCTOPUS_AGY_MODEL`, else resolves the selection from `~/.gemini/antigravity-cli/settings.json`, else fails safe to `default (unresolved)`; it's wired into `council_roster_entry_json` and the preflight banner. Purely diagnostic — never gates logic, and guarded with `declare -f` so standalone runs fall back to prior behavior.
+
 ## [9.48.0] - 2026-07-06
 
 ### Added

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -919,6 +919,12 @@ council_roster_entry_json() {
     [[ -n "$provider" ]] || provider="$(council_pick_provider "$preferred_provider")"
     provider_org="$(council_provider_org "$provider")"
     model="$(council_persona_model "$persona")"
+    # agy ignores the per-persona model (agy-exec runs `--model default`), so record
+    # the model agy will ACTUALLY use — resolved from its own settings — instead of
+    # the placeholder, so the seat's cross-lab lineage is verifiable from the artifact.
+    if [[ "$provider" == "agy" ]] && declare -f agy_current_model >/dev/null 2>&1; then
+        model="$(agy_current_model)"
+    fi
     seat="$(council_persona_seat "$persona")"
     family="$(council_persona_family "$persona")"
     permission_mode="$(council_agent_config_value "$persona" "permissionMode" | tr -d '"')"

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -90,7 +90,11 @@ cmd_detect_providers() {
     if command -v agy &>/dev/null; then
         echo "AGY_STATUS=ok"
         echo "AGY_AUTH=cli"
-        echo "AGY_MODEL=${OCTOPUS_AGY_MODEL:-}"
+        if declare -f agy_current_model >/dev/null 2>&1; then
+            echo "AGY_MODEL=$(agy_current_model)"
+        else
+            echo "AGY_MODEL=${OCTOPUS_AGY_MODEL:-}"
+        fi
     else
         echo "AGY_STATUS=not-installed"
         echo "AGY_AUTH=none"
@@ -207,6 +211,9 @@ cmd_detect_providers() {
     local agy_status=$(command -v agy &>/dev/null && echo "ok" || echo "not-installed")
     local agy_auth=$([[ "$agy_status" == "ok" ]] && echo "cli" || echo "none")
     local agy_model="${OCTOPUS_AGY_MODEL:-}"
+    if [[ "$agy_status" == "ok" ]] && declare -f agy_current_model >/dev/null 2>&1; then
+        agy_model="$(agy_current_model)"
+    fi
     local perplexity_status=$([[ -n "${PERPLEXITY_API_KEY:-}" ]] && echo "ok" || echo "not-configured")
     local perplexity_auth=$([[ -n "${PERPLEXITY_API_KEY:-}" ]] && echo "api-key" || echo "none")
     local ollama_status=$(command -v ollama &>/dev/null && { curl -sf http://localhost:11434/api/tags &>/dev/null && echo "running" || echo "stopped"; } || echo "not-installed")

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -991,6 +991,33 @@ EOF
     fi
 }
 
+# ── agy_current_model: resolve the model the Antigravity CLI will actually use ──
+# agy-exec.sh runs `agy --print` with `--model default` (no --model flag) unless
+# OCTOPUS_AGY_MODEL is set, so agy uses whatever is selected in its own /model UI —
+# persisted to ~/.gemini/antigravity-cli/settings.json. Resolve that here so the
+# council roster artifact and the activation banner record the REAL model
+# (e.g. "Gemini 3.1 Pro (Low)") instead of the opaque "default", which is what makes
+# a Codex+agy panel's cross-lab-vs-same-lineage status verifiable from the artifact.
+# Fail-safe: purely diagnostic, never gate logic — echo "default (unresolved)" if the
+# selection can't be read, and never abort a run.
+agy_current_model() {
+    local override="${OCTOPUS_AGY_MODEL:-}"
+    if [[ -n "$override" && "$override" != "default" ]]; then
+        printf '%s\n' "$override"
+        return 0
+    fi
+    local settings="${HOME}/.gemini/antigravity-cli/settings.json"
+    if [[ -f "$settings" ]] && command -v jq >/dev/null 2>&1; then
+        local m
+        m="$(jq -r '.model // empty' "$settings" 2>/dev/null)"
+        if [[ -n "$m" ]]; then
+            printf '%s\n' "$m"
+            return 0
+        fi
+    fi
+    printf '%s\n' "default (unresolved)"
+}
+
 # ── detect_providers: multi-CLI + auth detection (moved from orchestrate.sh v9.22.1) ──
 detect_providers() {
     local result=""


### PR DESCRIPTION
## Summary

`agy-exec` runs `agy --print` with `--model default` (so agy uses whatever is selected in its own `/model` UI), which means the council roster artifact and the preflight banner record the opaque string `"default"` for the agy seat. That makes a Codex+agy panel's cross-lab-vs-same-lineage status unverifiable from `summary.json` — a lead has to know agy's model out of band. With agy now a first-class council provider on `main`, the seat should report the lab/model it actually ran.

## Change (purely diagnostic — never gates logic)

- New `agy_current_model()` in `lib/providers.sh`: honors `OCTOPUS_AGY_MODEL` when set, else resolves the selection from `~/.gemini/antigravity-cli/settings.json` (`.model`), else fails safe to `"default (unresolved)"`.
- Wired into `council_roster_entry_json` — the agy seat records its real model (e.g. `"Gemini 3.1 Pro (Low)"`) in `summary.json`.
- Wired into `preflight.sh` — the provider-cache `AGY_MODEL` and activation banner show the real model instead of empty/`"agy default"`.
- Guarded with `declare -f` so standalone runs of preflight/council fall back to prior behavior.

## Test plan

- [x] `bash -n` clean on `providers.sh` / `council.sh` / `preflight.sh`
- [x] `tests/unit/test-council-command.sh` — 55/55 pass
- [x] Verified: override wins (`OCTOPUS_AGY_MODEL` → `Gemini 3.1 Pro (Low)`); missing settings → `default (unresolved)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AGY model reporting so the selected model is shown more accurately in status and diagnostic output.
  * Roster and preflight details now reflect the model actually in use, with a safe fallback when it can’t be determined.

* **Chores**
  * Updated the changelog with the latest fix entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->