### PR TITLE
feat: v9.50.0 — Claude Code 2026 compatibility layer

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -312,6 +312,16 @@
           "timeout": 10
         }
       ]
+    },
+    {
+      "matcher": {},
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/subagent-stop-gate.sh",
+          "timeout": 10
+        }
+      ]
     }
   ],
   "InstructionsLoaded": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.48.0"
+    "version": "9.50.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.48.0 - adds the xAI Grok CLI as a first-class provider; plus reliability fixes: crash-safe stale-lock recovery for atomic_json_update, hardened hook-test isolation (no more deleting tracked repo files), and late-tangle-completion reconciliation. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.48.0",
+      "description": "v9.50.0 - Claude Code 2026 compatibility layer: routines manifest, SubagentStop quality/cost gate, /octo:usage report, worktree bgIsolation opt-out, Claude Agent SDK seat (Opus 4.8, 1M context), starter skills pack, /plugin browse manifest. 42 agents, 50 commands, 58 skills. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
+      "version": "9.50.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -1,0 +1,57 @@
+{
+  "$comment": "Claude Code /plugin browse manifest (2026-06 schema). Surfaces projected context cost and component inventory in the plugin browse pane. Component detail lives in plugin.json / hooks.json / routines.json; this file is the browse-pane summary and must stay version-locked with them.",
+  "schemaVersion": "2026-06",
+  "name": "octo",
+  "displayName": "Claude Octopus",
+  "version": "9.50.0",
+  "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
+  "author": {
+    "name": "nyldn",
+    "url": "https://github.com/nyldn"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/nyldn/claude-octopus",
+  "category": "orchestration",
+  "projectedContextCost": {
+    "estimatedTokens": 4200,
+    "breakdown": {
+      "systemInstructions": 2600,
+      "commandFrontmatter": 900,
+      "hookAdditionalContext": 700
+    },
+    "notes": "Baseline session load. Skills load on invocation only; external provider dispatch happens out-of-context via orchestrate.sh."
+  },
+  "components": {
+    "commands": {
+      "count": 50,
+      "highlights": ["/octo:embrace", "/octo:discover", "/octo:develop", "/octo:review", "/octo:debate", "/octo:council", "/octo:usage", "/octo:setup"]
+    },
+    "agents": {
+      "count": 42,
+      "breakdown": {
+        "personas": 32,
+        "droids": 10
+      }
+    },
+    "skills": {
+      "count": 58,
+      "highlights": ["flow-discover", "flow-develop", "skill-council", "skill-debate", "octopus-starter-pack/debate-kickoff", "octopus-starter-pack/council-verdicts", "octopus-starter-pack/provider-health", "octopus-starter-pack/model-cost-compare"]
+    },
+    "hooks": {
+      "events": 20,
+      "highlights": ["SubagentStop (result capture + quality/cost gate)", "SessionStart", "PreCompact", "WorktreeCreate", "UserPromptSubmit"]
+    },
+    "mcpServers": {
+      "count": 0
+    },
+    "routines": {
+      "count": 4,
+      "manifest": ".claude-plugin/routines.json",
+      "notes": "All routines ship disabled; enable per-project."
+    }
+  },
+  "compatibility": {
+    "claudeCode": ">=2.1.50",
+    "notes": "Full feature set (worktree isolation opt-out, SubagentStop gating, routines) targets Claude Code 2026 releases; older versions degrade gracefully via SUPPORTS_* feature detection."
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.48.0",
-  "description": "v9.44.1 \u2014 Patch release for Gemini environment/version detection and qwen auth gating. Run /octo:setup.",
+  "version": "9.50.0",
+  "description": "v9.50.0 - Claude Code 2026 compatibility layer: routines manifest, SubagentStop quality/cost gate, /octo:usage report, worktree bgIsolation opt-out, Claude Agent SDK seat (Opus 4.8, 1M context), starter skills pack, /plugin browse manifest. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"
@@ -77,7 +77,11 @@
     "./skills/skill-verify",
     "./skills/skill-visual-feedback",
     "./skills/skill-writing-plans",
-    "./skills/sys-configure"
+    "./skills/sys-configure",
+    "./skills/octopus-starter-pack/debate-kickoff",
+    "./skills/octopus-starter-pack/council-verdicts",
+    "./skills/octopus-starter-pack/provider-health",
+    "./skills/octopus-starter-pack/model-cost-compare"
   ],
   "commands": [
     "./.claude/commands/auto.md",
@@ -128,6 +132,7 @@
     "./.claude/commands/council.md",
     "./.claude/commands/retro.md",
     "./.claude/commands/history.md",
-    "./.claude/commands/discipline.md"
+    "./.claude/commands/discipline.md",
+    "./.claude/commands/usage.md"
   ]
 }

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,0 +1,62 @@
+{
+  "$comment": "Claude Octopus routine manifest (v9.50.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "schemaVersion": 1,
+  "routines": [
+    {
+      "name": "octo-nightly-security-audit",
+      "description": "Multi-provider security audit of the working tree every night",
+      "enabled": false,
+      "trigger": {
+        "type": "schedule",
+        "cron": "0 3 * * *",
+        "timezone": "UTC"
+      },
+      "command": "/octo:security",
+      "args": "--scope full",
+      "providers": ["claude", "codex", "agy"],
+      "costNote": "Dispatches codex + agy seats; expect $0.10-0.60 per run"
+    },
+    {
+      "name": "octo-weekly-provider-health",
+      "description": "Provider availability, auth, and version drift check every Monday",
+      "enabled": false,
+      "trigger": {
+        "type": "schedule",
+        "cron": "0 9 * * 1",
+        "timezone": "UTC"
+      },
+      "command": "/octo:setup",
+      "args": "--check-only",
+      "providers": ["claude"],
+      "costNote": "Detection only; no external provider dispatch"
+    },
+    {
+      "name": "octo-usage-digest",
+      "description": "Weekly per-provider cost and token digest from usage records",
+      "enabled": false,
+      "trigger": {
+        "type": "schedule",
+        "cron": "0 18 * * 5",
+        "timezone": "UTC"
+      },
+      "command": "/octo:usage",
+      "args": "--format json",
+      "providers": ["claude"],
+      "costNote": "Reads local RESULTS_DIR artifacts; no provider dispatch"
+    },
+    {
+      "name": "octo-pr-review",
+      "description": "Multi-provider adversarial review when a pull request opens or updates",
+      "enabled": false,
+      "trigger": {
+        "type": "github",
+        "event": "pull_request",
+        "actions": ["opened", "synchronize"]
+      },
+      "command": "/octo:review",
+      "args": "--staged",
+      "providers": ["claude", "codex", "agy"],
+      "costNote": "Dispatches codex + agy seats per PR update; gate on repo size"
+    }
+  ]
+}

--- a/.claude/commands/usage.md
+++ b/.claude/commands/usage.md
@@ -1,0 +1,44 @@
+---
+command: usage
+description: "[advanced] Per-provider, per-skill, and per-MCP-server cost and token breakdown (Claude Code /usage schema)"
+allowed-tools: Bash, Read, Glob
+---
+
+# Usage Report (/octo:usage)
+
+**Your first output line MUST be:** `🐙 Octopus Usage Report`
+
+Produce a per-provider, per-skill, and per-MCP-server cost and token breakdown from recorded Octopus usage artifacts. Output schema matches Claude Code's native `/usage` report (`claude-code/usage-v1`), so results can be compared or merged with the host session's own usage pane.
+
+## EXECUTION CONTRACT (Mandatory)
+
+### STEP 1: Run the report helper
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/helpers/usage-report.sh --format table
+```
+
+If the user asked for machine-readable output (or passed `--format json`):
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/helpers/usage-report.sh --format json
+```
+
+The helper reads:
+- `~/.claude-octopus/usage/*.jsonl` — JSONL records written by `hooks/subagent-stop-gate.sh` and provider adapters
+- `~/.claude-octopus/results/**/summary.json` — council and workflow roster artifacts (query counts)
+
+### STEP 2: Present the breakdown
+
+Show the helper's table output directly. Then add a one-paragraph interpretation:
+- Which provider drove the most estimated cost
+- Whether any external CLI seat (🔴 Codex, 🧭 Antigravity) dominates and could be swapped for an included provider
+- Whether MCP server usage is material
+
+### STEP 3: Flag empty data honestly
+
+If the helper prints `No usage records found`, say so and point the user at `OCTOPUS_SUBAGENT_GATE_STRICT` and the SubagentStop gate hook (`hooks/subagent-stop-gate.sh`), which populates the usage log as subagents complete. Do not fabricate numbers.
+
+## Cost Reference
+
+Rates come from the table embedded in `scripts/helpers/usage-report.sh` and mirror the cost table in CLAUDE.md ($/MTok input/output). Providers with subscription or local backends (agy, copilot, ollama, cursor-agent, opencode native) report $0.00.

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.48.0",
+  "version": "9.50.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.48.0",
+  "version": "9.50.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.48.0"
+    "version": "9.50.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.48.0 - adds the xAI Grok CLI as a first-class provider; plus reliability fixes: crash-safe stale-lock recovery for atomic_json_update, hardened hook-test isolation (no more deleting tracked repo files), and late-tangle-completion reconciliation. 32 personas, 49 commands, 54 skills. Run /octo:setup.",
-      "version": "9.48.0",
+      "description": "v9.50.0 - Claude Code 2026 compatibility layer: routines manifest, SubagentStop quality/cost gate, /octo:usage report, worktree bgIsolation opt-out, Claude Agent SDK seat (Opus 4.8, 1M context), starter skills pack, /plugin browse manifest. 42 agents, 50 commands, 58 skills. Run /octo:setup.",
+      "version": "9.50.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.48.0",
+  "version": "9.50.0",
   "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,25 @@
 
 ## [Unreleased]
 
+## [9.50.0] - 2026-07-08
+
+Claude Code 2026 compatibility layer release.
+
 ### Added
 
+- **Routine manifest (`.claude-plugin/routines.json`)**: saved automation configs for Claude Code routines. Ships four routines (nightly security audit, weekly provider health, weekly usage digest, PR-open review), each mapping a schedule or GitHub event trigger to an `/octo:` command with an explicit provider roster and cost note. All routines ship disabled; enable per-project.
+- **SubagentStop gate hook (`hooks/subagent-stop-gate.sh`)**: runs after `subagent-result-capture.sh` in the SubagentStop chain. Attributes each finished subagent to its provider, computes a 0-100 quality heuristic, appends a JSONL usage record to `~/.claude-octopus/usage/subagent-usage.jsonl`, and pre-screens council verdict blocks for a recognizable verdict token. Non-blocking by default; `OCTOPUS_SUBAGENT_GATE_STRICT=true` blocks malformed verdicts and summaries below the `OCTOPUS_SUBAGENT_MIN_QUALITY` floor before they reach the lead.
+- **`/octo:usage` cost attribution**: new command backed by `scripts/helpers/usage-report.sh`. Reads usage JSONL records plus `results/**/summary.json` roster artifacts and produces a per-provider, per-skill, and per-MCP-server token and cost breakdown in Claude Code's `/usage` schema (`claude-code/usage-v1`), as a table or JSON.
+- **Worktree background isolation opt-out**: `OCTOPUS_WORKTREE_BG_ISOLATION=false` (mirror of Claude Code's `worktree.bgIsolation` session flag) disables worktree cloning for background agents; detection downgrades `SUPPORTS_WORKTREE_ISOLATION` and `hooks/worktree-setup.sh` short-circuits, so fast direct-edit runs skip the clone entirely. Default remains isolation on.
+- **Claude Agent SDK provider seat (`claude-sdk`)**: setting `CLAUDE_SDK_API_KEY` unlocks a new seat routed through `scripts/helpers/claude-sdk-exec.sh`, giving workflows Opus 4.8 and the 1M-token context window independent of the host session. Prefers the `claude-agent` SDK CLI, falls back to headless `claude --print` with session markers stripped. Model via `OCTOPUS_CLAUDE_SDK_MODEL` (default `claude-opus-4-8`); wired through dispatch, model resolution, allowlists (`OCTOPUS_CLAUDE_SDK_ALLOWED_MODELS`), routing, detection, and health checks.
+- **Skills starter pack (`skills/octopus-starter-pack/`)**: four opinionated starter skills: `debate-kickoff` (frame a decision as a seated multi-model debate), `council-verdicts` (interpret quorum, dissent, and cross-lab validity of a council run), `provider-health` (one-screen availability/auth/cost posture summary), and `model-cost-compare` (map a task to the cheapest adequate seat with a price spread).
+- **Plugin browse manifest (`.claude-plugin/plugin-manifest.json`)**: `/plugin browse` metadata (2026-06 schema) with projected context cost (about 4.2K tokens baseline), component inventory (50 commands, 42 agents, 58 skills, 20 hook events, 4 routines), and Claude Code compatibility range.
 - **Antigravity adapter (`agy-exec.sh`) hardened**: `OCTOPUS_AGY_SANDBOX=off` drops the `--sandbox` restriction, `OCTOPUS_AGY_INCLUDE_DIRS` (comma-separated) whitelists extra read dirs via `--add-dir`, and a single replay-from-stdin retry recovers a silent-empty success (opt out with `OCTOPUS_AGY_NO_RETRY=1`). The adapter stays a thin, env-driven wrapper — no model-fallback chain or error classifier.
+
+### Changed
+
+- **SubagentStop is now a two-hook chain**: `subagent-result-capture.sh` (result file bridging) then `subagent-stop-gate.sh` (quality/cost/verdict gate). Existing capture behavior is unchanged.
+- **Plugin metadata refreshed across all manifests** (`.claude-plugin`, `.codex-plugin`, `.cursor-plugin`, `.factory-plugin`): descriptions and component counts now reflect 50 commands, 42 agents, and 58 skills.
 
 ### Fixed
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -86,6 +86,10 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 - Token compression (`bin/octo-compress`): ~7,300 tokens saved per session
 - 170+ Claude Code feature flags tracked through v2.1.132
 
+## Claude Code 2026 Compatibility Layer (v9.50.0)
+
+The plugin tracks Claude Code's native capability surface instead of competing with it. As of v9.50.0 that means: a routine manifest so octopus workflows run on Claude Code's saved automations (schedules and GitHub events); a SubagentStop gate that scores, attributes, and cost-logs every subagent summary before the lead sees it; `/octo:usage` reporting in Claude Code's `/usage` schema; an opt-out mirror of the `worktree.bgIsolation` session flag; a Claude Agent SDK seat (`CLAUDE_SDK_API_KEY`) that gives workflows Opus 4.8 and the 1M context window; a four-skill starter pack matching the opinionated-skills-pack trend; and a `/plugin browse` manifest that discloses projected context cost up front. Native-first remains the rule: Octopus adds multi-provider disagreement on top of Claude Code, never a replacement for it.
+
 ## Known Product Gaps
 
 | Gap | Impact | Status |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.48.0-blue" alt="Version 9.48.0">
+  <img src="https://img.shields.io/badge/Version-9.50.0-blue" alt="Version 9.50.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -25,7 +25,7 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
 
 🔄 **Four-phase methodology, not just tools.** Every task moves through Discover → Define → Develop → Deliver, with quality gates between phases. Other orchestrators give you infrastructure. Octopus gives you the workflows.
 
-🐙 **32 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **49 commands** (slash commands you type), **54 skills** (reusable workflow modules). Say "audit my API" and the right expert activates. Don't know the command? The smart router figures it out.
+🐙 **32 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **50 commands** (slash commands you type), **58 skills** (reusable workflow modules). Say "audit my API" and the right expert activates. Don't know the command? The smart router figures it out.
 
 🐙 **Works with just Claude. Scales to nine.** Zero providers needed to start. Add them one at a time — each activates automatically when detected.
 
@@ -34,6 +34,13 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
 ---
 
 ## What's New
+
+> 🆕 **v9.50 — Claude Code 2026 compatibility layer.** Routine manifest for scheduled and GitHub-event automations, a SubagentStop quality/cost gate, `/octo:usage` per-provider cost attribution in Claude Code's `/usage` schema, a `worktree.bgIsolation` opt-out for fast direct-edit runs, a Claude Agent SDK seat (`CLAUDE_SDK_API_KEY`, Opus 4.8, 1M context), a four-skill starter pack, and a `/plugin browse` manifest with projected context cost.
+>
+> ```bash
+> /octo:usage --format table        # who spent what, per provider/skill/MCP server
+> OCTOPUS_WORKTREE_BG_ISOLATION=false   # skip worktree cloning for fast runs
+> ```
 
 > 🆕 **v9.41 — Multi-LLM Council.** `/octo:council` runs a structured 3/5/7-persona deliberation across Claude, Codex, Gemini, and OpenCode with goal modes (`advice`, `decision`, `plan`, `implement`, `review`), styles (`balanced`, `adversarial`, `red-team`, `executive`, `implementation`), benchmark-aware role routing, quorum + critical-veto gates, budget caps, and gated worktree handoff for approved plans. Use it when one model's opinion isn't enough.
 >
@@ -44,7 +51,8 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
 
 | Version | Best Features |
 |---------|--------------|
-| **v9.41** (new) | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
+| **v9.50** (new) | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (Opus 4.8, 1M context), starter skills pack, `/plugin browse` manifest with projected context cost. |
+| **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
 | **v9** (current) | Up to 9 providers (Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode). Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 175+ CC feature flags through v2.1.157, including Opus 4.8 and dynamic workflow awareness. |
 | **v8** | Multi-LLM code review with inline PR comments. Parallel workstreams in isolated git worktrees. Reaction engine — auto-responds to CI failures. 32 specialized personas. Dark Factory autonomous pipeline. |
 | **v7** | Double Diamond workflow. Multi-provider dispatch. Quality gates and consensus scoring. Configurable sandbox modes. |
@@ -356,7 +364,7 @@ Specialized agents that activate automatically based on your request. When you s
 
 Categories: Software Engineering (11), Specialized Development (6), Documentation & Communication (5), Research & Strategy (3), Business & Compliance (3), Creative & Design (4).
 
-[Full persona reference](docs/AGENTS.md) | [All 54 skills](docs/COMMAND-REFERENCE.md)
+[Full persona reference](docs/AGENTS.md) | [All 58 skills](docs/COMMAND-REFERENCE.md)
 
 ### Built-in Reaction Engine
 
@@ -405,6 +413,33 @@ OAuth users pay nothing beyond their existing subscriptions. Qwen is the excepti
 ### What You Get With Just Claude
 
 Everything except multi-AI features. You get all 32 personas, structured workflows, smart routing, context detection, and every skill. Multi-AI orchestration (parallel analysis, debate, consensus) activates when external providers are configured.
+
+---
+
+## Claude Code 2026 Compatibility Layer
+
+v9.50.0 aligns the plugin with Claude Code's 2026 native capabilities. Each piece degrades gracefully on older Claude Code versions via the existing `SUPPORTS_*` feature detection.
+
+- **Routines** (`.claude-plugin/routines.json`): saved automation configs mapping schedule and GitHub-event triggers to `/octo:` commands. All ship disabled; each entry carries a provider roster and a cost note so you know what enabling it will bill.
+- **SubagentStop gate** (`hooks/subagent-stop-gate.sh`): quality scoring, provider attribution, cost logging, and council verdict pre-screening before a subagent's summary reaches the lead.
+- **`/octo:usage`**: per-provider, per-skill, and per-MCP-server token and cost breakdown in Claude Code's `/usage` schema, built from local usage records (no provider dispatch).
+- **Worktree bgIsolation opt-out**: mirror of Claude Code's `worktree.bgIsolation` session flag; disables background worktree cloning for fast direct-edit runs.
+- **Claude Agent SDK seat** (`claude-sdk`): with `CLAUDE_SDK_API_KEY` set, workflows can seat Opus 4.8 with the 1M-token context window independent of the host session.
+- **Starter pack** (`skills/octopus-starter-pack/`): debate kickoff, council verdict interpretation, provider health summary, and model cost comparison skills.
+- **`/plugin browse` manifest** (`.claude-plugin/plugin-manifest.json`): projected context cost and component inventory for the plugin browse pane.
+
+### New environment variables (v9.50.0)
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `CLAUDE_SDK_API_KEY` | unset | Enables the `claude-sdk` provider seat (Claude Agent SDK; Opus 4.8, 1M context) |
+| `OCTOPUS_CLAUDE_SDK_MODEL` | `claude-opus-4-8` | Model for the `claude-sdk` seat |
+| `OCTOPUS_CLAUDE_SDK_MAX_TOKENS` | `8192` | Max output tokens for the `claude-sdk` seat (SDK CLI path) |
+| `OCTOPUS_CLAUDE_SDK_ALLOWED_MODELS` | unset | Comma-separated model allowlist for the `claude-sdk` seat |
+| `OCTOPUS_CLAUDE_SDK_CONTEXT_BUDGET` | `1000000` | Prompt context budget for `claude-sdk` agent types |
+| `OCTOPUS_WORKTREE_BG_ISOLATION` | `true` | Set `false` to skip background worktree cloning (fast direct-edit runs) |
+| `OCTOPUS_SUBAGENT_GATE_STRICT` | `false` | Set `true` to let the SubagentStop gate block malformed council verdicts and low-quality summaries |
+| `OCTOPUS_SUBAGENT_MIN_QUALITY` | `0` | Quality floor (0-100) enforced by the gate in strict mode; `0` disables |
 
 ---
 

--- a/hooks/subagent-stop-gate.sh
+++ b/hooks/subagent-stop-gate.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# SubagentStop Gate — Quality scoring, provider attribution, cost logging, and
+# council verdict pre-screening before a subagent's summary reaches the lead.
+#
+# Runs AFTER subagent-result-capture.sh in the SubagentStop chain (v9.50.0).
+# Responsibilities:
+#   1. Provider attribution — map agent_type to an Octopus provider name
+#   2. Quality score — cheap 0-100 heuristic (length + error markers)
+#   3. Cost logging — append a JSONL usage record for /octo:usage aggregation
+#   4. Council verdict pre-screen — flag malformed verdict blocks before they
+#      reach the lead; blocks only when OCTOPUS_SUBAGENT_GATE_STRICT=true
+#
+# Hook event: SubagentStop
+# Env knobs:
+#   OCTOPUS_SUBAGENT_GATE_STRICT   (default false) — block on gate failures
+#   OCTOPUS_SUBAGENT_MIN_QUALITY   (default 0)     — quality floor, 0 disables
+# Returns: exit 0 with no output (allow), or {"decision":"block","reason":...}
+
+set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
+trap _octo_hook_exit EXIT
+
+WORKSPACE_DIR="${OCTOPUS_WORKSPACE:-${HOME}/.claude-octopus}"
+USAGE_DIR="${WORKSPACE_DIR}/usage"
+
+# Guard: python3 required for JSON parsing
+if ! command -v python3 &>/dev/null; then
+    exit 0
+fi
+
+# Read hook input from stdin
+if [ -t 0 ]; then exit 0; fi
+if command -v timeout &>/dev/null; then
+    INPUT=$(timeout 3 cat 2>/dev/null || true)
+else
+    INPUT=$(cat 2>/dev/null || true)
+fi
+[[ -z "$INPUT" ]] && exit 0
+
+# Single python pass: parse payload, score, attribute, log, and pre-screen.
+# Emits either nothing (allow) or a block-decision JSON on stdout.
+_OCTOPUS_INPUT="$INPUT" \
+_OCTOPUS_USAGE_DIR="$USAGE_DIR" \
+_OCTOPUS_GATE_STRICT="${OCTOPUS_SUBAGENT_GATE_STRICT:-false}" \
+_OCTOPUS_MIN_QUALITY="${OCTOPUS_SUBAGENT_MIN_QUALITY:-0}" \
+_OCTOPUS_PHASE="${OCTOPUS_WORKFLOW_PHASE:-}" \
+_OCTOPUS_SKILL="${OCTOPUS_ACTIVE_SKILL:-}" \
+python3 - <<'PYEOF' 2>/dev/null || exit 0
+import json, os, re, sys, time
+
+try:
+    d = json.loads(os.environ.get("_OCTOPUS_INPUT", "") or "{}")
+except Exception:
+    sys.exit(0)
+
+msg = d.get("last_assistant_message", "") or ""
+agent_id = d.get("agent_id", "") or ""
+agent_type = (d.get("agent_type", "") or "").lower()
+
+# --- 1. Provider attribution ---------------------------------------------
+PROVIDER_PREFIXES = [
+    ("codex", "codex"), ("gemini", "gemini"), ("agy", "agy"),
+    ("antigravity", "agy"), ("claude-sdk", "claude-sdk"),
+    ("claude", "claude"), ("openrouter", "openrouter"),
+    ("atlascloud", "atlascloud"), ("openai-", "openai-compatible-agent"),
+    ("perplexity", "perplexity"), ("qwen", "qwen"),
+    ("cursor-agent", "cursor-agent"), ("grok", "grok"),
+    ("opencode", "opencode"), ("ollama", "ollama"),
+    ("copilot", "copilot"), ("vibe", "vibe"),
+]
+provider = "claude"  # native subagents default to Claude
+for prefix, name in PROVIDER_PREFIXES:
+    if agent_type.startswith(prefix):
+        provider = name
+        break
+
+# --- 2. Quality score (0-100 heuristic) ----------------------------------
+# Length component: 0 chars -> 0, 400+ chars -> 60. Error markers subtract.
+score = min(60, len(msg) // 7 if msg else 0)
+if re.search(r"^#+\s|\n[-*]\s|```", msg):
+    score += 20  # structured output (headings, lists, code blocks)
+if re.search(r"\b(SUCCESS|PASS|complete[d]?|verified)\b", msg, re.I):
+    score += 20
+for marker in ("Traceback", "command not found", "Permission denied",
+               "FATAL", "rate limit", "ETIMEDOUT"):
+    if marker in msg:
+        score -= 25
+score = max(0, min(100, score))
+
+# --- 3. Cost logging (JSONL for /octo:usage) ------------------------------
+est_tokens = max(1, len(msg) // 4) if msg else 0
+record = {
+    "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "source": "subagent-stop-gate",
+    "agent_id": agent_id,
+    "agent_type": agent_type,
+    "provider": provider,
+    "skill": os.environ.get("_OCTOPUS_SKILL", ""),
+    "phase": os.environ.get("_OCTOPUS_PHASE", ""),
+    "chars_out": len(msg),
+    "est_tokens_out": est_tokens,
+    "quality": score,
+}
+usage_dir = os.environ.get("_OCTOPUS_USAGE_DIR", "")
+if usage_dir:
+    try:
+        os.makedirs(usage_dir, exist_ok=True)
+        with open(os.path.join(usage_dir, "subagent-usage.jsonl"), "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception:
+        pass
+
+# --- 4. Council verdict pre-screen + quality floor ------------------------
+strict = os.environ.get("_OCTOPUS_GATE_STRICT", "false") == "true"
+try:
+    min_quality = int(os.environ.get("_OCTOPUS_MIN_QUALITY", "0"))
+except ValueError:
+    min_quality = 0
+
+reasons = []
+has_verdict_block = bool(re.search(r"(^|\n)#{0,3}\s*Verdict\b|VERDICT\s*:", msg, re.I))
+if has_verdict_block:
+    valid = re.search(
+        r"\b(APPROVE[D]?|REJECT[ED]?|ABSTAIN|REVISE|BLOCK|PASS|FAIL)\b", msg)
+    if not valid:
+        reasons.append(
+            "council verdict block present but no recognizable verdict token "
+            "(APPROVE/REJECT/ABSTAIN/REVISE/BLOCK/PASS/FAIL)")
+if min_quality > 0 and score < min_quality:
+    reasons.append(f"quality score {score} below floor {min_quality}")
+
+if reasons and strict:
+    print(json.dumps({
+        "decision": "block",
+        "reason": "subagent-stop-gate [{}]: {}".format(provider, "; ".join(reasons)),
+    }))
+PYEOF
+
+exit 0

--- a/hooks/worktree-setup.sh
+++ b/hooks/worktree-setup.sh
@@ -16,6 +16,15 @@ _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "
 trap _octo_hook_exit EXIT
 
 
+# v9.50.0: worktree.bgIsolation opt-out — when the user disables background
+# worktree isolation (OCTOPUS_WORKTREE_BG_ISOLATION=false) agents edit the
+# checkout directly, so there is no clone to seed. Short-circuit before any
+# stdin read or file writes.
+if [[ "${OCTOPUS_WORKTREE_BG_ISOLATION:-true}" == "false" ]]; then
+    echo '{"decision": "continue"}'
+    exit 0
+fi
+
 # Read worktree info from stdin (JSON payload from Claude Code)
 WORKTREE_DATA=""
 if [[ ! -t 0 ]]; then

--- a/openclaw/src/tools/index.ts
+++ b/openclaw/src/tools/index.ts
@@ -116,6 +116,7 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "staged-review", description: "[advanced] Two-stage review: spec compliance then code quality", type: "command", file: "staged-review.md" },
   { name: "tdd", description: "Test-driven development with red-green-refactor discipline", type: "command", file: "tdd.md" },
   { name: "unfreeze", description: "[advanced] Remove freeze mode edit restriction", type: "command", file: "unfreeze.md" },
+  { name: "usage", description: "[advanced] Per-provider, per-skill, and per-MCP-server cost and token breakdown (Claude Code /usage schema)", type: "command", file: "usage.md" },
 ];
 
-export const REGISTRY_COUNT = 101;
+export const REGISTRY_COUNT = 102;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.48.0",
+  "version": "9.50.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/scripts/helpers/claude-sdk-exec.sh
+++ b/scripts/helpers/claude-sdk-exec.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Claude Agent SDK stdin shim (v9.50.0). Routes the claude-sdk provider seat
+# to the Claude Agent SDK when CLAUDE_SDK_API_KEY is set, unlocking Opus 4.8
+# and the 1M-token context window independent of the host Claude Code session.
+#
+# octo pipes prompts via stdin (spawn.sh contract). Resolution order:
+#   1. `claude-agent` CLI (Claude Agent SDK) if on PATH — preferred
+#   2. `claude --print` headless fallback, authenticated with the SDK key
+#      (ANTHROPIC_API_KEY set from CLAUDE_SDK_API_KEY, session markers stripped
+#      so the inner claude never thinks it is a nested child — see #300 family)
+#
+# Env:
+#   CLAUDE_SDK_API_KEY            required — refuses to run without it
+#   OCTOPUS_CLAUDE_SDK_MODEL      default: claude-opus-4-8
+#   OCTOPUS_CLAUDE_SDK_MAX_TOKENS default: 8192
+set -euo pipefail
+
+if [[ -z "${CLAUDE_SDK_API_KEY:-}" ]]; then
+    # Standalone shim (exec'd by dispatch.sh) — matches grok-exec.sh / vibe-exec.sh
+    # which also use raw echo>&2 for startup validation (no shared logger in scope).
+    echo "claude-sdk-exec: CLAUDE_SDK_API_KEY is not set" >&2
+    exit 78
+fi
+
+prompt=""
+[[ ! -t 0 ]] && prompt="$(cat)"
+if [[ -z "${prompt//[[:space:]]/}" ]]; then
+    echo "claude-sdk-exec: no prompt provided on stdin" >&2
+    exit 64
+fi
+
+model="${OCTOPUS_CLAUDE_SDK_MODEL:-claude-opus-4-8}"
+max_tokens="${OCTOPUS_CLAUDE_SDK_MAX_TOKENS:-8192}"
+
+if command -v claude-agent &>/dev/null; then
+    exec env -u CLAUDECODE -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_SESSION_ID \
+        -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_EXECPATH \
+        "ANTHROPIC_API_KEY=${CLAUDE_SDK_API_KEY}" \
+        claude-agent --print --model "$model" --max-tokens "$max_tokens" <<<"$prompt"
+fi
+
+if command -v claude &>/dev/null; then
+    exec env -u CLAUDECODE -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_SESSION_ID \
+        -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_EXECPATH \
+        "ANTHROPIC_API_KEY=${CLAUDE_SDK_API_KEY}" \
+        claude --print --model "$model" <<<"$prompt"
+fi
+
+echo "claude-sdk-exec: neither claude-agent (Agent SDK) nor claude CLI found in PATH" >&2
+exit 69

--- a/scripts/helpers/usage-report.sh
+++ b/scripts/helpers/usage-report.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Usage report (v9.50.0) — per-provider / per-skill / per-MCP-server cost and
+# token breakdown for /octo:usage, matching Claude Code's /usage schema.
+#
+# Reads JSONL usage records from ${OCTOPUS_WORKSPACE:-~/.claude-octopus}/usage/
+# (written by hooks/subagent-stop-gate.sh and any provider adapters) plus
+# summary.json artifacts under the results dir.
+#
+# Usage: usage-report.sh [--format table|json] [--usage-dir DIR] [--results-dir DIR]
+set -euo pipefail
+
+FORMAT="table"
+WORKSPACE_DIR="${OCTOPUS_WORKSPACE:-${HOME}/.claude-octopus}"
+USAGE_DIR="${WORKSPACE_DIR}/usage"
+RESULTS_DIR="${WORKSPACE_DIR}/results"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --format)      FORMAT="${2:-table}"; shift 2 ;;
+        --usage-dir)   USAGE_DIR="${2:?}"; shift 2 ;;
+        --results-dir) RESULTS_DIR="${2:?}"; shift 2 ;;
+        *) echo "usage-report: unknown argument: $1" >&2; exit 64 ;;
+    esac
+done
+
+if [[ "$FORMAT" != "table" && "$FORMAT" != "json" ]]; then
+    echo "usage-report: --format must be 'table' or 'json'" >&2
+    exit 64
+fi
+
+if ! command -v python3 &>/dev/null; then
+    echo "usage-report: python3 is required" >&2
+    exit 69
+fi
+
+_OCTOPUS_USAGE_DIR="$USAGE_DIR" \
+_OCTOPUS_RESULTS_DIR="$RESULTS_DIR" \
+_OCTOPUS_FORMAT="$FORMAT" \
+python3 - <<'PYEOF'
+import glob, json, os, sys
+from collections import defaultdict
+
+usage_dir = os.environ["_OCTOPUS_USAGE_DIR"]
+results_dir = os.environ["_OCTOPUS_RESULTS_DIR"]
+fmt = os.environ["_OCTOPUS_FORMAT"]
+
+# $/MTok (input, output) — keep in sync with cost table in CLAUDE.md
+RATES = {
+    "claude":       (5.00, 25.00),   # Opus 4.8 default seat
+    "claude-sdk":   (5.00, 25.00),   # Agent SDK, Opus 4.8
+    "codex":        (5.00, 30.00),   # GPT-5.5 premium default
+    "agy":          (0.00, 0.00),    # included with Antigravity access
+    "gemini":       (0.00, 0.00),    # sunset; legacy records only
+    "perplexity":   (3.00, 15.00),   # Sonar Pro
+    "openrouter":   (2.00, 8.00),    # blended estimate
+    "atlascloud":   (2.00, 8.00),    # blended estimate
+    "openai-compatible-agent": (2.00, 8.00),
+    "ollama":       (0.00, 0.00),    # local
+    "copilot":      (0.00, 0.00),    # subscription
+    "qwen":         (0.00, 0.00),    # oauth/free tier
+    "grok":         (3.00, 15.00),
+    "cursor-agent": (0.00, 0.00),    # subscription
+    "opencode":     (0.00, 0.00),    # native models free
+    "vibe":         (0.00, 0.00),
+}
+DEFAULT_RATE = (2.00, 8.00)
+
+records = []
+for path in sorted(glob.glob(os.path.join(usage_dir, "*.jsonl"))):
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except Exception:
+                    continue
+    except Exception:
+        continue
+
+# Fold in council/workflow summary.json artifacts (queries only, no tokens)
+for path in sorted(glob.glob(os.path.join(results_dir, "**", "summary.json"),
+                             recursive=True)):
+    try:
+        d = json.load(open(path))
+    except Exception:
+        continue
+    for seat in d.get("roster", d.get("seats", [])) or []:
+        prov = (seat.get("provider") or "").lower()
+        if prov:
+            records.append({"provider": prov, "skill": d.get("workflow", ""),
+                            "est_tokens_in": 0, "est_tokens_out": 0,
+                            "source": "results-summary"})
+
+def bucket():
+    return {"queries": 0, "tokens_in": 0, "tokens_out": 0, "est_cost_usd": 0.0}
+
+by_provider = defaultdict(bucket)
+by_skill = defaultdict(bucket)
+by_mcp = defaultdict(bucket)
+totals = bucket()
+
+for r in records:
+    prov = (r.get("provider") or "unknown").lower()
+    tin = int(r.get("est_tokens_in") or r.get("tokens_in") or 0)
+    tout = int(r.get("est_tokens_out") or r.get("tokens_out") or 0)
+    rate = RATES.get(prov, DEFAULT_RATE)
+    cost = tin / 1e6 * rate[0] + tout / 1e6 * rate[1]
+    for target in (by_provider[prov], totals):
+        target["queries"] += 1
+        target["tokens_in"] += tin
+        target["tokens_out"] += tout
+        target["est_cost_usd"] += cost
+    skill = r.get("skill") or r.get("workflow") or ""
+    if skill:
+        b = by_skill[skill]
+        b["queries"] += 1; b["tokens_in"] += tin
+        b["tokens_out"] += tout; b["est_cost_usd"] += cost
+    mcp = r.get("mcp_server") or ""
+    if mcp:
+        b = by_mcp[mcp]
+        b["queries"] += 1; b["tokens_in"] += tin
+        b["tokens_out"] += tout; b["est_cost_usd"] += cost
+
+def rows(d):
+    return [dict(name=k, **{kk: (round(vv, 4) if kk == "est_cost_usd" else vv)
+                            for kk, vv in v.items()})
+            for k, v in sorted(d.items(), key=lambda kv: -kv[1]["est_cost_usd"])]
+
+report = {
+    "schema": "claude-code/usage-v1",
+    "totals": {**totals, "est_cost_usd": round(totals["est_cost_usd"], 4)},
+    "byProvider": rows(by_provider),
+    "bySkill": rows(by_skill),
+    "byMcpServer": rows(by_mcp),
+}
+
+if fmt == "json":
+    print(json.dumps(report, indent=2))
+    sys.exit(0)
+
+def table(title, items):
+    print(title)
+    print("=" * 64)
+    print(f"{'Name':<28}{'Queries':>8}{'Tok In':>10}{'Tok Out':>10}{'Est Cost':>10}")
+    print("-" * 64)
+    for it in items:
+        print(f"{it['name'][:27]:<28}{it['queries']:>8}{it['tokens_in']:>10}"
+              f"{it['tokens_out']:>10}{'$%.2f' % it['est_cost_usd']:>10}")
+    print("-" * 64)
+
+if not records:
+    print("No usage records found in", usage_dir)
+    sys.exit(0)
+
+table("Provider Usage Breakdown", report["byProvider"])
+if report["bySkill"]:
+    table("Skill Usage Breakdown", report["bySkill"])
+if report["byMcpServer"]:
+    table("MCP Server Usage Breakdown", report["byMcpServer"])
+t = report["totals"]
+print(f"TOTAL: {t['queries']} queries, {t['tokens_in']} in / "
+      f"{t['tokens_out']} out tokens, est ${t['est_cost_usd']:.2f}")
+PYEOF

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -284,6 +284,17 @@ get_agent_command() {
                 echo "${PLUGIN_DIR}/scripts/helpers/grok-exec.sh"
             fi
             ;;
+        claude-sdk|claude-sdk-agent|claude-sdk-research)  # v9.50.0: Claude Agent SDK seat
+            # Routes to helpers/claude-sdk-exec.sh when CLAUDE_SDK_API_KEY is set —
+            # unlocks Opus 4.8 + 1M context independent of the host session. Model
+            # wiring mirrors grok: env prefix so providers.json picks reach the shim.
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then return 1; fi
+            if [[ -n "$model" && "$model" != "default" ]]; then
+                echo "env OCTOPUS_CLAUDE_SDK_MODEL=${model} ${PLUGIN_DIR}/scripts/helpers/claude-sdk-exec.sh"
+            else
+                echo "${PLUGIN_DIR}/scripts/helpers/claude-sdk-exec.sh"
+            fi
+            ;;
         cursor-agent)  # v9.23.0: Cursor Agent CLI — Grok 4.20 via Cursor subscription
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
                 return 1
@@ -343,6 +354,7 @@ get_provider_context_limit() {
 
     case "$agent_type" in
         codex-large-context) echo "${OCTOPUS_CODEX_LARGE_CONTEXT_BUDGET:-${default_budget}}" ; return 0 ;;
+        claude-sdk*) echo "${OCTOPUS_CLAUDE_SDK_CONTEXT_BUDGET:-1000000}" ; return 0 ;;  # v9.50.0: Agent SDK 1M window
         claude-opus*|claude-sonnet|claude) echo "${OCTOPUS_CLAUDE_CONTEXT_BUDGET:-${default_budget}}" ; return 0 ;;
     esac
 
@@ -529,6 +541,7 @@ get_agent_model() {
         codex*)      provider="codex" ;;
         gemini*)     provider="gemini" ;;
         agy*|antigravity) provider="agy" ;;
+        claude-sdk*) provider="claude-sdk" ;;  # v9.50.0: must precede claude* glob
         claude*)     provider="claude" ;;
         openrouter*) provider="openrouter" ;;
         atlascloud*) provider="atlascloud" ;;
@@ -573,6 +586,7 @@ validate_model_allowed() {
         codex)      allowlist_var="OCTOPUS_CODEX_ALLOWED_MODELS" ;;
         gemini)     allowlist_var="OCTOPUS_GEMINI_ALLOWED_MODELS" ;;
         agy)        allowlist_var="OCTOPUS_AGY_ALLOWED_MODELS" ;;
+        claude-sdk) allowlist_var="OCTOPUS_CLAUDE_SDK_ALLOWED_MODELS" ;;
         claude)     allowlist_var="OCTOPUS_CLAUDE_ALLOWED_MODELS" ;;
         openrouter) allowlist_var="OCTOPUS_OPENROUTER_ALLOWED_MODELS" ;;
         atlascloud) allowlist_var="ATLASCLOUD_ALLOWED_MODELS" ;;

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -345,6 +345,7 @@ resolve_octopus_model() {
             gemini-fast|gemini-flash) resolved_model="gemini-3-flash-preview" ;;
             gemini*)         resolved_model="gemini-3.1-pro-preview" ;;
             agy*|antigravity) resolved_model="default" ;;
+            claude-sdk*)     resolved_model="${OCTOPUS_CLAUDE_SDK_MODEL:-claude-opus-4-8}" ;;  # v9.50.0: must precede claude* glob
             claude-opus-legacy*) resolved_model="claude-opus-4.6" ;;
             claude-opus*)    resolved_model="$(opus_default_model)" ;;
             claude*)         resolved_model="claude-sonnet-4.6" ;;

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -161,6 +161,14 @@ build_provider_env() {
             fi
             return 0
             ;;
+        claude-sdk*)
+            # v9.50.0: Agent SDK seat — the shim strips session markers and sets
+            # ANTHROPIC_API_KEY itself; just make sure the SDK key is resolvable.
+            if [[ -z "${CLAUDE_SDK_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
+                resolve_provider_env "CLAUDE_SDK_API_KEY" 2>/dev/null || true
+            fi
+            return 0
+            ;;
         claude*)
             # A headless claude (or clarp wrapping it) must NOT inherit the parent
             # Claude Code session markers, or the inner `claude` hangs thinking it
@@ -367,10 +375,10 @@ set_provider_model() {
 
     # v8.49.0: Provider whitelist validation
     case "$provider" in
-        codex|gemini|claude|perplexity|opencode|openrouter|atlascloud|openai-compatible|openai-tools|openai-compatible-agent|cursor-agent) ;;
+        codex|gemini|claude|claude-sdk|perplexity|opencode|openrouter|atlascloud|openai-compatible|openai-tools|openai-compatible-agent|cursor-agent) ;;
         *)
             if [[ "${4:-}" != "--force" ]]; then
-                echo "ERROR: Unknown provider '$provider'. Valid: codex, gemini, claude, perplexity, opencode, openrouter, atlascloud, openai-compatible, openai-tools, openai-compatible-agent, cursor-agent" >&2
+                echo "ERROR: Unknown provider '$provider'. Valid: codex, gemini, claude, claude-sdk, perplexity, opencode, openrouter, atlascloud, openai-compatible, openai-tools, openai-compatible-agent, cursor-agent" >&2
                 echo "  Use --force to set a custom provider (e.g., for local proxies)" >&2
                 return 1
             fi
@@ -477,12 +485,12 @@ reset_provider_model() {
         # Clear all overrides (v8.49.0: atomic)
         atomic_json_update "$config_file" '.overrides = {}'
         echo "✓ Cleared all model overrides"
-    elif [[ "$provider" =~ ^(codex|gemini|claude|perplexity|opencode|openrouter|atlascloud|openai-compatible|openai-tools|openai-compatible-agent|cursor-agent)$ ]]; then
+    elif [[ "$provider" =~ ^(codex|gemini|claude|claude-sdk|perplexity|opencode|openrouter|atlascloud|openai-compatible|openai-tools|openai-compatible-agent|cursor-agent)$ ]]; then
         # Clear specific override (v8.49.0: atomic + jq --arg)
         atomic_json_update "$config_file" 'del(.overrides[$p])' --arg p "$provider"
         echo "✓ Cleared $provider override"
     else
-        echo "ERROR: Invalid provider '$provider'. Use 'codex', 'gemini', 'claude', 'perplexity', 'opencode', 'openrouter', 'atlascloud', 'openai-compatible-agent', 'cursor-agent', or 'all'" >&2
+        echo "ERROR: Invalid provider '$provider'. Use 'codex', 'gemini', 'claude', 'claude-sdk', 'perplexity', 'opencode', 'openrouter', 'atlascloud', 'openai-compatible-agent', 'cursor-agent', or 'all'" >&2
         return 1
     fi
 

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -204,6 +204,13 @@ detect_claude_code_version() {
         SUPPORTS_FAST_OPUS_1M=true
     fi
 
+    # v9.50.0: worktree.bgIsolation opt-out — OCTOPUS_WORKTREE_BG_ISOLATION=false
+    # disables worktree cloning for background agents (fast direct-edit runs).
+    # Mirrors Claude Code's worktree.bgIsolation session flag.
+    if [[ "${OCTOPUS_WORKTREE_BG_ISOLATION:-true}" == "false" ]]; then
+        SUPPORTS_WORKTREE_ISOLATION=false
+    fi
+
     # Check for v2.1.51+ features (remote control, npm registries, fast bash, disk persist, account env vars, managed settings)
     if version_compare "$CLAUDE_CODE_VERSION" "2.1.51" ">="; then
         SUPPORTS_REMOTE_CONTROL=true
@@ -833,6 +840,18 @@ check_provider_health() {
                 return 1
             fi
             ;;
+        claude-sdk)
+            # v9.50.0: Agent SDK seat — key is the only hard requirement; the
+            # shim falls back from claude-agent to headless claude at exec time.
+            if [[ -z "${CLAUDE_SDK_API_KEY:-}" ]]; then
+                echo "claude-sdk: CLAUDE_SDK_API_KEY not set" >&2
+                return 1
+            fi
+            if ! command -v claude-agent &>/dev/null && ! command -v claude &>/dev/null; then
+                echo "claude-sdk: neither claude-agent (Agent SDK) nor claude CLI found in PATH" >&2
+                return 1
+            fi
+            ;;
         grok)
             if ! command -v grok &>/dev/null; then
                 echo "grok: CLI not found in PATH" >&2
@@ -889,7 +908,7 @@ check_all_providers() {
     local healthy=0 unhealthy=0
     local -a results=()
 
-    for provider in codex gemini agy claude perplexity openrouter atlascloud ollama copilot qwen cursor-agent grok vibe; do
+    for provider in codex gemini agy claude claude-sdk perplexity openrouter atlascloud ollama copilot qwen cursor-agent grok vibe; do
         local diag
         if diag=$(check_provider_health "$provider" 2>&1); then
             results+=("  ✓ $provider")
@@ -1167,6 +1186,15 @@ detect_providers() {
     # Detect xAI Grok CLI (standalone grok provider)
     if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed grok; } && declare -f grok_is_available >/dev/null 2>&1 && grok_is_available; then
         result="${result}grok:$(grok_auth_method) "
+    fi
+
+    # Detect Claude Agent SDK seat (v9.50.0 — CLAUDE_SDK_API_KEY unlocks Opus 4.8 + 1M context)
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed claude-sdk; } && [[ -n "${CLAUDE_SDK_API_KEY:-}" ]]; then
+        if command -v claude-agent &>/dev/null; then
+            result="${result}claude-sdk:agent-sdk "
+        elif command -v claude &>/dev/null; then
+            result="${result}claude-sdk:headless-fallback "
+        fi
     fi
 
     # Detect Vibe CLI (Mistral Vibe interactive CLI)

--- a/skills/octopus-starter-pack/council-verdicts/SKILL.md
+++ b/skills/octopus-starter-pack/council-verdicts/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: council-verdicts
+description: "Starter: interpret a council run's verdict artifacts — quorum, dissent, cross-lab validity, and what to do next"
+---
+
+# Council Verdict Interpretation (Starter Pack)
+
+Read a completed council run's artifacts and explain what the verdicts actually mean before anyone acts on them.
+
+## When to use
+
+A `/octo:council` run has finished and the user asks "so what did the council decide?" or pastes a summary.json path.
+
+## Steps
+
+1. **Locate artifacts.** Find the newest council output under `~/.claude-octopus/results/` (look for `summary.json` and per-seat verdict files). If none exist within the session window, say so; never invent a verdict.
+2. **Check roster validity.** From `summary.json`, confirm each seat's real provider and model (the agy seat records its resolved model, not `default`). Flag same-lineage panels: two seats backed by the same model family weaken the verdict's independence.
+3. **Tally the verdicts.** Report the raw count (APPROVE / REJECT / ABSTAIN / REVISE) and whether quorum was met. A malformed or missing verdict from a seat counts as ABSTAIN, and the SubagentStop gate (`hooks/subagent-stop-gate.sh`) may have flagged it; check the gate's usage log for quality scores.
+4. **Surface dissent.** Quote the strongest dissenting argument verbatim. A 2-1 split with a substantive dissent is a weaker mandate than 3-0; say which one this is.
+5. **Recommend the action.** Map the tally to a next step: unanimous APPROVE means proceed; majority with dissent means proceed with the dissent's concern as a follow-up item; majority REJECT means do not proceed and list what would change the outcome.
+
+## Guardrails
+
+- Verdicts gate decisions; they do not execute them. Never auto-apply a council outcome to code.
+- If seats disagree on facts (not judgment), the run is inconclusive; recommend a re-run with the factual dispute resolved first.

--- a/skills/octopus-starter-pack/debate-kickoff/SKILL.md
+++ b/skills/octopus-starter-pack/debate-kickoff/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: debate-kickoff
+description: "Starter: frame a decision as a multi-model debate — picks sides, seats providers, and launches /octo:debate with a well-formed motion"
+---
+
+# Debate Kickoff (Starter Pack)
+
+Turn a loosely stated decision ("Redis or Memcached?", "monorepo vs polyrepo") into a well-formed multi-model debate.
+
+## When to use
+
+The user has a two-or-more-sided technical decision and wants adversarial perspectives from different model families rather than one model's opinion.
+
+## Steps
+
+1. **Extract the motion.** Restate the user's question as a single debatable proposition (for example: "This project should use Redis over Memcached for session storage"). Confirm silently from context; do not interrogate the user.
+2. **Check seats.** Run `${CLAUDE_PLUGIN_ROOT}/scripts/helpers/check-providers.sh` and note which providers are available. A debate needs at least two seatable non-Claude providers for cross-lab disagreement; if only Claude is available, say so and offer a single-model pro/con instead.
+3. **Assign sides.** Give each available provider an explicit stance (affirmative, negative, or skeptic). Prefer cross-lab pairings (for example Codex affirmative, Antigravity negative) so disagreement is structural, not stylistic.
+4. **Launch.** Invoke `/octo:debate` with the motion and the side assignments. Display the standard Octopus banner with provider indicators before dispatch.
+5. **Synthesize.** After rounds complete, summarize where the models converged, where they genuinely disagreed, and give one recommendation with the strongest surviving argument.
+
+## Guardrails
+
+- External seats cost money; state the expected cost band from the CLAUDE.md cost table before dispatch.
+- Never fabricate a provider's position. If a seat fails, report the failure and continue with the remaining seats.

--- a/skills/octopus-starter-pack/model-cost-compare/SKILL.md
+++ b/skills/octopus-starter-pack/model-cost-compare/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: model-cost-compare
+description: "Starter: compare model costs for a described task — maps task shape to the cheapest adequate seat and shows the price spread"
+---
+
+# Model Cost Comparison (Starter Pack)
+
+Answer "which model should I use for this, and what will it cost?" with numbers instead of vibes.
+
+## When to use
+
+The user describes a task (bulk refactor, deep review, quick lookup, long-context analysis) and wants the cheapest seat that is still adequate.
+
+## Steps
+
+1. **Classify the task.** Bucket it: mechanical (rename, format), standard coding, hard reasoning (architecture, security review), long-context (>200K tokens input), or web research.
+2. **Estimate volume.** Rough input/output token estimate from the described scope (files touched × average size; state the assumption).
+3. **Price the roster.** Using the cost table in CLAUDE.md ($/MTok input/output), compute the estimated cost for each plausible seat: Claude Opus 4.8 ($5/$25), Fable 5 ($10/$50, 1M context, opt-in), Codex GPT-5.5 ($5/$30), Perplexity Sonar Pro ($3/$15), and the included-cost seats (agy, copilot, ollama, cursor-agent) at $0.
+4. **Recommend one seat.** Pick the cheapest adequate option and defend it in two sentences. Mechanical work goes to included seats; hard reasoning justifies Opus 4.8 at `xhigh` effort; only 1M-context needs justify Fable 5 or the claude-sdk seat.
+5. **Show the spread.** A three-row table: recommended seat, one cheaper-but-riskier option, one premium option, each with estimated dollars for this task.
+
+## Guardrails
+
+- Never recommend Fable 5 or fast-mode Opus by default; both are 2x standard Opus cost and are opt-in only.
+- If the estimate exceeds $1, say so explicitly before any dispatch happens.

--- a/skills/octopus-starter-pack/provider-health/SKILL.md
+++ b/skills/octopus-starter-pack/provider-health/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: provider-health
+description: "Starter: one-screen provider health summary — availability, auth method, version drift, and cost posture for every seatable provider"
+---
+
+# Provider Health Check Summary (Starter Pack)
+
+Produce a one-screen health summary of every provider Octopus can seat, so the user knows what a workflow will actually dispatch to before spending money.
+
+## When to use
+
+The user asks "what providers do I have?", a workflow banner showed `(unavailable - skipping)`, or a session is starting on a new machine.
+
+## Steps
+
+1. **Detect.** Run `${CLAUDE_PLUGIN_ROOT}/scripts/helpers/check-providers.sh` and `${CLAUDE_PLUGIN_ROOT}/scripts/helpers/check-versions.sh`.
+2. **Summarize per provider.** For each seat report: available or not, auth method (env key, oauth session, subscription), and the model it would resolve to today. Include the claude-sdk seat when `CLAUDE_SDK_API_KEY` is set (Agent SDK, Opus 4.8, 1M context).
+3. **Flag problems, ranked.** Expired auth first (breaks dispatch), then version drift (behavior skew), then missing optional providers (reduced diversity). One line each with the exact fix command (`grok login`, `opencode auth login`, key export).
+4. **State the cost posture.** Split the roster into included (Claude, agy, copilot, ollama, cursor-agent) versus billed (codex, perplexity, grok, openrouter, atlascloud, claude-sdk) so the user can predict what a multi-provider workflow costs before running it.
+
+## Output shape
+
+A single table, one row per provider, columns: Provider, Status, Auth, Model, Cost. Below it, at most three ranked fix-it lines. No prose beyond that.
+
+## Guardrails
+
+- Report only what the detection scripts return this session. A provider that worked yesterday but fails detection now is DOWN; do not soften it.

--- a/tests/unit/test-claude-sdk-provider.sh
+++ b/tests/unit/test-claude-sdk-provider.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Tests for the claude-sdk provider shim and its dispatch wiring.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "claude-sdk provider"
+
+SHIM="$PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+test_case "shim refuses to run without CLAUDE_SDK_API_KEY"
+set +e
+out=$(printf 'hello' | env -u CLAUDE_SDK_API_KEY bash "$SHIM" 2>&1)
+rc=$?
+set -e
+if [[ $rc -eq 78 && "$out" == *"CLAUDE_SDK_API_KEY is not set"* ]]; then
+    test_pass
+else
+    test_fail "expected exit 78 without key, got rc=$rc out=$out"
+fi
+
+test_case "shim refuses empty stdin prompt"
+set +e
+out=$(printf '   ' | CLAUDE_SDK_API_KEY=test-key bash "$SHIM" 2>&1)
+rc=$?
+set -e
+if [[ $rc -eq 64 && "$out" == *"no prompt provided on stdin"* ]]; then
+    test_pass
+else
+    test_fail "expected exit 64 for empty prompt, got rc=$rc out=$out"
+fi
+
+test_case "shim prefers claude-agent SDK CLI and passes model + key"
+cat > "$TMP_DIR/claude-agent" <<'STUB'
+#!/usr/bin/env bash
+echo "argv:$*"
+echo "key:${ANTHROPIC_API_KEY:-unset}"
+echo "nested:${CLAUDECODE:-unset}"
+cat
+STUB
+chmod +x "$TMP_DIR/claude-agent"
+out=$(printf 'test prompt' | PATH="$TMP_DIR:$PATH" CLAUDECODE=1 CLAUDE_SDK_API_KEY=sk-sdk-test bash "$SHIM")
+if [[ "$out" == *"--model claude-opus-4-8"* \
+   && "$out" == *"key:sk-sdk-test"* \
+   && "$out" == *"nested:unset"* \
+   && "$out" == *"test prompt"* ]]; then
+    test_pass
+else
+    test_fail "SDK CLI invocation wrong: $out"
+fi
+
+test_case "OCTOPUS_CLAUDE_SDK_MODEL overrides the default model"
+out=$(printf 'p' | PATH="$TMP_DIR:$PATH" CLAUDE_SDK_API_KEY=k OCTOPUS_CLAUDE_SDK_MODEL=claude-fable-5 bash "$SHIM")
+if [[ "$out" == *"--model claude-fable-5"* ]]; then
+    test_pass
+else
+    test_fail "model override ignored: $out"
+fi
+
+test_case "dispatch maps claude-sdk agent types before the claude* glob"
+if grep -q 'claude-sdk\*).*provider="claude-sdk"' "$PROJECT_ROOT/scripts/lib/dispatch.sh" \
+   && awk '/claude-sdk\*\).*claude-sdk/{sdk=NR} /claude\*\).*provider="claude"/{cl=NR} END{exit !(sdk && cl && sdk<cl)}' "$PROJECT_ROOT/scripts/lib/dispatch.sh"; then
+    test_pass
+else
+    test_fail "claude-sdk* case must exist and precede claude* in dispatch.sh"
+fi
+
+test_case "dispatch routes claude-sdk agent types to the shim"
+if grep -q 'claude-sdk-exec.sh' "$PROJECT_ROOT/scripts/lib/dispatch.sh"; then
+    test_pass
+else
+    test_fail "dispatch.sh does not reference claude-sdk-exec.sh"
+fi
+
+test_case "provider routing whitelists claude-sdk"
+count=$(grep -c 'claude-sdk' "$PROJECT_ROOT/scripts/lib/provider-routing.sh" || true)
+if (( count >= 2 )); then
+    test_pass
+else
+    test_fail "expected claude-sdk in provider-routing.sh whitelists, found $count references"
+fi
+
+test_case "provider detection reports claude-sdk when key is set"
+if grep -q 'CLAUDE_SDK_API_KEY' "$PROJECT_ROOT/scripts/lib/providers.sh"; then
+    test_pass
+else
+    test_fail "providers.sh does not detect CLAUDE_SDK_API_KEY"
+fi
+
+test_summary

--- a/tests/unit/test-subagent-stop-gate.sh
+++ b/tests/unit/test-subagent-stop-gate.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Tests for the SubagentStop gate hook (quality/cost/verdict pre-screen).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "SubagentStop gate"
+
+HOOK="$PROJECT_ROOT/hooks/subagent-stop-gate.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+run_hook() {
+    local payload="$1"; shift
+    printf '%s\n' "$payload" | OCTOPUS_WORKSPACE="$TMP_DIR" "$@" bash "$HOOK"
+}
+
+USAGE_LOG="$TMP_DIR/usage/subagent-usage.jsonl"
+
+test_case "logs usage record with provider attribution from agent_type"
+run_hook '{"agent_id":"a1","agent_type":"codex-research","last_assistant_message":"## Findings\n- OAuth flow verified, SUCCESS"}' env >/dev/null
+if [[ -f "$USAGE_LOG" ]] && grep -q '"provider": "codex"' "$USAGE_LOG"; then
+    test_pass
+else
+    test_fail "expected usage log with provider codex, got: $(cat "$USAGE_LOG" 2>/dev/null || echo '<missing>')"
+fi
+
+test_case "quality score is a bounded integer"
+score=$(python3 -c "
+import json
+r = [json.loads(l) for l in open('$USAGE_LOG')][-1]
+print(r['quality'])")
+if [[ "$score" =~ ^[0-9]+$ ]] && (( score >= 0 && score <= 100 )); then
+    test_pass
+else
+    test_fail "expected 0-100 integer quality score, got: $score"
+fi
+
+test_case "claude-sdk agent_type attributes to claude-sdk, not claude"
+run_hook '{"agent_id":"a2","agent_type":"claude-sdk-agent","last_assistant_message":"done"}' env >/dev/null
+if grep -q '"provider": "claude-sdk"' "$USAGE_LOG"; then
+    test_pass
+else
+    test_fail "expected provider claude-sdk in usage log"
+fi
+
+test_case "non-strict mode never blocks a malformed verdict"
+output=$(run_hook '{"agent_id":"a3","agent_type":"agy","last_assistant_message":"## Verdict\nno clear outcome here"}' env)
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "expected empty output (allow), got: $output"
+fi
+
+test_case "strict mode blocks a verdict block without a verdict token"
+output=$(run_hook '{"agent_id":"a4","agent_type":"agy","last_assistant_message":"## Verdict\nno clear outcome here"}' env OCTOPUS_SUBAGENT_GATE_STRICT=true)
+if [[ "$output" == *'"decision": "block"'* && "$output" == *"verdict"* ]]; then
+    test_pass
+else
+    test_fail "expected block decision for malformed verdict, got: ${output:-<empty>}"
+fi
+
+test_case "strict mode allows a well-formed verdict"
+output=$(run_hook '{"agent_id":"a5","agent_type":"agy","last_assistant_message":"## Verdict\nAPPROVE — implementation is sound and tested."}' env OCTOPUS_SUBAGENT_GATE_STRICT=true)
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "expected allow for APPROVE verdict, got: $output"
+fi
+
+test_case "strict mode enforces the quality floor"
+output=$(run_hook '{"agent_id":"a6","agent_type":"codex","last_assistant_message":"err"}' env OCTOPUS_SUBAGENT_GATE_STRICT=true OCTOPUS_SUBAGENT_MIN_QUALITY=50)
+if [[ "$output" == *'"decision": "block"'* && "$output" == *"quality score"* ]]; then
+    test_pass
+else
+    test_fail "expected block below quality floor, got: ${output:-<empty>}"
+fi
+
+test_case "empty stdin exits 0 without writing"
+before=$(wc -l < "$USAGE_LOG")
+printf '' | OCTOPUS_WORKSPACE="$TMP_DIR" bash "$HOOK"
+after=$(wc -l < "$USAGE_LOG")
+if [[ "$before" == "$after" ]]; then
+    test_pass
+else
+    test_fail "empty input should not append usage records"
+fi
+
+test_summary

--- a/tests/unit/test-usage-report.sh
+++ b/tests/unit/test-usage-report.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Tests for the usage-report helper (/octo:usage backend).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Usage report"
+
+HELPER="$PROJECT_ROOT/scripts/helpers/usage-report.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+mkdir -p "$TMP_DIR/usage" "$TMP_DIR/results/run1"
+
+cat > "$TMP_DIR/usage/subagent-usage.jsonl" <<'EOF'
+{"provider":"codex","skill":"flow-discover","est_tokens_in":10000,"est_tokens_out":2000,"quality":80}
+{"provider":"codex","skill":"flow-develop","est_tokens_in":5000,"est_tokens_out":1000,"quality":70}
+{"provider":"claude","skill":"flow-discover","mcp_server":"perplexity-mcp","est_tokens_in":20000,"est_tokens_out":4000,"quality":90}
+{"provider":"agy","skill":"flow-discover","est_tokens_in":8000,"est_tokens_out":3000,"quality":60}
+EOF
+
+cat > "$TMP_DIR/results/run1/summary.json" <<'EOF'
+{"workflow":"council","roster":[{"provider":"codex","model":"gpt-5.5"},{"provider":"agy","model":"gemini-3-pro"}]}
+EOF
+
+report() {
+    bash "$HELPER" --format json --usage-dir "$TMP_DIR/usage" --results-dir "$TMP_DIR/results"
+}
+
+test_case "json output matches claude-code/usage-v1 schema shape"
+out="$(report)"
+if python3 -c "
+import json, sys
+d = json.loads(sys.argv[1])
+assert d['schema'] == 'claude-code/usage-v1'
+assert set(['totals','byProvider','bySkill','byMcpServer']) <= set(d)
+" "$out" 2>/dev/null; then
+    test_pass
+else
+    test_fail "schema shape mismatch: $out"
+fi
+
+test_case "aggregates per provider including results-dir roster queries"
+if python3 -c "
+import json, sys
+d = json.loads(sys.argv[1])
+prov = {p['name']: p for p in d['byProvider']}
+assert prov['codex']['queries'] == 3, prov['codex']       # 2 jsonl + 1 roster
+assert prov['codex']['tokens_in'] == 15000
+assert prov['codex']['tokens_out'] == 3000
+assert prov['agy']['queries'] == 2                        # 1 jsonl + 1 roster
+" "$out" 2>/dev/null; then
+    test_pass
+else
+    test_fail "per-provider aggregation wrong: $out"
+fi
+
+test_case "computes nonzero cost for billed providers and zero for included"
+if python3 -c "
+import json, sys
+d = json.loads(sys.argv[1])
+prov = {p['name']: p for p in d['byProvider']}
+assert prov['codex']['est_cost_usd'] > 0
+assert prov['agy']['est_cost_usd'] == 0
+" "$out" 2>/dev/null; then
+    test_pass
+else
+    test_fail "cost computation wrong: $out"
+fi
+
+test_case "groups by skill and by mcp server"
+if python3 -c "
+import json, sys
+d = json.loads(sys.argv[1])
+skills = {s['name'] for s in d['bySkill']}
+assert 'flow-discover' in skills and 'flow-develop' in skills
+mcps = {m['name']: m for m in d['byMcpServer']}
+assert mcps['perplexity-mcp']['queries'] == 1
+" "$out" 2>/dev/null; then
+    test_pass
+else
+    test_fail "skill/mcp grouping wrong: $out"
+fi
+
+test_case "table format prints provider rows"
+table_out="$(bash "$HELPER" --format table --usage-dir "$TMP_DIR/usage" --results-dir "$TMP_DIR/results")"
+if [[ "$table_out" == *"Provider Usage Breakdown"* && "$table_out" == *"codex"* && "$table_out" == *"TOTAL:"* ]]; then
+    test_pass
+else
+    test_fail "table output missing expected rows: $table_out"
+fi
+
+test_case "empty usage dir reports no records instead of fabricating"
+empty_dir="$TMP_DIR/empty"
+mkdir -p "$empty_dir/usage" "$empty_dir/results"
+out2="$(bash "$HELPER" --format table --usage-dir "$empty_dir/usage" --results-dir "$empty_dir/results")"
+if [[ "$out2" == *"No usage records found"* ]]; then
+    test_pass
+else
+    test_fail "expected empty-data notice, got: $out2"
+fi
+
+test_case "rejects unknown format"
+if bash "$HELPER" --format xml --usage-dir "$TMP_DIR/usage" 2>/dev/null; then
+    test_fail "expected nonzero exit for --format xml"
+else
+    test_pass
+fi
+
+test_summary

--- a/tests/unit/test-worktree-bg-isolation.sh
+++ b/tests/unit/test-worktree-bg-isolation.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Tests for the worktree.bgIsolation opt-out flag (OCTOPUS_WORKTREE_BG_ISOLATION).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Worktree bgIsolation flag"
+
+HOOK="$PROJECT_ROOT/hooks/worktree-setup.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+payload() {
+    printf '{"worktreePath":"%s"}' "$1"
+}
+
+test_case "default (isolation on): worktree-setup injects .octopus-env"
+wt1="$TMP_DIR/wt1"; mkdir -p "$wt1"
+out=$(payload "$wt1" | env -u OCTOPUS_WORKTREE_BG_ISOLATION OPENAI_API_KEY=test-key bash "$HOOK")
+if [[ -f "$wt1/.octopus-env" && "$out" == *'"decision": "continue"'* ]]; then
+    test_pass
+else
+    test_fail "expected .octopus-env with isolation on, got: $out"
+fi
+
+test_case "OCTOPUS_WORKTREE_BG_ISOLATION=false: setup short-circuits, no env injection"
+wt2="$TMP_DIR/wt2"; mkdir -p "$wt2"
+out=$(payload "$wt2" | OCTOPUS_WORKTREE_BG_ISOLATION=false OPENAI_API_KEY=test-key bash "$HOOK")
+if [[ ! -f "$wt2/.octopus-env" && "$out" == *'"decision": "continue"'* ]]; then
+    test_pass
+else
+    test_fail "expected no .octopus-env with isolation off, got: $out"
+fi
+
+test_case "flag values other than false keep isolation on"
+wt3="$TMP_DIR/wt3"; mkdir -p "$wt3"
+payload "$wt3" | OCTOPUS_WORKTREE_BG_ISOLATION=true OPENAI_API_KEY=test-key bash "$HOOK" >/dev/null
+if [[ -f "$wt3/.octopus-env" ]]; then
+    test_pass
+else
+    test_fail "OCTOPUS_WORKTREE_BG_ISOLATION=true must not disable setup"
+fi
+
+test_case "providers.sh downgrades SUPPORTS_WORKTREE_ISOLATION when flag is false"
+if grep -q 'OCTOPUS_WORKTREE_BG_ISOLATION' "$PROJECT_ROOT/scripts/lib/providers.sh"; then
+    test_pass
+else
+    test_fail "providers.sh does not honor OCTOPUS_WORKTREE_BG_ISOLATION"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

Seven-item Claude Code 2026 compatibility layer plus full release mechanics (v9.50.0, minor bump).

### Added
- **Routines manifest** (`.claude-plugin/routines.json`): schedule + GitHub-event saved automations mapping to `/octo:` commands, all disabled by default with per-routine cost notes
- **SubagentStop gate** (`hooks/subagent-stop-gate.sh`): provider attribution, 0-100 quality heuristic, JSONL cost logging, council verdict pre-screen; blocking only with `OCTOPUS_SUBAGENT_GATE_STRICT=true`
- **`/octo:usage`** + `scripts/helpers/usage-report.sh`: per-provider / per-skill / per-MCP-server breakdown in Claude Code's `/usage` schema (`claude-code/usage-v1`)
- **worktree.bgIsolation opt-out**: `OCTOPUS_WORKTREE_BG_ISOLATION=false` skips background worktree cloning (providers.sh downgrade + worktree-setup.sh short-circuit)
- **claude-sdk provider seat**: `CLAUDE_SDK_API_KEY` routes through `scripts/helpers/claude-sdk-exec.sh` (Agent SDK preferred, headless claude fallback); Opus 4.8 default, 1M context budget; wired through dispatch, model resolution, allowlists, routing, detection, health checks
- **Starter pack** (`skills/octopus-starter-pack/`): debate-kickoff, council-verdicts, provider-health, model-cost-compare
- **`/plugin browse` manifest** (`.claude-plugin/plugin-manifest.json`): projected context cost + component inventory (50 commands, 42 agents, 58 skills, 20 hook events, 4 routines)

### Release mechanics
- CHANGELOG 9.50.0 entry (folds Unreleased); version 9.50.0 across package.json and all plugin manifests; marketplace descriptions/counts refreshed; README/PRODUCT compat sections + env var table

## Test plan
- 4 new unit suites, 27 cases, all green
- Regression: provider/dispatch/model/hook/worktree unit suites + smoke tests green
- Zero exec-bit mode changes vs main; new scripts committed 100755
- All version strings verified identical (9.50.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Released v9.50.0 with updated plugin browse metadata and a Claude Code 2026 compatibility layer.
  * Added `/octo:usage` for cost-attribution reporting, plus new scheduled/event routines (disabled by default).
  * Introduced a new Claude Agent SDK seat/provider (`claude-sdk`) with model/context controls and allowlisting.
  * Added four new starter-pack skills.
* **Bug Fixes**
  * Improved SubagentStop quality/verdict gating via a stricter two-step hook flow.
  * Added `OCTOPUS_WORKTREE_BG_ISOLATION=false` to opt out of background worktree isolation.
* **Documentation**
  * Updated README/PRODUCT and command docs for v9.50.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->