### PR TITLE
feat(design): anti-slop taste layer, WCAG validator, design dials, lineage persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Anti-slop design taste layer** (`skills/blocks/design-taste.md`): binary, mechanically checkable rules distilled from the highest-starred public taste rulebooks — the three banned AI-slop looks, banned default fonts (Inter, Roboto, Space Grotesk, Fraunces, Instrument Serif), palette and layout tells, content tells (placeholder personas, fake-perfect stats), and a pre-ship checklist. Wired into `/octo:design-ui-ux` as generation constraints, a new SLOP critique dimension in the three-way adversarial review, and a Deliver-phase gate. The Design Shotgun example variants themselves shipped two banned looks (AI-purple gradient, Space Grotesk default) and were replaced.
+- **WCAG contrast validator** (`scripts/helpers/contrast-check.py`, stdlib-only): computes WCAG 2.x contrast ratios for FG:BG hex pairs with normal/large thresholds, JSON output, and pairs-file input; exit 1 on any failure. The design skill's Deliver phase now runs it on every text/background token pair instead of prose-only "validate against WCAG AA".
+- **Design dials in `/octo:design-ui-ux`**: a fourth intake question maps to ui-ux-pro-max v2.11.0 `--variance/--motion/--density` flags (conservative/balanced/expressive/maximal presets), passed to searches and recorded in the design direction.
+- **Design-system persistence**: the design skill's final step now writes the design system to `~/.claude-octopus/designs/<slug>/` under the `skill-design-lineage` contract (branch-stamped, supersedes-chained), and downstream skills are directed to read the newest design document before inventing new tokens.
+
 ### Changed
 
 - **Vendored ui-ux-pro-max design intelligence refreshed from v2.0.1 to v2.11.0** (nextlevelbuilder/ui-ux-pro-max-skill, MIT). Brings 11 releases of new data and features into `/octo:design-ui-ux`: expanded databases (84 styles, 192 palettes, 74 font pairings, 161 UX reasoning rules), a Google Fonts collection, motion presets, design dials (`--variance/--motion/--density`), and `--persist` MASTER.md design-system persistence. The vendored subset is now slimmer (src/ plus license and docs; screenshots and the npm CLI are no longer copied) and carries a `VENDOR.json` manifest recording the pinned upstream tag. `scripts/check-vendor-updates.sh` was rewritten for plain-file vendoring (the old version silently exited because it still expected `.gitmodules`, dead since #253) and now compares the manifest tag against the latest upstream release; a nightly `Vendor Freshness` CI job fails when a vendored dependency goes stale.

--- a/scripts/helpers/contrast-check.py
+++ b/scripts/helpers/contrast-check.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""WCAG 2.x contrast-ratio checker. Zero dependencies (stdlib only).
+
+Usage:
+  contrast-check.py FG:BG [FG:BG ...] [--large] [--json]
+  contrast-check.py --pairs-file FILE      # one FG:BG pair per line, # comments ok
+
+Each pair is two hex colors separated by ':' (e.g. '#1D4ED8:#FFFFFF').
+Normal text needs >= 4.5:1 (AA); large text / UI components need >= 3:1.
+A pair may carry a per-pair size suffix: '#666:#FFF:large'.
+
+Exit codes: 0 = all pairs pass, 1 = at least one failure, 2 = usage error.
+"""
+import argparse
+import json
+import re
+import sys
+
+HEX_RE = re.compile(r"^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+
+
+def parse_hex(color: str):
+    m = HEX_RE.match(color.strip())
+    if not m:
+        raise ValueError(f"invalid hex color: {color!r}")
+    h = m.group(1)
+    if len(h) == 3:
+        h = "".join(c * 2 for c in h)
+    return tuple(int(h[i:i + 2], 16) for i in (0, 2, 4))
+
+
+def channel(c: int) -> float:
+    s = c / 255.0
+    return s / 12.92 if s <= 0.04045 else ((s + 0.055) / 1.055) ** 2.4
+
+
+def luminance(rgb) -> float:
+    r, g, b = (channel(c) for c in rgb)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def contrast_ratio(fg: str, bg: str) -> float:
+    l1 = luminance(parse_hex(fg))
+    l2 = luminance(parse_hex(bg))
+    lighter, darker = max(l1, l2), min(l1, l2)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def check_pair(spec: str, default_large: bool):
+    parts = spec.split(":")
+    if len(parts) == 2:
+        fg, bg = parts
+        large = default_large
+    elif len(parts) == 3 and parts[2].lower() in ("large", "normal"):
+        fg, bg = parts[0], parts[1]
+        large = parts[2].lower() == "large"
+    else:
+        raise ValueError(f"invalid pair (want FG:BG or FG:BG:large): {spec!r}")
+    ratio = contrast_ratio(fg, bg)
+    threshold = 3.0 if large else 4.5
+    return {
+        "fg": fg if fg.startswith("#") else f"#{fg}",
+        "bg": bg if bg.startswith("#") else f"#{bg}",
+        "ratio": round(ratio, 2),
+        "threshold": threshold,
+        "size": "large" if large else "normal",
+        "pass": ratio >= threshold,
+    }
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description="WCAG AA contrast checker")
+    ap.add_argument("pairs", nargs="*", help="FG:BG hex pairs, optional :large suffix")
+    ap.add_argument("--pairs-file", help="file with one FG:BG pair per line")
+    ap.add_argument("--large", action="store_true",
+                    help="treat all pairs as large text / UI components (3:1)")
+    ap.add_argument("--json", action="store_true", help="emit JSON results")
+    args = ap.parse_args(argv)
+
+    specs = list(args.pairs)
+    if args.pairs_file:
+        try:
+            with open(args.pairs_file, encoding="utf-8") as f:
+                for line in f:
+                    raw = line.strip()
+                    # comment/blank lines: hex pairs always contain ':'
+                    if not raw or ":" not in raw:
+                        continue
+                    specs.append(raw)
+        except OSError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 2
+
+    if not specs:
+        ap.print_usage(sys.stderr)
+        return 2
+
+    results = []
+    for spec in specs:
+        try:
+            results.append(check_pair(spec, args.large))
+        except ValueError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 2
+
+    failed = [r for r in results if not r["pass"]]
+    if args.json:
+        print(json.dumps({"results": results, "failed": len(failed)}, indent=2))
+    else:
+        for r in results:
+            mark = "PASS" if r["pass"] else "FAIL"
+            print(f"{mark}  {r['fg']} on {r['bg']}  ratio {r['ratio']}:1  "
+                  f"(needs {r['threshold']}:1, {r['size']} text)")
+        print(f"\n{len(results) - len(failed)}/{len(results)} pairs pass WCAG AA")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/blocks/design-taste.md
+++ b/skills/blocks/design-taste.md
@@ -1,0 +1,76 @@
+# Design Taste — Anti-Slop Rules (shared block)
+
+Shared constraint set for design-producing skills (`octopus-ui-ux-design`, `skill-extract`,
+`skill-deck`, frontend work in `flow-develop`). Rules are binary and mechanically checkable
+on purpose: "use sparingly" phrasing has been shown to fail under generation pressure, while
+countable rules hold. Derived from the highest-signal public taste rulebooks (Anthropic
+frontend-design, Leonxlnx/taste-skill, ui-ux-pro-max) plus octopus review experience.
+
+## 1. Aesthetic direction first
+
+Before any tokens or code, commit to a named aesthetic direction in one sentence
+("Reading this as: <page kind> for <audience>, with a <vibe> visual language").
+Then run the convergence check: **would another model, given the same brief, land on the
+same palette and fonts?** If yes, you are at the statistical center — move at least one
+axis (palette, type, or layout) somewhere deliberate. Spend boldness in ONE place;
+everything else stays quiet.
+
+## 2. Banned defaults (the three AI-slop looks)
+
+Never land on these unless the brief explicitly asks:
+
+1. **Warm-cream heritage**: cream background (#F4F1EA-family) + high-contrast display serif + terracotta accent
+2. **Dark acid**: near-black background + single acid-green or vermilion accent
+3. **AI purple**: #667EEA/#764BA2-family purple-violet gradients, purple glows on dark
+
+Palette rules:
+- No pure `#000000` backgrounds or text
+- Do not reuse the same palette family across consecutive projects in a session
+- Every text/background pair must pass WCAG AA — verify with the contrast checker
+  (`scripts/helpers/contrast-check.py`), never by eye
+
+## 3. Font rules
+
+- **Banned as unjustified defaults**: Inter, Roboto, Arial, Space Grotesk, Fraunces, Instrument Serif
+  (the statistically overused AI picks). Any of these requires a stated reason tied to the brief.
+- No mixed-family word emphasis inside a headline (serif word inside sans headline); use
+  weight or italic of the same family
+- Two families maximum; pair by contrast of role (display vs text), not by trend
+
+## 4. Layout and structure tells
+
+- Hero: headline ≤ 2 lines, subtext ≤ 20 words; "big number + small label + gradient accent" is the template answer — do something else
+- No third consecutive image/text zigzag split; 8+ sections need at least 4 distinct layout families
+- Numbered section markers (01/02/03) only when content is genuinely sequential
+- Eyebrow labels (uppercase tracking-wide): at most 1 per 3 sections
+- No div-built fake app screenshots; render real content or omit
+- No scroll-cue arrows, no decorative version badges (`V2.0`, `BETA`) in heroes
+
+## 5. Content tells
+
+- No placeholder personas: "Jane Doe", "John Smith", "Acme Corp", "Sarah Chen"
+- No fake-perfect stats (99.99%, 10x, "trusted by 10,000+ teams"); use organic numbers (47.2%) or none
+- No em dashes in UI copy; commas, semicolons, parentheses, or sentence breaks instead
+- Buttons name the action ("Save changes", not "Submit"); state persists through the flow
+  ("Publish" button leads to a "Published" toast); errors state the fix, never apologize
+- Copy self-audit before ship: flag anything that reads like an LLM trying to sound thoughtful
+
+## 6. Quality floor (never announce, always meet)
+
+- Responsive at 360px, 768px, 1280px without horizontal scroll
+- Visible focus states on all interactive elements; touch targets ≥ 44px
+- `prefers-reduced-motion` respected when motion is present
+- Real font fallback stacks, not a single family name
+
+## 7. Pre-ship slop check (binary, all must pass)
+
+- [ ] Aesthetic direction stated before code, and it is not one of the three banned looks
+- [ ] No banned default font without a stated, brief-tied reason
+- [ ] Contrast checker run on every text/background pair (not eyeballed)
+- [ ] Zero placeholder personas, fake-perfect stats, or em dashes in visible copy
+- [ ] Eyebrow count ≤ ceil(sections / 3); no third consecutive zigzag
+- [ ] Focus states, reduced-motion, and 360px responsiveness verified
+
+When any design output is critiqued (Step 5b of `octopus-ui-ux-design`, `/octo:review` on
+frontend diffs), SLOP is a first-class critique dimension: reviewers check this list and
+fail the direction if two or more items miss.

--- a/skills/octopus-ui-ux-design/SKILL.md
+++ b/skills/octopus-ui-ux-design/SKILL.md
@@ -59,10 +59,25 @@ AskUserQuestion({
         {label: "Page layouts", description: "Wireframe-level layout specifications"},
         {label: "Style guide", description: "Visual style direction with rationale"}
       ]
+    },
+    {
+      question: "How adventurous should the design be?",
+      header: "Dials",
+      multiSelect: false,
+      options: [
+        {label: "Conservative (v3 m2 d4)", description: "Familiar patterns, minimal motion — enterprise, gov, finance"},
+        {label: "Balanced (v5 m4 d5)", description: "Contemporary but safe — most SaaS and product work"},
+        {label: "Expressive (v7 m6 d5)", description: "Distinctive direction, noticeable motion — marketing, launch pages"},
+        {label: "Maximal (v9 m8 d6)", description: "Take real aesthetic risks — portfolios, creative brands"}
+      ]
     }
   ]
 })
 ```
+
+The dial answer maps to `--variance/--motion/--density` values (v/m/d above) passed to
+every `search.py` call and stated in the design direction. Infer instead of asking only
+when the user's brief already names a vibe ("brutalist", "playful", "corporate").
 
 ### STEP 2: Display Banner
 
@@ -135,6 +150,10 @@ python3 "$SEARCH_PY" "<key user flow>" --domain ux
 
 # 6. Stack-specific search (if user specified a stack)
 python3 "$SEARCH_PY" "<user's requirements>" --stack <stack>
+
+# 7. Full design-system draft with the dials from Step 1 (v2.11.0+)
+python3 "$SEARCH_PY" "<user's product description>" --design-system \
+  --variance <v> --motion <m> --density <d>
 ```
 
 **If user provided a Figma URL**, also pull design context:
@@ -159,13 +178,18 @@ Stack: [from Step 1]
 Search context: [key findings from Step 4 BM25 searches]
 
 Produce:
-1. A style name (2-3 words, e.g., "Warm Minimalism", "Bold Industrial", "Soft Gradient")
+1. A style name (2-3 words, e.g., "Warm Minimalism", "Bold Industrial", "Cobalt Editorial")
 2. Primary color palette (3-5 colors with hex values)
 3. Font pairing (heading + body)
 4. Layout philosophy (e.g., "generous whitespace with card-based content")
 5. One paragraph describing the overall feel
 
 Be distinctive — take a clear position rather than playing it safe.
+
+Hard constraints (see skills/blocks/design-taste.md): do NOT produce any of the three
+AI-slop looks (cream+serif+terracotta, near-black+acid accent, purple-violet gradients),
+and do not default to Inter, Roboto, Space Grotesk, Fraunces, or Instrument Serif
+without a brief-tied reason.
 ```
 
 **Dispatch to different providers for maximum diversity:**
@@ -185,14 +209,14 @@ Fonts: Inter + Source Serif 4
 Feel: Clean, approachable, content-first with warm accent touches
 
 ━━━ Variant B: "Bold Industrial" (🟡 Gemini) ━━━
-Colors: #0A0A0A, #FFFFFF, #FF6B35, #004E89, #1A936F
-Fonts: Space Grotesk + IBM Plex Sans
+Colors: #101418, #FFFFFF, #FF6B35, #004E89, #1A936F
+Fonts: Archivo + IBM Plex Sans
 Feel: High-contrast, technical authority, strong hierarchy
 
-━━━ Variant C: "Soft Gradient" (🔵 Claude) ━━━
-Colors: #667EEA, #764BA2, #F093FB, #F5F7FA, #1A202C
-Fonts: Satoshi + General Sans
-Feel: Modern, approachable, subtle depth through gradients
+━━━ Variant C: "Cobalt Editorial" (🔵 Claude) ━━━
+Colors: #1D4ED8, #F7F6F2, #14181F, #C8CFDB, #E8B04B
+Fonts: Newsreader + General Sans
+Feel: Confident print-inspired hierarchy with one saturated anchor color
 ```
 
 **Then ask the user to choose:**
@@ -224,6 +248,7 @@ Synthesize search results (and chosen variant if shotgun mode) into a design dir
 3. **Typography** — heading + body font pairing with Google Fonts import
 4. **Layout approach** — grid system, spacing scale, responsive strategy
 5. **Design principles** — 3-5 guiding principles derived from UX search results
+6. **Taste compliance** — one line confirming the direction passes `skills/blocks/design-taste.md` (not one of the three banned looks; no unjustified banned-default fonts; boldness spent in one place)
 
 **Output: Write the design direction as a structured section you can reference in the next step.**
 
@@ -242,6 +267,7 @@ Critique dimensions:
 2. PRACTICALITY — Does this typography actually render well on the stated tech stack? Are the fonts available and performant (file size, loading)? Does the spacing scale work with the layout system?
 3. FIT — Does the visual style actually match the product type and audience? Would a user of [product type] feel comfortable with this aesthetic?
 4. GAPS — What did the research miss? Are there common UX patterns for this product type that aren't addressed? Are there competitive norms being ignored?
+5. SLOP — Run the checklist in skills/blocks/design-taste.md. Is this one of the three AI-slop looks (cream+serif+terracotta, near-black+acid, purple gradients)? Banned default fonts without a stated reason? Would another model given the same brief land on the same palette and fonts? Two or more checklist misses fail the direction.
 
 For each issue found, state: what's wrong, why it matters, and what to do instead.
 ```
@@ -327,12 +353,21 @@ mcp__shadcn__search_items_in_registries({ query: "<component name>" })
 
 ### STEP 7: Phase 4 — Deliver (Validation)
 
-1. **Accessibility audit** — validate all colors against WCAG AA (4.5:1 for text, 3:1 for large text)
-2. **Completeness check** — verify all requested deliverables are present
-3. **Implementation readiness** — confirm specs are detailed enough for frontend-developer
-4. **Figma push-back** (if connected) — offer to push design tokens to Figma
+1. **Accessibility audit — run the checker, do not eyeball.** Every text/background pair in the token set goes through the contrast validator:
 
-### STEP 8: Present Results
+```bash
+python3 "${HOME}/.claude-octopus/plugin/scripts/helpers/contrast-check.py" \
+  '<text-hex>:<bg-hex>' '<heading-hex>:<bg-hex>:large' '<muted-hex>:<bg-hex>' ...
+```
+
+Exit 1 means at least one pair fails WCAG AA — fix the palette and re-run before delivering. Include the checker output in the final document as evidence.
+
+2. **Slop check** — run the pre-ship checklist in `skills/blocks/design-taste.md`; two or more misses means revise before delivering
+3. **Completeness check** — verify all requested deliverables are present
+4. **Implementation readiness** — confirm specs are detailed enough for frontend-developer
+5. **Figma push-back** (if connected) — offer to push design tokens to Figma
+
+### STEP 8: Present Results and Persist
 
 Format the final design system as a structured document with:
 - Executive summary (style direction + rationale)
@@ -341,6 +376,22 @@ Format the final design system as a structured document with:
 - Page layouts
 - Implementation notes for the development team
 - Sources (which search results informed each decision)
+
+**Persist the design system so it survives the session** (contract: `skill-design-lineage`):
+
+```bash
+SLUG=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo "no-branch")
+DATETIME=$(date -u +"%Y%m%d-%H%M%S")
+DESIGNS_DIR="${HOME}/.claude-octopus/designs/${SLUG}"
+mkdir -p "$DESIGNS_DIR"
+# Write the full design system document (with YAML frontmatter per skill-design-lineage)
+# to: ${DESIGNS_DIR}/${USER}-${BRANCH}-design-${DATETIME}.md
+```
+
+Later sessions (and `flow-develop` / `frontend-developer` handoffs) MUST check
+`~/.claude-octopus/designs/<slug>/` for the newest design document before inventing new
+tokens; a revision supersedes rather than edits (set the `supersedes:` frontmatter field).
 
 **Offer next steps:**
 - "Want me to implement these specs?" → hand off to frontend-developer persona

--- a/tests/unit/test-contrast-check.sh
+++ b/tests/unit/test-contrast-check.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Tests for scripts/helpers/contrast-check.py (WCAG AA validator).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "WCAG contrast checker"
+
+CHECKER="$PROJECT_ROOT/scripts/helpers/contrast-check.py"
+
+test_case "black on white is 21:1 and passes"
+if output=$(python3 "$CHECKER" '#000000:#FFFFFF') && [[ "$output" == *"21.0:1"* ]]; then
+    test_pass
+else
+    test_fail "expected 21.0:1 pass, got: $output"
+fi
+
+test_case "known AA boundary color #767676 passes normal text"
+if python3 "$CHECKER" '#767676:#FFFFFF' >/dev/null; then
+    test_pass
+else
+    test_fail "#767676 on white (4.54:1) should pass 4.5:1"
+fi
+
+test_case "AI-purple #667EEA fails on white and exits 1"
+if python3 "$CHECKER" '#667EEA:#FFFFFF' >/dev/null 2>&1; then
+    test_fail "expected exit 1 for 3.66:1 normal text"
+else
+    [[ $? -eq 1 ]] && test_pass || test_fail "expected exit code 1"
+fi
+
+test_case "large-text suffix lowers threshold to 3:1"
+if python3 "$CHECKER" '#949494:#FFFFFF:large' >/dev/null; then
+    test_pass
+else
+    test_fail "#949494 on white (3.03:1) should pass large-text 3:1"
+fi
+
+test_case "3-digit hex shorthand accepted"
+if output=$(python3 "$CHECKER" '#000:#FFF') && [[ "$output" == *"21.0:1"* ]]; then
+    test_pass
+else
+    test_fail "shorthand hex failed: $output"
+fi
+
+test_case "invalid hex exits 2"
+set +e
+python3 "$CHECKER" 'zzz:#FFF' >/dev/null 2>&1
+code=$?
+set -e
+if [[ $code -eq 2 ]]; then
+    test_pass
+else
+    test_fail "expected exit 2 on invalid hex, got $code"
+fi
+
+test_case "json output reports ratio and failed count"
+if output=$(python3 "$CHECKER" '#000:#FFF' --json) && echo "$output" | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+assert d['failed'] == 0 and d['results'][0]['ratio'] == 21.0
+"; then
+    test_pass
+else
+    test_fail "json shape wrong: $output"
+fi
+
+test_case "pairs file skips comments and blank lines"
+tmpfile="$TEST_TMP_DIR/pairs.txt"
+cat > "$tmpfile" <<'EOF'
+# comment line
+
+#000000:#FFFFFF
+#1D4ED8:#FFFFFF
+EOF
+if output=$(python3 "$CHECKER" --pairs-file "$tmpfile") && [[ "$output" == *"2/2 pairs pass"* ]]; then
+    test_pass
+else
+    test_fail "pairs file parse wrong: $output"
+fi
+
+test_summary


### PR DESCRIPTION
Reopens #641 (auto-closed when its stacked base branch was deleted on #640's merge). Content identical, rebased onto main.

## Summary
- **Anti-slop taste layer** `skills/blocks/design-taste.md`: binary rules (three banned AI looks, banned default fonts, layout/content tells, pre-ship checklist). Wired into shotgun variant prompts, the Define phase, and a new 5th SLOP critique dimension. The skill's own example variants shipped two banned looks (AI-purple #667EEA/#764BA2 gradient, Space Grotesk default); replaced.
- **WCAG contrast validator** `scripts/helpers/contrast-check.py` (stdlib only): Deliver phase executes it on every text/background pair; exit 1 blocks delivery.
- **Design dials**: 4th intake question maps to v2.11.0 `--variance/--motion/--density`.
- **Lineage persistence**: Step 8 writes the design system to `~/.claude-octopus/designs/<slug>/` per the skill-design-lineage contract.

## Test plan
- [x] `bash tests/unit/test-contrast-check.sh` 8/8
- [x] Full `make ci-local` on the stack tip: 174/175 suites; the 1 failure was a pre-existing local-env issue in test-hook-err-traps.sh (fixture tarred gitignored local files), fixed in the follow-up stacked PR