### PR TITLE
docs(debate): clarify Antigravity availability keys on the `agy` binary

### DIFF
--- a/.claude/skills/skill-debate/SKILL.md
+++ b/.claude/skills/skill-debate/SKILL.md
@@ -295,6 +295,8 @@ Provider Availability:
 🐙 Claude (Opus): Available ✓ (Moderator and participant)
 ```
 
+> **🧭 Antigravity availability:** Antigravity CLI = the `agy` binary; judge availability only via `command -v agy` (as `check-providers.sh` does), never from the `antigravity` desktop shortcut.
+
 **If providers are missing:**
 - If all external providers are unavailable: Inform user that debate requires at least one external provider and suggest running `/octo:setup` to configure them
 - If one or more providers are unavailable: Note which providers are missing and proceed with available provider(s) and Claude

--- a/skills/skill-debate/SKILL.md
+++ b/skills/skill-debate/SKILL.md
@@ -271,6 +271,8 @@ Provider Availability:
 🐙 current host model: Available ✓ (Moderator and participant)
 ```
 
+> **🧭 Antigravity availability:** Antigravity CLI = the `agy` binary; judge availability only via `command -v agy` (as `check-providers.sh` does), never from the `antigravity` desktop shortcut.
+
 **If providers are missing:**
 - If all external providers are unavailable: Inform user that debate requires at least one external provider and suggest running `/octo:setup` to configure them
 - If one or more providers are unavailable: Note which providers are missing and proceed with available provider(s) and Claude


### PR DESCRIPTION
## Summary

`skill-debate`'s Step 1 renders a "🧭 Antigravity CLI" row in the provider-availability banner but never states which binary backs it. On a machine where the `antigravity` *command* is a desktop shortcut (a shell function that runs `open -a Antigravity`), it's easy to judge that row from the wrong thing, mark it "not headless," and silently drop the advisor from the roster. The skill's own banned-actions list forbids exactly that (line 20: *"Dropping an available advisor (including `agy`) from the roster without telling the user"*).

The debate provider is the headless **`agy`** CLI (`~/.local/bin/agy`), which `check-providers.sh` and `build-fleet.sh` already detect via `command -v agy`. The banner template just didn't name it, leaving room for the `antigravity`-shortcut confusion.

## Change

One clarifying line under the availability banner, in both shipped copies:

> **🧭 Antigravity availability:** Antigravity CLI = the `agy` binary; judge availability only via `command -v agy` (as `check-providers.sh` does), never from the `antigravity` desktop shortcut.

- `skills/skill-debate/SKILL.md` (portable source)
- `.claude/skills/skill-debate/SKILL.md` (Claude Code mirror)

Docs-only, no behavior change. Detection logic is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the provider availability instructions to use the `agy` binary check (`command -v agy`) for Antigravity detection.
  * Aligned the guidance with the existing availability check behavior, reducing ambiguity for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->