### PR TITLE
fix(agy): pass prompt as --print's argument; add OCTOPUS_GEMINI_VIA_AGY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,7 @@ Always be mindful that external CLIs cost money:
 - 🔴 Codex: ~$0.01-0.30 per query depending on model (GPT-5.5 $5/$30 MTok — premium default as of v9.44, GPT-5.4 $2.50/$15, GPT-5.3-Codex $1.75/$14, Mini $0.25/$2.00 MTok)
 - 🟡 Gemini: ~$0.01-0.03 per query (Gemini 3.1 Pro Preview $2.50/$10 MTok, 3 Flash Preview $0.25/$1)
 - 🧭 Antigravity CLI (`agy`): Included with the user's Antigravity access/subscription; backend cost depends on selected `OCTOPUS_AGY_MODEL`. Because Antigravity's model list is service-owned, explicit pins should use labels returned by `agy models` (for example `Gemini 3.5 Flash (Low)`) or `default`/`agy/default` to use the CLI default.
+- `OCTOPUS_GEMINI_VIA_AGY=1` serves `gemini*` seats through the Antigravity CLI (`agy-exec.sh`) — the migration path now that gemini-cli free-tier OAuth is sunset (`IneligibleTierError`). Model pins then follow `OCTOPUS_AGY_MODEL`.
 - 🟣 Perplexity: ~$0.01-0.05 per query (Sonar Pro $3/$15 MTok, Sonar $1/$1 MTok)
 - 🔵 Claude (Sonnet 4.6): Included with Claude Code subscription
 - 🔵 Claude (Fable 5, Mythos-class, opt-in via `OCTOPUS_OPUS_MODEL=claude-fable-5`): **$10/$50 per MTok** — 2x Opus 4.8 cost. 1M context, 128K output. Never auto-selected. Note: Anthropic retains prompts/outputs up to 30 days for safety classifiers. When pinned, apply the dispatch profile in `skills/blocks/fable5-prompting.md` (prompt anti-patterns, effort discipline, refusal fallback, judgment routing).

--- a/config/providers/agy/CLAUDE.md
+++ b/config/providers/agy/CLAUDE.md
@@ -10,17 +10,25 @@ command -v agy
 
 ## Dispatch
 
-Prompts are delivered through stdin and executed with Antigravity print mode:
+Callers deliver prompts through stdin (the provider-uniform contract);
+`agy-exec.sh` caches the stdin prompt and passes it to Antigravity print mode
+as `--print`'s argument. `--print` is a value-consuming string flag — agy does
+NOT read a prompt from stdin, and a bare `agy --print --sandbox` invocation
+makes the literal string `--sandbox` the prompt:
 
 ```bash
-agy --print --sandbox --print-timeout "${OCTOPUS_AGY_PRINT_TIMEOUT:-5m0s}"
+agy --sandbox --print-timeout "${OCTOPUS_AGY_PRINT_TIMEOUT:-5m0s}" --print "$PROMPT"
 ```
 
+Prompts larger than 100KB (Linux caps one argv string at 128KB) stay in the
+cached temp file; agy is pointed at it with `--add-dir` and a read-this-file
+`--print` instruction.
+
 When `OCTOPUS_AGY_MODEL` is set to a non-empty value other than `default`,
-Octopus adds the model override:
+Octopus adds the model override before the prompt:
 
 ```bash
-agy --print --sandbox --print-timeout "${OCTOPUS_AGY_PRINT_TIMEOUT:-5m0s}" --model "$OCTOPUS_AGY_MODEL"
+agy --sandbox --print-timeout "${OCTOPUS_AGY_PRINT_TIMEOUT:-5m0s}" --model "$OCTOPUS_AGY_MODEL" --print "$PROMPT"
 ```
 
 Octopus dispatches through `scripts/helpers/agy-exec.sh`, which is the command
@@ -39,10 +47,22 @@ When `OCTOPUS_AGY_MODEL` is non-empty and not `default`, Octopus adds:
 ```
 
 The helper builds the command as a Bash argv array, preserving spaces in
-`--model "$model"`. Prompt content is piped to the provider via stdin with
-`printf '%s' ... | "${cmd_array[@]}"` in `scripts/lib/agent-sync.sh`.
+`--model "$model"`. Callers pipe prompt content via stdin with
+`printf '%s' ... | "${cmd_array[@]}"` in `scripts/lib/agent-sync.sh`;
+`agy-exec.sh` converts that into the `--print` argument.
 Antigravity also uses `agy --print-timeout`; Octopus enforces its own
 orchestration timeout as a fallback around the provider command.
+
+## Serving gemini seats through agy
+
+`OCTOPUS_GEMINI_VIA_AGY=1` (also `on`/`true`/`yes`) makes `scripts/lib/dispatch.sh`
+return `agy-exec.sh` for the `gemini|gemini-fast|gemini-image` agent types, so
+existing workflows, phase routing, and role routing that seat gemini keep
+working on Antigravity subscriptions. Google sunset Gemini Code Assist
+free-tier OAuth for gemini-cli (`IneligibleTierError`); this option is the
+migration path that does not require re-routing every gemini seat by hand.
+Model pins follow `OCTOPUS_AGY_MODEL` (labels from `agy models`), not gemini
+model ids, and provider health checks for gemini seats probe agy instead.
 
 ## Security Note
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -16,7 +16,7 @@ A provider is used only when its CLI is installed AND its auth check passes. If 
 | Provider | Availability check | Fix |
 |----------|-------------------|-----|
 | 🔴 Codex | `codex` on PATH, auth configured | `codex login` (ChatGPT subscription) or set `OPENAI_API_KEY` |
-| 🟡 Gemini | `gemini` on PATH, auth configured | Sign in via `gemini` (Google account) or set `GEMINI_API_KEY` |
+| 🟡 Gemini | `gemini` on PATH, auth configured | Free-tier OAuth was sunset by Google (`IneligibleTierError` on every call): set `GEMINI_API_KEY`, or export `OCTOPUS_GEMINI_VIA_AGY=1` to serve gemini seats through the Antigravity CLI (subscription auth) |
 | 🧭 Antigravity | `agy` on PATH | Install the Antigravity CLI and sign in; verify with `agy models` |
 | 🟢 Copilot | `copilot` on PATH plus one of: `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`, `~/.copilot/config.json`, or `gh auth status` passing | `gh auth login` is the simplest path |
 | 🟤 Qwen | `qwen` on PATH plus `~/.qwen/oauth_creds.json` or `QWEN_API_KEY` | Free OAuth ended 2026-04-15; set `QWEN_API_KEY` or Coding-Plan auth (`OPENAI_API_KEY` + `OPENAI_BASE_URL`) |

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -86,16 +86,19 @@ if [[ -z "${prompt_content//[[:space:]]/}" ]]; then
 fi
 
 # Single-argument size ceiling: Linux caps one argv string at MAX_ARG_STRLEN
-# (128 KiB). A council prompt exceeding it would fail exec with a cryptic E2BIG,
-# so check first and fail with a message that names the actual problem.
-if (( ${#prompt_content} > 120000 )); then
-    echo "agy-exec.sh: prompt exceeds ~120KB (single-argv ceiling for agy --print); trim the dispatch context" >&2
-    exit 2
+# (128 KiB). Oversized prompts stay in the cached temp file and agy is pointed
+# at it via --add-dir with a read-this-file --print instruction, instead of
+# failing the seat.
+if (( ${#prompt_content} > 100000 )); then
+    cmd+=(--add-dir "$(dirname "$prompt_file")")
+    cmd+=(--print "Read the file ${prompt_file} and follow the instructions in it as your task prompt. Do not summarize the file; execute it.")
+else
+    cmd+=(--print "$prompt_content")
 fi
 
 run_agy() {
     : > "$stdout_file"
-    "${cmd[@]}" --print "$prompt_content" > "$stdout_file"
+    "${cmd[@]}" > "$stdout_file" < /dev/null
 }
 
 set +e

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -91,7 +91,7 @@ fi
 # failing the seat.
 if (( ${#prompt_content} > 100000 )); then
     cmd+=(--add-dir "$(dirname "$prompt_file")")
-    cmd+=(--print "Read the file ${prompt_file} and follow the instructions in it as your task prompt. Do not summarize the file; execute it.")
+    cmd+=(--print "Read the file '${prompt_file}' and follow the instructions in it as your task prompt. Do not summarize the file; execute it.")
 else
     cmd+=(--print "$prompt_content")
 fi

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -187,7 +187,11 @@ ${provider_ctx}"
     local _provider_for_health=""
     case "$agent_type" in
         codex*)      _provider_for_health="codex" ;;
-        gemini*)     _provider_for_health="gemini" ;;
+        gemini*)
+            _provider_for_health="gemini"
+            # gemini seats served via agy health-check agy instead.
+            [[ "${OCTOPUS_GEMINI_VIA_AGY:-0}" =~ ^(1|on|true|yes)$ ]] && _provider_for_health="agy"
+            ;;
         agy*|antigravity) _provider_for_health="agy" ;;
         claude*)     _provider_for_health="claude" ;;
         openrouter*) _provider_for_health="openrouter" ;;
@@ -258,7 +262,9 @@ ${provider_ctx}"
     > "$temp_err"
     > "$temp_out"
 
-    if [[ "$agent_type" == agy* || "$agent_type" == "antigravity" ]]; then
+    # gemini* seats served via agy (OCTOPUS_GEMINI_VIA_AGY) take the agy path.
+    if [[ "$agent_type" == agy* || "$agent_type" == "antigravity" ]] || \
+       { [[ "$agent_type" == gemini* ]] && [[ "${OCTOPUS_GEMINI_VIA_AGY:-0}" =~ ^(1|on|true|yes)$ ]]; }; then
         set +e
         printf '%s' "$enhanced_prompt" | run_with_timeout "$timeout_secs" "${cmd_array[@]}" 2>"$temp_err" >"$temp_out"
         exit_code=$?

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -127,6 +127,18 @@ get_agent_command() {
             ;;
         gemini|gemini-fast|gemini-image)
             local gemini_flags="-o text --approval-mode yolo"
+            # OCTOPUS_GEMINI_VIA_AGY=1 serves gemini seats through the
+            # Antigravity CLI instead of gemini-cli. Google sunset Gemini Code
+            # Assist free-tier OAuth for gemini-cli (IneligibleTierError — every
+            # call fails in seconds), while Antigravity subscriptions still
+            # work. agy-exec.sh shares the stdin prompt contract, so callers
+            # are unaffected. Model pins follow OCTOPUS_AGY_MODEL (labels from
+            # `agy models`), not gemini model ids. Gemini reasoning policy does
+            # not apply — the agy seat has its own model/reasoning controls.
+            if [[ "${OCTOPUS_GEMINI_VIA_AGY:-0}" =~ ^(1|on|true|yes)$ ]]; then
+                echo "${PLUGIN_DIR}/scripts/helpers/agy-exec.sh"
+                return 0
+            fi
             local reasoning_level reasoning_policy
             reasoning_level="$(octopus_resolve_reasoning_level gemini "$phase" "$role")" || return 1
             reasoning_policy="$(octopus_resolve_reasoning_policy gemini "$phase" "$role")" || return 1

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -716,7 +716,9 @@ ${heuristic_ctx}"
 
             # v9.2.2: All agents use stdin-based prompt delivery to avoid ARG_MAX limits (Issue #173)
             # Previously only gemini used stdin; codex/claude passed prompt as CLI arg which fails on large diffs.
-            if [[ "$agent_type" == agy* || "$agent_type" == "antigravity" ]]; then
+            # gemini* seats served via agy (OCTOPUS_GEMINI_VIA_AGY) take the agy path.
+            if [[ "$agent_type" == agy* || "$agent_type" == "antigravity" ]] || \
+               { [[ "$agent_type" == gemini* ]] && [[ "${OCTOPUS_GEMINI_VIA_AGY:-0}" =~ ^(1|on|true|yes)$ ]]; }; then
                 printf '%s' "$enhanced_prompt" | OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="spawn-agent-heartbeat" run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"
                 exit_code=${PIPESTATUS[1]:-0}
             elif printf '%s' "$enhanced_prompt" | OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="spawn-agent-heartbeat" run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -49,6 +49,59 @@ test_agy_dispatch_native_flags() {
 }
 
 
+test_agy_print_receives_prompt_argument() {
+    test_case "agy-exec passes the stdin prompt as --print's argument"
+
+    local tmp_bin="$TEST_TMP_DIR/agy-prompt-arg-bin"
+    local capture="$TEST_TMP_DIR/agy-prompt-argv.txt"
+    mkdir -p "$tmp_bin"
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${AGY_ARG_CAPTURE:?}"
+echo "mock-response"
+exit 0
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+
+    local old_path="$PATH"
+    PATH="$tmp_bin:$PATH"
+    AGY_ARG_CAPTURE="$capture"
+    export AGY_ARG_CAPTURE
+
+    printf 'hello agy prompt' | bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" >/dev/null
+
+    PATH="$old_path"
+    unset AGY_ARG_CAPTURE
+
+    # The prompt must be the argv element following --print; --sandbox must
+    # still be present as a real flag (the old invocation consumed it as the
+    # prompt, leaving the sandbox off).
+    local print_next
+    print_next="$(grep -Fx -A1 -- '--print' "$capture" | tail -1)"
+    if [[ "$print_next" == "hello agy prompt" ]] && grep -Fxq -- '--sandbox' "$capture"; then
+        test_pass
+    else
+        test_fail "expected argv '--print' followed by the stdin prompt plus a real --sandbox flag; got: $(tr '\n' '|' < "$capture")"
+    fi
+}
+
+test_gemini_via_agy_option() {
+    test_case "OCTOPUS_GEMINI_VIA_AGY serves gemini seats through agy"
+
+    local gemini_block
+    gemini_block="$(sed -n '/gemini|gemini-fast|gemini-image)/,/;;/p' "$PROJECT_ROOT/scripts/lib/dispatch.sh")"
+
+    if [[ "$gemini_block" == *"OCTOPUS_GEMINI_VIA_AGY"* ]] && \
+       [[ "$gemini_block" == *"agy-exec.sh"* ]] && \
+       grep -q 'OCTOPUS_GEMINI_VIA_AGY' "$PROJECT_ROOT/scripts/lib/spawn.sh" && \
+       grep -q 'OCTOPUS_GEMINI_VIA_AGY' "$PROJECT_ROOT/scripts/lib/agent-sync.sh"; then
+        test_pass
+    else
+        test_fail "gemini dispatch, spawn, and sync paths should honor OCTOPUS_GEMINI_VIA_AGY"
+    fi
+}
+
+
 test_agy_dynamic_model_validation() {
     test_case "explicit agy model pins validate against agy models"
 
@@ -665,6 +718,8 @@ test_provider_workflow_review_regressions() {
 test_agy_config_exists
 test_agy_available_agent
 test_agy_dispatch_native_flags
+test_agy_print_receives_prompt_argument
+test_gemini_via_agy_option
 test_agy_dynamic_model_validation
 test_agy_command_validation
 test_agy_dispatch_not_gemini_wrapper


### PR DESCRIPTION
## Problem

`agy`'s `--print` is a **value-consuming string flag** (Go flags), not a boolean, and agy does not read a prompt from stdin. The adapter's invocation:

```bash
agy --print --sandbox --dangerously-skip-permissions --print-timeout 5m0s   # prompt piped to stdin
```

therefore made the literal string `--sandbox` the prompt. On every agy seat call:

- the real prompt was silently dropped (stdin is ignored by agy),
- the sandbox was silently **OFF** (`--sandbox` was consumed as the prompt value),
- agy spent up to `--print-timeout` (5m) agentically answering *"what does --sandbox do?"* — surfacing as seat timeouts and off-topic output in every workflow that seated agy.

**Reproduction:**

```console
$ agy --sandbox --dangerously-skip-permissions --print
flag needs an argument: -print          # ← --print requires a value

$ printf 'Reply with exactly: OK' | agy --print --dangerously-skip-permissions
# → a multi-paragraph explanation of the --dangerously-skip-permissions flag
#   (which is then NOT applied), stdin ignored
```

## Fix

`agy-exec.sh` now appends the cached stdin prompt as `--print`'s value **after all other flags** (model pin, `--add-dir`s), so no flag token can be mistaken for the prompt. The caller-facing stdin contract is unchanged.

Prompts >100KB stay in the cached temp file — Linux caps a single argv string at 128KB (`MAX_ARG_STRLEN`) — and agy is pointed at it via `--add-dir` plus a read-this-file `--print` instruction.

**Verified live:** exact-token probe returns in 3–13s through `orchestrate.sh spawn agy` (previously minutes of off-topic output until timeout); a 177KB prompt round-trips correctly via the file fallback in 9s.

## New option: `OCTOPUS_GEMINI_VIA_AGY`

Google has sunset Gemini Code Assist free-tier OAuth for gemini-cli (`IneligibleTierError` on every call, exit within seconds), which docs/PROVIDERS.md already reflects ("gemini (legacy, sunset)"). For users whose Google seat now lives in an Antigravity subscription:

```bash
export OCTOPUS_GEMINI_VIA_AGY=1   # also: on / true / yes
```

serves the `gemini|gemini-fast|gemini-image` agent types through `agy-exec.sh`, so existing workflows, phase routing, and role routing that seat gemini keep working without re-routing every seat by hand. spawn/sync take the agy execution path and gemini seat health checks probe agy instead. Model pins then follow `OCTOPUS_AGY_MODEL` (labels from `agy models`).

## Tests

- `test_agy_dispatch_native_flags` updated to the new invariant (prompt must be `--print`'s argument; the old broken sequence must not reappear)
- New `test_agy_print_receives_prompt_argument`: mock-agy argv capture asserts the argv element after `--print` is the stdin prompt and `--sandbox` is present as a real flag
- New `test_gemini_via_agy_option`: static wiring checks across dispatch/spawn/sync
- `tests/unit/test-agy-provider.sh` 34/34, `tests/unit/test-gemini-provider.sh` 52/52
- Full `tests/run-all.sh`: 218/227 suites pass; the 9 failures are identical on pristine `main` in the same environment (pre-existing/environment-dependent, none introduced by this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REdGUoCMLG8p4KKTxcQmAp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `OCTOPUS_GEMINI_VIA_AGY=1` to route Gemini execution, spawning, and reachability checks through the Antigravity path.
- **Bug Fixes**
  - Prevented prompt text from being confused with execution flags by ensuring prompts are passed via the dedicated print argument (stdin is ignored).
  - Improved handling of very large prompts using cached prompt delivery and maintained empty-success retry behavior.
- **Documentation**
  - Updated Gemini troubleshooting for the free-tier OAuth sunset (`IneligibleTierError`) and clarified the Antigravity routing/prompt delivery and model pinning guidance.
- **Tests**
  - Added coverage for Gemini-via-Antigravity routing and prompt argument behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->