### PR TITLE
fix(agy): force inline output so agy seats are not silently empty

### DIFF
--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -39,7 +39,10 @@ case "$(uname -s 2>/dev/null)" in
     MINGW*|MSYS*|CYGWIN*)
         if [[ -z "${USERPROFILE:-}" ]]; then
             if [[ -n "${HOME:-}" ]] && command -v cygpath >/dev/null 2>&1; then
-                USERPROFILE="$(cygpath -w "$HOME" 2>/dev/null)"
+                # `|| true` keeps set -e from killing the shim on a failed
+                # conversion, so the HOMEDRIVE+HOMEPATH and HOME fallbacks
+                # below still get their turn.
+                USERPROFILE="$(cygpath -w "$HOME" 2>/dev/null || true)"
             fi
             if [[ -z "${USERPROFILE:-}" && -n "${HOMEDRIVE:-}" && -n "${HOMEPATH:-}" ]]; then
                 USERPROFILE="${HOMEDRIVE}${HOMEPATH}"
@@ -138,15 +141,27 @@ fi
 
 # Silent prompt mutation is hard to diagnose from the outside: someone debugging an
 # odd agy response should be able to see that the adapter modified the prompt.
+# Raw stderr echo rather than `log`: this file is a standalone shim exec'd
+# directly by dispatch.sh, like the sibling Gemini and Grok shims, and does
+# not source the logging library by design.
 if [[ -n "$AGY_INLINE_DIRECTIVE" && "${OCTOPUS_DEBUG:-false}" == "true" ]]; then
     echo "agy-exec.sh: prepending force-inline directive to prompt (disable with OCTOPUS_AGY_FORCE_INLINE=0)" >&2
 fi
 
+# Byte length regardless of locale: MAX_ARG_STRLEN is a byte limit, and a
+# multibyte UTF-8 prompt has more bytes than ${#var} chars would suggest.
+byte_length() {
+    local LC_ALL=C
+    printf '%s' "${#1}"
+}
+
 # Single-argument size ceiling: Linux caps one argv string at MAX_ARG_STRLEN
 # (128 KiB). Oversized prompts stay in the cached temp file and agy is pointed
 # at it via --add-dir with a read-this-file --print instruction, instead of
-# failing the seat.
-if (( ${#prompt_content} > 100000 )); then
+# failing the seat. The ceiling is measured on the FULL --print argument the
+# inline branch would build (directive + prompt), not the prompt alone, so the
+# prepended directive can never push a near-ceiling prompt past the limit.
+if (( $(byte_length "${AGY_INLINE_DIRECTIVE}${prompt_content}") > 100000 )); then
     cmd+=(--add-dir "$(dirname "$prompt_file")")
     cmd+=(--print "${AGY_INLINE_DIRECTIVE_FILE}Read the file '${prompt_file}' and follow the instructions in it as your task prompt. Do not summarize the file; execute it.")
 else

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -85,15 +85,43 @@ if [[ -z "${prompt_content//[[:space:]]/}" ]]; then
     exit 2
 fi
 
+# Force-inline directive (default on; disable with OCTOPUS_AGY_FORCE_INLINE=0).
+# agy is an agentic CLI: given a council/analysis prompt it writes its real answer
+# to an internal "brain" artifact and returns only a "see the artifact" stub on
+# stdout, or nothing at all when a tool it wants needs a permission headless mode
+# cannot prompt for. Either way the council seat is silently empty, and the
+# silent-empty retry below cannot help because it reproduces the same behaviour.
+# This directive pins the full answer to the stdout response so the seat is captured.
+AGY_INLINE_DIRECTIVE="CRITICAL OUTPUT RULES: Respond with your COMPLETE answer directly inline as plain text in THIS response. Do NOT create files. Do NOT write artifacts or brain documents. Do NOT use terminal, command, or file tools. Do NOT say 'see the artifact' or reference any external document. Write the full answer here now, from your own expertise.
+
+"
+# Oversized prompts are handed over as a file path (see the size ceiling below), so
+# that branch needs a directive that permits reading exactly that one file. Reusing
+# the blanket no-file-tools wording above would contradict its own instruction to
+# read the prompt file.
+AGY_INLINE_DIRECTIVE_FILE="CRITICAL OUTPUT RULES: Respond with your COMPLETE answer directly inline as plain text in THIS response. You may read ONLY the prompt file named below. Apart from reading that one file, do NOT create files, do NOT write artifacts or brain documents, and do NOT use terminal or command tools. Do NOT say 'see the artifact' or reference any external document. Write the full answer here now.
+
+"
+if [[ "${OCTOPUS_AGY_FORCE_INLINE:-1}" != "1" ]]; then
+    AGY_INLINE_DIRECTIVE=""
+    AGY_INLINE_DIRECTIVE_FILE=""
+fi
+
+# Silent prompt mutation is hard to diagnose from the outside: someone debugging an
+# odd agy response should be able to see that the adapter modified the prompt.
+if [[ -n "$AGY_INLINE_DIRECTIVE" && "${OCTOPUS_DEBUG:-false}" == "true" ]]; then
+    echo "agy-exec.sh: prepending force-inline directive to prompt (disable with OCTOPUS_AGY_FORCE_INLINE=0)" >&2
+fi
+
 # Single-argument size ceiling: Linux caps one argv string at MAX_ARG_STRLEN
 # (128 KiB). Oversized prompts stay in the cached temp file and agy is pointed
 # at it via --add-dir with a read-this-file --print instruction, instead of
 # failing the seat.
 if (( ${#prompt_content} > 100000 )); then
     cmd+=(--add-dir "$(dirname "$prompt_file")")
-    cmd+=(--print "Read the file '${prompt_file}' and follow the instructions in it as your task prompt. Do not summarize the file; execute it.")
+    cmd+=(--print "${AGY_INLINE_DIRECTIVE_FILE}Read the file '${prompt_file}' and follow the instructions in it as your task prompt. Do not summarize the file; execute it.")
 else
-    cmd+=(--print "$prompt_content")
+    cmd+=(--print "${AGY_INLINE_DIRECTIVE}${prompt_content}")
 fi
 
 run_agy() {

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -41,7 +41,7 @@ test_agy_dispatch_native_flags() {
     # message.
     if grep -q 'scripts/helpers/agy-exec.sh' "$PROJECT_ROOT/scripts/lib/dispatch.sh" && \
        grep -q 'cmd=(agy)' "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" && \
-       grep -q -- '--print "$prompt_content"' "$PROJECT_ROOT/scripts/helpers/agy-exec.sh"; then
+       grep -q -- '--print "${AGY_INLINE_DIRECTIVE}${prompt_content}"' "$PROJECT_ROOT/scripts/helpers/agy-exec.sh"; then
         test_pass
     else
         test_fail "agy dispatch should use scripts/helpers/agy-exec.sh with the prompt as --print's argument"
@@ -68,7 +68,10 @@ MOCK_AGY
     AGY_ARG_CAPTURE="$capture"
     export AGY_ARG_CAPTURE
 
-    printf 'hello agy prompt' | bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" >/dev/null
+    # OCTOPUS_AGY_FORCE_INLINE=0 disables the force-inline directive, so --print's
+    # argument is the untouched prompt. This keeps the original prompt-as-argument
+    # assertion exact while also covering the opt-out path.
+    printf 'hello agy prompt' | OCTOPUS_AGY_FORCE_INLINE=0 bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" >/dev/null
 
     PATH="$old_path"
     unset AGY_ARG_CAPTURE
@@ -78,10 +81,61 @@ MOCK_AGY
     # prompt, leaving the sandbox off).
     local print_next
     print_next="$(grep -Fx -A1 -- '--print' "$capture" | tail -1)"
-    if [[ "$print_next" == "hello agy prompt" ]] && grep -Fxq -- '--sandbox' "$capture"; then
+    if [[ "$print_next" == "hello agy prompt" ]] && grep -Fxq -- '--sandbox' "$capture" && \
+       ! grep -Fq 'CRITICAL OUTPUT RULES' "$capture"; then
         test_pass
     else
-        test_fail "expected argv '--print' followed by the stdin prompt plus a real --sandbox flag; got: $(tr '\n' '|' < "$capture")"
+        test_fail "expected argv '--print' followed by the unmodified stdin prompt plus a real --sandbox flag, and no directive under OCTOPUS_AGY_FORCE_INLINE=0; got: $(tr '\n' '|' < "$capture")"
+    fi
+}
+
+test_agy_force_inline_directive_prepended_by_default() {
+    test_case "agy-exec prepends the force-inline directive by default"
+
+    local tmp_bin="$TEST_TMP_DIR/agy-inline-bin"
+    local capture="$TEST_TMP_DIR/agy-inline-argv.txt"
+    mkdir -p "$tmp_bin"
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${AGY_ARG_CAPTURE:?}"
+echo "mock-response"
+exit 0
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+
+    local old_path="$PATH"
+    PATH="$tmp_bin:$PATH"
+    AGY_ARG_CAPTURE="$capture"
+    export AGY_ARG_CAPTURE
+
+    printf 'hello agy prompt' | bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" >/dev/null
+
+    PATH="$old_path"
+    unset AGY_ARG_CAPTURE
+
+    # agy writes its real answer to a brain artifact and returns a stub unless it is
+    # told to answer inline, so the directive must reach agy ahead of the prompt --
+    # and the prompt itself must survive intact behind it.
+    if grep -Fq 'CRITICAL OUTPUT RULES' "$capture" && grep -Fq 'hello agy prompt' "$capture"; then
+        test_pass
+    else
+        test_fail "expected the force-inline directive prepended to the prompt; got: $(tr '\n' '|' < "$capture")"
+    fi
+}
+
+test_agy_file_prompt_directive_permits_reading_prompt_file() {
+    test_case "oversized-prompt directive permits reading the adapter's prompt file"
+
+    # The >100000 branch hands agy a file path to read. A blanket "do not use file
+    # tools" directive would contradict that instruction, so this branch must use
+    # the file-permitting variant while still forbidding artifacts.
+    local helper="$PROJECT_ROOT/scripts/helpers/agy-exec.sh"
+    if grep -q -- '--print "${AGY_INLINE_DIRECTIVE_FILE}Read the file' "$helper" && \
+       grep -q 'You may read ONLY the prompt file named below' "$helper" && \
+       grep -q 'AGY_INLINE_DIRECTIVE_FILE=""' "$helper"; then
+        test_pass
+    else
+        test_fail "the oversized-prompt branch should use AGY_INLINE_DIRECTIVE_FILE, which permits reading the supplied prompt file and is cleared by the opt-out"
     fi
 }
 
@@ -719,6 +773,8 @@ test_agy_config_exists
 test_agy_available_agent
 test_agy_dispatch_native_flags
 test_agy_print_receives_prompt_argument
+test_agy_force_inline_directive_prepended_by_default
+test_agy_file_prompt_directive_permits_reading_prompt_file
 test_gemini_via_agy_option
 test_agy_dynamic_model_validation
 test_agy_command_validation


### PR DESCRIPTION
## Problem

`agy` seats can come back empty even when the CLI runs successfully.

`agy` is agentic. Given a council or analysis prompt it writes its real answer to an internal "brain" artifact (`~/.gemini/antigravity-cli/brain/<uuid>/*.md`) and returns only a short stub on stdout:

> Please find the detailed strategic breakdown and comparison in the artifact:

Or it returns nothing at all, when a tool it wants requires a permission headless mode cannot grant:

```
jetski: no output produced - a tool required the "command" permission that
headless mode cannot prompt for, so it was auto-denied.
```

Either way the seat is captured as empty. The adapter's existing silent-empty retry can't help here, because replaying the same prompt reproduces the same behaviour.

## Fix

Prepend an explicit inline-output directive to the prompt so the complete answer lands on stdout, where the seat actually captures it. Opt out with `OCTOPUS_AGY_FORCE_INLINE=0`.

Because a silently mutated prompt is hard to diagnose from the outside, the adapter also notes the injection on stderr under `OCTOPUS_DEBUG=true`. stdout is unaffected either way.

## Verification

Windows 11 / Git Bash, `agy` 1.1.4, octo 9.54.0.

Real council run, `--providers claude,agy --members 3`:

| | before | after |
|---|---|---|
| `responding_providers` | `claude claude` | `claude agy claude` |
| `distinct_providers` | 1 | 2 |
| agy response file | not written | written, substantive |

Directly against the adapter, the same council-shaped prompt returns a stub referencing an artifact without the directive, and a complete inline answer with it.

## Open questions, and I'd genuinely like maintainer input

**1. Tested on Windows only.** I have no macOS or Linux box to verify on. The failure mode itself looks platform-independent (it's about agy's agentic behaviour, not the OS) and the change is prompt text rather than OS-specific code, but I can't claim cross-platform verification. If someone can confirm agy behaves the same way on macOS/Linux, that would firm this up considerably.

**2. Default-on vs opt-in.** I've defaulted it **on**, reasoning that the current default silently produces empty seats, which is the worse failure. But this does change prompt content for every agy user on every platform, on the strength of one person's testing. I'm entirely happy to flip it to opt-in (`OCTOPUS_AGY_FORCE_INLINE=1` to enable) if you'd prefer the conservative default. Say the word and I'll push the change.

**3. Is the adapter the right layer?** Injecting prompt directives inside a CLI wrapper is arguably a separation-of-concerns violation, and you could reasonably argue this belongs in council prompt construction instead. I put it here because the behaviour being corrected is specific to the agy CLI rather than to councils generally, and every agy dispatch flows through this one file. If you'd rather it live in the orchestration layer, I'm glad to move it.

Filed separately from the `USERPROFILE` startup fix, which is independent and uncontroversial, so that one isn't blocked behind this discussion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Antigravity CLI prompts now prepend a “force inline output” directive by default, including the oversized-prompt file path.
  * Added configurable directive behavior via environment settings (with opt-out support).
* **Bug Fixes**
  * Hardened the Windows/Git-Bash `USERPROFILE` fallback so `cygpath` conversion failures no longer abort execution.
  * Improved argv-size/ceiling logic to account for the directive when choosing the prompt execution path.
* **Tests**
  * Updated and expanded unit coverage for `--print` argument construction, opt-out behavior, and oversized-prompt file flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->