### PR TITLE
release: v9.53.1

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -21,7 +21,7 @@ You get:    A structured comparison with three independent viewpoints,
             scored for agreement. Disagreements are flagged, not hidden.
 ```
 
-This works for research, escalated code review, debugging, TDD, escalated security audits, UI design, PRDs, and full build-to-ship workflows — 49 commands, 54 skills, 32 specialized personas.
+This works for research, escalated code review, debugging, TDD, escalated security audits, UI design, PRDs, and full build-to-ship workflows — 50 commands, 58 skills, 32 specialized personas.
 
 Multi-provider runs show an agent summary before synthesis, so failed, timed out, or oversize-rejected Codex, Gemini, Antigravity, OpenRouter, and other perspectives are visible instead of being hidden behind a polished final answer.
 
@@ -68,7 +68,7 @@ Octopus orchestrates — it doesn't replace domain knowledge. If three models co
 ## Learn More
 
 - [**Full README**](../README.md) — feature deep-dive, provider grid, architecture, star history
-- [**Command Reference**](../docs/COMMAND-REFERENCE.md) — all 49 commands with triggers
+- [**Command Reference**](../docs/COMMAND-REFERENCE.md) — all 50 commands with triggers
 - [**Persona Guide**](../docs/AGENTS.md) — 32 specialized agents
 - [**Changelog**](../CHANGELOG.md) — release history
 - [**Issues**](https://github.com/nyldn/claude-octopus/issues) — bugs and feature requests

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.53.1 - v9.53.1 \u2014 Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
+      "description": "v9.53.1 - Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
       "version": "9.53.1",
       "author": {
         "name": "nyldn",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.53.0"
+    "version": "9.53.1"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.53.0 - Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
-      "version": "9.53.0",
+      "description": "v9.53.1 - v9.53.1 \u2014 Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
+      "version": "9.53.1",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": "2026-06",
   "name": "octo",
   "displayName": "Claude Octopus",
-  "version": "9.53.0",
+  "version": "9.53.1",
   "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
   "author": {
     "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.53.0",
-  "description": "v9.53.0 \u2014 Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. Run /octo:setup.",
+  "version": "9.53.1",
+  "description": "v9.53.1 \u2014 Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Claude Octopus routine manifest (v9.53.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "$comment": "Claude Octopus routine manifest (v9.53.1). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
   "schemaVersion": 1,
   "routines": [
     {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.53.0",
+  "version": "9.53.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.53.0",
+  "version": "9.53.1",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.53.0"
+    "version": "9.53.1"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.53.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 50 commands, 58 skills. Run /octo:setup after install.",
-      "version": "9.53.0",
+      "description": "v9.53.1 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 50 commands, 58 skills. Run /octo:setup after install.",
+      "version": "9.53.1",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.53.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.53.0. 32 expert personas, 50 commands, 58 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.53.1",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.53.1. 32 expert personas, 50 commands, 58 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## [Unreleased]
 
+## [9.53.1] - 2026-07-18
+
+
 ### Fixed
 
+- **Removed a redundant LLM-evaluated if-gate on the careful-check Bash hook** (#629). `hooks/hooks.json` pre-filtered the `careful-check.sh` PreToolUse hook with a natural-language `if` condition; Claude Code's hook harness evaluates such conditions via a model rather than literal regex, and it could hallucinate unrelated preconditions and deny every Bash call for the rest of the session. `careful-check.sh` already gates itself deterministically in bash (Bash-only, `/octo:careful` state-file opt-in, then real pattern matching), so the outer `if` was pure redundant risk. Careful-mode behavior is unchanged.
+
 - **Auto-router no longer coerces skill routing and never routes on system events** (#632). The UserPromptSubmit auto-router injected "MANDATORY: Invoke Skill(...) before responding" even when intent detection mis-scored a prompt, pressuring the agent to hijack the turn into an unrelated multi-provider workflow; it also fired on harness-generated turns (task notifications, system reminders) that are not user input. Routing context is now explicitly advisory on both sides of the contract (`user-prompt-submit.sh` message and `auto-router-inject.sh` session instruction), and prompts beginning with system-event markers (`[SYSTEM NOTIFICATION`, `<task-notification>`, `<system-reminder>`, `<local-command-stdout>`) are skipped before intent detection.
+
+- **`post-tool-dispatch.sh` reads `additionalContext` from the current hook schema location** (#631). `context-awareness.sh` and `output-compressor.sh` already emit `hookSpecificOutput.additionalContext` (from #626), but `post-tool-dispatch.sh`'s own extraction still read a stale top-level `additionalContext` key, so its combined output was silently empty on nearly every Read/Bash/Write/Edit/WebFetch/Grep call. Both sub-hook extraction sites now read the nested field.
 
 ## [9.53.0] - 2026-07-18
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 <p align="center">
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/Version-9.53.0-blue" alt="Version 9.53.0">
+  <img src="https://img.shields.io/badge/Version-9.53.1-blue" alt="Version 9.53.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.50+_required-blueviolet" alt="Requires Claude Code v2.1.50+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.53.0",
+  "version": "9.53.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Release v9.53.1

Patch release. All three merged fixes address PreToolUse/PostToolUse hooks misbehaving badly enough to block or misdirect an entire session — all three were filed as bug reports today and fixed same-day:

- **#629 / #636** — Removed a redundant natural-language `if`-gate on the `careful-check.sh` Bash hook. Claude Code's hook harness evaluates such conditions via a model, and it could hallucinate unrelated preconditions and deny every Bash call for the rest of the session. The script already gates itself deterministically in bash, so the outer `if` was pure risk with no functional benefit.
- **#632 / #634** — Made the UserPromptSubmit auto-router advisory instead of emitting a coercive "MANDATORY: Invoke Skill(...) before responding," and made it skip harness-generated turns (task notifications, system reminders) that were never user input.
- **#631 / #638** — `post-tool-dispatch.sh` was reading `additionalContext` from a stale top-level JSON key after the emission schema moved to `hookSpecificOutput.additionalContext` in #626; its own combined output was silently empty on nearly every Read/Bash/Write/Edit/WebFetch/Grep call.

## Changelog excerpt
See `CHANGELOG.md` [9.53.1] section for full entries.

## Version bump surfaces
- [x] `package.json`
- [x] `.claude-plugin/plugin.json` (version + description prefix)
- [x] `.claude-plugin/marketplace.json` (regenerated via `make sync`)
- [x] `.claude-plugin/plugin-manifest.json`
- [x] `.claude-plugin/routines.json` (`$comment` version)
- [x] `.codex-plugin/plugin.json`
- [x] `.cursor-plugin/plugin.json`
- [x] `.factory-plugin/plugin.json`
- [x] `.factory-plugin/marketplace.json`
- [x] `README.md` version badge
- [x] `CHANGELOG.md` new `[9.53.1]` section

## Testing
```bash
jq empty package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json \
  .claude-plugin/plugin-manifest.json .claude-plugin/routines.json \
  .codex-plugin/plugin.json .cursor-plugin/plugin.json \
  .factory-plugin/plugin.json .factory-plugin/marketplace.json      # all valid
make sync-check                                                     # marketplace.json + openclaw registry up to date
bash tests/unit/test-docs-sync.sh                                   # 135/135 pass
./tests/run-all.sh smoke                                            # 16/16 suites pass
grep -rn "9.53.0" --include="*.json" --include="*.md" .             # no leftover old-version refs (outside CHANGELOG history)
git diff origin/main...HEAD --summary | grep "mode change"          # empty
```
`make test-unit` was attempted but did not complete within the available time window in this environment; relied on the smoke suite + docs-sync + sync-check above, which is what CI's version/manifest-consistency checks actually gate on.

## Related Issues
Closes #629, #631, #632 (already closed by their respective merged PRs; this PR ships the release).

---
Per the automated triage routine that opened this: **not auto-merging.** Leaving for review since this cuts a tagged public release.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dnh6fVvT2bUDS2VUpkvgkw)_