### PR TITLE
Add agentmemory companion compatibility

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -42,6 +42,8 @@ echo "=== Companions ==="
 printf "graphify:%s\n" "$(command -v graphify >/dev/null 2>&1 && echo installed || echo missing)"
 GRAPHIFY_OUT_DIR="${GRAPHIFY_OUT:-graphify-out}"
 printf "graphify_graph:%s\n" "$([ -f "${GRAPHIFY_OUT_DIR}/graph.json" ] && [ -f "${GRAPHIFY_OUT_DIR}/GRAPH_REPORT.md" ] && echo available || echo missing)"
+printf "agentmemory:%s\n" "$(command -v agentmemory >/dev/null 2>&1 && echo installed || echo missing)"
+printf "agentmemory_server:%s\n" "$(curl -sf --max-time 1 "${AGENTMEMORY_URL:-http://localhost:3111}/agentmemory/livez" >/dev/null 2>&1 && echo running || echo missing)"
 echo "=== Token Optimization ==="
 printf "rtk:%s\n" "$(command -v rtk >/dev/null 2>&1 && echo "installed $(rtk --version 2>&1 | head -1)" || echo missing)"
 printf "rtk_hook:%s\n" "$(if grep -q 'rtk' "${HOME}/.claude/settings.json" 2>/dev/null; then echo active; else echo missing; fi)"
@@ -72,6 +74,11 @@ copilot_status="$(status_optional copilot)"
 qwen_status="$(status_optional qwen)"
 opencode_status="$(status_optional opencode)"
 vibe_status="$(status_optional vibe)"
+graphify_status="$(status_optional graphify)"
+GRAPHIFY_OUT_DIR="${GRAPHIFY_OUT:-graphify-out}"
+if [[ -f "${GRAPHIFY_OUT_DIR}/graph.json" && -f "${GRAPHIFY_OUT_DIR}/GRAPH_REPORT.md" ]]; then graphify_graph_status="Graph available ✓"; else graphify_graph_status="Graph missing"; fi
+agentmemory_status="$(status_optional agentmemory)"
+if curl -sf --max-time 1 "${AGENTMEMORY_URL:-http://localhost:3111}/agentmemory/livez" >/dev/null 2>&1; then agentmemory_server_status="Running ✓"; else agentmemory_server_status="Not running"; fi
 if command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; then ollama_status="Running ✓"; elif command -v ollama >/dev/null 2>&1; then ollama_status="Installed"; else ollama_status="Not installed"; fi
 cat <<BANNER
 🐙 Octopus Setup
@@ -87,6 +94,10 @@ Providers:
   🔶 Vibe (Mistral): ${vibe_status}
   ⚫ Ollama:         ${ollama_status}
   🔵 Claude:         Available ✓
+
+Companions:
+  Graphify:         ${graphify_status} (${graphify_graph_status})
+  agentmemory:      ${agentmemory_status} (${agentmemory_server_status})
 BANNER
 ```
 
@@ -113,6 +124,7 @@ Token Optimization:
 
 Companions:
   Graphify:         [CLI installed ✓ / Missing] [Graph available ✓ / Missing]
+  agentmemory:      [CLI installed ✓ / Missing] [Server running ✓ / Not running]
 
 Session:
   Remote/Web:       [Yes / No]
@@ -199,6 +211,7 @@ AskUserQuestion({
       {label: "Configure models", description: "Set which models are used for each workflow phase → launches /octo:model-config"},
       {label: "Set up token optimization (RTK)", description: "Install RTK for 60-90% token savings on bash output"},
       {label: "Set up Graphify companion", description: "Detect or install Graphify for optional knowledge-graph context"},
+      {label: "Set up memory companion", description: "Install or connect agentmemory for persistent cross-agent memory"},
       {label: "Change work mode", description: "Switch between Dev mode and Knowledge Work mode"},
       {label: "Set project tier", description: "Set OCTO_TIER=prototype|mvp|production as a routing hint"},
       {label: "Fine-tune preferences", description: "Auto-routing, banner verbosity, telemetry, cost mode"},
@@ -215,6 +228,7 @@ Route based on selection:
 - **Configure models** → Invoke `/octo:model-config` (the interactive model config wizard)
 - **Set up RTK** → Jump to the RTK section below
 - **Set up Graphify companion** → Jump to the Graphify Companion section below
+- **Set up memory companion** → Jump to the Memory Companion section below
 - **Change work mode** → Jump to the Work Mode section (STEP 4)
 - **Set project tier** → Jump to Project Tier Hint (STEP 4c)
 - **Fine-tune preferences** → Jump to the Fine-tune section (STEP 5)
@@ -398,6 +412,34 @@ graphify hook install
 ```
 
 Use `OCTOPUS_GRAPHIFY=0` to disable passive Graphify context injection.
+
+## Memory Companion
+
+agentmemory is optional and is not a provider. Octopus works without it. If agentmemory is installed and connected as an MCP server, Octopus can use it through the existing memory contract for cross-session context; if MCP tools are unavailable, Octopus falls back to the local REST bridge at `${AGENTMEMORY_URL:-http://localhost:3111}`.
+
+To install and connect agentmemory when the user opts in:
+
+```bash
+npm install -g @agentmemory/agentmemory
+agentmemory --version
+agentmemory connect claude-code
+```
+
+For Codex or Cursor installs, use the matching connector instead:
+
+```bash
+agentmemory connect codex
+agentmemory connect cursor
+```
+
+Start or verify the local server:
+
+```bash
+agentmemory &
+curl -fsS "${AGENTMEMORY_URL:-http://localhost:3111}/agentmemory/health"
+```
+
+If the user prefers not to install globally, use `npx -y @agentmemory/agentmemory@latest` in place of `agentmemory`. Use `OCTOPUS_MEMORY_BACKEND=agentmemory` to force Octopus to prefer agentmemory; `OCTOPUS_MEMORY_BACKEND=auto` detects an agentmemory MCP registration or `AGENTMEMORY_URL`.
 
 ## Remote/Web Session Defaults
 

--- a/.cursor-plugin/commands/octo-setup.md
+++ b/.cursor-plugin/commands/octo-setup.md
@@ -39,6 +39,8 @@ echo "=== Companions ==="
 printf "graphify:%s\n" "$(command -v graphify >/dev/null 2>&1 && echo installed || echo missing)"
 GRAPHIFY_OUT_DIR="${GRAPHIFY_OUT:-graphify-out}"
 printf "graphify_graph:%s\n" "$([ -f "${GRAPHIFY_OUT_DIR}/graph.json" ] && [ -f "${GRAPHIFY_OUT_DIR}/GRAPH_REPORT.md" ] && echo available || echo missing)"
+printf "agentmemory:%s\n" "$(command -v agentmemory >/dev/null 2>&1 && echo installed || echo missing)"
+printf "agentmemory_server:%s\n" "$(curl -sf --max-time 1 "${AGENTMEMORY_URL:-http://localhost:3111}/agentmemory/livez" >/dev/null 2>&1 && echo running || echo missing)"
 echo "=== Token Optimization ==="
 printf "rtk:%s\n" "$(command -v rtk >/dev/null 2>&1 && echo "installed $(rtk --version 2>&1 | head -1)" || echo missing)"
 printf "rtk_hook:%s\n" "$(if grep -q 'rtk' "${HOME}/.claude/settings.json" 2>/dev/null; then echo active; else echo missing; fi)"
@@ -69,6 +71,11 @@ copilot_status="$(status_optional copilot)"
 qwen_status="$(status_optional qwen)"
 opencode_status="$(status_optional opencode)"
 vibe_status="$(status_optional vibe)"
+graphify_status="$(status_optional graphify)"
+GRAPHIFY_OUT_DIR="${GRAPHIFY_OUT:-graphify-out}"
+if [[ -f "${GRAPHIFY_OUT_DIR}/graph.json" && -f "${GRAPHIFY_OUT_DIR}/GRAPH_REPORT.md" ]]; then graphify_graph_status="Graph available ✓"; else graphify_graph_status="Graph missing"; fi
+agentmemory_status="$(status_optional agentmemory)"
+if curl -sf --max-time 1 "${AGENTMEMORY_URL:-http://localhost:3111}/agentmemory/livez" >/dev/null 2>&1; then agentmemory_server_status="Running ✓"; else agentmemory_server_status="Not running"; fi
 if command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; then ollama_status="Running ✓"; elif command -v ollama >/dev/null 2>&1; then ollama_status="Installed"; else ollama_status="Not installed"; fi
 cat <<BANNER
 🐙 Octopus Setup
@@ -84,6 +91,10 @@ Providers:
   🔶 Vibe (Mistral): ${vibe_status}
   ⚫ Ollama:         ${ollama_status}
   🔵 Claude:         Available ✓
+
+Companions:
+  Graphify:         ${graphify_status} (${graphify_graph_status})
+  agentmemory:      ${agentmemory_status} (${agentmemory_server_status})
 BANNER
 ```
 
@@ -110,6 +121,7 @@ Token Optimization:
 
 Companions:
   Graphify:         [CLI installed ✓ / Missing] [Graph available ✓ / Missing]
+  agentmemory:      [CLI installed ✓ / Missing] [Server running ✓ / Not running]
 
 Session:
   Remote/Web:       [Yes / No]
@@ -196,6 +208,7 @@ AskUserQuestion({
       {label: "Configure models", description: "Set which models are used for each workflow phase → launches /octo:model-config"},
       {label: "Set up token optimization (RTK)", description: "Install RTK for 60-90% token savings on bash output"},
       {label: "Set up Graphify companion", description: "Detect or install Graphify for optional knowledge-graph context"},
+      {label: "Set up memory companion", description: "Install or connect agentmemory for persistent cross-agent memory"},
       {label: "Change work mode", description: "Switch between Dev mode and Knowledge Work mode"},
       {label: "Set project tier", description: "Set OCTO_TIER=prototype|mvp|production as a routing hint"},
       {label: "Fine-tune preferences", description: "Auto-routing, banner verbosity, telemetry, cost mode"},
@@ -212,6 +225,7 @@ Route based on selection:
 - **Configure models** → Invoke `/octo:model-config` (the interactive model config wizard)
 - **Set up RTK** → Jump to the RTK section below
 - **Set up Graphify companion** → Jump to the Graphify Companion section below
+- **Set up memory companion** → Jump to the Memory Companion section below
 - **Change work mode** → Jump to the Work Mode section (STEP 4)
 - **Set project tier** → Jump to Project Tier Hint (STEP 4c)
 - **Fine-tune preferences** → Jump to the Fine-tune section (STEP 5)
@@ -395,6 +409,34 @@ graphify hook install
 ```
 
 Use `OCTOPUS_GRAPHIFY=0` to disable passive Graphify context injection.
+
+## Memory Companion
+
+agentmemory is optional and is not a provider. Octopus works without it. If agentmemory is installed and connected as an MCP server, Octopus can use it through the existing memory contract for cross-session context; if MCP tools are unavailable, Octopus falls back to the local REST bridge at `${AGENTMEMORY_URL:-http://localhost:3111}`.
+
+To install and connect agentmemory when the user opts in:
+
+```bash
+npm install -g @agentmemory/agentmemory
+agentmemory --version
+agentmemory connect claude-code
+```
+
+For Codex or Cursor installs, use the matching connector instead:
+
+```bash
+agentmemory connect codex
+agentmemory connect cursor
+```
+
+Start or verify the local server:
+
+```bash
+agentmemory &
+curl -fsS "${AGENTMEMORY_URL:-http://localhost:3111}/agentmemory/health"
+```
+
+If the user prefers not to install globally, use `npx -y @agentmemory/agentmemory@latest` in place of `agentmemory`. Use `OCTOPUS_MEMORY_BACKEND=agentmemory` to force Octopus to prefer agentmemory; `OCTOPUS_MEMORY_BACKEND=auto` detects an agentmemory MCP registration or `AGENTMEMORY_URL`.
 
 ## Remote/Web Session Defaults
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
 
 🐙 **Research, build, review, and ship — with nine AI providers checking each other's work.** Say what you need, and the right workflow runs. Claude-native handles the ordinary path; Octopus handles the escalated path. A 75% consensus gate catches disagreements before they reach production. No single model's blind spots slip through.
 
-🧠 **Remembers across sessions.** Integrates with [claude-mem](https://github.com/thedotmack/claude-mem) for persistent memory — past decisions, research, and context survive session boundaries.
+🧠 **Remembers across sessions.** Integrates with [claude-mem](https://github.com/thedotmack/claude-mem) and [agentmemory](https://github.com/rohitg00/agentmemory) for persistent memory — past decisions, research, and context survive session boundaries.
 
 ⚡ **Spec in, software out.** Dark Factory mode takes a spec and autonomously runs the full pipeline — research, define, develop, deliver. You review the output, not every step.
 

--- a/hooks/session-start-memory.sh
+++ b/hooks/session-start-memory.sh
@@ -140,12 +140,14 @@ EOFSET
     fi
 fi
 
-# --- 5. Query claude-mem for recent project context (v8.57.0) ---
-BRIDGE_SCRIPT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd -P)}/scripts/claude-mem-bridge.sh"
-if [[ -x "$BRIDGE_SCRIPT" ]]; then
-    MEM_CONTEXT=$("$BRIDGE_SCRIPT" context "" 3 2>/dev/null || echo "")
+# --- 5. Query configured memory backend for recent project context ---
+MEMORY_LIB="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd -P)}/scripts/lib/memory.sh"
+if [[ -r "$MEMORY_LIB" ]]; then
+    # shellcheck disable=SC1090
+    source "$MEMORY_LIB" 2>/dev/null || true
+    MEM_CONTEXT=$(memory_context "" 3 2>/dev/null || echo "")
     if [[ -n "$MEM_CONTEXT" ]]; then
-        echo "[Octopus] claude-mem context available:"
+        echo "[Octopus] memory context available:"
         echo "$MEM_CONTEXT"
     fi
 fi

--- a/scripts/agentmemory-bridge.sh
+++ b/scripts/agentmemory-bridge.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# CLI-level fallback adapter for agentmemory (github.com/rohitg00/agentmemory).
+# Claude/Codex/Cursor MCP remains the primary path; this bridge lets Octopus
+# memory hooks use the same local server without requiring MCP tools in bash.
+# No-ops when the server is not reachable.
+
+set -euo pipefail
+
+AGENTMEMORY_URL="${AGENTMEMORY_URL:-http://localhost:3111}"
+AGENTMEMORY_URL="${AGENTMEMORY_URL%/}"
+AGENTMEMORY_TIMEOUT="${AGENTMEMORY_TIMEOUT:-3}"
+
+_agentmemory_curl() {
+    local method="$1" url="$2" data="${3:-}"
+    local args=(-sf --max-time "$AGENTMEMORY_TIMEOUT")
+    [[ -n "${AGENTMEMORY_SECRET:-}" ]] && args+=(-H "Authorization: Bearer ${AGENTMEMORY_SECRET}")
+    if [[ "$method" != "GET" ]]; then
+        args+=(-H "Content-Type: application/json" -X "$method" -d "$data")
+    fi
+    curl "${args[@]}" "$url"
+}
+
+agentmemory_available() {
+    _agentmemory_curl GET "${AGENTMEMORY_URL}/agentmemory/livez" >/dev/null 2>&1 ||
+    _agentmemory_curl GET "${AGENTMEMORY_URL}/agentmemory/health" >/dev/null 2>&1
+}
+
+_agentmemory_json_available() {
+    command -v jq >/dev/null 2>&1
+}
+
+agentmemory_search() {
+    local query="${1:-}" limit="${2:-5}" scope="${3:-}"
+    agentmemory_available || { echo ""; return 0; }
+    _agentmemory_json_available || { echo ""; return 0; }
+    [[ "$limit" =~ ^[0-9]+$ ]] || limit=5
+    [[ -n "$scope" ]] && query="${query} ${scope}"
+
+    local payload
+    payload=$(jq -n \
+        --arg query "$query" \
+        --argjson limit "$limit" \
+        '{query: $query, limit: $limit}')
+
+    _agentmemory_curl POST "${AGENTMEMORY_URL}/agentmemory/smart-search" "$payload" 2>/dev/null || echo ""
+}
+
+agentmemory_observe() {
+    local obs_type="${1:-note}" title="${2:-}" text="${3:-}" scope="${4:-}"
+    agentmemory_available || return 0
+    _agentmemory_json_available || return 0
+
+    local content payload
+    content="$title"
+    [[ -n "$text" ]] && content="${content}"$'\n\n'"${text}"
+
+    payload=$(jq -n \
+        --arg content "$content" \
+        --arg type "$obs_type" \
+        --arg scope "$scope" \
+        '{
+            content: $content,
+            concepts: (["octopus", $type] + (if $scope != "" then [$scope] else [] end))
+        }')
+
+    _agentmemory_curl POST "${AGENTMEMORY_URL}/agentmemory/remember" "$payload" >/dev/null 2>&1 &
+    return 0
+}
+
+agentmemory_context() {
+    local scope="${1:-}" limit="${2:-3}"
+    local results
+    results=$(agentmemory_search "recent work" "$limit" "$scope")
+    [[ -z "$results" || "$results" == "[]" ]] && { echo ""; return 0; }
+    printf '%s' "$results" | python3 -c "
+import json, sys
+try:
+    data = json.loads(sys.stdin.read())
+    if isinstance(data, dict):
+        items = data.get('results') or data.get('memories') or data.get('data') or []
+    elif isinstance(data, list):
+        items = data
+    else:
+        items = []
+    if not items:
+        sys.exit(0)
+    limit = int(sys.argv[1]) if len(sys.argv) > 1 else 3
+    print('## Recent agentmemory observations')
+    for item in items[:limit]:
+        if not isinstance(item, dict):
+            title = str(item)[:80]
+            created = ''
+        else:
+            content = item.get('content') or item.get('text') or item.get('memory') or item.get('summary') or ''
+            title = item.get('title') or item.get('name') or content[:80] or 'untitled'
+            created = (item.get('created_at') or item.get('timestamp') or item.get('date') or '')[:10]
+        suffix = f' ({created})' if created else ''
+        print(f'- {title}{suffix}')
+except Exception:
+    pass
+" "$limit" 2>/dev/null || echo ""
+}
+
+case "${1:-}" in
+    available) agentmemory_available && echo "true" || echo "false" ;;
+    search)    shift; agentmemory_search "$@" ;;
+    observe)   shift; agentmemory_observe "$@" ;;
+    context)   shift; agentmemory_context "$@" ;;
+    *)
+        echo "Usage: agentmemory-bridge.sh {available|search|observe|context} [args...]" >&2
+        exit 1
+        ;;
+esac

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -152,6 +152,11 @@ check_deps() {
         else
             missing+=("claude-mem:claude-mem plugin — persistent cross-session memory")
         fi
+        if grep -q 'agentmemory' "$plugins_json" 2>/dev/null || command -v agentmemory >/dev/null 2>&1; then
+            ok+=("agentmemory:agentmemory companion detected")
+        else
+            warnings+=("agentmemory:agentmemory companion — optional persistent cross-agent memory")
+        fi
         if grep -q '"document-skills@anthropic-agent-skills": true' "$plugins_json" 2>/dev/null; then
             ok+=("document-skills:document-skills plugin installed")
         else
@@ -237,6 +242,14 @@ install_plugins() {
         echo "📦 claude-mem — Persistent cross-session memory"
         echo "   Enables /mem-search, /make-plan, /do workflows"
         echo "   Install: /plugin install claude-mem@thedotmack"
+        echo ""
+        any_missing=true
+    fi
+
+    if [[ -f "$settings" ]] && ! grep -q 'agentmemory' "$settings" 2>/dev/null && ! command -v agentmemory >/dev/null 2>&1; then
+        echo "📦 agentmemory — Persistent cross-agent memory (optional)"
+        echo "   Enables shared memory through MCP/REST across Claude Code, Codex, Cursor, and other agents"
+        echo "   Install: npm install -g @agentmemory/agentmemory && agentmemory connect claude-code"
         echo ""
         any_missing=true
     fi

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -1413,6 +1413,29 @@ doctor_check_conflicts() {
             "claude-mem v${mem_version} detected (companion — persistent cross-session memory)" \
             "Octopus workflows can use claude-mem MCP tools (search, timeline, get_observations) for past session context"
     fi
+
+    local agentmemory_dir=""
+    for dir in \
+        "$HOME"/.claude/plugins/cache/rohitg00/agentmemory/*/ \
+        "$HOME"/.claude/plugins/cache/agentmemory/agentmemory/*/ \
+        "$HOME"/.codex/plugins/cache/rohitg00/agentmemory/*/ \
+        "$HOME"/.codex/plugins/cache/agentmemory/agentmemory/*/; do
+        [[ -d "$dir" ]] && agentmemory_dir="$dir" && break
+    done
+    if [[ -n "$agentmemory_dir" ]]; then
+        local agentmemory_version
+        agentmemory_version=$(basename "${agentmemory_dir%/}" 2>/dev/null || echo "unknown")
+        doctor_add "companion-agentmemory" "conflicts" "pass" \
+            "agentmemory v${agentmemory_version} detected (companion — persistent cross-agent memory)" \
+            "Octopus memory hooks can use agentmemory through MCP or the local REST bridge"
+    elif command -v agentmemory >/dev/null 2>&1; then
+        doctor_add "companion-agentmemory" "conflicts" "pass" \
+            "agentmemory CLI detected (companion — persistent cross-agent memory)" \
+            "$(command -v agentmemory)"
+    elif [[ -n "${AGENTMEMORY_URL:-}" ]]; then
+        doctor_add "companion-agentmemory" "conflicts" "info" \
+            "agentmemory URL configured" "$AGENTMEMORY_URL"
+    fi
 }
 
 # --- Category 9: Smoke Test (v8.19.0 - Issue #34) ---

--- a/scripts/lib/memory.sh
+++ b/scripts/lib/memory.sh
@@ -29,9 +29,21 @@ _memory_mcp_service_registered() {
     settings=$(_memory_claude_settings_path) || return 1
     command -v jq >/dev/null 2>&1 || return 1
     jq -e '
-        (.mcpServers // {}) as $m
+        ((.mcpServers // {}) + (.servers // {})) as $m
         | [$m | to_entries[] | (.value.command // "") + " " + ((.value.args // []) | join(" "))]
         | any(test("mcp-memory-service"))
+    ' "$settings" >/dev/null 2>&1
+}
+
+_memory_agentmemory_registered() {
+    [[ -n "${AGENTMEMORY_URL:-}" ]] && return 0
+    local settings
+    settings=$(_memory_claude_settings_path) || return 1
+    command -v jq >/dev/null 2>&1 || return 1
+    jq -e '
+        ((.mcpServers // {}) + (.servers // {})) as $m
+        | [$m | to_entries[] | (.key // "") + " " + (.value.command // "") + " " + ((.value.args // []) | join(" "))]
+        | any(test("agentmemory|@agentmemory/mcp"))
     ' "$settings" >/dev/null 2>&1
 }
 
@@ -41,11 +53,13 @@ memory_backends() {
         printf '%s\n' "$pref" | tr ',' '\n' | awk 'NF'
         return 0
     fi
-    if _memory_mcp_service_registered; then
-        printf 'mcp-memory-service\nclaude-mem\n'
-    else
-        printf 'claude-mem\n'
+    if _memory_agentmemory_registered; then
+        printf 'agentmemory\n'
     fi
+    if _memory_mcp_service_registered; then
+        printf 'mcp-memory-service\n'
+    fi
+    printf 'claude-mem\n'
 }
 
 memory_scope() {
@@ -65,6 +79,11 @@ _memory_invoke() {
     local backend="$1"; shift
     local primitive="$1"; shift
     case "$backend" in
+        agentmemory)
+            local bridge="${_MEMORY_BRIDGE_DIR}/agentmemory-bridge.sh"
+            [[ -x "$bridge" ]] || return 1
+            "$bridge" "$primitive" "$@"
+            ;;
         claude-mem)
             local bridge="${_MEMORY_BRIDGE_DIR}/claude-mem-bridge.sh"
             [[ -x "$bridge" ]] || return 1

--- a/tests/unit/test-agentmemory-integration.sh
+++ b/tests/unit/test-agentmemory-integration.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Static assertions for agentmemory companion compatibility.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "agentmemory companion integration"
+
+pass() { test_case "$1"; test_pass; }
+fail() { test_case "$1"; test_fail "${2:-$1}"; }
+
+BRIDGE="$PROJECT_ROOT/scripts/agentmemory-bridge.sh"
+MEMORY_LIB="$PROJECT_ROOT/scripts/lib/memory.sh"
+DOCTOR="$PROJECT_ROOT/scripts/lib/doctor.sh"
+SETUP="$PROJECT_ROOT/.claude/commands/setup.md"
+CURSOR_SETUP="$PROJECT_ROOT/.cursor-plugin/commands/octo-setup.md"
+README="$PROJECT_ROOT/README.md"
+
+if [[ -x "$BRIDGE" ]]; then
+    pass "agentmemory bridge exists and is executable"
+else
+    fail "agentmemory bridge exists and is executable" "missing or not executable"
+fi
+
+for cmd in available search observe context; do
+    if grep -q "${cmd})" "$BRIDGE"; then
+        pass "agentmemory bridge subcommand: $cmd"
+    else
+        fail "agentmemory bridge subcommand: $cmd" "case dispatch missing for $cmd"
+    fi
+done
+
+if grep -q '@agentmemory/mcp' "$MEMORY_LIB" && grep -q 'agentmemory-bridge.sh' "$MEMORY_LIB"; then
+    pass "memory contract detects and invokes agentmemory"
+else
+    fail "memory contract detects and invokes agentmemory" "missing detection or bridge invocation"
+fi
+
+if grep -q 'companion-agentmemory' "$DOCTOR"; then
+    pass "doctor reports agentmemory companion"
+else
+    fail "doctor reports agentmemory companion" "no companion-agentmemory doctor check"
+fi
+
+for file in "$SETUP" "$CURSOR_SETUP"; do
+    if grep -q 'agentmemory connect' "$file" && grep -q 'OCTOPUS_MEMORY_BACKEND=agentmemory' "$file"; then
+        pass "setup docs include agentmemory path: $(basename "$file")"
+    else
+        fail "setup docs include agentmemory path: $(basename "$file")" "missing agentmemory setup guidance"
+    fi
+done
+
+if grep -q 'github.com/rohitg00/agentmemory' "$README"; then
+    pass "README mentions agentmemory"
+else
+    fail "README mentions agentmemory" "missing README mention"
+fi
+
+test_summary

--- a/tests/unit/test-claude-mem-integration.sh
+++ b/tests/unit/test-claude-mem-integration.sh
@@ -102,12 +102,12 @@ else
     fail "Wired: save_session_checkpoint calls bridge observe" "no bridge observe or memory_observe call found"
 fi
 
-# ── 8. SessionStart memory hook queries claude-mem ───────────────────
+# ── 8. SessionStart memory hook queries the memory contract ──────────
 
-if grep -c 'BRIDGE_SCRIPT\|claude-mem-bridge' "$PROJECT_ROOT/hooks/session-start-memory.sh" >/dev/null 2>&1; then
-    pass "Wired: session-start-memory.sh queries claude-mem context"
+if grep -c 'memory_context\|scripts/lib/memory.sh' "$PROJECT_ROOT/hooks/session-start-memory.sh" >/dev/null 2>&1; then
+    pass "Wired: session-start-memory.sh queries memory contract context"
 else
-    fail "Wired: session-start-memory.sh queries claude-mem context" "no bridge reference in hook"
+    fail "Wired: session-start-memory.sh queries memory contract context" "no memory contract reference in hook"
 fi
 
 # ── 9. Provider report card function exists ──────────────────────────

--- a/tests/unit/test-memory-contract.sh
+++ b/tests/unit/test-memory-contract.sh
@@ -8,6 +8,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 MEM="$PROJECT_ROOT/scripts/lib/memory.sh"
 CLAUDE_MEM="$PROJECT_ROOT/scripts/claude-mem-bridge.sh"
 MCP_MEM="$PROJECT_ROOT/scripts/mcp-memory-bridge.sh"
+AGENTMEMORY="$PROJECT_ROOT/scripts/agentmemory-bridge.sh"
 
 # shellcheck disable=SC1090
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
@@ -22,6 +23,11 @@ test_contract_file_exists() {
 test_mcp_bridge_exists() {
     test_case "mcp-memory-bridge.sh exists and is executable"
     [[ -x "$MCP_MEM" ]] && test_pass || test_fail "mcp-memory-bridge.sh missing or not +x"
+}
+
+test_agentmemory_bridge_exists() {
+    test_case "agentmemory-bridge.sh exists and is executable"
+    [[ -x "$AGENTMEMORY" ]] && test_pass || test_fail "agentmemory-bridge.sh missing or not +x"
 }
 
 test_claude_mem_bridge_still_exists() {
@@ -60,11 +66,11 @@ test_backends_respects_explicit_env() {
     test_case "explicit OCTOPUS_MEMORY_BACKEND is honoured verbatim"
     local out
     # shellcheck disable=SC1090
-    out=$(OCTOPUS_MEMORY_BACKEND="mcp-memory-service,claude-mem" \
+    out=$(OCTOPUS_MEMORY_BACKEND="agentmemory,mcp-memory-service,claude-mem" \
           bash -c "source '$MEM'; memory_backends" | tr '\n' ',' | sed 's/,$//')
-    [[ "$out" == "mcp-memory-service,claude-mem" ]] \
+    [[ "$out" == "agentmemory,mcp-memory-service,claude-mem" ]] \
         && test_pass \
-        || test_fail "expected mcp-memory-service,claude-mem got: $out"
+        || test_fail "expected agentmemory,mcp-memory-service,claude-mem got: $out"
 }
 
 test_backends_detects_mcp_registered() {
@@ -77,11 +83,61 @@ JSON
     local out
     # shellcheck disable=SC1090
     out=$(OCTOPUS_MEMORY_BACKEND=auto CLAUDE_SETTINGS_FILE="$tmp_settings" \
-          bash -c "source '$MEM'; memory_backends" | head -1)
+          bash -c "source '$MEM'; memory_backends")
+    out=$(printf '%s\n' "$out" | sed -n '1p')
     rm -f "$tmp_settings"
     [[ "$out" == "mcp-memory-service" ]] \
         && test_pass \
         || test_fail "expected mcp-memory-service first, got: $out"
+}
+
+test_backends_detects_agentmemory_registered() {
+    test_case "auto detects agentmemory when present in mcpServers"
+    local tmp_settings
+    tmp_settings=$(mktemp)
+    cat >"$tmp_settings" <<'JSON'
+{"mcpServers": {"agentmemory": {"command": "npx", "args": ["-y", "@agentmemory/mcp"]}}}
+JSON
+    local out
+    # shellcheck disable=SC1090
+    out=$(OCTOPUS_MEMORY_BACKEND=auto CLAUDE_SETTINGS_FILE="$tmp_settings" \
+          bash -c "source '$MEM'; memory_backends")
+    out=$(printf '%s\n' "$out" | sed -n '1p')
+    rm -f "$tmp_settings"
+    [[ "$out" == "agentmemory" ]] \
+        && test_pass \
+        || test_fail "expected agentmemory first, got: $out"
+}
+
+test_backends_detects_agentmemory_registered_in_servers() {
+    test_case "auto detects agentmemory when present in servers"
+    local tmp_settings
+    tmp_settings=$(mktemp)
+    cat >"$tmp_settings" <<'JSON'
+{"servers": {"memory": {"command": "npx", "args": ["-y", "@agentmemory/mcp"]}}}
+JSON
+    local out
+    # shellcheck disable=SC1090
+    out=$(OCTOPUS_MEMORY_BACKEND=auto CLAUDE_SETTINGS_FILE="$tmp_settings" \
+          bash -c "source '$MEM'; memory_backends")
+    out=$(printf '%s\n' "$out" | sed -n '1p')
+    rm -f "$tmp_settings"
+    [[ "$out" == "agentmemory" ]] \
+        && test_pass \
+        || test_fail "expected agentmemory first, got: $out"
+}
+
+test_backends_detects_agentmemory_env() {
+    test_case "auto detects agentmemory when AGENTMEMORY_URL is set"
+    local out
+    # shellcheck disable=SC1090
+    out=$(OCTOPUS_MEMORY_BACKEND=auto CLAUDE_SETTINGS_FILE=/dev/null \
+          AGENTMEMORY_URL=http://localhost:3111 \
+          bash -c "source '$MEM'; memory_backends")
+    out=$(printf '%s\n' "$out" | sed -n '1p')
+    [[ "$out" == "agentmemory" ]] \
+        && test_pass \
+        || test_fail "expected agentmemory first, got: $out"
 }
 
 test_scope_uses_repo_basename() {
@@ -114,15 +170,29 @@ test_mcp_bridge_no_ops_when_cli_missing() {
         || test_fail "expected 'false' when CLI missing, got: $out"
 }
 
+test_agentmemory_bridge_no_ops_when_server_missing() {
+    test_case "agentmemory-bridge no-ops gracefully without the server"
+    local out
+    out=$(AGENTMEMORY_URL="http://127.0.0.1:9" AGENTMEMORY_TIMEOUT=1 "$AGENTMEMORY" available)
+    [[ "$out" == "false" ]] \
+        && test_pass \
+        || test_fail "expected 'false' when server missing, got: $out"
+}
+
 test_contract_file_exists
 test_mcp_bridge_exists
+test_agentmemory_bridge_exists
 test_claude_mem_bridge_still_exists
 test_primitives_defined
 test_backends_defaults_to_claude_mem
 test_backends_respects_explicit_env
 test_backends_detects_mcp_registered
+test_backends_detects_agentmemory_registered
+test_backends_detects_agentmemory_registered_in_servers
+test_backends_detects_agentmemory_env
 test_scope_uses_repo_basename
 test_scope_env_override_wins
 test_mcp_bridge_no_ops_when_cli_missing
+test_agentmemory_bridge_no_ops_when_server_missing
 
 test_summary


### PR DESCRIPTION
## Summary
- Add an optional `agentmemory` memory backend to the Octopus memory contract.
- Add `scripts/agentmemory-bridge.sh` as a REST fallback for environments where MCP tools are not available.
- Update setup/doctor/dependency messaging and README docs to describe agentmemory as an optional companion, not a provider.
- Add focused unit coverage for backend detection, REST no-op behavior, and setup documentation wiring.

## Compatibility Notes
- Uses the documented agentmemory REST endpoints:
  - `GET /agentmemory/livez` or `/agentmemory/health`
  - `POST /agentmemory/remember`
  - `POST /agentmemory/smart-search`
- Auto-detects agentmemory when it is registered in `mcpServers` or `servers`, or when `AGENTMEMORY_URL` is set.
- Leaves `claude-mem` as the fallback backend.

## Verification
- `bash -n scripts/agentmemory-bridge.sh scripts/lib/memory.sh hooks/session-start-memory.sh scripts/lib/doctor.sh scripts/install-deps.sh tests/unit/test-agentmemory-integration.sh tests/unit/test-memory-contract.sh tests/unit/test-claude-mem-integration.sh`
- `tests/unit/test-agentmemory-integration.sh`
- `tests/unit/test-memory-contract.sh`
- `tests/unit/test-claude-mem-integration.sh`
- `git diff --check`
- `make validate-plugin-assembly`
- `AGENTMEMORY_URL=http://127.0.0.1:9 AGENTMEMORY_TIMEOUT=1 scripts/agentmemory-bridge.sh available`

## Local Full-Suite Caveat
- `make test` reached 163/164 passing locally.
- The remaining failure was `unit/test-hook-err-traps.sh`, caused by the pre-existing untracked `plugin/` tree being included in that test's tar fixture and hitting `File name too long`. The tracked compatibility changes do not touch that fixture.

## Beads
- `bd` is blocked in this clone by the remote-backed schema guard: v49 -> v53 migrations require the designated migrator decision before issue writes are safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional persistent memory companion (**agentmemory**), including setup guidance, new setup wizard options, and companion status reporting.
  * Updated memory integration listings to include both **claude-mem** and **agentmemory**.
* **Bug Fixes**
  * Improved session memory context retrieval across sessions to use the updated memory backend approach.
  * Refined installation/diagnostics so companion availability and running status reflect what’s actually configured.
* **Documentation**
  * Expanded Claude/Cursor setup and dependency/install guidance for **agentmemory**, including health/verification and backend selection options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->