### PR TITLE
release: v9.48.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.48.0 - adds the xAI Grok CLI as a first-class provider; plus reliability fixes: crash-safe stale-lock recovery for atomic_json_update, hardened hook-test isolation (no more deleting tracked repo files), and late-tangle-completion reconciliation. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.48.0",
+      "description": "v9.48.1 - adds Atlas Cloud as an OpenAI-compatible provider and model-config role routing commands; plus reliability fixes: OpenAI-compatible routing untangled from the Codex wrapper, role routes now override phase routes, grok honors its configured model, and a macOS lifecycle-hook-timeout test flake. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "version": "9.48.1",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.48.0"
+    "version": "9.48.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
   "version": "9.48.1",
-  "description": "v9.44.1 — Patch release for Gemini environment/version detection and qwen auth gating. Run /octo:setup.",
+  "description": "v9.48.1 — adds Atlas Cloud provider and model-config role routing commands; plus provider-routing and reliability fixes. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.48.0",
-  "description": "v9.44.1 \u2014 Patch release for Gemini environment/version detection and qwen auth gating. Run /octo:setup.",
+  "version": "9.48.1",
+  "description": "v9.44.1 — Patch release for Gemini environment/version detection and qwen auth gating. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.48.0",
+  "version": "9.48.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"
@@ -31,7 +31,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Claude Octopus",
-    "shortDescription": "Multi-LLM orchestration \u2014 dispatch to 8 providers from one plugin.",
+    "shortDescription": "Multi-LLM orchestration — dispatch to 8 providers from one plugin.",
     "longDescription": "Claude Octopus orchestrates multiple AI providers (Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, OpenCode) through structured Double Diamond workflows. 32 personas, 49 commands, 54 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch includes prompt-size preflight, agent summary tables, circuit breakers, cost tracking, and model routing.",
     "composerIcon": "./assets/octopus-icon.svg",
     "developerName": "nyldn",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
-  "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.48.0",
+  "description": "Multi-LLM orchestration — up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
+  "version": "9.48.1",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "claude-octopus",
       "source": "./",
       "description": "v9.48.0 - adds the xAI Grok CLI as a first-class provider; plus reliability fixes: crash-safe stale-lock recovery for atomic_json_update, hardened hook-test isolation (no more deleting tracked repo files), and late-tangle-completion reconciliation. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.48.0",
+      "version": "9.48.1",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.48.0"
+    "version": "9.48.1"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.48.0 - adds the xAI Grok CLI as a first-class provider; plus reliability fixes: crash-safe stale-lock recovery for atomic_json_update, hardened hook-test isolation (no more deleting tracked repo files), and late-tangle-completion reconciliation. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
+      "description": "v9.48.1 - adds Atlas Cloud as an OpenAI-compatible provider and model-config role routing commands; plus reliability fixes: OpenAI-compatible routing untangled from the Codex wrapper, role routes now override phase routes, grok honors its configured model, and a macOS lifecycle-hook-timeout test flake. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
       "version": "9.48.1",
       "author": {
         "name": "nyldn"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
   "version": "9.48.1",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.48.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.48.0",
+  "version": "9.48.1",
   "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,23 @@
 
 ## [Unreleased]
 
+## [9.48.1] - 2026-07-08
+
 ### Added
 
 - **Antigravity adapter (`agy-exec.sh`) hardened**: `OCTOPUS_AGY_SANDBOX=off` drops the `--sandbox` restriction, `OCTOPUS_AGY_INCLUDE_DIRS` (comma-separated) whitelists extra read dirs via `--add-dir`, and a single replay-from-stdin retry recovers a silent-empty success (opt out with `OCTOPUS_AGY_NO_RETRY=1`). The adapter stays a thin, env-driven wrapper — no model-fallback chain or error classifier.
+- **Atlas Cloud provider** (#579): new `atlascloud` preset on the OpenAI-compatible tool-loop agent, registered in dispatch, provider detection, health checks, and allowlist aliases. Requires an explicit model via `ATLASCLOUD_MODEL` (or `OCTOPUS_ATLASCLOUD_MODEL` / `OPENAI_COMPAT_MODEL` / `providers.json`) — no model ID is hardcoded.
+- **`model-config` role routing commands** (#587): `octo-model-config show roles`, `route-role`, and `unroute-role` expose role/persona routing overrides (e.g. `researcher -> agy:default`) without hand-editing `providers.json`.
+- **`code-review` contract context** (#573): the `code-review` JSON profile accepts optional `contextFile`/`contextText`/`contextLabel`, injected into reviewer and verifier prompts so `/octo:review` can flag diffs that miss acceptance criteria or violate the supplied task contract.
 
 ### Fixed
 
 - **Session `results`/`logs`/`plans` dirs are now created early** in `orchestrate.sh`, before any subcommand dispatches provider seats. Codex/agy seats write into `RESULTS_DIR` during dispatch and previously crashed when it was missing. The `mkdir -p` is cheap and idempotent.
 - **Ollama and Codex OSS models can no longer trigger an unbounded auto-pull on fallback.** Both `ollama run <model>` and the Codex CLI's built-in OSS/local-model handling silently download a missing model, so a provider-failure cascade could kick off an unbounded multi-GB pull with no human in the loop (observed: a ~42 GB pull). All Ollama dispatch now routes through a fail-closed shim (`scripts/helpers/ollama-run.sh`), and Codex dispatch for OSS models (e.g. `gpt-oss:*`) routes through `scripts/helpers/codex-run.sh`; both share the guard in `scripts/helpers/ollama-pull-guard.lib.sh` and refuse to pull an absent model unless `OCTOPUS_OLLAMA_ALLOW_PULL=true`, capping an allowed pull at `OCTOPUS_OLLAMA_MAX_PULL_GB` (default 20). Cloud Codex models (e.g. `gpt-5.x`, `o3`, `gpt-4.1`, `gpt-5.2-codex`) are unaffected and bypass the guard.
+- **OpenAI-compatible providers route outside the Codex wrapper** (#574): new first-class `openai-compatible`/`openai-tools` aliases wired through dispatch, model resolution, provider config, review, and council, so generic OpenAI-compatible/niche providers no longer hide behind a Codex-compatible shim. `OCTOPUS_CODEX_BIN` is removed; Codex dispatch stays native Codex only.
+- **Role model routes now override phase routes** (#578): `resolve_octopus_model` prefers `routing.roles[$role]` before `routing.phases[$phase]`, so a specialist reviewer role (e.g. `logic-reviewer -> codex:logic_review`) no longer silently inherits the broad phase default. Phase routing still applies when no role override exists.
+- **Grok provider now honors the configured model, isolates its environment, and propagates failures** (#586): the `grok` dispatch arm resolves the model via the same resolver codex/gemini/qwen use instead of running grok's vendor default silently; grok now runs under `env -i` isolation like the other CLI providers; and a non-zero grok exit is no longer masked by partial stdout.
+- **Lifecycle hook timeout test flake on macOS runners** (#589, closes #588): `tests/unit/test-agent-lifecycle-events.sh` asserted a fixed 4s wall-clock bound around a 1s configured hook timeout, which macOS scheduling jitter could occasionally exceed. Widened to the configured timeout plus a 9s grace margin, and hardened the slow-hook fixtures to sleep longer than the widened bound so a broken timeout mechanism can't false-pass.
 - **The agy council seat now records its real model instead of `"default"`.** `agy-exec` runs `agy --print` with `--model default` (agy uses whatever is picked in its own `/model` UI), so the roster artifact and preflight banner logged the opaque string `default` for the agy seat — making a Codex+agy panel's cross-lab-vs-same-lineage status unverifiable from `summary.json`. New `agy_current_model()` (`lib/providers.sh`) honors `OCTOPUS_AGY_MODEL`, else resolves the selection from `~/.gemini/antigravity-cli/settings.json`, else fails safe to `default (unresolved)`; it's wired into `council_roster_entry_json` and the preflight banner. Purely diagnostic — never gates logic, and guarded with `declare -f` so standalone runs fall back to prior behavior.
 
 ## [9.48.0] - 2026-07-06

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.48.0-blue" alt="Version 9.48.0">
+  <img src="https://img.shields.io/badge/Version-9.48.1-blue" alt="Version 9.48.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.48.0",
+  "version": "9.48.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Description
Patch release bundling everything merged to `main` since `v9.48.0`, including today's flaky-test fix (#589, closes #588) plus several PRs from other contributors that merged during this run.

## Type of Change
- [x] Other (describe): version release

## Note on version number
This is cut as a **patch** release per the automated daily-triage routine's release policy. Two of the bundled PRs (#579 Atlas Cloud provider, #587 model-config role routing commands) add new user-facing functionality rather than fixing a bug — a `9.49.0` minor bump may be more semantically correct. Flagging for human judgment before merge; I did not make that call myself.

## Included

**Added**
- Atlas Cloud OpenAI-compatible provider (#579)
- `model-config` role routing commands (#587)
- `code-review` contract context (#573)
- Antigravity adapter hardening (`agy-exec.sh`) — already staged in CHANGELOG's Unreleased section prior to this run

**Fixed**
- OpenAI-compatible providers routed outside the Codex wrapper (#574)
- Role model routes now override phase routes (#578)
- Grok honors its configured model, isolates its environment, propagates non-zero exit (#586)
- Session `results`/`logs`/`plans` dirs created early (#501) — already staged
- Ollama/Codex OSS auto-pull guard (#532) — already staged
- Agy council seat records its real model (#585) — already staged
- **macOS lifecycle-hook-timeout test flake (#589, closes #588)** — the fix from this triage run

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-docs-sync.sh` (134/134)
- [x] Version bump: package.json + all plugin manifests (`.claude-plugin`, `.codex-plugin`, `.cursor-plugin`, `.factory-plugin`) + both marketplace.json entries + README.md badge
- [x] CHANGELOG.md updated (renamed `[Unreleased]` → `[9.48.1]`, added entries for the previously-undocumented merged PRs)

## Testing
```bash
jq empty package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json \
  .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json \
  .factory-plugin/marketplace.json          # all valid
bash tests/unit/test-docs-sync.sh            # 134/134 passed
make test-unit                               # 157/159 passed
make test-integration                        # 7/7 passed
```
The 2 unit-test failures (`test-github-work-queue-hook.sh`, `test-hud-smart-mode.sh`) are pre-existing and environment-related (missing GitHub/HUD context in this sandbox), unrelated to this diff.

## Related Issues
N/A — release PR bundling #589 (closes #588) and other already-merged work.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HRf4g7EYkYSFpinWVD2m1T)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Atlas Cloud provider preset tooling.
  * Added model-config role routing commands to view, route, and clear role overrides.
  * Added optional contract context support to code review checks.
* **Bug Fixes**
  * Improved OpenAI-compatible provider routing (outside the Codex wrapper).
  * Fixed role model routing overriding phase routing.
  * Improved Grok model honoring and failure handling reliability.
  * Prevented unbounded Ollama/Codex OSS auto-pulls and ensured session result/log/plan directories are created early.
  * Resolved a macOS lifecycle hook timeout test flake.
* **Chores**
  * Bumped all version metadata to **9.48.1** and updated release notes formatting in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->