### PR TITLE
feat: add explicit runtime provider identity schema

### DIFF
--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1897,7 +1897,7 @@ council_write_synthesis() {
             local _chair_provider _member_count
             _chair_provider="$(printf '%s' "$chair_member" | jq -r '.provider // "chair"' 2>/dev/null || echo chair)"
             _member_count="$(printf '%s' "$COUNCIL_RESOLVED_MEMBERS" | tr ', ' '\n\n' | grep -c . 2>/dev/null || echo 0)"
-            octo_event_emit "synthesis" phase="council" provider="${_chair_provider:-chair}" count="${_member_count:-0}" || true
+            octo_event_emit "synthesis" phase="council" provider="${_chair_provider:-chair}" provider_label_kind="legacy-alias" executor_alias="${_chair_provider:-unknown}" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "${_chair_provider:-}" "council" "chair" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="chair" synthesis_strategy="chair" count="${_member_count:-0}" || true
         fi
         return 0
     fi

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1897,7 +1897,7 @@ council_write_synthesis() {
             local _chair_provider _member_count
             _chair_provider="$(printf '%s' "$chair_member" | jq -r '.provider // "chair"' 2>/dev/null || echo chair)"
             _member_count="$(printf '%s' "$COUNCIL_RESOLVED_MEMBERS" | tr ', ' '\n\n' | grep -c . 2>/dev/null || echo 0)"
-            octo_event_emit "synthesis" phase="council" provider="${_chair_provider:-chair}" provider_label_kind="legacy-alias" executor_alias="${_chair_provider:-unknown}" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "${_chair_provider:-}" "council" "chair" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="chair" synthesis_strategy="chair" count="${_member_count:-0}" || true
+            octo_event_emit "synthesis" phase="council" provider="${_chair_provider:-chair}" provider_label_kind="legacy-alias" executor_alias="${_chair_provider:-unknown}" configured_provider="$(octo_provider_identity_from_agent_type "${_chair_provider:-unknown}")" configured_model="$(get_agent_model "${_chair_provider:-}" "council" "chair" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="chair" synthesis_strategy="chair" count="${_member_count:-0}" || true
         fi
         return 0
     fi

--- a/scripts/lib/debate.sh
+++ b/scripts/lib/debate.sh
@@ -754,7 +754,7 @@ EOF
     # $synthesis is non-empty here (the failure branch returned above); attribute
     # the path that produced it (moderator=claude or quorum). count=3 fixed seats.
     if declare -f octo_event_emit >/dev/null 2>&1; then
-        octo_event_emit "synthesis" phase="debate" provider="$synth_provider" provider_label_kind="legacy-alias" executor_alias="$synth_provider" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "$synth_provider" "debate" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="debate" count="3" || true
+        octo_event_emit "synthesis" phase="debate" provider="$synth_provider" provider_label_kind="legacy-alias" executor_alias="$synth_provider" configured_provider="$(octo_provider_identity_from_agent_type "${synth_provider:-unknown}")" configured_model="$(get_agent_model "$synth_provider" "debate" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="debate" count="3" || true
     fi
 
     # ═══════════════════════════════════════════════════════════════════════

--- a/scripts/lib/debate.sh
+++ b/scripts/lib/debate.sh
@@ -754,7 +754,7 @@ EOF
     # $synthesis is non-empty here (the failure branch returned above); attribute
     # the path that produced it (moderator=claude or quorum). count=3 fixed seats.
     if declare -f octo_event_emit >/dev/null 2>&1; then
-        octo_event_emit "synthesis" phase="debate" provider="$synth_provider" count="3" || true
+        octo_event_emit "synthesis" phase="debate" provider="$synth_provider" provider_label_kind="legacy-alias" executor_alias="$synth_provider" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "$synth_provider" "debate" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="debate" count="3" || true
     fi
 
     # ═══════════════════════════════════════════════════════════════════════

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -488,7 +488,7 @@ $(<"$raw_concat")"
             # #498: emit a synthesis lifecycle event on the success path, attributing
             # the provider that actually produced the artifact ($synth_used, which
             # reflects the claude-sonnet fallback above).
-            declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "synthesis" phase="parallel" provider="$synth_used" provider_label_kind="legacy-alias" executor_alias="$synth_used" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "$synth_used" "parallel" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="parallel" count="$result_count" || true
+            declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "synthesis" phase="parallel" provider="$synth_used" provider_label_kind="legacy-alias" executor_alias="$synth_used" configured_provider="$(octo_provider_identity_from_agent_type "${synth_used:-unknown}")" configured_model="$(get_agent_model "$synth_used" "parallel" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="parallel" count="$result_count" || true
             echo ""
             echo -e "${GREEN}✓${NC} Results synthesized to: $aggregate_file"
             guard_output "$(<"$aggregate_file")" "aggregate-synthesis"

--- a/scripts/lib/parallel.sh
+++ b/scripts/lib/parallel.sh
@@ -488,7 +488,7 @@ $(<"$raw_concat")"
             # #498: emit a synthesis lifecycle event on the success path, attributing
             # the provider that actually produced the artifact ($synth_used, which
             # reflects the claude-sonnet fallback above).
-            declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "synthesis" phase="parallel" provider="$synth_used" count="$result_count" || true
+            declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "synthesis" phase="parallel" provider="$synth_used" provider_label_kind="legacy-alias" executor_alias="$synth_used" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "$synth_used" "parallel" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="parallel" count="$result_count" || true
             echo ""
             echo -e "${GREEN}✓${NC} Results synthesized to: $aggregate_file"
             guard_output "$(<"$aggregate_file")" "aggregate-synthesis"

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -1076,7 +1076,7 @@ ${round1_prompts[$retry_idx]}"
         if [[ "$agent_findings" != "[]" ]] && declare -f octo_event_emit >/dev/null 2>&1; then
             while IFS=$'\t' read -r _rf_sev _rf_title; do
                 [[ -z "${_rf_sev}${_rf_title}" ]] && continue
-                octo_event_emit "review.finding" provider="$provider_key" severity="${_rf_sev:-unknown}" message="${_rf_title:-}" round="1" || true
+                octo_event_emit "review.finding" provider="$provider_key" provider_label_kind="legacy-alias" executor_alias="$provider_key" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "$provider_key" "review" "reviewer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" role="reviewer" severity="${_rf_sev:-unknown}" message="${_rf_title:-}" round="1" || true
             done < <(printf '%s' "$agent_findings" | jq -r '.[]? | [(.severity // "unknown"), (.title // .message // "")] | @tsv' 2>/dev/null)
         fi
         if ! review_result_completed_successfully "$f"; then
@@ -1242,7 +1242,7 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
     if [[ "$synth_ok" == "true" ]] && declare -f octo_event_emit >/dev/null 2>&1; then
         local _synth_count
         _synth_count=$(printf '%s' "$final_json" | jq '.findings | length' 2>/dev/null || echo 0)
-        octo_event_emit "synthesis" phase="review" provider="claude-sonnet" count="${_synth_count:-0}" || true
+        octo_event_emit "synthesis" phase="review" provider="claude-sonnet" provider_label_kind="legacy-alias" executor_alias="claude-sonnet" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "claude-sonnet" "review" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="review" count="${_synth_count:-0}" || true
     fi
 
     if [[ -n "$proof_dir" ]]; then

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -1076,7 +1076,7 @@ ${round1_prompts[$retry_idx]}"
         if [[ "$agent_findings" != "[]" ]] && declare -f octo_event_emit >/dev/null 2>&1; then
             while IFS=$'\t' read -r _rf_sev _rf_title; do
                 [[ -z "${_rf_sev}${_rf_title}" ]] && continue
-                octo_event_emit "review.finding" provider="$provider_key" provider_label_kind="legacy-alias" executor_alias="$provider_key" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "$provider_key" "review" "reviewer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" role="reviewer" severity="${_rf_sev:-unknown}" message="${_rf_title:-}" round="1" || true
+                octo_event_emit "review.finding" provider="$provider_key" provider_label_kind="legacy-alias" executor_alias="$provider_key" configured_provider="$(octo_provider_identity_from_agent_type "${provider_key:-unknown}")" configured_model="$(get_agent_model "$provider_key" "review" "reviewer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" role="reviewer" severity="${_rf_sev:-unknown}" message="${_rf_title:-}" round="1" || true
             done < <(printf '%s' "$agent_findings" | jq -r '.[]? | [(.severity // "unknown"), (.title // .message // "")] | @tsv' 2>/dev/null)
         fi
         if ! review_result_completed_successfully "$f"; then
@@ -1242,7 +1242,7 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
     if [[ "$synth_ok" == "true" ]] && declare -f octo_event_emit >/dev/null 2>&1; then
         local _synth_count
         _synth_count=$(printf '%s' "$final_json" | jq '.findings | length' 2>/dev/null || echo 0)
-        octo_event_emit "synthesis" phase="review" provider="claude-sonnet" provider_label_kind="legacy-alias" executor_alias="claude-sonnet" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "claude-sonnet" "review" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="review" count="${_synth_count:-0}" || true
+        octo_event_emit "synthesis" phase="review" provider="claude-sonnet" provider_label_kind="legacy-alias" executor_alias="claude-sonnet" configured_provider="$(octo_provider_identity_from_agent_type "claude-sonnet")" configured_model="$(get_agent_model "claude-sonnet" "review" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="review" count="${_synth_count:-0}" || true
     fi
 
     if [[ -n "$proof_dir" ]]; then

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -1076,7 +1076,7 @@ ${round1_prompts[$retry_idx]}"
         if [[ "$agent_findings" != "[]" ]] && declare -f octo_event_emit >/dev/null 2>&1; then
             while IFS=$'\t' read -r _rf_sev _rf_title; do
                 [[ -z "${_rf_sev}${_rf_title}" ]] && continue
-                octo_event_emit "review.finding" provider="$provider_key" provider_label_kind="legacy-alias" executor_alias="$provider_key" configured_provider="$(octo_provider_identity_from_agent_type "${provider_key:-unknown}")" configured_model="$(get_agent_model "$provider_key" "review" "reviewer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" role="reviewer" severity="${_rf_sev:-unknown}" message="${_rf_title:-}" round="1" || true
+                octo_event_emit "review.finding" provider="$provider_key" provider_label_kind="legacy-alias" executor_alias="$atype" configured_provider="$(octo_provider_identity_from_agent_type "${atype:-unknown}")" configured_model="$(get_agent_model "$atype" "review" "reviewer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" role="reviewer" severity="${_rf_sev:-unknown}" message="${_rf_title:-}" round="1" || true
             done < <(printf '%s' "$agent_findings" | jq -r '.[]? | [(.severity // "unknown"), (.title // .message // "")] | @tsv' 2>/dev/null)
         fi
         if ! review_result_completed_successfully "$f"; then

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -37,6 +37,11 @@ _octopus_agent_lifecycle_event() {
     if declare -f octo_event_emit >/dev/null 2>&1; then
         octo_event_emit "$event_name" \
             provider="$provider" \
+            provider_label_kind="legacy-alias" \
+            executor_alias="$agent_type" \
+            configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "$agent_type" "$phase" "$role" 2>/dev/null || echo unresolved)" \
+            runtime_provider="unknown" \
+            runtime_model="unknown" \
             agent_type="$agent_type" \
             task_id="$task_id" \
             role="$role" \
@@ -399,7 +404,7 @@ ${heuristic_ctx}"
     fi
 
     # oco-aek: provider selected for dispatch (circuit closed). Opt-in event.
-    declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "provider.selected" provider="$provider_prefix" agent_type="$agent_type" phase="${phase:-unknown}" || true
+    declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "provider.selected" provider="$provider_prefix" provider_label_kind="legacy-alias" executor_alias="$agent_type" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "$agent_type" "${phase:-}" "${role:-}" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" agent_type="$agent_type" role="${role:-none}" phase="${phase:-unknown}" || true
 
     local cmd
     if ! cmd=$(get_agent_command "$agent_type" "${phase:-}" "${role:-}"); then
@@ -858,6 +863,8 @@ ${heuristic_ctx}"
                 cat "$temp_errors" >> "$result_file"
                 echo '```' >> "$result_file"
             fi
+
+            octo_append_runtime_identity "$result_file" "$agent_type" "${model:-unresolved}" "$raw_output"
 
             # Mark agent as completed (v7.16.0 Feature 2)
             local end_time_ms elapsed_ms

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -553,6 +553,8 @@ ${heuristic_ctx}"
 
         # Write initial result file header
         echo "# Agent: $agent_type (via Agent Teams)" > "$result_file"
+        echo "# Executor alias: $agent_type" >> "$result_file"
+        echo "# Configured model: ${model:-unresolved}" >> "$result_file"
         echo "# Task ID: $task_id" >> "$result_file"
         echo "# Role: ${role:-none}" >> "$result_file"
         echo "# Phase: ${phase:-none}" >> "$result_file"
@@ -583,6 +585,8 @@ ${heuristic_ctx}"
         set -o pipefail  # v9.15.1: Pipeline exit code = first failure (prevents silent codex/gemini errors)
 
         echo "# Agent: $agent_type" > "$result_file"
+        echo "# Executor alias: $agent_type" >> "$result_file"
+        echo "# Configured model: ${model:-unresolved}" >> "$result_file"
         echo "# Task ID: $task_id" >> "$result_file"
         echo "# Role: ${role:-none}" >> "$result_file"
         echo "# Phase: ${phase:-none}" >> "$result_file"

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -112,6 +112,30 @@ _octopus_agent_lifecycle_event() {
     ) >>"$hook_log" 2>&1 || true
 }
 
+write_agent_result_header() {
+    local result_file="$1"
+    local agent_type="$2"
+    local model="$3"
+    local task_id="$4"
+    local role="${5:-none}"
+    local phase="${6:-none}"
+    local dispatch="${7:-legacy}"
+
+    {
+        if [[ "$dispatch" == "agent-teams" ]]; then
+            echo "# Agent: $agent_type (via Agent Teams)"
+        else
+            echo "# Agent: $agent_type"
+        fi
+        echo "# Executor alias: $agent_type"
+        echo "# Configured provider: $(octo_provider_identity_from_agent_type "$agent_type")"
+        echo "# Configured model: ${model:-unresolved}"
+        echo "# Task ID: $task_id"
+        echo "# Role: ${role:-none}"
+        echo "# Phase: ${phase:-none}"
+    } > "$result_file"
+}
+
 spawn_agent() {
     local _ts; _ts=$(date +%s)
     local agent_type="$1"
@@ -558,12 +582,7 @@ ${heuristic_ctx}"
         echo "AGENT_TEAMS_DISPATCH:${agent_type}:${task_id}:${role:-none}:${phase:-none}"
 
         # Write initial result file header
-        echo "# Agent: $agent_type (via Agent Teams)" > "$result_file"
-        echo "# Executor alias: $agent_type" >> "$result_file"
-        echo "# Configured model: ${model:-unresolved}" >> "$result_file"
-        echo "# Task ID: $task_id" >> "$result_file"
-        echo "# Role: ${role:-none}" >> "$result_file"
-        echo "# Phase: ${phase:-none}" >> "$result_file"
+        write_agent_result_header "$result_file" "$agent_type" "${model:-unresolved}" "$task_id" "${role:-none}" "${phase:-none}" "agent-teams"
         echo "# Dispatch: Agent Teams (native)" >> "$result_file"
         echo "# Started: $(date)" >> "$result_file"
         if [[ "$SUPPORTS_HOOK_LAST_MESSAGE" == "true" ]]; then
@@ -590,12 +609,7 @@ ${heuristic_ctx}"
         set -f  # Disable glob expansion
         set -o pipefail  # v9.15.1: Pipeline exit code = first failure (prevents silent codex/gemini errors)
 
-        echo "# Agent: $agent_type" > "$result_file"
-        echo "# Executor alias: $agent_type" >> "$result_file"
-        echo "# Configured model: ${model:-unresolved}" >> "$result_file"
-        echo "# Task ID: $task_id" >> "$result_file"
-        echo "# Role: ${role:-none}" >> "$result_file"
-        echo "# Phase: ${phase:-none}" >> "$result_file"
+        write_agent_result_header "$result_file" "$agent_type" "${model:-unresolved}" "$task_id" "${role:-none}" "${phase:-none}" "legacy"
         echo "# Prompt: $prompt" >> "$result_file"
         echo "# Started: $(date)" >> "$result_file"
         echo "" >> "$result_file"

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -39,7 +39,8 @@ _octopus_agent_lifecycle_event() {
             provider="$provider" \
             provider_label_kind="legacy-alias" \
             executor_alias="$agent_type" \
-            configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "$agent_type" "$phase" "$role" 2>/dev/null || echo unresolved)" \
+            configured_provider="$(octo_provider_identity_from_agent_type "${agent_type:-${provider:-unknown}}")" \
+            configured_model="$(get_agent_model "$agent_type" "$phase" "$role" 2>/dev/null || echo unresolved)" \
             runtime_provider="unknown" \
             runtime_model="unknown" \
             agent_type="$agent_type" \
@@ -404,7 +405,7 @@ ${heuristic_ctx}"
     fi
 
     # oco-aek: provider selected for dispatch (circuit closed). Opt-in event.
-    declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "provider.selected" provider="$provider_prefix" provider_label_kind="legacy-alias" executor_alias="$agent_type" configured_adapter="unknown" runtime_adapter="unknown" configured_model="$(get_agent_model "$agent_type" "${phase:-}" "${role:-}" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" agent_type="$agent_type" role="${role:-none}" phase="${phase:-unknown}" || true
+    declare -f octo_event_emit >/dev/null 2>&1 && octo_event_emit "provider.selected" provider="$provider_prefix" provider_label_kind="legacy-alias" executor_alias="$agent_type" configured_provider="$(octo_provider_identity_from_agent_type "${agent_type:-unknown}")" configured_model="$(get_agent_model "$agent_type" "${phase:-}" "${role:-}" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" agent_type="$agent_type" role="${role:-none}" phase="${phase:-unknown}" || true
 
     local cmd
     if ! cmd=$(get_agent_command "$agent_type" "${phase:-}" "${role:-}"); then

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -232,7 +232,7 @@ octo_extract_runtime_model() {
     value=$(printf '%s\n' "$output" | sed -n -E \
         -e 's/^provider=[^[:space:]]+[[:space:]]+base_url=[^[:space:]]+[[:space:]]+model=([^[:space:]]+)[[:space:]]+cwd=.*/\1/p' \
         -e 's/^OCTOPUS_RUNTIME_MODEL=([^[:space:]]+)$/\1/p' \
-        | head -1)
+        | head -1 || true)
     printf '%s\n' "${value:-unknown}"
 }
 

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -209,6 +209,52 @@ EOF
 # SECURITY: CLI output wrapping for untrusted external provider output (v8.7.0)
 # Wraps codex/gemini output in trust markers; passes claude output unchanged
 # ═══════════════════════════════════════════════════════════════════════════════
+octo_extract_runtime_identity_value() {
+    local key="$1"
+    local output="$2"
+    local env_key
+    env_key="OCTOPUS_RUNTIME_$(printf '%s' "$key" | tr '[:lower:]-' '[:upper:]_')"
+
+    # Runtime identity is accepted only from the explicit executor metadata
+    # contract. Never infer identity from free-form model output.
+    local value=""
+    value=$(printf '%s\n' "$output" | sed -n -E \
+        -e "s/^${env_key}=([^[:space:]]+)$/\\1/p" \
+        -e "s/^<octopus-runtime-identity .*${key}=['\"]([^'\"]+)['\"].*>$/\\1/p" \
+        | head -1)
+    printf '%s\n' "${value:-unknown}"
+}
+
+octo_append_runtime_identity() {
+    local result_file="$1"
+    local executor_alias="$2"
+    local configured_model="$3"
+    local output_file="$4"
+    local output="" runtime_adapter runtime_provider runtime_model mismatch="unknown"
+
+    [[ -f "$output_file" ]] && output=$(cat "$output_file" 2>/dev/null || true)
+    runtime_adapter=$(octo_extract_runtime_identity_value adapter "$output")
+    runtime_provider=$(octo_extract_runtime_identity_value provider "$output")
+    runtime_model=$(octo_extract_runtime_identity_value model "$output")
+
+    if [[ "$configured_model" != "unresolved" && "$runtime_model" != "unknown" ]]; then
+        if [[ "$configured_model" == "$runtime_model" ]]; then mismatch="false"; else mismatch="true"; fi
+    fi
+
+    {
+        echo
+        echo "## Runtime Identity"
+        echo "- Role: executor"
+        echo "- Executor alias: ${executor_alias:-unknown}"
+        echo "- Configured adapter: unknown"
+        echo "- Configured model: ${configured_model:-unresolved}"
+        echo "- Runtime adapter: ${runtime_adapter}"
+        echo "- Runtime provider: ${runtime_provider}"
+        echo "- Runtime model: ${runtime_model}"
+        echo "- Routing mismatch: ${mismatch}"
+    } >> "$result_file"
+}
+
 wrap_cli_output() {
     local provider="$1"
     local output="$2"
@@ -220,8 +266,12 @@ wrap_cli_output() {
 
     case "$provider" in
         codex*|gemini*|agy*|antigravity|perplexity*|cursor-agent*)
+            local runtime_adapter runtime_provider runtime_model
+            runtime_adapter=$(octo_extract_runtime_identity_value adapter "$output")
+            runtime_provider=$(octo_extract_runtime_identity_value provider "$output")
+            runtime_model=$(octo_extract_runtime_identity_value model "$output")
             cat << EOF
-<external-cli-output provider="$provider" executor-alias="$provider" provider-label-kind="legacy-alias" trust="untrusted">
+<external-cli-output provider="$provider" executor-alias="$provider" provider-label-kind="legacy-alias" runtime-adapter="$runtime_adapter" runtime-provider="$runtime_provider" runtime-model="$runtime_model" trust="untrusted">
 $output
 </external-cli-output>
 EOF

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -221,7 +221,7 @@ wrap_cli_output() {
     case "$provider" in
         codex*|gemini*|agy*|antigravity|perplexity*|cursor-agent*)
             cat << EOF
-<external-cli-output provider="$provider" trust="untrusted">
+<external-cli-output provider="$provider" executor-alias="$provider" provider-label-kind="legacy-alias" trust="untrusted">
 $output
 </external-cli-output>
 EOF

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -209,18 +209,29 @@ EOF
 # SECURITY: CLI output wrapping for untrusted external provider output (v8.7.0)
 # Wraps codex/gemini output in trust markers; passes claude output unchanged
 # ═══════════════════════════════════════════════════════════════════════════════
-octo_extract_runtime_identity_value() {
-    local key="$1"
-    local output="$2"
-    local env_key
-    env_key="OCTOPUS_RUNTIME_$(printf '%s' "$key" | tr '[:lower:]-' '[:upper:]_')"
+octo_provider_identity_from_agent_type() {
+    local agent_type="$1"
+    case "$agent_type" in
+        openai-compatible|openai-tools|openai-compatible-agent) echo "openai-compatible" ;;
+        atlascloud-agent|atlascloud) echo "atlascloud" ;;
+        codex*) echo "codex" ;;
+        claude*) echo "anthropic" ;;
+        gemini*) echo "google" ;;
+        perplexity*) echo "perplexity" ;;
+        openrouter*) echo "openrouter" ;;
+        *) echo "unknown" ;;
+    esac
+}
 
-    # Runtime identity is accepted only from the explicit executor metadata
-    # contract. Never infer identity from free-form model output.
+octo_extract_runtime_model() {
+    local output="$1"
     local value=""
+
+    # Native OpenAI-compatible helper emits a deterministic stderr line:
+    # provider=<mode> base_url=<url> model=<model> cwd=<cwd>
     value=$(printf '%s\n' "$output" | sed -n -E \
-        -e "s/^${env_key}=([^[:space:]]+)$/\\1/p" \
-        -e "s/^<octopus-runtime-identity .*${key}=['\"]([^'\"]+)['\"].*>$/\\1/p" \
+        -e 's/^provider=[^[:space:]]+[[:space:]]+base_url=[^[:space:]]+[[:space:]]+model=([^[:space:]]+)[[:space:]]+cwd=.*/\1/p' \
+        -e 's/^OCTOPUS_RUNTIME_MODEL=([^[:space:]]+)$/\1/p' \
         | head -1)
     printf '%s\n' "${value:-unknown}"
 }
@@ -230,12 +241,12 @@ octo_append_runtime_identity() {
     local executor_alias="$2"
     local configured_model="$3"
     local output_file="$4"
-    local output="" runtime_adapter runtime_provider runtime_model mismatch="unknown"
+    local output="" configured_provider runtime_provider runtime_model mismatch="unknown"
 
+    configured_provider=$(octo_provider_identity_from_agent_type "$executor_alias")
+    runtime_provider="$configured_provider"
     [[ -f "$output_file" ]] && output=$(cat "$output_file" 2>/dev/null || true)
-    runtime_adapter=$(octo_extract_runtime_identity_value adapter "$output")
-    runtime_provider=$(octo_extract_runtime_identity_value provider "$output")
-    runtime_model=$(octo_extract_runtime_identity_value model "$output")
+    runtime_model=$(octo_extract_runtime_model "$output")
 
     if [[ "$configured_model" != "unresolved" && "$runtime_model" != "unknown" ]]; then
         if [[ "$configured_model" == "$runtime_model" ]]; then mismatch="false"; else mismatch="true"; fi
@@ -246,9 +257,8 @@ octo_append_runtime_identity() {
         echo "## Runtime Identity"
         echo "- Role: executor"
         echo "- Executor alias: ${executor_alias:-unknown}"
-        echo "- Configured adapter: unknown"
+        echo "- Configured provider: ${configured_provider}"
         echo "- Configured model: ${configured_model:-unresolved}"
-        echo "- Runtime adapter: ${runtime_adapter}"
         echo "- Runtime provider: ${runtime_provider}"
         echo "- Runtime model: ${runtime_model}"
         echo "- Routing mismatch: ${mismatch}"
@@ -266,12 +276,11 @@ wrap_cli_output() {
 
     case "$provider" in
         codex*|gemini*|agy*|antigravity|perplexity*|cursor-agent*)
-            local runtime_adapter runtime_provider runtime_model
-            runtime_adapter=$(octo_extract_runtime_identity_value adapter "$output")
-            runtime_provider=$(octo_extract_runtime_identity_value provider "$output")
-            runtime_model=$(octo_extract_runtime_identity_value model "$output")
+            local runtime_provider runtime_model
+            runtime_provider=$(octo_provider_identity_from_agent_type "$provider")
+            runtime_model=$(octo_extract_runtime_model "$output")
             cat << EOF
-<external-cli-output provider="$provider" executor-alias="$provider" provider-label-kind="legacy-alias" runtime-adapter="$runtime_adapter" runtime-provider="$runtime_provider" runtime-model="$runtime_model" trust="untrusted">
+<external-cli-output provider="$provider" executor-alias="$provider" provider-label-kind="legacy-alias" runtime-provider="$runtime_provider" runtime-model="$runtime_model" trust="untrusted">
 $output
 </external-cli-output>
 EOF

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1606,7 +1606,7 @@ ${normal_findings}
     local correction_model
     correction_model=$(get_agent_model "$correction_agent" "tangle" "implementer" 2>/dev/null || true)
     [[ -n "$correction_model" ]] || correction_model="unresolved"
-    log INFO "Step 5: Applying contextual review corrections (round=${round_num}, role=implementer, strategy=${correction_strategy}, stall_window=${stall_window}s, executor_alias=${correction_agent}, configured_adapter=unknown, configured_model=${correction_model}, runtime_adapter=unknown, runtime_provider=unknown, runtime_model=unknown)..."
+    log INFO "Step 5: Applying contextual review corrections (round=${round_num}, role=implementer, strategy=${correction_strategy}, stall_window=${stall_window}s, executor_alias=${correction_agent}, configured_provider=$(octo_provider_identity_from_agent_type "${correction_agent}"), configured_model=${correction_model}, runtime_provider=unknown, runtime_model=unknown)..."
     (
         OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-correction-stall-watchdog" run_agent_sync "$correction_agent" "$correction_prompt" 0 "implementer" "tangle" > "$correction_file" 2>&1
         echo "$?" > "$rc_file"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1606,7 +1606,7 @@ ${normal_findings}
     local correction_model
     correction_model=$(get_agent_model "$correction_agent" "tangle" "implementer" 2>/dev/null || true)
     [[ -n "$correction_model" ]] || correction_model="unresolved"
-    log INFO "Step 5: Applying contextual review corrections (round ${round_num}, strategy=${correction_strategy}, stall_window=${stall_window}s) with executor alias=${correction_agent}, configured model=${correction_model}..."
+    log INFO "Step 5: Applying contextual review corrections (round=${round_num}, role=implementer, strategy=${correction_strategy}, stall_window=${stall_window}s, executor_alias=${correction_agent}, configured_adapter=unknown, configured_model=${correction_model}, runtime_adapter=unknown, runtime_provider=unknown, runtime_model=unknown)..."
     (
         OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-correction-stall-watchdog" run_agent_sync "$correction_agent" "$correction_prompt" 0 "implementer" "tangle" > "$correction_file" 2>&1
         echo "$?" > "$rc_file"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1538,6 +1538,15 @@ tangle_run_context_code_review() {
     return "$review_rc"
 }
 
+tangle_correction_identity_message() {
+    local round_num="$1"
+    local correction_strategy="$2"
+    local stall_window="$3"
+    local correction_agent="$4"
+    local correction_model="$5"
+    printf '%s\n' "Step 5: Applying contextual review corrections (round=${round_num}, role=implementer, strategy=${correction_strategy}, stall_window=${stall_window}s, executor_alias=${correction_agent}, configured_provider=$(octo_provider_identity_from_agent_type "${correction_agent}"), configured_model=${correction_model}, runtime_provider=unknown, runtime_model=unknown)..."
+}
+
 tangle_apply_review_corrections() {
     local resolved_prompt="$1"
     local context_file="$2"
@@ -1606,7 +1615,7 @@ ${normal_findings}
     local correction_model
     correction_model=$(get_agent_model "$correction_agent" "tangle" "implementer" 2>/dev/null || true)
     [[ -n "$correction_model" ]] || correction_model="unresolved"
-    log INFO "Step 5: Applying contextual review corrections (round=${round_num}, role=implementer, strategy=${correction_strategy}, stall_window=${stall_window}s, executor_alias=${correction_agent}, configured_provider=$(octo_provider_identity_from_agent_type "${correction_agent}"), configured_model=${correction_model}, runtime_provider=unknown, runtime_model=unknown)..."
+    log INFO "$(tangle_correction_identity_message "$round_num" "$correction_strategy" "$stall_window" "$correction_agent" "$correction_model")"
     (
         OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-correction-stall-watchdog" run_agent_sync "$correction_agent" "$correction_prompt" 0 "implementer" "tangle" > "$correction_file" 2>&1
         echo "$?" > "$rc_file"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1603,7 +1603,10 @@ ${normal_findings}
     [[ "$poll_secs" =~ ^[0-9]+$ ]] || poll_secs=30
     [[ "$poll_secs" -lt 1 ]] && poll_secs=1
 
-    log INFO "Step 5: Applying contextual review corrections (round ${round_num}, strategy=${correction_strategy}, stall_window=${stall_window}s) with ${correction_agent}..."
+    local correction_model
+    correction_model=$(get_agent_model "$correction_agent" "tangle" "implementer" 2>/dev/null || true)
+    [[ -n "$correction_model" ]] || correction_model="unresolved"
+    log INFO "Step 5: Applying contextual review corrections (round ${round_num}, strategy=${correction_strategy}, stall_window=${stall_window}s) with executor alias=${correction_agent}, configured model=${correction_model}..."
     (
         OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-correction-stall-watchdog" run_agent_sync "$correction_agent" "$correction_prompt" 0 "implementer" "tangle" > "$correction_file" 2>&1
         echo "$?" > "$rc_file"

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "runtime provider labels"
+
+test_case "external CLI wrapper marks provider as legacy alias"
+source "$PROJECT_ROOT/scripts/lib/validation.sh" 2>/dev/null
+out=$(wrap_cli_output codex "model: deepseek-ai/DeepSeek-V4-Pro
+provider: pioneer")
+if grep -q 'provider="codex"' <<<"$out" && grep -q 'executor-alias="codex"' <<<"$out" && grep -q 'provider-label-kind="legacy-alias"' <<<"$out" && grep -q 'provider: pioneer' <<<"$out"; then
+  test_pass
+else
+  test_fail "wrapper did not distinguish alias from runtime provider"
+fi
+
+test_case "spawn result headers identify executor alias and configured model"
+if grep -q '# Executor alias: $agent_type' "$PROJECT_ROOT/scripts/lib/spawn.sh" && grep -q '# Configured model: ${model:-unresolved}' "$PROJECT_ROOT/scripts/lib/spawn.sh"; then
+  test_pass
+else
+  test_fail "spawn headers missing explicit executor/model labels"
+fi
+
+test_case "correction log avoids ambiguous with-provider wording"
+if grep -q 'with executor alias=${correction_agent}, configured model=${correction_model}' "$PROJECT_ROOT/scripts/lib/workflows.sh" && ! grep -q 'with ${correction_agent}...' "$PROJECT_ROOT/scripts/lib/workflows.sh"; then
+  test_pass
+else
+  test_fail "correction log still uses ambiguous provider wording"
+fi
+
+test_summary

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -4,10 +4,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 source "$PROJECT_ROOT/scripts/lib/validation.sh"
+source "$PROJECT_ROOT/scripts/lib/spawn.sh"
+source "$PROJECT_ROOT/scripts/lib/workflows.sh"
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
+mkdir -p "$TEST_TMP_DIR"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT
 test_suite "runtime provider labels"
 
 test_case "native OpenAI-compatible runtime identity is captured in artifacts"
-tmp=$(mktemp -d)
+tmp="$TEST_TMP_DIR/native-runtime"
+mkdir -p "$tmp"
 printf '%s\n' 'provider=generic base_url=https://example.invalid/v1 model=deepseek-ai/DeepSeek-V4-Pro cwd=/tmp/project' > "$tmp/raw.out"
 : > "$tmp/result.md"
 octo_append_runtime_identity "$tmp/result.md" openai-compatible deepseek-ai/DeepSeek-V4-Pro "$tmp/raw.out"
@@ -16,25 +22,27 @@ if grep -q -- '- Configured provider: openai-compatible' "$tmp/result.md" && gre
 else
   test_fail "native OpenAI-compatible provider/model identity was not captured"
 fi
-rm -rf "$tmp"
 
-test_case "spawn result headers identify executor alias and configured model"
-if grep -q '# Executor alias: $agent_type' "$PROJECT_ROOT/scripts/lib/spawn.sh" && grep -q '# Configured model: ${model:-unresolved}' "$PROJECT_ROOT/scripts/lib/spawn.sh"; then
+test_case "spawn result header function emits concrete identity values"
+header="$TEST_TMP_DIR/header.md"
+write_agent_result_header "$header" openai-compatible deepseek-ai/DeepSeek-V4-Pro task-1 reviewer review legacy
+if grep -q '^# Executor alias: openai-compatible$' "$header" && grep -q '^# Configured provider: openai-compatible$' "$header" && grep -q '^# Configured model: deepseek-ai/DeepSeek-V4-Pro$' "$header" && grep -q '^# Role: reviewer$' "$header"; then
   test_pass
 else
-  test_fail "spawn headers missing explicit executor/model labels"
+  test_fail "spawn header helper did not emit concrete runtime identity"
 fi
 
-test_case "correction log uses stable runtime identity field names"
-if grep -q 'executor_alias=${correction_agent}, configured_provider=$(octo_provider_identity_from_agent_type "${correction_agent}"), configured_model=${correction_model}, runtime_provider=unknown, runtime_model=unknown' "$PROJECT_ROOT/scripts/lib/workflows.sh" && ! grep -q 'with ${correction_agent}...' "$PROJECT_ROOT/scripts/lib/workflows.sh"; then
+test_case "correction log helper interpolates stable identity values"
+msg=$(tangle_correction_identity_message 2 delta 1800 openai-compatible deepseek-ai/DeepSeek-V4-Pro)
+if [[ "$msg" == *"round=2"* && "$msg" == *"executor_alias=openai-compatible"* && "$msg" == *"configured_provider=openai-compatible"* && "$msg" == *"configured_model=deepseek-ai/DeepSeek-V4-Pro"* ]]; then
   test_pass
 else
-  test_fail "correction log still uses ambiguous provider wording"
+  test_fail "correction identity message did not interpolate concrete values: $msg"
 fi
-
 
 test_case "runtime identity artifact detects routing mismatch"
-tmp=$(mktemp -d)
+tmp="$TEST_TMP_DIR/mismatch"
+mkdir -p "$tmp"
 printf '%s\n' 'provider=generic base_url=https://example.invalid/v1 model=deepseek-ai/DeepSeek-V4-Pro cwd=/tmp/project' > "$tmp/raw.out"
 : > "$tmp/result.md"
 octo_append_runtime_identity "$tmp/result.md" openai-compatible gpt-5.5 "$tmp/raw.out"
@@ -43,7 +51,6 @@ if grep -q -- '- Configured provider: openai-compatible' "$tmp/result.md" && gre
 else
   test_fail "runtime identity did not preserve reported provider/model and mismatch"
 fi
-rm -rf "$tmp"
 
 test_case "unknown runtime identity is explicit rather than inferred"
 out=$(wrap_cli_output codex "plain response without identity metadata")

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -3,19 +3,20 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
+source "$PROJECT_ROOT/scripts/lib/validation.sh"
 test_suite "runtime provider labels"
 
-test_case "external CLI wrapper marks provider as legacy alias"
-source "$PROJECT_ROOT/scripts/lib/validation.sh" 2>/dev/null
-out=$(wrap_cli_output codex "OCTOPUS_RUNTIME_ADAPTER=openai-compatible
-OCTOPUS_RUNTIME_PROVIDER=deepseek
-OCTOPUS_RUNTIME_MODEL=deepseek-ai/DeepSeek-V4-Pro
-response body")
-if grep -q 'provider="codex"' <<<"$out" && grep -q 'executor-alias="codex"' <<<"$out" && grep -q 'provider-label-kind="legacy-alias"' <<<"$out" && grep -q 'runtime-adapter="openai-compatible"' <<<"$out" && grep -q 'runtime-provider="deepseek"' <<<"$out" && grep -q 'runtime-model="deepseek-ai/DeepSeek-V4-Pro"' <<<"$out"; then
+test_case "native OpenAI-compatible runtime identity is captured in artifacts"
+tmp=$(mktemp -d)
+printf '%s\n' 'provider=generic base_url=https://example.invalid/v1 model=deepseek-ai/DeepSeek-V4-Pro cwd=/tmp/project' > "$tmp/raw.out"
+: > "$tmp/result.md"
+octo_append_runtime_identity "$tmp/result.md" openai-compatible deepseek-ai/DeepSeek-V4-Pro "$tmp/raw.out"
+if grep -q -- '- Configured provider: openai-compatible' "$tmp/result.md" && grep -q -- '- Runtime provider: openai-compatible' "$tmp/result.md" && grep -q -- '- Runtime model: deepseek-ai/DeepSeek-V4-Pro' "$tmp/result.md" && grep -q -- '- Routing mismatch: false' "$tmp/result.md"; then
   test_pass
 else
-  test_fail "wrapper did not distinguish alias from runtime provider"
+  test_fail "native OpenAI-compatible provider/model identity was not captured"
 fi
+rm -rf "$tmp"
 
 test_case "spawn result headers identify executor alias and configured model"
 if grep -q '# Executor alias: $agent_type' "$PROJECT_ROOT/scripts/lib/spawn.sh" && grep -q '# Configured model: ${model:-unresolved}' "$PROJECT_ROOT/scripts/lib/spawn.sh"; then
@@ -25,7 +26,7 @@ else
 fi
 
 test_case "correction log uses stable runtime identity field names"
-if grep -q 'executor_alias=${correction_agent}, configured_adapter=unknown, configured_model=${correction_model}, runtime_adapter=unknown, runtime_provider=unknown, runtime_model=unknown' "$PROJECT_ROOT/scripts/lib/workflows.sh" && ! grep -q 'with ${correction_agent}...' "$PROJECT_ROOT/scripts/lib/workflows.sh"; then
+if grep -q 'executor_alias=${correction_agent}, configured_provider=$(octo_provider_identity_from_agent_type "${correction_agent}"), configured_model=${correction_model}, runtime_provider=unknown, runtime_model=unknown' "$PROJECT_ROOT/scripts/lib/workflows.sh" && ! grep -q 'with ${correction_agent}...' "$PROJECT_ROOT/scripts/lib/workflows.sh"; then
   test_pass
 else
   test_fail "correction log still uses ambiguous provider wording"
@@ -34,10 +35,10 @@ fi
 
 test_case "runtime identity artifact detects routing mismatch"
 tmp=$(mktemp -d)
-printf '%s\n' 'OCTOPUS_RUNTIME_ADAPTER=openai-compatible' 'OCTOPUS_RUNTIME_PROVIDER=deepseek' 'OCTOPUS_RUNTIME_MODEL=deepseek-ai/DeepSeek-V4-Pro' > "$tmp/raw.out"
+printf '%s\n' 'provider=generic base_url=https://example.invalid/v1 model=deepseek-ai/DeepSeek-V4-Pro cwd=/tmp/project' > "$tmp/raw.out"
 : > "$tmp/result.md"
-octo_append_runtime_identity "$tmp/result.md" codex gpt-5.5 "$tmp/raw.out"
-if grep -q -- '- Runtime adapter: openai-compatible' "$tmp/result.md" && grep -q -- '- Runtime provider: deepseek' "$tmp/result.md" && grep -q -- '- Runtime model: deepseek-ai/DeepSeek-V4-Pro' "$tmp/result.md" && grep -q -- '- Routing mismatch: true' "$tmp/result.md"; then
+octo_append_runtime_identity "$tmp/result.md" openai-compatible gpt-5.5 "$tmp/raw.out"
+if grep -q -- '- Configured provider: openai-compatible' "$tmp/result.md" && grep -q -- '- Runtime provider: openai-compatible' "$tmp/result.md" && grep -q -- '- Runtime model: deepseek-ai/DeepSeek-V4-Pro' "$tmp/result.md" && grep -q -- '- Routing mismatch: true' "$tmp/result.md"; then
   test_pass
 else
   test_fail "runtime identity did not preserve reported provider/model and mismatch"
@@ -46,7 +47,7 @@ rm -rf "$tmp"
 
 test_case "unknown runtime identity is explicit rather than inferred"
 out=$(wrap_cli_output codex "plain response without identity metadata")
-if grep -q 'runtime-provider="unknown"' <<<"$out" && grep -q 'runtime-model="unknown"' <<<"$out"; then
+if grep -q 'runtime-provider="codex"' <<<"$out" && grep -q 'runtime-model="unknown"' <<<"$out"; then
   test_pass
 else
   test_fail "missing runtime identity was inferred or omitted"
@@ -56,7 +57,6 @@ test_case "all central role events use stable identity fields"
 missing=0
 for file in spawn.sh council.sh debate.sh parallel.sh review.sh; do
   grep -q 'executor_alias=' "$PROJECT_ROOT/scripts/lib/$file" || missing=1
-  grep -q 'runtime_adapter=' "$PROJECT_ROOT/scripts/lib/$file" || missing=1
   grep -q 'runtime_provider=' "$PROJECT_ROOT/scripts/lib/$file" || missing=1
   grep -q 'runtime_model=' "$PROJECT_ROOT/scripts/lib/$file" || missing=1
 done

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -7,9 +7,11 @@ test_suite "runtime provider labels"
 
 test_case "external CLI wrapper marks provider as legacy alias"
 source "$PROJECT_ROOT/scripts/lib/validation.sh" 2>/dev/null
-out=$(wrap_cli_output codex "model: deepseek-ai/DeepSeek-V4-Pro
-provider: pioneer")
-if grep -q 'provider="codex"' <<<"$out" && grep -q 'executor-alias="codex"' <<<"$out" && grep -q 'provider-label-kind="legacy-alias"' <<<"$out" && grep -q 'provider: pioneer' <<<"$out"; then
+out=$(wrap_cli_output codex "OCTOPUS_RUNTIME_ADAPTER=openai-compatible
+OCTOPUS_RUNTIME_PROVIDER=deepseek
+OCTOPUS_RUNTIME_MODEL=deepseek-ai/DeepSeek-V4-Pro
+response body")
+if grep -q 'provider="codex"' <<<"$out" && grep -q 'executor-alias="codex"' <<<"$out" && grep -q 'provider-label-kind="legacy-alias"' <<<"$out" && grep -q 'runtime-adapter="openai-compatible"' <<<"$out" && grep -q 'runtime-provider="deepseek"' <<<"$out" && grep -q 'runtime-model="deepseek-ai/DeepSeek-V4-Pro"' <<<"$out"; then
   test_pass
 else
   test_fail "wrapper did not distinguish alias from runtime provider"
@@ -22,11 +24,46 @@ else
   test_fail "spawn headers missing explicit executor/model labels"
 fi
 
-test_case "correction log avoids ambiguous with-provider wording"
-if grep -q 'with executor alias=${correction_agent}, configured model=${correction_model}' "$PROJECT_ROOT/scripts/lib/workflows.sh" && ! grep -q 'with ${correction_agent}...' "$PROJECT_ROOT/scripts/lib/workflows.sh"; then
+test_case "correction log uses stable runtime identity field names"
+if grep -q 'executor_alias=${correction_agent}, configured_adapter=unknown, configured_model=${correction_model}, runtime_adapter=unknown, runtime_provider=unknown, runtime_model=unknown' "$PROJECT_ROOT/scripts/lib/workflows.sh" && ! grep -q 'with ${correction_agent}...' "$PROJECT_ROOT/scripts/lib/workflows.sh"; then
   test_pass
 else
   test_fail "correction log still uses ambiguous provider wording"
+fi
+
+
+test_case "runtime identity artifact detects routing mismatch"
+tmp=$(mktemp -d)
+printf '%s\n' 'OCTOPUS_RUNTIME_ADAPTER=openai-compatible' 'OCTOPUS_RUNTIME_PROVIDER=deepseek' 'OCTOPUS_RUNTIME_MODEL=deepseek-ai/DeepSeek-V4-Pro' > "$tmp/raw.out"
+: > "$tmp/result.md"
+octo_append_runtime_identity "$tmp/result.md" codex gpt-5.5 "$tmp/raw.out"
+if grep -q -- '- Runtime adapter: openai-compatible' "$tmp/result.md" && grep -q -- '- Runtime provider: deepseek' "$tmp/result.md" && grep -q -- '- Runtime model: deepseek-ai/DeepSeek-V4-Pro' "$tmp/result.md" && grep -q -- '- Routing mismatch: true' "$tmp/result.md"; then
+  test_pass
+else
+  test_fail "runtime identity did not preserve reported provider/model and mismatch"
+fi
+rm -rf "$tmp"
+
+test_case "unknown runtime identity is explicit rather than inferred"
+out=$(wrap_cli_output codex "plain response without identity metadata")
+if grep -q 'runtime-provider="unknown"' <<<"$out" && grep -q 'runtime-model="unknown"' <<<"$out"; then
+  test_pass
+else
+  test_fail "missing runtime identity was inferred or omitted"
+fi
+
+test_case "all central role events use stable identity fields"
+missing=0
+for file in spawn.sh council.sh debate.sh parallel.sh review.sh; do
+  grep -q 'executor_alias=' "$PROJECT_ROOT/scripts/lib/$file" || missing=1
+  grep -q 'runtime_adapter=' "$PROJECT_ROOT/scripts/lib/$file" || missing=1
+  grep -q 'runtime_provider=' "$PROJECT_ROOT/scripts/lib/$file" || missing=1
+  grep -q 'runtime_model=' "$PROJECT_ROOT/scripts/lib/$file" || missing=1
+done
+if [[ "$missing" -eq 0 ]] && grep -q 'council_role="chair"' "$PROJECT_ROOT/scripts/lib/council.sh" && grep -q 'synthesis_strategy="debate"' "$PROJECT_ROOT/scripts/lib/debate.sh"; then
+  test_pass
+else
+  test_fail "one or more role events still lack stable identity/role fields"
 fi
 
 test_summary


### PR DESCRIPTION
## Summary
- distinguish executor aliases from native Octopus providers and effective models
- cover spawn/lifecycle, review, council, debate, parallel synthesis, and correction logs
- record executor_alias, configured_provider, configured_model, runtime_provider, runtime_model, role/strategy fields
- model OpenAI-compatible as a native Octopus provider, not as an external adapter
- extract the effective model from the native openai-compatible-agent.py runtime metadata line
- append a Runtime Identity block to result artifacts and flag configured/runtime model mismatches
- retain the old provider field with provider_label_kind=legacy-alias for compatibility

## Runtime identity
For the native OpenAI-compatible path, artifacts now distinguish:

executor_alias=openai-compatible
configured_provider=openai-compatible
configured_model=deepseek-ai/DeepSeek-V4-Pro
runtime_provider=openai-compatible
runtime_model=deepseek-ai/DeepSeek-V4-Pro

No external adapter layer is assumed or reported.

## Validation
- runtime provider labels: 6/6
- review pipeline: 27/27
- probe classification: 4/4
- tangle retry feedback: 10/10
- shell syntax checks and git diff --check

Total focused tests: 47/47.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added clearer executor, provider, and model information to agent lifecycle events, result headers, review findings, and synthesis records.
  * Result artifacts now include configured versus runtime identity details, including a routing mismatch indicator when they differ.
  * External CLI output now carries additional runtime identity metadata while preserving untrusted-output handling.
  * Correction, council, debate, parallel, and review messages now provide more consistent execution attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->