### PR TITLE
fix: harden review aggregation and progress supervision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Review aggregation and progress supervision hardened** (#592, community contribution by @Jhacarreiro; maintainer takeover to land): review rounds now run without a wall-clock cap under progress-stall supervision (`OCTOPUS_REVIEW_STALL_WINDOW`, default 1800s), Round 1 codex empty-output-with-reconnect failures retry once, findings extraction tolerates prose-wrapped JSON, and severity counting is pipefail-safe. Maintainer fixes on top of the contribution: the stall fingerprint is scoped to each agent's own artifacts (previously it hashed all of RESULTS_DIR, so any concurrent activity reset every agent's stall timer); stall kills walk the full descendant tree (a single-level `pkill -P` could orphan the grandchild provider CLI mid-billing); and the findings extractor prefers the last non-empty findings array so a provider echoing the prompt's `{"findings": []}` format example cannot erase real findings. The `timeout_secs=0` contract this relies on is the `run_with_timeout` bypass that shipped with #593.
+
 ### Added
 
 - **RELEASING.md**: ordered release checklist covering every version-string location, the derived-artifact generators, CI-parity validation, exec-bit checks, fork-PR run approval, the tag-on-merge-commit rule, and GitHub Release creation. Encodes the three CI rounds the v9.50.0 release burned on undocumented generators.

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -215,6 +215,16 @@ review_file_mtime_epoch() {
     stat -c '%Y' "$file" 2>/dev/null || stat -f '%m' "$file" 2>/dev/null || echo 0
 }
 
+review_hash_stdin() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 | awk '{print $1}'
+    else
+        cksum | awk '{print $1}'
+    fi
+}
+
 review_progress_fingerprint_since() {
     local since_epoch="$1"
     local results_dir="${2:-${RESULTS_DIR:-${HOME}/.claude-octopus/results}}"
@@ -227,7 +237,7 @@ review_progress_fingerprint_since() {
         size=$(wc -c < "$file" 2>/dev/null || echo 0)
         size=${size//[[:space:]]/}
         printf '%s %s %s\n' "$file" "${size:-0}" "$mtime"
-    done | sort | sha256sum 2>/dev/null | awk '{print $1}'
+    done | sort | review_hash_stdin
 }
 
 review_run_agent_sync_progress() {
@@ -864,6 +874,8 @@ ${agent_prompt_base}"
     local codex_empty_retry_backoff="${OCTOPUS_REVIEW_CODEX_EMPTY_RETRY_BACKOFF_SECS:-90}"
     [[ "$codex_empty_retry_max" =~ ^[0-9]+$ ]] || codex_empty_retry_max=1
     [[ "$codex_empty_retry_backoff" =~ ^[0-9]+$ ]] || codex_empty_retry_backoff=90
+    codex_empty_retry_max=$((10#$codex_empty_retry_max))
+    codex_empty_retry_backoff=$((10#$codex_empty_retry_backoff))
     if [[ "$codex_empty_retry_max" -gt 0 ]]; then
         local retry_idx=0
         while [[ "$retry_idx" -lt "${#round1_files[@]}" ]]; do
@@ -888,7 +900,10 @@ ${round1_prompts[$retry_idx]}"
                 retry_pid="$!"
                 review_wait_for_result_status "$retry_result_file" "$retry_pid" "Round 1 ${retry_agent_type}/${retry_role} retry" "$RESULTS_DIR" "$review_stall_window" "$review_poll_secs"
                 round1_files[$retry_idx]="$retry_result_file"
-                if [[ -f "$retry_result_file" ]] && grep -qE '^## Status: SUCCESS' "$retry_result_file" 2>/dev/null; then
+                local retry_success_count
+                retry_success_count=$(grep -cE '^## Status: SUCCESS' "$retry_result_file" 2>/dev/null || true)
+                retry_success_count=${retry_success_count:-0}
+                if [[ -f "$retry_result_file" ]] && [[ "${retry_success_count%%$'\n'*}" -gt 0 ]]; then
                     log INFO "review_run: ${retry_agent_type}/${retry_role} retry recovered after Empty output"
                 else
                     log WARN "review_run: ${retry_agent_type}/${retry_role} retry did not recover; continuing with partial Round 1"
@@ -908,18 +923,28 @@ ${round1_prompts[$retry_idx]}"
     local round1_partial_count=0
     local round1_parse_miss_count=0
     for f in "${round1_files[@]}"; do
-        [[ ! -f "$f" ]] && { ((round1_partial_count++)) || true; continue; }
+        local atype="${round1_agent_types[$idx]}"
+        local provider_key="${atype%%[-_]*}"
+        if [[ ! -f "$f" ]]; then
+            ((round1_partial_count++)) || true
+            echo "${provider_key}|fallback|Round 1 agent missing result" >> "$provider_status_file"
+            ((idx++)) || true
+            continue
+        fi
         local agent_findings
-        agent_findings=$(review_extract_findings_array "$f" 2>/dev/null || echo "[]")
-        if [[ "$agent_findings" == "[]" ]] && grep -q '"severity"[[:space:]]*:[[:space:]]*"' "$f" 2>/dev/null; then
+        if ! agent_findings=$(review_extract_findings_array "$f" 2>/dev/null); then
+            agent_findings="[]"
+        fi
+        local severity_count
+        severity_count=$(grep -c '"severity"[[:space:]]*:[[:space:]]*"' "$f" 2>/dev/null || true)
+        severity_count=${severity_count:-0}
+        if [[ "$agent_findings" == "[]" ]] && [[ "${severity_count%%$'\n'*}" -gt 0 ]]; then
             ((round1_parse_miss_count++)) || true
             log WARN "review_run: possible findings in $(basename "$f") but extractor returned empty array"
         fi
         all_findings=$(printf '%s\n%s' "$all_findings" "$agent_findings" |             jq -s 'add' 2>/dev/null || echo "$all_findings")
 
         # v9.3.1: Write provider status for Round 1 agents (#187)
-        local atype="${round1_agent_types[$idx]}"
-        local provider_key="${atype%%[-_]*}"
         # #498: emit one review.finding lifecycle event per Round 1 finding, while
         # per-provider attribution is still in scope (it is dropped after the merge
         # above). round="1" lets consumers filter pre-verification noise.
@@ -950,9 +975,16 @@ ${round1_prompts[$retry_idx]}"
     local _r1_total=${#round1_files[@]}
     local _r1_failed=0
     for _rf in "${round1_files[@]}"; do
-        if [[ ! -f "$_rf" ]] || \
-           grep -qE '^## Status: (FAILED|TIMEOUT)' "$_rf" 2>/dev/null || \
-           [[ $(grep -c '^## Status:' "$_rf" 2>/dev/null || true) -eq 0 ]]; then
+        if [[ ! -f "$_rf" ]]; then
+            ((_r1_failed++)) || true
+            continue
+        fi
+        local _rf_failed_status_count _rf_status_count
+        _rf_failed_status_count=$(grep -cE '^## Status: (FAILED|TIMEOUT)' "$_rf" 2>/dev/null || true)
+        _rf_failed_status_count=${_rf_failed_status_count:-0}
+        _rf_status_count=$(grep -c '^## Status:' "$_rf" 2>/dev/null || true)
+        _rf_status_count=${_rf_status_count:-0}
+        if [[ "${_rf_failed_status_count%%$'\n'*}" -gt 0 ]] || [[ "${_rf_status_count%%$'\n'*}" -eq 0 ]]; then
             ((_r1_failed++)) || true
         fi
     done

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -296,11 +296,11 @@ review_run_agent_sync_progress() {
     return "$rc"
 }
 
-# review_codex_empty_output_retryable: returns true for transient Codex/Pioneer
+# review_openai_compat_empty_output_retryable: returns true for transient OpenAI-compatible adapter
 # review failures where the CLI exited with Empty output after reconnects. These
 # are usually provider-side transient stream/session failures rather than review
 # conclusions, so Round 1 may retry them once after backoff.
-review_codex_empty_output_retryable() {
+review_openai_compat_empty_output_retryable() {
     local result_file="$1"
     local agent_type="$2"
     [[ "$agent_type" == codex* ]] || return 1
@@ -866,22 +866,22 @@ ${agent_prompt_base}"
     done
     for _pid in "${round1_pids[@]}"; do wait "$_pid" 2>/dev/null || true; done
 
-    # Retry transient Codex/Pioneer Empty output failures once after backoff. We
+    # Retry transient OpenAI-compatible adapter Empty output failures once after backoff. We
     # only do this for Round 1 review specialists and only when the artifact shows
     # reconnects, because provider-side 180s empty responses can be recoverable
     # after a short pause.
-    local codex_empty_retry_max="${OCTOPUS_REVIEW_CODEX_EMPTY_RETRY_MAX:-1}"
-    local codex_empty_retry_backoff="${OCTOPUS_REVIEW_CODEX_EMPTY_RETRY_BACKOFF_SECS:-90}"
-    [[ "$codex_empty_retry_max" =~ ^[0-9]+$ ]] || codex_empty_retry_max=1
-    [[ "$codex_empty_retry_backoff" =~ ^[0-9]+$ ]] || codex_empty_retry_backoff=90
-    codex_empty_retry_max=$((10#$codex_empty_retry_max))
-    codex_empty_retry_backoff=$((10#$codex_empty_retry_backoff))
-    if [[ "$codex_empty_retry_max" -gt 0 ]]; then
+    local openai_compat_empty_retry_max="${OCTOPUS_REVIEW_OPENAI_COMPAT_EMPTY_RETRY_MAX:-1}"
+    local openai_compat_empty_retry_backoff="${OCTOPUS_REVIEW_OPENAI_COMPAT_EMPTY_RETRY_BACKOFF_SECS:-90}"
+    [[ "$openai_compat_empty_retry_max" =~ ^[0-9]+$ ]] || openai_compat_empty_retry_max=1
+    [[ "$openai_compat_empty_retry_backoff" =~ ^[0-9]+$ ]] || openai_compat_empty_retry_backoff=90
+    openai_compat_empty_retry_max=$((10#$openai_compat_empty_retry_max))
+    openai_compat_empty_retry_backoff=$((10#$openai_compat_empty_retry_backoff))
+    if [[ "$openai_compat_empty_retry_max" -gt 0 ]]; then
         local retry_idx=0
         while [[ "$retry_idx" -lt "${#round1_files[@]}" ]]; do
             local retry_file="${round1_files[$retry_idx]}"
             local retry_agent_type="${round1_agent_types[$retry_idx]}"
-            if review_codex_empty_output_retryable "$retry_file" "$retry_agent_type"; then
+            if review_openai_compat_empty_output_retryable "$retry_file" "$retry_agent_type"; then
                 local reconnect_count retry_role retry_task_id retry_prompt retry_result_file retry_pid archived_file
                 reconnect_count=$(grep -c 'Reconnecting' "$retry_file" 2>/dev/null || true)
                 reconnect_count=${reconnect_count:-0}
@@ -891,9 +891,9 @@ ${agent_prompt_base}"
                 retry_result_file="${RESULTS_DIR}/${retry_agent_type}-${retry_task_id}.md"
                 archived_file="${retry_file}.attempt1"
                 mv "$retry_file" "$archived_file" 2>/dev/null || true
-                log WARN "review_run: ${retry_agent_type}/${retry_role} ended Empty output after ${reconnect_count} reconnect(s); retrying once after ${codex_empty_retry_backoff}s (artifact=$(basename "$archived_file"))"
-                sleep "$codex_empty_retry_backoff"
-                retry_prompt="RETRY NOTICE: the previous ${retry_agent_type}/${retry_role} review attempt ended with Empty output after Pioneer reconnects. Review only the supplied diff/context; do not inspect the workspace unless strictly necessary. Return ONLY the required JSON object.
+                log WARN "review_run: ${retry_agent_type}/${retry_role} ended Empty output after ${reconnect_count} reconnect(s); retrying once after ${openai_compat_empty_retry_backoff}s (artifact=$(basename "$archived_file"))"
+                sleep "$openai_compat_empty_retry_backoff"
+                retry_prompt="RETRY NOTICE: the previous ${retry_agent_type}/${retry_role} review attempt ended with Empty output after adapter reconnects. Review only the supplied diff/context; do not inspect the workspace unless strictly necessary. Return ONLY the required JSON object.
 
 ${round1_prompts[$retry_idx]}"
                 spawn_agent "$retry_agent_type" "$retry_prompt" "$retry_task_id" "$retry_role" "review" &

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -210,11 +210,24 @@ build_review_fleet() {
     echo "$fleet"
 }
 
+review_file_mtime_epoch() {
+    local file="$1"
+    stat -c '%Y' "$file" 2>/dev/null || stat -f '%m' "$file" 2>/dev/null || echo 0
+}
+
 review_progress_fingerprint_since() {
     local since_epoch="$1"
     local results_dir="${2:-${RESULTS_DIR:-${HOME}/.claude-octopus/results}}"
-    find "$results_dir" -maxdepth 1 -type f -newermt "@${since_epoch}" \
-        -printf '%p %s %T@\n' 2>/dev/null | sort | sha256sum 2>/dev/null | awk '{print $1}'
+    [[ -d "$results_dir" ]] || { echo "empty"; return 0; }
+    find "$results_dir" -maxdepth 1 -type f 2>/dev/null | while IFS= read -r file; do
+        local mtime size
+        mtime=$(review_file_mtime_epoch "$file")
+        [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
+        [[ "$mtime" -ge "$since_epoch" ]] || continue
+        size=$(wc -c < "$file" 2>/dev/null || echo 0)
+        size=${size//[[:space:]]/}
+        printf '%s %s %s\n' "$file" "${size:-0}" "$mtime"
+    done | sort | sha256sum 2>/dev/null | awk '{print $1}'
 }
 
 review_run_agent_sync_progress() {
@@ -282,8 +295,13 @@ review_codex_empty_output_retryable() {
     local agent_type="$2"
     [[ "$agent_type" == codex* ]] || return 1
     [[ -f "$result_file" ]] || return 1
-    grep -qE '^## Status: FAILED \(Empty output\)' "$result_file" 2>/dev/null || return 1
-    [[ $(grep -c 'Reconnecting' "$result_file" 2>/dev/null || true) -gt 0 ]] || return 1
+    local empty_count reconnect_count
+    empty_count=$(grep -cE '^## Status: FAILED \(Empty output\)' "$result_file" 2>/dev/null || true)
+    empty_count=${empty_count:-0}
+    reconnect_count=$(grep -c 'Reconnecting' "$result_file" 2>/dev/null || true)
+    reconnect_count=${reconnect_count:-0}
+    [[ "${empty_count%%$'\n'*}" -gt 0 ]] || return 1
+    [[ "${reconnect_count%%$'\n'*}" -gt 0 ]] || return 1
 }
 
 # review_wait_for_result_status: waits for one result file to become terminal,
@@ -292,7 +310,7 @@ review_wait_for_result_status() {
     local result_file="$1"
     local pid="$2"
     local label="$3"
-    local results_dir="${4:-$RESULTS_DIR}"
+    local results_dir="${4:-${RESULTS_DIR:-${HOME}/.claude-octopus/results}}"
     local stall_window="${5:-${OCTOPUS_REVIEW_STALL_WINDOW:-1800}}"
     local poll_secs="${6:-${OCTOPUS_REVIEW_POLL_SECS:-30}}"
     local poll_start last_progress last_fp current_fp
@@ -300,7 +318,10 @@ review_wait_for_result_status() {
     last_progress="$poll_start"
     last_fp=$(review_progress_fingerprint_since "$poll_start" "$results_dir")
     while true; do
-        if [[ -f "$result_file" ]] && [[ $(grep -cE '^## Status:' "$result_file" 2>/dev/null || true) -gt 0 ]]; then
+        local status_count
+        status_count=$(grep -cE '^## Status:' "$result_file" 2>/dev/null || true)
+        status_count=${status_count:-0}
+        if [[ -f "$result_file" ]] && [[ "${status_count%%$'\n'*}" -gt 0 ]]; then
             break
         fi
         current_fp=$(review_progress_fingerprint_since "$poll_start" "$results_dir")
@@ -376,11 +397,13 @@ PYEXTRACT
 review_local_synthesis_json() {
     local findings_json="$1"
     local warning="${2:-}"
+    local sort_filter='def severity_rank: if .severity == "normal" then 0 elif .severity == "nit" then 1 elif .severity == "pre-existing" then 2 else 3 end; sort_by(severity_rank)'
     if [[ -n "$warning" ]]; then
-        printf '%s' "$findings_json" | jq -c --arg warning "$warning" '{findings:(. // [] | sort_by(.severity)), warning:$warning}' 2>/dev/null             || printf '{"findings":[],"warning":%s}\n' "$(printf '%s' "$warning" | jq -R .)"
+        printf '%s' "$findings_json" | jq -c --arg warning "$warning" "{findings:(. // [] | ${sort_filter}), warning:\$warning}" 2>/dev/null \
+            || printf '{"findings":[],"warning":%s}\n' "$(printf '%s' "$warning" | jq -R .)"
     else
         printf '%s' "$findings_json" | jq -c \
-            '{findings:(. // [] | sort_by(.severity))}' 2>/dev/null \
+            "{findings:(. // [] | ${sort_filter})}" 2>/dev/null \
             || echo '{"findings":[]}'
     fi
 }
@@ -839,6 +862,8 @@ ${agent_prompt_base}"
     # after a short pause.
     local codex_empty_retry_max="${OCTOPUS_REVIEW_CODEX_EMPTY_RETRY_MAX:-1}"
     local codex_empty_retry_backoff="${OCTOPUS_REVIEW_CODEX_EMPTY_RETRY_BACKOFF_SECS:-90}"
+    [[ "$codex_empty_retry_max" =~ ^[0-9]+$ ]] || codex_empty_retry_max=1
+    [[ "$codex_empty_retry_backoff" =~ ^[0-9]+$ ]] || codex_empty_retry_backoff=90
     if [[ "$codex_empty_retry_max" -gt 0 ]]; then
         local retry_idx=0
         while [[ "$retry_idx" -lt "${#round1_files[@]}" ]]; do
@@ -846,7 +871,9 @@ ${agent_prompt_base}"
             local retry_agent_type="${round1_agent_types[$retry_idx]}"
             if review_codex_empty_output_retryable "$retry_file" "$retry_agent_type"; then
                 local reconnect_count retry_role retry_task_id retry_prompt retry_result_file retry_pid archived_file
-                reconnect_count=$(grep -c 'Reconnecting' "$retry_file" 2>/dev/null || echo 0)
+                reconnect_count=$(grep -c 'Reconnecting' "$retry_file" 2>/dev/null || true)
+                reconnect_count=${reconnect_count:-0}
+                reconnect_count=${reconnect_count%%$'\n'*}
                 retry_role="${round1_roles[$retry_idx]}"
                 retry_task_id="${round1_task_ids[$retry_idx]}-retry1"
                 retry_result_file="${RESULTS_DIR}/${retry_agent_type}-${retry_task_id}.md"
@@ -1034,7 +1061,7 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
     final_json=$(review_run_agent_sync_progress "claude-sonnet" "$synthesis_prompt" "code-reviewer" "review" "synthesis-claude-sonnet") || {
         synth_ok="false"
         log WARN "review_run: synthesis failed, using confirmed findings sorted as-is"
-        final_json="{\"findings\":$(echo "$confirmed_findings" | jq -c 'sort_by(.severity)' 2>/dev/null || echo "[]")}"
+        final_json="$(review_local_synthesis_json "$confirmed_findings" "$round1_warning")"
     }
 
     # v9.3.1: Strip markdown fences from synthesis result (#188)
@@ -1043,6 +1070,9 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
         log WARN "review_run: synthesis returned invalid findings JSON, using local fallback"
         final_json=$(review_local_synthesis_json "$confirmed_findings" "$round1_warning")
         synth_ok="false"
+    elif [[ -n "$round1_warning" ]]; then
+        final_json=$(printf '%s' "$final_json" | jq -c --arg warning "$round1_warning" '. + {warning:$warning}' 2>/dev/null \
+            || review_local_synthesis_json "$confirmed_findings" "$round1_warning")
     fi
 
     # Write findings file

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -210,6 +210,69 @@ build_review_fleet() {
     echo "$fleet"
 }
 
+review_progress_fingerprint_since() {
+    local since_epoch="$1"
+    local results_dir="${2:-${RESULTS_DIR:-${HOME}/.claude-octopus/results}}"
+    find "$results_dir" -maxdepth 1 -type f -newermt "@${since_epoch}" \
+        -printf '%p %s %T@\n' 2>/dev/null | sort | sha256sum 2>/dev/null | awk '{print $1}'
+}
+
+review_run_agent_sync_progress() {
+    local agent_type="$1"
+    local prompt="$2"
+    local role="$3"
+    local phase="$4"
+    local label="${5:-sync}"
+    local results_dir="${RESULTS_DIR:-${HOME}/.claude-octopus/results}"
+    local stall_window="${OCTOPUS_REVIEW_STALL_WINDOW:-1800}"
+    local poll_secs="${OCTOPUS_REVIEW_POLL_SECS:-30}"
+    [[ "$stall_window" =~ ^[0-9]+$ ]] || stall_window=1800
+    [[ "$poll_secs" =~ ^[0-9]+$ ]] || poll_secs=30
+    [[ "$poll_secs" -lt 1 ]] && poll_secs=1
+    mkdir -p "$results_dir" 2>/dev/null || true
+
+    local start_epoch out_file rc_file pid rc last_progress last_fp current_fp now
+    start_epoch=$(date +%s)
+    out_file="${results_dir}/.tmp-review-sync-${label}-$$-${RANDOM}.out"
+    rc_file="${out_file}.rc"
+    : > "$out_file"
+    rm -f "$rc_file" 2>/dev/null || true
+
+    (
+        run_agent_sync "$agent_type" "$prompt" 0 "$role" "$phase" > "$out_file" 2>&1
+        echo "$?" > "$rc_file"
+    ) &
+    pid=$!
+    last_progress=$(date +%s)
+    last_fp=$(review_progress_fingerprint_since "$start_epoch" "$results_dir")
+
+    while kill -0 "$pid" 2>/dev/null; do
+        sleep "$poll_secs"
+        now=$(date +%s)
+        current_fp=$(review_progress_fingerprint_since "$start_epoch" "$results_dir")
+        if [[ "$current_fp" != "$last_fp" ]]; then
+            last_fp="$current_fp"
+            last_progress="$now"
+            log INFO "review_run: ${label} progress observed"
+        elif [[ "$stall_window" -gt 0 && $((now - last_progress)) -ge "$stall_window" ]]; then
+            log WARN "review_run: ${label} stalled after ${stall_window}s with no observable progress — stopping provider and preserving partial output"
+            pkill -TERM -P "$pid" 2>/dev/null || true
+            kill -TERM "$pid" 2>/dev/null || true
+            sleep 5
+            pkill -KILL -P "$pid" 2>/dev/null || true
+            kill -KILL "$pid" 2>/dev/null || true
+            break
+        fi
+    done
+
+    wait "$pid" 2>/dev/null || true
+    rc=1
+    [[ -f "$rc_file" ]] && rc=$(cat "$rc_file" 2>/dev/null || echo 1)
+    cat "$out_file" 2>/dev/null || true
+    rm -f "$out_file" "$rc_file" 2>/dev/null || true
+    return "$rc"
+}
+
 # review_extract_findings_array: returns a JSON array of findings from a Round 1
 # markdown result file. Providers sometimes echo the full prompt or wrap JSON in
 # prose; prefer the exact ## Output jq path, then fall back to scanning the file
@@ -590,18 +653,15 @@ Use this context as the requested behavior and constraints. Flag severity=normal
         fi
     fi
 
-    # ── Scale timeout by diff size (#303) ───────────────────────────────────
+    # ── Progress-supervised review execution ────────────────────────────────
     local diff_lines
     diff_lines=$(echo "$diff_content" | wc -l | tr -d ' ')
-    local review_timeout="${OCTOPUS_REVIEW_TIMEOUT:-480}"
-    if [[ "$review_timeout" -eq 480 ]]; then
-        if [[ "$diff_lines" -gt 5000 ]]; then
-            review_timeout=900
-        elif [[ "$diff_lines" -gt 2000 ]]; then
-            review_timeout=600
-        fi
-    fi
-    export TIMEOUT="$review_timeout"
+    local review_stall_window="${OCTOPUS_REVIEW_STALL_WINDOW:-1800}"
+    local review_poll_secs="${OCTOPUS_REVIEW_POLL_SECS:-30}"
+    [[ "$review_stall_window" =~ ^[0-9]+$ ]] || review_stall_window=1800
+    [[ "$review_poll_secs" =~ ^[0-9]+$ ]] || review_poll_secs=30
+    [[ "$review_poll_secs" -lt 1 ]] && review_poll_secs=1
+    export TIMEOUT=0
 
     if [[ -n "$proof_dir" ]]; then
         octo_proof_event "$proof_dir" "review_scope" "$(jq -n \
@@ -620,7 +680,7 @@ Use this context as the requested behavior and constraints. Flag severity=normal
     fi
 
     # ── ROUND 1: Parallel agent fleet ────────────────────────────────────────
-    log INFO "review_run: Round 1 — parallel specialist fleet (timeout=${review_timeout}s, diff=${diff_lines} lines)"
+    log INFO "review_run: Round 1 — parallel specialist fleet (no wall timeout, stall_window=${review_stall_window}s, diff=${diff_lines} lines)"
     local fleet
     fleet=$(build_review_fleet)
 
@@ -657,6 +717,7 @@ CRITICAL OUTPUT FORMAT: Return ONLY a valid JSON object. No markdown, no prose, 
 
     local round1_files=()
     local round1_agent_types=()
+    local round1_pids=()
 
     fleet_dispatch_begin
     while IFS=: read -r agent_type role specialty; do
@@ -672,16 +733,18 @@ CRITICAL OUTPUT FORMAT: Return ONLY a valid JSON object. No markdown, no prose, 
 ${agent_prompt_base}"
 
         spawn_agent "$agent_type" "$agent_prompt" "$task_id" "$role" "review" &
+        round1_pids+=("$!")
     done <<< "$fleet"
 
     fleet_dispatch_end
 
-    # Wait for all Round 1 agents
-    # v9.3.1: wait only catches direct children; spawn_agent's actual CLI runs as
-    # grandchild processes. Poll result files for ## Status markers instead (#190).
-    wait  # Wait for spawn_agent setup to finish
-    local _poll_start
+    # Wait for all Round 1 agents with a progress watchdog instead of a wall timeout.
+    # timeout_secs=0 disables provider wall-clock caps; this loop only stops when
+    # every result is terminal or no result/output changes for the stall window.
+    local _poll_start _last_progress _last_fp _current_fp _round1_stalled=false
     _poll_start=$(date +%s)
+    _last_progress="$_poll_start"
+    _last_fp=$(review_progress_fingerprint_since "$_poll_start" "$RESULTS_DIR")
     while true; do
         local _all_done=true
         for _rf in "${round1_files[@]}"; do
@@ -691,12 +754,29 @@ ${agent_prompt_base}"
             fi
         done
         [[ "$_all_done" == "true" ]] && break
-        if [[ $(( $(date +%s) - _poll_start )) -ge $review_timeout ]]; then
-            log WARN "review_run: Round 1 timed out after ${review_timeout}s — collecting partial results"
+
+        _current_fp=$(review_progress_fingerprint_since "$_poll_start" "$RESULTS_DIR")
+        if [[ "$_current_fp" != "$_last_fp" ]]; then
+            _last_fp="$_current_fp"
+            _last_progress=$(date +%s)
+            log INFO "review_run: Round 1 progress observed"
+        elif [[ "$review_stall_window" -gt 0 && $(( $(date +%s) - _last_progress )) -ge "$review_stall_window" ]]; then
+            _round1_stalled=true
+            log WARN "review_run: Round 1 stalled after ${review_stall_window}s — collecting partial results"
+            for _pid in "${round1_pids[@]}"; do
+                pkill -TERM -P "$_pid" 2>/dev/null || true
+                kill -TERM "$_pid" 2>/dev/null || true
+            done
+            sleep 5
+            for _pid in "${round1_pids[@]}"; do
+                pkill -KILL -P "$_pid" 2>/dev/null || true
+                kill -KILL "$_pid" 2>/dev/null || true
+            done
             break
         fi
-        sleep 2
+        sleep "$review_poll_secs"
     done
+    for _pid in "${round1_pids[@]}"; do wait "$_pid" 2>/dev/null || true; done
     log INFO "review_run: Round 1 complete"
 
     # Collect Round 1 findings — robustly extract the last JSON object with a
@@ -772,9 +852,6 @@ ${agent_prompt_base}"
 
     # ── ROUND 2: Verification ─────────────────────────────────────────────────
     log INFO "review_run: Round 2 — verification"
-    local review_verifier_timeout
-    review_verifier_timeout="${OCTOPUS_REVIEW_VERIFIER_TIMEOUT:-300}"
-    [[ "$review_verifier_timeout" =~ ^[0-9]+$ ]] || review_verifier_timeout=300
     local verifier_prompt
     verifier_prompt="You are a code review verifier. For each finding below, check whether it is a real bug (confirmed), a false positive, or needs debate (uncertain/conflicting).
 
@@ -794,13 +871,13 @@ $(echo "$all_findings" | jq -c '.')
 Return ONLY valid JSON with 'findings' array including verdict field."
 
     local verified_findings
-    verified_findings=$(run_agent_sync "codex" "$verifier_prompt" "$review_verifier_timeout" "code-reviewer" "review") && {
+    verified_findings=$(review_run_agent_sync_progress "codex" "$verifier_prompt" "code-reviewer" "review" "verifier-codex") && {
         echo "codex|ok|Round 2 verification" >> "$provider_status_file"
     } || {
         log WARN "review_run: codex verifier failed, falling back to claude-sonnet"
         log "USER" "⚠ Round 2: Codex unavailable → claude-sonnet (fallback). Codex API usage will NOT change."
         echo "codex|fallback|Round 2 → claude-sonnet" >> "$provider_status_file"
-        verified_findings=$(run_agent_sync "claude-sonnet" "$verifier_prompt" "$review_verifier_timeout" "code-reviewer" "review") || {
+        verified_findings=$(review_run_agent_sync_progress "claude-sonnet" "$verifier_prompt" "code-reviewer" "review" "verifier-claude-sonnet") || {
             log WARN "review_run: verification failed entirely, using all findings as confirmed"
             verified_findings="{\"findings\":$(echo "$all_findings" | \
                 jq 'map(. + {"verdict":"confirmed"})' 2>/dev/null || echo "[]")}"
@@ -828,7 +905,7 @@ Return ONLY valid JSON with 'findings' array including verdict field."
 Findings: $(echo "$debate_candidates" | jq -c '.')
 Return JSON: {\"include\": [...finding titles...], \"exclude\": [...finding titles...]}"
             local debate_result
-            debate_result=$(run_agent_sync "codex" "$debate_prompt" 120 "code-reviewer" "review") && {
+            debate_result=$(review_run_agent_sync_progress "codex" "$debate_prompt" "code-reviewer" "review" "debate-codex") && {
                 echo "codex|ok|Round 3 debate" >> "$provider_status_file"
             } || {
                 log WARN "review_run: debate agent failed, including all contested findings"
@@ -859,10 +936,8 @@ Findings: $(echo "$confirmed_findings" | jq -c '.')
 
 Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
 
-    local final_json synth_ok="true" review_synthesis_timeout
-    review_synthesis_timeout="${OCTOPUS_REVIEW_SYNTHESIS_TIMEOUT:-120}"
-    [[ "$review_synthesis_timeout" =~ ^[0-9]+$ ]] || review_synthesis_timeout=120
-    final_json=$(run_agent_sync "claude-sonnet" "$synthesis_prompt" "$review_synthesis_timeout" "code-reviewer" "review") || {
+    local final_json synth_ok="true"
+    final_json=$(review_run_agent_sync_progress "claude-sonnet" "$synthesis_prompt" "code-reviewer" "review" "synthesis-claude-sonnet") || {
         synth_ok="false"
         log WARN "review_run: synthesis failed, using confirmed findings sorted as-is"
         final_json="{\"findings\":$(echo "$confirmed_findings" | jq -c 'sort_by(.severity)' 2>/dev/null || echo "[]")}"

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -273,6 +273,55 @@ review_run_agent_sync_progress() {
     return "$rc"
 }
 
+# review_codex_empty_output_retryable: returns true for transient Codex/Pioneer
+# review failures where the CLI exited with Empty output after reconnects. These
+# are usually provider-side transient stream/session failures rather than review
+# conclusions, so Round 1 may retry them once after backoff.
+review_codex_empty_output_retryable() {
+    local result_file="$1"
+    local agent_type="$2"
+    [[ "$agent_type" == codex* ]] || return 1
+    [[ -f "$result_file" ]] || return 1
+    grep -qE '^## Status: FAILED \(Empty output\)' "$result_file" 2>/dev/null || return 1
+    [[ $(grep -c 'Reconnecting' "$result_file" 2>/dev/null || true) -gt 0 ]] || return 1
+}
+
+# review_wait_for_result_status: waits for one result file to become terminal,
+# using the same progress-stall semantics as Round 1. No wall-clock cap.
+review_wait_for_result_status() {
+    local result_file="$1"
+    local pid="$2"
+    local label="$3"
+    local results_dir="${4:-$RESULTS_DIR}"
+    local stall_window="${5:-${OCTOPUS_REVIEW_STALL_WINDOW:-1800}}"
+    local poll_secs="${6:-${OCTOPUS_REVIEW_POLL_SECS:-30}}"
+    local poll_start last_progress last_fp current_fp
+    poll_start=$(date +%s)
+    last_progress="$poll_start"
+    last_fp=$(review_progress_fingerprint_since "$poll_start" "$results_dir")
+    while true; do
+        if [[ -f "$result_file" ]] && [[ $(grep -cE '^## Status:' "$result_file" 2>/dev/null || true) -gt 0 ]]; then
+            break
+        fi
+        current_fp=$(review_progress_fingerprint_since "$poll_start" "$results_dir")
+        if [[ "$current_fp" != "$last_fp" ]]; then
+            last_fp="$current_fp"
+            last_progress=$(date +%s)
+            log INFO "review_run: ${label} progress observed"
+        elif [[ "$stall_window" -gt 0 && $(( $(date +%s) - last_progress )) -ge "$stall_window" ]]; then
+            log WARN "review_run: ${label} stalled after ${stall_window}s — stopping retry"
+            pkill -TERM -P "$pid" 2>/dev/null || true
+            kill -TERM "$pid" 2>/dev/null || true
+            sleep 5
+            pkill -KILL -P "$pid" 2>/dev/null || true
+            kill -KILL "$pid" 2>/dev/null || true
+            break
+        fi
+        sleep "$poll_secs"
+    done
+    wait "$pid" 2>/dev/null || true
+}
+
 # review_extract_findings_array: returns a JSON array of findings from a Round 1
 # markdown result file. Providers sometimes echo the full prompt or wrap JSON in
 # prose; prefer the exact ## Output jq path, then fall back to scanning the file
@@ -717,6 +766,9 @@ CRITICAL OUTPUT FORMAT: Return ONLY a valid JSON object. No markdown, no prose, 
 
     local round1_files=()
     local round1_agent_types=()
+    local round1_roles=()
+    local round1_task_ids=()
+    local round1_prompts=()
     local round1_pids=()
 
     fleet_dispatch_begin
@@ -727,10 +779,13 @@ CRITICAL OUTPUT FORMAT: Return ONLY a valid JSON object. No markdown, no prose, 
         local result_file="${RESULTS_DIR}/${agent_type}-${task_id}.md"
         round1_files+=("$result_file")
         round1_agent_types+=("$agent_type")
+        round1_roles+=("$role")
+        round1_task_ids+=("$task_id")
 
         local agent_prompt="You are the ${role} specialist. Focus on: ${specialty}.
 
 ${agent_prompt_base}"
+        round1_prompts+=("$agent_prompt")
 
         spawn_agent "$agent_type" "$agent_prompt" "$task_id" "$role" "review" &
         round1_pids+=("$!")
@@ -777,6 +832,45 @@ ${agent_prompt_base}"
         sleep "$review_poll_secs"
     done
     for _pid in "${round1_pids[@]}"; do wait "$_pid" 2>/dev/null || true; done
+
+    # Retry transient Codex/Pioneer Empty output failures once after backoff. We
+    # only do this for Round 1 review specialists and only when the artifact shows
+    # reconnects, because provider-side 180s empty responses can be recoverable
+    # after a short pause.
+    local codex_empty_retry_max="${OCTOPUS_REVIEW_CODEX_EMPTY_RETRY_MAX:-1}"
+    local codex_empty_retry_backoff="${OCTOPUS_REVIEW_CODEX_EMPTY_RETRY_BACKOFF_SECS:-90}"
+    if [[ "$codex_empty_retry_max" -gt 0 ]]; then
+        local retry_idx=0
+        while [[ "$retry_idx" -lt "${#round1_files[@]}" ]]; do
+            local retry_file="${round1_files[$retry_idx]}"
+            local retry_agent_type="${round1_agent_types[$retry_idx]}"
+            if review_codex_empty_output_retryable "$retry_file" "$retry_agent_type"; then
+                local reconnect_count retry_role retry_task_id retry_prompt retry_result_file retry_pid archived_file
+                reconnect_count=$(grep -c 'Reconnecting' "$retry_file" 2>/dev/null || echo 0)
+                retry_role="${round1_roles[$retry_idx]}"
+                retry_task_id="${round1_task_ids[$retry_idx]}-retry1"
+                retry_result_file="${RESULTS_DIR}/${retry_agent_type}-${retry_task_id}.md"
+                archived_file="${retry_file}.attempt1"
+                mv "$retry_file" "$archived_file" 2>/dev/null || true
+                log WARN "review_run: ${retry_agent_type}/${retry_role} ended Empty output after ${reconnect_count} reconnect(s); retrying once after ${codex_empty_retry_backoff}s (artifact=$(basename "$archived_file"))"
+                sleep "$codex_empty_retry_backoff"
+                retry_prompt="RETRY NOTICE: the previous ${retry_agent_type}/${retry_role} review attempt ended with Empty output after Pioneer reconnects. Review only the supplied diff/context; do not inspect the workspace unless strictly necessary. Return ONLY the required JSON object.
+
+${round1_prompts[$retry_idx]}"
+                spawn_agent "$retry_agent_type" "$retry_prompt" "$retry_task_id" "$retry_role" "review" &
+                retry_pid="$!"
+                review_wait_for_result_status "$retry_result_file" "$retry_pid" "Round 1 ${retry_agent_type}/${retry_role} retry" "$RESULTS_DIR" "$review_stall_window" "$review_poll_secs"
+                round1_files[$retry_idx]="$retry_result_file"
+                if [[ -f "$retry_result_file" ]] && grep -qE '^## Status: SUCCESS' "$retry_result_file" 2>/dev/null; then
+                    log INFO "review_run: ${retry_agent_type}/${retry_role} retry recovered after Empty output"
+                else
+                    log WARN "review_run: ${retry_agent_type}/${retry_role} retry did not recover; continuing with partial Round 1"
+                fi
+            fi
+            ((retry_idx++)) || true
+        done
+    fi
+
     log INFO "review_run: Round 1 complete"
 
     # Collect Round 1 findings — robustly extract the last JSON object with a

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -210,6 +210,69 @@ build_review_fleet() {
     echo "$fleet"
 }
 
+# review_extract_findings_array: returns a JSON array of findings from a Round 1
+# markdown result file. Providers sometimes echo the full prompt or wrap JSON in
+# prose; prefer the exact ## Output jq path, then fall back to scanning the file
+# for the last JSON object with a findings array.
+review_extract_findings_array() {
+    local review_md="$1"
+    local output_text direct_json
+    [[ -f "$review_md" ]] || { echo "[]"; return 1; }
+
+    output_text=$(awk '/^## Output$/{found=1;next} /^## /{if(found)exit} found && !/^```(json|JSON)?$/{print}' "$review_md" 2>/dev/null || true)
+    if [[ -n "$output_text" ]]; then
+        direct_json=$(printf '%s' "$output_text" | jq -c '.findings // empty' 2>/dev/null || true)
+        if [[ -n "$direct_json" && "$direct_json" != "null" ]]; then
+            printf '%s\n' "$direct_json"
+            return 0
+        fi
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$review_md" <<'PYEXTRACT'
+import json, sys
+from pathlib import Path
+path = Path(sys.argv[1])
+text = path.read_text(errors='ignore')
+decoder = json.JSONDecoder()
+best = None
+idx = 0
+while True:
+    idx = text.find('{', idx)
+    if idx < 0:
+        break
+    try:
+        obj, end = decoder.raw_decode(text[idx:])
+    except Exception:
+        idx += 1
+        continue
+    if isinstance(obj, dict) and isinstance(obj.get('findings'), list):
+        best = obj.get('findings')
+    idx += max(1, end)
+if best is None:
+    print('[]')
+    sys.exit(1)
+print(json.dumps(best, separators=(',', ':')))
+PYEXTRACT
+        return $?
+    fi
+
+    echo "[]"
+    return 1
+}
+
+review_local_synthesis_json() {
+    local findings_json="$1"
+    local warning="${2:-}"
+    if [[ -n "$warning" ]]; then
+        printf '%s' "$findings_json" | jq -c --arg warning "$warning" '{findings:(. // [] | sort_by(.severity)), warning:$warning}' 2>/dev/null             || printf '{"findings":[],"warning":%s}\n' "$(printf '%s' "$warning" | jq -R .)"
+    else
+        printf '%s' "$findings_json" | jq -c \
+            '{findings:(. // [] | sort_by(.severity))}' 2>/dev/null \
+            || echo '{"findings":[]}'
+    fi
+}
+
 # review_collect_diff: resolves a review target to unified diff content.
 # Targets can be built-in scopes (staged, working-tree), a PR number, a git
 # pathspec, or an already-generated .diff/.patch file.
@@ -636,17 +699,22 @@ ${agent_prompt_base}"
     done
     log INFO "review_run: Round 1 complete"
 
-    # Collect Round 1 findings — extract ## Output section, strip markdown fences, parse JSON
+    # Collect Round 1 findings — robustly extract the last JSON object with a
+    # findings array. Some providers echo the full prompt before the final JSON;
+    # a strict jq of the whole ## Output block silently loses those findings.
     local all_findings="[]"
     local idx=0
+    local round1_partial_count=0
+    local round1_parse_miss_count=0
     for f in "${round1_files[@]}"; do
-        [[ ! -f "$f" ]] && continue
+        [[ ! -f "$f" ]] && { ((round1_partial_count++)) || true; continue; }
         local agent_findings
-        # v9.20.1: Extract content from ## Output section (portable awk, fixes BSD sed #255)
-        agent_findings=$(awk '/^## Output$/{found=1;next} /^## /{if(found)exit} found && !/^```(json|JSON)?$/{print}' "$f" | \
-            jq -r '.findings // []' 2>/dev/null || echo "[]")
-        all_findings=$(printf '%s\n%s' "$all_findings" "$agent_findings" | \
-            jq -s 'add' 2>/dev/null || echo "$all_findings")
+        agent_findings=$(review_extract_findings_array "$f" 2>/dev/null || echo "[]")
+        if [[ "$agent_findings" == "[]" ]] && grep -q '"severity"[[:space:]]*:[[:space:]]*"' "$f" 2>/dev/null; then
+            ((round1_parse_miss_count++)) || true
+            log WARN "review_run: possible findings in $(basename "$f") but extractor returned empty array"
+        fi
+        all_findings=$(printf '%s\n%s' "$all_findings" "$agent_findings" |             jq -s 'add' 2>/dev/null || echo "$all_findings")
 
         # v9.3.1: Write provider status for Round 1 agents (#187)
         local atype="${round1_agent_types[$idx]}"
@@ -660,13 +728,22 @@ ${agent_prompt_base}"
                 octo_event_emit "review.finding" provider="$provider_key" severity="${_rf_sev:-unknown}" message="${_rf_title:-}" round="1" || true
             done < <(printf '%s' "$agent_findings" | jq -r '.[]? | [(.severity // "unknown"), (.title // .message // "")] | @tsv' 2>/dev/null)
         fi
-        if [[ $(grep -c "Status: FAILED" "$f" 2>/dev/null || true) -gt 0 ]]; then
-            echo "${provider_key}|fallback|Round 1 agent failed" >> "$provider_status_file"
+        if [[ $(grep -cE "Status: (FAILED|TIMEOUT)" "$f" 2>/dev/null || true) -gt 0 ]]; then
+            ((round1_partial_count++)) || true
+            echo "${provider_key}|fallback|Round 1 agent failed or timed out" >> "$provider_status_file"
         elif [[ "$agent_findings" != "[]" ]]; then
             echo "${provider_key}|ok|Round 1 findings" >> "$provider_status_file"
         fi
         ((idx++)) || true
     done
+
+    local round1_findings_file="${results_dir}/review-round1-findings-${timestamp}.json"
+    local round1_warning=""
+    if [[ "$round1_partial_count" -gt 0 || "$round1_parse_miss_count" -gt 0 ]]; then
+        round1_warning="Round 1 was partial: ${round1_partial_count} provider(s) missing/failed/timed out, ${round1_parse_miss_count} provider output(s) had possible unparsed findings."
+    fi
+    review_local_synthesis_json "$all_findings" "$round1_warning" > "$round1_findings_file"
+    log INFO "review_run: Round 1 findings snapshot saved to $round1_findings_file"
 
     # v9.20.1: Detect total fleet failure — all providers crashed/timed out (#255)
     local _r1_total=${#round1_files[@]}
@@ -695,6 +772,9 @@ ${agent_prompt_base}"
 
     # ── ROUND 2: Verification ─────────────────────────────────────────────────
     log INFO "review_run: Round 2 — verification"
+    local review_verifier_timeout
+    review_verifier_timeout="${OCTOPUS_REVIEW_VERIFIER_TIMEOUT:-300}"
+    [[ "$review_verifier_timeout" =~ ^[0-9]+$ ]] || review_verifier_timeout=300
     local verifier_prompt
     verifier_prompt="You are a code review verifier. For each finding below, check whether it is a real bug (confirmed), a false positive, or needs debate (uncertain/conflicting).
 
@@ -714,13 +794,13 @@ $(echo "$all_findings" | jq -c '.')
 Return ONLY valid JSON with 'findings' array including verdict field."
 
     local verified_findings
-    verified_findings=$(run_agent_sync "codex" "$verifier_prompt" "${TIMEOUT:-300}" "code-reviewer" "review") && {
+    verified_findings=$(run_agent_sync "codex" "$verifier_prompt" "$review_verifier_timeout" "code-reviewer" "review") && {
         echo "codex|ok|Round 2 verification" >> "$provider_status_file"
     } || {
         log WARN "review_run: codex verifier failed, falling back to claude-sonnet"
         log "USER" "⚠ Round 2: Codex unavailable → claude-sonnet (fallback). Codex API usage will NOT change."
         echo "codex|fallback|Round 2 → claude-sonnet" >> "$provider_status_file"
-        verified_findings=$(run_agent_sync "claude-sonnet" "$verifier_prompt" "${TIMEOUT:-300}" "code-reviewer" "review") || {
+        verified_findings=$(run_agent_sync "claude-sonnet" "$verifier_prompt" "$review_verifier_timeout" "code-reviewer" "review") || {
             log WARN "review_run: verification failed entirely, using all findings as confirmed"
             verified_findings="{\"findings\":$(echo "$all_findings" | \
                 jq 'map(. + {"verdict":"confirmed"})' 2>/dev/null || echo "[]")}"
@@ -779,8 +859,10 @@ Findings: $(echo "$confirmed_findings" | jq -c '.')
 
 Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
 
-    local final_json synth_ok="true"
-    final_json=$(run_agent_sync "claude-sonnet" "$synthesis_prompt" 120 "code-reviewer" "review") || {
+    local final_json synth_ok="true" review_synthesis_timeout
+    review_synthesis_timeout="${OCTOPUS_REVIEW_SYNTHESIS_TIMEOUT:-120}"
+    [[ "$review_synthesis_timeout" =~ ^[0-9]+$ ]] || review_synthesis_timeout=120
+    final_json=$(run_agent_sync "claude-sonnet" "$synthesis_prompt" "$review_synthesis_timeout" "code-reviewer" "review") || {
         synth_ok="false"
         log WARN "review_run: synthesis failed, using confirmed findings sorted as-is"
         final_json="{\"findings\":$(echo "$confirmed_findings" | jq -c 'sort_by(.severity)' 2>/dev/null || echo "[]")}"
@@ -788,6 +870,11 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
 
     # v9.3.1: Strip markdown fences from synthesis result (#188)
     final_json=$(echo "$final_json" | sed '/^```json$/d; /^```JSON$/d; /^```$/d')
+    if ! printf '%s' "$final_json" | jq -e '.findings | type == "array"' >/dev/null 2>&1; then
+        log WARN "review_run: synthesis returned invalid findings JSON, using local fallback"
+        final_json=$(review_local_synthesis_json "$confirmed_findings" "$round1_warning")
+        synth_ok="false"
+    fi
 
     # Write findings file
     echo "$final_json" > "$findings_file"

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -228,8 +228,12 @@ review_hash_stdin() {
 review_progress_fingerprint_since() {
     local since_epoch="$1"
     local results_dir="${2:-${RESULTS_DIR:-${HOME}/.claude-octopus/results}}"
+    # Optional filename pattern scopes the fingerprint to one agent's artifacts.
+    # Without it, any concurrent activity in the shared RESULTS_DIR resets the
+    # stall timer for every agent, so a genuinely hung provider never trips it.
+    local name_pattern="${3:-}"
     [[ -d "$results_dir" ]] || { echo "empty"; return 0; }
-    find "$results_dir" -maxdepth 1 -type f 2>/dev/null | while IFS= read -r file; do
+    find "$results_dir" -maxdepth 1 -type f ${name_pattern:+-name "$name_pattern"} 2>/dev/null | while IFS= read -r file; do
         local mtime size
         mtime=$(review_file_mtime_epoch "$file")
         [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
@@ -238,6 +242,17 @@ review_progress_fingerprint_since() {
         size=${size//[[:space:]]/}
         printf '%s %s %s\n' "$file" "${size:-0}" "$mtime"
     done | sort | review_hash_stdin
+}
+
+# review_kill_tree <SIG> <pid>: depth-first kill of a process and all its
+# descendants. The provider CLI runs as a grandchild of the backgrounded
+# wrapper, so a single-level pkill -P can orphan it mid-billing (#190).
+review_kill_tree() {
+    local sig="$1" pid="$2" kid
+    for kid in $(pgrep -P "$pid" 2>/dev/null); do
+        review_kill_tree "$sig" "$kid"
+    done
+    kill "-${sig}" "$pid" 2>/dev/null || true
 }
 
 review_run_agent_sync_progress() {
@@ -267,23 +282,23 @@ review_run_agent_sync_progress() {
     ) &
     pid=$!
     last_progress=$(date +%s)
-    last_fp=$(review_progress_fingerprint_since "$start_epoch" "$results_dir")
+    local own_pattern
+    own_pattern="$(basename "$out_file")*"
+    last_fp=$(review_progress_fingerprint_since "$start_epoch" "$results_dir" "$own_pattern")
 
     while kill -0 "$pid" 2>/dev/null; do
         sleep "$poll_secs"
         now=$(date +%s)
-        current_fp=$(review_progress_fingerprint_since "$start_epoch" "$results_dir")
+        current_fp=$(review_progress_fingerprint_since "$start_epoch" "$results_dir" "$own_pattern")
         if [[ "$current_fp" != "$last_fp" ]]; then
             last_fp="$current_fp"
             last_progress="$now"
             log INFO "review_run: ${label} progress observed"
         elif [[ "$stall_window" -gt 0 && $((now - last_progress)) -ge "$stall_window" ]]; then
             log WARN "review_run: ${label} stalled after ${stall_window}s with no observable progress — stopping provider and preserving partial output"
-            pkill -TERM -P "$pid" 2>/dev/null || true
-            kill -TERM "$pid" 2>/dev/null || true
+            review_kill_tree TERM "$pid"
             sleep 5
-            pkill -KILL -P "$pid" 2>/dev/null || true
-            kill -KILL "$pid" 2>/dev/null || true
+            review_kill_tree KILL "$pid"
             break
         fi
     done
@@ -326,7 +341,9 @@ review_wait_for_result_status() {
     local poll_start last_progress last_fp current_fp
     poll_start=$(date +%s)
     last_progress="$poll_start"
-    last_fp=$(review_progress_fingerprint_since "$poll_start" "$results_dir")
+    local own_pattern
+    own_pattern="$(basename "$result_file")*"
+    last_fp=$(review_progress_fingerprint_since "$poll_start" "$results_dir" "$own_pattern")
     while true; do
         local status_count
         status_count=$(grep -cE '^## Status:' "$result_file" 2>/dev/null || true)
@@ -334,18 +351,16 @@ review_wait_for_result_status() {
         if [[ -f "$result_file" ]] && [[ "${status_count%%$'\n'*}" -gt 0 ]]; then
             break
         fi
-        current_fp=$(review_progress_fingerprint_since "$poll_start" "$results_dir")
+        current_fp=$(review_progress_fingerprint_since "$poll_start" "$results_dir" "$own_pattern")
         if [[ "$current_fp" != "$last_fp" ]]; then
             last_fp="$current_fp"
             last_progress=$(date +%s)
             log INFO "review_run: ${label} progress observed"
         elif [[ "$stall_window" -gt 0 && $(( $(date +%s) - last_progress )) -ge "$stall_window" ]]; then
             log WARN "review_run: ${label} stalled after ${stall_window}s — stopping retry"
-            pkill -TERM -P "$pid" 2>/dev/null || true
-            kill -TERM "$pid" 2>/dev/null || true
+            review_kill_tree TERM "$pid"
             sleep 5
-            pkill -KILL -P "$pid" 2>/dev/null || true
-            kill -KILL "$pid" 2>/dev/null || true
+            review_kill_tree KILL "$pid"
             break
         fi
         sleep "$poll_secs"
@@ -390,7 +405,14 @@ while True:
         idx += 1
         continue
     if isinstance(obj, dict) and isinstance(obj.get('findings'), list):
-        best = obj.get('findings')
+        # Prefer the last NON-EMPTY findings array. The Round 1 prompt embeds
+        # {"findings": []} as a format example; a provider that echoes the
+        # prompt after its real answer must not have its findings replaced by
+        # the echoed empty example.
+        if obj.get('findings'):
+            best = obj.get('findings')
+        elif best is None:
+            best = obj.get('findings')
     idx += max(1, end)
 if best is None:
     print('[]')

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Tests for robust review findings extraction / aggregation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "review aggregation robustness"
+
+REVIEW_SH="$PROJECT_ROOT/scripts/lib/review.sh"
+TMP_MD="$(mktemp "${TMPDIR:-/tmp}/octo-review-md.XXXXXX")"
+trap 'rm -f "$TMP_MD"' EXIT
+
+cat > "$TMP_MD" <<'EOF'
+# Agent: claude-sonnet
+## Output
+```
+The provider echoed prompt text first.
+Example: {"findings": []}
+Now the actual answer:
+{"findings":[{"file":"api/terminal.js","line":12,"severity":"normal","category":"security","title":"Broken regex","detail":"The regex is wrong","confidence":0.9}]}
+```
+
+## Status: SUCCESS
+EOF
+
+test_case "extractor helper is present"
+if grep -q "review_extract_findings_array" "$REVIEW_SH"; then test_pass; else test_fail "missing helper"; fi
+
+test_case "round1 snapshot is written"
+if grep -q "review-round1-findings" "$REVIEW_SH"; then test_pass; else test_fail "missing round1 snapshot"; fi
+
+test_case "extractor recovers last JSON findings object"
+source "$REVIEW_SH" >/dev/null 2>&1 || true
+out=$(review_extract_findings_array "$TMP_MD")
+count=$(printf '%s' "$out" | jq 'length')
+title=$(printf '%s' "$out" | jq -r '.[0].title')
+if [[ "$count" == "1" && "$title" == "Broken regex" ]]; then
+    test_pass
+else
+    test_fail "unexpected extraction output: $out"
+fi
+
+test_case "verifier timeout is review-scoped"
+if grep -q "OCTOPUS_REVIEW_VERIFIER_TIMEOUT" "$REVIEW_SH"; then test_pass; else test_fail "missing verifier timeout"; fi
+
+test_case "synthesis timeout is review-scoped"
+if grep -q "OCTOPUS_REVIEW_SYNTHESIS_TIMEOUT" "$REVIEW_SH"; then test_pass; else test_fail "missing synthesis timeout"; fi
+
+test_case "invalid synthesis has local fallback"
+if grep -q "synthesis returned invalid findings JSON" "$REVIEW_SH"; then test_pass; else test_fail "missing local fallback"; fi
+
+test_summary

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -42,11 +42,22 @@ else
     test_fail "unexpected extraction output: $out"
 fi
 
-test_case "verifier timeout is review-scoped"
-if grep -q "OCTOPUS_REVIEW_VERIFIER_TIMEOUT" "$REVIEW_SH"; then test_pass; else test_fail "missing verifier timeout"; fi
+test_case "review agents run without absolute timeout"
+if grep -q "export TIMEOUT=0" "$REVIEW_SH" && grep -q "review_run_agent_sync_progress" "$REVIEW_SH"; then
+    test_pass
+else
+    test_fail "review no-wall-timeout wiring missing"
+fi
 
-test_case "synthesis timeout is review-scoped"
-if grep -q "OCTOPUS_REVIEW_SYNTHESIS_TIMEOUT" "$REVIEW_SH"; then test_pass; else test_fail "missing synthesis timeout"; fi
+test_case "old review timeout envs are removed"
+if grep -q "OCTOPUS_REVIEW_VERIFIER_TIMEOUT\|OCTOPUS_REVIEW_SYNTHESIS_TIMEOUT\|OCTOPUS_REVIEW_TIMEOUT" "$REVIEW_SH"; then
+    test_fail "old review timeout env still present"
+else
+    test_pass
+fi
+
+test_case "review uses stall watchdog"
+if grep -q "OCTOPUS_REVIEW_STALL_WINDOW" "$REVIEW_SH"; then test_pass; else test_fail "missing review stall window"; fi
 
 test_case "invalid synthesis has local fallback"
 if grep -q "synthesis returned invalid findings JSON" "$REVIEW_SH"; then test_pass; else test_fail "missing local fallback"; fi

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -33,13 +33,18 @@ if grep -q "review-round1-findings" "$REVIEW_SH"; then test_pass; else test_fail
 
 test_case "extractor recovers last JSON findings object"
 source "$REVIEW_SH" >/dev/null 2>&1 || true
-out=$(review_extract_findings_array "$TMP_MD")
-count=$(printf '%s' "$out" | jq 'length')
-title=$(printf '%s' "$out" | jq -r '.[0].title')
-if [[ "$count" == "1" && "$title" == "Broken regex" ]]; then
-    test_pass
+if out=$(review_extract_findings_array "$TMP_MD" 2>/dev/null); then
+    if count=$(printf '%s' "$out" | jq 'length' 2>/dev/null) && title=$(printf '%s' "$out" | jq -r '.[0].title' 2>/dev/null); then
+        if [[ "$count" == "1" && "$title" == "Broken regex" ]]; then
+            test_pass
+        else
+            test_fail "unexpected extraction output: $out"
+        fi
+    else
+        test_fail "extractor returned invalid JSON: $out"
+    fi
 else
-    test_fail "unexpected extraction output: $out"
+    test_fail "extractor failed to recover findings"
 fi
 
 test_case "review agents run without absolute timeout"

--- a/tests/unit/test-review-run.sh
+++ b/tests/unit/test-review-run.sh
@@ -113,14 +113,14 @@ assert_contains "$(grep -A4 'avg_confidence=$(jq' "$ALL_SRC" 2>/dev/null | head 
 assert_contains "$(grep -A2 'commit_id.*headRefOid' "$ALL_SRC" 2>/dev/null | head -10)" \
   'commit_id' "post_inline_comments: empty commit_id guarded"
 
-assert_contains "$(grep -c 'review_codex_empty_output_retryable' "$ALL_SRC" 2>/dev/null || echo 0)" \
-  "[1-9]" "review_run: codex Empty output retry classifier exists"
+assert_contains "$(grep -c 'review_openai_compat_empty_output_retryable' "$ALL_SRC" 2>/dev/null || echo 0)" \
+  "[1-9]" "review_run: OpenAI-compatible Empty output retry classifier exists"
 
-assert_contains "$(grep -c 'OCTOPUS_REVIEW_CODEX_EMPTY_RETRY_BACKOFF_SECS' "$ALL_SRC" 2>/dev/null || echo 0)" \
-  "[1-9]" "review_run: codex Empty output retry has configurable backoff"
+assert_contains "$(grep -c 'OCTOPUS_REVIEW_OPENAI_COMPAT_EMPTY_RETRY_BACKOFF_SECS' "$ALL_SRC" 2>/dev/null || echo 0)" \
+  "[1-9]" "review_run: OpenAI-compatible Empty output retry has configurable backoff"
 
 assert_contains "$(grep -c 'attempt1' "$ALL_SRC" 2>/dev/null || echo 0)" \
-  "[1-9]" "review_run: codex Empty output retry preserves first artifact"
+  "[1-9]" "review_run: OpenAI-compatible Empty output retry preserves first artifact"
 
 # ── diff target file support ─────────────────────────────────────────────────
 
@@ -139,35 +139,35 @@ EOF
 assert_contains "$(review_collect_diff "$DIFF_TARGET")" \
   "diff --git a/foo.txt b/foo.txt" "review_collect_diff: reads unified diff file targets"
 
-CODEX_EMPTY_RETRYABLE="$TMPDIR_TEST/codex-empty-retryable.md"
-cat > "$CODEX_EMPTY_RETRYABLE" <<'EOF'
-# Agent: codex
+OPENAI_COMPAT_EMPTY_RETRYABLE="$TMPDIR_TEST/openai-compat-empty-retryable.md"
+cat > "$OPENAI_COMPAT_EMPTY_RETRYABLE" <<'EOF'
+# Agent: openai-compatible
 ## Status: FAILED (Empty output)
 Reconnecting... 1/5
 EOF
 
-CODEX_EMPTY_NO_RECONNECT="$TMPDIR_TEST/codex-empty-no-reconnect.md"
-cat > "$CODEX_EMPTY_NO_RECONNECT" <<'EOF'
-# Agent: codex
+OPENAI_COMPAT_EMPTY_NO_RECONNECT="$TMPDIR_TEST/openai-compat-empty-no-reconnect.md"
+cat > "$OPENAI_COMPAT_EMPTY_NO_RECONNECT" <<'EOF'
+# Agent: openai-compatible
 ## Status: FAILED (Empty output)
 EOF
 
-if review_codex_empty_output_retryable "$CODEX_EMPTY_RETRYABLE" "codex"; then
-  pass "review_run: codex Empty output with reconnect is retryable"
+if review_openai_compat_empty_output_retryable "$OPENAI_COMPAT_EMPTY_RETRYABLE" "codex"; then
+  pass "review_run: OpenAI-compatible Empty output with reconnect is retryable"
 else
-  fail "review_run: codex Empty output with reconnect is retryable"
+  fail "review_run: OpenAI-compatible Empty output with reconnect is retryable"
 fi
 
-if review_codex_empty_output_retryable "$CODEX_EMPTY_NO_RECONNECT" "codex"; then
-  fail "review_run: codex Empty output without reconnect is not retryable"
+if review_openai_compat_empty_output_retryable "$OPENAI_COMPAT_EMPTY_NO_RECONNECT" "codex"; then
+  fail "review_run: OpenAI-compatible Empty output without reconnect is not retryable"
 else
-  pass "review_run: codex Empty output without reconnect is not retryable"
+  pass "review_run: OpenAI-compatible Empty output without reconnect is not retryable"
 fi
 
-if review_codex_empty_output_retryable "$CODEX_EMPTY_RETRYABLE" "gemini"; then
-  fail "review_run: non-codex Empty output is not retried by codex policy"
+if review_openai_compat_empty_output_retryable "$OPENAI_COMPAT_EMPTY_RETRYABLE" "gemini"; then
+  fail "review_run: non-OpenAI-compatible Empty output is not retried by adapter policy"
 else
-  pass "review_run: non-codex Empty output is not retried by codex policy"
+  pass "review_run: non-OpenAI-compatible Empty output is not retried by adapter policy"
 fi
 
 # ── MCP schema ───────────────────────────────────────────────────────────────

--- a/tests/unit/test-review-run.sh
+++ b/tests/unit/test-review-run.sh
@@ -113,6 +113,15 @@ assert_contains "$(grep -A4 'avg_confidence=$(jq' "$ALL_SRC" 2>/dev/null | head 
 assert_contains "$(grep -A2 'commit_id.*headRefOid' "$ALL_SRC" 2>/dev/null | head -10)" \
   'commit_id' "post_inline_comments: empty commit_id guarded"
 
+assert_contains "$(grep -c 'review_codex_empty_output_retryable' "$ALL_SRC" 2>/dev/null || echo 0)" \
+  "[1-9]" "review_run: codex Empty output retry classifier exists"
+
+assert_contains "$(grep -c 'OCTOPUS_REVIEW_CODEX_EMPTY_RETRY_BACKOFF_SECS' "$ALL_SRC" 2>/dev/null || echo 0)" \
+  "[1-9]" "review_run: codex Empty output retry has configurable backoff"
+
+assert_contains "$(grep -c 'attempt1' "$ALL_SRC" 2>/dev/null || echo 0)" \
+  "[1-9]" "review_run: codex Empty output retry preserves first artifact"
+
 # ── diff target file support ─────────────────────────────────────────────────
 
 source "$PROJECT_ROOT/scripts/lib/review.sh"
@@ -129,6 +138,37 @@ EOF
 
 assert_contains "$(review_collect_diff "$DIFF_TARGET")" \
   "diff --git a/foo.txt b/foo.txt" "review_collect_diff: reads unified diff file targets"
+
+CODEX_EMPTY_RETRYABLE="$TMPDIR_TEST/codex-empty-retryable.md"
+cat > "$CODEX_EMPTY_RETRYABLE" <<'EOF'
+# Agent: codex
+## Status: FAILED (Empty output)
+Reconnecting... 1/5
+EOF
+
+CODEX_EMPTY_NO_RECONNECT="$TMPDIR_TEST/codex-empty-no-reconnect.md"
+cat > "$CODEX_EMPTY_NO_RECONNECT" <<'EOF'
+# Agent: codex
+## Status: FAILED (Empty output)
+EOF
+
+if review_codex_empty_output_retryable "$CODEX_EMPTY_RETRYABLE" "codex"; then
+  pass "review_run: codex Empty output with reconnect is retryable"
+else
+  fail "review_run: codex Empty output with reconnect is retryable"
+fi
+
+if review_codex_empty_output_retryable "$CODEX_EMPTY_NO_RECONNECT" "codex"; then
+  fail "review_run: codex Empty output without reconnect is not retryable"
+else
+  pass "review_run: codex Empty output without reconnect is not retryable"
+fi
+
+if review_codex_empty_output_retryable "$CODEX_EMPTY_RETRYABLE" "gemini"; then
+  fail "review_run: non-codex Empty output is not retried by codex policy"
+else
+  pass "review_run: non-codex Empty output is not retried by codex policy"
+fi
 
 # ── MCP schema ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- make Round 1 review finding extraction resilient to provider prose/echoed prompts
- replace fixed review wall-clock timeouts with progress/stall supervision
- add one retry for transient OpenAI-compatible adapter Empty output after reconnects
- preserve partial/snapshot artifacts and use local synthesis fallback when needed
- address review edge cases from automated review: portable hashing, pipefail-safe checks, missing-result provider indexing, numeric env validation

## Tests

- bash -n scripts/lib/review.sh tests/unit/test-review-aggregation-robustness.sh tests/unit/test-review-run.sh
- timeout 40s bash tests/unit/test-review-run.sh
- timeout 40s bash tests/unit/test-review-aggregation-robustness.sh
- git diff --check origin/main..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review runs now use progress-based supervision, helping long-running checks continue as long as output is still advancing.
  * Findings extraction is more resilient and can recover results from mixed markdown and JSON output.

* **Bug Fixes**
  * Improved handling of stalled or reconnecting review runs, including a one-time retry for certain empty-output cases.
  * Better fallback behavior when final review JSON is incomplete or invalid, preserving partial results and warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->