### PR TITLE
docs+ci: agent orientation layer (RELEASING.md, provider map, make ci-local, exec-bit lint)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,33 @@ jobs:
             hooks/*.sh \
             2>&1 || true
 
+      # Exec-bit lint: shell/python entrypoints must stay 100755. Both contributor
+      # tooling and editor-based rewrites have silently dropped exec bits (root
+      # cause of PR #579's "Permission denied" failures). Intentional mode changes:
+      # add the 'allow-mode-change' label to the PR.
+      - name: Executable-bit lint
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          ALLOW_MODE_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'allow-mode-change') }}
+        run: |
+          git fetch --no-tags origin "$BASE_REF" --depth=100 2>/dev/null || git fetch --no-tags origin "$BASE_REF"
+          changes=$(git diff --summary "origin/${BASE_REF}...HEAD" 2>/dev/null | grep "mode change" || true)
+          if [[ -z "$changes" ]]; then
+            echo "OK: no file-mode changes vs ${BASE_REF}."
+            exit 0
+          fi
+          echo "File-mode changes detected vs ${BASE_REF}:"
+          echo "$changes"
+          if [[ "$ALLOW_MODE_CHANGE" == "true" ]]; then
+            echo "Label 'allow-mode-change' present; passing."
+            exit 0
+          fi
+          echo ""
+          echo "Shell scripts and Python helpers must keep the executable bit (100755)."
+          echo "Fix: chmod +x <file> && git add <file>, or add the 'allow-mode-change' label if intentional."
+          exit 1
+
   smoke:
     name: Smoke Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,17 @@ The MCP server (`mcp-server/`) exposes Claude Octopus workflows as MCP tools.
 For MCP-aware coding agents, connect to the MCP server rather than invoking
 agents directly.
 
+## Repo Orientation for Agents
+
+Mirror of the "Repo Orientation for Agents" section in `CLAUDE.md` (keep both in sync). Essentials:
+
+- **Derived artifacts, never hand-edit**: `.claude-plugin/marketplace.json` (regen: `./scripts/sync-marketplace.sh`) and `openclaw/src/tools/index.ts` (regen: `./scripts/build-openclaw.sh`). README prose counts must match `plugin.json`. Run `make sync` after component changes; `make ci-local` before push.
+- **Exec bits**: scripts stay `100755`; `git diff origin/main...HEAD --summary | grep "mode change"` must be empty (CI-enforced; `allow-mode-change` label bypasses).
+- **Provider wiring**: 7-point checklist across 5 files, documented in `docs/PROVIDERS.md`. Case globs are order-sensitive (`claude-sdk*` before `claude*`).
+- **Releases**: follow `RELEASING.md`; tag the squash-merge commit on `main`, never the branch head.
+- **Secret-scan quoting**: write `"SOME_API_KEY=${VAR}"`, not `SOME_API_KEY="${VAR}"`.
+- **beads blocked?** If bd writes are blocked by pending schema migrations, do NOT migrate; record work in the session handoff and flag the blockage.
+
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
 ## Beads Issue Tracker
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **RELEASING.md**: ordered release checklist covering every version-string location, the derived-artifact generators, CI-parity validation, exec-bit checks, fork-PR run approval, the tag-on-merge-commit rule, and GitHub Release creation. Encodes the three CI rounds the v9.50.0 release burned on undocumented generators.
+- **docs/PROVIDERS.md**: provider wiring map. Seven wiring points across five files per provider, with anchors and the traps that have bitten real PRs (case-glob ordering, the two provider-routing whitelists, exec bits, the stdin shim contract, secret-scanner quoting, nested-session markers).
+- **`make sync` / `make sync-check` / `make ci-local`**: one target to regenerate all derived artifacts, one to verify them, and a CI-parity target that mirrors the required checks plus CI-only verifications so local green predicts remote green.
+- **Executable-bit lint in CI** (Portability Lint job): PRs fail if tracked files change mode vs the base branch; the `allow-mode-change` PR label bypasses intentional changes. Root cause class of PR #579's "Permission denied" failures, now caught pre-merge.
+- **"Repo Orientation for Agents" section in CLAUDE.md** (mirrored in AGENTS.md): derived-artifacts table, hard rules distilled from real CI failures, and a memory ruling for the beads blocked-writes failure mode (do not migrate; record in handoff and flag).
+
 ## [9.50.0] - 2026-07-08
 
 Claude Code 2026 compatibility layer release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,40 @@ Skills use the **Validation Gate Pattern** to ensure multi-LLM dispatch actually
 
 > Developer reference (modular config, E2E testing, enforcement patterns): see `docs/DEVELOPER.md`
 
+---
+
+## Repo Orientation for Agents (read before editing)
+
+The rules below encode failures that have already cost real CI rounds. Every one is enforced by a CI check; none of them is guesswork.
+
+### Derived artifacts (never hand-edit)
+
+| Generated file | Regenerate with | CI check that fails if stale |
+|----------------|-----------------|------------------------------|
+| `.claude-plugin/marketplace.json` (octo description + counts) | `./scripts/sync-marketplace.sh` | Smoke job "Verify marketplace.json is up to date" |
+| `openclaw/src/tools/index.ts` | `./scripts/build-openclaw.sh` | `tests/unit/test-openclaw-compat.sh` |
+| README prose counts ("**N commands** ... **N skills**", "[All N skills]") | Edit by hand to match `plugin.json` | `tests/unit/test-docs-sync.sh` |
+
+After changing commands, skills, agents, or `plugin.json`: run `make sync`. Before any push: run `make ci-local` (mirrors the required checks plus CI-only verifications; targeted test suites alone do NOT predict CI green).
+
+### Hard rules (each one has broken a real PR)
+
+- Never hand-write component counts into `plugin.json`'s description; the marketplace generator appends its own counts and `--check` fails on the collision.
+- Shell scripts and Python helpers stay `100755`. Verify before push: `git diff origin/main...HEAD --summary | grep "mode change"` must be empty. CI enforces this (Portability Lint job; `allow-mode-change` PR label bypasses when intentional).
+- Provider case globs are order-sensitive: `claude-sdk*` before `claude*`, `gemini-image` before `gemini*`. A shadowed arm fails silently.
+- `provider-routing.sh` has TWO provider whitelists (plus two matching error strings). Update all four sites or dispatch rejects the provider inconsistently.
+- In shell, quote env assignments as whole arguments: `"SOME_API_KEY=${VAR}"`, not `SOME_API_KEY="${VAR}"`. The expert-review secret scanner false-positives on the latter.
+- CI waiters must assert the named required checks (Smoke Tests, Unit Tests, Integration Tests) are PRESENT and terminal. `all(.bucket != "pending")` over an empty list is vacuously true and fires instantly.
+- Timeout-test fixtures must run LONGER than the pass bound, or a broken timeout false-passes. A test must be able to fail; prove it can.
+- Tag releases on the squash-merge commit on `main`, never on the branch head. Full release procedure: `RELEASING.md`.
+- Fork PRs stall at `action_required` after every push; approve with `gh api -X POST repos/nyldn/claude-octopus/actions/runs/<id>/approve`.
+- Provider wiring is a 7-point checklist across 5 files: `docs/PROVIDERS.md`. Do not wing it from one example.
+
+### Memory ruling (single source of truth)
+
+beads (`bd`) is the system of record. Known failure mode: pending Dolt schema migrations block ALL bd writes with "refusing to auto-apply ... migrations". Do NOT run the migration (single-designated-migrator rule); instead record the work in your session handoff, note the blockage explicitly, and flag it to the maintainer. Do not silently drop tracking.
+
+---
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
 ## Beads Issue Tracker

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,23 @@
-.PHONY: test test-smoke test-unit test-integration test-e2e test-live test-coverage test-all test-plugin-name validate-plugin-assembly clean-tests help
+.PHONY: test test-smoke test-unit test-integration test-e2e test-live test-coverage test-all test-plugin-name validate-plugin-assembly clean-tests help sync sync-check ci-local
 
 # Default: smoke + unit (fast feedback)
 test: test-smoke test-unit
+
+# Regenerate ALL derived artifacts (run after changing commands/skills/agents or plugin.json)
+# See RELEASING.md step 3 for the artifact-to-generator map.
+sync:
+	@./scripts/sync-marketplace.sh
+	@./scripts/build-openclaw.sh
+
+# Verify derived artifacts are current (what CI enforces)
+sync-check:
+	@./scripts/sync-marketplace.sh --check
+	@./scripts/build-openclaw.sh --check
+
+# CI parity: everything the required checks run, locally.
+# Local green here predicts remote green; targeted suites alone do not.
+ci-local: sync-check test-smoke test-unit test-integration
+	@echo "ci-local complete: matches required checks (Smoke/Unit/Integration) + CI-only verifications"
 
 # Validate plugin name (critical - prevents command prefix breakage)
 test-plugin-name:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,91 @@
+# Releasing claude-octopus
+
+Ordered checklist for shipping a release. Every step exists because skipping it has already broken CI at least once (v9.50.0 shipped in three CI rounds; all three failures were steps on this list). Human and agent contributors follow the same list.
+
+## 0. Preconditions
+
+- Work on a branch cut from current `main`. Branch protection is strict: the branch must be up to date with `main` at merge time, and the required checks are exactly **Smoke Tests**, **Unit Tests**, **Integration Tests**.
+- Never build a release on top of a dirty working tree you do not own. Use a separate worktree (`git worktree add <dir> -b release/<name> origin/main`).
+
+## 1. Decide the version
+
+Minor (9.x+1.0) for additive changes: new providers, new commands/skills/hooks, new env vars with safe defaults. Precedent: grok (9.48.0) and atlascloud shipped as minors. Major only for: breaking an existing config or provider contract, incompatible plugin manifest schema changes, or removing a provider category.
+
+## 2. Bump every version location
+
+Find them all; do not assume this list is complete next release (`grep -rn "<old-version>" --include="*.json" --include="*.md" .`):
+
+| File | Field |
+|------|-------|
+| `package.json` | `version` |
+| `.claude-plugin/plugin.json` | `version`, `description` (starts with `vX.Y.Z - ...`) |
+| `.claude-plugin/marketplace.json` | GENERATED, see step 3 |
+| `.claude-plugin/plugin-manifest.json` | `version`, component counts |
+| `.codex-plugin/plugin.json` | `version` |
+| `.cursor-plugin/plugin.json` | `version` |
+| `.factory-plugin/plugin.json` | `version` |
+| `.factory-plugin/marketplace.json` | `metadata.version`, plugin entry `version` + `description` |
+| `README.md` | version badge (line ~15) |
+| `CHANGELOG.md` | new `## [X.Y.Z] - YYYY-MM-DD` section (fold Unreleased into it) |
+
+## 3. Regenerate derived artifacts (`make sync`)
+
+Do NOT hand-edit these; CI diffs them against their generators:
+
+| Generated artifact | Generator | CI check that fails if stale |
+|--------------------|-----------|------------------------------|
+| `.claude-plugin/marketplace.json` (octo entry description + counts) | `./scripts/sync-marketplace.sh` | Smoke job step "Verify marketplace.json is up to date" |
+| `openclaw/src/tools/index.ts` | `./scripts/build-openclaw.sh` | `tests/unit/test-openclaw-compat.sh` |
+
+Rules learned the hard way:
+- The marketplace generator injects its own component counts ("32 personas, N commands, N skills") into the description. Never hand-write counts into `plugin.json`'s description; the generator appends them and `--check` will fail on the collision.
+- README body prose counts must match `plugin.json`: the "**N commands** ... **N skills**" sentence (README ~line 28) and the "[All N skills]" link (~line 367) are asserted by `tests/unit/test-docs-sync.sh`.
+
+`make sync` runs both generators; `make sync-check` runs both `--check` modes.
+
+## 4. Validate locally with CI parity
+
+```bash
+make ci-local
+```
+
+This mirrors the required checks plus the CI-only verifications that targeted test runs miss (`sync-check`, docs-sync, openclaw-compat, plugin expert review). Local green here predicts remote green; targeted suites alone do not (v9.50.0 passed every targeted suite locally and still failed three CI-only checks).
+
+Known scanner gotcha: `tests/integration/test-plugin-expert-review.sh` greps tracked non-md files for `(API_KEY|SECRET|PASSWORD)\s*=\s*['\"]<20+ chars>`. A shell line like `ANTHROPIC_API_KEY="${VAR}"` false-positives. Quote the whole env argument instead: `"ANTHROPIC_API_KEY=${VAR}"`.
+
+## 5. Check file modes
+
+```bash
+git diff origin/main...HEAD --summary | grep "mode change"
+```
+
+Must be empty. Shell scripts and Python helpers must stay `100755`; both contributor tooling and editor-based rewrites have silently dropped exec bits before (root cause of PR #579's "Permission denied" CI failures). CI enforces this via the executable-bit lint in the Portability Lint job; the `allow-mode-change` PR label bypasses it for intentional mode changes.
+
+## 6. PR and CI
+
+- Open the PR against `main`. Same-repo branches run CI immediately; **fork PRs stall at `action_required`** until approved: `gh api -X POST repos/nyldn/claude-octopus/actions/runs/<run-id>/approve` (needed after every push to the fork branch).
+- Known flake: macOS runner timing in `tests/unit/test-agent-lifecycle-events.sh` ("hook timeout did not return promptly"). If it hits, `gh run rerun <run-id> --failed` once before investigating.
+- Squash-merge is the repo convention.
+
+## 7. Tag AFTER the squash-merge
+
+The tag must point at the merge commit on `main`, not at the branch head (squash rewrites the SHA):
+
+```bash
+sha=$(gh pr view <pr> --json mergeCommit --jq .mergeCommit.oid)
+git fetch origin main
+git tag -a vX.Y.Z "$sha" -m "vX.Y.Z: one-line summary"
+git push origin vX.Y.Z
+```
+
+## 8. GitHub Release
+
+```bash
+gh release create vX.Y.Z --title "vX.Y.Z" --notes-file <(awk '/^## \[X.Y.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)
+```
+
+Marketplace consumers pin by release; a bare tag is not enough.
+
+## 9. Post-merge verification
+
+Watch the main-branch Test Suite run on the merge commit until `completed/success`. A release is not done while main is red.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -1,0 +1,39 @@
+# Provider Wiring Map
+
+Adding or modifying a provider touches **seven wiring points across five files**. Both the claude-sdk seat (v9.50.0, 12 edit sites) and PR #579's atlascloud merge conflicts hit exactly these sites; this map exists so the next change is a checklist, not an archaeology dig. Line numbers are anchors, not contracts; re-grep before editing.
+
+## The seven wiring points
+
+| # | Concern | File | Anchor | What to add |
+|---|---------|------|--------|-------------|
+| 1 | Agent-type to provider mapping | `scripts/lib/dispatch.sh` | `case "$agent_type" in` near `get_agent_model` (~line 530) | `myprov*) provider="myprov" ;;` |
+| 2 | Command builder | `scripts/lib/dispatch.sh` | main dispatch `case` with per-provider arms (~lines 150-300) | Arm that echoes the exec command or shim path |
+| 3 | Model allowlist var | `scripts/lib/dispatch.sh` | `allowlist_var` case (~line 576) | `myprov) allowlist_var="OCTOPUS_MYPROV_ALLOWED_MODELS" ;;` |
+| 4 | Hard-coded model fallback | `scripts/lib/model-resolver.sh` | Priority-7 fallback case (~line 347) | `myprov*) resolved_model="..." ;;` |
+| 5 | Routing whitelists (TWO sites) | `scripts/lib/provider-routing.sh` | `set_provider_model` whitelist (~line 370 + error message ~373) AND override-clear regex (~line 480 + error message ~485) | Add provider to both lists and both error strings |
+| 6 | Env isolation | `scripts/lib/provider-routing.sh` | env isolation `case` (~lines 120-180) | Arm before any glob that would shadow it; minimal `env -i` allowlist or `resolve_provider_env` |
+| 7 | Detection + health | `scripts/lib/providers.sh` | detection function (~line 1160 region), health-check `case` (~line 836), `check_all_providers` loop (~line 900) | Detection block, validation arm, loop entry |
+
+Plus, usually:
+- `scripts/helpers/<provider>-exec.sh` shim (stdin prompt contract; see `grok-exec.sh` as the minimal template)
+- Context budget arm in `scripts/lib/dispatch.sh` (~line 345) if the provider has a non-default window
+- `config/providers/<provider>/CLAUDE.md` if unit tests expect one (agy, ollama, gemini do)
+- Unit test in `tests/unit/test-<provider>-provider.sh`
+- `docs/DEVELOPER.md` / README provider tables
+
+## Traps (each has bitten a real PR)
+
+1. **Case glob ordering.** `claude-sdk*` must precede `claude*`; `gemini-image` must precede `gemini*`. A late arm behind an earlier glob is silently unreachable; there is no error.
+2. **Two whitelist sites in provider-routing.sh, not one.** PR #579 resolved the first and initially missed the second (~line 480). Grep the file for the existing provider list and count matches: expect at least 4 (two lists, two error messages).
+3. **Exec bits.** New shims and any rewritten script must be `100755`. `git diff origin/main...HEAD --summary | grep "mode change"` must come back empty (see RELEASING.md step 5).
+4. **Stdin contract.** spawn.sh pipes the prompt on stdin. CLIs that want argv prompts need a shim that reads stdin and re-passes it (`grok-exec.sh`, `vibe-exec.sh` pattern). Model selection reaches shims via an `env OCTOPUS_X_MODEL=... shim.sh` prefix emitted by the command builder, not via shell export.
+5. **Secret-scanner quoting.** In shims, write `"SOME_API_KEY=${VAR}"` (quote the whole env argument). `SOME_API_KEY="${VAR}"` false-positives the expert-review secret scan.
+6. **Nested-session markers.** Anything that execs a headless `claude` must strip `CLAUDECODE`, `CLAUDE_CODE_SESSION_ID`, `CLAUDE_CODE_CHILD_SESSION`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_EXECPATH`, or the child hangs believing it is nested.
+
+## Current providers
+
+codex, gemini (legacy, sunset), agy (Antigravity, Google seat), claude, claude-sdk (Agent SDK seat), perplexity, openrouter, atlascloud, openai-compatible-agent, ollama, copilot, qwen, cursor-agent, grok, vibe, opencode.
+
+## Longer term
+
+This map documents sprawl; it does not remove it. If provider additions continue at the current rate, a table-driven registry (one row per provider consumed by dispatch/routing/detection) collapses wiring points 1, 3, 5, and 7 into data. Decision tracked informally; raise before the next two provider additions.


### PR DESCRIPTION
## Summary

Implements the highest-priority items from the project self-learning review: the v9.50.0 release burned three CI rounds on repo knowledge that existed only inside CI checks. This PR turns that knowledge into orientation docs, make targets, and one new lint.

- **RELEASING.md** (new): ordered release checklist — version-string locations (10 files), derived-artifact generators, CI-parity validation, exec-bit check, fork-PR run approval, tag-on-squash-merge-commit rule, GitHub Release step, macOS flake guidance
- **docs/PROVIDERS.md** (new): provider wiring map — 7 wiring points across 5 files with anchors, plus the six traps that have bitten real PRs (glob ordering, dual whitelists in provider-routing.sh, exec bits, stdin shim contract, secret-scanner quoting, nested-session markers)
- **Makefile**: `make sync` / `make sync-check` (all derived-artifact generators), `make ci-local` (required checks + CI-only verifications)
- **CI**: executable-bit lint in the Portability Lint job — PRs fail on file-mode changes vs base (root cause class of #579's Permission-denied failures); `allow-mode-change` label bypasses; base ref passed via env per Actions injection guidance
- **CLAUDE.md**: new 'Repo Orientation for Agents' section (derived-artifacts table, hard rules distilled from real CI failures, beads blocked-writes ruling); condensed mirror in AGENTS.md
- **CHANGELOG**: Unreleased entries

## Test plan
- docs-sync 135/0, openclaw-compat 31/0, plugin-expert-review 50/50, sync-marketplace --check clean
- Workflow YAML parses; zero mode changes vs main
- test-enforcement-pattern's 5 failures pre-exist on clean upstream/main (verified via stash) and are not CI-gating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new local validation target for running sync checks alongside test suites.
  * Added a documented provider wiring reference and expanded agent orientation guidance.

* **Bug Fixes**
  * Added CI checks to catch executable-bit changes on pull requests and block unexpected file mode updates.

* **Documentation**
  * Expanded release and contribution guidance with clearer publishing, verification, and handoff steps.
  * Updated the changelog with the latest workflow and repository guidance changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->