### PR TITLE
fix: remove redundant if-gate on careful-check.sh that could block all Bash

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -55,7 +55,6 @@
       },
       {
         "matcher": "Bash",
-        "if": "input matches '(rm\\s|mv\\s|git\\s+(push|reset|checkout\\s+\\.)|docker\\s+rm|DROP\\s+TABLE|sudo)'",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Description
`hooks/hooks.json` registered `careful-check.sh` on the `Bash` PreToolUse matcher with a natural-language `"if"` pre-filter (`input matches '(rm\s|mv\s|git\s+(push|reset|checkout\s+\.)|docker\s+rm|DROP\s+TABLE|sudo)'`). Claude Code's hook harness evaluates `"if"` conditions like this via a model, not a literal regex engine, and per #629 that evaluation can hallucinate unrelated preconditions ("check if there are existing validation results", "before running tangle phase") and deny every Bash call for the rest of the session — the only recovery being to disable the plugin.

`hooks/careful-check.sh` (`hooks/careful-check.sh:21-47`) already gates itself deterministically and correctly, with no dependency on the outer `"if"`:
- Bails immediately unless `tool_name == "Bash"`
- Bails unless `/octo:careful` has written its session state file (careful mode is opt-in)
- Only then runs its own bash regex checks for `rm -rf`, destructive SQL, `git push --force`, `git reset --hard`, `git checkout/restore .`, `kubectl delete`, `docker rm -f`/`system prune`

So the outer `"if"` was pure redundant risk: same gating twice, once safely in bash and once through a model that can misfire and block the whole session. This PR removes the `"if"` field (`hooks/hooks.json:57-58` in the old file) — `careful-check.sh` still runs on every Bash call but only produces a decision when careful mode is on and a destructive pattern actually matches.

## Type of Change
- [x] Bug fix

## Root cause / fix
- `hooks/hooks.json`: dropped the `"if": "input matches ..."` entry from the `careful-check.sh` PreToolUse registration. One line removed, no other behavior changes.

## Testing
```bash
jq empty hooks/hooks.json                       # valid JSON
bash -n hooks/careful-check.sh                   # valid syntax
bash tests/smoke/test-safety-hooks.sh            # 24/24 pass
bash tests/unit/test-hook-err-traps.sh           # 8/8 pass
bash tests/unit/test-shell-safe-hooks-v2183.sh   # 8/8 pass
./tests/run-all.sh smoke                         # 16/16 suites pass
bash tests/unit/test-openclaw-compat.sh          # 32/32 pass
./scripts/build-openclaw.sh --check              # registry up to date
```
Also manually exercised `careful-check.sh` end-to-end with a synthetic PreToolUse payload:
- careful mode off + `rm -rf ...` → silent pass-through (no block)
- careful mode on + `rm -rf ...` → `permissionDecision: ask` with the destructive-command message
- careful mode on + `ls -la` → silent pass-through

`make test-unit` was attempted but did not complete within 5 minutes in this environment (unrelated to this change — the doc comment estimates 1-2min); ran the directly affected suites above instead, per the smallest-meaningful-surface guidance.

## Related Issues
Closes #629


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dnh6fVvT2bUDS2VUpkvgkw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bash safety checks now run for every Bash command, improving consistency and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->