### PR TITLE
fix: avoid duplicate zero from grep count

### DIFF
--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -862,7 +862,7 @@ search_similar_errors() {
     fi
 
     local match_count
-    match_count=$(grep -ci "$keywords" "$error_file" 2>/dev/null || echo "0")
+    match_count=$(grep -ci "$keywords" "$error_file" 2>/dev/null) || match_count=0
     echo "$match_count"
 }
 

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -862,7 +862,8 @@ search_similar_errors() {
     fi
 
     local match_count
-    match_count=$(grep -ci "$keywords" "$error_file" 2>/dev/null) || match_count=0
+    match_count=$(grep -ci -- "$keywords" "$error_file" 2>/dev/null || true)
+    match_count="${match_count:-0}"
     echo "$match_count"
 }
 

--- a/tests/unit/test-error-learning.sh
+++ b/tests/unit/test-error-learning.sh
@@ -33,6 +33,28 @@ test_search_similar_errors_function_exists() {
     fi
 }
 
+
+test_search_similar_errors_returns_single_zero() {
+    test_case "search_similar_errors returns a single zero when there are no matches"
+
+    local tmp_workspace output
+    tmp_workspace=$(mktemp -d)
+    mkdir -p "$tmp_workspace/.octo/errors"
+    printf '%s
+' "unrelated error" > "$tmp_workspace/.octo/errors/error-log.md"
+
+    output=$(WORKSPACE_DIR="$tmp_workspace" bash -c '
+        source "$1/scripts/lib/quality.sh" 2>/dev/null
+        search_similar_errors "react act test"
+    ' _ "$PROJECT_ROOT")
+
+    rm -rf "$tmp_workspace"
+    if [[ "$output" == "0" ]]; then
+        test_pass
+    else
+        test_fail "expected exactly one zero, got: $(printf %q "$output")"
+    fi
+}
 test_flag_repeat_error_function_exists() {
     test_case "flag_repeat_error function exists"
 
@@ -125,6 +147,7 @@ test_dry_run_with_error_learning() {
 # Run tests
 test_record_error_function_exists
 test_search_similar_errors_function_exists
+test_search_similar_errors_returns_single_zero
 test_flag_repeat_error_function_exists
 test_error_format
 test_error_cap_100


### PR DESCRIPTION
## Summary
- prevent search_similar_errors from returning two zero lines when grep finds no matches
- add a regression test that asserts the function returns exactly one zero

## Root cause
grep -c prints 0 and exits 1 when there are no matches. The existing command substitution used grep ... || echo 0, producing 0\n0 and later breaking numeric comparisons.

## Validation
- bash tests/unit/test-error-learning.sh (10/10 passing)
- bash -n scripts/lib/quality.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error-pattern matching so searches with no matches return a single, accurate zero.
  * Improved repeated-error detection reliability.

* **Tests**
  * Added a unit test to verify that unmatched error searches return the expected result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->