### PR TITLE
fix: emit hookSpecificOutput schema in post-tool-dispatch.sh

### DIFF
--- a/hooks/post-tool-dispatch.sh
+++ b/hooks/post-tool-dispatch.sh
@@ -60,7 +60,7 @@ fi
 # Emit combined response
 if [[ -n "$CONTEXTS" ]]; then
     escaped=$(echo "$CONTEXTS" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))" 2>/dev/null | sed 's/^"//;s/"$//')
-    echo "{\"decision\":\"continue\",\"additionalContext\":\"${escaped}\"}"
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"${escaped}\"}}"
 else
     : # pass-through — current hook schema treats silence as continue
 fi


### PR DESCRIPTION
## Root cause

PR #626 (merged today) converted ~60 legacy `{"decision":"continue"}` emission sites across 25 hook scripts to the current Claude Code hook JSON schema. It missed one call site: `hooks/post-tool-dispatch.sh:63` still emits the old top-level shape,

```
{"decision":"continue","additionalContext":"..."}
```

when it has context to forward from its sub-hooks (`context-awareness.sh`, `output-compressor.sh`). Every other `additionalContext`-emitting hook in the codebase (those two sub-hooks themselves, `user-prompt-submit.sh`, `auto-router-inject.sh`) uses `hookSpecificOutput.additionalContext`.

`post-tool-dispatch.sh` fires on almost every tool call via the blanket matcher `Bash|Agent|Write|Edit|Read|WebFetch|Grep`, so the stale shape produced "Hook JSON output validation failed — (root): Invalid input" on ordinary Read/Bash calls — matching the report in #631.

## Fix

`hooks/post-tool-dispatch.sh:63` — wrap the emission in `hookSpecificOutput.additionalContext` to match the convention used everywhere else in this PostToolUse path.

## Test plan

- `bash -n hooks/post-tool-dispatch.sh` — syntax OK
- Simulated the emit path in isolation and validated the JSON parses with `hookSpecificOutput.hookEventName == "PostToolUse"` and the expected `additionalContext`
- `tests/smoke/test-syntax.sh` — pass
- `tests/unit/test-auto-router-hooks.sh` (closest existing hook-schema coverage) — 9/9 pass
- No existing unit test targets `post-tool-dispatch.sh` directly (verified via grep), so there's nothing to update there; this is a single-line, minimal-diff fix and `make test-unit` was too large to complete in the available time budget for a change this scoped

Closes #631.

Note: this triage pass also looked at #629, #630, #632, and #633. #629 and #630 describe hook behavior (an LLM-evaluated `if:` condition, an "OpenAI API credentials" block message) that doesn't match anything currently in `hooks/hooks.json` or `hooks/codex-exec-guard.sh`, so I left them alone rather than guessing at a fix. #632's root cause is also identifiable (`user-prompt-submit.sh` doesn't distinguish real user prompts from system-generated events before running keyword-based auto-invoke), but per the daily one-fix cap I'm leaving it for a follow-up run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VXJV7qYZkcjgYB7t5KR6Qy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of additional context after tool usage by returning it in the expected format.
  * Preserved existing pass-through behavior when no additional context is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->