### PR TITLE
fix: clarify provider docs and harden release metadata sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Repository review follow-ups**: clarified README provider counting and cost assumptions, routed marketplace-sync errors through the script logger, and made release manifest updates portable while keeping browse-manifest hook and routine counts current.
+
 ## [9.52.0] - 2026-07-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐙 Claude Octopus
 
-Every AI model has blind spots. Claude Octopus puts up to ten of them on every task, so blind spots surface before you ship — not after. It orchestrates Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok alongside Claude Code, with consensus gates that flag any disagreements.
+Every AI model has blind spots. Claude Octopus supports ten external provider integrations — Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok — alongside the built-in Claude Code host, with consensus gates that flag disagreements before you ship.
 
 **Claude-native first, Octopus for escalation.** Use Claude-native `/init`, `/review`, and `/security-review` when Claude is enough. Use Octopus when you want multiple model opinions, adversarial review, or stricter multi-LLM workflows.
 
@@ -16,7 +16,7 @@ Every AI model has blind spots. Claude Octopus puts up to ten of them on every t
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
 
-🐙 **Research, build, review, and ship — with ten AI providers checking each other's work.** Say what you need, and the right workflow runs. Claude-native handles the ordinary path; Octopus handles the escalated path. A 75% consensus gate catches disagreements before they reach production. No single model's blind spots slip through.
+🐙 **Research, build, review, and ship — with ten external providers checking the host's work.** Say what you need, and the right workflow runs. Claude-native handles the ordinary path; Octopus handles the escalated path. A 75% consensus gate catches disagreements before they reach production. No single model's blind spots slip through.
 
 🧠 **Remembers across sessions.** Integrates with [claude-mem](https://github.com/thedotmack/claude-mem) and [agentmemory](https://github.com/rohitg00/agentmemory) for persistent memory — past decisions, research, and context survive session boundaries.
 
@@ -26,7 +26,7 @@ Every AI model has blind spots. Claude Octopus puts up to ten of them on every t
 
 🐙 **32 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **50 commands** (slash commands you type), **58 skills** (reusable workflow modules). Say "audit my API" and the right expert activates. Don't know the command? The smart router figures it out.
 
-🐙 **Works with just Claude. Scales to ten.** Zero providers needed to start. Add them one at a time — each activates automatically when detected.
+🐙 **Works with just Claude. Adds up to ten external provider integrations.** Zero external providers are needed to start. Add them one at a time — each activates automatically when detected.
 
 💰 **Five providers cost nothing extra when you already have access.** Codex, Gemini, Antigravity CLI, and Copilot use existing subscriptions or local auth. Ollama runs locally for free. Qwen now requires API-key or Coding-Plan auth; its free OAuth tier ended on 2026-04-15.
 
@@ -52,7 +52,7 @@ Every AI model has blind spots. Claude Octopus puts up to ten of them on every t
 |---------|--------------|
 | **v9.50** (new) | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (Opus 4.8, 1M context), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
-| **v9** (current) | Up to 9 providers (Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode). Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 175+ CC feature flags through v2.1.157, including Opus 4.8 and dynamic workflow awareness. |
+| **v9** (current) | Up to 10 external provider integrations (Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 175+ CC feature flags through v2.1.157, including Opus 4.8 and dynamic workflow awareness. |
 | **v8** | Multi-LLM code review with inline PR comments. Parallel workstreams in isolated git worktrees. Reaction engine — auto-responds to CI failures. 32 specialized personas. Dark Factory autonomous pipeline. |
 | **v7** | Double Diamond workflow. Multi-provider dispatch. Quality gates and consensus scoring. Configurable sandbox modes. |
 
@@ -316,8 +316,8 @@ Or skip the table — type `/octo:auto <what you want>` or just say `octo <what 
 
 | | Claude Code alone | [Superpowers](https://github.com/obra/superpowers) | Claude Octopus |
 |---|---|---|---|
-| **Core idea** | One model, your prompts | Structured methodology for one agent | Up to 9 providers cross-checking each other |
-| **Providers** | Claude only | Claude only | Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode |
+| **Core idea** | One model, your prompts | Structured methodology for one agent | Built-in Claude plus up to 10 external integrations cross-checking each other |
+| **Providers** | Claude only | Claude only | Claude host; Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, Grok |
 | **Workflow** | Ad-hoc | Spec → plan → subagent-driven dev | Discover → Define → Develop → Deliver (Double Diamond) |
 | **Strength** | Simple, no setup | Long autonomous runs with discipline | Multiple perspectives catching blind spots |
 | **Consensus gates** | No | No | Yes — 75% agreement threshold |
@@ -332,9 +332,9 @@ Or skip the table — type `/octo:auto <what you want>` or just say `octo <what 
 
 ## How It Works
 
-### How 10 Providers Work Together
+### How 10 External Providers Work Together
 
-Claude Octopus coordinates up to ten AI providers:
+Claude Octopus coordinates ten external provider integrations alongside the built-in Claude Code host. The optional `claude-sdk` route is a second Anthropic seat, so it is shown below but is not counted as a separate provider family.
 
 | Provider | Role |
 |----------|------|
@@ -346,9 +346,10 @@ Claude Octopus coordinates up to ten AI providers:
 | 🟢 Copilot (GitHub) | Zero-cost research — uses existing GitHub Copilot subscription |
 | 🟤 Qwen (Alibaba) | Qwen3-Coder research via API-key or Coding-Plan auth |
 | ⚫ Ollama (Local) | Zero-cost local LLM — offline, privacy-sensitive, fallback |
+| 🟠 OpenCode | Alternate coding-agent integration and cross-checking seat |
 | ⚡ Grok (xAI, via cursor-agent) | Frontier-model second opinion — added as a first-class seat in v9.48 |
 | 🔵 Claude (Anthropic, Opus 4.8 + Sonnet 4.6) | Architecture, strategy, security review, orchestration, consensus, final synthesis |
-| 🔵 Claude Agent SDK seat (`claude-sdk`) | Opus 4.8 with the 1M-token context window, independent of the host session (set `CLAUDE_SDK_API_KEY`) |
+| 🔵 Claude Agent SDK seat (`claude-sdk`) | Optional second Anthropic seat: Opus 4.8 with the 1M-token context window, independent of the host session (set `CLAUDE_SDK_API_KEY`) |
 
 Providers run in parallel for research, sequentially for problem scoping, and adversarially for review. A 75% consensus quality gate prevents questionable work from shipping. Only Claude is required — all others are optional and auto-detected.
 
@@ -423,14 +424,16 @@ OAuth users pay nothing beyond their existing subscriptions. Qwen is the excepti
 
 ### What a Typical Run Costs
 
-Rough per-run estimates on API-key billing at current rates (GPT-5.5 $5/$30, Gemini 3.1 Pro $2.50/$10, Sonar Pro $3/$15, Opus 4.8 $5/$25 per MTok). OAuth/subscription seats (Codex via ChatGPT, Gemini via Google account, Antigravity, Copilot) bill nothing extra; Ollama is free. Numbers scale with prompt size — treat them as order-of-magnitude.
+Illustrative token-only estimates, using standard global API rates checked **2026-07-13**: [GPT-5.5](https://developers.openai.com/api/docs/models/gpt-5.5) $5/$30, [Gemini 3.1 Pro Preview](https://ai.google.dev/gemini-api/docs/pricing) $2/$12 for prompts through 200K tokens and $4/$18 for prompts over 200K, [Sonar Pro](https://docs.perplexity.ai/docs/getting-started/pricing) $3/$15, and [Opus 4.8](https://www.anthropic.com/news/claude-opus-4-8) $5/$25 per million input/output tokens. The ranges assume roughly 90% input and 10% output tokens, standard (not batch, flex, priority, or fast) processing, no cache discounts, and a representative mix of those models. OAuth/subscription seats (Codex via ChatGPT, Gemini via Google account, Antigravity, Copilot) bill nothing extra; Ollama is free.
 
-| Run | Typical volume | API-key cost range |
-|-----|----------------|--------------------|
-| Single probe / quick question (one provider) | 5-20K tokens | $0.01-0.15 |
-| Debate (2-3 providers, multi-round) | 30-80K tokens | $0.20-0.80 |
-| Council (4-6 seats + synthesis) | 60-150K tokens | $0.50-2.00 |
-| Full embrace (4 phases, multi-provider) | 150-400K tokens | $1.00-5.00 |
+The table excludes provider tool charges. Sonar Pro adds a **request fee** of $6-$14 per 1,000 requests depending on search-context size; Gemini search grounding can add query fees after its included allowance. GPT-5.5 sessions above 272K input tokens and Gemini prompts over 200K use higher long-context rates, so large runs can exceed the upper range. Treat these as planning bounds and check the linked rate cards before material spend.
+
+| Run | Typical volume | Illustrative API token cost (tool fees excluded) |
+|-----|----------------|-----------------------------------------------|
+| Single probe / quick question (one provider) | 5-20K tokens | $0.01-0.20 |
+| Debate (2-3 providers, multi-round) | 30-80K tokens | $0.20-1.00 |
+| Council (4-6 seats + synthesis) | 60-150K tokens | $0.50-2.50 |
+| Full embrace (4 phases, multi-provider) | 150-400K tokens | $1.00-6.00+ |
 
 Before an expensive run, `/octo:costs` shows a session cost projection; after runs, `/octo:usage` breaks down actual spend per provider and skill. Anything projected over $1 is called out before dispatch.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -136,21 +136,18 @@ if persona_count == 0:
     raise SystemExit(1)
 
 droid_dir = pathlib.Path('agents/droids')
-droid_count = len(list(droid_dir.glob('*.md'))) if droid_dir.is_dir() else 0
+if not droid_dir.is_dir():
+    print('ERROR: agents/droids is missing; cannot calculate browse manifest counts', file=sys.stderr)
+    raise SystemExit(1)
+droid_count = len(list(droid_dir.glob('*.md')))
 
-manifest_path = pathlib.Path('.claude-plugin/plugin-manifest.json')
-manifest = json.loads(manifest_path.read_text())
-manifest['version'] = version
-components = manifest.setdefault('components', {})
-components.setdefault('commands', {})['count'] = command_count
-components.setdefault('skills', {})['count'] = skill_count
-agents = components.setdefault('agents', {})
-agents['count'] = persona_count + droid_count
-breakdown = agents.setdefault('breakdown', {})
-breakdown['personas'] = persona_count
-breakdown['droids'] = droid_count
-manifest_path.write_text(json.dumps(manifest, indent=2) + '\n')
-print('   .claude-plugin/plugin-manifest.json')
+with open('.claude-plugin/routines.json') as f:
+    routines = json.load(f)
+routine_count = len(routines.get('routines', []))
+
+with open('.claude-plugin/hooks.json') as f:
+    hooks = json.load(f)
+hook_event_count = len(hooks)
 
 count_phrase = f'{persona_count} personas, {command_count} commands, {skill_count} skills'
 expert_count_phrase = f'{persona_count} expert personas, {command_count} commands, {skill_count} skills'
@@ -164,8 +161,36 @@ for path in ('README.md', '.claude-plugin/README.md'):
     text = re.sub(r'\*\*\d+ skills\*\*', f'**{skill_count} skills**', text)
     text = re.sub(r'\b\d+ commands, \d+ skills, \d+ specialized personas\b', specialized_count_phrase, text)
     text = re.sub(r'\ball \d+ commands\b', f'all {command_count} commands', text)
+    if path == 'README.md':
+        text = re.sub(r'Version-\d+\.\d+\.\d+-blue', f'Version-{version}-blue', text)
+        text = re.sub(r'Version \d+\.\d+\.\d+', f'Version {version}', text)
     readme_path.write_text(text)
 print('   README count surfaces')
+
+routines['$comment'] = re.sub(r'\(v\d+\.\d+\.\d+\)', f'(v{version})', routines.get('$comment', ''))
+with open('.claude-plugin/routines.json', 'w') as f:
+    json.dump(routines, f, indent=2)
+    f.write('\n')
+print('   .claude-plugin/routines.json')
+
+plugin_manifest_path = pathlib.Path('.claude-plugin/plugin-manifest.json')
+with plugin_manifest_path.open() as f:
+    plugin_manifest = json.load(f)
+plugin_manifest['version'] = version
+components = plugin_manifest.setdefault('components', {})
+components.setdefault('commands', {})['count'] = command_count
+agents = components.setdefault('agents', {})
+agents['count'] = persona_count + droid_count
+agent_breakdown = agents.setdefault('breakdown', {})
+agent_breakdown['personas'] = persona_count
+agent_breakdown['droids'] = droid_count
+components.setdefault('skills', {})['count'] = skill_count
+components.setdefault('hooks', {})['events'] = hook_event_count
+components.setdefault('routines', {})['count'] = routine_count
+with plugin_manifest_path.open('w') as f:
+    json.dump(plugin_manifest, f, indent=2)
+    f.write('\n')
+print('   .claude-plugin/plugin-manifest.json')
 
 path = pathlib.Path('.claude-plugin/marketplace.json')
 with open(path) as f:
@@ -208,13 +233,6 @@ with open(path, 'w') as f:
     f.write('\\n')
 print(f'   {path}')
 "
-
-# README badge
-sed -i '' -E "s/\(v[0-9]+\.[0-9]+\.[0-9]+\)/(v${VERSION})/" .claude-plugin/routines.json
-echo "   .claude-plugin/routines.json"
-sed -i '' "s/Version-[0-9]*\.[0-9]*\.[0-9]*-blue/Version-${VERSION}-blue/g" README.md
-sed -i '' "s/Version [0-9]*\.[0-9]*\.[0-9]*/Version ${VERSION}/g" README.md
-echo "   README.md"
 
 octo_release_update_changelog CHANGELOG.md "$VERSION" "$DATE" "$SUMMARY"
 

--- a/scripts/sync-marketplace.sh
+++ b/scripts/sync-marketplace.sh
@@ -11,6 +11,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
+log() {
+    local level="$1"
+    shift
+    printf '[%s] %s\n' "$level" "$*" >&2
+}
+
 CHECK_ONLY=false
 [[ "${1:-}" == "--check" ]] && CHECK_ONLY=true
 
@@ -49,7 +55,7 @@ else:
 # personas variants), and the trailing "Run /octo:setup." (re-appended below).
 PLUGIN_DESC=$(python3 -c "import json; print(json.load(open('$PLUGIN_JSON')).get('description', ''))")
 if [[ -z "$PLUGIN_DESC" ]]; then
-    echo "ERROR: description missing in $PLUGIN_JSON" >&2
+    log ERROR "description missing in $PLUGIN_JSON"
     exit 1
 fi
 FEATURE_SUMMARY=$(echo "$PLUGIN_DESC" | sed -E 's/^v[0-9]+\.[0-9]+\.[0-9]+ [-—] //' | sed -E 's/[.,] [0-9]+ (agents|personas),[^.]*\.//g' | sed -E 's/\.? *Run \/octo:setup\.?$//' | sed -E 's/\.$//')

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -136,6 +136,53 @@ test_release_stages_routines_manifest() {
     fi
 }
 
+test_release_updates_and_stages_browse_manifest() {
+    test_case "release.sh updates and stages the plugin browse manifest"
+
+    local commit_block
+    commit_block="$(sed -n '/^echo "2\/8 Committing\.\.\."/,/^git commit /p' "$RELEASE_SCRIPT")"
+    if grep -q "plugin_manifest_path = pathlib.Path('.claude-plugin/plugin-manifest.json')" "$RELEASE_SCRIPT" &&
+       grep -q '\.claude-plugin/plugin-manifest\.json' <<<"$commit_block"; then
+        test_pass
+    else
+        test_fail "release.sh does not version/count and stage plugin-manifest.json"
+    fi
+}
+
+test_release_file_updates_are_portable() {
+    test_case "release.sh avoids platform-specific sed -i syntax"
+    if ! grep -q "sed -i ''" "$RELEASE_SCRIPT"; then
+        test_pass
+    else
+        test_fail "release.sh still contains BSD-only sed -i syntax"
+    fi
+}
+
+test_readme_provider_and_cost_contract() {
+    test_case "README defines provider counting and auditable cost assumptions"
+
+    if grep -q 'ten external provider integrations' "$PROJECT_ROOT/README.md" &&
+       ! grep -q 'Up to 9 providers' "$PROJECT_ROOT/README.md" &&
+       grep -q 'developers.openai.com/api/docs/models/gpt-5.5' "$PROJECT_ROOT/README.md" &&
+       grep -q 'ai.google.dev/gemini-api/docs/pricing' "$PROJECT_ROOT/README.md" &&
+       grep -q 'docs.perplexity.ai/docs/getting-started/pricing' "$PROJECT_ROOT/README.md" &&
+       grep -q 'prompts over 200K' "$PROJECT_ROOT/README.md" &&
+       grep -q 'request fee' "$PROJECT_ROOT/README.md"; then
+        test_pass
+    else
+        test_fail "README provider count or pricing assumptions remain ambiguous"
+    fi
+}
+
+test_marketplace_description_error_uses_logger() {
+    test_case "sync-marketplace routes missing descriptions through the logger"
+    if grep -q 'log ERROR "description missing in \$PLUGIN_JSON"' "$PROJECT_ROOT/scripts/sync-marketplace.sh"; then
+        test_pass
+    else
+        test_fail "sync-marketplace uses raw output for the missing-description error"
+    fi
+}
+
 test_release_promotes_unreleased_changelog_notes() {
     test_case "release changelog helper promotes Unreleased notes into version entry"
 
@@ -254,6 +301,10 @@ test_shared_marketplace_sync_updates_only_octo() {
 test_sync_script_exists
 test_release_script_invokes_shared_marketplace_sync
 test_release_stages_routines_manifest
+test_release_updates_and_stages_browse_manifest
+test_release_file_updates_are_portable
+test_readme_provider_and_cost_contract
+test_marketplace_description_error_uses_logger
 test_release_promotes_unreleased_changelog_notes
 test_release_ci_parser_matches_exact_aggregate_checks
 test_shared_marketplace_sync_updates_only_octo


### PR DESCRIPTION
## Summary

- clarify the README's ten external provider integrations versus the built-in Claude host and make the cost estimates auditable against current provider rate cards
- keep release updates portable while refreshing browse-manifest command, skill, agent, hook-event, and routine counts; preserve the remote/worktree-safe flow merged in #605
- route marketplace description errors through the script logger and add regression coverage for the review findings

## Verification

- `make sync`
- `tests/unit/test-release-sh-worktree-flow.sh` — 6/6
- `tests/unit/test-shared-marketplace-sync.sh` — 12/12
- `CI=1 make ci-local` — 16 smoke suites, 170 unit suites, 7 integration suites
- ShellCheck and Bash syntax checks for changed shell files
- no executable-bit drift after restoring known local-test fixture side effects


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified support for up to 10 external provider integrations, including Grok and OpenCode.
  - Updated guidance to state that no providers are required to get started.
  - Revised provider coordination language and token-only cost estimates.

- **Bug Fixes**
  - Improved marketplace synchronization error reporting.
  - Made release updates portable across environments.
  - Kept release manifest, routine, hook, and provider counts current.

- **Tests**
  - Added coverage for release portability, manifest updates, documentation wording, and marketplace error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->