### PR TITLE
fix: council roster records dispatch-resolved model, not the persona pin

### DIFF
--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -917,7 +917,7 @@ council_roster_contains() {
 council_roster_entry_json() {
     local persona="$1"
     local provider="${2:-}"
-    local preferred_provider provider_org model seat benchmark_signal score permission_mode family
+    local preferred_provider provider_org model seat benchmark_signal score permission_mode family dispatch_model
 
     preferred_provider="$(council_persona_default_provider "$persona")"
     [[ -n "$provider" ]] || provider="$(council_pick_provider "$preferred_provider")"
@@ -928,6 +928,22 @@ council_roster_entry_json() {
     # the placeholder, so the seat's cross-lab lineage is verifiable from the artifact.
     if [[ "$provider" == "agy" ]] && declare -f agy_current_model >/dev/null 2>&1; then
         model="$(agy_current_model)"
+    elif declare -f get_agent_model >/dev/null 2>&1; then
+        # The same lineage principle applies to every other provider: the council
+        # dispatch path never reads the persona's configured model
+        # (council_dispatch_member passes only provider+persona; run_agent_sync
+        # resolves the model via get_agent_model from env/providers.json). So when
+        # org-diversity or availability seats a persona on a provider other than
+        # its configured one, the persona pin names a model this seat will never
+        # run — and the wrong value also feeds benchmark_signal and score below,
+        # scoring the seat against the wrong model. Record dispatch's own
+        # resolution instead (issue #599 problem 3: a codex seat recorded as
+        # claude-opus-4.6 while its rollout log showed a GPT model ran). Fall back
+        # to the persona pin only when the resolver isn't loaded (council.sh
+        # sourced standalone in unit tests).
+        if dispatch_model="$(get_agent_model "$provider" "council" "$persona" 2>/dev/null)" && [[ -n "$dispatch_model" ]]; then
+            model="$dispatch_model"
+        fi
     fi
     seat="$(council_persona_seat "$persona")"
     family="$(council_persona_family "$persona")"

--- a/tests/unit/test-council-model-selection-fixes.sh
+++ b/tests/unit/test-council-model-selection-fixes.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Regression tests for PR #600: agy model-validation stdin leak and the
-# council_pick_provider diversity short-circuit. Both tests fail on the
-# pre-#600 code (verified during review) — they are not string greps.
+# Regression tests for PR #600 (agy model-validation stdin leak, the
+# council_pick_provider diversity short-circuit) and issue #599 problem 3
+# (roster entries recording the persona's pinned model instead of the model
+# dispatch actually resolves for the seated provider). Every test fails on
+# the corresponding pre-fix code (verified) — they are not string greps.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -103,6 +105,59 @@ if [[ "$out" == "claude" || "$out" == "opencode" ]]; then
     test_pass
 else
     test_fail "expected an available provider from the any-available fallback, got '$out'"
+fi
+
+# ── roster model lineage (issue #599 problem 3) ────────────────────────────
+# council_roster_entry_json recorded council_persona_model (the persona's
+# configured pin) even when seating placed the persona on a different
+# provider, so summary.json/config.json could label a seat with a model it
+# never ran — and benchmark_signal/score were computed against that wrong
+# model. Post-fix the entry records the same resolution dispatch uses
+# (get_agent_model provider/council/persona), with the persona pin kept only
+# as the fallback when the resolver isn't loaded. The stubs isolate the
+# behavior from the repo's live agents/config.yaml and providers.json.
+roster_entry_model() {
+    local persona="$1" provider="$2" mode="$3"
+    bash -c '
+        log() { :; }
+        source "'"$PROJECT_ROOT"'/scripts/lib/council.sh" 2>/dev/null
+        COUNCIL_ROSTER_JSON="[]"
+        council_agent_config_value() {
+            [[ "$2" == "model" ]] && echo "persona-pinned-model"
+            return 0
+        }
+        case "$3" in
+            *resolver*) get_agent_model() { echo "dispatch-resolved-model"; } ;;
+        esac
+        case "$3" in
+            *agy*) agy_current_model() { echo "agy-actual-model"; } ;;
+        esac
+        council_roster_entry_json "$1" "$2" | jq -r .model
+    ' _ "$persona" "$provider" "$mode"
+}
+
+test_case "seat records the dispatch-resolved model, not the persona pin"
+out=$(roster_entry_model security-auditor opencode resolver)
+if [[ "$out" == "dispatch-resolved-model" ]]; then
+    test_pass
+else
+    test_fail "roster recorded '$out' — persona pin leaked into the seat artifact (lineage regressed)"
+fi
+
+test_case "persona pin remains the fallback when the dispatch resolver is not loaded"
+out=$(roster_entry_model security-auditor opencode plain)
+if [[ "$out" == "persona-pinned-model" ]]; then
+    test_pass
+else
+    test_fail "expected persona-pinned-model without a resolver, got '$out'"
+fi
+
+test_case "agy seat still records agy_current_model, not the generic resolver"
+out=$(roster_entry_model backend-architect agy "resolver agy")
+if [[ "$out" == "agy-actual-model" ]]; then
+    test_pass
+else
+    test_fail "expected agy-actual-model (agy carve-out), got '$out'"
 fi
 
 test_summary

--- a/tests/unit/test-council-model-selection-fixes.sh
+++ b/tests/unit/test-council-model-selection-fixes.sh
@@ -116,6 +116,11 @@ fi
 # (get_agent_model provider/council/persona), with the persona pin kept only
 # as the fallback when the resolver isn't loaded. The stubs isolate the
 # behavior from the repo's live agents/config.yaml and providers.json.
+# The resolver stub records its received arguments to a file (the stub runs in
+# the bash -c subshell, so a variable would not survive back to this shell) —
+# letting the call-site's argument order/values be asserted, not just the
+# return-value plumbing.
+GET_AGENT_MODEL_ARGS_FILE="$TEST_TMP_DIR/get-agent-model-args.txt"
 roster_entry_model() {
     local persona="$1" provider="$2" mode="$3"
     bash -c '
@@ -127,7 +132,11 @@ roster_entry_model() {
             return 0
         }
         case "$3" in
-            *resolver*) get_agent_model() { echo "dispatch-resolved-model"; } ;;
+            *resolver-empty*) get_agent_model() { return 1; } ;;
+            *resolver*) get_agent_model() {
+                printf "%s|%s|%s\n" "$1" "$2" "$3" > "'"$GET_AGENT_MODEL_ARGS_FILE"'"
+                echo "dispatch-resolved-model"
+            } ;;
         esac
         case "$3" in
             *agy*) agy_current_model() { echo "agy-actual-model"; } ;;
@@ -137,11 +146,22 @@ roster_entry_model() {
 }
 
 test_case "seat records the dispatch-resolved model, not the persona pin"
+rm -f "$GET_AGENT_MODEL_ARGS_FILE"
 out=$(roster_entry_model security-auditor opencode resolver)
 if [[ "$out" == "dispatch-resolved-model" ]]; then
     test_pass
 else
     test_fail "roster recorded '$out' — persona pin leaked into the seat artifact (lineage regressed)"
+fi
+
+test_case "resolver is called with the seated provider, the council phase, and the persona as role"
+# Pins the call-site contract: get_agent_model(provider, "council", persona) —
+# the same tuple run_agent_sync resolves with, which is the symmetry the fix
+# claims. An argument-order regression would silently resolve the wrong model.
+if [[ "$(cat "$GET_AGENT_MODEL_ARGS_FILE" 2>/dev/null)" == "opencode|council|security-auditor" ]]; then
+    test_pass
+else
+    test_fail "expected opencode|council|security-auditor, got '$(cat "$GET_AGENT_MODEL_ARGS_FILE" 2>/dev/null)'"
 fi
 
 test_case "persona pin remains the fallback when the dispatch resolver is not loaded"
@@ -150,6 +170,14 @@ if [[ "$out" == "persona-pinned-model" ]]; then
     test_pass
 else
     test_fail "expected persona-pinned-model without a resolver, got '$out'"
+fi
+
+test_case "persona pin is used when the loaded resolver fails or returns empty"
+out=$(roster_entry_model security-auditor opencode resolver-empty)
+if [[ "$out" == "persona-pinned-model" ]]; then
+    test_pass
+else
+    test_fail "expected persona-pinned-model when resolver returns non-zero/empty, got '$out'"
 fi
 
 test_case "agy seat still records agy_current_model, not the generic resolver"


### PR DESCRIPTION
## What?

Makes each council seat's recorded model in `summary.json`/`config.json` the model dispatch will actually run for that seat's provider, instead of the persona's configured pin. This is problem 3 from #599, which #600 deliberately left open pending a direction.

## Why?

After a real 3-seat council run (codex, agy, opencode), my summary.json said the codex chair ran `claude-opus-4.6` and the opencode skeptic ran `gpt-5.6-sol`. The providers' own session logs showed what actually ran: `gpt-5.6-sol` (codex rollout log) and `glm-5.2` (opencode.log). The recorded labels come from each persona's configured model, which seating ignores — so whenever org-diversity or availability moves a persona onto a different provider, the run's own artifact names a model the seat never touched. That breaks cost attribution and any "what actually ran" verification, and the same wrong model feeds `benchmark_signal` and the seat score, so seat scoring is computed against the wrong model too.

## How?

The roster entry now asks the dispatch path's own resolver (`get_agent_model`, the same call `run_agent_sync` records) what the seated provider will run. The persona pin remains only as the fallback when the resolver isn't loaded (council.sh sourced standalone in unit tests), and the existing agy carve-out (`agy_current_model`) is unchanged.

## Testing?

- Three regression tests added to `tests/unit/test-council-model-selection-fixes.sh`. The lineage case fails on pre-fix code with exactly the observed symptom (persona pin leaking into the seat artifact); the other two pin the fallback and the agy carve-out so the fix can't regress them.
- Council suites green (8/8 model-selection, 56/56 council command); `make ci-local` green.
- Live validation: re-ran the same 3-provider council against the patched code; every seat's recorded model now matches its provider's own session log.

## Anything Else?

I used Claude Code to trace the mechanism (`council_roster_entry_json` copies `council_persona_model`; `council_dispatch_member` passes only provider+persona to `run_agent_sync`, so the pin never reaches dispatch) and to draft the fix and tests. The live mismatch and the post-fix validation were both checked against each CLI's own session logs rather than the run's self-report.

Follow-up to the problem-3 thread in #599 — thanks for the quick turnaround on #600.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Council roster entries now store the dispatch-resolved model when available, improving benchmark and scoring consistency.
  * Added robust fallback to the persona-pinned model when model resolution is missing or fails.
  * Preserved special handling for the current AGY model selection.
* **Tests**
  * Added/expanded regression coverage for model lineage, including resolver invocation validation, fallback behavior, and AGY vs non-AGY selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->