### PR TITLE
fix: nest PostToolUse additionalContext under hookSpecificOutput

### DIFF
--- a/hooks/post-tool-dispatch.sh
+++ b/hooks/post-tool-dispatch.sh
@@ -60,7 +60,7 @@ fi
 # Emit combined response
 if [[ -n "$CONTEXTS" ]]; then
     escaped=$(echo "$CONTEXTS" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))" 2>/dev/null | sed 's/^"//;s/"$//')
-    echo "{\"decision\":\"continue\",\"additionalContext\":\"${escaped}\"}"
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"${escaped}\"}}"
 else
     : # pass-through — current hook schema treats silence as continue
 fi


### PR DESCRIPTION
## Description
`hooks/post-tool-dispatch.sh` — the consolidated PostToolUse dispatcher registered on the blanket matcher `Bash|Agent|Write|Edit|Read|WebFetch|Grep` — emitted a malformed hook response whenever it had context to relay from its sub-hooks (`context-awareness.sh`, `output-compressor.sh`):

```json
{"decision":"continue","additionalContext":"..."}
```

Two problems with that shape:
- `"continue"` is not a valid value for the `decision` field (valid values are `"block"` or omitting the field entirely).
- `additionalContext` must be nested under `hookSpecificOutput`, not top-level.

Every other hook in this repo already uses the correct nested schema for this exact field — including the two sub-hooks this dispatcher wraps and reads `additionalContext` from (`hooks/context-awareness.sh:151`, `hooks/output-compressor.sh:155`). The dispatcher just failed to preserve that contract when re-emitting the combined context.

This is what produced the `Hook JSON output validation failed — (root): Invalid input` errors reported on Read/Bash in #631 — since this dispatcher fires on nearly every tool call.

## Type of Change
- [x] Bug fix

## Fix
`hooks/post-tool-dispatch.sh:63` — changed the emitted JSON from the flat, invalid shape to `{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"..."}}`, matching the pattern used everywhere else in the codebase.

## Testing
- `bash -n hooks/post-tool-dispatch.sh` and `bash -n scripts/*.sh scripts/lib/*.sh hooks/*.sh` — all pass.
- `bash -n scripts/orchestrate.sh` — pass.
- Manually verified the new output is valid JSON with the field nested correctly under `hookSpecificOutput`.
- `bash tests/unit/test-hook-err-traps.sh` (iterates `hooks/*.sh`) — 8/8 pass.
- `bash tests/unit/test-shell-safe-hooks-v2183.sh` — 8/8 pass.
- `bash tests/unit/test-docs-sync.sh` — 135/135 pass.
- `bash tests/unit/test-openclaw-compat.sh` — 32/32 pass.
- Full `make test-unit` did not complete within the available run time (repo-wide suite runs long); given the change is a single-line, mechanical schema fix isolated to one hook script, I scoped verification to the suites above that directly exercise `hooks/*.sh` output and hook JSON schema, per the task's "smallest meaningful test surface" guidance. Flagging this so `make test-unit`/`make test-integration` can be run in full by CI or a follow-up review before merge.

## Related Issues
Closes #631

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pn8PdkmcLARMHPpSnFqMAc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of additional context after tool execution.
  * Updated post-execution responses to use the expected event format, improving compatibility with consumers that process tool results.
  * Existing behavior remains unchanged when no additional context is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->