### PR TITLE
fix: council model selection stdin leak and diversity short-circuit

### DIFF
--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -882,7 +882,7 @@ council_provider_is_available() {
 
 council_pick_provider() {
     local preferred="$1"
-    if council_provider_is_available "$preferred"; then
+    if council_provider_is_available "$preferred" && ! council_roster_has_provider_org "$(council_provider_org "$preferred")"; then
         echo "$preferred"
         return 0
     fi

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -75,7 +75,7 @@ validate_agy_model_name() {
     fi
 
     local available_models=""
-    if ! available_models="$(agy models 2>/dev/null)" || [[ -z "$available_models" ]]; then
+    if ! available_models="$(agy models </dev/null 2>/dev/null)" || [[ -z "$available_models" ]]; then
         log ERROR "Cannot validate OCTOPUS_AGY_MODEL because 'agy models' returned no models"
         return 1
     fi

--- a/tests/unit/test-council-model-selection-fixes.sh
+++ b/tests/unit/test-council-model-selection-fixes.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Regression tests for PR #600: agy model-validation stdin leak and the
+# council_pick_provider diversity short-circuit. Both tests fail on the
+# pre-#600 code (verified during review) — they are not string greps.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "council model selection fixes (#600)"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# ── agy stdin leak ─────────────────────────────────────────────────────────
+# The real agy CLI consumes stdin. When validate_agy_model_name ran
+# `agy models` inside a command substitution with the parent's stdin attached
+# to a prompt pipe, agy ate the prompt and returned chat output instead of a
+# model list, so valid pins were rejected. The mock reproduces that behavior:
+# with data on stdin it returns garbage; with empty stdin (the </dev/null fix)
+# it returns the model list.
+STUB_BIN="$TMP_DIR/bin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "models" ]]; then
+    stdin_content="$(cat)"
+    if [[ -n "$stdin_content" ]]; then
+        echo "I received your prompt: $stdin_content"
+        exit 0
+    fi
+    printf '%s\n' \
+        'Gemini 3.5 Flash (Low)' \
+        'Claude Sonnet 4.6 (Thinking)'
+    exit 0
+fi
+exit 0
+MOCK_AGY
+chmod 755 "$STUB_BIN/agy"
+
+test_case "agy model pin validates even when parent stdin is a pipe"
+if printf 'council prompt payload' | env PATH="$STUB_BIN:$PATH" bash -c '
+    log() { :; }
+    source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+    validate_agy_model_name "Gemini 3.5 Flash (Low)"
+' 2>/dev/null; then
+    test_pass
+else
+    test_fail "pin rejected under piped stdin — agy models consumed the prompt (stdin leak regressed)"
+fi
+
+test_case "agy model pin still rejects unknown labels"
+if printf 'payload' | env PATH="$STUB_BIN:$PATH" bash -c '
+    log() { :; }
+    source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+    validate_agy_model_name "Nonexistent Model (Ultra)"
+' 2>/dev/null; then
+    test_fail "unknown model label was accepted"
+else
+    test_pass
+fi
+
+# ── council diversity short-circuit ────────────────────────────────────────
+pick_provider() {
+    local roster_json="$1" preferred="$2"
+    bash -c '
+        log() { :; }
+        source "'"$PROJECT_ROOT"'/scripts/lib/council.sh" 2>/dev/null
+        COUNCIL_ROSTER_JSON="$1"
+        COUNCIL_PROVIDER_STATUS_JSON="{\"claude\":\"host-native\",\"opencode\":\"available\"}"
+        COUNCIL_PROVIDERS="claude,opencode"
+        council_pick_provider "$2"
+    ' _ "$roster_json" "$preferred"
+}
+
+test_case "preferred provider passed over when its org already holds a seat"
+out=$(pick_provider '[{"persona":"strategy-analyst","provider":"claude","provider_org":"anthropic"}]' claude)
+if [[ "$out" == "opencode" ]]; then
+    test_pass
+else
+    test_fail "expected opencode (anthropic already seated), got '$out'"
+fi
+
+test_case "preferred provider kept when its org is not yet seated"
+out=$(pick_provider '[]' claude)
+if [[ "$out" == "claude" ]]; then
+    test_pass
+else
+    test_fail "expected claude on empty roster, got '$out'"
+fi
+
+test_case "falls back to preferred when every org is already seated"
+out=$(bash -c '
+    log() { :; }
+    source "'"$PROJECT_ROOT"'/scripts/lib/council.sh" 2>/dev/null
+    COUNCIL_ROSTER_JSON="[{\"persona\":\"a\",\"provider\":\"claude\",\"provider_org\":\"anthropic\"},{\"persona\":\"b\",\"provider\":\"opencode\",\"provider_org\":\"opencode\"}]"
+    COUNCIL_PROVIDER_STATUS_JSON="{\"claude\":\"host-native\",\"opencode\":\"available\"}"
+    COUNCIL_PROVIDERS="claude,opencode"
+    council_pick_provider claude
+')
+if [[ "$out" == "claude" || "$out" == "opencode" ]]; then
+    test_pass
+else
+    test_fail "expected an available provider from the any-available fallback, got '$out'"
+fi
+
+test_summary

--- a/tests/unit/test-council-model-selection-fixes.sh
+++ b/tests/unit/test-council-model-selection-fixes.sh
@@ -10,8 +10,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "council model selection fixes (#600)"
 
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT
 
 # ── agy stdin leak ─────────────────────────────────────────────────────────
 # The real agy CLI consumes stdin. When validate_agy_model_name ran
@@ -20,7 +20,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 # model list, so valid pins were rejected. The mock reproduces that behavior:
 # with data on stdin it returns garbage; with empty stdin (the </dev/null fix)
 # it returns the model list.
-STUB_BIN="$TMP_DIR/bin"
+STUB_BIN="$TEST_TMP_DIR/bin"
 mkdir -p "$STUB_BIN"
 cat > "$STUB_BIN/agy" <<'MOCK_AGY'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Description
Fixes two of the three problems reported in #599 for council model selection.

1. **`OCTOPUS_AGY_MODEL` pins wrongly rejected.** `validate_agy_model_name()` in `scripts/lib/model-resolver.sh:78` ran `agy models` without detaching stdin. During council dispatch, stdin has data on it, and `agy models` treats piped stdin as a prompt instead of listing models — so the validator compared the pin against chat output, rejected it, and the seat silently downgraded to the default model. Fix: redirect stdin from `/dev/null`.

2. **An available `opencode` seat was never used.** `council_pick_provider()` in `scripts/lib/council.sh:885` short-circuited to the preferred provider whenever it was merely *available*, without checking whether that provider's org was already represented on the roster. That meant the org-diversity fallback loop right below it only ever ran when the preferred provider was down — with claude/codex/agy all healthy, every persona landed on those three and opencode was never seated. Fix: gate the short-circuit on the org not already being on the roster, matching the check the diversity loop below it already uses (`council_roster_has_provider_org`).

Problem 3 from the issue (mismatched provider/model labels in `summary.json`) is **not** addressed here — the reporter explicitly flagged it as an unscoped design call ("I haven't attempted a fix for this one... that's a design call for you"), so it's left for a separate issue/PR.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync — not applicable, no skill/command changes
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` — not applicable
- [ ] Version bump — not applicable, no release in this PR
- [ ] Documentation updated — not applicable, no behavior contract changed
- [ ] CHANGELOG.md updated — left for release PR per this project's daily-triage process

## Testing
```bash
bash -n scripts/lib/model-resolver.sh scripts/lib/council.sh
bash tests/unit/test-agy-provider.sh          # 32/32 pass
bash tests/unit/test-council-command.sh       # 55/55 pass
bash tests/unit/test-qwen-council-provider.sh # 6/6 pass
bash tests/unit/test-openclaw-compat.sh       # 31/31 pass
make test-unit                                # 163/165 suites pass
```
The 2 unit-suite failures under `make test-unit` (`test-github-work-queue-hook.sh`, `test-hud-smart-mode.sh`) are pre-existing — reproduced identically on a clean `origin/main` checkout in this sandbox (they depend on live GitHub/network access and a HUD binary that aren't available here) and are unrelated to this change.

No live provider smoke was run against a real `agy`/`opencode` install; validation is unit-level plus the mocked-CLI test coverage above.

## Related Issues
Closes #599 (problems 1 and 2 of 3; problem 3 tracked separately)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DqFngsoLLyz1bQKxNSZN2j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved council provider selection so the initially “preferred” provider is only chosen when available and its organization isn’t already on the roster.
  * Updated model name validation to query the model list using stdin redirected from an empty input source, maintaining existing failure handling when no models are returned.
* **Tests**
  * Added a bash regression test suite covering the preferred-provider diversity rules and the updated model name validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->