### PR TITLE
fix: preserve provider results in restricted host sandboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Restricted host sandboxes now preserve provider results when Octopus state is unwritable** (#648). The orchestrator probes only the host-selected state root and, when writes are denied, disables optional persistence and streams the provider result synchronously without inventing a project or temporary fallback. Event logging is strictly fail-open, nested Claude dispatches from Codex/Gemini exclude user-scoped plugin hooks while retaining authentication, and debug mode emits at most one structured persistence diagnostic.
+
 ## [9.54.0] - 2026-07-18
 
 

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -209,6 +209,14 @@ ${provider_ctx}"
         fi
     fi
 
+    if [[ "${OCTOPUS_PERSISTENCE_AVAILABLE:-true}" == "false" ]]; then
+        local degraded_cmd
+        degraded_cmd=$(get_agent_command "$agent_type" "$phase" "$role") || return 1
+        octopus_run_provider_without_persistence \
+            "$agent_type" "$enhanced_prompt" "$timeout_secs" "$degraded_cmd"
+        return $?
+    fi
+
     record_agent_call "$agent_type" "$model" "$enhanced_prompt" "${phase:-unknown}" "${role:-none}" "0"
 
     # v7.25.0: Record metrics start

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -81,6 +81,14 @@ get_agent_command() {
     # for `claude -p`, instead of metered API). Default unchanged. May include
     # args (word-split downstream by read -ra), e.g. "clarp --strict-mcp-config".
     local _claude_bin="${OCTOPUS_CLAUDE_BIN:-claude}"
+    # A Claude provider nested under a non-Claude host must not recursively load
+    # user-scoped plugins/hooks. Unlike --bare, limiting setting sources keeps
+    # OAuth/keychain authentication available.
+    if [[ "${OCTOPUS_HOST:-standalone}" == "codex" || "${OCTOPUS_HOST:-standalone}" == "gemini" ]]; then
+        if [[ " $_claude_bin " != *" --setting-sources "* ]]; then
+            _claude_bin="${_claude_bin} --setting-sources project,local"
+        fi
+    fi
 
     # Configurable sandbox mode (v7.13.1 - Issue #9)
     # Priority: OCTOPUS_CODEX_SANDBOX env var > default (workspace-write)

--- a/scripts/lib/events.sh
+++ b/scripts/lib/events.sh
@@ -129,7 +129,7 @@ octo_event_emit() {
 
     local dir
     dir="$(dirname "$log_file")"
-    mkdir -p "$dir" 2>/dev/null || return 1
+    mkdir -p "$dir" 2>/dev/null || return 0
 
     local record
     printf -v record '{"timestamp":%s,"event":%s,"source":%s,"pid":%s,"session_id":%s,"attributes":{%s}}\n' \
@@ -145,13 +145,15 @@ octo_event_emit() {
     # can't be acquired (~1s spin), fall back to a lockless write — same
     # best-effort behavior as before, and it never blocks the caller.
     if _octo_event_lock "$log_file"; then
-        { printf '%s' "$record" >> "$log_file" && _octo_event_trim "$log_file"; } || {
+        { printf '%s' "$record" 2>/dev/null >> "$log_file" && _octo_event_trim "$log_file"; } || {
             _octo_event_unlock "$log_file"
-            return 1
+            return 0
         }
         _octo_event_unlock "$log_file"
     else
-        printf '%s' "$record" >> "$log_file" || return 1
-        _octo_event_trim "$log_file"
+        printf '%s' "$record" 2>/dev/null >> "$log_file" || return 0
+        _octo_event_trim "$log_file" || return 0
     fi
+
+    return 0
 }

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -451,6 +451,14 @@ ${heuristic_ctx}"
         return 1
     fi
 
+    # A restricted host may deny the selected state root. Preserve the provider
+    # result by degrading this background/persistent path to synchronous stdout.
+    if [[ "${OCTOPUS_PERSISTENCE_AVAILABLE:-true}" == "false" ]]; then
+        octopus_run_provider_without_persistence \
+            "$agent_type" "$enhanced_prompt" "${TIMEOUT:-0}" "$cmd"
+        return $?
+    fi
+
     local log_file="${LOGS_DIR}/${agent_type}-${task_id}.log"
     local result_file="${RESULTS_DIR}/${agent_type}-${task_id}.md"
 

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -451,6 +451,11 @@ ${heuristic_ctx}"
         return 1
     fi
 
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log INFO "[DRY-RUN] Would execute: $cmd with role=${role:-none}"
+        return 0
+    fi
+
     # A restricted host may deny the selected state root. Preserve the provider
     # result by degrading this background/persistent path to synchronous stdout.
     if [[ "${OCTOPUS_PERSISTENCE_AVAILABLE:-true}" == "false" ]]; then
@@ -532,11 +537,6 @@ ${heuristic_ctx}"
     local metrics_id=""
     if command -v record_agent_start &> /dev/null; then
         metrics_id=$(record_agent_start "$agent_type" "$model" "$enhanced_prompt" "${phase:-unknown}") || true
-    fi
-
-    if [[ "$DRY_RUN" == "true" ]]; then
-        log INFO "[DRY-RUN] Would execute: $cmd with role=${role:-none}"
-        return 0
     fi
 
     # Store metrics mapping for batch completion recording (after DRY_RUN gate)

--- a/scripts/lib/state-root.sh
+++ b/scripts/lib/state-root.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Claude Octopus — state-root capability helpers
+#
+# Restricted hosts own filesystem policy. These helpers only test the state
+# root already selected by the host/caller; they never select a fallback path.
+
+octopus_state_root_is_writable() {
+    local root="${1:-}"
+    [[ -n "$root" ]] || return 1
+
+    mkdir -p "$root" 2>/dev/null || return 1
+
+    local probe="${root}/.octopus-write-probe-$$-${RANDOM:-0}"
+    (umask 077; : >"$probe") 2>/dev/null || return 1
+    rm -f "$probe" 2>/dev/null || true
+    return 0
+}
+
+octopus_configure_persistence() {
+    local root="${1:-}"
+    if octopus_state_root_is_writable "$root"; then
+        OCTOPUS_PERSISTENCE_AVAILABLE=true
+    else
+        OCTOPUS_PERSISTENCE_AVAILABLE=false
+        unset OCTO_EVENT_LOG
+    fi
+    export OCTOPUS_PERSISTENCE_AVAILABLE
+}
+
+octopus_persistence_diagnostic() {
+    [[ "${OCTOPUS_PERSISTENCE_AVAILABLE:-true}" == "false" ]] || return 0
+    [[ "${OCTOPUS_DEBUG:-false}" == "true" ]] || return 0
+    [[ "${_OCTOPUS_PERSISTENCE_DIAGNOSTIC_EMITTED:-false}" == "true" ]] && return 0
+
+    _OCTOPUS_PERSISTENCE_DIAGNOSTIC_EMITTED=true
+    local escaped_root
+    escaped_root=$(json_escape "${WORKSPACE_DIR:-unavailable}")
+    printf '{"source":"octopus","event":"persistence.disabled","state_root":"%s"}\n' \
+        "$escaped_root" >&2
+}
+
+# Run a provider without Octopus-owned result, metric, event, PID, or log files.
+# Output is streamed directly to the caller so a denied optional state root
+# cannot hide an otherwise successful provider result.
+octopus_run_provider_without_persistence() {
+    local agent_type="$1"
+    local prompt="$2"
+    local timeout_secs="$3"
+    local cmd="$4"
+    local -a cmd_array
+    local -a inner_cmd_array
+
+    octopus_persistence_diagnostic
+    build_provider_env "$agent_type"
+    read -ra inner_cmd_array <<<"$cmd"
+    if [[ ${#PROVIDER_ENV_ARRAY[@]} -gt 0 ]]; then
+        cmd_array=("${PROVIDER_ENV_ARRAY[@]}" "${inner_cmd_array[@]}")
+    else
+        cmd_array=("${inner_cmd_array[@]}")
+    fi
+
+    if [[ "$agent_type" == gemini* || "$agent_type" == copilot* || \
+          "$agent_type" == qwen* || "$agent_type" == cursor-agent* ]]; then
+        cmd_array+=(-p "")
+    fi
+
+    local exit_code=0
+    set +e
+    printf '%s' "$prompt" | run_with_timeout "$timeout_secs" "${cmd_array[@]}"
+    exit_code=${PIPESTATUS[1]:-1}
+    set -e
+    return "$exit_code"
+}

--- a/scripts/lib/state-root.sh
+++ b/scripts/lib/state-root.sh
@@ -65,9 +65,11 @@ octopus_run_provider_without_persistence() {
     fi
 
     local exit_code=0
-    set +e
-    printf '%s' "$prompt" | run_with_timeout "$timeout_secs" "${cmd_array[@]}"
-    exit_code=${PIPESTATUS[1]:-1}
-    set -e
+    if printf '%s' "$prompt" | run_with_timeout "$timeout_secs" "${cmd_array[@]}"; then
+        exit_code=0
+    else
+        local -a pipeline_status=("${PIPESTATUS[@]}")
+        exit_code="${pipeline_status[1]:-1}"
+    fi
     return "$exit_code"
 }

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -101,6 +101,7 @@ source "${SCRIPT_DIR}/agent-teams-bridge.sh"
 # Source Wave 1 extractions (v9.3.0 decomposition)
 source "${SCRIPT_DIR}/lib/common.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/utils.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/lib/state-root.sh"
 source "${SCRIPT_DIR}/lib/session-id.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/similarity.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/models.sh" 2>/dev/null || true
@@ -507,11 +508,17 @@ RESULTS_DIR="$SESSION_RESULTS_DIR"
 LOGS_DIR="$SESSION_LOGS_DIR"
 PID_FILE="${WORKSPACE_DIR}/pids"
 
+# Probe only the state root selected above. Restricted hosts do not get an
+# automatic project/TMPDIR fallback: optional persistence degrades instead.
+octopus_configure_persistence "$WORKSPACE_DIR"
+
 # Telemetry: enable the opt-in JSONL event stream by default for every run so
 # provider.status + dispatch lifecycle events are captured (usage data + the
 # basis for a control-plane HUD). Stdout is unchanged (events.sh appends to the
 # log only). Opt out with OCTO_EVENT_LOG=off; override the path by setting it.
-if [[ -z "${OCTO_EVENT_LOG:-}" ]]; then
+if [[ "${OCTOPUS_PERSISTENCE_AVAILABLE}" == "false" ]]; then
+    unset OCTO_EVENT_LOG
+elif [[ -z "${OCTO_EVENT_LOG:-}" ]]; then
     export OCTO_EVENT_LOG="${RESULTS_DIR}/events.jsonl"
 elif [[ "${OCTO_EVENT_LOG}" == "off" ]]; then
     unset OCTO_EVENT_LOG

--- a/tests/unit/test-codex-sandbox-persistence.sh
+++ b/tests/unit/test-codex-sandbox-persistence.sh
@@ -28,7 +28,7 @@ trap cleanup_fixture EXIT INT TERM
 
 test_case "event logging fails open without stderr when its path is denied"
 readonly_events="$TEST_TMP_DIR/readonly-events"
-mkdir -p "$readonly_events"
+mkdir -p "$readonly_events/events.jsonl"
 chmod 500 "$readonly_events"
 
 set +e
@@ -44,7 +44,7 @@ set -e
 if [[ "$event_rc" -eq 0 ]] && \
    [[ ! -s "$TEST_TMP_DIR/event.stdout" ]] && \
    [[ ! -s "$TEST_TMP_DIR/event.stderr" ]] && \
-   [[ ! -e "$readonly_events/events.jsonl" ]]; then
+   [[ -d "$readonly_events/events.jsonl" ]]; then
     test_pass
 else
     test_fail "optional event logging changed command behavior (rc=$event_rc, stderr=$(<"$TEST_TMP_DIR/event.stderr"))"
@@ -77,8 +77,10 @@ test_case "Codex host streams provider output when legacy state root is denied"
 fake_home="$TEST_TMP_DIR/home"
 fake_bin="$TEST_TMP_DIR/bin"
 project_dir="$TEST_TMP_DIR/project"
+blocked_state_root="$fake_home/blocked-state-root"
 mkdir -p "$fake_home/.claude-octopus" "$fake_bin" "$project_dir"
 ln -s "$PROJECT_ROOT" "$fake_home/.claude-octopus/plugin"
+: >"$blocked_state_root"
 
 cat >"$fake_bin/claude" <<'FAKE_CLAUDE'
 #!/usr/bin/env bash
@@ -100,6 +102,7 @@ if [[ " $* " != *" --setting-sources project,local "* ]]; then
     exit 42
 fi
 
+[[ -n "${FAKE_CLAUDE_MARKER:-}" ]] && : >"$FAKE_CLAUDE_MARKER"
 cat >/dev/null
 echo "SANDBOX_PROVIDER_OK"
 FAKE_CLAUDE
@@ -114,6 +117,7 @@ set +e
     cd "$project_dir"
     HOME="$fake_home" \
     PATH="$fake_bin:$PATH" \
+    CLAUDE_PLUGIN_DATA="$blocked_state_root" \
     CI= \
     GITHUB_ACTIONS= \
     CODEX_SANDBOX=workspace-write \
@@ -131,6 +135,56 @@ if [[ "$spawn_rc" -eq 0 ]] && \
     test_pass
 else
     test_fail "restricted Codex dispatch failed (rc=$spawn_rc, stderr=$(<"$TEST_TMP_DIR/spawn.stderr"))"
+fi
+
+test_case "dry run never invokes a provider when persistence is unavailable"
+dry_run_marker="$TEST_TMP_DIR/dry-run-provider-invoked"
+set +e
+(
+    cd "$project_dir"
+    HOME="$fake_home" \
+    PATH="$fake_bin:$PATH" \
+    CLAUDE_PLUGIN_DATA="$blocked_state_root" \
+    CI= \
+    GITHUB_ACTIONS= \
+    CODEX_SANDBOX=workspace-write \
+    OCTOPUS_SKIP_PROVIDER_PROBES=true \
+    OCTOPUS_DEBUG=false \
+    FAKE_CLAUDE_MARKER="$dry_run_marker" \
+        bash "$PROJECT_ROOT/scripts/orchestrate.sh" --dry-run spawn claude \
+            "Do not execute this provider"
+) >"$TEST_TMP_DIR/dry-run.stdout" 2>"$TEST_TMP_DIR/dry-run.stderr"
+dry_run_rc=$?
+set -e
+
+if [[ "$dry_run_rc" -eq 0 ]] && [[ ! -e "$dry_run_marker" ]]; then
+    test_pass
+else
+    test_fail "dry run invoked the degraded provider (rc=$dry_run_rc)"
+fi
+
+test_case "degraded provider preserves the caller's disabled errexit state"
+set +e
+errexit_output=$(
+    set +e
+    source "$PROJECT_ROOT/scripts/lib/state-root.sh"
+    build_provider_env() { PROVIDER_ENV_ARRAY=(); }
+    run_with_timeout() { return 23; }
+    export OCTOPUS_PERSISTENCE_AVAILABLE=false
+    export OCTOPUS_DEBUG=false
+
+    octopus_run_provider_without_persistence claude "provider failure" 30 "ignored-command" >/dev/null
+    provider_rc=$?
+    [[ $- != *e* ]] || exit 90
+    printf 'provider_rc=%s' "$provider_rc"
+)
+errexit_shell_rc=$?
+set -e
+
+if [[ "$errexit_shell_rc" -eq 0 ]] && [[ "$errexit_output" == "provider_rc=23" ]]; then
+    test_pass
+else
+    test_fail "degraded provider changed caller errexit (shell_rc=$errexit_shell_rc, output=$errexit_output)"
 fi
 
 test_case "synchronous provider path also streams without persistent state"

--- a/tests/unit/test-codex-sandbox-persistence.sh
+++ b/tests/unit/test-codex-sandbox-persistence.sh
@@ -114,6 +114,8 @@ set +e
     cd "$project_dir"
     HOME="$fake_home" \
     PATH="$fake_bin:$PATH" \
+    CI= \
+    GITHUB_ACTIONS= \
     CODEX_SANDBOX=workspace-write \
     OCTOPUS_SKIP_PROVIDER_PROBES=true \
     OCTOPUS_DEBUG=false \

--- a/tests/unit/test-codex-sandbox-persistence.sh
+++ b/tests/unit/test-codex-sandbox-persistence.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #648: restricted Codex hosts must not let
+# optional Octopus persistence block an otherwise healthy provider call.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Codex sandbox persistence degradation"
+
+prepare_cleanup() {
+    chmod u+w "$TEST_TMP_DIR/home/.claude-octopus" "$TEST_TMP_DIR/home" 2>/dev/null || true
+    chmod -R u+w "$TEST_TMP_DIR" 2>/dev/null || true
+}
+
+cleanup_fixture() {
+    prepare_cleanup
+    cleanup_test_environment
+}
+
+after_all prepare_cleanup
+trap cleanup_fixture EXIT INT TERM
+
+test_case "event logging fails open without stderr when its path is denied"
+readonly_events="$TEST_TMP_DIR/readonly-events"
+mkdir -p "$readonly_events"
+chmod 500 "$readonly_events"
+
+set +e
+(
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/scripts/lib/events.sh"
+    export OCTO_EVENT_LOG="$readonly_events/events.jsonl"
+    octo_event_emit "sandbox.test" "host=codex"
+) >"$TEST_TMP_DIR/event.stdout" 2>"$TEST_TMP_DIR/event.stderr"
+event_rc=$?
+set -e
+
+if [[ "$event_rc" -eq 0 ]] && \
+   [[ ! -s "$TEST_TMP_DIR/event.stdout" ]] && \
+   [[ ! -s "$TEST_TMP_DIR/event.stderr" ]] && \
+   [[ ! -e "$readonly_events/events.jsonl" ]]; then
+    test_pass
+else
+    test_fail "optional event logging changed command behavior (rc=$event_rc, stderr=$(<"$TEST_TMP_DIR/event.stderr"))"
+fi
+
+test_case "debug mode emits one valid structured persistence diagnostic"
+diagnostic_root="$TEST_TMP_DIR/state with spaces"
+diagnostic_output=$( {
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/scripts/lib/utils.sh"
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/scripts/lib/state-root.sh"
+    export OCTOPUS_PERSISTENCE_AVAILABLE=false
+    export OCTOPUS_DEBUG=true
+    export WORKSPACE_DIR="$diagnostic_root"
+    octopus_persistence_diagnostic
+    octopus_persistence_diagnostic
+} 2>&1 )
+
+diagnostic_lines=$(printf '%s\n' "$diagnostic_output" | wc -l | tr -d ' ')
+if [[ "$diagnostic_lines" -eq 1 ]] && \
+   [[ "$(printf '%s' "$diagnostic_output" | jq -r '.event')" == "persistence.disabled" ]] && \
+   [[ "$(printf '%s' "$diagnostic_output" | jq -r '.state_root')" == "$diagnostic_root" ]]; then
+    test_pass
+else
+    test_fail "debug persistence diagnostic was not one valid JSON record: $diagnostic_output"
+fi
+
+test_case "Codex host streams provider output when legacy state root is denied"
+fake_home="$TEST_TMP_DIR/home"
+fake_bin="$TEST_TMP_DIR/bin"
+project_dir="$TEST_TMP_DIR/project"
+mkdir -p "$fake_home/.claude-octopus" "$fake_bin" "$project_dir"
+ln -s "$PROJECT_ROOT" "$fake_home/.claude-octopus/plugin"
+
+cat >"$fake_bin/claude" <<'FAKE_CLAUDE'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    --version)
+        echo "2.1.214 (Claude Code)"
+        exit 0
+        ;;
+    --help)
+        echo "--setting-sources <sources>"
+        exit 0
+        ;;
+esac
+
+if [[ " $* " != *" --setting-sources project,local "* ]]; then
+    echo "nested Claude did not exclude user/plugin settings" >&2
+    exit 42
+fi
+
+cat >/dev/null
+echo "SANDBOX_PROVIDER_OK"
+FAKE_CLAUDE
+chmod +x "$fake_bin/claude"
+
+# Existing legacy layout, but denied by the outer host. The stable plugin link
+# is created before permissions are removed so startup does not need to heal it.
+chmod 500 "$fake_home" "$fake_home/.claude-octopus"
+
+set +e
+(
+    cd "$project_dir"
+    HOME="$fake_home" \
+    PATH="$fake_bin:$PATH" \
+    CODEX_SANDBOX=workspace-write \
+    OCTOPUS_SKIP_PROVIDER_PROBES=true \
+    OCTOPUS_DEBUG=false \
+        bash "$PROJECT_ROOT/scripts/orchestrate.sh" spawn claude \
+            "Reply exactly SANDBOX_PROVIDER_OK"
+) >"$TEST_TMP_DIR/spawn.stdout" 2>"$TEST_TMP_DIR/spawn.stderr"
+spawn_rc=$?
+set -e
+
+if [[ "$spawn_rc" -eq 0 ]] && \
+   grep -q '^SANDBOX_PROVIDER_OK$' "$TEST_TMP_DIR/spawn.stdout" && \
+   [[ ! -s "$TEST_TMP_DIR/spawn.stderr" ]]; then
+    test_pass
+else
+    test_fail "restricted Codex dispatch failed (rc=$spawn_rc, stderr=$(<"$TEST_TMP_DIR/spawn.stderr"))"
+fi
+
+test_case "synchronous provider path also streams without persistent state"
+set +e
+sync_output=$(
+    source "$PROJECT_ROOT/scripts/lib/state-root.sh"
+
+    log() { :; }
+    apply_persona() { printf '%s' "$2"; }
+    get_persona_override() { return 1; }
+    load_earned_skills() { :; }
+    build_provider_context() { :; }
+    sanitize_external_content() { printf '%s' "$1"; }
+    enforce_context_budget() { printf '%s' "$1"; }
+    get_agent_model() { echo "test-model"; }
+    check_provider_health() { return 0; }
+    get_agent_command() { echo "$fake_bin/claude --setting-sources project,local --print"; }
+    build_provider_env() { PROVIDER_ENV_ARRAY=(); }
+    run_with_timeout() { local _timeout="$1"; shift; "$@"; }
+
+    export OCTOPUS_PERSISTENCE_AVAILABLE=false
+    export OCTOPUS_DEBUG=false
+    export RESULTS_DIR="$readonly_events"
+    export WORKSPACE_DIR="$fake_home/.claude-octopus"
+
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/scripts/lib/agent-sync.sh"
+    run_agent_sync claude "Reply exactly SANDBOX_PROVIDER_OK" 30 reviewer review
+) 2>"$TEST_TMP_DIR/sync.stderr"
+sync_rc=$?
+set -e
+
+if [[ "$sync_rc" -eq 0 ]] && \
+   [[ "$sync_output" == "SANDBOX_PROVIDER_OK" ]] && \
+   [[ ! -s "$TEST_TMP_DIR/sync.stderr" ]]; then
+    test_pass
+else
+    test_fail "restricted synchronous dispatch failed (rc=$sync_rc, output=$sync_output, stderr=$(<"$TEST_TMP_DIR/sync.stderr"))"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

- probe only the state root selected by the host/caller and disable optional persistence when it is unwritable
- degrade persistent/background dispatch to synchronous stdout so filesystem denial cannot hide a successful provider result
- make event logging strictly fail-open and isolate nested Claude settings from user-scoped plugin hooks on Codex/Gemini hosts
- add regression coverage for denied event paths, structured diagnostics, async spawn, and synchronous dispatch

## Verification

- `make ci-local` (twice; Smoke, Unit, Integration, and CI-only checks all passed)
- `tests/unit/test-codex-sandbox-persistence.sh` (4/4)
- Amy live test: Claude Code 2.1.214 inside Codex 0.114.0 `workspace-write`; provider exit 0, non-empty stdout, 0 stderr bytes

Closes #648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability in restricted sandboxes when the configured state/persistence location isn’t writable.
  * When persistence is unavailable, provider results stream synchronously and runs no longer block on persistence/background artifacts.
  * Event logging now fails open: issues creating/writing/trimming the event log no longer interrupt execution.
  * Nested Claude dispatch avoids user-scoped plugin hooks while keeping authentication working.
  * Debug persistence diagnostics emit at most one structured notice.
* **Tests**
  * Added regression coverage for restricted Codex sandbox persistence degradation, fail-open logging, diagnostic output, and synchronous degraded-provider behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->