### PR TITLE
fix: close review aggregation hardening gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - **Repository review follow-ups**: clarified README provider counting and cost assumptions, routed marketplace-sync errors through the script logger, and made release manifest updates portable while keeping browse-manifest hook and routine counts current.
+- **Review aggregation follow-up hardening** (#592): each Round 1 agent now has an independent progress timer; completed results require anchored terminal statuses; provider exits without a terminal status are classified as partial; leading-zero timing inputs are normalized as decimal; stall cleanup snapshots and terminates the full descendant process tree; and findings extraction accepts only arrays while preferring the last non-empty result.
 
 ## [9.52.0] - 2026-07-09
 
@@ -47,6 +48,7 @@
 
 ### Fixed
 
+- **Review aggregation and progress supervision hardened** (#592, community contribution by @Jhacarreiro; maintainer takeover to land): review rounds now run without a wall-clock cap under progress-stall supervision (`OCTOPUS_REVIEW_STALL_WINDOW`, default 1800s), Round 1 codex empty-output-with-reconnect failures retry once, findings extraction tolerates prose-wrapped JSON, and severity counting is pipefail-safe. Maintainer fixes on top of the contribution: each Round 1 agent has an independent progress timer, completed results require anchored terminal statuses, timing inputs are normalized as decimal values, stall kills snapshot and terminate the full descendant tree so TERM-ignoring provider CLIs cannot be orphaned mid-billing, and the findings extractor accepts only arrays while preferring the last non-empty result. The `timeout_secs=0` contract this relies on is the `run_with_timeout` bypass that shipped with #593.
 - **`OCTOPUS_OPUS_MODEL=claude-fable-5` now reaches the dispatched model flag.** The `claude-opus` dispatch case always passed the bare `--model opus` alias, which the host resolves to its default Opus — so a Fable 5 pin changed cost labels and resolver output but never the model actually dispatched (the claude-sdk seat was the only real Fable 5 path). The dispatch command now emits `--model claude-fable-5` for pinned non-security dispatches and `--model claude-opus-4-8` for security dispatches.
 
 ## [9.50.0] - 2026-07-08

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -441,6 +441,12 @@ review_supervise_round1() {
     local round1_last_fp=()
     local round1_settled=()
 
+    [[ "$review_stall_window" =~ ^[0-9]+$ ]] || review_stall_window=1800
+    [[ "$review_poll_secs" =~ ^[0-9]+$ ]] || review_poll_secs=30
+    review_stall_window=$((10#$review_stall_window))
+    review_poll_secs=$((10#$review_poll_secs))
+    [[ "$review_poll_secs" -lt 1 ]] && review_poll_secs=1
+
     _poll_start=$(date +%s)
     _idx=0
     while [[ "$_idx" -lt "${#round1_files[@]}" ]]; do

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -363,14 +363,18 @@ review_openai_compat_empty_output_retryable() {
 
 review_result_has_terminal_status() {
     local result_file="$1"
+    local terminal_count
     [[ -f "$result_file" ]] || return 1
-    grep -qE '^## Status: (SUCCESS|FAILED|TIMEOUT)([[:space:](]|$)' "$result_file" 2>/dev/null
+    terminal_count=$(grep -cE '^## Status: (SUCCESS|FAILED|TIMEOUT)([[:space:](]|$)' "$result_file" 2>/dev/null || true)
+    [[ "${terminal_count:-0}" -gt 0 ]]
 }
 
 review_result_completed_successfully() {
     local result_file="$1"
+    local success_count
     [[ -f "$result_file" ]] || return 1
-    grep -qE '^## Status: SUCCESS([[:space:](]|$)' "$result_file" 2>/dev/null
+    success_count=$(grep -cE '^## Status: SUCCESS([[:space:](]|$)' "$result_file" 2>/dev/null || true)
+    [[ "${success_count:-0}" -gt 0 ]]
 }
 
 # review_wait_for_result_status: waits for one result file to become terminal,

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -427,6 +427,77 @@ review_wait_for_result_status() {
     wait "$pid" 2>/dev/null || true
 }
 
+# review_supervise_round1: monitor each Round 1 provider independently so
+# progress from one provider cannot keep a stalled peer alive. The round1_*
+# arrays are intentionally resolved through Bash's dynamic function scope;
+# review_run owns them, while unit tests can supply a minimal observable fleet.
+# shellcheck disable=SC2154
+review_supervise_round1() {
+    local review_stall_window="$1"
+    local review_poll_secs="$2"
+    local results_dir="$3"
+    local _poll_start _now _idx _rf _pid _current_fp _round1_active
+    local round1_last_progress=()
+    local round1_last_fp=()
+    local round1_settled=()
+
+    _poll_start=$(date +%s)
+    _idx=0
+    while [[ "$_idx" -lt "${#round1_files[@]}" ]]; do
+        _rf="${round1_files[$_idx]}"
+        round1_last_progress[$_idx]="$_poll_start"
+        round1_last_fp[$_idx]=$(review_progress_fingerprint_since "$_poll_start" "$results_dir" "$(basename "$_rf")*")
+        round1_settled[$_idx]=false
+        ((_idx++)) || true
+    done
+
+    while true; do
+        _round1_active=false
+        _now=$(date +%s)
+        _idx=0
+        while [[ "$_idx" -lt "${#round1_files[@]}" ]]; do
+            if [[ "${round1_settled[$_idx]:-false}" == "true" ]]; then
+                ((_idx++)) || true
+                continue
+            fi
+
+            _rf="${round1_files[$_idx]}"
+            _pid="${round1_pids[$_idx]}"
+            if review_result_has_terminal_status "$_rf"; then
+                round1_settled[$_idx]=true
+                ((_idx++)) || true
+                continue
+            fi
+            if ! review_process_is_running "$_pid"; then
+                log WARN "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} exited without a terminal status"
+                round1_settled[$_idx]=true
+                ((_idx++)) || true
+                continue
+            fi
+
+            _current_fp=$(review_progress_fingerprint_since "$_poll_start" "$results_dir" "$(basename "$_rf")*")
+            if [[ "$_current_fp" != "${round1_last_fp[$_idx]}" ]]; then
+                round1_last_fp[$_idx]="$_current_fp"
+                round1_last_progress[$_idx]="$_now"
+                log INFO "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} progress observed"
+            elif [[ "$review_stall_window" -gt 0 && $((_now - ${round1_last_progress[$_idx]})) -ge "$review_stall_window" ]]; then
+                log WARN "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} stalled after ${review_stall_window}s — collecting partial result"
+                review_terminate_process_tree "$_pid" 5
+                round1_settled[$_idx]=true
+                ((_idx++)) || true
+                continue
+            fi
+
+            _round1_active=true
+            ((_idx++)) || true
+        done
+
+        [[ "$_round1_active" == "false" ]] && break
+        sleep "$review_poll_secs"
+    done
+    for _pid in "${round1_pids[@]}"; do wait "$_pid" 2>/dev/null || true; done
+}
+
 # review_extract_findings_array: returns a JSON array of findings from a Round 1
 # markdown result file. Providers sometimes echo the full prompt or wrap JSON in
 # prose; prefer the exact ## Output jq path, then fall back to scanning the file
@@ -909,67 +980,9 @@ ${agent_prompt_base}"
 
     fleet_dispatch_end
 
-    # Supervise each Round 1 agent independently. A healthy provider or an
-    # unrelated workflow writing RESULTS_DIR must not reset a hung peer's timer.
-    local _poll_start _now _idx _rf _pid _current_fp _round1_active
-    local round1_last_progress=()
-    local round1_last_fp=()
-    local round1_settled=()
-    _poll_start=$(date +%s)
-    _idx=0
-    while [[ "$_idx" -lt "${#round1_files[@]}" ]]; do
-        _rf="${round1_files[$_idx]}"
-        round1_last_progress[$_idx]="$_poll_start"
-        round1_last_fp[$_idx]=$(review_progress_fingerprint_since "$_poll_start" "$RESULTS_DIR" "$(basename "$_rf")*")
-        round1_settled[$_idx]=false
-        ((_idx++)) || true
-    done
-
-    while true; do
-        _round1_active=false
-        _now=$(date +%s)
-        _idx=0
-        while [[ "$_idx" -lt "${#round1_files[@]}" ]]; do
-            if [[ "${round1_settled[$_idx]:-false}" == "true" ]]; then
-                ((_idx++)) || true
-                continue
-            fi
-
-            _rf="${round1_files[$_idx]}"
-            _pid="${round1_pids[$_idx]}"
-            if review_result_has_terminal_status "$_rf"; then
-                round1_settled[$_idx]=true
-                ((_idx++)) || true
-                continue
-            fi
-            if ! review_process_is_running "$_pid"; then
-                log WARN "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} exited without a terminal status"
-                round1_settled[$_idx]=true
-                ((_idx++)) || true
-                continue
-            fi
-
-            _current_fp=$(review_progress_fingerprint_since "$_poll_start" "$RESULTS_DIR" "$(basename "$_rf")*")
-            if [[ "$_current_fp" != "${round1_last_fp[$_idx]}" ]]; then
-                round1_last_fp[$_idx]="$_current_fp"
-                round1_last_progress[$_idx]="$_now"
-                log INFO "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} progress observed"
-            elif [[ "$review_stall_window" -gt 0 && $((_now - ${round1_last_progress[$_idx]})) -ge "$review_stall_window" ]]; then
-                log WARN "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} stalled after ${review_stall_window}s — collecting partial result"
-                review_terminate_process_tree "$_pid" 5
-                round1_settled[$_idx]=true
-                ((_idx++)) || true
-                continue
-            fi
-
-            _round1_active=true
-            ((_idx++)) || true
-        done
-
-        [[ "$_round1_active" == "false" ]] && break
-        sleep "$review_poll_secs"
-    done
-    for _pid in "${round1_pids[@]}"; do wait "$_pid" 2>/dev/null || true; done
+    # A healthy provider or unrelated RESULTS_DIR activity must not reset a
+    # hung peer's timer.
+    review_supervise_round1 "$review_stall_window" "$review_poll_secs" "$RESULTS_DIR"
 
     # Retry transient OpenAI-compatible adapter Empty output failures once after backoff. We
     # only do this for Round 1 review specialists and only when the artifact shows

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -257,6 +257,16 @@ review_process_tree_depth_first() {
     printf '%s\n' "$pid"
 }
 
+# kill -0 still succeeds for unreaped zombies on macOS, so also inspect state.
+review_process_is_running() {
+    local pid="$1"
+    local process_stat
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    process_stat=$(ps -o stat= -p "$pid" 2>/dev/null) || return 1
+    [[ "$process_stat" != *Z* ]]
+}
+
 review_terminate_process_tree() {
     local root_pid="$1"
     local grace_secs="${2:-5}"
@@ -310,7 +320,7 @@ review_run_agent_sync_progress() {
     own_pattern="$(basename "$out_file")*"
     last_fp=$(review_progress_fingerprint_since "$start_epoch" "$results_dir" "$own_pattern")
 
-    while kill -0 "$pid" 2>/dev/null; do
+    while review_process_is_running "$pid"; do
         sleep "$poll_secs"
         now=$(date +%s)
         current_fp=$(review_progress_fingerprint_since "$start_epoch" "$results_dir" "$own_pattern")
@@ -387,7 +397,7 @@ review_wait_for_result_status() {
         if review_result_has_terminal_status "$result_file"; then
             break
         fi
-        if ! kill -0 "$pid" 2>/dev/null; then
+        if ! review_process_is_running "$pid"; then
             log WARN "review_run: ${label} exited without a terminal status"
             break
         fi
@@ -921,7 +931,7 @@ ${agent_prompt_base}"
                 ((_idx++)) || true
                 continue
             fi
-            if ! kill -0 "$_pid" 2>/dev/null; then
+            if ! review_process_is_running "$_pid"; then
                 log WARN "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} exited without a terminal status"
                 round1_settled[$_idx]=true
                 ((_idx++)) || true

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -371,10 +371,17 @@ review_result_has_terminal_status() {
 
 review_result_completed_successfully() {
     local result_file="$1"
-    local success_count
+    local final_status
     [[ -f "$result_file" ]] || return 1
-    success_count=$(grep -cE '^## Status: SUCCESS([[:space:](]|$)' "$result_file" 2>/dev/null || true)
-    [[ "${success_count:-0}" -gt 0 ]]
+    final_status=$(awk '
+        /^## Status: (SUCCESS|FAILED|TIMEOUT)([[:space:](]|$)/ {
+            status = $0
+            sub(/^## Status: /, "", status)
+            sub(/[[:space:](].*$/, "", status)
+        }
+        END { print status }
+    ' "$result_file" 2>/dev/null || true)
+    [[ "$final_status" == "SUCCESS" ]]
 }
 
 # review_wait_for_result_status: waits for one result file to become terminal,

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -231,9 +231,9 @@ review_progress_fingerprint_since() {
     # Optional filename pattern scopes the fingerprint to one agent's artifacts.
     # Without it, any concurrent activity in the shared RESULTS_DIR resets the
     # stall timer for every agent, so a genuinely hung provider never trips it.
-    local name_pattern="${3:-}"
+    local name_pattern="${3:-*}"
     [[ -d "$results_dir" ]] || { echo "empty"; return 0; }
-    find "$results_dir" -maxdepth 1 -type f ${name_pattern:+-name "$name_pattern"} 2>/dev/null | while IFS= read -r file; do
+    find "$results_dir" -maxdepth 1 -type f -name "$name_pattern" 2>/dev/null | while IFS= read -r file; do
         local mtime size
         mtime=$(review_file_mtime_epoch "$file")
         [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
@@ -244,15 +244,37 @@ review_progress_fingerprint_since() {
     done | sort | review_hash_stdin
 }
 
-# review_kill_tree <SIG> <pid>: depth-first kill of a process and all its
-# descendants. The provider CLI runs as a grandchild of the backgrounded
-# wrapper, so a single-level pkill -P can orphan it mid-billing (#190).
-review_kill_tree() {
-    local sig="$1" pid="$2" kid
-    for kid in $(pgrep -P "$pid" 2>/dev/null); do
-        review_kill_tree "$sig" "$kid"
-    done
-    kill "-${sig}" "$pid" 2>/dev/null || true
+# Snapshot descendants depth-first before signaling. Re-walking after TERM is
+# unsafe because a TERM-ignoring child can be reparented when its wrapper exits,
+# making it invisible to the later KILL pass.
+review_process_tree_depth_first() {
+    local pid="$1" child
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 0
+    while IFS= read -r child; do
+        [[ "$child" =~ ^[0-9]+$ ]] || continue
+        review_process_tree_depth_first "$child"
+    done < <(pgrep -P "$pid" 2>/dev/null || true)
+    printf '%s\n' "$pid"
+}
+
+review_terminate_process_tree() {
+    local root_pid="$1"
+    local grace_secs="${2:-5}"
+    local process_tree target_pid
+    [[ "$grace_secs" =~ ^[0-9]+$ ]] || grace_secs=5
+    grace_secs=$((10#$grace_secs))
+    process_tree="$(review_process_tree_depth_first "$root_pid")"
+    [[ -n "$process_tree" ]] || return 0
+
+    while IFS= read -r target_pid; do
+        [[ "$target_pid" =~ ^[0-9]+$ ]] || continue
+        kill -TERM "$target_pid" 2>/dev/null || true
+    done <<< "$process_tree"
+    sleep "$grace_secs"
+    while IFS= read -r target_pid; do
+        [[ "$target_pid" =~ ^[0-9]+$ ]] || continue
+        kill -KILL "$target_pid" 2>/dev/null || true
+    done <<< "$process_tree"
 }
 
 review_run_agent_sync_progress() {
@@ -266,6 +288,8 @@ review_run_agent_sync_progress() {
     local poll_secs="${OCTOPUS_REVIEW_POLL_SECS:-30}"
     [[ "$stall_window" =~ ^[0-9]+$ ]] || stall_window=1800
     [[ "$poll_secs" =~ ^[0-9]+$ ]] || poll_secs=30
+    stall_window=$((10#$stall_window))
+    poll_secs=$((10#$poll_secs))
     [[ "$poll_secs" -lt 1 ]] && poll_secs=1
     mkdir -p "$results_dir" 2>/dev/null || true
 
@@ -296,9 +320,7 @@ review_run_agent_sync_progress() {
             log INFO "review_run: ${label} progress observed"
         elif [[ "$stall_window" -gt 0 && $((now - last_progress)) -ge "$stall_window" ]]; then
             log WARN "review_run: ${label} stalled after ${stall_window}s with no observable progress — stopping provider and preserving partial output"
-            review_kill_tree TERM "$pid"
-            sleep 5
-            review_kill_tree KILL "$pid"
+            review_terminate_process_tree "$pid" 5
             break
         fi
     done
@@ -329,6 +351,18 @@ review_openai_compat_empty_output_retryable() {
     [[ "${reconnect_count%%$'\n'*}" -gt 0 ]] || return 1
 }
 
+review_result_has_terminal_status() {
+    local result_file="$1"
+    [[ -f "$result_file" ]] || return 1
+    grep -qE '^## Status: (SUCCESS|FAILED|TIMEOUT)([[:space:](]|$)' "$result_file" 2>/dev/null
+}
+
+review_result_completed_successfully() {
+    local result_file="$1"
+    [[ -f "$result_file" ]] || return 1
+    grep -qE '^## Status: SUCCESS([[:space:](]|$)' "$result_file" 2>/dev/null
+}
+
 # review_wait_for_result_status: waits for one result file to become terminal,
 # using the same progress-stall semantics as Round 1. No wall-clock cap.
 review_wait_for_result_status() {
@@ -339,16 +373,22 @@ review_wait_for_result_status() {
     local stall_window="${5:-${OCTOPUS_REVIEW_STALL_WINDOW:-1800}}"
     local poll_secs="${6:-${OCTOPUS_REVIEW_POLL_SECS:-30}}"
     local poll_start last_progress last_fp current_fp
+    [[ "$stall_window" =~ ^[0-9]+$ ]] || stall_window=1800
+    [[ "$poll_secs" =~ ^[0-9]+$ ]] || poll_secs=30
+    stall_window=$((10#$stall_window))
+    poll_secs=$((10#$poll_secs))
+    [[ "$poll_secs" -lt 1 ]] && poll_secs=1
     poll_start=$(date +%s)
     last_progress="$poll_start"
     local own_pattern
     own_pattern="$(basename "$result_file")*"
     last_fp=$(review_progress_fingerprint_since "$poll_start" "$results_dir" "$own_pattern")
     while true; do
-        local status_count
-        status_count=$(grep -cE '^## Status:' "$result_file" 2>/dev/null || true)
-        status_count=${status_count:-0}
-        if [[ -f "$result_file" ]] && [[ "${status_count%%$'\n'*}" -gt 0 ]]; then
+        if review_result_has_terminal_status "$result_file"; then
+            break
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            log WARN "review_run: ${label} exited without a terminal status"
             break
         fi
         current_fp=$(review_progress_fingerprint_since "$poll_start" "$results_dir" "$own_pattern")
@@ -358,9 +398,7 @@ review_wait_for_result_status() {
             log INFO "review_run: ${label} progress observed"
         elif [[ "$stall_window" -gt 0 && $(( $(date +%s) - last_progress )) -ge "$stall_window" ]]; then
             log WARN "review_run: ${label} stalled after ${stall_window}s — stopping retry"
-            review_kill_tree TERM "$pid"
-            sleep 5
-            review_kill_tree KILL "$pid"
+            review_terminate_process_tree "$pid" 5
             break
         fi
         sleep "$poll_secs"
@@ -379,7 +417,7 @@ review_extract_findings_array() {
 
     output_text=$(awk '/^## Output$/{found=1;next} /^## /{if(found)exit} found && !/^```(json|JSON)?$/{print}' "$review_md" 2>/dev/null || true)
     if [[ -n "$output_text" ]]; then
-        direct_json=$(printf '%s' "$output_text" | jq -c '.findings // empty' 2>/dev/null || true)
+        direct_json=$(printf '%s' "$output_text" | jq -c 'select((.findings | type) == "array") | .findings' 2>/dev/null || true)
         if [[ -n "$direct_json" && "$direct_json" != "null" ]]; then
             printf '%s\n' "$direct_json"
             return 0
@@ -764,6 +802,8 @@ Use this context as the requested behavior and constraints. Flag severity=normal
     local review_poll_secs="${OCTOPUS_REVIEW_POLL_SECS:-30}"
     [[ "$review_stall_window" =~ ^[0-9]+$ ]] || review_stall_window=1800
     [[ "$review_poll_secs" =~ ^[0-9]+$ ]] || review_poll_secs=30
+    review_stall_window=$((10#$review_stall_window))
+    review_poll_secs=$((10#$review_poll_secs))
     [[ "$review_poll_secs" -lt 1 ]] && review_poll_secs=1
     export TIMEOUT=0
 
@@ -848,42 +888,64 @@ ${agent_prompt_base}"
 
     fleet_dispatch_end
 
-    # Wait for all Round 1 agents with a progress watchdog instead of a wall timeout.
-    # timeout_secs=0 disables provider wall-clock caps; this loop only stops when
-    # every result is terminal or no result/output changes for the stall window.
-    local _poll_start _last_progress _last_fp _current_fp _round1_stalled=false
+    # Supervise each Round 1 agent independently. A healthy provider or an
+    # unrelated workflow writing RESULTS_DIR must not reset a hung peer's timer.
+    local _poll_start _now _idx _rf _pid _current_fp _round1_active
+    local round1_last_progress=()
+    local round1_last_fp=()
+    local round1_settled=()
     _poll_start=$(date +%s)
-    _last_progress="$_poll_start"
-    _last_fp=$(review_progress_fingerprint_since "$_poll_start" "$RESULTS_DIR")
-    while true; do
-        local _all_done=true
-        for _rf in "${round1_files[@]}"; do
-            if [[ ! -f "$_rf" ]] || [[ $(grep -cE '^## Status:' "$_rf" 2>/dev/null || true) -eq 0 ]]; then
-                _all_done=false
-                break
-            fi
-        done
-        [[ "$_all_done" == "true" ]] && break
+    _idx=0
+    while [[ "$_idx" -lt "${#round1_files[@]}" ]]; do
+        _rf="${round1_files[$_idx]}"
+        round1_last_progress[$_idx]="$_poll_start"
+        round1_last_fp[$_idx]=$(review_progress_fingerprint_since "$_poll_start" "$RESULTS_DIR" "$(basename "$_rf")*")
+        round1_settled[$_idx]=false
+        ((_idx++)) || true
+    done
 
-        _current_fp=$(review_progress_fingerprint_since "$_poll_start" "$RESULTS_DIR")
-        if [[ "$_current_fp" != "$_last_fp" ]]; then
-            _last_fp="$_current_fp"
-            _last_progress=$(date +%s)
-            log INFO "review_run: Round 1 progress observed"
-        elif [[ "$review_stall_window" -gt 0 && $(( $(date +%s) - _last_progress )) -ge "$review_stall_window" ]]; then
-            _round1_stalled=true
-            log WARN "review_run: Round 1 stalled after ${review_stall_window}s — collecting partial results"
-            for _pid in "${round1_pids[@]}"; do
-                pkill -TERM -P "$_pid" 2>/dev/null || true
-                kill -TERM "$_pid" 2>/dev/null || true
-            done
-            sleep 5
-            for _pid in "${round1_pids[@]}"; do
-                pkill -KILL -P "$_pid" 2>/dev/null || true
-                kill -KILL "$_pid" 2>/dev/null || true
-            done
-            break
-        fi
+    while true; do
+        _round1_active=false
+        _now=$(date +%s)
+        _idx=0
+        while [[ "$_idx" -lt "${#round1_files[@]}" ]]; do
+            if [[ "${round1_settled[$_idx]:-false}" == "true" ]]; then
+                ((_idx++)) || true
+                continue
+            fi
+
+            _rf="${round1_files[$_idx]}"
+            _pid="${round1_pids[$_idx]}"
+            if review_result_has_terminal_status "$_rf"; then
+                round1_settled[$_idx]=true
+                ((_idx++)) || true
+                continue
+            fi
+            if ! kill -0 "$_pid" 2>/dev/null; then
+                log WARN "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} exited without a terminal status"
+                round1_settled[$_idx]=true
+                ((_idx++)) || true
+                continue
+            fi
+
+            _current_fp=$(review_progress_fingerprint_since "$_poll_start" "$RESULTS_DIR" "$(basename "$_rf")*")
+            if [[ "$_current_fp" != "${round1_last_fp[$_idx]}" ]]; then
+                round1_last_fp[$_idx]="$_current_fp"
+                round1_last_progress[$_idx]="$_now"
+                log INFO "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} progress observed"
+            elif [[ "$review_stall_window" -gt 0 && $((_now - ${round1_last_progress[$_idx]})) -ge "$review_stall_window" ]]; then
+                log WARN "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} stalled after ${review_stall_window}s — collecting partial result"
+                review_terminate_process_tree "$_pid" 5
+                round1_settled[$_idx]=true
+                ((_idx++)) || true
+                continue
+            fi
+
+            _round1_active=true
+            ((_idx++)) || true
+        done
+
+        [[ "$_round1_active" == "false" ]] && break
         sleep "$review_poll_secs"
     done
     for _pid in "${round1_pids[@]}"; do wait "$_pid" 2>/dev/null || true; done
@@ -976,11 +1038,11 @@ ${round1_prompts[$retry_idx]}"
                 octo_event_emit "review.finding" provider="$provider_key" severity="${_rf_sev:-unknown}" message="${_rf_title:-}" round="1" || true
             done < <(printf '%s' "$agent_findings" | jq -r '.[]? | [(.severity // "unknown"), (.title // .message // "")] | @tsv' 2>/dev/null)
         fi
-        if [[ $(grep -cE "Status: (FAILED|TIMEOUT)" "$f" 2>/dev/null || true) -gt 0 ]]; then
+        if ! review_result_completed_successfully "$f"; then
             ((round1_partial_count++)) || true
-            echo "${provider_key}|fallback|Round 1 agent failed or timed out" >> "$provider_status_file"
-        elif [[ "$agent_findings" != "[]" ]]; then
-            echo "${provider_key}|ok|Round 1 findings" >> "$provider_status_file"
+            echo "${provider_key}|fallback|Round 1 agent did not complete successfully" >> "$provider_status_file"
+        else
+            echo "${provider_key}|ok|Round 1 completed" >> "$provider_status_file"
         fi
         ((idx++)) || true
     done

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -980,8 +980,9 @@ CRITICAL OUTPUT FORMAT: Return ONLY a valid JSON object. No markdown, no prose, 
 ${agent_prompt_base}"
         round1_prompts+=("$agent_prompt")
 
-        spawn_agent "$agent_type" "$agent_prompt" "$task_id" "$role" "review" &
-        round1_pids+=("$!")
+        local round1_pid
+        round1_pid=$(spawn_agent_capture_pid "$agent_type" "$agent_prompt" "$task_id" "$role" "review")
+        round1_pids+=("$round1_pid")
     done <<< "$fleet"
 
     fleet_dispatch_end

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -438,7 +438,7 @@ review_extract_findings_array() {
 
     output_text=$(awk '/^## Output$/{found=1;next} /^## /{if(found)exit} found && !/^```(json|JSON)?$/{print}' "$review_md" 2>/dev/null || true)
     if [[ -n "$output_text" ]]; then
-        direct_json=$(printf '%s' "$output_text" | jq -c 'select((.findings | type) == "array") | .findings' 2>/dev/null || true)
+        direct_json=$(printf '%s' "$output_text" | jq -cs '[.[] | objects | .findings | select(type == "array" and length > 0)] | last // []' 2>/dev/null || true)
         if [[ -n "$direct_json" && "$direct_json" != "null" ]]; then
             printf '%s\n' "$direct_json"
             return 0

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -9,8 +9,9 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "review aggregation robustness"
 
 REVIEW_SH="$PROJECT_ROOT/scripts/lib/review.sh"
-TMP_MD="$(mktemp "${TMPDIR:-/tmp}/octo-review-md.XXXXXX")"
-trap 'rm -f "$TMP_MD"' EXIT
+TMP_TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-review-robustness.XXXXXX")"
+TMP_MD="$TMP_TEST_DIR/review.md"
+trap 'rm -rf "$TMP_TEST_DIR"' EXIT
 
 cat > "$TMP_MD" <<'EOF'
 # Agent: claude-sonnet
@@ -20,6 +21,7 @@ The provider echoed prompt text first.
 Example: {"findings": []}
 Now the actual answer:
 {"findings":[{"file":"api/terminal.js","line":12,"severity":"normal","category":"security","title":"Broken regex","detail":"The regex is wrong","confidence":0.9}]}
+The provider then echoed the prompt example again: {"findings": []}
 ```
 
 ## Status: SUCCESS
@@ -31,7 +33,8 @@ if grep -q "review_extract_findings_array" "$REVIEW_SH"; then test_pass; else te
 test_case "round1 snapshot is written"
 if grep -q "review-round1-findings" "$REVIEW_SH"; then test_pass; else test_fail "missing round1 snapshot"; fi
 
-test_case "extractor recovers last JSON findings object"
+test_case "extractor prefers the last non-empty findings array"
+log() { :; }
 source "$REVIEW_SH" >/dev/null 2>&1 || true
 if out=$(review_extract_findings_array "$TMP_MD" 2>/dev/null); then
     if count=$(printf '%s' "$out" | jq 'length' 2>/dev/null) && title=$(printf '%s' "$out" | jq -r '.[0].title' 2>/dev/null); then
@@ -45,6 +48,166 @@ if out=$(review_extract_findings_array "$TMP_MD" 2>/dev/null); then
     fi
 else
     test_fail "extractor failed to recover findings"
+fi
+
+test_case "extractor rejects non-array findings values"
+cat > "$TMP_TEST_DIR/non-array.md" <<'EOF'
+# Agent: malformed-provider
+## Output
+{"findings":"not-an-array"}
+## Status: SUCCESS
+EOF
+non_array_out="$(review_extract_findings_array "$TMP_TEST_DIR/non-array.md" 2>/dev/null || true)"
+if [[ "$(printf '%s' "$non_array_out" | jq -r 'type' 2>/dev/null || true)" == "array" ]] &&
+   [[ "$(printf '%s' "$non_array_out" | jq -r 'length' 2>/dev/null || true)" == "0" ]]; then
+    test_pass
+else
+    test_fail "non-array findings escaped extraction: $non_array_out"
+fi
+
+test_case "progress fingerprint ignores unrelated result artifacts"
+progress_dir="$TMP_TEST_DIR/progress"
+mkdir -p "$progress_dir"
+printf 'target-v1\n' > "$progress_dir/target.out"
+printf 'other-v1\n' > "$progress_dir/other.out"
+since_epoch=$(( $(date +%s) - 1 ))
+target_fp_before="$(review_progress_fingerprint_since "$since_epoch" "$progress_dir" 'target.out')"
+printf 'other-v2-with-more-bytes\n' > "$progress_dir/other.out"
+target_fp_after_unrelated="$(review_progress_fingerprint_since "$since_epoch" "$progress_dir" 'target.out')"
+printf 'target-v2-with-more-bytes\n' > "$progress_dir/target.out"
+target_fp_after_target="$(review_progress_fingerprint_since "$since_epoch" "$progress_dir" 'target.out')"
+if [[ "$target_fp_before" == "$target_fp_after_unrelated" && "$target_fp_before" != "$target_fp_after_target" ]]; then
+    test_pass
+else
+    test_fail "fingerprint was not scoped to the requested artifact pattern"
+fi
+
+test_case "process-tree termination reaches TERM-ignoring grandchildren"
+if ! declare -F review_terminate_process_tree >/dev/null 2>&1; then
+    test_fail "missing recursive process-tree termination helper"
+else
+    process_dir="$TMP_TEST_DIR/process-tree"
+    mkdir -p "$process_dir"
+    cat > "$process_dir/grandchild.sh" <<'PROCESS_GRANDCHILD'
+trap '' TERM
+while :; do sleep 1; done
+PROCESS_GRANDCHILD
+    cat > "$process_dir/child.sh" <<'PROCESS_CHILD'
+trap '' TERM
+bash "$1/grandchild.sh" &
+echo "$!" > "$1/grandchild.pid"
+wait
+PROCESS_CHILD
+    cat > "$process_dir/root.sh" <<'PROCESS_ROOT'
+trap '' TERM
+bash "$1/child.sh" "$1" &
+echo "$!" > "$1/child.pid"
+wait
+PROCESS_ROOT
+    bash "$process_dir/root.sh" "$process_dir" &
+    root_pid=$!
+    for _ in 1 2 3 4 5; do
+        [[ -s "$process_dir/child.pid" && -s "$process_dir/grandchild.pid" ]] && break
+        sleep 1
+    done
+    child_pid="$(cat "$process_dir/child.pid" 2>/dev/null || true)"
+    grandchild_pid="$(cat "$process_dir/grandchild.pid" 2>/dev/null || true)"
+
+    review_terminate_process_tree "$root_pid" 1
+    wait "$root_pid" 2>/dev/null || true
+
+    process_is_running() {
+        local pid="$1"
+        [[ -n "$pid" ]] || return 1
+        ps -o stat= -p "$pid" 2>/dev/null | grep -Eqv '^[[:space:]]*Z'
+    }
+    if [[ -n "$child_pid" && -n "$grandchild_pid" ]] &&
+       ! process_is_running "$root_pid" &&
+       ! process_is_running "$child_pid" &&
+       ! process_is_running "$grandchild_pid"; then
+        test_pass
+    else
+        kill -KILL "$root_pid" "$child_pid" "$grandchild_pid" 2>/dev/null || true
+        test_fail "recursive termination left a process alive"
+    fi
+fi
+
+test_case "timing knobs accept leading-zero decimal values"
+run_agent_sync() { printf 'ok\n'; }
+timing_err="$TMP_TEST_DIR/timing.err"
+if OCTOPUS_REVIEW_STALL_WINDOW=08 OCTOPUS_REVIEW_POLL_SECS=08 \
+   review_run_agent_sync_progress codex prompt role review timing-test \
+       >/dev/null 2>"$timing_err" &&
+   ! grep -q 'value too great for base' "$timing_err"; then
+    test_pass
+else
+    test_fail "leading-zero timing knob triggered Bash octal parsing"
+fi
+
+test_case "retry wait stops when provider exits without terminal status"
+dead_result="$TMP_TEST_DIR/dead-result.md"
+sleep 1 &
+dead_provider_pid=$!
+review_wait_for_result_status "$dead_result" "$dead_provider_pid" dead-provider "$TMP_TEST_DIR" 02 01 &
+waiter_pid=$!
+waiter_finished=false
+for _ in 1 2 3 4; do
+    if ! kill -0 "$waiter_pid" 2>/dev/null; then
+        waiter_finished=true
+        break
+    fi
+    sleep 1
+done
+if [[ "$waiter_finished" == "true" ]]; then
+    wait "$waiter_pid" 2>/dev/null || true
+    test_pass
+else
+    kill -KILL "$waiter_pid" 2>/dev/null || true
+    wait "$waiter_pid" 2>/dev/null || true
+    test_fail "waiter remained alive after provider exited"
+fi
+
+test_case "retry wait accepts only terminal status markers"
+wait_helper_body="$(sed -n '/^review_wait_for_result_status()/,/^}/p' "$REVIEW_SH")"
+terminal_helper_body="$(sed -n '/^review_result_has_terminal_status()/,/^}/p' "$REVIEW_SH")"
+if grep -q 'review_result_has_terminal_status' <<< "$wait_helper_body" &&
+   grep -q "Status: (SUCCESS|FAILED|TIMEOUT)" <<< "$terminal_helper_body"; then
+    test_pass
+else
+    test_fail "retry wait still accepts arbitrary status markers"
+fi
+
+test_case "result success requires anchored terminal SUCCESS marker"
+if ! declare -F review_result_completed_successfully >/dev/null 2>&1; then
+    test_fail "missing terminal success classifier"
+else
+    printf '{"findings":[{"title":"partial"}]}\n' > "$TMP_TEST_DIR/partial.md"
+    printf '## Status: FAILED (exit code: 1)\n' > "$TMP_TEST_DIR/failed.md"
+    printf '## Status: SUCCESS\n' > "$TMP_TEST_DIR/success.md"
+    if ! review_result_completed_successfully "$TMP_TEST_DIR/partial.md" &&
+       ! review_result_completed_successfully "$TMP_TEST_DIR/failed.md" &&
+       review_result_completed_successfully "$TMP_TEST_DIR/success.md"; then
+        test_pass
+    else
+        test_fail "terminal success classifier accepted a partial or failed result"
+    fi
+fi
+
+test_case "Round 1 supervision tracks progress per agent"
+if grep -q 'round1_last_progress' "$REVIEW_SH" &&
+   grep -q 'round1_settled' "$REVIEW_SH" &&
+   grep -Eq 'basename.*(_rf|round1_files)' "$REVIEW_SH"; then
+    test_pass
+else
+    test_fail "Round 1 still uses a fleet-wide stall fingerprint"
+fi
+
+test_case "Unreleased changelog has one Fixed section"
+unreleased_fixed_count=$(sed -n '/^## \[Unreleased\]/,/^## \[[0-9]/p' "$PROJECT_ROOT/CHANGELOG.md" | grep -c '^### Fixed$' || true)
+if [[ "$unreleased_fixed_count" == "1" ]]; then
+    test_pass
+else
+    test_fail "Unreleased contains $unreleased_fixed_count Fixed sections"
 fi
 
 test_case "review agents run without absolute timeout"

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -184,8 +184,12 @@ else
     printf '{"findings":[{"title":"partial"}]}\n' > "$TMP_TEST_DIR/partial.md"
     printf '## Status: FAILED (exit code: 1)\n' > "$TMP_TEST_DIR/failed.md"
     printf '## Status: SUCCESS\n' > "$TMP_TEST_DIR/success.md"
+    printf '## Status: SUCCESS\n## Status: FAILED (exit code: 1)\n' > "$TMP_TEST_DIR/success-then-failed.md"
+    printf '## Status: SUCCESS\n## Status: TIMEOUT\n' > "$TMP_TEST_DIR/success-then-timeout.md"
     if ! review_result_completed_successfully "$TMP_TEST_DIR/partial.md" &&
        ! review_result_completed_successfully "$TMP_TEST_DIR/failed.md" &&
+       ! review_result_completed_successfully "$TMP_TEST_DIR/success-then-failed.md" &&
+       ! review_result_completed_successfully "$TMP_TEST_DIR/success-then-timeout.md" &&
        review_result_completed_successfully "$TMP_TEST_DIR/success.md"; then
         test_pass
     else

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -216,13 +216,57 @@ else
     fi
 fi
 
-test_case "Round 1 supervision tracks progress per agent"
-if grep -q 'round1_last_progress' "$REVIEW_SH" &&
-   grep -q 'round1_settled' "$REVIEW_SH" &&
-   grep -Eq 'basename.*(_rf|round1_files)' "$REVIEW_SH"; then
+test_case "Round 1 supervision isolates a stalled agent from a progressing peer"
+round1_dir="$TEST_TMP_DIR/round1-supervision"
+mkdir -p "$round1_dir"
+stalled_result="$round1_dir/codex-stalled.md"
+healthy_result="$round1_dir/gemini-healthy.md"
+stalled_terminated="$round1_dir/stalled-terminated"
+healthy_completed="$round1_dir/healthy-completed"
+
+bash -c 'trap '\''touch "$1"; exit 0'\'' TERM; while :; do sleep 1; done' _ "$stalled_terminated" \
+    >/dev/null 2>&1 &
+stalled_pid=$!
+bash -c '
+    for tick in 1 2 3 4 5; do
+        printf "%s\n" "$tick" >> "$1.progress"
+        sleep 1
+    done
+    printf "## Status: SUCCESS\n" > "$1"
+    touch "$2"
+' _ "$healthy_result" "$healthy_completed" &
+healthy_pid=$!
+
+round1_files=("$stalled_result" "$healthy_result")
+round1_pids=("$stalled_pid" "$healthy_pid")
+round1_agent_types=(codex gemini)
+round1_roles=(stalled healthy)
+review_supervise_round1 2 1 "$round1_dir" &
+supervisor_pid=$!
+
+supervisor_finished=false
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    if ! review_process_is_running "$supervisor_pid"; then
+        supervisor_finished=true
+        break
+    fi
+    sleep 1
+done
+if [[ "$supervisor_finished" != "true" ]]; then
+    kill -KILL "$supervisor_pid" "$stalled_pid" "$healthy_pid" 2>/dev/null || true
+fi
+wait "$supervisor_pid" 2>/dev/null || true
+wait "$stalled_pid" 2>/dev/null || true
+wait "$healthy_pid" 2>/dev/null || true
+
+if [[ "$supervisor_finished" == "true" ]] &&
+   [[ -f "$stalled_terminated" && -f "$healthy_completed" ]] &&
+   ! review_result_has_terminal_status "$stalled_result" &&
+   review_result_completed_successfully "$healthy_result"; then
     test_pass
 else
-    test_fail "Round 1 still uses a fleet-wide stall fingerprint"
+    kill -KILL "$supervisor_pid" "$stalled_pid" "$healthy_pid" 2>/dev/null || true
+    test_fail "Round 1 supervision did not isolate stalled and healthy agent outcomes"
 fi
 
 test_case "Unreleased changelog has one Fixed section"

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -216,6 +216,34 @@ else
     fi
 fi
 
+test_case "Round 1 supervisor accepts leading-zero decimal timing values"
+round1_decimal_dir="$TEST_TMP_DIR/round1-decimal-timing"
+mkdir -p "$round1_decimal_dir"
+round1_decimal_err="$round1_decimal_dir/stderr"
+if (
+    sleep 0.5 &
+    decimal_provider_pid=$!
+    round1_files=("$round1_decimal_dir/provider.md")
+    round1_pids=("$decimal_provider_pid")
+    round1_agent_types=(codex)
+    round1_roles=(decimal-timing)
+    date() {
+        if [[ -e "$round1_decimal_dir/date-called" ]]; then
+            printf '110\n'
+        else
+            touch "$round1_decimal_dir/date-called"
+            printf '100\n'
+        fi
+    }
+    review_terminate_process_tree() { kill -TERM "$1" 2>/dev/null || true; }
+    review_supervise_round1 08 01 "$round1_decimal_dir"
+) 2>"$round1_decimal_err" &&
+   ! grep -q 'value too great for base' "$round1_decimal_err"; then
+    test_pass
+else
+    test_fail "Round 1 supervisor triggered Bash octal parsing"
+fi
+
 test_case "Round 1 supervision isolates a stalled agent from a progressing peer"
 round1_dir="$TEST_TMP_DIR/round1-supervision"
 mkdir -p "$round1_dir"

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -244,6 +244,15 @@ else
     test_fail "Round 1 supervisor triggered Bash octal parsing"
 fi
 
+test_case "Round 1 tracks provider processes instead of spawn wrappers"
+round1_spawn_block="$(sed -n '/^[[:space:]]*fleet_dispatch_begin$/,/^[[:space:]]*fleet_dispatch_end$/p' "$REVIEW_SH")"
+if grep -q 'spawn_agent_capture_pid' <<< "$round1_spawn_block" &&
+   ! grep -Eq 'spawn_agent .*&' <<< "$round1_spawn_block"; then
+    test_pass
+else
+    test_fail "Round 1 still supervises short-lived spawn wrappers"
+fi
+
 test_case "Round 1 supervision isolates a stalled agent from a progressing peer"
 round1_dir="$TEST_TMP_DIR/round1-supervision"
 mkdir -p "$round1_dir"

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -9,9 +9,11 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "review aggregation robustness"
 
 REVIEW_SH="$PROJECT_ROOT/scripts/lib/review.sh"
-TMP_TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-review-robustness.XXXXXX")"
-TMP_MD="$TMP_TEST_DIR/review.md"
-trap 'rm -rf "$TMP_TEST_DIR"' EXIT
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
+rm -rf "$TEST_TMP_DIR"
+mkdir -p "$TEST_TMP_DIR"
+TMP_MD="$TEST_TMP_DIR/review.md"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT
 
 cat > "$TMP_MD" <<'EOF'
 # Agent: claude-sonnet
@@ -50,14 +52,31 @@ else
     test_fail "extractor failed to recover findings"
 fi
 
+test_case "extractor fast path returns only the last non-empty findings array"
+cat > "$TEST_TMP_DIR/multiple-json.md" <<'EOF'
+# Agent: multiple-json-provider
+## Output
+{"findings":[{"title":"First finding"}]}
+{"findings":[]}
+{"findings":[{"title":"Last finding"}]}
+## Status: SUCCESS
+EOF
+multiple_json_out="$(review_extract_findings_array "$TEST_TMP_DIR/multiple-json.md" 2>/dev/null || true)"
+if [[ "$(printf '%s' "$multiple_json_out" | jq -r 'length' 2>/dev/null || true)" == "1" ]] &&
+   [[ "$(printf '%s' "$multiple_json_out" | jq -r '.[0].title' 2>/dev/null || true)" == "Last finding" ]]; then
+    test_pass
+else
+    test_fail "fast path returned multiple or stale findings arrays: $multiple_json_out"
+fi
+
 test_case "extractor rejects non-array findings values"
-cat > "$TMP_TEST_DIR/non-array.md" <<'EOF'
+cat > "$TEST_TMP_DIR/non-array.md" <<'EOF'
 # Agent: malformed-provider
 ## Output
 {"findings":"not-an-array"}
 ## Status: SUCCESS
 EOF
-non_array_out="$(review_extract_findings_array "$TMP_TEST_DIR/non-array.md" 2>/dev/null || true)"
+non_array_out="$(review_extract_findings_array "$TEST_TMP_DIR/non-array.md" 2>/dev/null || true)"
 if [[ "$(printf '%s' "$non_array_out" | jq -r 'type' 2>/dev/null || true)" == "array" ]] &&
    [[ "$(printf '%s' "$non_array_out" | jq -r 'length' 2>/dev/null || true)" == "0" ]]; then
     test_pass
@@ -66,7 +85,7 @@ else
 fi
 
 test_case "progress fingerprint ignores unrelated result artifacts"
-progress_dir="$TMP_TEST_DIR/progress"
+progress_dir="$TEST_TMP_DIR/progress"
 mkdir -p "$progress_dir"
 printf 'target-v1\n' > "$progress_dir/target.out"
 printf 'other-v1\n' > "$progress_dir/other.out"
@@ -86,7 +105,7 @@ test_case "process-tree termination reaches TERM-ignoring grandchildren"
 if ! declare -F review_terminate_process_tree >/dev/null 2>&1; then
     test_fail "missing recursive process-tree termination helper"
 else
-    process_dir="$TMP_TEST_DIR/process-tree"
+    process_dir="$TEST_TMP_DIR/process-tree"
     mkdir -p "$process_dir"
     cat > "$process_dir/grandchild.sh" <<'PROCESS_GRANDCHILD'
 trap '' TERM
@@ -134,7 +153,7 @@ fi
 
 test_case "timing knobs accept leading-zero decimal values"
 run_agent_sync() { printf 'ok\n'; }
-timing_err="$TMP_TEST_DIR/timing.err"
+timing_err="$TEST_TMP_DIR/timing.err"
 if OCTOPUS_REVIEW_STALL_WINDOW=08 OCTOPUS_REVIEW_POLL_SECS=08 \
    review_run_agent_sync_progress codex prompt role review timing-test \
        >/dev/null 2>"$timing_err" &&
@@ -145,14 +164,14 @@ else
 fi
 
 test_case "retry wait stops when provider exits without terminal status"
-dead_result="$TMP_TEST_DIR/dead-result.md"
+dead_result="$TEST_TMP_DIR/dead-result.md"
 sleep 1 &
 dead_provider_pid=$!
-review_wait_for_result_status "$dead_result" "$dead_provider_pid" dead-provider "$TMP_TEST_DIR" 02 01 &
+review_wait_for_result_status "$dead_result" "$dead_provider_pid" dead-provider "$TEST_TMP_DIR" 02 01 &
 waiter_pid=$!
 waiter_finished=false
 for _ in 1 2 3 4; do
-    if ! kill -0 "$waiter_pid" 2>/dev/null; then
+    if ! review_process_is_running "$waiter_pid"; then
         waiter_finished=true
         break
     fi
@@ -181,16 +200,16 @@ test_case "result success requires anchored terminal SUCCESS marker"
 if ! declare -F review_result_completed_successfully >/dev/null 2>&1; then
     test_fail "missing terminal success classifier"
 else
-    printf '{"findings":[{"title":"partial"}]}\n' > "$TMP_TEST_DIR/partial.md"
-    printf '## Status: FAILED (exit code: 1)\n' > "$TMP_TEST_DIR/failed.md"
-    printf '## Status: SUCCESS\n' > "$TMP_TEST_DIR/success.md"
-    printf '## Status: SUCCESS\n## Status: FAILED (exit code: 1)\n' > "$TMP_TEST_DIR/success-then-failed.md"
-    printf '## Status: SUCCESS\n## Status: TIMEOUT\n' > "$TMP_TEST_DIR/success-then-timeout.md"
-    if ! review_result_completed_successfully "$TMP_TEST_DIR/partial.md" &&
-       ! review_result_completed_successfully "$TMP_TEST_DIR/failed.md" &&
-       ! review_result_completed_successfully "$TMP_TEST_DIR/success-then-failed.md" &&
-       ! review_result_completed_successfully "$TMP_TEST_DIR/success-then-timeout.md" &&
-       review_result_completed_successfully "$TMP_TEST_DIR/success.md"; then
+    printf '{"findings":[{"title":"partial"}]}\n' > "$TEST_TMP_DIR/partial.md"
+    printf '## Status: FAILED (exit code: 1)\n' > "$TEST_TMP_DIR/failed.md"
+    printf '## Status: SUCCESS\n' > "$TEST_TMP_DIR/success.md"
+    printf '## Status: SUCCESS\n## Status: FAILED (exit code: 1)\n' > "$TEST_TMP_DIR/success-then-failed.md"
+    printf '## Status: SUCCESS\n## Status: TIMEOUT\n' > "$TEST_TMP_DIR/success-then-timeout.md"
+    if ! review_result_completed_successfully "$TEST_TMP_DIR/partial.md" &&
+       ! review_result_completed_successfully "$TEST_TMP_DIR/failed.md" &&
+       ! review_result_completed_successfully "$TEST_TMP_DIR/success-then-failed.md" &&
+       ! review_result_completed_successfully "$TEST_TMP_DIR/success-then-timeout.md" &&
+       review_result_completed_successfully "$TEST_TMP_DIR/success.md"; then
         test_pass
     else
         test_fail "terminal success classifier accepted a partial or failed result"

--- a/tests/unit/test-review-run.sh
+++ b/tests/unit/test-review-run.sh
@@ -113,13 +113,13 @@ assert_contains "$(grep -A4 'avg_confidence=$(jq' "$ALL_SRC" 2>/dev/null | head 
 assert_contains "$(grep -A2 'commit_id.*headRefOid' "$ALL_SRC" 2>/dev/null | head -10)" \
   'commit_id' "post_inline_comments: empty commit_id guarded"
 
-assert_contains "$(grep -c 'review_openai_compat_empty_output_retryable' "$ALL_SRC" 2>/dev/null || echo 0)" \
+assert_contains "$(grep -c 'review_openai_compat_empty_output_retryable' "$ALL_SRC" 2>/dev/null || true)" \
   "[1-9]" "review_run: OpenAI-compatible Empty output retry classifier exists"
 
-assert_contains "$(grep -c 'OCTOPUS_REVIEW_OPENAI_COMPAT_EMPTY_RETRY_BACKOFF_SECS' "$ALL_SRC" 2>/dev/null || echo 0)" \
+assert_contains "$(grep -c 'OCTOPUS_REVIEW_OPENAI_COMPAT_EMPTY_RETRY_BACKOFF_SECS' "$ALL_SRC" 2>/dev/null || true)" \
   "[1-9]" "review_run: OpenAI-compatible Empty output retry has configurable backoff"
 
-assert_contains "$(grep -c 'attempt1' "$ALL_SRC" 2>/dev/null || echo 0)" \
+assert_contains "$(grep -c 'attempt1' "$ALL_SRC" 2>/dev/null || true)" \
   "[1-9]" "review_run: OpenAI-compatible Empty output retry preserves first artifact"
 
 # ── diff target file support ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- supervise Round 1 review agents with independent progress timers and anchored terminal statuses
- snapshot and terminate the complete descendant process tree when a review stalls
- treat unreaped zombie processes as stopped so macOS does not wait until the stall timeout
- normalize decimal timing inputs and accept only valid findings arrays, preferring the last non-empty result
- expand review regression coverage and document the follow-up in Unreleased

## Verification
- CI=1 make ci-local: 16 smoke, 170 unit, and 7 integration suites passed after the macOS fix
- tests/unit/test-review-aggregation-robustness.sh: 16/16 passed three consecutive times after the fix
- tests/unit/test-review-run.sh: 27/27 passed
- tests/unit/test-heartbeat-timeout.sh: 12/12 passed
- bash syntax passed; GitHub Portability Lint passed on the original head and will rerun for the updated head
- no executable-bit drift in the committed diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Round 1 supervision with independent per-agent artifact progress tracking and isolated stall handling.
  * Hardened terminal/completion detection using anchored status markers; providers without terminal status are treated as partial.
  * Strengthened stall cleanup by terminating the full provider process tree using a safer TERM-then-KILL approach.
  * Tightened findings extraction to accept only non-empty `findings` arrays and prefer the last non-empty result.
* **Tests**
  * Expanded robustness coverage for extraction ordering/type checks, process-tree termination, and additional review-run assertions.
* **Documentation**
  * Updated the changelog with the new detailed “Fixed” entry for Unreleased and the matching released version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->