### PR TITLE
fix: remove banner PreToolUse prompt hooks that trip the adjudicator

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,10 +5,6 @@
         "matcher": "Bash",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "\ud83d\udc19 **CLAUDE OCTOPUS ACTIVATED** - Using external CLI providers (Codex/Gemini) for this task. This is NOT a Claude subagent - external APIs will be invoked."
-          },
-          {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/provider-routing-validator.sh",
             "additionalContext": "Session: ${CLAUDE_SESSION_ID}, Workflow: ${OCTOPUS_WORKFLOW_PHASE:-unknown}",
@@ -42,24 +38,6 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/codex-exec-guard.sh",
             "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "\ud83d\udd34 **Codex CLI Executing** - Using your OpenAI API credentials directly."
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "\ud83d\udfe1 **Gemini CLI Executing** - Using your Google API credentials directly."
           }
         ]
       },

--- a/tests/unit/test-docs-sync.sh
+++ b/tests/unit/test-docs-sync.sh
@@ -262,12 +262,6 @@ sys.exit(0 if isinstance(d.get('hooks'), dict) and d['hooks'] else 1)
     fail "hooks.json missing Codex CLI hook"
   fi
 
-  if grep -qi "gemini" "$hooks_json"; then
-    pass "hooks.json has Gemini CLI hook"
-  else
-    fail "hooks.json missing Gemini CLI hook"
-  fi
-
   if python3 -c "
 import json,sys
 d=json.load(open('$hooks_json'))


### PR DESCRIPTION
## Description
Removes the three `type: "prompt"` PreToolUse hooks on the bare `Bash` matcher in `hooks/hooks.json` (the 🐙 "CLAUDE OCTOPUS ACTIVATED", 🔴 "Codex CLI Executing", and 🟡 "Gemini CLI Executing" banners).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Root cause
`type: "prompt"` PreToolUse hooks are sent to Claude Code's hook adjudicator as the policy instruction for whether a tool call may proceed — they are not display banners. The "🐙 CLAUDE OCTOPUS ACTIVATED... This is NOT a Claude subagent - external APIs will be invoked" text, attached to every ordinary `Bash` call via the bare `Bash` matcher, gets classified by the adjudicator as a prompt-injection / social-engineering attempt and **denies the call**, making any session with the plugin enabled unable to run Bash. See `hooks/hooks.json` lines 7-10 (🐙 banner, bundled with `provider-routing-validator.sh`), and the two standalone 🔴/🟡 banner blocks.

## Fix
Removed the three prompt hooks entirely, per the issue's suggested fix ("remove the three banner prompts ... If per-call provider notices are wanted, emit them from the dispatch path in `orchestrate.sh` where the provider is actually known"). The real `provider-routing-validator.sh` command hook that shared a block with the 🐙 banner is untouched.

`tests/unit/test-docs-sync.sh` had a `grep -qi "gemini" hooks.json` assertion labeled "hooks.json has Gemini CLI hook" — it was only ever satisfied by the now-removed 🟡 banner text; there's no dedicated Gemini hook script (unlike Codex's `codex-exec-guard.sh`, which the neighboring assertion correctly still checks for). Dropped that stale assertion rather than keep a check with nothing real behind it.

## Scope
This PR addresses **Defect 1** from #621 — the blocking one (adjudicator denies Bash calls). **Defect 2** (legacy `{"decision": ...}` stdout shape used across ~15 other hook scripts, which the schema now rejects — cosmetic noise, not blocking) touches far more files and is intentionally left out of this PR as a separate, larger follow-up.

## Testing
```
jq empty hooks/hooks.json                        # valid JSON
bash -n scripts/orchestrate.sh                    # syntax OK
bash tests/unit/test-hook-err-traps.sh            # 8/8 pass
bash tests/unit/test-docs-sync.sh                 # 135/135 pass
bash tests/unit/test-github-work-queue-hook.sh    # 4/4 pass
bash tests/unit/test-auto-router-hooks.sh         # 9/9 pass
bash tests/unit/test-shell-safe-hooks-v2183.sh    # 8/8 pass
bash tests/unit/test-cc-v2183-sync.sh             # 39/39 pass
bash tests/unit/test-cc-v2184-91-sync.sh          # 66/66 pass
bash tests/unit/test-fable5-mode.sh               # 26/26 pass
bash tests/unit/test-context-bridge.sh            # 12/12 pass
bash tests/unit/test-openclaw-compat.sh           # 32/32 pass
./scripts/build-openclaw.sh --check               # registry up to date
make test-unit                                    # 171/172 suites pass
```
The one `make test-unit` failure (`test-hud-smart-mode.sh`) reproduces identically on unmodified `origin/main` in this environment — pre-existing/environment-dependent, not introduced by this change.

- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [x] OpenClaw registry in sync: `scripts/build-openclaw.sh --check`
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` (n/a — no new skills/commands)
- [ ] Version bump (if releasing) (n/a — bug fix only, no release in this PR)
- [ ] Documentation updated (if applicable) (n/a)
- [ ] CHANGELOG.md updated (for features/fixes) (n/a — deferred to release PR if/when this ships)

## Related Issues
Addresses (does not fully close, see Scope) #621

---
_Generated by [Claude Code](https://claude.ai/code/session_014GAQ8hwZTpJVp5gBTwkKhs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command validation before tools run by adding provider-routing checks.
  * Removed redundant execution announcement prompts for CLI-based operations.
* **Tests**
  * Updated configuration checks to reflect the streamlined command-hook setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->