### PR TITLE
fix: agy adapter delivers the prompt as --print's argument, not stdin

### DIFF
--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Antigravity CLI stdin adapter.
+# Antigravity CLI stdin-to-argument adapter.
 #
 # This intentionally stays a thin, env-driven adapter. It does NOT implement a
 # model-fallback chain or an error classifier the way the Gemini adapter does:
@@ -7,6 +7,14 @@
 # unauthenticated on a given box), and forcing a specific --model pushes agy onto
 # an exhaustible quota group. The only added robustness is provider-agnostic — a
 # single replay-from-cached-stdin retry on a silent-empty success.
+#
+# Prompt delivery: current agy takes the prompt as --print's ARGUMENT VALUE and
+# ignores stdin in print mode; with `--print` placed before other flags, agy
+# reads the NEXT FLAG as the message. Empirically probed 2026-07-11: piping the
+# prompt to `agy --print --sandbox ...` delivers no task at all — the seat then
+# answers from its own instruction-file context instead of the council prompt.
+# So this adapter still ACCEPTS the prompt on stdin (the dispatch contract),
+# but hands it to agy as the --print value, with all other flags placed first.
 set -euo pipefail
 
 # Default to "default" → don't pass --model, so agy uses the model you picked in
@@ -20,9 +28,11 @@ print_timeout="${OCTOPUS_AGY_PRINT_TIMEOUT:-5m0s}"
 # --dangerously-skip-permissions: auto-approve agy's folder-trust + tool prompts so
 # council seats don't block on a per-worktree trust prompt (already --sandbox'd).
 # OCTOPUS_AGY_SANDBOX=off drops the sandbox restriction; the default keeps it on.
-cmd=(agy --print --sandbox --dangerously-skip-permissions --print-timeout "$print_timeout")
+# NOTE: --print is deliberately NOT in this array — it must come LAST with the
+# prompt as its value (see prompt-delivery note in the header).
+cmd=(agy --sandbox --dangerously-skip-permissions --print-timeout "$print_timeout")
 if [[ "${OCTOPUS_AGY_SANDBOX:-on}" == "off" ]]; then
-    cmd=(agy --print --dangerously-skip-permissions --print-timeout "$print_timeout")
+    cmd=(agy --dangerously-skip-permissions --print-timeout "$print_timeout")
 fi
 
 # Model-pin guard adopted from #555: query-free, treats agy/default as "no pin".
@@ -43,8 +53,9 @@ if [[ -n "${OCTOPUS_AGY_INCLUDE_DIRS:-}" ]]; then
     done
 fi
 
-# agy --print reads the prompt from stdin; cache it so a retry can replay it
-# (stdin is consumed once). Buffer stdout to a file to preserve output fidelity.
+# The dispatch contract still delivers the prompt on OUR stdin; cache it so a
+# retry can replay it (stdin is consumed once) and so it can be handed to agy as
+# the --print argument. Buffer stdout to a file to preserve output fidelity.
 prompt_file=""
 stdout_file=$(mktemp -t "octo-agy-stdout.XXXXXX")
 trap 'rm -f "${prompt_file:-}" "${stdout_file:-}"' EXIT
@@ -57,13 +68,26 @@ if [[ ! -t 0 ]]; then
     cat > "$prompt_file"
 fi
 
+# No prompt on stdin = nothing to dispatch. Fail loudly rather than invoking agy
+# promptless — a promptless print-mode agy answers from its own instruction-file
+# context, which is precisely the silent-degenerate-seat failure this adapter
+# exists to prevent.
+if [[ -z "$prompt_file" || ! -s "$prompt_file" ]]; then
+    echo "agy-exec.sh: no prompt received on stdin; refusing to dispatch a promptless seat" >&2
+    exit 2
+fi
+
+# Single-argument size ceiling: Linux caps one argv string at MAX_ARG_STRLEN
+# (128 KiB). A council prompt exceeding it would fail exec with a cryptic E2BIG,
+# so check first and fail with a message that names the actual problem.
+if (( $(wc -c < "$prompt_file") > 120000 )); then
+    echo "agy-exec.sh: prompt exceeds ~120KB (single-argv ceiling for agy --print); trim the dispatch context" >&2
+    exit 2
+fi
+
 run_agy() {
     : > "$stdout_file"
-    if [[ -n "$prompt_file" ]]; then
-        "${cmd[@]}" < "$prompt_file" > "$stdout_file"
-    else
-        "${cmd[@]}" > "$stdout_file"
-    fi
+    "${cmd[@]}" --print "$(<"$prompt_file")" > "$stdout_file"
 }
 
 set +e

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -28,12 +28,15 @@ print_timeout="${OCTOPUS_AGY_PRINT_TIMEOUT:-5m0s}"
 # --dangerously-skip-permissions: auto-approve agy's folder-trust + tool prompts so
 # council seats don't block on a per-worktree trust prompt (already --sandbox'd).
 # OCTOPUS_AGY_SANDBOX=off drops the sandbox restriction; the default keeps it on.
+# Built incrementally so the sandbox toggle can't drift out of lockstep with the
+# shared flags (this PR had to edit two duplicate array literals in step).
 # NOTE: --print is deliberately NOT in this array — it must come LAST with the
 # prompt as its value (see prompt-delivery note in the header).
-cmd=(agy --sandbox --dangerously-skip-permissions --print-timeout "$print_timeout")
-if [[ "${OCTOPUS_AGY_SANDBOX:-on}" == "off" ]]; then
-    cmd=(agy --dangerously-skip-permissions --print-timeout "$print_timeout")
+cmd=(agy)
+if [[ "${OCTOPUS_AGY_SANDBOX:-on}" != "off" ]]; then
+    cmd+=(--sandbox)
 fi
+cmd+=(--dangerously-skip-permissions --print-timeout "$print_timeout")
 
 # Model-pin guard adopted from #555: query-free, treats agy/default as "no pin".
 case "$model" in
@@ -71,8 +74,13 @@ fi
 # No prompt on stdin = nothing to dispatch. Fail loudly rather than invoking agy
 # promptless — a promptless print-mode agy answers from its own instruction-file
 # context, which is precisely the silent-degenerate-seat failure this adapter
-# exists to prevent.
-if [[ -z "$prompt_file" || ! -s "$prompt_file" ]]; then
+# exists to prevent. Read the content once here: $(<file) strips trailing
+# whitespace, so a whitespace-only payload would pass a byte-size (-s) check yet
+# still hand agy an empty --print value — the stripped content, not the file
+# size, is what must be non-empty.
+prompt_content=""
+[[ -n "$prompt_file" ]] && prompt_content="$(<"$prompt_file")"
+if [[ -z "${prompt_content//[[:space:]]/}" ]]; then
     echo "agy-exec.sh: no prompt received on stdin; refusing to dispatch a promptless seat" >&2
     exit 2
 fi
@@ -80,14 +88,14 @@ fi
 # Single-argument size ceiling: Linux caps one argv string at MAX_ARG_STRLEN
 # (128 KiB). A council prompt exceeding it would fail exec with a cryptic E2BIG,
 # so check first and fail with a message that names the actual problem.
-if (( $(wc -c < "$prompt_file") > 120000 )); then
+if (( ${#prompt_content} > 120000 )); then
     echo "agy-exec.sh: prompt exceeds ~120KB (single-argv ceiling for agy --print); trim the dispatch context" >&2
     exit 2
 fi
 
 run_agy() {
     : > "$stdout_file"
-    "${cmd[@]}" --print "$(<"$prompt_file")" > "$stdout_file"
+    "${cmd[@]}" --print "$prompt_content" > "$stdout_file"
 }
 
 set +e

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -35,8 +35,11 @@ test_agy_available_agent() {
 test_agy_dispatch_native_flags() {
     test_case "dispatch.sh uses native agy helper"
 
+    # The adapter builds flags first (agy --sandbox ...) and appends --print
+    # LAST with the prompt as its argument — current agy ignores stdin in print
+    # mode, and a leading --print would eat the next flag as the message.
     if grep -q 'scripts/helpers/agy-exec.sh' "$PROJECT_ROOT/scripts/lib/dispatch.sh" && \
-       grep -q 'agy --print --sandbox' "$PROJECT_ROOT/scripts/helpers/agy-exec.sh"; then
+       grep -q 'agy --sandbox' "$PROJECT_ROOT/scripts/helpers/agy-exec.sh"; then
         test_pass
     else
         test_fail "agy dispatch should use scripts/helpers/agy-exec.sh"
@@ -154,20 +157,27 @@ JSON
         return
     fi
 
-    OCTOPUS_AGY_MODEL='agy/default' bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" </dev/null
+    # The adapter refuses promptless dispatch (a promptless print-mode agy
+    # answers from its own instruction-file context — the degenerate-seat
+    # failure), so every invocation must pipe a prompt.
+    printf 'ping' | OCTOPUS_AGY_MODEL='agy/default' bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh"
     if grep -q -- '--model' "$capture"; then
         restore_agy_dynamic_model_env
         test_fail "agy/default should not be passed to agy --model"
         return
     fi
 
-    OCTOPUS_AGY_MODEL='Gemini 3.5 Flash (Low)' bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" </dev/null
-    if grep -Fxq -- '--model' "$capture" && grep -Fxq -- 'Gemini 3.5 Flash (Low)' "$capture"; then
+    printf 'ping' | OCTOPUS_AGY_MODEL='Gemini 3.5 Flash (Low)' bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh"
+    # 'ping' appearing in argv is the discriminating check for prompt-as-argument
+    # delivery: pre-fix, the prompt went to stdin (which agy ignores) and never
+    # reached argv, so this fails on the pre-fix adapter.
+    if grep -Fxq -- '--model' "$capture" && grep -Fxq -- 'Gemini 3.5 Flash (Low)' "$capture" && \
+       grep -Fxq -- '--print' "$capture" && grep -Fxq -- 'ping' "$capture"; then
         restore_agy_dynamic_model_env
         test_pass
     else
         restore_agy_dynamic_model_env
-        test_fail "explicit agy model labels should be passed as one --model argument"
+        test_fail "explicit agy model labels should be one --model argument and the prompt must reach argv via --print"
     fi
 }
 test_agy_command_validation() {

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -35,14 +35,16 @@ test_agy_available_agent() {
 test_agy_dispatch_native_flags() {
     test_case "dispatch.sh uses native agy helper"
 
-    # The adapter builds flags first (agy --sandbox ...) and appends --print
-    # LAST with the prompt as its argument — current agy ignores stdin in print
-    # mode, and a leading --print would eat the next flag as the message.
+    # The adapter builds flags incrementally from a bare `agy` and appends
+    # --print LAST with the prompt as its argument — current agy ignores stdin
+    # in print mode, and a leading --print would eat the next flag as the
+    # message.
     if grep -q 'scripts/helpers/agy-exec.sh' "$PROJECT_ROOT/scripts/lib/dispatch.sh" && \
-       grep -q 'agy --sandbox' "$PROJECT_ROOT/scripts/helpers/agy-exec.sh"; then
+       grep -q 'cmd=(agy)' "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" && \
+       grep -q -- '--print "$prompt_content"' "$PROJECT_ROOT/scripts/helpers/agy-exec.sh"; then
         test_pass
     else
-        test_fail "agy dispatch should use scripts/helpers/agy-exec.sh"
+        test_fail "agy dispatch should use scripts/helpers/agy-exec.sh with the prompt as --print's argument"
     fi
 }
 
@@ -159,7 +161,18 @@ JSON
 
     # The adapter refuses promptless dispatch (a promptless print-mode agy
     # answers from its own instruction-file context — the degenerate-seat
-    # failure), so every invocation must pipe a prompt.
+    # failure), so every invocation must pipe a prompt. Whitespace-only stdin
+    # must count as promptless too: $(<file) strips trailing whitespace, so a
+    # byte-size check alone would pass '\n' through as an empty --print value.
+    : > "$capture"
+    local ws_rc=0
+    printf '\n  \n' | bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" 2>/dev/null || ws_rc=$?
+    if [[ "$ws_rc" -ne 2 || -s "$capture" ]]; then
+        restore_agy_dynamic_model_env
+        test_fail "whitespace-only stdin should be refused as promptless (rc=$ws_rc)"
+        return
+    fi
+
     printf 'ping' | OCTOPUS_AGY_MODEL='agy/default' bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh"
     if grep -q -- '--model' "$capture"; then
         restore_agy_dynamic_model_env


### PR DESCRIPTION
## What?

Makes `agy-exec.sh` hand the prompt to agy as `--print`'s argument value instead of piping it to stdin, with all other flags placed before `--print`. Adds a loud failure for promptless invocation and for prompts over the single-argv kernel ceiling.

## Why?

Current agy ignores stdin in print mode and takes the prompt as `--print`'s argument — and with `--print` placed first, agy reads the next flag (`--sandbox`) as the message. So every agy council seat was dispatched with no task at all. The seat then answers from whatever context it does have, which is worse than an error: I got plausible-looking responses that never addressed the council task, they counted toward quorum, and nothing flagged them. On my box the tell was the seat returning a summary of its own instruction-file context instead of the task; a probe through the old shape reproduced it, and the same prompt through the new shape returned exactly the requested output.

## How?

The adapter's dispatch contract is unchanged — it still accepts the prompt on its own stdin — but it now caches stdin and passes it as the `--print` value. Two guards ride along: promptless invocation exits with a named error instead of dispatching a degenerate seat, and prompts over ~120KB fail with a message naming the real problem (Linux caps a single argv string at 128KiB, which would otherwise surface as a cryptic E2BIG).

## Testing?

- `tests/unit/test-agy-provider.sh` updated to the new contract; the argv-capture assertion now requires the prompt to reach argv via `--print` — verified this discriminating check fails on the pre-fix adapter (prompt went to stdin, never reached argv).
- Full suite green locally (`make ci-local`, 169/169).
- Live validation: a 3-provider council (codex, agy, opencode) that previously produced task-free agy responses ran end to end with the patched adapter — the agy seat answered the dispatched task in its requested format.

## Anything Else?

I used Claude Code to trace this: the seat's off-task responses led to the adapter, and an empirical probe of the current agy CLI's flag handling (`--print` first eats the following flag as the message; stdin ignored) confirmed the delivery gap. Related to my #607/#608 in the sense that all three surfaced from the same council runs, but independent in mechanism — this one is purely about prompt delivery to the agy subprocess.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Antigravity command execution so prompt content is always passed reliably and `--print` is handled consistently.
  * Added early validation to block empty (whitespace-only) prompts and to reject overly large prompt payloads.
  * Preserved retry behavior for silent/empty-success runs, now using the same cached prompt/output checks.
  * Tightened dispatch behavior for sandbox and model argument handling.
* **Tests**
  * Updated unit tests to assert correct flag ordering and stricter prompt delivery and argv validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->