### PR TITLE
fix: track provider pid after delayed spawn

### DIFF
--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -1100,6 +1100,10 @@ spawn_agent_capture_pid() {
     local pid=""
     local attempts=0
     local "max_attempts=${OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS:-1200}"
+    if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+        log "WARN" "invalid OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS='$max_attempts'; using default 1200" >&2
+        max_attempts=1200
+    fi
     while [[ $attempts -lt $max_attempts ]]; do
         pid=$(awk '/^[0-9]+$/ { value=$1 } END { print value }' "$pid_file" 2>/dev/null)
         [[ -n "$pid" ]] && break

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -1099,7 +1099,7 @@ spawn_agent_capture_pid() {
 
     local pid=""
     local attempts=0
-    local max_attempts="${OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS:-1200}"
+    local "max_attempts=${OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS:-1200}"
     while [[ $attempts -lt $max_attempts ]]; do
         pid=$(awk '/^[0-9]+$/ { value=$1 } END { print value }' "$pid_file" 2>/dev/null)
         [[ -n "$pid" ]] && break

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -1099,10 +1099,13 @@ spawn_agent_capture_pid() {
 
     local pid=""
     local attempts=0
-    while [[ $attempts -lt 100 ]]; do
+    local max_attempts="${OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS:-1200}"
+    while [[ $attempts -lt $max_attempts ]]; do
         pid=$(awk '/^[0-9]+$/ { value=$1 } END { print value }' "$pid_file" 2>/dev/null)
         [[ -n "$pid" ]] && break
-        if ! kill -0 "$wrapper_pid" 2>/dev/null && [[ -s "$pid_file" ]]; then
+        if ! kill -0 "$wrapper_pid" 2>/dev/null; then
+            wait "$wrapper_pid" 2>/dev/null || true
+            pid=$(awk '/^[0-9]+$/ { value=$1 } END { print value }' "$pid_file" 2>/dev/null)
             break
         fi
         sleep 0.1
@@ -1110,8 +1113,14 @@ spawn_agent_capture_pid() {
     done
 
     if [[ -z "$pid" ]]; then
-        log "WARN" "spawn_agent produced no provider PID for $task_id within 10s; tracking wrapper PID $wrapper_pid" >&2
-        pid="$wrapper_pid"
+        log "ERROR" "spawn_agent produced no provider PID for $task_id; refusing to track wrapper PID $wrapper_pid" >&2
+        if [[ -s "$pid_file" ]]; then
+            tail -20 "$pid_file" >&2 || true
+        fi
+        kill "$wrapper_pid" 2>/dev/null || true
+        wait "$wrapper_pid" 2>/dev/null || true
+        rm -f "$pid_file"
+        return 1
     fi
 
     rm -f "$pid_file"

--- a/tests/unit/test-spawn-agent-capture-pid.sh
+++ b/tests/unit/test-spawn-agent-capture-pid.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "spawn agent PID capture"
+
+# Load only the helper under test so the fixture controls spawn_agent and log.
+eval "$(sed -n '/^spawn_agent_capture_pid() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/spawn.sh")"
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT INT TERM
+
+log() { printf '%s %s\n' "${1:-}" "${2:-}" >> "$TMP_ROOT/log"; }
+
+# The wrapper does meaningful setup before it can print the provider PID.
+# Capture must wait for that PID rather than returning the wrapper PID.
+test_case "returns delayed provider PID rather than wrapper PID"
+spawn_agent() {
+    sleep 0.3
+    printf '%s\n' 424242
+}
+export OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS=20
+pid=$(spawn_agent_capture_pid codex prompt delayed-task implementer tangle)
+if [[ "$pid" == "424242" ]]; then
+    test_pass
+else
+    test_fail "expected provider PID 424242, got: ${pid:-empty}"
+fi
+
+# A failed setup must fail dispatch. Returning the short-lived wrapper PID would
+# make downstream wait loops report a false missing completion marker.
+test_case "fails when spawn_agent exits without provider PID"
+spawn_agent() {
+    printf '%s\n' "setup failed before provider launch"
+    return 1
+}
+export OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS=20
+if pid=$(spawn_agent_capture_pid codex prompt failed-task implementer tangle 2>/dev/null); then
+    test_fail "expected failure, got wrapper/provider PID: ${pid:-empty}"
+else
+    test_pass
+fi
+
+test_case "implementation has no wrapper PID fallback"
+if grep -q 'tracking wrapper PID' "$PROJECT_ROOT/scripts/lib/spawn.sh"; then
+    test_fail "unsafe wrapper PID fallback still present"
+else
+    test_pass
+fi
+
+test_summary

--- a/tests/unit/test-spawn-agent-capture-pid.sh
+++ b/tests/unit/test-spawn-agent-capture-pid.sh
@@ -9,10 +9,11 @@ test_suite "spawn agent PID capture"
 # Load only the helper under test so the fixture controls spawn_agent and log.
 eval "$(sed -n '/^spawn_agent_capture_pid() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/spawn.sh")"
 
-TMP_ROOT=$(mktemp -d)
-trap 'rm -rf "$TMP_ROOT"' EXIT INT TERM
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
+mkdir -p "$TEST_TMP_DIR"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
 
-log() { printf '%s %s\n' "${1:-}" "${2:-}" >> "$TMP_ROOT/log"; }
+log() { printf '%s %s\n' "${1:-}" "${2:-}" >> "$TEST_TMP_DIR/log"; }
 
 # The wrapper does meaningful setup before it can print the provider PID.
 # Capture must wait for that PID rather than returning the wrapper PID.
@@ -21,7 +22,7 @@ spawn_agent() {
     sleep 0.3
     printf '%s\n' 424242
 }
-export OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS=20
+export "OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS=20"
 pid=$(spawn_agent_capture_pid codex prompt delayed-task implementer tangle)
 if [[ "$pid" == "424242" ]]; then
     test_pass
@@ -36,7 +37,7 @@ spawn_agent() {
     printf '%s\n' "setup failed before provider launch"
     return 1
 }
-export OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS=20
+export "OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS=20"
 if pid=$(spawn_agent_capture_pid codex prompt failed-task implementer tangle 2>/dev/null); then
     test_fail "expected failure, got wrapper/provider PID: ${pid:-empty}"
 else


### PR DESCRIPTION
## Summary
- wait for the real provider PID instead of falling back to the short-lived spawn wrapper after 10 seconds
- fail dispatch if no provider PID is ever produced
- add regression coverage for delayed PID emission and failed pre-launch setup

## Why
Tangle workers can spend more than 10 seconds preparing prompts and context before launching the provider. The old fallback tracked the wrapper PID, which exited early while the provider continued orphaned. Downstream then reported missing completion markers and could enter correction loops despite successful code changes.

## Tests
- tests/unit/test-spawn-agent-capture-pid.sh
- tests/unit/test-tangle-missing-done-marker.sh
- tests/unit/test-tangle-dispatch-stdin-isolation.sh
- tests/unit/test-tangle-subtask-context.sh
- tests/smoke/test-fleet-dispatch-guard.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process monitoring to reliably detect and return the provider PID (not the wrapper PID).
  * Added a configurable retry-based waiting window for provider PID capture (via `OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS`, default 1200).
  * Improved timeout behavior with clearer error reporting and safer cleanup when no provider PID appears.
* **Tests**
  * Added unit coverage for delayed provider PID startup, early spawn failure, and confirmation that wrapper PID fallback behavior is not used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->