### PR TITLE
refactor: centralize workflow provider resolution

### DIFF
--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -29,38 +29,12 @@ fi
 #   OCTOPUS_CODING_AGENT
 #   <default passed by caller>
 octopus_agent_override() {
-    local phase="$1"
-    local role="$2"
-    local default_agent="$3"
-    local phase_key role_key env_name value
-
-    phase_key=$(printf '%s' "$phase" | tr '[:lower:]-' '[:upper:]_' | sed -E 's/[^A-Z0-9_]+/_/g; s/^_+//; s/_+$//')
-    role_key=$(printf '%s' "$role" | tr '[:lower:]-' '[:upper:]_' | sed -E 's/[^A-Z0-9_]+/_/g; s/^_+//; s/_+$//')
-
-    if [[ -n "$phase_key" && -n "$role_key" ]]; then
-        env_name="OCTOPUS_${phase_key}_${role_key}_AGENT"
-        value="${!env_name:-}"
-        [[ -n "$value" ]] && { echo "$value"; return 0; }
-    fi
-
-    if [[ -n "$phase_key" ]]; then
-        env_name="OCTOPUS_${phase_key}_AGENT"
-        value="${!env_name:-}"
-        [[ -n "$value" ]] && { echo "$value"; return 0; }
-    fi
-
-    if [[ -n "$role_key" ]]; then
-        env_name="OCTOPUS_${role_key}_AGENT"
-        value="${!env_name:-}"
-        [[ -n "$value" ]] && { echo "$value"; return 0; }
-    fi
-
-    if declare -f octopus_profile_provider >/dev/null 2>&1; then
-        value="$(octopus_profile_provider "$phase" "$role" "$default_agent" 2>/dev/null || true)"
-        [[ -n "$value" ]] && { echo "$value"; return 0; }
-    fi
-    echo "$default_agent"
+    local phase="$1" operation="$2" default_agent="$3"
+    local explicit
+    explicit="$(octopus_explicit_provider_override "$phase" "$operation" 2>/dev/null || true)"
+    printf '%s\n' "${explicit:-$default_agent}"
 }
+
 
 # v9.19.0: Safe default for --bare flag (set by providers.sh, but guard for standalone sourcing)
 _BARE_OPT="${_BARE_OPT:-}"

--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -131,6 +131,25 @@ log_role_assignment() {
     log DEBUG "Using ${role} role (${agent}, persona: ${has_persona}) for: ${purpose}"
 }
 
+
+# Resolve a phase/operation override on top of the configured execution-profile
+# role. Explicit env overrides keep their existing precedence; routing.roles is
+# used before the historical caller default.
+octopus_role_profile_agent_override() {
+    local phase="$1"
+    local override_role="$2"
+    local execution_role="$3"
+    local historical_default="$4"
+    local profile_default="$historical_default"
+
+    if declare -f octopus_profile_provider >/dev/null 2>&1; then
+        profile_default=$(octopus_profile_provider "$phase" "$execution_role" "$historical_default" 2>/dev/null || printf '%s\n' "$historical_default")
+        profile_default="${profile_default:-$historical_default}"
+    fi
+
+    octopus_agent_override "$phase" "$override_role" "$profile_default"
+}
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # v3.3 FEATURE: AGENT PERSONAS
 # Specialized system instructions for each agent role

--- a/scripts/lib/execution-profile.sh
+++ b/scripts/lib/execution-profile.sh
@@ -34,6 +34,51 @@ _octopus_profile_field() {
   esac
 }
 
+_octopus_profile_env_key() {
+  printf '%s' "${1:-}" | tr '[:lower:]-' '[:upper:]_' | sed -E 's/[^A-Z0-9_]+/_/g; s/^_+//; s/_+$//'
+}
+
+octopus_explicit_provider_override() {
+  local phase="$1" operation="$2" phase_key operation_key env_name value
+  phase_key="$(_octopus_profile_env_key "$phase")"
+  operation_key="$(_octopus_profile_env_key "$operation")"
+
+  if [[ -n "$phase_key" && -n "$operation_key" ]]; then
+    env_name="OCTOPUS_${phase_key}_${operation_key}_AGENT"
+    value="${!env_name:-}"
+    [[ -n "$value" ]] && { printf '%s\n' "$value"; return 0; }
+  fi
+  if [[ -n "$phase_key" ]]; then
+    env_name="OCTOPUS_${phase_key}_AGENT"
+    value="${!env_name:-}"
+    [[ -n "$value" ]] && { printf '%s\n' "$value"; return 0; }
+  fi
+  if [[ -n "$operation_key" ]]; then
+    env_name="OCTOPUS_${operation_key}_AGENT"
+    value="${!env_name:-}"
+    [[ -n "$value" ]] && { printf '%s\n' "$value"; return 0; }
+  fi
+  return 1
+}
+
+# Canonical provider resolution for workflow dispatch.
+# Precedence: explicit operation/phase env override > configured role/phase
+# route > historical caller default. Workflows should not duplicate this logic.
+octopus_execution_profile_provider() {
+  local phase="$1" operation="$2" role="$3" default_provider="$4"
+  local explicit_provider configured_provider
+
+  explicit_provider="$(octopus_explicit_provider_override "$phase" "$operation" 2>/dev/null || true)"
+  if [[ -n "$explicit_provider" ]]; then
+    printf '%s\n' "$explicit_provider"
+    return 0
+  fi
+
+  configured_provider="$(octopus_profile_provider "$phase" "$role" "$default_provider" 2>/dev/null || true)"
+  printf '%s\n' "${configured_provider:-$default_provider}"
+}
+
+
 octopus_profile_provider() {
   local phase="$1" role="$2" default_provider="$3" value
   value="$(_octopus_profile_field "$phase" "$role" provider 2>/dev/null || true)"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1085,8 +1085,8 @@ ${previous_decomposition}
 
     local tangle_decompose_agent="agy" tangle_decompose_fallback_agent="codex"
     if declare -f octopus_agent_override >/dev/null 2>&1; then
-        tangle_decompose_agent=$(octopus_role_profile_agent_override "tangle" "decompose" "researcher" "agy")
-        tangle_decompose_fallback_agent=$(octopus_agent_override "tangle" "decompose_fallback" "codex")
+        tangle_decompose_agent=$(octopus_execution_profile_provider "tangle" "decompose" "researcher" "agy")
+        tangle_decompose_fallback_agent=$(octopus_execution_profile_provider "tangle" "decompose_fallback" "implementer" "codex")
     fi
 
     OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-reformat-validation" run_agent_sync "$tangle_decompose_agent" "$reformat_prompt" 0 "researcher" "tangle" || \
@@ -1857,8 +1857,8 @@ Every [CODING] line must include a same-line Files: clause."
     # selects the dispatch agent; the fail-closed contract below is unchanged.
     local tangle_decompose_agent="agy" tangle_decompose_fallback_agent="codex"
     if declare -f octopus_agent_override >/dev/null 2>&1; then
-        tangle_decompose_agent=$(octopus_agent_override "tangle" "decompose" "agy")
-        tangle_decompose_fallback_agent=$(octopus_agent_override "tangle" "decompose_fallback" "codex")
+        tangle_decompose_agent=$(octopus_execution_profile_provider "tangle" "decompose" "researcher" "agy")
+        tangle_decompose_fallback_agent=$(octopus_execution_profile_provider "tangle" "decompose_fallback" "implementer" "codex")
     fi
 
     local subtasks
@@ -1950,8 +1950,8 @@ Every [CODING] line must include a same-line Files: clause."
     local tangle_coding_agent="codex"
     local tangle_reasoning_agent="agy"
     if declare -f octopus_agent_override >/dev/null 2>&1; then
-        tangle_coding_agent=$(octopus_role_profile_agent_override "tangle" "coding" "implementer" "codex")
-        tangle_reasoning_agent=$(octopus_role_profile_agent_override "tangle" "reasoning" "researcher" "agy")
+        tangle_coding_agent=$(octopus_execution_profile_provider "tangle" "coding" "implementer" "codex")
+        tangle_reasoning_agent=$(octopus_execution_profile_provider "tangle" "reasoning" "researcher" "agy")
     fi
 
     # [REASONING] falls back through available providers. Without this, users

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1085,7 +1085,7 @@ ${previous_decomposition}
 
     local tangle_decompose_agent="agy" tangle_decompose_fallback_agent="codex"
     if declare -f octopus_agent_override >/dev/null 2>&1; then
-        tangle_decompose_agent=$(octopus_agent_override "tangle" "decompose" "agy")
+        tangle_decompose_agent=$(octopus_role_profile_agent_override "tangle" "decompose" "researcher" "agy")
         tangle_decompose_fallback_agent=$(octopus_agent_override "tangle" "decompose_fallback" "codex")
     fi
 
@@ -1950,8 +1950,8 @@ Every [CODING] line must include a same-line Files: clause."
     local tangle_coding_agent="codex"
     local tangle_reasoning_agent="agy"
     if declare -f octopus_agent_override >/dev/null 2>&1; then
-        tangle_coding_agent=$(octopus_agent_override "tangle" "coding" "codex")
-        tangle_reasoning_agent=$(octopus_agent_override "tangle" "reasoning" "agy")
+        tangle_coding_agent=$(octopus_role_profile_agent_override "tangle" "coding" "implementer" "codex")
+        tangle_reasoning_agent=$(octopus_role_profile_agent_override "tangle" "reasoning" "researcher" "agy")
     fi
 
     # [REASONING] falls back through available providers. Without this, users

--- a/tests/unit/test-agy-workflow-routing.sh
+++ b/tests/unit/test-agy-workflow-routing.sh
@@ -40,7 +40,7 @@ test_no_functional_gemini_dispatch() {
 test_tangle_decompose_default_is_agy() {
     test_case "tangle decompose default agent is agy"
     if grep -q 'tangle_decompose_agent="agy"' "$PROJECT_ROOT/scripts/lib/workflows.sh" && \
-       grep -q 'octopus_agent_override "tangle" "decompose" "agy"' "$PROJECT_ROOT/scripts/lib/workflows.sh"; then
+       grep -q 'octopus_execution_profile_provider "tangle" "decompose" "researcher" "agy"' "$PROJECT_ROOT/scripts/lib/workflows.sh"; then
         test_pass
     else test_fail "tangle decompose still defaults to gemini"; fi
 }

--- a/tests/unit/test-tangle-coding-agent-override.sh
+++ b/tests/unit/test-tangle-coding-agent-override.sh
@@ -63,9 +63,9 @@ cat > "$TEST_TMP_DIR/config/providers.json" <<'JSON'
 {"routing":{"roles":{"implementer":"openai-compatible-agent:deepseek-ai/DeepSeek-V4-Pro","researcher":"gemini:gemini-3.1-pro-preview"}}}
 JSON
 if (
-    export OCTOPUS_PROVIDERS_CONFIG="$TEST_TMP_DIR/config/providers.json"
+    export "OCTOPUS_PROVIDERS_CONFIG=$TEST_TMP_DIR/config/providers.json"
     unset OCTOPUS_TANGLE_CODING_AGENT OCTOPUS_TANGLE_AGENT OCTOPUS_CODING_AGENT || true
-    [[ "$(octopus_role_profile_agent_override tangle coding implementer codex)" == "openai-compatible-agent" ]]
+    [[ "$(octopus_execution_profile_provider tangle coding implementer codex)" == "openai-compatible-agent" ]]
 ); then
     test_pass
 else
@@ -74,9 +74,9 @@ fi
 
 test_case "explicit tangle coding env override remains higher priority than role profile"
 if (
-    export OCTOPUS_PROVIDERS_CONFIG="$TEST_TMP_DIR/config/providers.json"
-    export OCTOPUS_TANGLE_CODING_AGENT="claude-sonnet"
-    [[ "$(octopus_role_profile_agent_override tangle coding implementer codex)" == "claude-sonnet" ]]
+    export "OCTOPUS_PROVIDERS_CONFIG=$TEST_TMP_DIR/config/providers.json"
+    export "OCTOPUS_TANGLE_CODING_AGENT=claude-sonnet"
+    [[ "$(octopus_execution_profile_provider tangle coding implementer codex)" == "claude-sonnet" ]]
 ); then
     test_pass
 else
@@ -85,10 +85,10 @@ fi
 
 test_case "configured researcher role is used for tangle reasoning and decomposition"
 if (
-    export OCTOPUS_PROVIDERS_CONFIG="$TEST_TMP_DIR/config/providers.json"
+    export "OCTOPUS_PROVIDERS_CONFIG=$TEST_TMP_DIR/config/providers.json"
     unset OCTOPUS_TANGLE_REASONING_AGENT OCTOPUS_REASONING_AGENT OCTOPUS_TANGLE_DECOMPOSE_AGENT OCTOPUS_DECOMPOSE_AGENT OCTOPUS_TANGLE_AGENT || true
-    [[ "$(octopus_role_profile_agent_override tangle reasoning researcher agy)" == "gemini" ]]
-    [[ "$(octopus_role_profile_agent_override tangle decompose researcher agy)" == "gemini" ]]
+    [[ "$(octopus_execution_profile_provider tangle reasoning researcher agy)" == "gemini" ]] &&
+    [[ "$(octopus_execution_profile_provider tangle decompose researcher agy)" == "gemini" ]]
 ); then
     test_pass
 else
@@ -100,9 +100,9 @@ cat > "$TEST_TMP_DIR/config/empty.json" <<'JSON'
 {"routing":{"roles":{}}}
 JSON
 if (
-    export OCTOPUS_PROVIDERS_CONFIG="$TEST_TMP_DIR/config/empty.json"
+    export "OCTOPUS_PROVIDERS_CONFIG=$TEST_TMP_DIR/config/empty.json"
     unset OCTOPUS_TANGLE_CODING_AGENT OCTOPUS_TANGLE_AGENT OCTOPUS_CODING_AGENT || true
-    [[ "$(octopus_role_profile_agent_override tangle coding implementer codex)" == "codex" ]]
+    [[ "$(octopus_execution_profile_provider tangle coding implementer codex)" == "codex" ]]
 ); then
     test_pass
 else
@@ -119,6 +119,16 @@ if [[ "$configured_agent_count" -gt 0 ]] && [[ "$hardcoded_codex_count" -eq 0 ]]
     test_pass
 else
     test_fail "tangle coding loop still hardcodes codex"
+fi
+
+
+test_case "Tangle primary dispatch sites use only the canonical profile resolver"
+primary_count=$(grep -c 'octopus_execution_profile_provider "tangle"' "$WORKFLOWS" || true)
+legacy_primary_count=$(grep -cE 'octopus_(agent_override|role_profile_agent_override) "tangle" "(coding|reasoning|decompose)"' "$WORKFLOWS" || true)
+if [[ "$primary_count" -ge 5 && "$legacy_primary_count" -eq 0 ]]; then
+    test_pass
+else
+    test_fail "Tangle still contains local provider resolution (canonical=$primary_count legacy=$legacy_primary_count)"
 fi
 
 test_summary

--- a/tests/unit/test-tangle-coding-agent-override.sh
+++ b/tests/unit/test-tangle-coding-agent-override.sh
@@ -57,12 +57,56 @@ else
     test_fail "OCTOPUS_CODING_AGENT was not used as final coding fallback"
 fi
 
-test_case "tangle_develop resolves tangle_coding_agent through octopus_agent_override"
-resolver_count=$(grep -c 'tangle_coding_agent=$(octopus_agent_override "tangle" "coding" "codex")' "$WORKFLOWS" || true)
-if [[ "$resolver_count" -gt 0 ]]; then
+test_case "configured implementer role is the tangle coding default"
+mkdir -p "$TEST_TMP_DIR/config"
+cat > "$TEST_TMP_DIR/config/providers.json" <<'JSON'
+{"routing":{"roles":{"implementer":"openai-compatible-agent:deepseek-ai/DeepSeek-V4-Pro","researcher":"gemini:gemini-3.1-pro-preview"}}}
+JSON
+if (
+    export OCTOPUS_PROVIDERS_CONFIG="$TEST_TMP_DIR/config/providers.json"
+    unset OCTOPUS_TANGLE_CODING_AGENT OCTOPUS_TANGLE_AGENT OCTOPUS_CODING_AGENT || true
+    [[ "$(octopus_role_profile_agent_override tangle coding implementer codex)" == "openai-compatible-agent" ]]
+); then
     test_pass
 else
-    test_fail "tangle_develop does not resolve OCTOPUS_TANGLE_CODING_AGENT"
+    test_fail "configured implementer role was ignored"
+fi
+
+test_case "explicit tangle coding env override remains higher priority than role profile"
+if (
+    export OCTOPUS_PROVIDERS_CONFIG="$TEST_TMP_DIR/config/providers.json"
+    export OCTOPUS_TANGLE_CODING_AGENT="claude-sonnet"
+    [[ "$(octopus_role_profile_agent_override tangle coding implementer codex)" == "claude-sonnet" ]]
+); then
+    test_pass
+else
+    test_fail "explicit coding override did not beat configured implementer role"
+fi
+
+test_case "configured researcher role is used for tangle reasoning and decomposition"
+if (
+    export OCTOPUS_PROVIDERS_CONFIG="$TEST_TMP_DIR/config/providers.json"
+    unset OCTOPUS_TANGLE_REASONING_AGENT OCTOPUS_REASONING_AGENT OCTOPUS_TANGLE_DECOMPOSE_AGENT OCTOPUS_DECOMPOSE_AGENT OCTOPUS_TANGLE_AGENT || true
+    [[ "$(octopus_role_profile_agent_override tangle reasoning researcher agy)" == "gemini" ]]
+    [[ "$(octopus_role_profile_agent_override tangle decompose researcher agy)" == "gemini" ]]
+); then
+    test_pass
+else
+    test_fail "configured researcher role was ignored"
+fi
+
+test_case "historical defaults remain when no role route exists"
+cat > "$TEST_TMP_DIR/config/empty.json" <<'JSON'
+{"routing":{"roles":{}}}
+JSON
+if (
+    export OCTOPUS_PROVIDERS_CONFIG="$TEST_TMP_DIR/config/empty.json"
+    unset OCTOPUS_TANGLE_CODING_AGENT OCTOPUS_TANGLE_AGENT OCTOPUS_CODING_AGENT || true
+    [[ "$(octopus_role_profile_agent_override tangle coding implementer codex)" == "codex" ]]
+); then
+    test_pass
+else
+    test_fail "historical coding default was not preserved"
 fi
 
 test_case "[CODING] subtasks use configured tangle_coding_agent instead of hardcoded codex"


### PR DESCRIPTION
## Why this PR exists

Octopus already has a canonical execution-profile system in `scripts/lib/execution-profile.sh`, including `routing.roles` and `routing.phases`. Tangle nevertheless kept separate provider-selection logic in `workflows.sh` and `agent-utils.sh`, with historical hardcoded defaults such as `codex` and `agy`.

That duplication allowed a configured role route to be ignored. In the reproduced failure, `routing.roles.implementer` was set to `openai-compatible-agent:deepseek-ai/DeepSeek-V4-Pro`, but Tangle dispatched the implementation subtask as `codex`.

This was not a missing environment variable and not an invalid configuration. The workflow bypassed the canonical resolver.

## Structural change

- add `octopus_execution_profile_provider()` to `execution-profile.sh` as the single provider resolver for workflow dispatch
- keep explicit operation/phase environment overrides at the highest precedence
- otherwise resolve through the configured execution profile (`routing.roles` / `routing.phases`)
- retain historical provider defaults only when no explicit override or configured route exists
- make all Tangle primary dispatch paths use the canonical resolver:
  - coding → implementer
  - reasoning → researcher
  - decomposition → researcher
  - decomposition fallback → implementer
- reduce `octopus_agent_override()` to a backward-compatible wrapper around explicit override lookup instead of a second routing implementation

## Precedence

1. `OCTOPUS_<PHASE>_<OPERATION>_AGENT`
2. `OCTOPUS_<PHASE>_AGENT`
3. `OCTOPUS_<OPERATION>_AGENT`
4. configured execution profile (`routing.roles`, then `routing.phases`)
5. historical caller default

## Scope

This PR does **not** reject or rewrite provider/model combinations. User-configured combinations remain authoritative. If a configured provider/model is invalid at runtime, the existing dispatch error and fallback behavior remains responsible for handling it.

The purpose here is narrower and structural: workflows must consume the configured execution profile rather than silently substitute local defaults.

## Validation

- Tangle provider-routing matrix: 9/9
- execution-profile dispatch: pass
- model-config role routing: 4/4
- Tangle reformat routing: 4/4
- shell syntax checks
- `git diff --check`

Focused validation: 18/18 checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added phase- and operation-specific agent overrides with clear precedence, enabling more precise control of workflow behavior.
  * Introduced execution-profile-based routing for tangle agents, using configured defaults with robust fallback behavior.
* **Bug Fixes**
  * Improved agent selection for tangle coding, reasoning, and decomposition, including correct role-based defaults.
  * Preserved historical defaults when role routing is empty or no match exists.
* **Tests**
  * Updated and expanded unit tests to validate role-profile routing, environment override behavior, and canonical workflow selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->