### PR TITLE
feat: add tangle contextual review correction loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Added
 
+- **Tangle contextual review correction loop** (#593, community contribution by @Jhacarreiro; hardening by maintainers): after the tangle validation gate, a contextual code review runs against the develop diff and blocking findings feed a correction loop (delta → single-finding → cleanup-and-fix strategies) until blockers reach zero or a guard trips. Guards: convergence limit (`OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS`, default 3 no-progress rounds), stall watchdog (`OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW`, default 1800s), opt-in bounded mode (`OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded` + `OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS`), and a maintainer-added absolute round ceiling (`OCTOPUS_TANGLE_CORRECTION_HARD_CAP`, default 10, applies in both modes, 0 opts out) so the default unbounded mode cannot spin paid provider calls indefinitely. The loop was extracted into `tangle_contextual_review_gate()` and covered by behavioral tests (`tests/unit/test-tangle-correction-loop-behavior.sh`) driving stubbed rounds and asserting round counts and exit codes.
+
+### Changed
+
+- **Timeout model for supervised long dispatches** (#593): design-review ceremony, ink delivery review, tangle decompose/reformat, and the new correction loop now dispatch with `timeout_secs=0` (no wall clock) under heartbeat/stall supervision; `run_with_timeout` gained an explicit `0 = unlimited` bypass covering both the GNU-timeout and in-process fallback paths. Per-provider caps (e.g. `OCTOPUS_GEMINI_TIMEOUT`) still apply.
+- **`code-review` on a clean tree now exits non-zero** (#593): `review_run` returns 1 when there is no diff to review ("nothing to review" is no longer a pass). Scripts that ran `octo code-review` on clean trees and relied on exit 0 must handle exit 1.
+
+## [Unreleased]
+
+### Added
+
 - **RELEASING.md**: ordered release checklist covering every version-string location, the derived-artifact generators, CI-parity validation, exec-bit checks, fork-PR run approval, the tag-on-merge-commit rule, and GitHub Release creation. Encodes the three CI rounds the v9.50.0 release burned on undocumented generators.
 - **docs/PROVIDERS.md**: provider wiring map. Seven wiring points across five files per provider, with anchors and the traps that have bitten real PRs (case-glob ordering, the two provider-routing whitelists, exec bits, the stdin shim contract, secret-scanner quoting, nested-session markers).
 - **`make sync` / `make sync-check` / `make ci-local`**: one target to regenerate all derived artifacts, one to verify them, and a CI-parity target that mirrors the required checks plus CI-only verifications so local green predicts remote green.

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -146,9 +146,9 @@ run_with_timeout() {
         octo_event_emit "dispatch.start" command="$_octo_cmd_label" timeout="$timeout_secs" || true
     fi
 
-    # timeout_secs=0 means no absolute timeout. Higher-level workflows can still
-    # supervise progress with silence/heartbeat watchdogs and decide whether to
-    # keep partial writes, validate, review, continue, or escalate.
+    # timeout_secs=0 means no absolute timeout. Callers that choose it must set
+    # OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED to document the external heartbeat,
+    # stall, or workflow-level watchdog responsible for recovery.
     if [[ "$timeout_secs" =~ ^[0-9]+$ ]] && [[ "$timeout_secs" -eq 0 ]]; then
         "$@"
         exit_code=$?

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -146,6 +146,20 @@ run_with_timeout() {
         octo_event_emit "dispatch.start" command="$_octo_cmd_label" timeout="$timeout_secs" || true
     fi
 
+    # timeout_secs=0 means no absolute timeout. Higher-level workflows can still
+    # supervise progress with silence/heartbeat watchdogs and decide whether to
+    # keep partial writes, validate, review, continue, or escalate.
+    if [[ "$timeout_secs" =~ ^[0-9]+$ ]] && [[ "$timeout_secs" -eq 0 ]]; then
+        "$@"
+        exit_code=$?
+        if declare -f octo_event_emit >/dev/null 2>&1; then
+            local _octo_outcome="ok"
+            [[ $exit_code -eq 0 ]] || _octo_outcome="error"
+            octo_event_emit "dispatch.end" command="$_octo_cmd_label" exit_code="$exit_code" outcome="$_octo_outcome" timeout="none" || true
+        fi
+        return "$exit_code"
+    fi
+
     # v9.20.1: Detect if command is a shell function (e.g. perplexity_execute,
     # openrouter_execute). External timeout/gtimeout can only exec binaries —
     # shell functions require the in-process fallback path. (#255)

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -501,19 +501,19 @@ Be concise and specific. This is a planning exercise, not implementation."
     local design_agy_agent="${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-agy}}"
     local design_claude_agent="${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}"
     local design_synthesis_agent="${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}"
-    local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-120}"
-    local design_synth_timeout="${OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT:-120}"
-    if [[ ! "$design_timeout" =~ ^[0-9]+$ ]] || [[ "$design_timeout" -lt 120 ]]; then
-        log WARN "Invalid OCTOPUS_DESIGN_REVIEW_TIMEOUT='${design_timeout}', defaulting to 120s"
-        design_timeout=120
+    local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-0}"
+    local design_synth_timeout="${OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT:-0}"
+    if [[ ! "$design_timeout" =~ ^[0-9]+$ ]]; then
+        log WARN "Invalid OCTOPUS_DESIGN_REVIEW_TIMEOUT='${design_timeout}', defaulting to no wall timeout"
+        design_timeout=0
     fi
-    if [[ ! "$design_synth_timeout" =~ ^[0-9]+$ ]] || [[ "$design_synth_timeout" -lt 120 ]]; then
-        log WARN "Invalid OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT='${design_synth_timeout}', defaulting to 120s"
-        design_synth_timeout=120
+    if [[ ! "$design_synth_timeout" =~ ^[0-9]+$ ]]; then
+        log WARN "Invalid OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT='${design_synth_timeout}', defaulting to no wall timeout"
+        design_synth_timeout=0
     fi
 
     log INFO "Design review: gathering provider approaches..."
-    log INFO "Design review agents: codex=${design_codex_agent}, agy=${design_agy_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${design_timeout}s, synth_timeout=${design_synth_timeout}s"
+    log INFO "Design review agents: codex=${design_codex_agent}, agy=${design_agy_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=none, synth_timeout=none"
 
     codex_approach=$(run_agent_sync "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
     gemini_approach=$(run_agent_sync "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -515,9 +515,9 @@ Be concise and specific. This is a planning exercise, not implementation."
     log INFO "Design review: gathering provider approaches..."
     log INFO "Design review agents: codex=${design_codex_agent}, agy=${design_agy_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=none, synth_timeout=none"
 
-    codex_approach=$(run_agent_sync "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
-    gemini_approach=$(run_agent_sync "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
-    sonnet_approach=$(run_agent_sync "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony" 2>/dev/null) || true
+    codex_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
+    gemini_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
+    sonnet_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony" 2>/dev/null) || true
 
     # Synthesize conflicts and resolution
     local synthesis

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -512,8 +512,13 @@ Be concise and specific. This is a planning exercise, not implementation."
         design_synth_timeout=0
     fi
 
+    local _design_timeout_label="none"
+    [[ "$design_timeout" != "0" ]] && _design_timeout_label="${design_timeout}s"
+    local _synth_timeout_label="none"
+    [[ "$design_synth_timeout" != "0" ]] && _synth_timeout_label="${design_synth_timeout}s"
+
     log INFO "Design review: gathering provider approaches..."
-    log INFO "Design review agents: codex=${design_codex_agent}, agy=${design_agy_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=none, synth_timeout=none"
+    log INFO "Design review agents: codex=${design_codex_agent}, agy=${design_agy_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${_design_timeout_label}, synth_timeout=${_synth_timeout_label}"
 
     codex_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
     gemini_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
@@ -521,7 +526,7 @@ Be concise and specific. This is a planning exercise, not implementation."
 
     # Synthesize conflicts and resolution
     local synthesis
-    synthesis=$(run_agent_sync "$design_synthesis_agent" "You are synthesizing a design review ceremony.
+    synthesis=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_synthesis_agent" "You are synthesizing a design review ceremony.
 
 Three providers stated their approach to this task:
 

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -469,7 +469,7 @@ Use this context as the requested behavior and constraints. Flag severity=normal
 
     if [[ -z "$diff_content" ]]; then
         log WARN "review_run: no diff found for target=$target"
-        echo '{"findings":[],"message":"No changes found to review"}' > "$findings_file"
+        echo '{"findings":[],"warning":"No changes found to review","message":"No changes found to review"}' > "$findings_file"
         if [[ -n "$proof_dir" ]]; then
             octo_proof_artifact "$proof_dir" "review-findings" "$findings_file" "no changes found"
             octo_proof_claim "$proof_dir" "No changes found to review" "verified" "$findings_file"
@@ -479,7 +479,7 @@ Use this context as the requested behavior and constraints. Flag severity=normal
         fi
         rm -f "$provider_status_file"
         render_terminal_report "$findings_file"
-        return 0
+        return 1
     fi
 
     # Apply skip patterns from REVIEW.md (pre-filter before spending tokens)

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -663,13 +663,16 @@ ${heuristic_ctx}"
         while true; do
             exit_code=0
 
-            # oco-2kw: per-provider timeout. Gemini has no request timeout and its
-            # non-interactive maxSessionTurns default is unlimited, so a quota-loop
-            # or stall could burn the global TIMEOUT (~600s). Cap gemini separately;
-            # all others keep the global TIMEOUT. Plain scalar — bash 3.2 safe.
-            local _eff_timeout="$TIMEOUT"
+            # Per-provider timeout. TIMEOUT=0 means no absolute timeout; higher-level
+            # workflows supervise progress/stalls. Gemini only gets its legacy cap when
+            # TIMEOUT is non-zero and OCTOPUS_GEMINI_TIMEOUT is not explicitly set.
+            local _eff_timeout="${TIMEOUT:-0}"
             if [[ "$agent_type" == gemini* ]]; then
-                _eff_timeout="${OCTOPUS_GEMINI_TIMEOUT:-180}"
+                if [[ -n "${OCTOPUS_GEMINI_TIMEOUT:-}" ]]; then
+                    _eff_timeout="$OCTOPUS_GEMINI_TIMEOUT"
+                elif [[ "$_eff_timeout" != "0" ]]; then
+                    _eff_timeout="180"
+                fi
             fi
 
             # oco-48z: quota/terminal-error fast-fail watcher for ALL providers (was
@@ -909,7 +912,7 @@ ${heuristic_ctx}"
             echo "" >> "$result_file"
             echo "## Status: TIMEOUT - PARTIAL RESULTS (exit code: $exit_code)" >> "$result_file"
             echo "" >> "$result_file"
-            echo "⚠️  **Warning**: Agent timed out after ${TIMEOUT}s but partial output preserved above." >> "$result_file"
+            echo "⚠️  **Warning**: Agent timed out after ${_eff_timeout}s but partial output preserved above." >> "$result_file"
             echo "" >> "$result_file"
             echo "**Recommendations**:" >> "$result_file"
             echo "- Partial results may still be valuable" >> "$result_file"

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -916,7 +916,11 @@ ${heuristic_ctx}"
             echo "" >> "$result_file"
             echo "**Recommendations**:" >> "$result_file"
             echo "- Partial results may still be valuable" >> "$result_file"
-            echo "- Consider increasing timeout: \`--timeout $((TIMEOUT * 2))\`" >> "$result_file"
+            if [[ "$_eff_timeout" =~ ^[0-9]+$ && "$_eff_timeout" -gt 0 ]]; then
+                echo "- Consider increasing timeout: \`--timeout $((_eff_timeout * 2))\`" >> "$result_file"
+            else
+                echo "- Consider setting an explicit timeout only if this task needs a wall-clock cap" >> "$result_file"
+            fi
             echo "- Simplify prompt to reduce complexity" >> "$result_file"
 
             # Append error details

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -693,9 +693,9 @@ ${heuristic_ctx}"
             # v9.2.2: All agents use stdin-based prompt delivery to avoid ARG_MAX limits (Issue #173)
             # Previously only gemini used stdin; codex/claude passed prompt as CLI arg which fails on large diffs.
             if [[ "$agent_type" == agy* || "$agent_type" == "antigravity" ]]; then
-                printf '%s' "$enhanced_prompt" | run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"
+                printf '%s' "$enhanced_prompt" | OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="spawn-agent-heartbeat" run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"
                 exit_code=${PIPESTATUS[1]:-0}
-            elif printf '%s' "$enhanced_prompt" | run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then
+            elif printf '%s' "$enhanced_prompt" | OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="spawn-agent-heartbeat" run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then
                 exit_code=0
             else
                 exit_code=$?

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -25,11 +25,21 @@ extract_tangle_result_output() {
     ' "$result_file" 2>/dev/null || true
 }
 
+extract_tangle_result_body() {
+    local result_file="$1"
+    [[ -f "$result_file" ]] || return 0
+    if grep -q '^## Output[[:space:]]*$' "$result_file" 2>/dev/null; then
+        extract_tangle_result_output "$result_file"
+    else
+        cat "$result_file" 2>/dev/null || true
+    fi
+}
+
 tangle_result_has_blocker_output() {
     local result_file="$1"
     local output
     local blocker_pattern='(blocker report|cannot complete|unable to complete|sandbox (is )?blocking|blocked by (the )?sandbox|landlock|no write tools available|all shell commands (are )?blocked|filesystem access is blocked|cannot create or modify files|apply_patch.*not available)'
-    output=$(extract_tangle_result_output "$result_file")
+    output=$(extract_tangle_result_body "$result_file")
 
     grep -Eiq "$blocker_pattern" <<< "$output"
 }
@@ -150,6 +160,11 @@ validate_tangle_results() {
     local worktree_before_file="${3:-}"
     local validation_file="${RESULTS_DIR}/tangle-validation-${task_group}.md"
     local quality_retry_count=0
+    local correction_file="${OCTOPUS_TANGLE_VALIDATION_CORRECTION_FILE:-}"
+    local correction_round="${OCTOPUS_TANGLE_VALIDATION_CORRECTION_ROUND:-}"
+    local correction_status="${OCTOPUS_TANGLE_VALIDATION_CORRECTION_STATUS:-}"
+    local correction_changed="${OCTOPUS_TANGLE_VALIDATION_CORRECTION_CHANGED:-}"
+    local correction_overlay_applied=false
 
     while true; do
         # Collect all results
@@ -165,7 +180,7 @@ validate_tangle_results() {
 
         for result in "$RESULTS_DIR"/*-tangle-${task_group}*.md; do
             [[ -f "$result" ]] || continue
-            [[ "$result" == *validation* ]] && continue
+            [[ "$(basename "$result")" == *validation* ]] && continue
 
             # v8.20.0: Run file path validation (non-blocking warnings)
             if [[ "${OCTOPUS_FILE_VALIDATION:-true}" == "true" ]] && type run_file_validation &>/dev/null 2>&1; then
@@ -200,11 +215,9 @@ validate_tangle_results() {
                 fi
             fi
             results+="$(<"$result")\n\n---\n\n"
-            result_outputs+="$(extract_tangle_result_output "$result")"$'\n'
+            result_outputs+="$(extract_tangle_result_body "$result")"$'\n'
         done
 
-        local missing_explicit_files
-        missing_explicit_files=$(check_explicit_file_coverage "$original_prompt" "$result_outputs")
         local worktree_changes=""
         local requires_worktree_changes=false
         if [[ -n "$worktree_before_file" && -f "$worktree_before_file" ]] && \
@@ -213,12 +226,46 @@ validate_tangle_results() {
             worktree_changes=$(check_tangle_worktree_changes "$worktree_before_file")
         fi
 
+        local correction_result_body=""
+        if [[ -n "$correction_file" && -f "$correction_file" ]]; then
+            correction_result_body=$(extract_tangle_result_body "$correction_file")
+            results+="
+---
+
+## Correction Overlay${correction_round:+ Round $correction_round}
+$(<"$correction_file")
+"
+            result_outputs+="$correction_result_body"$'
+'
+            result_outputs+="$worktree_changes"$'
+'
+        fi
+
+        local missing_explicit_files
+        missing_explicit_files=$(check_explicit_file_coverage "$original_prompt" "$result_outputs")
+
         # Quality gate check (using configurable per-phase threshold - v8.19.0)
         local tangle_threshold
         tangle_threshold=$(get_gate_threshold "tangle")
         local total=$((success_count + fail_count))
         local success_rate=0
         [[ $total -gt 0 ]] && success_rate=$((success_count * 100 / total))
+        local static_success_count="$success_count"
+        local static_fail_count="$fail_count"
+        local static_total="$total"
+        local static_success_rate="$success_rate"
+
+        if [[ -n "$correction_file" && -f "$correction_file" ]] &&            grep -q "Status: SUCCESS" "$correction_file" 2>/dev/null &&            [[ "${correction_changed:-0}" == "1" || -n "$worktree_changes" ]]; then
+            correction_overlay_applied=true
+            # Correction rounds repair the worktree, not immutable initial subtask
+            # result files. Do not let an initial failed result pin validation
+            # forever after a successful correction overlay.
+            fail_count=0
+            success_count=$(( static_total > 0 ? static_total : 1 ))
+            total=$((success_count + fail_count))
+            success_rate=100
+            log INFO "Post-correction validation overlay applied${correction_round:+ for round ${correction_round}}: static tangle result rate ${static_success_rate}% -> effective ${success_rate}%"
+        fi
 
         local gate_status="PASSED"
         local gate_color="${GREEN}"
@@ -336,6 +383,11 @@ $challenge_result
 - Failed: ${fail_count}/${total} result files
 - Decision Branch: ${quality_branch}
 - Retry Attempts: ${quality_retry_count}/$(tangle_quality_retry_limit_value)
+$(if [[ "$correction_overlay_applied" == "true" ]]; then
+    echo "- Static Subtask Rate Before Correction Overlay: ${static_success_rate}% (${static_success_count}/${static_total} successful, ${static_fail_count}/${static_total} failed)"
+    echo "- Correction Overlay: ${correction_file}"
+    echo "- Correction Status: ${correction_status:-unknown}; changed=${correction_changed:-unknown}"
+fi)
 
 ### Explicit File Coverage
 $(if [[ -n "$missing_explicit_files" ]]; then

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -165,6 +165,8 @@ validate_tangle_results() {
     local correction_status="${OCTOPUS_TANGLE_VALIDATION_CORRECTION_STATUS:-}"
     local correction_changed="${OCTOPUS_TANGLE_VALIDATION_CORRECTION_CHANGED:-}"
     local correction_overlay_applied=false
+    local tangle_threshold
+    tangle_threshold=$(get_gate_threshold "tangle")
 
     while true; do
         # Collect all results
@@ -245,8 +247,6 @@ $(<"$correction_file")
         missing_explicit_files=$(check_explicit_file_coverage "$original_prompt" "$result_outputs")
 
         # Quality gate check (using configurable per-phase threshold - v8.19.0)
-        local tangle_threshold
-        tangle_threshold=$(get_gate_threshold "tangle")
         local total=$((success_count + fail_count))
         local success_rate=0
         [[ $total -gt 0 ]] && success_rate=$((success_count * 100 / total))
@@ -255,16 +255,20 @@ $(<"$correction_file")
         local static_total="$total"
         local static_success_rate="$success_rate"
 
+        local effective_success_count="$success_count"
+        local effective_fail_count="$fail_count"
+        local effective_total="$total"
+        local effective_success_rate="$success_rate"
         if [[ -n "$correction_file" && -f "$correction_file" ]] &&            grep -q "Status: SUCCESS" "$correction_file" 2>/dev/null &&            [[ "${correction_changed:-0}" == "1" || -n "$worktree_changes" ]]; then
             correction_overlay_applied=true
-            # Correction rounds repair the worktree, not immutable initial subtask
-            # result files. Do not let an initial failed result pin validation
-            # forever after a successful correction overlay.
-            fail_count=0
-            success_count=$(( static_total > 0 ? static_total : 1 ))
-            total=$((success_count + fail_count))
-            success_rate=100
-            log INFO "Post-correction validation overlay applied${correction_round:+ for round ${correction_round}}: static tangle result rate ${static_success_rate}% -> effective ${success_rate}%"
+            # Correction rounds can prove the worktree was repaired, but keep the
+            # original subtask result rate as the quality-gate decision input.
+            # The overlay is reported separately for operator diagnosis.
+            effective_fail_count=0
+            effective_success_count=$(( static_total > 0 ? static_total : 1 ))
+            effective_total=$((effective_success_count + effective_fail_count))
+            effective_success_rate=100
+            log INFO "Post-correction validation overlay applied${correction_round:+ for round ${correction_round}}: static tangle result rate ${static_success_rate}% -> effective ${effective_success_rate}%"
         fi
 
         local gate_status="PASSED"
@@ -385,6 +389,7 @@ $challenge_result
 - Retry Attempts: ${quality_retry_count}/$(tangle_quality_retry_limit_value)
 $(if [[ "$correction_overlay_applied" == "true" ]]; then
     echo "- Static Subtask Rate Before Correction Overlay: ${static_success_rate}% (${static_success_count}/${static_total} successful, ${static_fail_count}/${static_total} failed)"
+    echo "- Effective Rate After Correction Overlay: ${effective_success_rate}% (${effective_success_count}/${effective_total} successful, ${effective_fail_count}/${effective_total} failed)"
     echo "- Correction Overlay: ${correction_file}"
     echo "- Correction Status: ${correction_status:-unknown}; changed=${correction_changed:-unknown}"
 fi)

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -215,13 +215,15 @@ Uses a map-reduce pattern: decompose → parallel implement → validate → con
 ${YELLOW}Quality Gates:${NC}
   • Tangle validation report checks subtask status and worktree evidence
   • Contextual code review compares the diff against the task contract/decomposition
-  • severity=normal findings trigger bounded correction rounds before delivery
+  • severity=normal findings trigger a progress-supervised correction loop before delivery
 
 ${YELLOW}Environment:${NC}
   OCTOPUS_TANGLE_CODE_REVIEW=false              Skip contextual code review
-  OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded Bound correction rounds explicitly
-  OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=3     Bound count when mode=bounded
-  OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW=1800   Stop only after silence/no progress
+  OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=unbounded Progress-supervised loop (default)
+  OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded   Opt into explicit round cap
+  OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=3       Bound count when mode=bounded
+  OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW=1800     Stop only after silence/no progress
+  OCTOPUS_TANGLE_CORRECTION_POLL_SECS=30          Progress check cadence
   OCTOPUS_TANGLE_REVIEW_TARGET=working-tree     Review target passed to code-review
   OCTOPUS_TANGLE_INK=true                       Run optional ink/deliver after review passes
 

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -210,12 +210,18 @@ ${YELLOW}develop${NC} (alias: tangle) - Implementation phase
 ${YELLOW}Usage:${NC} $(basename "$0") develop <prompt> [define-file]
 
 Implements the solution with built-in quality validation.
-Uses a map-reduce pattern: decompose → parallel implement → synthesize.
+Uses a map-reduce pattern: decompose → parallel implement → validate → contextual code review.
 
 ${YELLOW}Quality Gates:${NC}
-  • ≥90%: ${GREEN}PASSED${NC} - proceed to delivery
-  • 75-89%: ${YELLOW}WARNING${NC} - proceed with caution
-  • <75%: ${RED}FAILED${NC} - needs review
+  • Tangle validation report checks subtask status and worktree evidence
+  • Contextual code review compares the diff against the task contract/decomposition
+  • severity=normal findings trigger bounded correction rounds before delivery
+
+${YELLOW}Environment:${NC}
+  OCTOPUS_TANGLE_CODE_REVIEW=false          Skip contextual code review
+  OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=1 Number of internal correction rounds
+  OCTOPUS_TANGLE_REVIEW_TARGET=working-tree Review target passed to code-review
+  OCTOPUS_TANGLE_INK=true                   Run optional ink/deliver after review passes
 
 ${YELLOW}Examples:${NC}
   $(basename "$0") develop "build the user authentication API"

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -218,10 +218,12 @@ ${YELLOW}Quality Gates:${NC}
   • severity=normal findings trigger bounded correction rounds before delivery
 
 ${YELLOW}Environment:${NC}
-  OCTOPUS_TANGLE_CODE_REVIEW=false          Skip contextual code review
-  OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=1 Number of internal correction rounds
-  OCTOPUS_TANGLE_REVIEW_TARGET=working-tree Review target passed to code-review
-  OCTOPUS_TANGLE_INK=true                   Run optional ink/deliver after review passes
+  OCTOPUS_TANGLE_CODE_REVIEW=false              Skip contextual code review
+  OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded Bound correction rounds explicitly
+  OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=3     Bound count when mode=bounded
+  OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW=1800   Stop only after silence/no progress
+  OCTOPUS_TANGLE_REVIEW_TARGET=working-tree     Review target passed to code-review
+  OCTOPUS_TANGLE_INK=true                       Run optional ink/deliver after review passes
 
 ${YELLOW}Examples:${NC}
   $(basename "$0") develop "build the user authentication API"

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -223,6 +223,7 @@ ${YELLOW}Environment:${NC}
   OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded   Opt into explicit round cap
   OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=3       Bound count when mode=bounded
   OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW=1800     Stop only after silence/no progress
+  OCTOPUS_TANGLE_CORRECTION_HARD_CAP=10           Absolute round ceiling, both modes (0 disables)
   OCTOPUS_TANGLE_CORRECTION_POLL_SECS=30          Progress check cadence
   OCTOPUS_TANGLE_REVIEW_TARGET=working-tree     Review target passed to code-review
   OCTOPUS_TANGLE_INK=true                       Run optional ink/deliver after review passes

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1195,6 +1195,67 @@ tangle_normal_findings_summary() {
     jq -r '.findings[]? | select((.severity // "") == "normal") | "### " + (.title // "untitled") + "\n- Location: " + (.file // "unknown") + ":" + ((.line // 0)|tostring) + "\n- Confidence: " + ((.confidence // 0)|tostring) + "\n\n" + (.detail // "") + "\n"' "$findings_file" 2>/dev/null || true
 }
 
+tangle_findings_signature() {
+    local findings_file="$1"
+    [[ -f "$findings_file" ]] || { echo "missing"; return 0; }
+    jq -r '[.findings[]? | select((.severity // "") == "normal") | (.title // .message // "untitled")] | sort | join(" | ")' "$findings_file" 2>/dev/null || echo "unparseable"
+}
+
+tangle_worktree_fingerprint() {
+    local repo_root
+    repo_root=$(tangle_resolve_repo_root 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || pwd)
+    {
+        git -C "$repo_root" status --porcelain 2>/dev/null || true
+        git -C "$repo_root" diff --stat 2>/dev/null || true
+        git -C "$repo_root" ls-files --others --exclude-standard 2>/dev/null || true
+    } | sha256sum 2>/dev/null | awk '{print $1}'
+}
+
+tangle_scope_contamination_summary() {
+    local repo_root
+    repo_root=$(tangle_resolve_repo_root 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || pwd)
+    git -C "$repo_root" status --porcelain 2>/dev/null \
+        | awk '{print $2}' \
+        | grep -E '(^|/)(_wr\.py|.*\.bak$|.*_new\.[^.]+$|.*_p[0-9]+\.[^.]+$|.*\.tmp$|.*\.orig$)' \
+        || true
+}
+
+tangle_correction_strategy_prompt() {
+    local strategy="${1:-delta}"
+    case "$strategy" in
+        cleanup-and-fix)
+            cat <<'EOF'
+Strategy for this round:
+- First remove or reverse out-of-scope scratch/backup files created by earlier attempts.
+- Then fix the smallest set of blocking findings possible.
+- Do not create backup, scratch, _new, _pN, .tmp, .orig, or helper files.
+EOF
+            ;;
+        single-finding)
+            cat <<'EOF'
+Strategy for this round:
+- Do not attempt to fix all findings at once.
+- Pick the highest-impact blocking finding and fix that one cleanly.
+- If tests or OpenAPI are the selected blocker, add only the required files/scripts.
+- Do not create backup, scratch, _new, _pN, .tmp, .orig, or helper files.
+EOF
+            ;;
+        *)
+            cat <<'EOF'
+Strategy for this round:
+- Apply a minimal delta patch that reduces the current blocking findings.
+- Prefer small, path-scoped edits over rewrites.
+- Do not create backup, scratch, _new, _pN, .tmp, .orig, or helper files.
+EOF
+            ;;
+    esac
+}
+
+TANGLE_CORRECTION_FILE=""
+TANGLE_CORRECTION_STATUS=""
+TANGLE_CORRECTION_CHANGED="0"
+TANGLE_CORRECTION_CONTAMINATION=""
+
 tangle_build_develop_review_context() {
     local task_group="$1"
     local resolved_prompt="$2"
@@ -1336,23 +1397,39 @@ tangle_apply_review_corrections() {
     local findings_file="$3"
     local round_num="$4"
     local correction_agent="${5:-codex}"
+    local correction_strategy="${6:-delta}"
     local correction_file="${RESULTS_DIR:-${HOME}/.claude-octopus/results}/tangle-review-corrections-${round_num}-$(date +%s).md"
-    local normal_findings
-    normal_findings=$(tangle_normal_findings_summary "$findings_file")
+    local rc_file="${correction_file}.rc"
+    local normal_findings strategy_text before_fp after_fp last_fp last_size last_progress now
 
+    TANGLE_CORRECTION_FILE="$correction_file"
+    TANGLE_CORRECTION_STATUS="unknown"
+    TANGLE_CORRECTION_CHANGED="0"
+    TANGLE_CORRECTION_CONTAMINATION=""
+
+    normal_findings=$(tangle_normal_findings_summary "$findings_file")
     if [[ -z "$normal_findings" ]]; then
         log INFO "No normal findings to correct in $findings_file"
+        TANGLE_CORRECTION_STATUS="no-findings"
         return 0
     fi
 
+    strategy_text=$(tangle_correction_strategy_prompt "$correction_strategy")
     local correction_prompt="You are in Octopus tangle correction round ${round_num}.
 
 Do not reimplement the whole plan.
 Do not expand scope.
 Do not restart from scratch.
 Preserve existing working-tree changes unless a change is necessary to fix a blocking finding.
-Fix only the blocking severity=normal findings below.
+Fix blocking severity=normal findings using the requested strategy.
 After editing, report files changed and tests/checks run.
+
+${strategy_text}
+
+Hard rules:
+- Do not declare success unless the intended edits were actually written.
+- Do not leave backup/scratch files in the worktree.
+- Prefer exact edits and tests over prose.
 
 Original task contract:
 \`\`\`markdown
@@ -1366,8 +1443,75 @@ Blocking findings to fix:
 ${normal_findings}
 "
 
-    log INFO "Step 5: Applying contextual review corrections (round ${round_num}) with ${correction_agent}..."
-    if run_agent_sync "$correction_agent" "$correction_prompt" "${OCTOPUS_TANGLE_CORRECTION_TIMEOUT:-480}" "implementer" "tangle" > "$correction_file" 2>&1; then
+    before_fp=$(tangle_worktree_fingerprint)
+    last_fp="$before_fp"
+    last_size=0
+    last_progress=$(date +%s)
+    : > "$correction_file"
+    rm -f "$rc_file" 2>/dev/null || true
+
+    local stall_window="${OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW:-1800}"
+    local poll_secs="${OCTOPUS_TANGLE_CORRECTION_POLL_SECS:-30}"
+    [[ "$stall_window" =~ ^[0-9]+$ ]] || stall_window=1800
+    [[ "$poll_secs" =~ ^[0-9]+$ ]] || poll_secs=30
+    [[ "$poll_secs" -lt 1 ]] && poll_secs=1
+
+    log INFO "Step 5: Applying contextual review corrections (round ${round_num}, strategy=${correction_strategy}, stall_window=${stall_window}s) with ${correction_agent}..."
+    (
+        run_agent_sync "$correction_agent" "$correction_prompt" 0 "implementer" "tangle" > "$correction_file" 2>&1
+        echo "$?" > "$rc_file"
+    ) &
+    local correction_pid=$!
+    local stalled="false"
+
+    while kill -0 "$correction_pid" 2>/dev/null; do
+        sleep "$poll_secs"
+        local current_fp current_size
+        current_fp=$(tangle_worktree_fingerprint)
+        current_size=$(stat -c '%s' "$correction_file" 2>/dev/null || echo 0)
+        if [[ "$current_fp" != "$last_fp" || "$current_size" != "$last_size" ]]; then
+            last_fp="$current_fp"
+            last_size="$current_size"
+            last_progress=$(date +%s)
+            log INFO "Correction round ${round_num}: progress observed (worktree/output changed)"
+        fi
+        now=$(date +%s)
+        if [[ "$stall_window" -gt 0 && $((now - last_progress)) -ge "$stall_window" ]]; then
+            stalled="true"
+            log WARN "Correction round ${round_num}: no observable progress for ${stall_window}s — stopping agent and preserving partial writes"
+            pkill -TERM -P "$correction_pid" 2>/dev/null || true
+            kill -TERM "$correction_pid" 2>/dev/null || true
+            sleep 2
+            pkill -KILL -P "$correction_pid" 2>/dev/null || true
+            kill -KILL "$correction_pid" 2>/dev/null || true
+            break
+        fi
+    done
+
+    wait "$correction_pid" 2>/dev/null || true
+    local correction_rc="1"
+    [[ -f "$rc_file" ]] && correction_rc=$(cat "$rc_file" 2>/dev/null || echo 1)
+    rm -f "$rc_file" 2>/dev/null || true
+
+    after_fp=$(tangle_worktree_fingerprint)
+    if [[ "$after_fp" != "$before_fp" ]]; then
+        TANGLE_CORRECTION_CHANGED="1"
+    fi
+    TANGLE_CORRECTION_CONTAMINATION=$(tangle_scope_contamination_summary)
+
+    if [[ "$stalled" == "true" ]]; then
+        TANGLE_CORRECTION_STATUS="stalled-partial"
+        {
+            echo ""
+            echo "## Status: STALLED - PARTIAL RESULTS"
+            echo "# Completed: $(date)"
+        } >> "$correction_file"
+        log WARN "Correction round ${round_num} stalled; partial writes changed=${TANGLE_CORRECTION_CHANGED}; result: $correction_file"
+        return 0
+    fi
+
+    if [[ "$correction_rc" == "0" ]]; then
+        TANGLE_CORRECTION_STATUS="completed"
         {
             echo ""
             echo "## Status: SUCCESS"
@@ -1377,14 +1521,27 @@ ${normal_findings}
         return 0
     fi
 
+    if [[ "$TANGLE_CORRECTION_CHANGED" == "1" ]]; then
+        TANGLE_CORRECTION_STATUS="failed-partial"
+        {
+            echo ""
+            echo "## Status: FAILED - PARTIAL WRITES PRESERVED"
+            echo "# Completed: $(date)"
+        } >> "$correction_file"
+        log WARN "Correction round ${round_num} failed but left partial writes; validation/review should continue: $correction_file"
+        return 0
+    fi
+
+    TANGLE_CORRECTION_STATUS="failed-no-progress"
     {
         echo ""
-        echo "## Status: FAILED"
+        echo "## Status: FAILED - NO PROGRESS"
         echo "# Completed: $(date)"
     } >> "$correction_file"
-    log WARN "Correction round ${round_num} failed: $correction_file"
+    log WARN "Correction round ${round_num} failed with no observable worktree change: $correction_file"
     return 1
 }
+
 
 # Phase 3: TANGLE (Develop) - Enhanced map-reduce with validation
 # Tentacles work together in a coordinated tangle of activity
@@ -1840,14 +1997,35 @@ Every [CODING] line must include a same-line Files: clause."
     local normal_count
     normal_count=$(tangle_review_blocking_count "$findings_file")
 
-    local max_correction_rounds="${OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS:-1}"
-    [[ "$max_correction_rounds" =~ ^[0-9]+$ ]] || max_correction_rounds=1
+    local correction_mode="${OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE:-unbounded}"
+    local max_correction_rounds="${OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS:-0}"
+    [[ "$max_correction_rounds" =~ ^[0-9]+$ ]] || max_correction_rounds=0
     local correction_round=1
+    local previous_normal_count="$normal_count"
+    local previous_signature
+    previous_signature=$(tangle_findings_signature "$findings_file")
+    local correction_strategy="delta"
 
-    while [[ "${normal_count:-0}" -gt 0 && "$correction_round" -le "$max_correction_rounds" ]]; do
-        tangle_apply_review_corrections "$resolved_prompt" "$review_context_file" "$findings_file" "$correction_round" "$tangle_coding_agent" || return 1
+    while [[ "${normal_count:-0}" -gt 0 ]]; do
+        if [[ "$correction_mode" == "bounded" && "$max_correction_rounds" -gt 0 && "$correction_round" -gt "$max_correction_rounds" ]]; then
+            log WARN "Contextual code review still has ${normal_count} blocking finding(s) after bounded ${max_correction_rounds} correction round(s): ${findings_file}"
+            return 1
+        fi
 
-        log INFO "Re-running validation gate after correction round ${correction_round}..."
+        if ! tangle_apply_review_corrections "$resolved_prompt" "$review_context_file" "$findings_file" "$correction_round" "$tangle_coding_agent" "$correction_strategy"; then
+            log WARN "Correction round ${correction_round} made no observable progress; escalating without starting a hot loop"
+            return 1
+        fi
+
+        if [[ -n "${TANGLE_CORRECTION_CONTAMINATION:-}" ]]; then
+            log WARN "Correction round ${correction_round} created out-of-scope/scratch files:"
+            printf '%s\n' "$TANGLE_CORRECTION_CONTAMINATION" | while IFS= read -r _contam; do
+                [[ -n "$_contam" ]] && log WARN "  $_contam"
+            done
+            correction_strategy="cleanup-and-fix"
+        fi
+
+        log INFO "Re-running validation gate after correction round ${correction_round} (status=${TANGLE_CORRECTION_STATUS}, changed=${TANGLE_CORRECTION_CHANGED})..."
         validation_rc=0
         validate_tangle_results "$task_group" "$resolved_prompt" "$worktree_before_file" || validation_rc=$?
 
@@ -1856,11 +2034,36 @@ Every [CODING] line must include a same-line Files: clause."
         tangle_run_context_code_review "$task_group" "$review_context_file" "correction-${correction_round}" || review_rc=$?
         findings_file="$TANGLE_REVIEW_FINDINGS_FILE"
         normal_count=$(tangle_review_blocking_count "$findings_file")
+        local current_signature
+        current_signature=$(tangle_findings_signature "$findings_file")
+
+        if [[ "${normal_count:-0}" -lt "${previous_normal_count:-0}" ]]; then
+            log INFO "Correction round ${correction_round} improved blockers: ${previous_normal_count} -> ${normal_count}"
+            correction_strategy="delta"
+        elif [[ "${normal_count:-0}" -gt "${previous_normal_count:-0}" ]]; then
+            log WARN "Correction round ${correction_round} worsened blockers: ${previous_normal_count} -> ${normal_count}; switching strategy"
+            correction_strategy="single-finding"
+        else
+            if [[ "$current_signature" == "$previous_signature" ]]; then
+                log WARN "Correction round ${correction_round} repeated the same blocking findings; switching strategy"
+            else
+                log WARN "Correction round ${correction_round} did not reduce blocker count (${normal_count}); switching strategy"
+            fi
+            correction_strategy="single-finding"
+        fi
+
+        if [[ "${TANGLE_CORRECTION_CHANGED:-0}" != "1" && "${TANGLE_CORRECTION_STATUS:-}" == *"stalled"* ]]; then
+            log WARN "Correction stalled without partial writes; stopping to avoid a no-progress loop"
+            return 1
+        fi
+
+        previous_normal_count="$normal_count"
+        previous_signature="$current_signature"
         ((correction_round++)) || true
     done
 
     if [[ "${normal_count:-0}" -gt 0 ]]; then
-        log WARN "Contextual code review still has ${normal_count} blocking finding(s) after ${max_correction_rounds} correction round(s): ${findings_file}"
+        log WARN "Contextual code review still has ${normal_count} blocking finding(s): ${findings_file}"
         return 1
     fi
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1860,11 +1860,14 @@ Every [CODING] line must include a same-line Files: clause."
     # Wait with progress monitoring — poll .done marker files written by spawn_agent
     # rather than kill -0 $pid (which tracks wrapper PID, not provider PID)
     local _done_dir="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents"
-    local _tangle_max_wait="${OCTOPUS_TANGLE_DEADLINE:-$(( ${TIMEOUT:-600} + 60 ))}"
-    [[ "$_tangle_max_wait" =~ ^[0-9]+$ ]] || _tangle_max_wait=$(( ${TIMEOUT:-600} + 60 ))
+    local _tangle_max_wait="${OCTOPUS_TANGLE_DEADLINE:-0}"
+    [[ "$_tangle_max_wait" =~ ^[0-9]+$ ]] || _tangle_max_wait=0
     local _missing_marker_grace="${OCTOPUS_TANGLE_MISSING_MARKER_GRACE:-180}"
     [[ "$_missing_marker_grace" =~ ^[0-9]+$ ]] || _missing_marker_grace=180
-    local _deadline=$(( $(date +%s) + _tangle_max_wait ))
+    local _deadline=0
+    if [[ "$_tangle_max_wait" -gt 0 ]]; then
+        _deadline=$(( $(date +%s) + _tangle_max_wait ))
+    fi
     local completed=0
     local _failed_tasks=()
     local _terminal_task_ids=""
@@ -1879,7 +1882,7 @@ Every [CODING] line must include a same-line Files: clause."
                 ((completed++)) || true
             else
                 local _wrapper_pid="${pids[$i]:-}"
-                if (( $(date +%s) > _deadline )); then
+                if [[ "$_tangle_max_wait" -gt 0 ]] && (( $(date +%s) > _deadline )); then
                     log WARN "Thread ${task_ids[$i]} deadline exceeded — killing and marking timeout"
                     if [[ -n "$_wrapper_pid" ]]; then
                         pkill -TERM -P "$_wrapper_pid" 2>/dev/null || true

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1319,9 +1319,14 @@ tangle_run_context_code_review() {
     fi
 
     TANGLE_REVIEW_FINDINGS_FILE="$findings_file"
-    local normal_count
+    local normal_count review_warning
     normal_count=$(tangle_review_blocking_count "$findings_file")
+    review_warning=$(jq -r '.warning // empty' "$findings_file" 2>/dev/null || true)
     log INFO "Contextual code review findings: $findings_file (normal=${normal_count})"
+    if [[ -n "$review_warning" ]]; then
+        log WARN "Contextual code review warning: ${review_warning}"
+        return 1
+    fi
     return "$review_rc"
 }
 
@@ -1864,12 +1869,17 @@ Every [CODING] line must include a same-line Files: clause."
         return "$review_rc"
     fi
 
+    if [[ "$validation_rc" -ne 0 ]]; then
+        log WARN "Skipping ink/deliver because tangle validation gate returned non-zero (${validation_rc})"
+        return "$validation_rc"
+    fi
+
     if octo_bool_enabled "${OCTOPUS_TANGLE_INK:-false}"; then
         log INFO "OCTOPUS_TANGLE_INK enabled — running ink/deliver after contextual review passed"
         ink_deliver "$resolved_prompt"
     fi
 
-    return "$validation_rc"
+    return 0
 }
 
 ink_delivery_sanitize_context() {

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1407,7 +1407,18 @@ tangle_run_context_code_review() {
     review_run "$review_profile"
     review_rc=$?
 
-    findings_file=$(find "${RESULTS_DIR:-${HOME}/.claude-octopus/results}" -maxdepth 1 -type f -name 'review-findings-*.json' -newer "$marker" -printf '%T@ %p\n' 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2- || true)
+    findings_file=""
+    local _findings_candidate _findings_mtime _best_findings_mtime=0
+    while IFS= read -r _findings_candidate; do
+        [[ -f "$_findings_candidate" ]] || continue
+        [[ "$_findings_candidate" -nt "$marker" ]] || continue
+        _findings_mtime=$(stat -c '%Y' "$_findings_candidate" 2>/dev/null || stat -f '%m' "$_findings_candidate" 2>/dev/null || echo 0)
+        [[ "$_findings_mtime" =~ ^[0-9]+$ ]] || _findings_mtime=0
+        if [[ "$_findings_mtime" -ge "$_best_findings_mtime" ]]; then
+            _best_findings_mtime="$_findings_mtime"
+            findings_file="$_findings_candidate"
+        fi
+    done < <(find "${RESULTS_DIR:-${HOME}/.claude-octopus/results}" -maxdepth 1 -type f -name 'review-findings-*.json' 2>/dev/null || true)
     rm -f "$marker" 2>/dev/null || true
 
     if [[ -z "$findings_file" || ! -f "$findings_file" ]]; then
@@ -1948,7 +1959,7 @@ Every [CODING] line must include a same-line Files: clause."
                     _now=$(date +%s)
                     if [[ -z "${_missing_marker_since[$i]:-}" ]]; then
                         _missing_marker_since[$i]="$_now"
-                        log WARN "Thread ${task_ids[$i]} exited or became zombie without completion marker — waiting up to ${_missing_marker_grace}s for late result/marker"
+                        log WARN "Thread ${task_ids[$i]} wrapper exited without completion marker; exited or became zombie without completion marker — waiting up to ${_missing_marker_grace}s for late result/marker"
                     elif (( _now - ${_missing_marker_since[$i]} >= _missing_marker_grace )); then
                         log WARN "Thread ${task_ids[$i]} still lacks completion marker after ${_missing_marker_grace}s — marking failed"
                         mkdir -p "$_done_dir" 2>/dev/null || true

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1162,6 +1162,225 @@ tangle_validate_parallel_write_scopes() {
     return 0
 }
 
+
+octo_bool_disabled() {
+    case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+        0|false|off|no|disabled) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+octo_bool_enabled() {
+    case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+        1|true|on|yes|enabled) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+tangle_review_blocking_count() {
+    local findings_file="$1"
+    [[ -f "$findings_file" ]] || { echo 0; return 0; }
+    jq '[.findings[]? | select((.severity // "") == "normal")] | length' "$findings_file" 2>/dev/null || echo 0
+}
+
+tangle_review_findings_summary() {
+    local findings_file="$1"
+    [[ -f "$findings_file" ]] || return 0
+    jq -r '.findings[]? | "- [" + (.severity // "unknown") + "] " + (.title // "untitled") + " — " + (.file // "unknown") + ":" + ((.line // 0)|tostring) + "\n  " + (.detail // "")' "$findings_file" 2>/dev/null || true
+}
+
+tangle_normal_findings_summary() {
+    local findings_file="$1"
+    [[ -f "$findings_file" ]] || return 0
+    jq -r '.findings[]? | select((.severity // "") == "normal") | "### " + (.title // "untitled") + "\n- Location: " + (.file // "unknown") + ":" + ((.line // 0)|tostring) + "\n- Confidence: " + ((.confidence // 0)|tostring) + "\n\n" + (.detail // "") + "\n"' "$findings_file" 2>/dev/null || true
+}
+
+tangle_build_develop_review_context() {
+    local task_group="$1"
+    local resolved_prompt="$2"
+    local grasp_context="$3"
+    local subtasks="$4"
+    local validation_file="$5"
+    local worktree_before_file="$6"
+    local round_label="${7:-initial}"
+    local context_file="${RESULTS_DIR:-${HOME}/.claude-octopus/results}/develop-review-context-${task_group}-${round_label}.md"
+    local repo_root
+    repo_root=$(tangle_resolve_repo_root 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+    {
+        echo "# Develop Review Context"
+        echo
+        echo "## Purpose"
+        echo "Review the current working-tree diff against the original task contract, grasp/define context, tangle decomposition, and validation evidence."
+        echo
+        echo "## Review round"
+        echo "$round_label"
+        echo
+        echo "## Repository"
+        echo '```text'
+        echo "$repo_root"
+        echo '```'
+        echo
+        echo "## Git status"
+        echo '```text'
+        git -C "$repo_root" status --short --branch 2>/dev/null || true
+        echo '```'
+        echo
+        echo "## Changed files"
+        echo '```text'
+        {
+            git -C "$repo_root" diff --name-status 2>/dev/null || true
+            git -C "$repo_root" ls-files --others --exclude-standard 2>/dev/null | sed 's/^/??\t/' || true
+        } | sort -u
+        echo '```'
+        echo
+        echo "## Worktree diff stat"
+        echo '```text'
+        git -C "$repo_root" diff --stat 2>/dev/null || true
+        echo '```'
+        echo
+        if [[ -f "$worktree_before_file" ]]; then
+            echo "## Worktree snapshot before tangle"
+            echo '```text'
+            sed -n '1,200p' "$worktree_before_file" 2>/dev/null || true
+            echo '```'
+            echo
+        fi
+        echo "## Original task / task contract"
+        echo '```markdown'
+        printf '%s\n' "$resolved_prompt"
+        echo '```'
+        echo
+        if [[ -n "$grasp_context" ]]; then
+            echo "## Grasp / define context"
+            echo '```markdown'
+            printf '%s\n' "$grasp_context"
+            echo '```'
+            echo
+        fi
+        echo "## Tangle decomposition"
+        echo '```text'
+        printf '%s\n' "$subtasks"
+        echo '```'
+        echo
+        if [[ -f "$validation_file" ]]; then
+            echo "## Tangle validation report excerpt"
+            echo '```markdown'
+            sed -n '1,260p' "$validation_file" 2>/dev/null || true
+            echo '```'
+            echo
+            echo "## Tangle validation key lines"
+            echo '```text'
+            grep -n "Quality Gate\|Success Rate\|Failed\|Decision Branch\|Worktree Change Evidence\|Missing\|Status:" "$validation_file" 2>/dev/null | head -120 || true
+            echo '```'
+        fi
+    } > "$context_file"
+
+    echo "$context_file"
+}
+
+TANGLE_REVIEW_FINDINGS_FILE=""
+
+tangle_run_context_code_review() {
+    local task_group="$1"
+    local context_file="$2"
+    local round_label="${3:-initial}"
+    local marker findings_file review_profile review_rc
+    TANGLE_REVIEW_FINDINGS_FILE=""
+
+    if ! declare -F review_run >/dev/null 2>&1; then
+        log ERROR "tangle review gate cannot run: review_run is unavailable"
+        return 1
+    fi
+
+    marker=$(mktemp "${TMPDIR:-/tmp}/octopus-tangle-review-marker.XXXXXX")
+    touch "$marker"
+
+    review_profile=$(jq -n \
+        --arg target "${OCTOPUS_TANGLE_REVIEW_TARGET:-working-tree}" \
+        --arg contextFile "$context_file" \
+        --arg contextLabel "Octopus tangle develop review context (${round_label})" \
+        --arg provenance "octopus-tangle" \
+        --arg autonomy "${OCTOPUS_TANGLE_REVIEW_AUTONOMY:-autonomous}" \
+        --arg publish "${OCTOPUS_TANGLE_REVIEW_PUBLISH:-never}" \
+        --arg history "${OCTOPUS_TANGLE_REVIEW_HISTORY:-fresh}" \
+        '{target:$target, contextFile:$contextFile, contextLabel:$contextLabel, focus:["correctness","security","architecture","tdd","plan-conformance"], provenance:$provenance, autonomy:$autonomy, publish:$publish, history:$history}')
+
+    log INFO "Step 4: Contextual code review (${round_label})..."
+    review_run "$review_profile"
+    review_rc=$?
+
+    findings_file=$(find "${RESULTS_DIR:-${HOME}/.claude-octopus/results}" -maxdepth 1 -type f -name 'review-findings-*.json' -newer "$marker" -printf '%T@ %p\n' 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2- || true)
+    rm -f "$marker" 2>/dev/null || true
+
+    if [[ -z "$findings_file" || ! -f "$findings_file" ]]; then
+        log ERROR "Contextual code review did not produce a findings file"
+        return 1
+    fi
+
+    TANGLE_REVIEW_FINDINGS_FILE="$findings_file"
+    local normal_count
+    normal_count=$(tangle_review_blocking_count "$findings_file")
+    log INFO "Contextual code review findings: $findings_file (normal=${normal_count})"
+    return "$review_rc"
+}
+
+tangle_apply_review_corrections() {
+    local resolved_prompt="$1"
+    local context_file="$2"
+    local findings_file="$3"
+    local round_num="$4"
+    local correction_agent="${5:-codex}"
+    local correction_file="${RESULTS_DIR:-${HOME}/.claude-octopus/results}/tangle-review-corrections-${round_num}-$(date +%s).md"
+    local normal_findings
+    normal_findings=$(tangle_normal_findings_summary "$findings_file")
+
+    if [[ -z "$normal_findings" ]]; then
+        log INFO "No normal findings to correct in $findings_file"
+        return 0
+    fi
+
+    local correction_prompt="You are in Octopus tangle correction round ${round_num}.
+
+Do not reimplement the whole plan.
+Do not expand scope.
+Do not restart from scratch.
+Preserve existing working-tree changes unless a change is necessary to fix a blocking finding.
+Fix only the blocking severity=normal findings below.
+After editing, report files changed and tests/checks run.
+
+Original task contract:
+\`\`\`markdown
+${resolved_prompt}
+\`\`\`
+
+Review context file for reference:
+${context_file}
+
+Blocking findings to fix:
+${normal_findings}
+"
+
+    log INFO "Step 5: Applying contextual review corrections (round ${round_num}) with ${correction_agent}..."
+    if run_agent_sync "$correction_agent" "$correction_prompt" "${OCTOPUS_TANGLE_CORRECTION_TIMEOUT:-480}" "implementer" "tangle" > "$correction_file" 2>&1; then
+        {
+            echo ""
+            echo "## Status: SUCCESS"
+            echo "# Completed: $(date)"
+        } >> "$correction_file"
+        log INFO "Correction round ${round_num} result: $correction_file"
+        return 0
+    fi
+
+    {
+        echo ""
+        echo "## Status: FAILED"
+        echo "# Completed: $(date)"
+    } >> "$correction_file"
+    log WARN "Correction round ${round_num} failed: $correction_file"
+    return 1
+}
+
 # Phase 3: TANGLE (Develop) - Enhanced map-reduce with validation
 # Tentacles work together in a coordinated tangle of activity
 tangle_develop() {
@@ -1598,7 +1817,59 @@ Every [CODING] line must include a same-line Files: clause."
 
     # Step 3: Validation gate
     log INFO "Step 3: Validation gate..."
-    validate_tangle_results "$task_group" "$resolved_prompt" "$worktree_before_file"
+    local validation_file="${RESULTS_DIR:-${HOME}/.claude-octopus/results}/tangle-validation-${task_group}.md"
+    local validation_rc=0
+    validate_tangle_results "$task_group" "$resolved_prompt" "$worktree_before_file" || validation_rc=$?
+
+    if octo_bool_disabled "${OCTOPUS_TANGLE_CODE_REVIEW:-true}"; then
+        log INFO "Contextual code review disabled by OCTOPUS_TANGLE_CODE_REVIEW"
+        return "$validation_rc"
+    fi
+
+    local review_context_file
+    review_context_file=$(tangle_build_develop_review_context "$task_group" "$resolved_prompt" "$context" "$subtasks" "$validation_file" "$worktree_before_file" "initial")
+
+    local review_rc=0
+    tangle_run_context_code_review "$task_group" "$review_context_file" "initial" || review_rc=$?
+    local findings_file="$TANGLE_REVIEW_FINDINGS_FILE"
+    local normal_count
+    normal_count=$(tangle_review_blocking_count "$findings_file")
+
+    local max_correction_rounds="${OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS:-1}"
+    [[ "$max_correction_rounds" =~ ^[0-9]+$ ]] || max_correction_rounds=1
+    local correction_round=1
+
+    while [[ "${normal_count:-0}" -gt 0 && "$correction_round" -le "$max_correction_rounds" ]]; do
+        tangle_apply_review_corrections "$resolved_prompt" "$review_context_file" "$findings_file" "$correction_round" "$tangle_coding_agent" || return 1
+
+        log INFO "Re-running validation gate after correction round ${correction_round}..."
+        validation_rc=0
+        validate_tangle_results "$task_group" "$resolved_prompt" "$worktree_before_file" || validation_rc=$?
+
+        review_context_file=$(tangle_build_develop_review_context "$task_group" "$resolved_prompt" "$context" "$subtasks" "$validation_file" "$worktree_before_file" "correction-${correction_round}")
+        review_rc=0
+        tangle_run_context_code_review "$task_group" "$review_context_file" "correction-${correction_round}" || review_rc=$?
+        findings_file="$TANGLE_REVIEW_FINDINGS_FILE"
+        normal_count=$(tangle_review_blocking_count "$findings_file")
+        ((correction_round++)) || true
+    done
+
+    if [[ "${normal_count:-0}" -gt 0 ]]; then
+        log WARN "Contextual code review still has ${normal_count} blocking finding(s) after ${max_correction_rounds} correction round(s): ${findings_file}"
+        return 1
+    fi
+
+    if [[ "$review_rc" -ne 0 ]]; then
+        log WARN "Contextual code review returned non-zero despite zero blocking findings"
+        return "$review_rc"
+    fi
+
+    if octo_bool_enabled "${OCTOPUS_TANGLE_INK:-false}"; then
+        log INFO "OCTOPUS_TANGLE_INK enabled — running ink/deliver after contextual review passed"
+        ink_deliver "$resolved_prompt"
+    fi
+
+    return "$validation_rc"
 }
 
 ink_delivery_sanitize_context() {

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -2061,6 +2061,25 @@ Every [CODING] line must include a same-line Files: clause."
     local validation_rc=0
     validate_tangle_results "$task_group" "$resolved_prompt" "$worktree_before_file" || validation_rc=$?
 
+    tangle_contextual_review_gate "$task_group" "$resolved_prompt" "$context" "$subtasks" \
+        "$validation_file" "$worktree_before_file" "$validation_rc" "$tangle_coding_agent"
+    return $?
+}
+
+# Contextual review gate + correction loop for tangle_develop. Extracted so
+# round accounting, the convergence guard, and the absolute round ceiling are
+# unit-testable with stubbed review/correction functions
+# (tests/unit/test-tangle-correction-loop-behavior.sh).
+tangle_contextual_review_gate() {
+    local task_group="$1"
+    local resolved_prompt="$2"
+    local context="$3"
+    local subtasks="$4"
+    local validation_file="$5"
+    local worktree_before_file="$6"
+    local validation_rc="${7:-0}"
+    local tangle_coding_agent="${8:-codex}"
+
     if octo_bool_disabled "${OCTOPUS_TANGLE_CODE_REVIEW:-true}"; then
         log INFO "Contextual code review disabled by OCTOPUS_TANGLE_CODE_REVIEW"
         return "$validation_rc"
@@ -2096,10 +2115,21 @@ Every [CODING] line must include a same-line Files: clause."
     # count resets convergence; validation signature movement is diagnostic only.
     local validation_progress_resets_convergence="${OCTOPUS_TANGLE_CONVERGENCE_VALIDATION_PROGRESS:-false}"
     local correction_strategy="delta"
+    # Absolute ceiling on correction rounds. Each round dispatches paid provider
+    # calls, so even the default unbounded mode stops here; the stall watchdog
+    # and convergence guard remain the primary stops. Setting the ceiling to 0
+    # is an explicit opt-in to a truly unbounded loop.
+    local hard_round_cap="${OCTOPUS_TANGLE_CORRECTION_HARD_CAP:-10}"
+    [[ "$hard_round_cap" =~ ^[0-9]+$ ]] || hard_round_cap=10
 
     while [[ "${normal_count:-0}" -gt 0 ]]; do
         if [[ "$correction_mode" == "bounded" && "$max_correction_rounds" -gt 0 && "$correction_round" -gt "$max_correction_rounds" ]]; then
             log WARN "Contextual code review still has ${normal_count} blocking finding(s) after bounded ${max_correction_rounds} correction round(s): ${findings_file}"
+            return 1
+        fi
+
+        if [[ "$hard_round_cap" -gt 0 && "$correction_round" -gt "$hard_round_cap" ]]; then
+            log ERROR "Correction loop hit the absolute round ceiling (${hard_round_cap}) with ${normal_count} blocking finding(s) remaining: ${findings_file} — raise or disable with OCTOPUS_TANGLE_CORRECTION_HARD_CAP (0 = no ceiling)"
             return 1
         fi
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1213,6 +1213,19 @@ tangle_findings_signature() {
     jq -r '[.findings[]? | select((.severity // "") == "normal") | (.title // .message // "untitled")] | sort | join(" | ")' "$findings_file" 2>/dev/null || echo "unparseable"
 }
 
+# Fingerprint only the actionable validation-gate decision. This lets the
+# correction loop distinguish useful validation movement from a static gate that
+# is being recomputed from immutable initial subtask result files.
+tangle_validation_signature() {
+    local validation_file="$1"
+    [[ -f "$validation_file" ]] || { echo "missing"; return 0; }
+    awk '
+        /^### Quality Gate:/ { capture=1 }
+        /^### Subtask Results/ { capture=0 }
+        capture { print }
+    ' "$validation_file" 2>/dev/null | sha256sum | awk '{print $1}'
+}
+
 tangle_worktree_fingerprint() {
     local repo_root
     repo_root=$(tangle_resolve_repo_root 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -2019,6 +2032,11 @@ Every [CODING] line must include a same-line Files: clause."
     local previous_normal_count="$normal_count"
     local previous_signature
     previous_signature=$(tangle_findings_signature "$findings_file")
+    local previous_validation_signature
+    previous_validation_signature=$(tangle_validation_signature "$validation_file")
+    local best_normal_count="$normal_count"
+    local no_progress_rounds=0
+    local convergence_round_limit="${OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS:-3}"
     local correction_strategy="delta"
 
     while [[ "${normal_count:-0}" -gt 0 ]]; do
@@ -2072,13 +2090,37 @@ Every [CODING] line must include a same-line Files: clause."
             correction_strategy="single-finding"
         fi
 
+        local current_validation_signature
+        current_validation_signature=$(tangle_validation_signature "$validation_file")
+        local made_progress=0
+        if [[ "${normal_count:-0}" -lt "${best_normal_count:-0}" ]]; then
+            best_normal_count="$normal_count"
+            made_progress=1
+        fi
+        if [[ "$current_validation_signature" != "$previous_validation_signature" ]]; then
+            made_progress=1
+        fi
+
+        if [[ "$made_progress" -eq 1 ]]; then
+            no_progress_rounds=0
+        else
+            no_progress_rounds=$((no_progress_rounds + 1))
+            log WARN "Correction round ${correction_round} did not improve best blockers or validation signature (${no_progress_rounds}/${convergence_round_limit})"
+        fi
+
         if [[ "${TANGLE_CORRECTION_CHANGED:-0}" != "1" && "${TANGLE_CORRECTION_STATUS:-}" == *"stalled"* ]]; then
             log WARN "Correction stalled without partial writes; stopping to avoid a no-progress loop"
             return 1
         fi
 
+        if [[ "${convergence_round_limit:-0}" -gt 0 && "$no_progress_rounds" -ge "$convergence_round_limit" ]]; then
+            log ERROR "Stopping tangle correction loop after ${no_progress_rounds} rounds without new best blockers or validation progress (best_normal=${best_normal_count}, current_normal=${normal_count})"
+            return 1
+        fi
+
         previous_normal_count="$normal_count"
         previous_signature="$current_signature"
+        previous_validation_signature="$current_validation_signature"
         ((correction_round++)) || true
     done
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1089,8 +1089,8 @@ ${previous_decomposition}
         tangle_decompose_fallback_agent=$(octopus_agent_override "tangle" "decompose_fallback" "codex")
     fi
 
-    run_agent_sync "$tangle_decompose_agent" "$reformat_prompt" 120 "researcher" "tangle" || \
-    run_agent_sync "$tangle_decompose_fallback_agent" "$reformat_prompt" 120 "researcher" "tangle"
+    run_agent_sync "$tangle_decompose_agent" "$reformat_prompt" 0 "researcher" "tangle" || \
+    run_agent_sync "$tangle_decompose_fallback_agent" "$reformat_prompt" 0 "researcher" "tangle"
 }
 
 tangle_validate_parallel_write_scopes() {
@@ -1700,8 +1700,8 @@ Every [CODING] line must include a same-line Files: clause."
     fi
 
     local subtasks
-    subtasks=$(run_agent_sync "$tangle_decompose_agent" "$decompose_prompt" 120 "researcher" "tangle") || \
-    subtasks=$(run_agent_sync "$tangle_decompose_fallback_agent" "$decompose_prompt" 120 "researcher" "tangle") || {
+    subtasks=$(run_agent_sync "$tangle_decompose_agent" "$decompose_prompt" 0 "researcher" "tangle") || \
+    subtasks=$(run_agent_sync "$tangle_decompose_fallback_agent" "$decompose_prompt" 0 "researcher" "tangle") || {
         log ERROR "Decomposition failed with all providers; refusing monolithic direct fallback"
         return 1
     }
@@ -2296,8 +2296,8 @@ ink_deliver() {
     # Sonnet 4.6 quality review before synthesis
     log INFO "Step 2a: Sonnet 4.6 quality review..."
     local sonnet_review ink_review_timeout
-    ink_review_timeout="${OCTOPUS_INK_REVIEW_TIMEOUT:-240}"
-    [[ "$ink_review_timeout" =~ ^[0-9]+$ ]] || ink_review_timeout=240
+    ink_review_timeout="${OCTOPUS_INK_REVIEW_TIMEOUT:-0}"
+    [[ "$ink_review_timeout" =~ ^[0-9]+$ ]] || ink_review_timeout=0
     sonnet_review=$(run_agent_sync "claude-sonnet" "Review these development results for quality, completeness, and correctness.
 Flag any issues, gaps, or improvements needed.
 Rate each dimension explicitly as 'Security: N/10', 'Reliability: N/10', 'Performance: N/10', 'Accessibility: N/10'.
@@ -2359,7 +2359,7 @@ Be specific — list files and line numbers. If the code is already clean, say s
 Code to review:
 ${all_results}"
         local simplify_result
-        simplify_result=$(run_agent_sync "claude-sonnet" "$simplify_prompt" 120 "code-reviewer" "ink") || true
+        simplify_result=$(run_agent_sync "claude-sonnet" "$simplify_prompt" 0 "code-reviewer" "ink") || true
         if [[ -n "$simplify_result" ]]; then
             if [[ ${#simplify_result} -gt 12000 ]]; then
                 simplify_result="${simplify_result:0:12000}
@@ -2391,7 +2391,7 @@ Compact source context to synthesize:
 $all_results"
 
     local delivery
-    delivery=$(run_agent_sync "agy" "$synthesis_prompt" 180 "synthesizer" "ink") || {
+    delivery=$(run_agent_sync "agy" "$synthesis_prompt" 0 "synthesizer" "ink") || {
         delivery=$(build_ink_fallback_delivery "$prompt" "$sonnet_review" "$all_results")
     }
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -2060,7 +2060,11 @@ Every [CODING] line must include a same-line Files: clause."
 
         log INFO "Re-running validation gate after correction round ${correction_round} (status=${TANGLE_CORRECTION_STATUS}, changed=${TANGLE_CORRECTION_CHANGED})..."
         validation_rc=0
-        validate_tangle_results "$task_group" "$resolved_prompt" "$worktree_before_file" || validation_rc=$?
+        OCTOPUS_TANGLE_VALIDATION_CORRECTION_FILE="${TANGLE_CORRECTION_FILE:-}" \
+        OCTOPUS_TANGLE_VALIDATION_CORRECTION_ROUND="$correction_round" \
+        OCTOPUS_TANGLE_VALIDATION_CORRECTION_STATUS="${TANGLE_CORRECTION_STATUS:-}" \
+        OCTOPUS_TANGLE_VALIDATION_CORRECTION_CHANGED="${TANGLE_CORRECTION_CHANGED:-0}" \
+            validate_tangle_results "$task_group" "$resolved_prompt" "$worktree_before_file" || validation_rc=$?
 
         review_context_file=$(tangle_build_develop_review_context "$task_group" "$resolved_prompt" "$context" "$subtasks" "$validation_file" "$worktree_before_file" "correction-${correction_round}")
         review_rc=0

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1236,6 +1236,17 @@ tangle_worktree_fingerprint() {
     } | sha256sum 2>/dev/null | awk '{print $1}'
 }
 
+tangle_process_is_active_non_zombie() {
+    local pid="${1:-}"
+    [[ -n "$pid" ]] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    local stat
+    stat=$(ps -o stat= -p "$pid" 2>/dev/null | awk 'NR==1 {print $1}') || stat=""
+    [[ -n "$stat" ]] || return 1
+    [[ "$stat" == Z* ]] && return 1
+    return 0
+}
+
 tangle_scope_contamination_summary() {
     local repo_root
     repo_root=$(tangle_resolve_repo_root 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -1544,6 +1555,17 @@ ${normal_findings}
         } >> "$correction_file"
         log INFO "Correction round ${round_num} result: $correction_file"
         return 0
+    fi
+
+    if [[ "$correction_rc" == "130" || "$correction_rc" == "137" || "$correction_rc" == "143" ]]; then
+        TANGLE_CORRECTION_STATUS="interrupted-partial"
+        {
+            echo ""
+            echo "## Status: INTERRUPTED - PARTIAL WRITES PRESERVED"
+            echo "# Completed: $(date)"
+        } >> "$correction_file"
+        log WARN "Correction round ${round_num} was interrupted (rc=${correction_rc}); preserving partial writes but stopping correction loop: $correction_file"
+        return 1
     fi
 
     if [[ "$TANGLE_CORRECTION_CHANGED" == "1" ]]; then
@@ -1921,12 +1943,12 @@ Every [CODING] line must include a same-line Files: clause."
                         log WARN "Failed to write timeout marker for ${task_ids[$i]} at $_done_file"
                     fi
                     [[ " $_terminal_task_ids " == *" ${task_ids[$i]} "* ]] || _terminal_task_ids="${_terminal_task_ids:+$_terminal_task_ids }${task_ids[$i]}"
-                elif [[ -n "$_wrapper_pid" ]] && ! kill -0 "$_wrapper_pid" 2>/dev/null; then
+                elif [[ -n "$_wrapper_pid" ]] && ! tangle_process_is_active_non_zombie "$_wrapper_pid"; then
                     local _now
                     _now=$(date +%s)
                     if [[ -z "${_missing_marker_since[$i]:-}" ]]; then
                         _missing_marker_since[$i]="$_now"
-                        log WARN "Thread ${task_ids[$i]} wrapper exited without completion marker — waiting up to ${_missing_marker_grace}s for late result/marker"
+                        log WARN "Thread ${task_ids[$i]} exited or became zombie without completion marker — waiting up to ${_missing_marker_grace}s for late result/marker"
                     elif (( _now - ${_missing_marker_since[$i]} >= _missing_marker_grace )); then
                         log WARN "Thread ${task_ids[$i]} still lacks completion marker after ${_missing_marker_grace}s — marking failed"
                         mkdir -p "$_done_dir" 2>/dev/null || true
@@ -2037,6 +2059,10 @@ Every [CODING] line must include a same-line Files: clause."
     local best_normal_count="$normal_count"
     local no_progress_rounds=0
     local convergence_round_limit="${OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS:-3}"
+    # Validation files are re-rendered each correction round and can change even
+    # when the actionable gate is static. By default, only a new best blocker
+    # count resets convergence; validation signature movement is diagnostic only.
+    local validation_progress_resets_convergence="${OCTOPUS_TANGLE_CONVERGENCE_VALIDATION_PROGRESS:-false}"
     local correction_strategy="delta"
 
     while [[ "${normal_count:-0}" -gt 0 ]]; do
@@ -2102,14 +2128,18 @@ Every [CODING] line must include a same-line Files: clause."
             made_progress=1
         fi
         if [[ "$current_validation_signature" != "$previous_validation_signature" ]]; then
-            made_progress=1
+            if octo_bool_enabled "$validation_progress_resets_convergence"; then
+                made_progress=1
+            else
+                log INFO "Correction round ${correction_round}: validation signature changed but blocker best did not improve; not resetting convergence guard"
+            fi
         fi
 
         if [[ "$made_progress" -eq 1 ]]; then
             no_progress_rounds=0
         else
             no_progress_rounds=$((no_progress_rounds + 1))
-            log WARN "Correction round ${correction_round} did not improve best blockers or validation signature (${no_progress_rounds}/${convergence_round_limit})"
+            log WARN "Correction round ${correction_round} did not improve best blockers (${no_progress_rounds}/${convergence_round_limit})"
         fi
 
         if [[ "${TANGLE_CORRECTION_CHANGED:-0}" != "1" && "${TANGLE_CORRECTION_STATUS:-}" == *"stalled"* ]]; then
@@ -2118,7 +2148,7 @@ Every [CODING] line must include a same-line Files: clause."
         fi
 
         if [[ "${convergence_round_limit:-0}" -gt 0 && "$no_progress_rounds" -ge "$convergence_round_limit" ]]; then
-            log ERROR "Stopping tangle correction loop after ${no_progress_rounds} rounds without new best blockers or validation progress (best_normal=${best_normal_count}, current_normal=${normal_count})"
+            log ERROR "Stopping tangle correction loop after ${no_progress_rounds} rounds without new best blockers (best_normal=${best_normal_count}, current_normal=${normal_count})"
             return 1
         fi
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -2089,7 +2089,9 @@ ink_deliver() {
 
     # Sonnet 4.6 quality review before synthesis
     log INFO "Step 2a: Sonnet 4.6 quality review..."
-    local sonnet_review
+    local sonnet_review ink_review_timeout
+    ink_review_timeout="${OCTOPUS_INK_REVIEW_TIMEOUT:-240}"
+    [[ "$ink_review_timeout" =~ ^[0-9]+$ ]] || ink_review_timeout=240
     sonnet_review=$(run_agent_sync "claude-sonnet" "Review these development results for quality, completeness, and correctness.
 Flag any issues, gaps, or improvements needed.
 Rate each dimension explicitly as 'Security: N/10', 'Reliability: N/10', 'Performance: N/10', 'Accessibility: N/10'.
@@ -2097,7 +2099,7 @@ Rate each dimension explicitly as 'Security: N/10', 'Reliability: N/10', 'Perfor
 Original task: $prompt
 
 Results:
-$all_results" 120 "code-reviewer" "ink") || {
+$all_results" "$ink_review_timeout" "code-reviewer" "ink") || {
         sonnet_review="[Quality review unavailable]"
     }
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1089,8 +1089,8 @@ ${previous_decomposition}
         tangle_decompose_fallback_agent=$(octopus_agent_override "tangle" "decompose_fallback" "codex")
     fi
 
-    run_agent_sync "$tangle_decompose_agent" "$reformat_prompt" 0 "researcher" "tangle" || \
-    run_agent_sync "$tangle_decompose_fallback_agent" "$reformat_prompt" 0 "researcher" "tangle"
+    OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-reformat-validation" run_agent_sync "$tangle_decompose_agent" "$reformat_prompt" 0 "researcher" "tangle" || \
+    OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-reformat-validation" run_agent_sync "$tangle_decompose_fallback_agent" "$reformat_prompt" 0 "researcher" "tangle"
 }
 
 tangle_validate_parallel_write_scopes() {
@@ -1192,7 +1192,13 @@ tangle_review_blocking_count() {
         echo 1
         return 0
     fi
-    jq '[.findings[]? | select((.severity // "") == "normal")] | length' "$findings_file" 2>/dev/null || echo 0
+    local count
+    if ! count=$(jq '[.findings[]? | select((.severity // "") == "normal")] | length' "$findings_file" 2>/dev/null); then
+        # fail closed: malformed/truncated findings must block delivery.
+        echo 1
+        return 0
+    fi
+    echo "$count"
 }
 
 tangle_review_findings_summary() {
@@ -1392,6 +1398,9 @@ tangle_run_context_code_review() {
 
     marker=$(mktemp "${TMPDIR:-/tmp}/octopus-tangle-review-marker.XXXXXX")
     touch "$marker"
+    local _marker_cleanup_trap
+    _marker_cleanup_trap=$(trap -p RETURN || true)
+    trap 'rm -f "${marker:-}" 2>/dev/null || true' RETURN
 
     review_profile=$(jq -n \
         --arg target "${OCTOPUS_TANGLE_REVIEW_TARGET:-working-tree}" \
@@ -1420,6 +1429,10 @@ tangle_run_context_code_review() {
         fi
     done < <(find "${RESULTS_DIR:-${HOME}/.claude-octopus/results}" -maxdepth 1 -type f -name 'review-findings-*.json' 2>/dev/null || true)
     rm -f "$marker" 2>/dev/null || true
+    trap - RETURN
+    if [[ -n "$_marker_cleanup_trap" ]]; then
+        eval "$_marker_cleanup_trap"
+    fi
 
     if [[ -z "$findings_file" || ! -f "$findings_file" ]]; then
         log ERROR "Contextual code review did not produce a findings file"
@@ -1505,17 +1518,21 @@ ${normal_findings}
 
     log INFO "Step 5: Applying contextual review corrections (round ${round_num}, strategy=${correction_strategy}, stall_window=${stall_window}s) with ${correction_agent}..."
     (
-        run_agent_sync "$correction_agent" "$correction_prompt" 0 "implementer" "tangle" > "$correction_file" 2>&1
+        OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-correction-stall-watchdog" run_agent_sync "$correction_agent" "$correction_prompt" 0 "implementer" "tangle" > "$correction_file" 2>&1
         echo "$?" > "$rc_file"
     ) &
     local correction_pid=$!
     local stalled="false"
 
-    while kill -0 "$correction_pid" 2>/dev/null; do
+    while true; do
+        [[ -f "$rc_file" ]] && break
+        if ! tangle_process_is_active_non_zombie "$correction_pid"; then
+            break
+        fi
         sleep "$poll_secs"
         local current_fp current_size
         current_fp=$(tangle_worktree_fingerprint)
-        current_size=$(stat -c '%s' "$correction_file" 2>/dev/null || echo 0)
+        current_size=$(stat -c '%s' "$correction_file" 2>/dev/null || stat -f '%z' "$correction_file" 2>/dev/null || echo 0)
         if [[ "$current_fp" != "$last_fp" || "$current_size" != "$last_size" ]]; then
             last_fp="$current_fp"
             last_size="$current_size"
@@ -1758,8 +1775,8 @@ Every [CODING] line must include a same-line Files: clause."
     fi
 
     local subtasks
-    subtasks=$(run_agent_sync "$tangle_decompose_agent" "$decompose_prompt" 0 "researcher" "tangle") || \
-    subtasks=$(run_agent_sync "$tangle_decompose_fallback_agent" "$decompose_prompt" 0 "researcher" "tangle") || {
+    subtasks=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-dispatch-watcher" run_agent_sync "$tangle_decompose_agent" "$decompose_prompt" 0 "researcher" "tangle") || \
+    subtasks=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-dispatch-watcher" run_agent_sync "$tangle_decompose_fallback_agent" "$decompose_prompt" 0 "researcher" "tangle") || {
         log ERROR "Decomposition failed with all providers; refusing monolithic direct fallback"
         return 1
     }
@@ -2061,6 +2078,10 @@ Every [CODING] line must include a same-line Files: clause."
     local correction_mode="${OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE:-unbounded}"
     local max_correction_rounds="${OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS:-0}"
     [[ "$max_correction_rounds" =~ ^[0-9]+$ ]] || max_correction_rounds=0
+    if [[ "$correction_mode" == "bounded" && "$max_correction_rounds" -eq 0 ]]; then
+        log WARN "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded with no OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS set — defaulting to 1 round"
+        max_correction_rounds=1
+    fi
     local correction_round=1
     local previous_normal_count="$normal_count"
     local previous_signature
@@ -2463,7 +2484,7 @@ Be specific — list files and line numbers. If the code is already clean, say s
 Code to review:
 ${all_results}"
         local simplify_result
-        simplify_result=$(run_agent_sync "claude-sonnet" "$simplify_prompt" 0 "code-reviewer" "ink") || true
+        simplify_result=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="ink-review-watchdog" run_agent_sync "claude-sonnet" "$simplify_prompt" 0 "code-reviewer" "ink") || true
         if [[ -n "$simplify_result" ]]; then
             if [[ ${#simplify_result} -gt 12000 ]]; then
                 simplify_result="${simplify_result:0:12000}
@@ -2495,7 +2516,7 @@ Compact source context to synthesize:
 $all_results"
 
     local delivery
-    delivery=$(run_agent_sync "agy" "$synthesis_prompt" 0 "synthesizer" "ink") || {
+    delivery=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="ink-delivery-watchdog" run_agent_sync "agy" "$synthesis_prompt" 0 "synthesizer" "ink") || {
         delivery=$(build_ink_fallback_delivery "$prompt" "$sonnet_review" "$all_results")
     }
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1177,9 +1177,21 @@ octo_bool_enabled() {
     esac
 }
 
+tangle_review_warning_text() {
+    local findings_file="$1"
+    [[ -f "$findings_file" ]] || return 0
+    jq -r '(.warning // (if ((.message // "") | test("No changes found to review"; "i")) then .message else "" end)) // ""' "$findings_file" 2>/dev/null || true
+}
+
 tangle_review_blocking_count() {
     local findings_file="$1"
     [[ -f "$findings_file" ]] || { echo 0; return 0; }
+    local review_warning
+    review_warning=$(tangle_review_warning_text "$findings_file")
+    if [[ -n "$review_warning" ]]; then
+        echo 1
+        return 0
+    fi
     jq '[.findings[]? | select((.severity // "") == "normal")] | length' "$findings_file" 2>/dev/null || echo 0
 }
 
@@ -1382,7 +1394,7 @@ tangle_run_context_code_review() {
     TANGLE_REVIEW_FINDINGS_FILE="$findings_file"
     local normal_count review_warning
     normal_count=$(tangle_review_blocking_count "$findings_file")
-    review_warning=$(jq -r '.warning // empty' "$findings_file" 2>/dev/null || true)
+    review_warning=$(tangle_review_warning_text "$findings_file")
     log INFO "Contextual code review findings: $findings_file (normal=${normal_count})"
     if [[ -n "$review_warning" ]]; then
         log WARN "Contextual code review warning: ${review_warning}"
@@ -2039,6 +2051,11 @@ Every [CODING] line must include a same-line Files: clause."
         normal_count=$(tangle_review_blocking_count "$findings_file")
         local current_signature
         current_signature=$(tangle_findings_signature "$findings_file")
+
+        if [[ "$review_rc" -ne 0 ]]; then
+            log WARN "Contextual code review returned non-zero after correction round ${correction_round}; not treating review warning/no-diff as improvement"
+            return "$review_rc"
+        fi
 
         if [[ "${normal_count:-0}" -lt "${previous_normal_count:-0}" ]]; then
             log INFO "Correction round ${correction_round} improved blockers: ${previous_normal_count} -> ${normal_count}"

--- a/tests/unit/test-develop-md-file-resolution.sh
+++ b/tests/unit/test-develop-md-file-resolution.sh
@@ -12,6 +12,9 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 
 test_suite "develop Markdown plan resolution"
 
+# These tests exercise tangle dispatch/validation behavior, not contextual review.
+export OCTOPUS_TANGLE_CODE_REVIEW=false
+
 assert_has() {
     local pattern="$1"
     local label="$2"
@@ -204,7 +207,7 @@ date() {
         if [[ $count -le 2 ]]; then
             printf '%s\n' "100"
         else
-            printf '%s\n' "101"
+            printf '%s\n' "102"
         fi
         return 0
     fi
@@ -213,7 +216,7 @@ date() {
 
 CAPTURED_VALIDATE_PROMPT=""
 deadline_override_ok=false
-if OCTOPUS_TANGLE_DEADLINE=0 tangle_develop "deadline override task" >/dev/null 2>&1 && \
+if OCTOPUS_TANGLE_DEADLINE=1 tangle_develop "deadline override task" >/dev/null 2>&1 && \
    grep -q "deadline exceeded" "$LOG_CAPTURE_FILE" && \
    grep -q "finished with status: timeout" "$LOG_CAPTURE_FILE" && \
    [[ "$CAPTURED_VALIDATE_PROMPT" == "deadline override task" ]]; then

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Static tests for tangle contextual review/correction loop wiring.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "tangle contextual review loop"
+
+WORKFLOWS="$PROJECT_ROOT/scripts/lib/workflows.sh"
+HELP="$PROJECT_ROOT/scripts/lib/usage-help.sh"
+
+assert_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    test_case "$label"
+    if grep -q "$pattern" "$file"; then
+        test_pass
+    else
+        test_fail "missing pattern: $pattern"
+        return 1
+    fi
+}
+
+assert_contains "$WORKFLOWS" "tangle_build_develop_review_context" "tangle builds review context"
+assert_contains "$WORKFLOWS" "tangle_run_context_code_review" "tangle runs contextual code review"
+assert_contains "$WORKFLOWS" "contextFile" "review profile passes contextFile"
+assert_contains "$WORKFLOWS" "plan-conformance" "review focus includes plan conformance"
+assert_contains "$WORKFLOWS" "tangle_apply_review_corrections" "tangle applies review corrections"
+assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS" "correction rounds are configurable"
+assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CODE_REVIEW" "code review gate is toggleable"
+assert_contains "$HELP" "Contextual code review" "develop help documents contextual review"
+assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS" "develop help documents correction rounds"
+
+test_summary

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -31,6 +31,8 @@ assert_contains "$WORKFLOWS" "plan-conformance" "review focus includes plan conf
 assert_contains "$WORKFLOWS" "tangle_apply_review_corrections" "tangle applies review corrections"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE" "correction loop supports explicit bounded mode"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW" "correction loop uses stall watchdog"
+assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_DEADLINE:-0" "initial tangle deadline defaults to no absolute timeout"
+assert_contains "$WORKFLOWS" "_tangle_max_wait" "initial tangle deadline is optional"
 assert_contains "$WORKFLOWS" "failed but left partial writes" "partial writes continue to validation/review"
 assert_contains "$WORKFLOWS" 'run_agent_sync "$correction_agent" "$correction_prompt" 0' "corrections run without absolute timeout"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CODE_REVIEW" "code review gate is toggleable"
@@ -43,5 +45,8 @@ assert_contains "$WORKFLOWS" "OCTOPUS_INK_REVIEW_TIMEOUT" "ink review timeout is
 
 HEARTBEAT="$PROJECT_ROOT/scripts/lib/heartbeat.sh"
 assert_contains "$HEARTBEAT" "timeout_secs=0 means no absolute timeout" "timeout zero disables absolute timeout"
+SPAWN="$PROJECT_ROOT/scripts/lib/spawn.sh"
+assert_contains "$SPAWN" "TIMEOUT=0 means no absolute timeout" "spawn respects TIMEOUT=0"
+assert_contains "$SPAWN" "OCTOPUS_GEMINI_TIMEOUT" "gemini timeout can be explicitly overridden"
 
 test_summary

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -35,5 +35,6 @@ assert_contains "$WORKFLOWS" "Contextual code review warning" "review warnings a
 assert_contains "$WORKFLOWS" "Skipping ink/deliver because tangle validation gate returned non-zero" "ink is skipped when validation fails"
 assert_contains "$HELP" "Contextual code review" "develop help documents contextual review"
 assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS" "develop help documents correction rounds"
+assert_contains "$WORKFLOWS" "OCTOPUS_INK_REVIEW_TIMEOUT" "ink review timeout is configurable"
 
 test_summary

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -61,4 +61,10 @@ SPAWN="$PROJECT_ROOT/scripts/lib/spawn.sh"
 assert_contains "$SPAWN" "TIMEOUT=0 means no absolute timeout" "spawn respects TIMEOUT=0"
 assert_contains "$SPAWN" "OCTOPUS_GEMINI_TIMEOUT" "gemini timeout can be explicitly overridden"
 
+TESTING="$PROJECT_ROOT/scripts/lib/testing.sh"
+assert_contains "$TESTING" "OCTOPUS_TANGLE_VALIDATION_CORRECTION_FILE" "post-correction validation overlay is wired"
+assert_contains "$TESTING" "Static Subtask Rate Before Correction Overlay" "post-correction validation reports static subtask rate"
+assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_VALIDATION_CORRECTION_CHANGED" "correction loop passes validation overlay context"
+assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS" "correction loop has convergence guard"
+
 test_summary

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -52,7 +52,7 @@ assert_contains "$REVIEW" "return 1" "review no-diff returns non-zero"
 
 QUALITY="$PROJECT_ROOT/scripts/lib/quality.sh"
 assert_contains "$QUALITY" "OCTOPUS_DESIGN_REVIEW_TIMEOUT:-0" "design review uses no wall timeout by default"
-assert_contains "$QUALITY" "timeout=none" "design review reports no wall timeout"
+assert_contains "$QUALITY" "_design_timeout_label" "design review reports effective timeout label"
 
 HEARTBEAT="$PROJECT_ROOT/scripts/lib/heartbeat.sh"
 assert_contains "$HEARTBEAT" "timeout_secs=0 means no absolute timeout" "timeout zero disables absolute timeout"

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -39,11 +39,17 @@ assert_contains "$WORKFLOWS" "failed but left partial writes" "partial writes co
 assert_contains "$WORKFLOWS" 'run_agent_sync "$correction_agent" "$correction_prompt" 0' "corrections run without absolute timeout"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CODE_REVIEW" "code review gate is toggleable"
 assert_contains "$WORKFLOWS" "Contextual code review warning" "review warnings are blocking"
+assert_contains "$WORKFLOWS" "No changes found to review" "legacy no-diff message is detected"
+assert_contains "$WORKFLOWS" "not treating review warning/no-diff as improvement" "no-diff review is blocking"
 assert_contains "$WORKFLOWS" "Skipping ink/deliver because tangle validation gate returned non-zero" "ink is skipped when validation fails"
 assert_contains "$HELP" "Contextual code review" "develop help documents contextual review"
 assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE" "develop help documents bounded mode"
 assert_contains "$HELP" "OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW" "develop help documents stall window"
 assert_contains "$WORKFLOWS" "OCTOPUS_INK_REVIEW_TIMEOUT:-0" "ink review has no wall timeout by default"
+
+REVIEW="$PROJECT_ROOT/scripts/lib/review.sh"
+assert_contains "$REVIEW" "\"warning\":\"No changes found to review\"" "review no-diff writes warning"
+assert_contains "$REVIEW" "return 1" "review no-diff returns non-zero"
 
 QUALITY="$PROJECT_ROOT/scripts/lib/quality.sh"
 assert_contains "$QUALITY" "OCTOPUS_DESIGN_REVIEW_TIMEOUT:-0" "design review uses no wall timeout by default"

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -32,6 +32,8 @@ assert_contains "$WORKFLOWS" "tangle_apply_review_corrections" "tangle applies r
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE" "correction loop supports explicit bounded mode"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW" "correction loop uses stall watchdog"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_DEADLINE:-0" "initial tangle deadline defaults to no absolute timeout"
+assert_contains "$WORKFLOWS" "decompose_prompt" "decomposition prompt is present"
+assert_contains "$WORKFLOWS" '"$decompose_prompt" 0' "decomposition runs without absolute timeout"
 assert_contains "$WORKFLOWS" "_tangle_max_wait" "initial tangle deadline is optional"
 assert_contains "$WORKFLOWS" "failed but left partial writes" "partial writes continue to validation/review"
 assert_contains "$WORKFLOWS" 'run_agent_sync "$correction_agent" "$correction_prompt" 0' "corrections run without absolute timeout"
@@ -41,7 +43,11 @@ assert_contains "$WORKFLOWS" "Skipping ink/deliver because tangle validation gat
 assert_contains "$HELP" "Contextual code review" "develop help documents contextual review"
 assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE" "develop help documents bounded mode"
 assert_contains "$HELP" "OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW" "develop help documents stall window"
-assert_contains "$WORKFLOWS" "OCTOPUS_INK_REVIEW_TIMEOUT" "ink review timeout is configurable"
+assert_contains "$WORKFLOWS" "OCTOPUS_INK_REVIEW_TIMEOUT:-0" "ink review has no wall timeout by default"
+
+QUALITY="$PROJECT_ROOT/scripts/lib/quality.sh"
+assert_contains "$QUALITY" "OCTOPUS_DESIGN_REVIEW_TIMEOUT:-0" "design review uses no wall timeout by default"
+assert_contains "$QUALITY" "timeout=none" "design review reports no wall timeout"
 
 HEARTBEAT="$PROJECT_ROOT/scripts/lib/heartbeat.sh"
 assert_contains "$HEARTBEAT" "timeout_secs=0 means no absolute timeout" "timeout zero disables absolute timeout"

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -20,7 +20,6 @@ assert_contains() {
         test_pass
     else
         test_fail "missing pattern: $pattern"
-        return 1
     fi
 }
 
@@ -66,6 +65,11 @@ assert_contains "$TESTING" "OCTOPUS_TANGLE_VALIDATION_CORRECTION_FILE" "post-cor
 assert_contains "$TESTING" "Static Subtask Rate Before Correction Overlay" "post-correction validation reports static subtask rate"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_VALIDATION_CORRECTION_CHANGED" "correction loop passes validation overlay context"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS" "correction loop has convergence guard"
+assert_contains "$WORKFLOWS" "tangle_review_blocking_count" "review blocking count helper exists"
+assert_contains "$WORKFLOWS" "fail closed" "malformed review findings fail closed"
+assert_contains "$WORKFLOWS" "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED" "unbounded agent calls document external supervision"
+assert_contains "$WORKFLOWS" "stat -f '%z'" "correction progress size uses BSD stat fallback"
+assert_contains "$WORKFLOWS" "defaulting to 1 round" "bounded correction mode has implicit cap"
 assert_contains "$WORKFLOWS" "tangle_process_is_active_non_zombie" "tangle watcher treats zombies as terminal"
 assert_contains "$WORKFLOWS" "exited or became zombie without completion marker" "tangle watcher logs zombie missing-marker grace"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CONVERGENCE_VALIDATION_PROGRESS" "convergence guard does not treat validation rerenders as progress by default"

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -31,6 +31,8 @@ assert_contains "$WORKFLOWS" "plan-conformance" "review focus includes plan conf
 assert_contains "$WORKFLOWS" "tangle_apply_review_corrections" "tangle applies review corrections"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS" "correction rounds are configurable"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CODE_REVIEW" "code review gate is toggleable"
+assert_contains "$WORKFLOWS" "Contextual code review warning" "review warnings are blocking"
+assert_contains "$WORKFLOWS" "Skipping ink/deliver because tangle validation gate returned non-zero" "ink is skipped when validation fails"
 assert_contains "$HELP" "Contextual code review" "develop help documents contextual review"
 assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS" "develop help documents correction rounds"
 

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -66,5 +66,11 @@ assert_contains "$TESTING" "OCTOPUS_TANGLE_VALIDATION_CORRECTION_FILE" "post-cor
 assert_contains "$TESTING" "Static Subtask Rate Before Correction Overlay" "post-correction validation reports static subtask rate"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_VALIDATION_CORRECTION_CHANGED" "correction loop passes validation overlay context"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS" "correction loop has convergence guard"
+assert_contains "$WORKFLOWS" "tangle_process_is_active_non_zombie" "tangle watcher treats zombies as terminal"
+assert_contains "$WORKFLOWS" "exited or became zombie without completion marker" "tangle watcher logs zombie missing-marker grace"
+assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CONVERGENCE_VALIDATION_PROGRESS" "convergence guard does not treat validation rerenders as progress by default"
+assert_contains "$WORKFLOWS" "validation signature changed but blocker best did not improve" "convergence guard logs ignored validation-only movement"
+assert_contains "$WORKFLOWS" "interrupted-partial" "correction loop stops on interrupted partial writes"
+assert_contains "$WORKFLOWS" "rc=" "interrupted correction logs provider exit code"
 
 test_summary

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -29,12 +29,19 @@ assert_contains "$WORKFLOWS" "tangle_run_context_code_review" "tangle runs conte
 assert_contains "$WORKFLOWS" "contextFile" "review profile passes contextFile"
 assert_contains "$WORKFLOWS" "plan-conformance" "review focus includes plan conformance"
 assert_contains "$WORKFLOWS" "tangle_apply_review_corrections" "tangle applies review corrections"
-assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS" "correction rounds are configurable"
+assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE" "correction loop supports explicit bounded mode"
+assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW" "correction loop uses stall watchdog"
+assert_contains "$WORKFLOWS" "failed but left partial writes" "partial writes continue to validation/review"
+assert_contains "$WORKFLOWS" 'run_agent_sync "$correction_agent" "$correction_prompt" 0' "corrections run without absolute timeout"
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CODE_REVIEW" "code review gate is toggleable"
 assert_contains "$WORKFLOWS" "Contextual code review warning" "review warnings are blocking"
 assert_contains "$WORKFLOWS" "Skipping ink/deliver because tangle validation gate returned non-zero" "ink is skipped when validation fails"
 assert_contains "$HELP" "Contextual code review" "develop help documents contextual review"
-assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS" "develop help documents correction rounds"
+assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE" "develop help documents bounded mode"
+assert_contains "$HELP" "OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW" "develop help documents stall window"
 assert_contains "$WORKFLOWS" "OCTOPUS_INK_REVIEW_TIMEOUT" "ink review timeout is configurable"
+
+HEARTBEAT="$PROJECT_ROOT/scripts/lib/heartbeat.sh"
+assert_contains "$HEARTBEAT" "timeout_secs=0 means no absolute timeout" "timeout zero disables absolute timeout"
 
 test_summary

--- a/tests/unit/test-tangle-correction-loop-behavior.sh
+++ b/tests/unit/test-tangle-correction-loop-behavior.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Behavioral tests for tangle_contextual_review_gate (PR #593 correction loop).
+# Drives the extracted loop with stubbed review/correction functions and asserts
+# round counts and exit codes — complements the static grep assertions in
+# test-tangle-context-review-loop.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "tangle correction loop behavior"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+export RESULTS_DIR="$TMP_DIR/results"
+mkdir -p "$RESULTS_DIR"
+
+# ── Harness ────────────────────────────────────────────────────────────────
+# run_gate <blocker-count-sequence...>
+# Each stubbed review round pops the next count from the sequence. Correction
+# and validation always "succeed with changes". Prints "rounds=<n> rc=<n>".
+run_gate() {
+    local seq="$*"
+    bash -c '
+        set -u
+        log() { :; }
+        octo_event_emit() { :; }
+        write_agent_status() { :; }
+        record_agents_batch_complete() { :; }
+        ink_deliver() { :; }
+        run_agent_sync() { :; }
+        octopus_agent_override() { echo "codex"; }
+
+        COUNTS=($1)
+        IDX_FILE="$RESULTS_DIR/count-idx"
+        echo 0 > "$IDX_FILE"
+        CORRECTION_CALLS=0
+
+        source "$2/scripts/lib/workflows.sh" 2>/dev/null
+
+        tangle_build_develop_review_context() { echo "$RESULTS_DIR/ctx-$7.md"; }
+        tangle_run_context_code_review() {
+            TANGLE_REVIEW_FINDINGS_FILE="$RESULTS_DIR/findings-$3.json"
+            echo "{\"findings\":[]}" > "$TANGLE_REVIEW_FINDINGS_FILE"
+            return 0
+        }
+        # Stub state lives in a file: these stubs run inside command
+        # substitutions, so in-shell variable increments would be lost.
+        tangle_review_blocking_count() {
+            local idx c
+            idx=$(cat "$IDX_FILE")
+            c="${COUNTS[$idx]:-0}"
+            if [[ $idx -lt $(( ${#COUNTS[@]} - 1 )) ]]; then
+                echo $((idx + 1)) > "$IDX_FILE"
+            fi
+            echo "$c"
+        }
+        tangle_findings_signature() { echo "sig-$(cat "$IDX_FILE")"; }
+        tangle_validation_signature() { echo "vsig"; }
+        tangle_apply_review_corrections() {
+            CORRECTION_CALLS=$((CORRECTION_CALLS + 1))
+            TANGLE_CORRECTION_STATUS="done"
+            TANGLE_CORRECTION_CHANGED=1
+            TANGLE_CORRECTION_CONTAMINATION=""
+            TANGLE_CORRECTION_FILE="$RESULTS_DIR/corr-$CORRECTION_CALLS.md"
+            return 0
+        }
+        validate_tangle_results() { return 0; }
+
+        rc=0
+        tangle_contextual_review_gate tg "prompt" "ctx" "subtasks" \
+            "$RESULTS_DIR/validation.md" "$RESULTS_DIR/wt.txt" 0 codex || rc=$?
+        echo "rounds=$CORRECTION_CALLS rc=$rc"
+    ' _ "$seq" "$PROJECT_ROOT"
+}
+
+# ── Cases ──────────────────────────────────────────────────────────────────
+
+test_case "zero initial blockers: no correction rounds, exit 0"
+out=$(run_gate "0")
+if [[ "$out" == "rounds=0 rc=0" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=0 rc=0, got '$out'"
+fi
+
+test_case "decreasing blockers converge to zero: exit 0 after 3 rounds"
+out=$(run_gate "3 2 1 0")
+if [[ "$out" == "rounds=3 rc=0" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=3 rc=0, got '$out'"
+fi
+
+test_case "static blockers trip convergence guard (default 3 no-progress rounds)"
+out=$(OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 run_gate "5 5 5 5 5 5 5 5 5 5")
+if [[ "$out" == "rounds=3 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=3 rc=1, got '$out'"
+fi
+
+test_case "hard cap stops improving-but-never-zero loop"
+# counts keep improving (each round is a new best), so the convergence guard
+# never fires — only the absolute ceiling can stop this.
+out=$(OCTOPUS_TANGLE_CORRECTION_HARD_CAP=4 run_gate "20 19 18 17 16 15 14 13 12 11 10 9 8")
+if [[ "$out" == "rounds=4 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=4 rc=1, got '$out'"
+fi
+
+test_case "hard cap closes the convergence-guard-disabled foot-gun"
+out=$(OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=0 OCTOPUS_TANGLE_CORRECTION_HARD_CAP=5 run_gate "9 8 7 6 5 4 4 4 4 4 4 4 4 4 4")
+if [[ "$out" == "rounds=5 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=5 rc=1, got '$out'"
+fi
+
+test_case "default hard cap is 10 when unset"
+out=$(OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=0 run_gate "30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15")
+if [[ "$out" == "rounds=10 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=10 rc=1, got '$out'"
+fi
+
+test_case "bounded mode round cap still enforced"
+out=$(OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=2 run_gate "8 7 6 5 4 3")
+if [[ "$out" == "rounds=2 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=2 rc=1, got '$out'"
+fi
+
+test_summary

--- a/tests/unit/test-tangle-direct-fallback.sh
+++ b/tests/unit/test-tangle-direct-fallback.sh
@@ -12,6 +12,9 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 
 test_suite "tangle direct fallback"
 
+# These tests exercise tangle dispatch/validation behavior, not contextual review.
+export OCTOPUS_TANGLE_CODE_REVIEW=false
+
 test_case "workflows.sh has valid bash syntax"
 if bash -n "$WORKFLOWS" 2>/dev/null; then
     test_pass

--- a/tests/unit/test-tangle-dispatch-stdin-isolation.sh
+++ b/tests/unit/test-tangle-dispatch-stdin-isolation.sh
@@ -13,6 +13,9 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 
 test_suite "tangle dispatch stdin isolation"
 
+# These tests exercise tangle dispatch/validation behavior, not contextual review.
+export OCTOPUS_TANGLE_CODE_REVIEW=false
+
 test_case "workflows.sh has valid bash syntax"
 if bash -n "$WORKFLOWS" 2>/dev/null; then
     test_pass

--- a/tests/unit/test-tangle-missing-done-marker.sh
+++ b/tests/unit/test-tangle-missing-done-marker.sh
@@ -8,6 +8,9 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "tangle missing done marker recovery"
 
+# These tests exercise tangle dispatch/validation behavior, not contextual review.
+export OCTOPUS_TANGLE_CODE_REVIEW=false
+
 WORKFLOWS="$PROJECT_ROOT/scripts/lib/workflows.sh"
 TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
 rm -rf "$TEST_TMP_DIR"

--- a/tests/unit/test-tangle-reformat-agent-routing.sh
+++ b/tests/unit/test-tangle-reformat-agent-routing.sh
@@ -45,7 +45,7 @@ if (
     export OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT="codex"
     result=$(tangle_reformat_decomposition "task" "bad decomposition" "overlap" "")
     [[ "$result" == *"Reformatted task"* ]] &&
-    [[ "$(sed -n '1p' "$CALL_LOG")" == "gemini|120|researcher|tangle" ]] &&
+    [[ "$(sed -n '1p' "$CALL_LOG")" == "gemini|0|researcher|tangle" ]] &&
     [[ "$(wc -l < "$CALL_LOG")" -eq 1 ]]
 ); then
     test_pass
@@ -60,8 +60,8 @@ if (
     export OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT="gemini"
     result=$(tangle_reformat_decomposition "task" "bad decomposition" "overlap" "")
     [[ "$result" == *"Reformatted task"* ]] &&
-    [[ "$(sed -n '1p' "$CALL_LOG")" == "unavailable-agent|120|researcher|tangle" ]] &&
-    [[ "$(sed -n '2p' "$CALL_LOG")" == "gemini|120|researcher|tangle" ]]
+    [[ "$(sed -n '1p' "$CALL_LOG")" == "unavailable-agent|0|researcher|tangle" ]] &&
+    [[ "$(sed -n '2p' "$CALL_LOG")" == "gemini|0|researcher|tangle" ]]
 ); then
     test_pass
 else
@@ -77,7 +77,7 @@ if (
     unset OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT
     result=$(tangle_reformat_decomposition "task" "bad decomposition" "overlap" "")
     [[ "$result" == *"Reformatted task"* ]] &&
-    [[ "$(sed -n '1p' "$CALL_LOG")" == "agy|120|researcher|tangle" ]] &&
+    [[ "$(sed -n '1p' "$CALL_LOG")" == "agy|0|researcher|tangle" ]] &&
     [[ "$(wc -l < "$CALL_LOG")" -eq 1 ]]
 ); then
     test_pass

--- a/tests/unit/test-tangle-subtask-context.sh
+++ b/tests/unit/test-tangle-subtask-context.sh
@@ -12,6 +12,9 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 
 test_suite "tangle subtask context preservation"
 
+# These tests exercise tangle dispatch/validation behavior, not contextual review.
+export OCTOPUS_TANGLE_CODE_REVIEW=false
+
 test_case "workflows.sh has valid bash syntax"
 if bash -n "$WORKFLOWS" 2>/dev/null; then
     test_pass

--- a/tests/unit/test-tangle-write-scope-safety.sh
+++ b/tests/unit/test-tangle-write-scope-safety.sh
@@ -12,6 +12,9 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 
 test_suite "tangle write-scope safety"
 
+# These tests exercise tangle dispatch/validation behavior, not contextual review.
+export OCTOPUS_TANGLE_CODE_REVIEW=false
+
 test_case "workflows.sh has valid bash syntax"
 if bash -n "$WORKFLOWS" 2>/dev/null; then
     test_pass


### PR DESCRIPTION
## Summary

Adds a contextual code-review and correction loop to the tangle/develop phase:

- build a bounded review context from plan, decomposition, validation and worktree state
- run contextual code review after tangle validation
- treat review warnings / no-diff review as blocking
- apply correction rounds with progress/stall supervision
- preserve partial writes for validation/review instead of discarding them on failure
- default tangle/design/ink review waits away from fixed wall-clock timeouts, while preserving explicit timeout overrides
- validate corrected worktree overlays and stop non-convergent correction loops
- harden tangle watcher handling for missing markers, zombies, interruptions and validation-only rerenders

This is intentionally separate from #592, which ports review pipeline hardening independently.

## Validation

- `bash -n scripts/lib/workflows.sh scripts/lib/testing.sh scripts/lib/quality.sh scripts/lib/spawn.sh scripts/lib/heartbeat.sh scripts/lib/review.sh tests/unit/test-tangle-context-review-loop.sh`
- `bash tests/unit/test-tangle-context-review-loop.sh` → 39/39 PASS
- `git diff --check`

No live provider smoke was run for this PR; validation is static/unit-level only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Double Diamond contextual code review gate that runs review findings, applies review-driven corrections in iterative rounds when blockers remain, and re-validates/reviews until convergence or a hard cap.
* **Bug Fixes**
  * Improved “no changes to review” handling: findings now include warning + message, and the run result is treated as non-clean when applicable.
  * Updated timeout behavior: `0` now means “no absolute timeout” (with clearer `timeout=none` reporting).
* **Documentation**
  * Updated `develop|tangle` help for the new validation + contextual review flow and related environment controls.
* **Tests**
  * Added/expanded unit tests covering the review/correction loop wiring, overlay reporting, and updated timeout/deadline semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->