### PR TITLE
test: isolate provider and memory suites

### DIFF
--- a/scripts/lib/memory.sh
+++ b/scripts/lib/memory.sh
@@ -27,6 +27,7 @@ _memory_claude_settings_path() {
 _memory_mcp_service_registered() {
     local settings
     settings=$(_memory_claude_settings_path) || return 1
+    [[ -s "$settings" ]] || return 1
     command -v jq >/dev/null 2>&1 || return 1
     jq -e '
         ((.mcpServers // {}) + (.servers // {})) as $m
@@ -39,6 +40,7 @@ _memory_agentmemory_registered() {
     [[ -n "${AGENTMEMORY_URL:-}" ]] && return 0
     local settings
     settings=$(_memory_claude_settings_path) || return 1
+    [[ -s "$settings" ]] || return 1
     command -v jq >/dev/null 2>&1 || return 1
     jq -e '
         ((.mcpServers // {}) + (.servers // {})) as $m

--- a/tests/test-provider-activation.sh
+++ b/tests/test-provider-activation.sh
@@ -228,24 +228,8 @@ else
 fi
 
 # 5.4: synthesis admits short-but-usable probe findings instead of using a hard byte cutoff
-extract_function_body() {
-    local function_name="$1" file="$2"
-    awk -v fn="$function_name" '
-        $0 ~ "^" fn "\\(\\)[[:space:]]*\\{" { in_fn=1 }
-        in_fn {
-            print
-            opens = gsub(/\{/, "{")
-            closes = gsub(/\}/, "}")
-            depth += opens - closes
-        }
-        in_fn && depth == 0 { exit }
-    ' "$file"
-}
-heuristics_file="$PROJECT_ROOT/scripts/lib/heuristics.sh"
-synthesis_body="$(extract_function_body synthesize_probe_results "$heuristics_file")"
-context_body="$(extract_function_body build_probe_synthesis_context "$heuristics_file")"
-if grep -q 'probe_result_file_is_usable' <<<"$synthesis_body" && \
-   grep -q 'probe_result_file_is_usable' <<<"$context_body"; then
+if grep -A 30 'synthesize_probe_results()' "$PROJECT_ROOT/scripts/lib/heuristics.sh" | grep -q 'probe_result_file_is_usable' && \
+   grep -A 40 'build_probe_synthesis_context()' "$PROJECT_ROOT/scripts/lib/heuristics.sh" | grep -q 'probe_result_file_is_usable'; then
     pass "5.4 Synthesis classifies non-empty probe results without a hard byte cutoff"
 else
     fail "5.4 Synthesis should classify usable probe results before synthesis"

--- a/tests/test-provider-activation.sh
+++ b/tests/test-provider-activation.sh
@@ -228,8 +228,8 @@ else
 fi
 
 # 5.4: synthesis admits short-but-usable probe findings instead of using a hard byte cutoff
-if grep -rA 30 'synthesize_probe_results()' $SCRIPTS_ALL | grep -q 'probe_result_file_is_usable' && \
-   grep -rA 80 'build_probe_synthesis_context()' $SCRIPTS_ALL | grep -q 'probe_result_file_is_usable'; then
+if grep -A 30 'synthesize_probe_results()' "$PROJECT_ROOT/scripts/lib/heuristics.sh" | grep -q 'probe_result_file_is_usable' && \
+   grep -A 40 'build_probe_synthesis_context()' "$PROJECT_ROOT/scripts/lib/heuristics.sh" | grep -q 'probe_result_file_is_usable'; then
     pass "5.4 Synthesis classifies non-empty probe results without a hard byte cutoff"
 else
     fail "5.4 Synthesis should classify usable probe results before synthesis"

--- a/tests/test-provider-activation.sh
+++ b/tests/test-provider-activation.sh
@@ -228,8 +228,24 @@ else
 fi
 
 # 5.4: synthesis admits short-but-usable probe findings instead of using a hard byte cutoff
-if grep -A 30 'synthesize_probe_results()' "$PROJECT_ROOT/scripts/lib/heuristics.sh" | grep -q 'probe_result_file_is_usable' && \
-   grep -A 40 'build_probe_synthesis_context()' "$PROJECT_ROOT/scripts/lib/heuristics.sh" | grep -q 'probe_result_file_is_usable'; then
+extract_function_body() {
+    local function_name="$1" file="$2"
+    awk -v fn="$function_name" '
+        $0 ~ "^" fn "\\(\\)[[:space:]]*\\{" { in_fn=1 }
+        in_fn {
+            print
+            opens = gsub(/\{/, "{")
+            closes = gsub(/\}/, "}")
+            depth += opens - closes
+        }
+        in_fn && depth == 0 { exit }
+    ' "$file"
+}
+heuristics_file="$PROJECT_ROOT/scripts/lib/heuristics.sh"
+synthesis_body="$(extract_function_body synthesize_probe_results "$heuristics_file")"
+context_body="$(extract_function_body build_probe_synthesis_context "$heuristics_file")"
+if grep -q 'probe_result_file_is_usable' <<<"$synthesis_body" && \
+   grep -q 'probe_result_file_is_usable' <<<"$context_body"; then
     pass "5.4 Synthesis classifies non-empty probe results without a hard byte cutoff"
 else
     fail "5.4 Synthesis should classify usable probe results before synthesis"

--- a/tests/test-provider-activation.sh
+++ b/tests/test-provider-activation.sh
@@ -228,8 +228,11 @@ else
 fi
 
 # 5.4: synthesis admits short-but-usable probe findings instead of using a hard byte cutoff
-if grep -A 30 'synthesize_probe_results()' "$PROJECT_ROOT/scripts/lib/heuristics.sh" | grep -q 'probe_result_file_is_usable' && \
-   grep -A 40 'build_probe_synthesis_context()' "$PROJECT_ROOT/scripts/lib/heuristics.sh" | grep -q 'probe_result_file_is_usable'; then
+heuristics_file="$PROJECT_ROOT/scripts/lib/heuristics.sh"
+synthesis_body=$(bash -c 'source "$1"; declare -f synthesize_probe_results' _ "$heuristics_file")
+context_body=$(bash -c 'source "$1"; declare -f build_probe_synthesis_context' _ "$heuristics_file")
+if grep -q 'probe_result_file_is_usable' <<<"$synthesis_body" && \
+   grep -q 'probe_result_file_is_usable' <<<"$context_body"; then
     pass "5.4 Synthesis classifies non-empty probe results without a hard byte cutoff"
 else
     fail "5.4 Synthesis should classify usable probe results before synthesis"

--- a/tests/test-provider-activation.sh
+++ b/tests/test-provider-activation.sh
@@ -229,8 +229,8 @@ fi
 
 # 5.4: synthesis admits short-but-usable probe findings instead of using a hard byte cutoff
 heuristics_file="$PROJECT_ROOT/scripts/lib/heuristics.sh"
-synthesis_body=$(bash -c 'source "$1"; declare -f synthesize_probe_results' _ "$heuristics_file")
-context_body=$(bash -c 'source "$1"; declare -f build_probe_synthesis_context' _ "$heuristics_file")
+synthesis_body=$(bash -c 'source "$1"; declare -f synthesize_probe_results' _ "$heuristics_file") || synthesis_body=""
+context_body=$(bash -c 'source "$1"; declare -f build_probe_synthesis_context' _ "$heuristics_file") || context_body=""
 if grep -q 'probe_result_file_is_usable' <<<"$synthesis_body" && \
    grep -q 'probe_result_file_is_usable' <<<"$context_body"; then
     pass "5.4 Synthesis classifies non-empty probe results without a hard byte cutoff"

--- a/tests/unit/test-memory-contract.sh
+++ b/tests/unit/test-memory-contract.sh
@@ -52,8 +52,8 @@ test_backends_defaults_to_claude_mem() {
     test_case "with no MCP config registered, backends resolves to claude-mem"
     local out
     # shellcheck disable=SC1090
-    out=$(env -i PATH="$PATH" OCTOPUS_MEMORY_BACKEND=auto CLAUDE_SETTINGS_FILE=/dev/null \
-          HOME="$TEST_TMP_DIR/empty-home" \
+    out=$(env -i "PATH=${PATH}" "OCTOPUS_MEMORY_BACKEND=auto" "CLAUDE_SETTINGS_FILE=/dev/null" \
+          "HOME=${TEST_TMP_DIR}/empty-home" \
           bash -c "source '$MEM'; memory_backends")
     if [[ "$(printf '%s' "$out" | head -1)" == "claude-mem" ]]; then
         test_pass

--- a/tests/unit/test-memory-contract.sh
+++ b/tests/unit/test-memory-contract.sh
@@ -52,8 +52,8 @@ test_backends_defaults_to_claude_mem() {
     test_case "with no MCP config registered, backends resolves to claude-mem"
     local out
     # shellcheck disable=SC1090
-    out=$(OCTOPUS_MEMORY_BACKEND=auto CLAUDE_SETTINGS_FILE=/dev/null \
-          HOME=/nonexistent-for-test \
+    out=$(env -i PATH="$PATH" OCTOPUS_MEMORY_BACKEND=auto CLAUDE_SETTINGS_FILE=/dev/null \
+          HOME="$TEST_TMP_DIR/empty-home" \
           bash -c "source '$MEM'; memory_backends")
     if [[ "$(printf '%s' "$out" | head -1)" == "claude-mem" ]]; then
         test_pass

--- a/tests/unit/test-mode-switching.sh
+++ b/tests/unit/test-mode-switching.sh
@@ -11,8 +11,9 @@ source "$SCRIPT_DIR/../helpers/mock-helpers.sh"
 test_suite "Two-Mode System (Dev Work vs Knowledge Work)"
 
 # Setup: Create a temporary config for testing
-TEST_CONFIG_DIR="$TEST_TMP_DIR/mode-switching-config"
+TEST_CONFIG_DIR=$(mktemp -d)
 TEST_CONFIG_FILE="$TEST_CONFIG_DIR/user-config.yaml"
+trap 'rm -rf "$TEST_CONFIG_DIR"' EXIT
 
 setup_test_config() {
     mkdir -p "$TEST_CONFIG_DIR"

--- a/tests/unit/test-mode-switching.sh
+++ b/tests/unit/test-mode-switching.sh
@@ -11,9 +11,8 @@ source "$SCRIPT_DIR/../helpers/mock-helpers.sh"
 test_suite "Two-Mode System (Dev Work vs Knowledge Work)"
 
 # Setup: Create a temporary config for testing
-TEST_CONFIG_DIR=$(mktemp -d)
+TEST_CONFIG_DIR="$TEST_TMP_DIR/mode-switching-config"
 TEST_CONFIG_FILE="$TEST_CONFIG_DIR/user-config.yaml"
-trap 'rm -rf "$TEST_CONFIG_DIR"' EXIT
 
 setup_test_config() {
     mkdir -p "$TEST_CONFIG_DIR"

--- a/tests/unit/test-mode-switching.sh
+++ b/tests/unit/test-mode-switching.sh
@@ -11,7 +11,7 @@ source "$SCRIPT_DIR/../helpers/mock-helpers.sh"
 test_suite "Two-Mode System (Dev Work vs Knowledge Work)"
 
 # Setup: Create a temporary config for testing
-TEST_CONFIG_DIR="$HOME/.claude-octopus-test"
+TEST_CONFIG_DIR="$TEST_TMP_DIR/mode-switching-config"
 TEST_CONFIG_FILE="$TEST_CONFIG_DIR/user-config.yaml"
 
 setup_test_config() {

--- a/tests/unit/test-provider-allowlist.sh
+++ b/tests/unit/test-provider-allowlist.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
+export OCTOPUS_CONFIG_DIR="$TEST_TMP_DIR/provider-allowlist-root"
+unset CLAUDE_CODE_SESSION_ID OCTO_ALLOWED_PROVIDERS
 test_suite "Provider allowlist"
 
 ALLOWLIST_LIB="$PROJECT_ROOT/scripts/lib/provider-allowlist.sh"

--- a/tests/unit/test-provider-health-probe.sh
+++ b/tests/unit/test-provider-health-probe.sh
@@ -20,11 +20,11 @@ test_suite "Provider health probe (oco-cbb)"
 
 log() { :; }
 
-FIXTURE="$(mktemp -d)"
+FIXTURE="$TEST_TMP_DIR/provider-health-probe"
+mkdir -p "$FIXTURE"
 export OCTOPUS_CONFIG_DIR="$FIXTURE/config"
 export OCTO_ALLOWED_PROVIDERS="perplexity openrouter"
 unset CLAUDE_CODE_SESSION_ID
-trap 'rm -rf "$FIXTURE"' EXIT
 
 # ── 1. Perplexity payload contains max_tokens and is valid JSON ────────────────
 

--- a/tests/unit/test-provider-health-probe.sh
+++ b/tests/unit/test-provider-health-probe.sh
@@ -21,6 +21,9 @@ test_suite "Provider health probe (oco-cbb)"
 log() { :; }
 
 FIXTURE="$(mktemp -d)"
+export OCTOPUS_CONFIG_DIR="$FIXTURE/config"
+export OCTO_ALLOWED_PROVIDERS="perplexity openrouter"
+unset CLAUDE_CODE_SESSION_ID
 trap 'rm -rf "$FIXTURE"' EXIT
 
 # ── 1. Perplexity payload contains max_tokens and is valid JSON ────────────────


### PR DESCRIPTION
## Summary
- isolate provider allowlist and health-probe tests from real session config
- use test-owned config paths for mode switching
- make probe synthesis assertion target the implementation file directly
- reject empty Claude settings files before memory backend detection
- run the memory default case in a clean environment

## Validation
- tests/test-provider-activation.sh: 25/25
- tests/unit/test-provider-allowlist.sh: 10/10
- tests/unit/test-provider-health-probe.sh: 12/12
- tests/unit/test-memory-contract.sh: 15/15
- tests/unit/test-mode-switching.sh: 4/4
- git diff --check

The memory guard fixes a real false-positive: jq can exit successfully on an empty settings file, causing unavailable backends to be reported as registered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented processing errors when the Claude settings file is empty by ensuring it contains content before parsing.
* **Tests**
  * Strengthened provider activation verification by extracting function bodies and confirming they reference probe-usable logic.
  * Improved memory backend contract checks by running in a minimal, scrubbed environment.
  * Enhanced test isolation: mode switching, provider allowlist, and provider health probe tests now use dedicated temp config directories and controlled environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->