### PR TITLE
feat: add model-config role routing commands

### DIFF
--- a/.claude/commands/model-config.md
+++ b/.claude/commands/model-config.md
@@ -107,6 +107,7 @@ AskUserQuestion({
     options: [
       {label: "Provider defaults", description: "Set default models for Codex, Gemini, Antigravity, OpenRouter, etc."},
       {label: "Phase routing", description: "Choose which model handles each workflow phase (discover, develop, review, etc.)"},
+      {label: "Role routing overrides", description: "Route specific roles/personas such as researcher, logic-reviewer, or qa-reviewer"},
       {label: "Debate & multi-LLM", description: "Configure which providers participate in debates, parallel execution, and reviews"},
       {label: "Session provider availability", description: "Temporarily enable or disable providers for this Claude Code session"},
       {label: "Cost mode", description: "Switch between budget, standard, and premium model tiers"},
@@ -359,6 +360,26 @@ To make permanent: add to ~/.zshrc or ~/.bashrc
 
 Or offer to set it in the config file.
 
+
+### Route: Role Routing Overrides
+
+Use role routing when a specific persona or workflow role should use a different provider/model than the phase or provider default. Examples: route `researcher` to `agy:default`, route `logic-reviewer` to `codex:logic_review`, or route QA roles to a review model while implementation remains on the provider default.
+
+Show current role overrides:
+
+```bash
+${HOME}/.claude-octopus/plugin/scripts/helpers/octo-model-config.sh show roles
+```
+
+Set or remove an override:
+
+```bash
+${HOME}/.claude-octopus/plugin/scripts/helpers/octo-model-config.sh route-role <role> <provider:capability-or-model>
+${HOME}/.claude-octopus/plugin/scripts/helpers/octo-model-config.sh unroute-role <role>
+```
+
+Role overrides are intentionally sparse. Do not restate defaults; add a role only when it needs deterministic routing different from the provider/persona default.
+
 ### Route: Session Provider Availability
 
 Use this when the user wants to turn a provider off for the current session, for example when Codex quota is exhausted and they want Claude + Gemini only.
@@ -453,10 +474,13 @@ When invoked WITH arguments (e.g., `/octo:model-config codex gpt-5.4`), skip the
 
 1. **Parse arguments** to determine action:
    - `show phases` → Display formatted phase routing table
+   - `show roles` → Display explicit role routing overrides
    - `<provider> <model>` → Set model (persistent)
    - `<provider>.<capability> <model>` → Set capability-specific model
    - `<provider> <model> --session` → Set model (session only)
    - `phase <phase> <model>` → Set phase-specific model routing
+   - `route-role <role> <target>` → Set role/persona routing override
+   - `unroute-role <role>` → Remove role/persona routing override
    - `providers` → Show current provider allowlist source and value
    - `allow <providers...> --session` → Use only these providers for the current session
    - `disable <providers...> --session` → Remove providers from the current session

--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -26,8 +26,11 @@ usage() {
     echo "Commands:"
     echo "  list                        List current configuration"
     echo "  show phases                 Show phase routing table"
+    echo "  show roles                  Show role routing override table"
     echo "  set <provider> <model>      Set default model for a provider"
     echo "  route <phase> <target>      Route a phase to a specific model/capability"
+    echo "  route-role <role> <target>  Route a role/persona to a model/capability"
+    echo "  unroute-role <role>         Remove an explicit role route override"
     echo "  reset [provider|all]        Reset configuration to defaults"
     echo "  models [filter]             List all known models with capabilities"
     echo "  providers                   Show active provider allowlist"
@@ -133,6 +136,14 @@ validate_model() {
         return 1
     fi
     [[ "$model" == /* ]] && return 1
+    return 0
+}
+
+validate_role_name() {
+    local role="$1"
+    [[ -z "$role" ]] && return 1
+    [[ "$role" =~ ^[A-Za-z0-9_.-]+$ ]] || return 1
+    [[ "$role" == .* || "$role" == *..* || "$role" == /* ]] && return 1
     return 0
 }
 
@@ -409,6 +420,24 @@ cmd_show_phases() {
     done
 }
 
+cmd_show_roles() {
+    ensure_config
+    echo -e "${CYAN}Role Routing Overrides${NC}"
+    echo "─────────────────────────────────────────────────"
+    printf "  %-28s %s\n" "Role" "Target"
+    echo "  ────────────────────────────────────────────────"
+
+    local roles
+    roles=$(jq -r '.routing.roles // {} | to_entries | sort_by(.key)[] | "\(.key)	\(.value)"' "$CONFIG_FILE" 2>/dev/null || true)
+    if [[ -z "$roles" ]]; then
+        echo "  (none — using provider/persona defaults)"
+    else
+        echo "$roles" | while IFS=$'	' read -r role target; do
+            printf "  %-28s %s\n" "$role" "$target"
+        done
+    fi
+}
+
 cmd_verify() {
     ensure_config
     log_info "Verifying model accessibility..."
@@ -510,6 +539,46 @@ cmd_route() {
     clear_cache
 }
 
+cmd_route_role() {
+    local role="$1"
+    local target="$2"
+
+    [[ -z "$role" || -z "$target" ]] && { usage; exit 1; }
+
+    if ! validate_role_name "$role"; then
+        log_error "Invalid role: '$role'"
+        log_warn "Role names may contain only letters, digits, dot, underscore, and hyphen."
+        exit 1
+    fi
+
+    if ! validate_model "$target"; then
+        log_error "Invalid target: '$target'"
+        exit 1
+    fi
+
+    ensure_config
+    jq --arg r "$role" --arg t "$target" '.routing.roles[$r] = $t' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp.$$" && mv "${CONFIG_FILE}.tmp.$$" "$CONFIG_FILE"
+    log_info "Routed role '$role' → '$target'"
+    clear_cache
+}
+
+cmd_unroute_role() {
+    local role="$1"
+
+    [[ -z "$role" ]] && { usage; exit 1; }
+
+    if ! validate_role_name "$role"; then
+        log_error "Invalid role: '$role'"
+        log_warn "Role names may contain only letters, digits, dot, underscore, and hyphen."
+        exit 1
+    fi
+
+    ensure_config
+    jq --arg r "$role" 'del(.routing.roles[$r])' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp.$$" && mv "${CONFIG_FILE}.tmp.$$" "$CONFIG_FILE"
+    log_info "Removed role route override: $role"
+    clear_cache
+}
+
 cmd_models() {
     local filter="${1:-}"
     echo -e "${CYAN}Model Catalog${NC}"
@@ -597,11 +666,14 @@ case "$COMMAND" in
     show)
         case "${1:-}" in
             phases) cmd_show_phases ;;
+            roles) cmd_show_roles ;;
             *) cmd_list ;;
         esac
         ;;
     set) cmd_set "$@" ;;
     route) cmd_route "$@" ;;
+    route-role|role-route) cmd_route_role "$@" ;;
+    unroute-role|role-unroute) cmd_unroute_role "$@" ;;
     reset) cmd_reset "$@" ;;
     models) cmd_models "$@" ;;
     providers|allowlist) cmd_provider_allowlist ;;

--- a/tests/unit/test-model-config-role-routing.sh
+++ b/tests/unit/test-model-config-role-routing.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "model-config role routing"
+
+HELPER="$SCRIPT_DIR/../../scripts/helpers/octo-model-config.sh"
+TMP_HOME="$(mktemp -d)"
+TMP_OUT="$TMP_HOME/model-config-role-route.out"
+TMP_ERR="$TMP_HOME/model-config-bad-role.out"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+run_helper() {
+    HOME="$TMP_HOME" "$HELPER" "$@"
+}
+
+test_case "route-role writes routing.roles override"
+run_helper route-role qa-reviewer codex:council >"$TMP_OUT"
+if jq -e '.routing.roles["qa-reviewer"] == "codex:council"' "$TMP_HOME/.claude-octopus/config/providers.json" >/dev/null; then
+    test_pass
+else
+    test_fail "route-role did not write expected role override"
+fi
+
+test_case "show roles displays explicit overrides"
+run_helper route-role researcher agy:default >"$TMP_OUT"
+if run_helper show roles | grep -c 'researcher.*agy:default' >/dev/null; then
+    test_pass
+else
+    test_fail "show roles did not display role override"
+fi
+
+test_case "unroute-role removes override"
+run_helper unroute-role qa-reviewer >"$TMP_OUT"
+if jq -e '.routing.roles["qa-reviewer"] == null' "$TMP_HOME/.claude-octopus/config/providers.json" >/dev/null; then
+    test_pass
+else
+    test_fail "unroute-role did not remove role override"
+fi
+
+test_case "invalid role name is rejected"
+if run_helper route-role 'bad role' codex:default >"$TMP_ERR" 2>&1; then
+    test_fail "invalid role name unexpectedly succeeded"
+elif grep -c 'Invalid role' "$TMP_ERR" >/dev/null; then
+    test_pass
+else
+    test_fail "invalid role error message missing"
+fi
+
+test_summary


### PR DESCRIPTION
Depends on #578 — this PR exposes the role-routing configuration surface; #578 fixes resolver precedence semantics for provider-scoped role routes.

Adds first-class model-config commands for role/persona routing overrides, so users do not need to hand-edit providers.json.routing.roles.

New commands:
- octo-model-config show roles
- octo-model-config route-role <role> <target>
- octo-model-config unroute-role <role>

Why:
- phase routing is already manageable via model-config, but role routing was only technically supported by providers.json;
- role overrides are the right mechanism for cases like researcher -> agy:default, logic-reviewer -> codex:logic_review, or QA/review roles -> codex:council while implementation remains on codex:default;
- the helper validates role names and uses jq --arg for safe JSON updates.

Validation:
- bash -n scripts/helpers/octo-model-config.sh .claude/commands/model-config.md tests/unit/test-model-config-role-routing.sh
- bash tests/unit/test-model-config-role-routing.sh -> 4/4 PASS
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role routing overrides to target different providers/models per role/persona.
  * Updated the model-config wizard with a “Route: Role Routing Overrides” section.
  * Added CLI commands to show, add (route-role), and remove (unroute-role) role overrides.
* **Bug Fixes**
  * Strengthened role name validation and refreshed routing cache after updates.
* **Tests**
  * Added unit tests for role override set/show/unroute and invalid input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->