### PR TITLE
fix(agy): restore USERPROFILE so agy seats start on Windows

### DIFF
--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -25,6 +25,35 @@ set -euo pipefail
 model="${OCTOPUS_AGY_MODEL:-default}"
 print_timeout="${OCTOPUS_AGY_PRINT_TIMEOUT:-5m0s}"
 
+# agy (jetski) resolves its home/log/AppData config dir by expanding %USERPROFILE%.
+# On Windows/Git Bash the orchestrator's spawn context can drop USERPROFILE from
+# agy's environment, so agy crashes at startup (exit 1) with
+# "%userprofile% is not defined" before it ever reads the prompt, so the council
+# seat fails silently. Re-derive and export it from any available source so agy
+# always starts. Gated to Windows shell environments (MSYS/MinGW/Cygwin) so a
+# macOS/Linux host, where USERPROFILE is normally unset and unused, is never
+# given a spurious one; exported only when a fallback actually resolved a value,
+# so an empty USERPROFILE is never exported.
+# Reproduce with: env -u USERPROFILE agy --print "say ok"
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*)
+        if [[ -z "${USERPROFILE:-}" ]]; then
+            if [[ -n "${HOME:-}" ]] && command -v cygpath >/dev/null 2>&1; then
+                USERPROFILE="$(cygpath -w "$HOME" 2>/dev/null)"
+            fi
+            if [[ -z "${USERPROFILE:-}" && -n "${HOMEDRIVE:-}" && -n "${HOMEPATH:-}" ]]; then
+                USERPROFILE="${HOMEDRIVE}${HOMEPATH}"
+            fi
+            if [[ -z "${USERPROFILE:-}" && -n "${HOME:-}" ]]; then
+                USERPROFILE="$HOME"
+            fi
+            if [[ -n "${USERPROFILE:-}" ]]; then
+                export USERPROFILE
+            fi
+        fi
+        ;;
+esac
+
 # --dangerously-skip-permissions: auto-approve agy's folder-trust + tool prompts so
 # council seats don't block on a per-worktree trust prompt (already --sandbox'd).
 # OCTOPUS_AGY_SANDBOX=off drops the sandbox restriction; the default keeps it on.


### PR DESCRIPTION
## Problem

On Windows/Git Bash, every `agy` council seat fails before it reads the prompt.

`agy` (jetski) resolves its home, log, and AppData config directories by expanding `%USERPROFILE%`. The orchestrator's spawn context can drop `USERPROFILE` from `agy`'s environment, so `agy` exits 1 at startup:

```
E main.go:335] Failed to redirect output for CLI: resolving log directory:
  getting home directory: %userprofile% is not defined
E server.go:1346] Failed to get AppDataDir for crash reporter: %userprofile% is not defined
E main.go:437] CLI failed to start - %userprofile% is not defined
```

The council then logs `Agent agy failed with exit code 1` and silently continues with the remaining providers, so a `--providers claude,agy` run quietly degrades to claude-only.

## Reproduce

```bash
env -u USERPROFILE agy --print "say ok"   # exit 1, the error above
USERPROFILE='C:\Users\you' agy --print "say ok"   # exit 0, "ok"
```

## Fix

Re-derive and export `USERPROFILE` in `agy-exec.sh` when it is absent, preferring `cygpath` on `$HOME`, then `HOMEDRIVE`+`HOMEPATH`, then `$HOME`.

The guard only runs when `USERPROFILE` is empty, so it is inert on macOS/Linux, which do not use that variable. No behaviour change on any non-Windows platform.

## Verification

Windows 11 / Git Bash, `agy` 1.1.4, octo 9.54.0.

With `USERPROFILE` deliberately stripped, the patched adapter returns a full response and exit 0, where the unpatched adapter exits 1 without ever reading the prompt.

## Notes

This is one of two independent problems I hit with agy seats. The other (agy writing its answer to a brain artifact instead of stdout) is a separate, more debatable change and is filed on its own so this Windows correctness fix isn't blocked behind it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability on Windows and Git Bash when user profile environment settings are missing.
  * The app now derives the user profile directory from available environment variables and proceeds without failing early, ensuring configuration and home directory resolution works correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->