### PR TITLE
fix(grok): honor providers.json model, isolate env, propagate non-zero exit

### DIFF
--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -223,7 +223,18 @@ get_agent_command() {
             echo "env NODE_NO_WARNINGS=1 NO_BROWSER=1 qwen -o text --approval-mode yolo -m ${model} ${qwen_auth_flag}"
             ;;
         grok|grok-research)  # xAI Grok CLI — headless single-turn via helpers/grok-exec.sh
-            echo "${PLUGIN_DIR}/scripts/helpers/grok-exec.sh"
+            # Wire config/env model selection through to the shim (parity with codex/
+            # gemini/qwen). get_agent_model reads providers.json + OCTOPUS_GROK_MODEL;
+            # pass it via an env prefix so grok-exec.sh emits --model. Grok model ids are
+            # single tokens (grok-4-fast, ...) so the prefix survives argv word-splitting.
+            # Without this, providers.json model picks were silently ignored (the shim
+            # only saw a shell-exported OCTOPUS_GROK_MODEL).
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then return 1; fi
+            if [[ -n "$model" && "$model" != "default" ]]; then
+                echo "env OCTOPUS_GROK_MODEL=${model} ${PLUGIN_DIR}/scripts/helpers/grok-exec.sh"
+            else
+                echo "${PLUGIN_DIR}/scripts/helpers/grok-exec.sh"
+            fi
             ;;
         cursor-agent)  # v9.23.0: Cursor Agent CLI — Grok 4.20 via Cursor subscription
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then

--- a/scripts/lib/grok.sh
+++ b/scripts/lib/grok.sh
@@ -52,7 +52,10 @@ grok_execute(){
         if printf '%s' "$response" | grep -ciE 'unauthorized|forbidden|(401|403)|not authorized|invalid token|expired token|please .?login|login required' >/dev/null; then
             _grok_log ERROR "grok: auth failure — run: grok login (or set XAI_API_KEY)"; return 1
         fi
-        _grok_log WARN "grok: exit $exit_code"
+        # A non-zero exit is a failure even when grok emitted partial stdout. Do not
+        # let an aborted/errored run masquerade as a successful response, or debate and
+        # council verdicts that treat any non-empty output as success get corrupted.
+        _grok_log WARN "grok: exit $exit_code"; return 1
     fi
     [[ -z "$response" ]] && { _grok_log WARN "grok: empty response"; return 1; }
     if [[ -n "$output_file" ]]; then printf '%s\n' "$response" > "$output_file"; else printf '%s\n' "$response"; fi

--- a/scripts/lib/grok.sh
+++ b/scripts/lib/grok.sh
@@ -55,7 +55,7 @@ grok_execute(){
         # A non-zero exit is a failure even when grok emitted partial stdout. Do not
         # let an aborted/errored run masquerade as a successful response, or debate and
         # council verdicts that treat any non-empty output as success get corrupted.
-        _grok_log WARN "grok: exit $exit_code"; return 1
+        _grok_log ERROR "grok: exit $exit_code"; return 1
     fi
     [[ -z "$response" ]] && { _grok_log WARN "grok: empty response"; return 1; }
     if [[ -n "$output_file" ]]; then printf '%s\n' "$response" > "$output_file"; else printf '%s\n' "$response"; fi

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -114,6 +114,27 @@ build_provider_env() {
                 fi
             fi
             ;;
+        grok*)
+            # Grok defaults to a minimal environment (parity with codex/gemini/agy).
+            # Users needing full desktop/session inheritance can opt out.
+            if [[ "${OCTOPUS_ALLOW_FULL_GROK_ENV:-false}" == "true" ]]; then
+                if [[ "${OCTOPUS_SECURITY_V870:-true}" == "true" ]] && declare -f log_warn >/dev/null 2>&1; then
+                    log_warn "Grok CLI inherits the parent shell environment because OCTOPUS_ALLOW_FULL_GROK_ENV=true."
+                fi
+                PROVIDER_ENV_ARRAY=()
+            else
+                if [[ -z "${XAI_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
+                    resolve_provider_env "XAI_API_KEY" 2>/dev/null || true
+                fi
+                PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "TERM=${TERM:-dumb}" "TMPDIR=${TMPDIR:-/tmp}")
+                if [[ -n "${XAI_API_KEY:-}" ]]; then
+                    PROVIDER_ENV_ARRAY+=("XAI_API_KEY=${XAI_API_KEY}")
+                fi
+                if [[ ${#_trace_env[@]} -gt 0 ]]; then
+                    PROVIDER_ENV_ARRAY+=("${_trace_env[@]}")
+                fi
+            fi
+            ;;
         perplexity*)
             # perplexity_execute is a shell function — env -i cannot exec it (#300)
             if [[ -z "${PERPLEXITY_API_KEY:-}" ]]; then

--- a/tests/unit/test-grok-provider.sh
+++ b/tests/unit/test-grok-provider.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# tests/unit/test-grok-provider.sh
+# Contract coverage for the xAI Grok CLI provider (#542 follow-ups):
+#   1. dispatch routes through the stdin->-p shim (helpers/grok-exec.sh).
+#   2. config/env model selection is wired to runtime (get_agent_model +
+#      OCTOPUS_GROK_MODEL env prefix) so providers.json picks reach the shim.
+#   3. providers.json grok model resolves and grok-exec.sh emits --model;
+#      "default" emits no --model.
+#   4. provider-routing isolates grok by default (env -i) with a full-env opt-in,
+#      matching codex/gemini/agy.
+#   5. grok_execute propagates a non-zero exit even when stdout is non-empty.
+#   6. grok_is_available requires the binary AND auth.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "xAI Grok CLI Provider"
+
+# Stub log() — grok.sh/model-resolver.sh call it outside orchestrate.sh.
+log() { :; }
+
+# ── 1. dispatch routes through the shim ───────────────────────────────────────
+test_grok_dispatch_shim() {
+    test_case "dispatch.sh routes grok through helpers/grok-exec.sh"
+    if grep -q 'scripts/helpers/grok-exec.sh' "$PROJECT_ROOT/scripts/lib/dispatch.sh" && \
+       grep -q 'grok -p "$prompt"' "$PROJECT_ROOT/scripts/helpers/grok-exec.sh"; then
+        test_pass
+    else
+        test_fail "grok dispatch should use scripts/helpers/grok-exec.sh"
+    fi
+}
+
+# ── 2. dispatch wires config/env model to the shim ────────────────────────────
+test_grok_dispatch_wires_model() {
+    test_case "dispatch grok arm resolves model and env-prefixes OCTOPUS_GROK_MODEL"
+    local arm
+    arm="$(sed -n '/grok|grok-research)/,/;;/p' "$PROJECT_ROOT/scripts/lib/dispatch.sh")"
+    if [[ "$arm" == *"get_agent_model"* ]] && [[ "$arm" == *"env OCTOPUS_GROK_MODEL="* ]]; then
+        test_pass
+    else
+        test_fail "grok arm should call get_agent_model and pass OCTOPUS_GROK_MODEL to the shim"
+    fi
+}
+
+# ── 3. provider-routing env isolation parity ──────────────────────────────────
+test_grok_env_isolation() {
+    test_case "provider routing isolates grok by default with full-env opt-in"
+    local block
+    block="$(sed -n '/grok\*)/,/;;/p' "$PROJECT_ROOT/scripts/lib/provider-routing.sh")"
+    if [[ "$block" == *"OCTOPUS_ALLOW_FULL_GROK_ENV"* ]] && \
+       [[ "$block" == *"PROVIDER_ENV_ARRAY=(env -i"* ]] && \
+       [[ "$block" == *"XAI_API_KEY"* ]] && \
+       [[ "$block" == *"PROVIDER_ENV_ARRAY=()"* ]]; then
+        test_pass
+    else
+        test_fail "grok should isolate by default (env -i + XAI_API_KEY) and honor OCTOPUS_ALLOW_FULL_GROK_ENV=true"
+    fi
+}
+
+# ── 4. config-file model resolves and reaches the shim as --model ─────────────
+test_grok_config_runtime_model() {
+    test_case "providers.json grok model resolves and grok-exec.sh emits --model"
+    local tmp_bin capture config_home old_path old_home resolved
+    tmp_bin="$TEST_TMP_DIR/grok-bin"; capture="$TEST_TMP_DIR/grok-argv.txt"; config_home="$TEST_TMP_DIR/grok-home"
+    mkdir -p "$tmp_bin" "$config_home/.claude-octopus/config"
+    cat > "$tmp_bin/grok" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${GROK_ARG_CAPTURE:?}"
+exit 0
+MOCK
+    chmod +x "$tmp_bin/grok"
+    cat > "$config_home/.claude-octopus/config/providers.json" <<'JSON'
+{"providers":{"grok":{"default":"grok-4-fast"}}}
+JSON
+    old_path="$PATH"; old_home="$HOME"
+    PATH="$tmp_bin:$PATH"; export GROK_ARG_CAPTURE="$capture"
+    source "$PROJECT_ROOT/scripts/lib/model-resolver.sh" 2>/dev/null || true
+
+    HOME="$config_home"
+    resolved="$(resolve_octopus_model grok grok "" "" 2>/dev/null || true)"
+    HOME="$old_home"
+    if [[ "$resolved" != "grok-4-fast" ]]; then
+        PATH="$old_path"; unset GROK_ARG_CAPTURE
+        test_fail "config providers.json grok model should resolve to grok-4-fast, got: '$resolved'"
+        return
+    fi
+
+    OCTOPUS_GROK_MODEL="grok-4-fast" bash "$PROJECT_ROOT/scripts/helpers/grok-exec.sh" <<<"probe" >/dev/null 2>&1 || true
+    PATH="$old_path"; unset GROK_ARG_CAPTURE
+    if grep -Fxq -- '--model' "$capture" && grep -Fxq -- 'grok-4-fast' "$capture"; then
+        test_pass
+    else
+        test_fail "grok-exec.sh should pass the resolved model as --model; argv: $(tr '\n' ' ' < "$capture" 2>/dev/null)"
+    fi
+}
+
+# ── 5. "default" model => no --model flag ─────────────────────────────────────
+test_grok_default_no_model() {
+    test_case "OCTOPUS_GROK_MODEL=default is not passed to grok --model"
+    local tmp_bin capture old_path
+    tmp_bin="$TEST_TMP_DIR/grok-bin-def"; capture="$TEST_TMP_DIR/grok-argv-def.txt"
+    mkdir -p "$tmp_bin"
+    cat > "$tmp_bin/grok" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${GROK_ARG_CAPTURE:?}"
+exit 0
+MOCK
+    chmod +x "$tmp_bin/grok"
+    old_path="$PATH"; PATH="$tmp_bin:$PATH"; export GROK_ARG_CAPTURE="$capture"
+    OCTOPUS_GROK_MODEL="default" bash "$PROJECT_ROOT/scripts/helpers/grok-exec.sh" <<<"probe" >/dev/null 2>&1 || true
+    PATH="$old_path"; unset GROK_ARG_CAPTURE
+    if grep -q -- '--model' "$capture"; then
+        test_fail "default should not be passed to grok --model; argv: $(tr '\n' ' ' < "$capture" 2>/dev/null)"
+    else
+        test_pass
+    fi
+}
+
+# ── 6. non-zero exit propagates even with stdout ──────────────────────────────
+test_grok_exit_propagation() {
+    test_case "grok_execute returns non-zero when grok exits non-zero (even with stdout)"
+    local tmp_bin old_path rc
+    tmp_bin="$TEST_TMP_DIR/grok-bin-fail"
+    mkdir -p "$tmp_bin"
+    cat > "$tmp_bin/grok" <<'MOCK'
+#!/usr/bin/env bash
+printf 'partial answer before crash\n'   # non-empty stdout
+exit 3
+MOCK
+    chmod +x "$tmp_bin/grok"
+    old_path="$PATH"; PATH="$tmp_bin:$PATH"
+    source "$PROJECT_ROOT/scripts/lib/grok.sh" 2>/dev/null || true
+    rc=0
+    grok_execute grok "probe" >/dev/null 2>&1 || rc=$?
+    PATH="$old_path"
+    if [[ "$rc" -ne 0 ]]; then
+        test_pass
+    else
+        test_fail "grok_execute masked a non-zero exit (returned 0) despite grok exiting 3"
+    fi
+}
+
+# ── 7. availability requires binary AND auth ──────────────────────────────────
+test_grok_detection() {
+    test_case "grok_is_available requires the grok binary and auth"
+    local tmp_bin old_path old_home old_key rc_auth rc_noauth
+    tmp_bin="$TEST_TMP_DIR/grok-bin-det"
+    mkdir -p "$tmp_bin"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$tmp_bin/grok"; chmod +x "$tmp_bin/grok"
+    old_path="$PATH"; old_home="$HOME"; old_key="${XAI_API_KEY:-}"
+    PATH="$tmp_bin:$PATH"; HOME="$TEST_TMP_DIR/grok-empty-home"; mkdir -p "$HOME"
+    source "$PROJECT_ROOT/scripts/lib/grok.sh" 2>/dev/null || true
+
+    XAI_API_KEY="xai-test-key"
+    rc_auth=0; grok_is_available >/dev/null 2>&1 || rc_auth=$?
+    unset XAI_API_KEY
+    rc_noauth=0; grok_is_available >/dev/null 2>&1 || rc_noauth=$?
+
+    PATH="$old_path"; HOME="$old_home"; [[ -n "$old_key" ]] && export XAI_API_KEY="$old_key"
+    if [[ "$rc_auth" -eq 0 && "$rc_noauth" -ne 0 ]]; then
+        test_pass
+    else
+        test_fail "grok_is_available should be true with XAI_API_KEY ($rc_auth) and false without auth ($rc_noauth)"
+    fi
+}
+
+test_grok_dispatch_shim
+test_grok_dispatch_wires_model
+test_grok_env_isolation
+test_grok_config_runtime_model
+test_grok_default_no_model
+test_grok_exit_propagation
+test_grok_detection
+
+test_summary


### PR DESCRIPTION
## Summary

Three follow-ups that harden the xAI Grok CLI provider (added in #542) to parity with the other CLI providers: config→runtime model selection, environment isolation, and non-zero exit propagation.

## Problem

Post-#542 review flagged three gaps:

1. **The config file is phantom for grok.** `octo-model-config.sh` writes model selections to `~/.claude-octopus/config/providers.json`, and `resolve_octopus_model` reads them, but the grok dispatch arm never called the resolver. It launched `helpers/grok-exec.sh` directly, and the shim only reads `OCTOPUS_GROK_MODEL` from the environment. So `/octo:model-config set grok <model>` silently ran grok's vendor default and misattributed outputs with no error, which is worse than a missing provider.
2. **No env isolation.** codex/gemini/agy run under `env -i` in `build_provider_env`; grok fell to the no-isolation default and inherited the full parent environment.
3. **Exit-code masking.** `grok_execute` returned 0 when grok exited non-zero but emitted partial stdout, so an aborted run could feed a corrupt answer into debate/council verdicts.

## Changes

- **`lib/dispatch.sh`** — the `grok` arm resolves the model via `get_agent_model` (the same resolver codex/gemini/qwen use: env override → `providers.json` → default) and passes it as an `env OCTOPUS_GROK_MODEL=<model>` prefix to the shim. Grok model ids are single tokens, so the prefix survives `read -ra` argv splitting.
- **`lib/provider-routing.sh`** — new `grok*)` arm in `build_provider_env`: `env -i` with `PATH`/`HOME`/`TERM`/`TMPDIR` + `XAI_API_KEY` (recovered via `resolve_provider_env`), plus an `OCTOPUS_ALLOW_FULL_GROK_ENV=true` opt-out. Mirrors the agy arm. Composes with the model prefix (`env -i … env OCTOPUS_GROK_MODEL=… shim`).
- **`lib/grok.sh`** — `grok_execute` returns non-zero on a non-zero grok exit even when stdout is non-empty.
- **`tests/unit/test-grok-provider.sh`** — 7 cases covering all of the above.

## Why grok-only

agy has the identical config→runtime gap, but its model labels contain spaces (e.g. `Gemini 3.5 Flash (Medium)`), which a dispatch-string env prefix cannot carry through `read -ra` word-splitting. That needs the spaces-safe array-injection approach in `build_provider_env`, a distinct change left as a follow-up to keep this PR focused and low-risk.

## Verification

- `bash tests/unit/test-grok-provider.sh` → 7/7
- `bash tests/unit/test-provider-allowlist.sh` → 10/0
- `bash tests/unit/test-provider-auth-validity.sh` → 18/0
- `bash tests/unit/test-agy-provider.sh` → 32/0 (no regression to the sibling shim provider)

A local `tests/run-all-tests.sh` shows 6 unrelated suites failing **identically on this branch and on pristine `main`** (a local-environment gap on the dev machine, not introduced by this change). CI is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grok requests now honor the selected model when available, automatically carrying the chosen model through the execution flow.
  * Grok provider runs in a safer, minimal environment by default, with an opt-in full-environment mode.
* **Bug Fixes**
  * Grok execution now stops immediately on non-zero exit codes to prevent partially errored output from being treated as valid.
  * Availability checks are more reliable when Grok is installed and credentials are configured.
* **Tests**
  * Added unit test coverage for Grok dispatch, model handling, provider routing, and error/availability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->