### PR TITLE
release: v9.51.0 — Fable 5 dispatch profile + auto-enforced guards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.50.0 - Claude Code 2026 compatibility layer: routines manifest, SubagentStop quality/cost gate, /octo:usage report, worktree bgIsolation opt-out, Claude Agent SDK seat (Opus 4.8, 1M context), starter skills pack, /plugin browse manifest. 42 agents, 50 commands, 58 skills. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
-      "version": "9.50.0",
+      "description": "v9.51.0 - Claude Code 2026 compatibility layer: routines manifest, SubagentStop quality/cost gate, /octo:usage report, worktree bgIsolation opt-out, Claude Agent SDK seat (Opus 4.8, 1M context), starter skills pack, /plugin browse manifest. 42 agents, 50 commands, 58 skills. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
+      "version": "9.51.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": "2026-06",
   "name": "octo",
   "displayName": "Claude Octopus",
-  "version": "9.50.0",
+  "version": "9.51.0",
   "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
   "author": {
     "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.50.0",
-  "description": "v9.50.0 - Claude Code 2026 compatibility layer: routines manifest, SubagentStop quality/cost gate, /octo:usage report, worktree bgIsolation opt-out, Claude Agent SDK seat (Opus 4.8, 1M context), starter skills pack, /plugin browse manifest. Run /octo:setup.",
+  "version": "9.51.0",
+  "description": "v9.51.0 - Fable 5 support: dispatch profile block, auto-enforced guards on claude-fable-5 pins (security reroute to Opus 4.8, effort clamp, refusal retry), SessionStart guidance hook; plus agent orientation layer (RELEASING.md, provider wiring map, make ci-local, exec-bit CI lint). Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Claude Octopus routine manifest (v9.50.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "$comment": "Claude Octopus routine manifest (v9.51.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
   "schemaVersion": 1,
   "routines": [
     {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.50.0",
+  "version": "9.51.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.50.0",
+  "version": "9.51.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.50.0"
+    "version": "9.51.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.50.0 - Claude Code 2026 compatibility layer: routines manifest, SubagentStop quality/cost gate, /octo:usage report, worktree bgIsolation opt-out, Claude Agent SDK seat (Opus 4.8, 1M context), starter skills pack, /plugin browse manifest. 42 agents, 50 commands, 58 skills. Run /octo:setup.",
-      "version": "9.50.0",
+      "description": "v9.51.0 - Fable 5 support: dispatch profile block, auto-enforced guards on claude-fable-5 pins (security reroute to Opus 4.8, effort clamp, refusal retry), SessionStart guidance hook; plus agent orientation layer (RELEASING.md, provider wiring map, make ci-local, exec-bit CI lint). 42 agents, 50 commands, 58 skills. Run /octo:setup.",
+      "version": "9.51.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.50.0",
+  "version": "9.51.0",
   "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.44.1. 32 expert personas, 49 commands, 54 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [9.51.0] - 2026-07-09
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus puts up to nine of them on every 
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Tests-117_suites_passing-brightgreen" alt="117 suites passing">
-  <img src="https://img.shields.io/badge/Version-9.50.0-blue" alt="Version 9.50.0">
+  <img src="https://img.shields.io/badge/Version-9.51.0-blue" alt="Version 9.51.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/README.md
+++ b/README.md
@@ -443,6 +443,25 @@ v9.50.0 aligns the plugin with Claude Code's 2026 native capabilities. Each piec
 
 ---
 
+## Fable 5 Support
+
+v9.51.0 adds first-class support for Claude Fable 5 (Anthropic's Mythos-class model, $10/$50 per MTok — 2x Opus 4.8). Fable 5 is never auto-selected; pin it with `OCTOPUS_OPUS_MODEL=claude-fable-5` (opus seats) or `OCTOPUS_CLAUDE_SDK_MODEL=claude-fable-5` (the 1M-context SDK seat). When a pin is detected, the plugin auto-enables three guards and prints a one-line banner:
+
+- **Security reroute** — security-audit dispatches (security-auditor persona, squeeze red/blue workflow) run on Opus 4.8 instead of Fable 5, whose safety classifiers can refuse adversarial security phrasing even in authorized audits.
+- **Effort clamp** — `xhigh`/`max` effort clamps to `high` for Fable dispatches. Fable 5 effort applies per tool call; higher settings widen scope at 2x cost without extending runs.
+- **Refusal retry** — a refused or empty Fable 5 dispatch on the `claude-sdk` seat retries once on Opus 4.8 instead of failing the seat.
+
+A SessionStart hook injects the dispatch profile (prompt anti-patterns, judgment routing, risk-surface escalation) whenever a pin is active. Full guidance: `skills/blocks/fable5-prompting.md`.
+
+### New environment variables (v9.51.0)
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `OCTOPUS_FABLE5_MODE` | `auto` | `off` disables all Fable 5 guards; `on` forces them without a pin |
+| `OCTOPUS_FABLE5_NO_RETRY` | unset | Set `1` to disable the refusal retry on the `claude-sdk` seat |
+
+---
+
 ## Trust, Safety, and Limits
 
 **Command namespace** — Slash commands are namespaced under `/octo:*` and the `octo` natural-language prefix routes through the plugin's intent detection. Lifecycle hooks (session start/end, prompt submit, tool use, compaction, plan mode, worktrees, task lifecycle, idle, config change, permission events) also attach to Claude Code so multi-provider routing, freeze/discipline modes, and the work-queue watcher can function. See `.claude-plugin/hooks.json` for the full list. Uninstall removes every hook.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.50.0",
+  "version": "9.51.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts v9.51.0. Folds two unreleased changesets into the release:

- **PR #597** — Fable 5 dispatch profile (`skills/blocks/fable5-prompting.md`), auto-enforced guards on `claude-fable-5` pins (security reroute to Opus 4.8, effort clamp, refusal retry via the claude-sdk shim), `hooks/fable5-inject.sh` SessionStart injection, and the dispatch fix so `OCTOPUS_OPUS_MODEL=claude-fable-5` actually reaches the dispatched `--model` flag.
- **PR #594** — agent orientation layer (RELEASING.md, docs/PROVIDERS.md, `make sync`/`sync-check`/`ci-local`, exec-bit CI lint, CLAUDE.md/AGENTS.md orientation sections).

## Changes in this PR
- Version 9.50.0 → 9.51.0: package.json, .claude-plugin/{plugin.json, plugin-manifest.json, routines.json comment}, .codex-plugin, .cursor-plugin, .factory-plugin (plugin.json + marketplace.json), README badge.
- plugin.json description updated (no hand-written counts; generator appends them).
- CHANGELOG: Unreleased folded into `[9.51.0] - 2026-07-09`.
- `.claude-plugin/marketplace.json` regenerated via `make sync`.

## Validation
- `make ci-local` exit 0 in the release worktree
- `make sync-check` green (marketplace + openclaw both current)
- No exec-bit mode changes vs main (three chmod drifts from the local test run were caught and reverted before push)

Post-merge: tag `v9.51.0` on the squash-merge commit, then GitHub Release per RELEASING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class support for **Claude Fable 5** when pinned, including automatic guard/reroute behavior and configurable retry handling.
* **Chores**
  * Bumped the release/version number to **9.51.0** across app and plugin metadata (including marketplace/manifests/packages).
* **Documentation**
  * Updated the changelog to start with the **[9.51.0]** release header.
  * Refreshed the README version badge and added **Fable 5** setup/config details (including `OCTOPUS_FABLE5_MODE` and `OCTOPUS_FABLE5_NO_RETRY`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->