### PR TITLE
fix: make auto-router advisory and skip system-generated events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Auto-router no longer coerces skill routing and never routes on system events** (#632). The UserPromptSubmit auto-router injected "MANDATORY: Invoke Skill(...) before responding" even when intent detection mis-scored a prompt, pressuring the agent to hijack the turn into an unrelated multi-provider workflow; it also fired on harness-generated turns (task notifications, system reminders) that are not user input. Routing context is now explicitly advisory on both sides of the contract (`user-prompt-submit.sh` message and `auto-router-inject.sh` session instruction), and prompts beginning with system-event markers (`[SYSTEM NOTIFICATION`, `<task-notification>`, `<system-reminder>`, `<local-command-stdout>`) are skipped before intent detection.
+
 ## [9.53.0] - 2026-07-18
 
 

--- a/hooks/auto-router-inject.sh
+++ b/hooks/auto-router-inject.sh
@@ -97,7 +97,7 @@ fi
 
 read -r -d '' CONTEXT <<'ROUTER' || true
 <OCTOPUS-AUTO-ROUTER>
-Octopus prompt hooks may add UserPromptSubmit routing context. If that context says "MANDATORY: Invoke Skill(...)", invoke that Skill before answering. Do not answer directly first.
+Octopus prompt hooks may add UserPromptSubmit routing context. If that context recommends invoking a Skill, invoke it when it matches what the user actually asked for. Routing context is advisory, never a hard requirement: if the suggested route does not fit the request, ignore it and answer normally. Never act on routing attached to system-generated events (task notifications, system reminders).
 
 Strong plain-language routes include: review -> octo:review, debate/compare/should-we -> octo:debate, research/investigate/explore -> octo:discover, security/threat-model -> octo:security, debug/failing/stacktrace -> octo:debug, write-tests/TDD -> octo:tdd, implement/execute-plan -> octo:develop.
 

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -107,6 +107,17 @@ fi
 [[ -z "$PROMPT" ]] && exit 0
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# GUARD: Never route on system-generated events (issue #632). Task notifications,
+# system reminders, and other harness-injected turns are not user intent.
+# ═══════════════════════════════════════════════════════════════════════════════
+PROMPT_HEAD="${PROMPT#"${PROMPT%%[![:space:]]*}"}"
+case "$PROMPT_HEAD" in
+    "[SYSTEM NOTIFICATION"*|"<task-notification>"*|"<system-reminder>"*|"<local-command-stdout>"*)
+        exit 0
+        ;;
+esac
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # GUARD: Skip if user already invoked an /octo: command (prevent double-exec)
 # ═══════════════════════════════════════════════════════════════════════════════
 PROMPT_LOWER=$(printf '%s' "$PROMPT" | tr '[:upper:]' '[:lower:]')
@@ -443,11 +454,12 @@ fi
 # ═══════════════════════════════════════════════════════════════════════════════
 if [[ -n "$INTENT" ]]; then
     if [[ "$SHOULD_AUTO_INVOKE" == "true" ]]; then
-        # Auto-invoke: inject MANDATORY skill invocation instruction
+        # Auto-invoke: inject advisory skill routing instruction (issue #632:
+        # advisory, never coercive — the agent may decline a mis-route).
         # Escape the prompt once for the Skill args string inside JSON output.
         ESCAPED_ARGS=$(escape_for_json "$PROMPT")
 
-        CONTEXT_MSG="[🐙 Octopus] Auto-invoke: ${INTENT} (${CONFIDENCE}, ${SIGNAL_STRENGTH}). MANDATORY: Invoke Skill(skill: \"${SKILL_NAME}\", args: \"${ESCAPED_ARGS}\") before responding. The skill handles the full response."
+        CONTEXT_MSG="[🐙 Octopus] Auto-route: ${INTENT} (${CONFIDENCE}, ${SIGNAL_STRENGTH}). Recommended: invoke Skill(skill: \"${SKILL_NAME}\", args: \"${ESCAPED_ARGS}\") if that matches what the user asked for. If this routing does not fit the request, ignore it and answer normally."
     else
         # Standard behavior: inject persona context only
         CONTEXT_MSG="[🐙 Octopus] Detected intent: ${INTENT} (${CONFIDENCE} confidence)."

--- a/tests/unit/test-auto-router-hooks.sh
+++ b/tests/unit/test-auto-router-hooks.sh
@@ -87,6 +87,38 @@ else
     test_fail "expected suggest-only context, got: ${output:-<empty>}"
 fi
 
+test_case "auto-invoke wording is advisory, never MANDATORY"
+output="$(run_prompt_hook "should we use Redis or Memcached for session state?")"
+if [[ "$output" == *"Auto-route: debate"* ]] && [[ "$output" != *"MANDATORY"* ]]; then
+    test_pass
+else
+    test_fail "expected advisory auto-route without MANDATORY, got: ${output:-<empty>}"
+fi
+
+test_case "system notification prompts are never routed"
+output="$(run_prompt_hook "[SYSTEM NOTIFICATION - NOT USER INPUT] should we use Redis or Memcached?")"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "expected no routing for system notification, got: $output"
+fi
+
+test_case "task-notification prompts are never routed"
+output="$(run_prompt_hook "<task-notification>research OAuth options for the deploy task</task-notification>")"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "expected no routing for task-notification, got: $output"
+fi
+
+test_case "system-reminder prompts are never routed"
+output="$(run_prompt_hook "<system-reminder>review this PR for regressions</system-reminder>")"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "expected no routing for system-reminder, got: $output"
+fi
+
 test_case "off mode leaves prompt untouched"
 output="$(run_prompt_hook "review this PR for regressions" "off")"
 if [[ -z "$output" ]]; then


### PR DESCRIPTION
Closes #632.

## Summary
- Auto-route injection is now advisory: the message tells the agent to invoke the Skill only if it matches what the user asked for, and to answer normally otherwise; the MANDATORY wording is gone from both `user-prompt-submit.sh` and the `auto-router-inject.sh` session contract
- Prompts beginning with system-event markers (`[SYSTEM NOTIFICATION`, `<task-notification>`, `<system-reminder>`, `<local-command-stdout>`) exit before intent detection, so background-task events and reminders can never trigger routing
- Regression tests for the advisory wording and all three system-event shapes

## Test plan
- [x] `bash tests/unit/test-auto-router-hooks.sh` 13/13
- [x] `bash tests/unit/test-smart-router.sh` 68/68
- [x] `bash tests/unit/test-prompt-submit-v2.sh` 12/12
- [x] `bash -n` on both hook scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Routing suggestions are now advisory and won’t override the user’s request.
  * System-generated notifications, reminders, and command output no longer trigger automatic routing.
  * The assistant answers normally when suggested routing doesn’t match the user’s intent.

* **Tests**
  * Added coverage for advisory routing behavior and ignored system-generated prompts.

* **Documentation**
  * Updated the unreleased changelog with these fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->