### PR TITLE
fix: PostToolUse dispatcher still emitted legacy hook JSON shape

### DIFF
--- a/hooks/post-tool-dispatch.sh
+++ b/hooks/post-tool-dispatch.sh
@@ -40,7 +40,7 @@ BRIDGE="/tmp/octopus-ctx-${SESSION}.json"
 if [[ -f "$BRIDGE" ]]; then
     ctx=$("$HOOKS_DIR/context-awareness.sh" <<< "" 2>/dev/null || echo "")
     if [[ -n "$ctx" ]] && echo "$ctx" | grep -q 'additionalContext'; then
-        msg=$(echo "$ctx" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('additionalContext',''))" 2>/dev/null || echo "")
+        msg=$(echo "$ctx" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('hookSpecificOutput',{}).get('additionalContext',''))" 2>/dev/null || echo "")
         [[ -n "$msg" ]] && CONTEXTS="${CONTEXTS}${CONTEXTS:+ | }${msg}"
     fi
 fi
@@ -52,7 +52,7 @@ bash "$HOOKS_DIR/strategy-rotation.sh" <<< "$STDIN_DATA" 2>/dev/null || true
 if [[ ${#STDIN_DATA} -gt 3000 && "${OCTOPUS_COMPRESS_ENABLED:-true}" == "true" ]]; then
     comp=$("$HOOKS_DIR/output-compressor.sh" <<< "$STDIN_DATA" 2>/dev/null || echo "")
     if [[ -n "$comp" ]] && echo "$comp" | grep -q 'additionalContext'; then
-        msg=$(echo "$comp" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('additionalContext',''))" 2>/dev/null || echo "")
+        msg=$(echo "$comp" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('hookSpecificOutput',{}).get('additionalContext',''))" 2>/dev/null || echo "")
         [[ -n "$msg" ]] && CONTEXTS="${CONTEXTS}${CONTEXTS:+ | }${msg}"
     fi
 fi
@@ -60,7 +60,7 @@ fi
 # Emit combined response
 if [[ -n "$CONTEXTS" ]]; then
     escaped=$(echo "$CONTEXTS" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))" 2>/dev/null | sed 's/^"//;s/"$//')
-    echo "{\"decision\":\"continue\",\"additionalContext\":\"${escaped}\"}"
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"${escaped}\"}}"
 else
     : # pass-through — current hook schema treats silence as continue
 fi


### PR DESCRIPTION
## Description
`hooks/post-tool-dispatch.sh` (the consolidated PostToolUse dispatcher registered on the blanket `Bash|Agent|Write|Edit|Read|WebFetch|Grep` matcher) still had two bugs left over from the #621/#626 hook-schema conversion:

1. Its final combined-response echo (`hooks/post-tool-dispatch.sh:63`) still emitted the legacy root-level `{"decision":"continue","additionalContext":...}` shape, which Claude Code's current hook contract rejects with `Hook JSON output validation failed`.
2. Its extraction of sub-hook output (`hooks/post-tool-dispatch.sh:43,55`) read a top-level `additionalContext` key from `context-awareness.sh` and `output-compressor.sh` — but both of those scripts already nest that field under `hookSpecificOutput` (per the same #621/#626 fix), so the extracted message was always empty and context notices were silently dropped even when the (invalid) emission format wasn't triggered.

Root cause: PR #626 ("convert hook script stdout to the current hook schema") converted the silent pass-through branch of `post-tool-dispatch.sh` (the `else` at line 65) but missed the content branch (line 63) and the two extraction sites that feed it, so the conversion was incomplete for this one file.

Closes #631.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync — not touched by this change
- [ ] New skills/commands registered — n/a, no new components
- [ ] Version bump — not applicable to a single bug-fix PR
- [ ] Documentation updated — not applicable
- [ ] CHANGELOG.md updated — left to the release step per repo convention (Unreleased section)

## Testing
- `bash -n hooks/post-tool-dispatch.sh` — syntax OK
- Manually simulated the extraction + emission logic with a mock sub-hook payload shaped like `context-awareness.sh`'s real output (`{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"..."}}`); confirmed the message now survives the round trip and the final JSON validates and nests correctly under `hookSpecificOutput.additionalContext`.
- `make test-unit` (`./tests/run-all.sh unit`, 173 suites): 171 passed, 2 pre-existing failures unrelated to this change (`test-github-work-queue-hook.sh`, `test-hud-smart-mode.sh` — neither references `post-tool-dispatch.sh`, `context-awareness.sh`, or `output-compressor.sh`).
- `bash tests/unit/test-context-awareness-v2.sh`, `test-context-bridge.sh`, `test-hook-err-traps.sh`, `test-shell-safe-hooks-v2183.sh`, `test-openclaw-compat.sh` — all pass.

## Related Issues
Closes #631

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzGzz9qBXFtMqi2gCCUfEB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-action context handling so relevant information is consistently captured and passed along.
  * Updated the emitted response format to improve compatibility with downstream processing.
  * Preserved normal continuation behavior when no additional context is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->