### PR TITLE
fix: nest post-tool-dispatch additionalContext under hookSpecificOutput

### DIFF
--- a/hooks/post-tool-dispatch.sh
+++ b/hooks/post-tool-dispatch.sh
@@ -40,7 +40,7 @@ BRIDGE="/tmp/octopus-ctx-${SESSION}.json"
 if [[ -f "$BRIDGE" ]]; then
     ctx=$("$HOOKS_DIR/context-awareness.sh" <<< "" 2>/dev/null || echo "")
     if [[ -n "$ctx" ]] && echo "$ctx" | grep -q 'additionalContext'; then
-        msg=$(echo "$ctx" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('additionalContext',''))" 2>/dev/null || echo "")
+        msg=$(echo "$ctx" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('hookSpecificOutput',{}).get('additionalContext',''))" 2>/dev/null || echo "")
         [[ -n "$msg" ]] && CONTEXTS="${CONTEXTS}${CONTEXTS:+ | }${msg}"
     fi
 fi
@@ -52,7 +52,7 @@ bash "$HOOKS_DIR/strategy-rotation.sh" <<< "$STDIN_DATA" 2>/dev/null || true
 if [[ ${#STDIN_DATA} -gt 3000 && "${OCTOPUS_COMPRESS_ENABLED:-true}" == "true" ]]; then
     comp=$("$HOOKS_DIR/output-compressor.sh" <<< "$STDIN_DATA" 2>/dev/null || echo "")
     if [[ -n "$comp" ]] && echo "$comp" | grep -q 'additionalContext'; then
-        msg=$(echo "$comp" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('additionalContext',''))" 2>/dev/null || echo "")
+        msg=$(echo "$comp" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('hookSpecificOutput',{}).get('additionalContext',''))" 2>/dev/null || echo "")
         [[ -n "$msg" ]] && CONTEXTS="${CONTEXTS}${CONTEXTS:+ | }${msg}"
     fi
 fi
@@ -60,7 +60,7 @@ fi
 # Emit combined response
 if [[ -n "$CONTEXTS" ]]; then
     escaped=$(echo "$CONTEXTS" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))" 2>/dev/null | sed 's/^"//;s/"$//')
-    echo "{\"decision\":\"continue\",\"additionalContext\":\"${escaped}\"}"
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"${escaped}\"}}"
 else
     : # pass-through — current hook schema treats silence as continue
 fi

--- a/tests/unit/test-post-tool-dispatch.sh
+++ b/tests/unit/test-post-tool-dispatch.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Tests for the PostToolUse dispatcher hook (hooks/post-tool-dispatch.sh).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "PostToolUse dispatcher"
+
+HOOK="$PROJECT_ROOT/hooks/post-tool-dispatch.sh"
+
+# Build a >3000-char, >40-line, non-timestamped payload so output-compressor.sh
+# classifies it as "verbose" and produces a compressed summary.
+build_verbose_payload() {
+    local i
+    for i in $(seq 1 80); do
+        echo "line ${i}: some verbose tool output that is not a timestamped log entry"
+    done
+}
+
+test_case "emits hookSpecificOutput (not legacy root decision) when a sub-hook adds context"
+SESSION="test-ptd-$$"
+DEBOUNCE_FILE="/tmp/octopus-compress-debounce-${SESSION}.count"
+rm -f "$DEBOUNCE_FILE"
+
+PAYLOAD="$(build_verbose_payload)"
+output=""
+# output-compressor.sh only analyzes every 3rd call (debounce); drive it there.
+for _ in 1 2 3; do
+    output="$(CLAUDE_SESSION_ID="$SESSION" printf '%s' "$PAYLOAD" | CLAUDE_SESSION_ID="$SESSION" bash "$HOOK")"
+done
+rm -f "$DEBOUNCE_FILE"
+
+if [[ "$output" == *'"hookSpecificOutput":{"hookEventName":"PostToolUse"'* ]] \
+   && [[ "$output" == *'"additionalContext"'* ]] \
+   && [[ "$output" != '{"decision"'* ]]; then
+    test_pass
+else
+    test_fail "expected nested hookSpecificOutput.additionalContext, got: ${output:-<empty>}"
+fi
+
+test_case "output is valid JSON per the current hook schema"
+if command -v jq &>/dev/null; then
+    if [[ -n "$output" ]] && echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1 \
+       && ! echo "$output" | jq -e '.decision' >/dev/null 2>&1; then
+        test_pass
+    else
+        test_fail "output did not parse as the expected schema: ${output:-<empty>}"
+    fi
+else
+    test_skip "jq not available"
+fi
+
+test_case "emits nothing (pass-through) when no sub-hook has context to add"
+output="$(printf 'ok' | bash "$HOOK")"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "expected silence for small/uninteresting output, got: ${output:-<empty>}"
+fi
+
+test_summary

--- a/tests/unit/test-post-tool-dispatch.sh
+++ b/tests/unit/test-post-tool-dispatch.sh
@@ -10,6 +10,10 @@ test_suite "PostToolUse dispatcher"
 
 HOOK="$PROJECT_ROOT/hooks/post-tool-dispatch.sh"
 
+SESSION="test-ptd-$$"
+DEBOUNCE_FILE="/tmp/octopus-compress-debounce-${SESSION}.count"
+trap 'rm -f "$DEBOUNCE_FILE"; cleanup_test_environment' EXIT
+
 # Build a >3000-char, >40-line, non-timestamped payload so output-compressor.sh
 # classifies it as "verbose" and produces a compressed summary.
 build_verbose_payload() {
@@ -20,8 +24,6 @@ build_verbose_payload() {
 }
 
 test_case "emits hookSpecificOutput (not legacy root decision) when a sub-hook adds context"
-SESSION="test-ptd-$$"
-DEBOUNCE_FILE="/tmp/octopus-compress-debounce-${SESSION}.count"
 rm -f "$DEBOUNCE_FILE"
 
 PAYLOAD="$(build_verbose_payload)"


### PR DESCRIPTION
## Root cause

#626 (merged today, in v9.53.0) fixed ~60 hook-stdout emission sites across 25 scripts that printed the legacy root-level `{"decision": "continue"}` shape, which current Claude Code rejects with `Hook JSON output validation failed`. It missed one site: `hooks/post-tool-dispatch.sh:63` still emitted:

```
{"decision":"continue","additionalContext":"..."}
```

`post-tool-dispatch.sh` is the blanket PostToolUse hook (matcher `Bash|Agent|Write|Edit|Read|WebFetch|Grep`), so this fires on nearly every tool call once a sub-hook (context-awareness, output-compressor) has something to add — matching the reported "fired on almost every Read/Bash for a stretch" in #631.

Fixing the emission alone wasn't sufficient: `context-awareness.sh` and `output-compressor.sh` were already correctly migrated (in the same #626 PR) to emit the nested `hookSpecificOutput.additionalContext` shape. But `post-tool-dispatch.sh`'s own extraction logic (`hooks/post-tool-dispatch.sh:43,55`) still read a top-level `additionalContext` key via `d.get('additionalContext','')`, so `CONTEXTS` silently ended up empty even once the final emission is fixed. Traced this with `bash -x` against a synthetic >3000-char payload — confirmed `output-compressor.sh` returns a correctly-nested payload, and the old extraction line finds nothing in it.

## Fix

- `hooks/post-tool-dispatch.sh:63` — emit `{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"..."}}` instead of the flat legacy shape.
- `hooks/post-tool-dispatch.sh:43,55` — extract via `d.get('hookSpecificOutput',{}).get('additionalContext','')` to match what the upstream sub-hooks actually emit post-#626.

## Test plan

- Added `tests/unit/test-post-tool-dispatch.sh`: drives the debounced output-compressor path with a synthetic verbose payload and asserts (1) the combined response nests under `hookSpecificOutput` with no root-level `decision` key, (2) it parses under the current schema via `jq`, (3) silence (pass-through) when no sub-hook has context.
- `bash -n` over all of `scripts/*.sh scripts/lib/*.sh hooks/*.sh` — no syntax errors.
- `bash tests/unit/test-post-tool-dispatch.sh` — 3/3 pass.
- `bash tests/unit/test-codex-exec-guard.sh` and `bash tests/unit/test-worktree-bg-isolation.sh` (adjacent hook-schema tests touched by #626) — no regressions.
- Full `make test-unit` (174 files) run in the background; no failures observed through the portion completed at the time of this PR (will report final result on the issue/PR if anything turns up).

Closes #631.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S6ZuKsfKnGjxGgwHH8kps7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostToolUse handling so extra context provided by downstream hooks is captured reliably.
  * Updated the hook’s emitted response structure to match the current expected format when additional context is present.
  * Kept the hook silent (no output) when it has nothing to add.
* **Tests**
  * Added unit coverage for context dispatch, response formatting/schema validation (when available), and debounce timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->