### PR TITLE
fix: release.sh remote/branch assumptions and missing plugin-manifest.json bump

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,6 +43,11 @@ REMOTE="${OCTO_RELEASE_REMOTE:-origin}"
 
 cd "$PLUGIN_ROOT"
 
+# gh infers the target repo from remotes independently of $REMOTE, so a dev
+# clone pointing $REMOTE at the canonical repo (with origin left on a fork)
+# would otherwise create the PR/release against the wrong repo. Pin it.
+REPO_SLUG="$(git remote get-url "$REMOTE" | sed -E 's#^(git@|https://)([^:/]+)[:/]##; s#\.git$##')"
+
 # --- Preflight ---
 
 if ! git diff --quiet 2>/dev/null; then
@@ -245,6 +250,8 @@ echo ""
 
 echo "4/8 Creating PR..."
 PR_URL=$(gh pr create \
+    -R "$REPO_SLUG" \
+    --head "$BRANCH" \
     --title "chore: release v${VERSION}" \
     --body "## Release v${VERSION}
 
@@ -263,7 +270,7 @@ echo "5/8 Waiting for CI..."
 # Poll until required checks finish (max 5 minutes)
 DEADLINE=$((SECONDS + 300))
 while [[ $SECONDS -lt $DEADLINE ]]; do
-    CHECKS=$(gh pr checks "$PR_NUM" --json name,state 2>&1 || true)
+    CHECKS=$(gh pr checks "$PR_NUM" -R "$REPO_SLUG" --json name,state 2>&1 || true)
     SMOKE=$(octo_pr_check_state "$CHECKS" "Smoke Tests")
     UNIT=$(octo_pr_check_state "$CHECKS" "Unit Tests")
     INTEG=$(octo_pr_check_state "$CHECKS" "Integration Tests")
@@ -275,7 +282,7 @@ while [[ $SECONDS -lt $DEADLINE ]]; do
 
     if [[ "$SMOKE" == "fail" || "$UNIT" == "fail" || "$INTEG" == "fail" ]]; then
         echo "   CI FAILED — Smoke: ${SMOKE} | Unit: ${UNIT} | Integration: ${INTEG}"
-        echo "   Fix failures, then run: gh pr merge ${PR_NUM} --merge"
+        echo "   Fix failures, then run: gh pr merge ${PR_NUM} --merge -R ${REPO_SLUG}"
         exit 1
     fi
 
@@ -284,8 +291,8 @@ done
 
 if [[ $SECONDS -ge $DEADLINE ]]; then
     echo "   CI timed out after 5 minutes."
-    echo "   Check manually: gh pr checks ${PR_NUM}"
-    echo "   Then merge: gh pr merge ${PR_NUM} --merge"
+    echo "   Check manually: gh pr checks ${PR_NUM} -R ${REPO_SLUG}"
+    echo "   Then merge: gh pr merge ${PR_NUM} --merge -R ${REPO_SLUG}"
     exit 1
 fi
 echo ""
@@ -293,7 +300,7 @@ echo ""
 # --- 6. Merge + Release ---
 
 echo "6/8 Merging and creating release..."
-gh pr merge "$PR_NUM" --merge --quiet 2>/dev/null || gh pr merge "$PR_NUM" --merge
+gh pr merge "$PR_NUM" -R "$REPO_SLUG" --merge --quiet 2>/dev/null || gh pr merge "$PR_NUM" -R "$REPO_SLUG" --merge
 
 if [[ "$ON_RELEASE_BRANCH" == "true" ]]; then
     # main is normally still checked out in the worktree this release branch
@@ -309,6 +316,7 @@ else
 fi
 
 gh release create "v${VERSION}" \
+    -R "$REPO_SLUG" \
     --target "$MERGE_SHA" \
     --title "v${VERSION} — ${SUMMARY}" \
     --notes "### Changed
@@ -317,6 +325,7 @@ gh release create "v${VERSION}" \
 **Full Changelog**: https://github.com/nyldn/claude-octopus/compare/v${CURRENT}...v${VERSION}" \
     --quiet 2>/dev/null || \
 gh release create "v${VERSION}" \
+    -R "$REPO_SLUG" \
     --target "$MERGE_SHA" \
     --title "v${VERSION} — ${SUMMARY}" \
     --notes "### Changed

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,6 +39,7 @@ VERSION="$1"
 SUMMARY="$2"
 DATE=$(date +%Y-%m-%d)
 BRANCH="release/v${VERSION}"
+REMOTE="${OCTO_RELEASE_REMOTE:-origin}"
 
 cd "$PLUGIN_ROOT"
 
@@ -49,12 +50,20 @@ if ! git diff --quiet 2>/dev/null; then
     exit 1
 fi
 
-if [[ "$(git branch --show-current)" != "main" ]]; then
-    echo "Error: must be on main branch."
+# RELEASING.md §0 allows two flows: run from main and let this script cut the
+# release branch, or (worktree flow) cut ${BRANCH} from origin/main yourself
+# and run this script already checked out on it.
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ "$CURRENT_BRANCH" != "main" && "$CURRENT_BRANCH" != "$BRANCH" ]]; then
+    echo "Error: must be on main, or on ${BRANCH} cut from main (see RELEASING.md §0)."
     exit 1
 fi
+ON_RELEASE_BRANCH=false
+[[ "$CURRENT_BRANCH" == "$BRANCH" ]] && ON_RELEASE_BRANCH=true
 
-git pull --quiet origin main
+if [[ "$ON_RELEASE_BRANCH" == "false" ]]; then
+    git pull --quiet "$REMOTE" main
+fi
 
 CURRENT=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
 echo "Releasing: ${CURRENT} → ${VERSION}"
@@ -120,6 +129,22 @@ persona_count = len(list(persona_dir.glob('*.md')))
 if persona_count == 0:
     print('ERROR: agents/personas contains no persona markdown files', file=sys.stderr)
     raise SystemExit(1)
+
+droid_dir = pathlib.Path('agents/droids')
+droid_count = len(list(droid_dir.glob('*.md'))) if droid_dir.is_dir() else 0
+
+manifest_path = pathlib.Path('.claude-plugin/plugin-manifest.json')
+manifest = json.loads(manifest_path.read_text())
+manifest['version'] = version
+components = manifest.get('components', {})
+components.get('commands', {})['count'] = command_count
+components.get('skills', {})['count'] = skill_count
+agents = components.get('agents', {})
+agents['count'] = persona_count + droid_count
+agents.get('breakdown', {})['personas'] = persona_count
+agents.get('breakdown', {})['droids'] = droid_count
+manifest_path.write_text(json.dumps(manifest, indent=2) + '\n')
+print('   .claude-plugin/plugin-manifest.json')
 
 count_phrase = f'{persona_count} personas, {command_count} commands, {skill_count} skills'
 expert_count_phrase = f'{persona_count} expert personas, {command_count} commands, {skill_count} skills'
@@ -192,8 +217,10 @@ echo ""
 # --- 2. Commit ---
 
 echo "2/8 Committing..."
-git checkout -b "$BRANCH" --quiet
-git add package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .claude-plugin/routines.json .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json .factory-plugin/marketplace.json README.md CHANGELOG.md
+if [[ "$ON_RELEASE_BRANCH" == "false" ]]; then
+    git checkout -b "$BRANCH" --quiet
+fi
+git add package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .claude-plugin/plugin-manifest.json .claude-plugin/routines.json .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json .factory-plugin/marketplace.json README.md CHANGELOG.md
 git commit --quiet -m "chore: release v${VERSION} — ${SUMMARY}
 
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
@@ -204,7 +231,7 @@ echo ""
 
 echo "3/8 Pushing..."
 # --no-verify: skip pre-push hook (CI validates on PR; pre-push re-runs tests already run at commit)
-PUSH_OUTPUT=$(git push --quiet --no-verify -u origin "$BRANCH" 2>&1) || {
+PUSH_OUTPUT=$(git push --quiet --no-verify -u "$REMOTE" "$BRANCH" 2>&1) || {
     printf '%s\n' "$PUSH_OUTPUT" | grep -v "^remote:" || true
     echo "   ERROR: Push failed. Aborting release."
     exit 1
@@ -267,7 +294,7 @@ echo ""
 echo "6/8 Merging and creating release..."
 gh pr merge "$PR_NUM" --merge --quiet 2>/dev/null || gh pr merge "$PR_NUM" --merge
 git checkout main --quiet
-git pull --quiet origin main
+git pull --quiet "$REMOTE" main
 git branch -d "$BRANCH" --quiet 2>/dev/null || true
 
 gh release create "v${VERSION}" \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -293,11 +293,22 @@ echo ""
 
 echo "6/8 Merging and creating release..."
 gh pr merge "$PR_NUM" --merge --quiet 2>/dev/null || gh pr merge "$PR_NUM" --merge
-git checkout main --quiet
-git pull --quiet "$REMOTE" main
-git branch -d "$BRANCH" --quiet 2>/dev/null || true
+
+if [[ "$ON_RELEASE_BRANCH" == "true" ]]; then
+    # main is normally still checked out in the worktree this release branch
+    # was cut from; don't touch this worktree's checkout or delete the
+    # branch we're standing on. Just fetch the merge commit to tag it.
+    git fetch --quiet "$REMOTE" main
+    MERGE_SHA=$(git rev-parse FETCH_HEAD)
+else
+    git checkout main --quiet
+    git pull --quiet "$REMOTE" main
+    git branch -d "$BRANCH" --quiet 2>/dev/null || true
+    MERGE_SHA=$(git rev-parse main)
+fi
 
 gh release create "v${VERSION}" \
+    --target "$MERGE_SHA" \
     --title "v${VERSION} — ${SUMMARY}" \
     --notes "### Changed
 - ${SUMMARY}
@@ -305,6 +316,7 @@ gh release create "v${VERSION}" \
 **Full Changelog**: https://github.com/nyldn/claude-octopus/compare/v${CURRENT}...v${VERSION}" \
     --quiet 2>/dev/null || \
 gh release create "v${VERSION}" \
+    --target "$MERGE_SHA" \
     --title "v${VERSION} — ${SUMMARY}" \
     --notes "### Changed
 - ${SUMMARY}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -136,13 +136,14 @@ droid_count = len(list(droid_dir.glob('*.md'))) if droid_dir.is_dir() else 0
 manifest_path = pathlib.Path('.claude-plugin/plugin-manifest.json')
 manifest = json.loads(manifest_path.read_text())
 manifest['version'] = version
-components = manifest.get('components', {})
-components.get('commands', {})['count'] = command_count
-components.get('skills', {})['count'] = skill_count
-agents = components.get('agents', {})
+components = manifest.setdefault('components', {})
+components.setdefault('commands', {})['count'] = command_count
+components.setdefault('skills', {})['count'] = skill_count
+agents = components.setdefault('agents', {})
 agents['count'] = persona_count + droid_count
-agents.get('breakdown', {})['personas'] = persona_count
-agents.get('breakdown', {})['droids'] = droid_count
+breakdown = agents.setdefault('breakdown', {})
+breakdown['personas'] = persona_count
+breakdown['droids'] = droid_count
 manifest_path.write_text(json.dumps(manifest, indent=2) + '\n')
 print('   .claude-plugin/plugin-manifest.json')
 

--- a/tests/unit/test-release-sh-worktree-flow.sh
+++ b/tests/unit/test-release-sh-worktree-flow.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# tests/unit/test-release-sh-worktree-flow.sh
+# Regression tests for the release.sh worktree/branch/remote flow (issue #603).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RELEASE_SH="$PROJECT_ROOT/scripts/release.sh"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "release.sh worktree/branch/remote flow"
+
+test_remote_configurable() {
+    test_case "remote is configurable via OCTO_RELEASE_REMOTE, not hardcoded to origin"
+
+    if grep -q 'REMOTE="\${OCTO_RELEASE_REMOTE:-origin}"' "$RELEASE_SH" \
+        && ! grep -qE 'git (pull|push) .*\borigin\b' "$RELEASE_SH"; then
+        test_pass
+    else
+        test_fail "REMOTE var missing, or a git pull/push still hardcodes origin"
+    fi
+}
+
+test_preflight_accepts_release_branch() {
+    test_case "preflight accepts either main or the target release branch"
+
+    if grep -A 4 'CURRENT_BRANCH="\$(git branch --show-current)"' "$RELEASE_SH" \
+        | grep -q '"\$CURRENT_BRANCH" != "main" && "\$CURRENT_BRANCH" != "\$BRANCH"'; then
+        test_pass
+    else
+        test_fail "preflight branch check no longer allows the worktree-flow release branch"
+    fi
+}
+
+test_plugin_manifest_staged() {
+    test_case "plugin-manifest.json is version-bumped and staged"
+
+    if grep -q "plugin-manifest.json" "$RELEASE_SH" \
+        && grep -q "^git add" "$RELEASE_SH" \
+        && grep "^git add" "$RELEASE_SH" | grep -q "plugin-manifest.json"; then
+        test_pass
+    else
+        test_fail "plugin-manifest.json is not bumped/staged by the version-update step"
+    fi
+}
+
+test_post_merge_skips_checkout_on_release_branch() {
+    test_case "post-merge step fetches instead of checking out main when already on the release branch"
+
+    local merge_block
+    merge_block=$(awk '/# --- 6\. Merge \+ Release/,/^gh release create/' "$RELEASE_SH")
+
+    if echo "$merge_block" | grep -q 'ON_RELEASE_BRANCH" == "true"' \
+        && echo "$merge_block" | grep -q 'git fetch --quiet "\$REMOTE" main' \
+        && echo "$merge_block" | grep -q 'MERGE_SHA=\$(git rev-parse FETCH_HEAD)' \
+        && ! echo "$merge_block" | grep -B2 'git checkout main' | grep -q 'ON_RELEASE_BRANCH" == "true"'; then
+        test_pass
+    else
+        test_fail "post-merge step still unconditionally checks out main (breaks when main is checked out in another worktree)"
+    fi
+}
+
+test_release_targets_merge_sha() {
+    test_case "gh release create targets the resolved merge SHA"
+
+    if grep -q -- '--target "\$MERGE_SHA"' "$RELEASE_SH"; then
+        test_pass
+    else
+        test_fail "gh release create does not pin --target to MERGE_SHA"
+    fi
+}
+
+# Functional: reproduce the exact worktree scenario from RELEASING.md §0
+# (main checked out in one worktree, release/vX.Y.Z cut in another) and prove
+# the fetch+FETCH_HEAD approach release.sh now uses succeeds there, while the
+# git checkout main it replaced would fail.
+test_fetch_head_approach_works_when_main_checked_out_elsewhere() {
+    test_case "fetch+FETCH_HEAD resolves the merge SHA without touching main's checkout"
+
+    local sandbox
+    sandbox=$(mktemp -d)
+    local origin="$sandbox/origin.git"
+    local main_wt="$sandbox/main-worktree"
+    local release_wt="$sandbox/release-worktree"
+
+    (
+        set -e
+        git init --quiet --bare -b main "$origin"
+        git clone --quiet "$origin" "$main_wt" 2>/dev/null
+        cd "$main_wt"
+        git config user.email test@example.com
+        git config user.name "Test"
+        git commit --quiet --allow-empty -m "init"
+        git push --quiet origin main
+
+        # Cut the release branch in a second worktree, as RELEASING.md §0
+        # documents, while `main` stays checked out in $main_wt.
+        git worktree add --quiet -b release/v9.99.0 "$release_wt" origin/main
+
+        # Simulate the PR merge landing on main via a third clone (a real
+        # merge would come from GitHub; a push works the same for this test).
+        local merger="$sandbox/merger"
+        git clone --quiet "$origin" "$merger"
+        cd "$merger"
+        git config user.email test@example.com
+        git config user.name "Test"
+        git commit --quiet --allow-empty -m "chore: release v9.99.0"
+        git push --quiet origin main
+    ) || { test_fail "sandbox setup failed"; rm -rf "$sandbox"; return; }
+
+    local expected_sha
+    expected_sha=$(git -C "$origin" rev-parse main)
+
+    # This is the exact scenario the review comment flagged: main is
+    # checked out in $main_wt, so a checkout in $release_wt must fail.
+    if (cd "$release_wt" && git checkout main --quiet) 2>/dev/null; then
+        test_fail "test invariant broken: git checkout main unexpectedly succeeded while main was checked out elsewhere"
+        rm -rf "$sandbox"
+        return
+    fi
+
+    local resolved_sha
+    if ! resolved_sha=$(cd "$release_wt" && git fetch --quiet origin main && git rev-parse FETCH_HEAD); then
+        test_fail "git fetch + rev-parse FETCH_HEAD failed from the release worktree"
+        rm -rf "$sandbox"
+        return
+    fi
+
+    rm -rf "$sandbox"
+
+    if [[ "$resolved_sha" == "$expected_sha" ]]; then
+        test_pass
+    else
+        test_fail "resolved SHA ($resolved_sha) != merged main tip ($expected_sha)"
+    fi
+}
+
+test_remote_configurable
+test_preflight_accepts_release_branch
+test_plugin_manifest_staged
+test_post_merge_skips_checkout_on_release_branch
+test_release_targets_merge_sha
+test_fetch_head_approach_works_when_main_checked_out_elsewhere
+
+test_summary

--- a/tests/unit/test-release-sh-worktree-flow.sh
+++ b/tests/unit/test-release-sh-worktree-flow.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # tests/unit/test-release-sh-worktree-flow.sh
 # Regression tests for the release.sh worktree/branch/remote flow (issue #603).
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"

--- a/tests/unit/test-release-sh-worktree-flow.sh
+++ b/tests/unit/test-release-sh-worktree-flow.sh
@@ -80,8 +80,11 @@ test_release_targets_merge_sha() {
 test_fetch_head_approach_works_when_main_checked_out_elsewhere() {
     test_case "fetch+FETCH_HEAD resolves the merge SHA without touching main's checkout"
 
-    local sandbox
-    sandbox=$(mktemp -d)
+    local sandbox="/tmp/octopus-tests-$$-worktree"
+    rm -rf "$sandbox"
+    mkdir -p "$sandbox"
+    trap 'rm -rf "$sandbox"' RETURN
+
     local origin="$sandbox/origin.git"
     local main_wt="$sandbox/main-worktree"
     local release_wt="$sandbox/release-worktree"
@@ -109,7 +112,7 @@ test_fetch_head_approach_works_when_main_checked_out_elsewhere() {
         git config user.name "Test"
         git commit --quiet --allow-empty -m "chore: release v9.99.0"
         git push --quiet origin main
-    ) || { test_fail "sandbox setup failed"; rm -rf "$sandbox"; return; }
+    ) || { test_fail "sandbox setup failed"; return; }
 
     local expected_sha
     expected_sha=$(git -C "$origin" rev-parse main)
@@ -118,18 +121,14 @@ test_fetch_head_approach_works_when_main_checked_out_elsewhere() {
     # checked out in $main_wt, so a checkout in $release_wt must fail.
     if (cd "$release_wt" && git checkout main --quiet) 2>/dev/null; then
         test_fail "test invariant broken: git checkout main unexpectedly succeeded while main was checked out elsewhere"
-        rm -rf "$sandbox"
         return
     fi
 
     local resolved_sha
     if ! resolved_sha=$(cd "$release_wt" && git fetch --quiet origin main && git rev-parse FETCH_HEAD); then
         test_fail "git fetch + rev-parse FETCH_HEAD failed from the release worktree"
-        rm -rf "$sandbox"
         return
     fi
-
-    rm -rf "$sandbox"
 
     if [[ "$resolved_sha" == "$expected_sha" ]]; then
         test_pass

--- a/tests/unit/test-release-sh-worktree-flow.sh
+++ b/tests/unit/test-release-sh-worktree-flow.sh
@@ -25,8 +25,10 @@ test_remote_configurable() {
 test_preflight_accepts_release_branch() {
     test_case "preflight accepts either main or the target release branch"
 
-    if grep -A 4 'CURRENT_BRANCH="\$(git branch --show-current)"' "$RELEASE_SH" \
-        | grep -q '"\$CURRENT_BRANCH" != "main" && "\$CURRENT_BRANCH" != "\$BRANCH"'; then
+    local preflight_block
+    preflight_block="$(grep -A 4 'CURRENT_BRANCH="\$(git branch --show-current)"' "$RELEASE_SH" || true)"
+
+    if grep -q '"\$CURRENT_BRANCH" != "main" && "\$CURRENT_BRANCH" != "\$BRANCH"' <<< "$preflight_block"; then
         test_pass
     else
         test_fail "preflight branch check no longer allows the worktree-flow release branch"
@@ -37,8 +39,7 @@ test_plugin_manifest_staged() {
     test_case "plugin-manifest.json is version-bumped and staged"
 
     if grep -q "plugin-manifest.json" "$RELEASE_SH" \
-        && grep -q "^git add" "$RELEASE_SH" \
-        && grep "^git add" "$RELEASE_SH" | grep -q "plugin-manifest.json"; then
+        && grep -qE '^git add.*plugin-manifest\.json' "$RELEASE_SH"; then
         test_pass
     else
         test_fail "plugin-manifest.json is not bumped/staged by the version-update step"
@@ -48,13 +49,14 @@ test_plugin_manifest_staged() {
 test_post_merge_skips_checkout_on_release_branch() {
     test_case "post-merge step fetches instead of checking out main when already on the release branch"
 
-    local merge_block
+    local merge_block checkout_context
     merge_block=$(awk '/# --- 6\. Merge \+ Release/,/^gh release create/' "$RELEASE_SH")
+    checkout_context="$(grep -B2 'git checkout main' <<< "$merge_block" || true)"
 
-    if echo "$merge_block" | grep -q 'ON_RELEASE_BRANCH" == "true"' \
-        && echo "$merge_block" | grep -q 'git fetch --quiet "\$REMOTE" main' \
-        && echo "$merge_block" | grep -q 'MERGE_SHA=\$(git rev-parse FETCH_HEAD)' \
-        && ! echo "$merge_block" | grep -B2 'git checkout main' | grep -q 'ON_RELEASE_BRANCH" == "true"'; then
+    if grep -q 'ON_RELEASE_BRANCH" == "true"' <<< "$merge_block" \
+        && grep -q 'git fetch --quiet "\$REMOTE" main' <<< "$merge_block" \
+        && grep -q 'MERGE_SHA=\$(git rev-parse FETCH_HEAD)' <<< "$merge_block" \
+        && ! grep -q 'ON_RELEASE_BRANCH" == "true"' <<< "$checkout_context"; then
         test_pass
     else
         test_fail "post-merge step still unconditionally checks out main (breaks when main is checked out in another worktree)"


### PR DESCRIPTION
## Description
`scripts/release.sh` had three gaps versus the release flow documented in `RELEASING.md` (added in #601), all confirmed by reading the script directly:

1. **Hardcoded `origin`**: `git pull origin main` (release.sh:57) and `git push -u origin "$BRANCH"` (release.sh:207, pre-fix) assume `origin` is the canonical repo. In a dev clone where `origin` is a fork, this pulls/pushes against the wrong remote. Now configurable via `OCTO_RELEASE_REMOTE` (defaults to `origin`, so no behavior change for the common case).
2. **Required `main` branch**: release.sh:52-55 exited with "must be on main branch", but `RELEASING.md` §0 documents cutting the release branch in a separate worktree (`git worktree add <dir> -b release/<name> origin/main`) and running the script already checked out on it. The script now accepts either `main` or the target `release/vX.Y.Z` branch, and skips the redundant `git pull`/`git checkout -b` when already on the release branch.
3. **`.claude-plugin/plugin-manifest.json` never touched**: `RELEASING.md` §2 lists it as needing `version` + component counts, and the file's own `$comment` says it "must stay version-locked" with `plugin.json` — but release.sh never read or wrote it, and it wasn't in the `git add` list, so the bump was silently skipped every release (v9.52.0 was cut manually because of this). The version-bump step now updates `version`, `components.commands.count`, `components.skills.count`, and `components.agents.count`/`breakdown` (personas + droids), and stages the file.

## Type of Change
- [x] Bug fix

## Testing
- `bash -n scripts/*.sh scripts/lib/*.sh` — passes.
- No existing test targets `release.sh` directly. Extracted the modified "1/8 Updating version files" step and ran it standalone against a scratch copy of the actual repo tree (VERSION=9.51.1): confirmed `.claude-plugin/plugin-manifest.json` gets `version: "9.51.1"` and correct counts (`commands: 50, skills: 58, agents: {count: 42, breakdown: {personas: 32, droids: 10}}`), and that the resulting JSON is valid.
- `git diff origin/main...HEAD --summary | grep "mode change"` — empty, no exec-bit drift.
- Did not run the interactive PR/CI/merge portion of the script (steps 3-8) against this repo — that would create real branches/PRs/releases as a side effect of testing, which is out of scope for this fix.
- `make test-unit` was started but exceeded the time budget available in this session before completing; the change is confined to `scripts/release.sh`, which has no existing unit coverage, so the targeted verification above is the meaningful test surface for this diff.

## Related Issues
Closes #603

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4gMacU1AHE3tpCkYgqboE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release automation can run from `main` or directly from an existing release branch.
  * Release syncing now supports a configurable git remote, and GitHub PR/checks/release actions are scoped to it.
  * Plugin manifest updates now refresh release version and component/persona/droid/agent counts and breakdowns.
* **Bug Fixes**
  * Improved merge-and-release behavior when already on the release branch by targeting the release tag to the fetched `main` SHA.
  * Avoids redundant release branch creation and updates remote usage for push/pull operations.
* **Tests**
  * Added regression coverage for worktree/branch/remote flow, staging of the plugin manifest, and SHA targeting for release creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->