### PR TITLE
fix: make configured multi-provider review reliable on Windows

### DIFF
--- a/bin/octopus
+++ b/bin/octopus
@@ -8,6 +8,7 @@
 #   octopus session    — Show current session info
 #   octopus fleet      — Show provider fleet status
 #   octopus agent-summary — Show current run provider status
+#   octopus gate status|acknowledge — Inspect or acknowledge a failed gate
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
@@ -43,6 +44,23 @@ case "${1:-help}" in
         shift
         "$ORCHESTRATE" agent-summary "$@"
         ;;
+    gate)
+        shift
+        gate_command="${1:-status}"
+        shift || true
+        case "$gate_command" in
+            status)
+                bash "${SCRIPT_DIR}/hooks/quality-gate.sh" --status "${1:-latest}"
+                ;;
+            ack|acknowledge)
+                bash "${SCRIPT_DIR}/hooks/quality-gate.sh" --ack "${1:-latest}"
+                ;;
+            *)
+                echo "Usage: octopus gate <status|acknowledge> [report]" >&2
+                exit 2
+                ;;
+        esac
+        ;;
     help|--help|-h|*)
         echo "octopus — Claude Octopus CLI"
         echo ""
@@ -54,6 +72,7 @@ case "${1:-help}" in
         echo "  session   Show current session info"
         echo "  fleet     Show provider fleet status"
         echo "  agent-summary  Show current run provider status"
+        echo "  gate      Show or acknowledge the current quality gate"
         echo "  help      Show this help"
         ;;
 esac

--- a/hooks/auto-router-inject.sh
+++ b/hooks/auto-router-inject.sh
@@ -7,6 +7,8 @@
 set -euo pipefail
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
+_OCTO_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_OCTO_HOOK_DIR/../scripts/lib/python-runtime.sh" 2>/dev/null || true
 
 escape_for_json() {
     local s="$1"

--- a/hooks/context-awareness.sh
+++ b/hooks/context-awareness.sh
@@ -20,6 +20,8 @@ set -euo pipefail
 # the hook's logic already handles. See issue #313.
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
+_OCTO_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_OCTO_HOOK_DIR/../scripts/lib/python-runtime.sh" 2>/dev/null || true
 
 
 # Read stdin (required by hook protocol — drain to prevent SIGPIPE)

--- a/hooks/context-reinforcement.sh
+++ b/hooks/context-reinforcement.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 # the hook's logic already handles. See issue #313.
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
+_OCTO_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_OCTO_HOOK_DIR/../scripts/lib/python-runtime.sh" 2>/dev/null || true
 
 
 # Read JSON payload from stdin (required by hook protocol)

--- a/hooks/done-criteria.sh
+++ b/hooks/done-criteria.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 # the hook's logic already handles. See issue #313.
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
+_OCTO_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_OCTO_HOOK_DIR/../scripts/lib/python-runtime.sh" 2>/dev/null || true
 
 
 # Read input with timeout guard

--- a/hooks/plan-mode-interceptor.sh
+++ b/hooks/plan-mode-interceptor.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 # the hook's logic already handles. See issue #313.
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
+_OCTO_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_OCTO_HOOK_DIR/../scripts/lib/python-runtime.sh" 2>/dev/null || true
 
 
 # Read JSON payload from stdin (required by hook protocol)

--- a/hooks/post-tool-dispatch.sh
+++ b/hooks/post-tool-dispatch.sh
@@ -16,6 +16,8 @@ set -euo pipefail
 # the hook's logic already handles. See issue #313.
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
+_OCTO_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_OCTO_HOOK_DIR/../scripts/lib/python-runtime.sh" 2>/dev/null || true
 
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"

--- a/hooks/provider-routing-validator.sh
+++ b/hooks/provider-routing-validator.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 # the hook's logic already handles. See issue #313.
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
+_OCTO_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_OCTO_HOOK_DIR/../scripts/lib/python-runtime.sh" 2>/dev/null || true
 
 
 # Get the plugin root directory

--- a/hooks/quality-gate.sh
+++ b/hooks/quality-gate.sh
@@ -11,20 +11,141 @@ set -euo pipefail
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
+QUALITY_GATE_RESULTS_DIR="${HOME}/.claude-octopus/results"
+QUALITY_GATE_ACK_DIR="${QUALITY_GATE_RESULTS_DIR}/quality-gate-ack"
+QUALITY_GATE_HOOK_INPUT=""
+if [[ $# -eq 0 && ! -t 0 ]]; then
+    QUALITY_GATE_HOOK_INPUT=$(cat 2>/dev/null || true)
+fi
 
-VALIDATION_FILE=$(ls -t ~/.claude-octopus/results/tangle-validation-*.md 2>/dev/null | head -1 || true)
+quality_gate_latest_report() {
+    ls -t "${QUALITY_GATE_RESULTS_DIR}"/tangle-validation-*.md 2>/dev/null | head -1 || true
+}
+
+quality_gate_report_value() {
+    local report="$1" label="$2"
+    awk -v prefix="## ${label}: " '
+        index($0, prefix) == 1 {
+            sub(prefix, "")
+            sub(/\r$/, "")
+            print
+            exit
+        }
+    ' "$report" 2>/dev/null || true
+}
+
+quality_gate_fingerprint() {
+    cksum "$1" 2>/dev/null | awk '{print $1 ":" $2}'
+}
+
+quality_gate_current_session() {
+    local session="${CLAUDE_SESSION_ID:-${OCTOPUS_SESSION_ID:-}}"
+    if [[ -z "$session" && -n "$QUALITY_GATE_HOOK_INPUT" ]] && command -v jq >/dev/null 2>&1; then
+        session=$(printf '%s' "$QUALITY_GATE_HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+    fi
+    printf '%s\n' "$session"
+}
+
+quality_gate_context_matches() {
+    local report="$1"
+    local report_workspace report_session current_workspace current_session
+    report_workspace=$(quality_gate_report_value "$report" "Workspace")
+    report_session=$(quality_gate_report_value "$report" "Session")
+    current_workspace=$(pwd -P)
+    current_session=$(quality_gate_current_session)
+
+    # Legacy unscoped reports are retained as evidence but cannot globally
+    # intercept unrelated sessions or workspaces.
+    [[ -n "$report_workspace" && -n "$report_session" ]] || return 1
+    [[ "$report_session" != "unknown" && -n "$current_session" ]] || return 1
+    [[ "$report_workspace" == "$current_workspace" ]] || return 1
+    [[ "$report_session" == "$current_session" ]] || return 1
+}
+
+quality_gate_find_matching_report() {
+    local candidate
+    while IFS= read -r candidate; do
+        [[ -f "$candidate" ]] || continue
+        if quality_gate_context_matches "$candidate"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done < <(ls -t "${QUALITY_GATE_RESULTS_DIR}"/tangle-validation-*.md 2>/dev/null || true)
+    return 1
+}
+
+quality_gate_ack_file() {
+    local report="$1" gate_id
+    gate_id=$(quality_gate_report_value "$report" "Gate ID")
+    [[ "$gate_id" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
+    printf '%s/%s.ack\n' "$QUALITY_GATE_ACK_DIR" "$gate_id"
+}
+
+quality_gate_is_acknowledged() {
+    local report="$1" ack_file fingerprint
+    ack_file=$(quality_gate_ack_file "$report") || return 1
+    [[ -f "$ack_file" ]] || return 1
+    fingerprint=$(quality_gate_fingerprint "$report")
+    [[ "$(<"$ack_file")" == "$fingerprint" ]]
+}
+
+quality_gate_acknowledge() {
+    local report="${1:-}"
+    [[ -n "$report" && "$report" != "latest" ]] || report=$(quality_gate_latest_report)
+    [[ -f "$report" ]] || { echo "No tangle validation report found." >&2; return 1; }
+
+    local gate_id ack_file fingerprint
+    gate_id=$(quality_gate_report_value "$report" "Gate ID")
+    ack_file=$(quality_gate_ack_file "$report") || {
+        echo "Cannot acknowledge an unscoped legacy validation report." >&2
+        return 1
+    }
+    fingerprint=$(quality_gate_fingerprint "$report")
+    mkdir -p "$QUALITY_GATE_ACK_DIR"
+    printf '%s\n' "$fingerprint" > "$ack_file"
+    echo "Acknowledged quality gate ${gate_id}: ${report}"
+}
+
+quality_gate_status() {
+    local report="${1:-}"
+    [[ -n "$report" && "$report" != "latest" ]] || report=$(quality_gate_find_matching_report 2>/dev/null || quality_gate_latest_report)
+    [[ -f "$report" ]] || { echo "No tangle validation report found."; return 0; }
+    local gate_id status state="pending"
+    gate_id=$(quality_gate_report_value "$report" "Gate ID")
+    status=$(grep -E '^#{2,3}[[:space:]]+(Quality Gate|Status):' "$report" 2>/dev/null | head -1 || true)
+    quality_gate_is_acknowledged "$report" && state="acknowledged"
+    echo "Gate: ${gate_id:-legacy}"
+    echo "State: ${state}"
+    echo "Status: ${status:-unknown}"
+    echo "Report: ${report}"
+}
+
+case "${1:-}" in
+    --ack|ack|acknowledge)
+        shift
+        quality_gate_acknowledge "${1:-latest}"
+        exit $?
+        ;;
+    --status|status)
+        shift
+        quality_gate_status "${1:-latest}"
+        exit $?
+        ;;
+esac
+
+VALIDATION_FILE=$(quality_gate_find_matching_report 2>/dev/null || true)
 
 if [[ -f "$VALIDATION_FILE" ]]; then
     # Check if quality gate passed. `|| true` — grep-no-match must not cascade
     # under `set -o pipefail` and trigger the silent-fail path (issue #313).
-    STATUS=$(grep -E "^## (Quality Gate|Status):" "$VALIDATION_FILE" 2>/dev/null | head -1 || true)
+    STATUS=$(grep -E '^#{2,3}[[:space:]]+(Quality Gate|Status):' "$VALIDATION_FILE" 2>/dev/null | head -1 || true)
 
-    if echo "$STATUS" | grep -qi "failed"; then
+    if ! quality_gate_is_acknowledged "$VALIDATION_FILE" && echo "$STATUS" | grep -qi "failed"; then
         echo '{"decision": "block", "reason": "Quality gate validation failed. Review tangle output before proceeding."}'
         exit 0
     fi
 
-    if echo "$STATUS" | grep -qi "warning"; then
+    if ! quality_gate_is_acknowledged "$VALIDATION_FILE" && echo "$STATUS" | grep -qi "warning"; then
         echo '{"decision": "block", "reason": "Quality gate has warnings. Review tangle output before proceeding."}'
         exit 0
     fi

--- a/hooks/quality-gate.sh
+++ b/hooks/quality-gate.sh
@@ -91,8 +91,8 @@ quality_gate_is_acknowledged() {
 
 quality_gate_acknowledge() {
     local report="${1:-}"
-    [[ -n "$report" && "$report" != "latest" ]] || report=$(quality_gate_latest_report)
-    [[ -f "$report" ]] || { echo "No tangle validation report found." >&2; return 1; }
+    [[ -n "$report" && "$report" != "latest" ]] || report=$(quality_gate_find_matching_report 2>/dev/null || true)
+    [[ -f "$report" ]] || { echo "No active quality gate for this workspace/session." >&2; return 1; }
 
     local gate_id ack_file fingerprint
     gate_id=$(quality_gate_report_value "$report" "Gate ID")
@@ -108,8 +108,8 @@ quality_gate_acknowledge() {
 
 quality_gate_status() {
     local report="${1:-}"
-    [[ -n "$report" && "$report" != "latest" ]] || report=$(quality_gate_find_matching_report 2>/dev/null || quality_gate_latest_report)
-    [[ -f "$report" ]] || { echo "No tangle validation report found."; return 0; }
+    [[ -n "$report" && "$report" != "latest" ]] || report=$(quality_gate_find_matching_report 2>/dev/null || true)
+    [[ -f "$report" ]] || { echo "No active quality gate for this workspace/session."; return 0; }
     local gate_id status state="pending"
     gate_id=$(quality_gate_report_value "$report" "Gate ID")
     status=$(grep -E '^#{2,3}[[:space:]]+(Quality Gate|Status):' "$report" 2>/dev/null | head -1 || true)

--- a/hooks/subagent-result-capture.sh
+++ b/hooks/subagent-result-capture.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 # the hook's logic already handles. See issue #313.
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
+_OCTO_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_OCTO_HOOK_DIR/../scripts/lib/python-runtime.sh" 2>/dev/null || true
 
 
 WORKSPACE_DIR="${OCTOPUS_WORKSPACE:-${HOME}/.claude-octopus}"

--- a/hooks/subagent-stop-gate.sh
+++ b/hooks/subagent-stop-gate.sh
@@ -23,6 +23,8 @@ set -euo pipefail
 # the hook's logic already handles. See issue #313.
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
+_OCTO_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_OCTO_HOOK_DIR/../scripts/lib/python-runtime.sh" 2>/dev/null || true
 
 WORKSPACE_DIR="${OCTOPUS_WORKSPACE:-${HOME}/.claude-octopus}"
 USAGE_DIR="${WORKSPACE_DIR}/usage"

--- a/hooks/task-completion-checkpoint.sh
+++ b/hooks/task-completion-checkpoint.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 # the hook's logic already handles. See issue #313.
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
+_OCTO_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_OCTO_HOOK_DIR/../scripts/lib/python-runtime.sh" 2>/dev/null || true
 
 
 # Get the plugin root directory

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -22,6 +22,8 @@ set -euo pipefail
 # the hook's logic already handles. See issue #313.
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
+_OCTO_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_OCTO_HOOK_DIR/../scripts/lib/python-runtime.sh" 2>/dev/null || true
 
 escape_for_json() {
     local s="$1"

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -5,7 +5,7 @@
 # Replaces hardcoded fleet tables in skill files.
 #
 # Usage: build-fleet.sh <workflow> <intensity> [prompt]
-#   workflow:  research | review | security | architecture | debate
+#   workflow:  research | review | develop | security | architecture | debate
 #   intensity: quick | standard | deep
 #   prompt:    (optional) the user's prompt, used for context-aware assignment
 #
@@ -24,6 +24,11 @@ source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/auth.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/qwen.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/grok.sh" 2>/dev/null || true
+# The code-review pipeline owns the configured review-roster parser. Reuse it
+# here so skill-facing banners and the runtime dispatch cannot build different
+# fleets from the same providers.json.
+if ! declare -f log >/dev/null 2>&1; then log() { :; }; fi
+source "${SCRIPT_DIR}/../lib/review.sh" 2>/dev/null || true
 
 WORKFLOW="${1:-research}"
 INTENSITY="${2:-standard}"
@@ -257,6 +262,29 @@ build_research_fleet() {
 
 # ── Review Fleet ──────────────────────────────────────────────────────────────
 build_review_fleet() {
+    local configured_fleet=""
+    if declare -f _review_fleet_from_config >/dev/null 2>&1; then
+        configured_fleet=$(_review_fleet_from_config)
+    fi
+    if [[ -n "$configured_fleet" ]]; then
+        local configured_agent configured_role configured_specialty configured_label
+        while IFS=':' read -r configured_agent configured_role configured_specialty; do
+            configured_agent=${configured_agent//$'\r'/}
+            [[ -z "$configured_agent" ]] && continue
+            case "$configured_role" in
+                logic-reviewer) configured_label="Logic Reviewer" ;;
+                security-reviewer) configured_label="Security Reviewer" ;;
+                arch-reviewer) configured_label="Architecture Reviewer" ;;
+                cve-reviewer) configured_label="CVE Reviewer" ;;
+                diversity-reviewer) configured_label="Diversity Reviewer" ;;
+                *) configured_label="Configured Reviewer" ;;
+            esac
+            emit "$configured_agent" "$configured_label" \
+                "Review $PROMPT for ${configured_specialty:-the configured perspective}."
+        done <<< "$configured_fleet"
+        return 0
+    fi
+
     local logic_provider
     logic_provider=$(pick_provider "claude-sonnet" codex opencode copilot)
     [[ -n "$logic_provider" ]] && emit "$logic_provider" "Logic Reviewer" "Review for correctness and logic bugs, edge cases, regressions in: $PROMPT"
@@ -353,7 +381,7 @@ build_architecture_fleet() {
 # Normalize workflow name
 case "$WORKFLOW" in
     research|discover)     build_research_fleet ;;
-    review|security)       build_review_fleet ;;
+    review|develop|development|security) build_review_fleet ;;
     debate)                build_debate_fleet ;;
     architecture)          build_architecture_fleet ;;
     *)                     build_research_fleet ;;

--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -68,12 +68,12 @@ ensure_config() {
   "version": "3.0",
   "providers": {
     "codex": {
-      "default": "gpt-5.4",
-      "fallback": "gpt-5.4",
-      "spark": "gpt-5.4",
-      "mini": "gpt-5.4-mini",
-      "reasoning": "o3",
-      "large_context": "gpt-5.4"
+      "default": "gpt-5.6-sol",
+      "fallback": "gpt-5.6-sol",
+      "spark": "gpt-5.6-sol",
+      "mini": "gpt-5.6-sol",
+      "reasoning": "gpt-5.6-sol",
+      "large_context": "gpt-5.6-sol"
     },
     "gemini": {
       "default": "gemini-3.1-pro-preview",
@@ -593,6 +593,7 @@ cmd_models() {
 
     # Inline catalog (matches orchestrate.sh get_model_catalog)
     local -a models=(
+        "gpt-5.6-sol|400|yes|yes|yes|codex|premium|active"
         "gpt-5.4|400|yes|yes|no|codex|standard|active"
         "gpt-5.4-pro|400|yes|yes|no|codex|premium|active"
         "gpt-5.3-codex|400|yes|yes|no|codex|standard|active"

--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -23,7 +23,7 @@ PROVIDERS = {
 
 
 def configure_utf8_stdio(*streams) -> None:
-    targets = streams or (sys.stdout, sys.stderr)
+    targets = streams or (sys.stdin, sys.stdout, sys.stderr)
     for stream in targets:
         reconfigure = getattr(stream, "reconfigure", None)
         if callable(reconfigure):

--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python3
-import argparse, json, os, subprocess, sys, time, urllib.parse, urllib.request, urllib.error
+import argparse, json, os, re, subprocess, sys, time, urllib.parse, urllib.request, urllib.error
 from pathlib import Path
 
 PROVIDERS = {
     "generic": {"base_url": "", "api_key_env": "OPENAI_API_KEY", "model": "", "headers": {}},
+    "openrouter": {
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "model": "",
+        "headers": {
+            "HTTP-Referer": "https://github.com/nyldn/claude-octopus",
+            "X-Title": "Claude Octopus",
+        },
+    },
     "atlascloud": {
         "base_url": "https://api.atlascloud.ai/v1",
         "api_key_env": "ATLASCLOUD_API_KEY",
@@ -35,12 +44,23 @@ def env_float(name: str, default: float, minimum: float = 0.1) -> float:
         return default
     return max(minimum, value)
 
-TOOLS = [
+READ_ONLY_TOOLS = [
     {"type":"function","function":{"name":"read_file","description":"Read a UTF-8 file under cwd.","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}},
+    {"type":"function","function":{"name":"list_files","description":"List files under a path within cwd.","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}},
+    {"type":"function","function":{"name":"git_status","description":"Return concise git status for cwd.","parameters":{"type":"object","properties":{}}}},
+    {"type":"function","function":{"name":"git_diff","description":"Return staged and unstaged git diff for cwd.","parameters":{"type":"object","properties":{}}}},
+]
+
+WRITE_TOOLS = [
     {"type":"function","function":{"name":"write_file","description":"Write UTF-8 content to a file under cwd.","parameters":{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}}},
     {"type":"function","function":{"name":"run_command","description":"Run a shell command in cwd with a short timeout.","parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}},
-    {"type":"function","function":{"name":"git_diff","description":"Return git diff for cwd.","parameters":{"type":"object","properties":{}}}},
 ]
+
+TOOLS = READ_ONLY_TOOLS + WRITE_TOOLS
+
+
+def tools_for_mode(mode: str) -> list:
+    return READ_ONLY_TOOLS if mode == "readonly" else TOOLS
 
 def resolve_path(cwd: Path, rel: str) -> Path:
     p = (cwd / rel).resolve(); c = cwd.resolve()
@@ -48,10 +68,29 @@ def resolve_path(cwd: Path, rel: str) -> Path:
         raise ValueError("path escapes cwd")
     return p
 
-def tool_exec(cwd: Path, name: str, args: dict) -> str:
+def tool_exec(cwd: Path, name: str, args: dict, tool_mode: str = "full") -> str:
     try:
+        allowed = {item["function"]["name"] for item in tools_for_mode(tool_mode)}
+        if name not in allowed:
+            return f"ERROR: tool {name} is unavailable in {tool_mode} mode"
         if name == "read_file":
             return resolve_path(cwd, str(args.get("path", ""))).read_text(encoding="utf-8", errors="replace")[:20000]
+        if name == "list_files":
+            base = resolve_path(cwd, str(args.get("path", ".")))
+            if base.is_file():
+                return str(base.relative_to(cwd.resolve()))
+            files = []
+            for path in sorted(base.rglob("*")):
+                if path.is_file() and ".git" not in path.parts:
+                    files.append(str(path.relative_to(cwd.resolve())))
+                    if len(files) >= 500:
+                        files.append("... output limited to 500 files")
+                        break
+            return "\n".join(files)
+        if name == "git_status":
+            timeout = env_float("OPENAI_COMPAT_COMMAND_TIMEOUT", 20.0)
+            r = subprocess.run(["git", "status", "--short"], cwd=str(cwd), text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout, check=False)
+            return (f"exit={r.returncode}\n" + r.stdout)[-20000:]
         if name == "write_file":
             p = resolve_path(cwd, str(args.get("path", ""))); p.parent.mkdir(parents=True, exist_ok=True)
             p.write_text(str(args.get("content", "")), encoding="utf-8")
@@ -64,14 +103,17 @@ def tool_exec(cwd: Path, name: str, args: dict) -> str:
             return (f"exit={r.returncode}\n" + r.stdout)[-20000:]
         if name == "git_diff":
             timeout = env_float("OPENAI_COMPAT_COMMAND_TIMEOUT", 20.0)
-            r = subprocess.run(["git", "diff", "--", "."], cwd=str(cwd), text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout, check=False)
-            return (f"exit={r.returncode}\n" + r.stdout)[-30000:]
+            unstaged = subprocess.run(["git", "diff", "--", "."], cwd=str(cwd), text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout, check=False)
+            staged = subprocess.run(["git", "diff", "--cached", "--", "."], cwd=str(cwd), text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout, check=False)
+            combined = f"UNSTAGED exit={unstaged.returncode}\n{unstaged.stdout}\nSTAGED exit={staged.returncode}\n{staged.stdout}"
+            return combined[-40000:]
         return f"ERROR: unknown tool {name}"
     except Exception as e:
         return f"ERROR: {type(e).__name__}: {e}"
 
-def api_call(base_url, key, model, headers_extra, messages, max_tokens=1400, request_timeout=60.0, max_retries=3, reasoning_effort=None, reasoning_policy="best_effort"):
-    payload = {"model": model, "messages": messages, "tools": TOOLS, "tool_choice": "auto", "temperature": 0}
+def api_call(base_url, key, model, headers_extra, messages, max_tokens=1400, request_timeout=60.0, max_retries=3, reasoning_effort=None, reasoning_policy="best_effort", tools=None):
+    active_tools = TOOLS if tools is None else tools
+    payload = {"model": model, "messages": messages, "tools": active_tools, "tool_choice": "auto", "temperature": 0}
     if reasoning_effort:
         payload["reasoning_effort"] = reasoning_effort
     if max_tokens > 0:
@@ -109,6 +151,7 @@ def api_call(base_url, key, model, headers_extra, messages, max_tokens=1400, req
                     max_retries=max_retries,
                     reasoning_effort=None,
                     reasoning_policy="strict",
+                    tools=active_tools,
                 )
             last_error = RuntimeError(f"HTTP {e.code}: {body_text}")
             print(f"chat_error attempt={attempt}/{max(1, max_retries)} status={e.code} elapsed={time.time() - started:.2f}s", file=sys.stderr)
@@ -126,6 +169,23 @@ def parse_args(raw: str) -> dict:
     try: return json.loads(raw or "{}")
     except Exception: return {"_raw": raw}
 
+
+def is_unevaluated_tool_text(content: str) -> bool:
+    text = content.strip()
+    if not text:
+        return False
+    if re.search(r"<\s*(tool_call|function_call|function_calls)\b", text, re.IGNORECASE):
+        return True
+    # Intent-only transitions are intermediate agent messages, not verdicts.
+    return bool(
+        len(text) < 1200
+        and re.search(
+            r"(?:^|\n)\s*(?:i(?:'ll| will| need to)|let me)\s+(?:first\s+)?(?:inspect|read|check|run|look|review)\b",
+            text,
+            re.IGNORECASE,
+        )
+    )
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--provider", choices=sorted(PROVIDERS), default="generic")
@@ -133,6 +193,7 @@ def main() -> int:
     ap.add_argument("--cwd", required=True); ap.add_argument("--max-turns", type=int, default=env_int("OPENAI_COMPAT_MAX_TURNS", 20, 1)); ap.add_argument("--prompt")
     ap.add_argument("--reasoning-effort", choices=["low", "medium", "high", "xhigh", "max"])
     ap.add_argument("--reasoning-policy", choices=["strict", "best_effort"], default="best_effort")
+    ap.add_argument("--tool-mode", choices=["full", "readonly"], default="full")
     args = ap.parse_args(); cfg = PROVIDERS[args.provider]
     base_url = args.base_url or os.environ.get("OPENAI_COMPAT_BASE_URL") or cfg["base_url"]
     key_env = args.api_key_env or os.environ.get("OPENAI_COMPAT_API_KEY_ENV") or cfg["api_key_env"]
@@ -152,15 +213,24 @@ def main() -> int:
     request_timeout = env_float("OPENAI_COMPAT_REQUEST_TIMEOUT", 60.0)
     max_retries = env_int("OPENAI_COMPAT_MAX_RETRIES", 3, 1)
     cwd = Path(args.cwd).resolve(); prompt = args.prompt if args.prompt is not None else sys.stdin.read()
+    system_prompt = (
+        "You are a read-only code-review agent. Use the provided structured tools to inspect the worktree. "
+        "Never modify files. Do not stop after announcing what you will inspect and never print tool calls as text. "
+        "Finish with a visible evidence-based verdict."
+        if args.tool_mode == "readonly"
+        else
+        "You are a coding agent. Use tools when needed. For implementation tasks, edit files, call git_diff before final, and do not stop after only reading files. Final answer must be visible text. If a verification command fails because a local dependency or tool is missing, stop retrying that same command, call git_diff if not already done, and give a final answer that reports the blocker and the worktree changes."
+    )
+    active_tools = tools_for_mode(args.tool_mode)
     messages = [
-        {"role":"system","content":"You are a coding agent. Use tools when needed. For implementation tasks, edit files, call git_diff before final, and do not stop after only reading files. Final answer must be visible text. If a verification command fails because a local dependency or tool is missing, stop retrying that same command, call git_diff if not already done, and give a final answer that reports the blocker and the worktree changes."},
+        {"role":"system","content":system_prompt},
         {"role":"user","content":prompt},
     ]
     print(f"provider={args.provider} base_url={base_url} model={model} cwd={cwd}", file=sys.stderr)
     requested_reasoning = args.reasoning_effort or "none"
     print(f"chat_reasoning requested={requested_reasoning} policy={args.reasoning_policy}", file=sys.stderr)
     for turn in range(1, args.max_turns + 1):
-        d = api_call(base_url, key, model, cfg.get("headers", {}), messages, max_tokens=max_tokens, request_timeout=request_timeout, max_retries=max_retries, reasoning_effort=args.reasoning_effort, reasoning_policy=args.reasoning_policy)
+        d = api_call(base_url, key, model, cfg.get("headers", {}), messages, max_tokens=max_tokens, request_timeout=request_timeout, max_retries=max_retries, reasoning_effort=args.reasoning_effort, reasoning_policy=args.reasoning_policy, tools=active_tools)
         ch = d.get("choices", [{}])[0]; msg = ch.get("message", {})
         finish = ch.get("finish_reason")
         raw_content = msg.get("content")
@@ -176,9 +246,14 @@ def main() -> int:
             messages.append({"role":"assistant", "content": content, "tool_calls": calls})
             for tc in calls:
                 fn = (tc.get("function") or {}).get("name", ""); raw = (tc.get("function") or {}).get("arguments", "{}")
-                out = tool_exec(cwd, fn, parse_args(raw))
+                out = tool_exec(cwd, fn, parse_args(raw), args.tool_mode)
                 print(f"tool {fn} -> {len(out)} chars", file=sys.stderr)
                 messages.append({"role":"tool", "tool_call_id": tc.get("id"), "name": fn, "content": out})
+            continue
+        if is_unevaluated_tool_text(content):
+            print("unevaluated_tool_text detected; requesting structured continuation", file=sys.stderr)
+            messages.append({"role":"assistant", "content":content})
+            messages.append({"role":"user", "content":"Your previous response stopped at an unevaluated tool call or an intent-only transition. Use the provided structured tools now, then return a visible evidence-based verdict."})
             continue
         if content.strip():
             print(content); return 0

--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -33,6 +33,17 @@ def configure_utf8_stdio(*streams) -> None:
                 pass
 
 
+def normalize_cli_path(value: str) -> str:
+    if os.name != "nt":
+        return value
+    match = re.match(r"^/(?:cygdrive/)?([A-Za-z])(?:/(.*))?$", value)
+    if not match:
+        return value
+    drive = match.group(1).upper()
+    tail = (match.group(2) or "").replace("/", "\\")
+    return f"{drive}:\\{tail}"
+
+
 def env_int(name: str, default: int, minimum: int = 0) -> int:
     raw = os.environ.get(name, "")
     if raw == "":
@@ -224,7 +235,7 @@ def main() -> int:
     max_tokens = env_int("OPENAI_COMPAT_MAX_TOKENS", 1400, 0)
     request_timeout = env_float("OPENAI_COMPAT_REQUEST_TIMEOUT", 60.0)
     max_retries = env_int("OPENAI_COMPAT_MAX_RETRIES", 3, 1)
-    cwd = Path(args.cwd).resolve(); prompt = args.prompt if args.prompt is not None else sys.stdin.read()
+    cwd = Path(normalize_cli_path(args.cwd)).resolve(); prompt = args.prompt if args.prompt is not None else sys.stdin.read()
     system_prompt = (
         "You are a read-only code-review agent. Use the provided structured tools to inspect the worktree. "
         "Never modify files. Do not stop after announcing what you will inspect and never print tool calls as text. "

--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -22,6 +22,17 @@ PROVIDERS = {
 }
 
 
+def configure_utf8_stdio(*streams) -> None:
+    targets = streams or (sys.stdout, sys.stderr)
+    for stream in targets:
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (AttributeError, ValueError, OSError):
+                pass
+
+
 def env_int(name: str, default: int, minimum: int = 0) -> int:
     raw = os.environ.get(name, "")
     if raw == "":
@@ -187,6 +198,7 @@ def is_unevaluated_tool_text(content: str) -> bool:
     )
 
 def main() -> int:
+    configure_utf8_stdio()
     ap = argparse.ArgumentParser()
     ap.add_argument("--provider", choices=sorted(PROVIDERS), default="generic")
     ap.add_argument("--base-url"); ap.add_argument("--api-key-env"); ap.add_argument("--model")

--- a/scripts/helpers/openai-compatible-agent.sh
+++ b/scripts/helpers/openai-compatible-agent.sh
@@ -2,9 +2,18 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER_PATH="$SCRIPT_DIR/openai-compatible-agent.py"
+
+case "$(uname -s 2>/dev/null || true)" in
+    MINGW*|MSYS*|CYGWIN*)
+        if command -v cygpath >/dev/null 2>&1; then
+            HELPER_PATH="$(cygpath -w "$HELPER_PATH")"
+        fi
+        ;;
+esac
 
 if [[ -n "${OCTOPUS_PYTHON_BIN:-}" ]]; then
-    exec "$OCTOPUS_PYTHON_BIN" "$SCRIPT_DIR/openai-compatible-agent.py" "$@"
+    exec "$OCTOPUS_PYTHON_BIN" "$HELPER_PATH" "$@"
 fi
 
 is_windows_alias() {
@@ -23,16 +32,16 @@ for candidate in "${candidates[@]}"; do
     resolved="$(command -v "$candidate" 2>/dev/null || true)"
     [[ -n "$resolved" ]] || continue
     is_windows_alias "$resolved" && continue
-    exec "$resolved" "$SCRIPT_DIR/openai-compatible-agent.py" "$@"
+    exec "$resolved" "$HELPER_PATH" "$@"
 done
 
 for candidate in "${HOME}"/.cache/codex-runtimes/*/dependencies/python/python.exe; do
     [[ -x "$candidate" ]] || continue
-    exec "$candidate" "$SCRIPT_DIR/openai-compatible-agent.py" "$@"
+    exec "$candidate" "$HELPER_PATH" "$@"
 done
 
 if command -v py >/dev/null 2>&1; then
-    exec py -3 "$SCRIPT_DIR/openai-compatible-agent.py" "$@"
+    exec py -3 "$HELPER_PATH" "$@"
 fi
 
 echo "ERROR: no real Python runtime found; set OCTOPUS_PYTHON_BIN" >&2

--- a/scripts/helpers/openai-compatible-agent.sh
+++ b/scripts/helpers/openai-compatible-agent.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -n "${OCTOPUS_PYTHON_BIN:-}" ]]; then
+    exec "$OCTOPUS_PYTHON_BIN" "$SCRIPT_DIR/openai-compatible-agent.py" "$@"
+fi
+
+is_windows_alias() {
+    case "${1:-}" in
+        *Microsoft/WindowsApps*|*Microsoft\\WindowsApps*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+case "$(uname -s 2>/dev/null || true)" in
+    MINGW*|MSYS*|CYGWIN*) candidates=(python python3) ;;
+    *) candidates=(python3 python) ;;
+esac
+
+for candidate in "${candidates[@]}"; do
+    resolved="$(command -v "$candidate" 2>/dev/null || true)"
+    [[ -n "$resolved" ]] || continue
+    is_windows_alias "$resolved" && continue
+    exec "$resolved" "$SCRIPT_DIR/openai-compatible-agent.py" "$@"
+done
+
+for candidate in "${HOME}"/.cache/codex-runtimes/*/dependencies/python/python.exe; do
+    [[ -x "$candidate" ]] || continue
+    exec "$candidate" "$SCRIPT_DIR/openai-compatible-agent.py" "$@"
+done
+
+if command -v py >/dev/null 2>&1; then
+    exec py -3 "$SCRIPT_DIR/openai-compatible-agent.py" "$@"
+fi
+
+echo "ERROR: no real Python runtime found; set OCTOPUS_PYTHON_BIN" >&2
+exit 127

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -243,8 +243,18 @@ ${provider_ctx}"
     # Capture output and exit code separately
     local output
     local exit_code
-    local temp_err="${RESULTS_DIR}/.tmp-agent-error-$$.err"
-    local temp_out="${RESULTS_DIR}/.tmp-agent-out-$$.out"
+    local temp_err
+    local temp_out
+    mkdir -p "${RESULTS_DIR}" 2>/dev/null || true
+    if ! temp_err=$(mktemp "${RESULTS_DIR}/.tmp-agent-error.XXXXXX"); then
+        log ERROR "Could not create isolated stderr capture for $agent_type"
+        return 1
+    fi
+    if ! temp_out=$(mktemp "${RESULTS_DIR}/.tmp-agent-out.XXXXXX"); then
+        log ERROR "Could not create isolated stdout capture for $agent_type"
+        rm -f "$temp_err"
+        return 1
+    fi
 
     # v8.10.0: Gemini uses stdin-based prompt delivery (Issue #25)
     # -p "" triggers headless mode; prompt content comes via stdin to avoid OS arg limits
@@ -265,8 +275,7 @@ ${provider_ctx}"
     local _quota_watcher_pid=""
     local _dispatch_pid=""
 
-    # Always init temp files so readers never fail on missing file.
-    mkdir -p "${RESULTS_DIR}" 2>/dev/null || true
+    # Always initialize the per-call files so readers never see stale content.
     > "$temp_err"
     > "$temp_out"
 

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -39,6 +39,18 @@ fleet_dispatch_end() {
 should_use_agent_teams() {
     local agent_type="$1"
 
+    # Native Agent Teams instructions are consumed only by the Claude Code host.
+    # Codex/Gemini/standalone subprocesses can have a recent Claude CLI installed
+    # (and therefore SUPPORTS_STABLE_AGENT_TEAMS=true) without any host-side Agent
+    # tool to pick up the instruction. In those hosts, invoke Claude CLI directly.
+    case "${OCTOPUS_HOST:-claude}" in
+        claude) ;;
+        *)
+            log "DEBUG" "Non-Claude host (${OCTOPUS_HOST:-unknown}) — skipping Agent Teams for $agent_type"
+            return 1
+            ;;
+    esac
+
     # P0-B fix: When orchestrate.sh runs as a Bash tool subprocess (not inside
     # Claude Code's native context), Agent Teams JSON instruction files are never
     # picked up and SubagentStop hooks never fire.  Probe phase sets this flag

--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -44,23 +44,23 @@ _BARE_OPT="${_BARE_OPT:-}"
 #
 # v9.29: Role defaults refreshed based on April 2026 benchmark + forum consensus.
 #   - architect/strategist/security-reviewer → claude-opus (SWE-bench Pro 64.3, LMArena #1, MCP-Atlas +9.2)
-#   - code-reviewer/implementer              → gpt-5.5    (Terminal-Bench 75.1, edge-case review)
+#   - code-reviewer/implementer              → gpt-5.6-sol (ChatGPT subscription Codex seat)
 # Opt-out:   OCTOPUS_LEGACY_ROLES=1 restores the v9.28 mapping.
 # Fallback:  consumers (see lib/agents.sh get_fallback_agent) silently downshift when the
-#            preferred CLI is unavailable (e.g. no Anthropic auth → architect → gpt-5.5).
+#            preferred CLI is unavailable (e.g. no Anthropic auth → architect → GPT-5.6 Sol).
 get_role_mapping() {
     local role="$1"
 
     # Legacy opt-out — v9.28 mapping, preserved verbatim.
     if [[ "${OCTOPUS_LEGACY_ROLES:-0}" == "1" ]]; then
         case "$role" in
-            architect)    echo "codex:gpt-5.5" ;;
+            architect)    echo "codex:gpt-5.6-sol" ;;
             researcher)   echo "gemini:gemini-3.1-pro-preview" ;;
-            reviewer|code-reviewer|security-reviewer) echo "codex-review:gpt-5.5" ;;
-            implementer|implementer-heavy) echo "codex:gpt-5.5" ;;
+            reviewer|code-reviewer|security-reviewer) echo "codex-review:gpt-5.6-sol" ;;
+            implementer|implementer-heavy) echo "codex:gpt-5.6-sol" ;;
             synthesizer)  echo "claude:claude-sonnet-4.6" ;;
             strategist)   echo "claude-opus:claude-opus-4.6" ;;
-            *)            echo "codex:gpt-5.5" ;;
+            *)            echo "codex:gpt-5.6-sol" ;;
         esac
         return 0
     fi
@@ -68,13 +68,13 @@ get_role_mapping() {
     case "$role" in
         architect)         echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-4.7)" ;;  # Planning, UI/UX, architecture
         researcher)        echo "agy:Gemini 3.1 Pro (High)" ;;                                             # Deep investigation via Antigravity (Google seat)
-        reviewer|code-reviewer) echo "codex-review:gpt-5.5" ;;                                              # Code review, edge cases; `reviewer` = alias
+        reviewer|code-reviewer) echo "codex-review:gpt-5.6-sol" ;;                                          # Code review, edge cases; `reviewer` = alias
         security-reviewer) echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-4.7)" ;;  # Adversarial reasoning
-        implementer)       echo "codex:gpt-5.5" ;;                                                          # Default code generation; terminal-heavy
+        implementer)       echo "codex:gpt-5.6-sol" ;;                                                      # Default code generation; terminal-heavy
         implementer-heavy) echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-4.7)" ;;  # Opt-in: greenfield/refactor/UI-heavy
         synthesizer)       echo "claude:claude-sonnet-4.6" ;;                                               # Result aggregation
         strategist)        echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-4.7)" ;;  # Premium synthesis
-        *)                 echo "codex:gpt-5.5" ;;                                                          # Safe default
+        *)                 echo "codex:gpt-5.6-sol" ;;                                                      # Safe default
     esac
 }
 

--- a/scripts/lib/agents.sh
+++ b/scripts/lib/agents.sh
@@ -406,6 +406,20 @@ load_agent_skill_content() {
     fi
 
     if [[ -f "$skill_file" ]]; then
+        # Enforced command skills are host-side orchestration contracts. Injecting
+        # one into a provider prompt asks the child model to recursively launch
+        # Octopus (and can reintroduce disallowed providers). Keep domain-only
+        # skills, but never pass a host execution contract across the boundary.
+        if awk '
+            BEGIN { in_fm=0; enforced=0 }
+            /^---$/ { in_fm=!in_fm; if (!in_fm) exit }
+            in_fm && /^[[:space:]]*execution_mode:[[:space:]]*enforced[[:space:]]*$/ { enforced=1 }
+            END { exit enforced ? 0 : 1 }
+        ' "$skill_file" 2>/dev/null && grep -q 'orchestrate\.sh' "$skill_file" 2>/dev/null; then
+            log "DEBUG" "Skipping host-only orchestration skill in provider context: $skill_name" 2>/dev/null || true
+            return 0
+        fi
+
         # Extract content after YAML frontmatter
         awk '
             BEGIN { in_fm=0; past_fm=0 }

--- a/scripts/lib/agents.sh
+++ b/scripts/lib/agents.sh
@@ -320,11 +320,56 @@ get_agent_config() {
         found && /^  [a-z]/ { found=0 }
         found && $0 ~ "^    " field ":" {
             gsub(/^[[:space:]]*[a-z_]+:[[:space:]]*/, "")
+            sub(/[[:space:]]+#.*$/, "")
+            sub(/[[:space:]]+$/, "")
             gsub(/[\[\]"]/, "")
             print
             exit
         }
     ' "$AGENTS_CONFIG"
+}
+
+# Resolve an explicit curated persona to the first configured provider executor
+# that is both allowed and available. The persona name remains the dispatch role;
+# only the provider-facing agent alias is returned here.
+resolve_curated_agent_executor() {
+    local persona_name="$1"
+    local persona_file primary fallback candidate provider
+
+    persona_file=$(get_agent_config "$persona_name" "file")
+    [[ -n "$persona_file" ]] || return 1
+
+    primary=$(get_agent_config "$persona_name" "cli")
+    fallback=$(get_agent_config "$persona_name" "fallback_cli")
+    [[ -n "$primary" ]] || primary="codex"
+
+    for candidate in "$primary" "$fallback"; do
+        [[ -n "$candidate" ]] || continue
+        if [[ -n "${AVAILABLE_AGENTS:-}" && " $AVAILABLE_AGENTS " != *" $candidate "* ]]; then
+            continue
+        fi
+        if declare -F octo_provider_allowed >/dev/null 2>&1 \
+            && ! octo_provider_allowed "$candidate"; then
+            continue
+        fi
+        provider="${candidate%%-*}"
+        case "$candidate" in
+            antigravity) provider="agy" ;;
+            claude*) provider="claude" ;;
+            openrouter*) provider="openrouter" ;;
+            cursor-agent*) provider="cursor-agent" ;;
+        esac
+        if declare -F check_provider_health >/dev/null 2>&1; then
+            check_provider_health "$provider" >/dev/null 2>&1 || continue
+        elif declare -F is_agent_available_v2 >/dev/null 2>&1 \
+            && ! is_agent_available_v2 "$candidate"; then
+            continue
+        fi
+        printf '%s\n' "$candidate"
+        return 0
+    done
+
+    return 1
 }
 
 # v8.2.0: Get agent memory scope from config (project/none)

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -248,8 +248,13 @@ get_agent_command() {
             # then 4.7/4.6 on older hosts or enterprise backends.
             # Use `env VAR=val` prefix so the assignment survives read -ra word-splitting
             # in spawn.sh — a bare VAR=val prefix only works in shell eval context.
-            local opus_effort="high"
-            if declare -f get_effort_level >/dev/null 2>&1; then
+            local opus_effort="high" configured_claude_effort=""
+            if declare -f octopus_resolve_reasoning_level >/dev/null 2>&1; then
+                configured_claude_effort="$(octopus_resolve_reasoning_level claude "$phase" "$role" 2>/dev/null || true)"
+            fi
+            if [[ -n "$configured_claude_effort" ]]; then
+                opus_effort="$configured_claude_effort"
+            elif declare -f get_effort_level >/dev/null 2>&1; then
                 local opus_complexity="2"
                 case "${phase:-}" in
                     tangle|develop|ink|deliver) opus_complexity="3" ;;
@@ -259,23 +264,28 @@ get_agent_command() {
             elif [[ -n "${OCTOPUS_EFFORT_OVERRIDE:-}" ]]; then
                 opus_effort="$OCTOPUS_EFFORT_OVERRIDE"
             fi
+            if declare -f fable5_clamp_effort >/dev/null 2>&1; then
+                opus_effort="$(fable5_clamp_effort "$opus_effort")"
+            fi
             # v9.51: Honor a Fable 5 pin in the dispatched model flag. The bare
             # `opus` alias always resolves to the host's default Opus, so
             # without this the pin changed cost labels but never the model.
             # Security dispatches reroute to Opus 4.8 (lib/fable5.sh).
-            local opus_model_flag="opus"
-            if [[ "${OCTOPUS_OPUS_MODEL:-}" == "claude-fable-5" ]]; then
-                opus_model_flag="claude-fable-5"
-                if declare -f fable5_maybe_reroute >/dev/null 2>&1; then
-                    if [[ "$(fable5_maybe_reroute "claude-fable-5" "$role" "$agent_type" "$phase")" != "claude-fable-5" ]]; then
-                        opus_model_flag="claude-opus-4-8"
-                    fi
-                fi
+            local configured_opus_model="${OCTOPUS_OPUS_MODEL:-opus}"
+            if declare -f get_agent_model >/dev/null 2>&1; then
+                configured_opus_model="$(get_agent_model "$agent_type" "$phase" "$role")" || return 1
             fi
+            local opus_model_flag="$configured_opus_model"
+            case "$configured_opus_model" in
+                claude-opus-4.8) opus_model_flag="claude-opus-4-8" ;;
+                claude-opus-4.6) opus_model_flag="claude-opus-4-6" ;;
+            esac
             if [[ "${SUPPORTS_EFFORT_COMMAND:-false}" == "true" || "${SUPPORTS_XHIGH_EFFORT:-false}" == "true" ]]; then
-                echo "env CLAUDE_CODE_EFFORT_LEVEL=${opus_effort} ${_claude_bin}${_BARE_OPT} --print --model ${opus_model_flag} ${claude_perm}"
+                echo "env OCTOPUS_OPUS_MODEL=${configured_opus_model} CLAUDE_CODE_EFFORT_LEVEL=${opus_effort} ${_claude_bin}${_BARE_OPT:-} --print --model ${opus_model_flag} --effort ${opus_effort} ${claude_perm}"
+            elif [[ "$configured_opus_model" == "claude-fable-5" ]]; then
+                echo "env OCTOPUS_OPUS_MODEL=${configured_opus_model} ${_claude_bin}${_BARE_OPT:-} --print --model ${opus_model_flag} ${claude_perm}"
             else
-                echo "${_claude_bin}${_BARE_OPT} --print --model ${opus_model_flag} ${claude_perm}"
+                echo "${_claude_bin}${_BARE_OPT:-} --print --model ${opus_model_flag} ${claude_perm}"
             fi
             ;;
         claude-opus-fast)

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -288,7 +288,9 @@ get_agent_command() {
         claude-opus-legacy) echo "${_claude_bin}${_BARE_OPT} --print --model claude-opus-4-6 ${claude_perm}" ;; # v9.23: explicit 4.6 opt-in
         openrouter) echo "openrouter_execute" ;;                 # OpenRouter API (v4.8)
         openrouter-glm5) echo "openrouter_execute_model z-ai/glm-5" ;;           # v8.11.0: GLM-5 via OpenRouter
+        openrouter-glm52) echo "openrouter_execute_model z-ai/glm-5.2" ;;        # GLM 5.2 via OpenRouter
         openrouter-kimi) echo "openrouter_execute_model moonshotai/kimi-k2.5" ;; # v8.11.0: Kimi K2.5 via OpenRouter
+        openrouter-kimi-k3) echo "openrouter_execute_model moonshotai/kimi-k3" ;; # Kimi K3 via OpenRouter
         openrouter-deepseek) echo "openrouter_execute_model deepseek/deepseek-r1-0528" ;; # v8.11.0: DeepSeek R1 via OpenRouter
         openai-compatible|openai-tools|openai-compatible-agent)  # Generic OpenAI-compatible tool-loop agent
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
@@ -881,7 +883,7 @@ find_capable_fallback() {
         claude)
             candidates=(claude-sonnet-4.6 claude-opus-4.6) ;;
         openrouter)
-            candidates=(z-ai/glm-5 moonshotai/kimi-k2.5 deepseek/deepseek-r1-0528) ;;
+            candidates=(z-ai/glm-5.2 moonshotai/kimi-k3 z-ai/glm-5 moonshotai/kimi-k2.5 deepseek/deepseek-r1-0528) ;;
         perplexity)
             candidates=(sonar sonar-pro) ;;
         cursor-agent)

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -875,7 +875,9 @@ find_capable_fallback() {
     local -a candidates=()
     case "$provider" in
         codex)
-            candidates=(gpt-5.4-mini gpt-5.2-codex gpt-5.3-codex gpt-5.4 gpt-5.4-pro o3) ;;
+            # The Codex seat is subscription-pinned. Never substitute a fast,
+            # mini, API-priced, or otherwise different model.
+            candidates=(gpt-5.6-sol) ;;
         gemini)
             candidates=(gemini-3-flash-preview gemini-3.1-pro-preview) ;;
         agy)

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -298,9 +298,21 @@ get_agent_command() {
         claude-opus-legacy) echo "${_claude_bin}${_BARE_OPT} --print --model claude-opus-4-6 ${claude_perm}" ;; # v9.23: explicit 4.6 opt-in
         openrouter) echo "openrouter_execute" ;;                 # OpenRouter API (v4.8)
         openrouter-glm5) echo "openrouter_execute_model z-ai/glm-5" ;;           # v8.11.0: GLM-5 via OpenRouter
-        openrouter-glm52) echo "openrouter_execute_model z-ai/glm-5.2" ;;        # GLM 5.2 via OpenRouter
+        openrouter-glm52)
+            if ! _octopus_is_safe_openai_compatible_dispatch_value "${PWD}"; then
+                log ERROR "Invalid OpenRouter cwd: ${PWD}"
+                return 1
+            fi
+            echo "${PLUGIN_DIR}/scripts/helpers/openai-compatible-agent.sh --provider openrouter --model z-ai/glm-5.2 --tool-mode readonly --cwd ${PWD}"
+            ;;
         openrouter-kimi) echo "openrouter_execute_model moonshotai/kimi-k2.5" ;; # v8.11.0: Kimi K2.5 via OpenRouter
-        openrouter-kimi-k3) echo "openrouter_execute_model moonshotai/kimi-k3" ;; # Kimi K3 via OpenRouter
+        openrouter-kimi-k3)
+            if ! _octopus_is_safe_openai_compatible_dispatch_value "${PWD}"; then
+                log ERROR "Invalid OpenRouter cwd: ${PWD}"
+                return 1
+            fi
+            echo "${PLUGIN_DIR}/scripts/helpers/openai-compatible-agent.sh --provider openrouter --model moonshotai/kimi-k3 --tool-mode readonly --cwd ${PWD}"
+            ;;
         openrouter-deepseek) echo "openrouter_execute_model deepseek/deepseek-r1-0528" ;; # v8.11.0: DeepSeek R1 via OpenRouter
         openai-compatible|openai-tools|openai-compatible-agent)  # Generic OpenAI-compatible tool-loop agent
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
@@ -320,7 +332,7 @@ get_agent_command() {
             reasoning_fragment="$(octopus_reasoning_cli_fragment openai-compatible-agent "$reasoning_level" "$reasoning_policy")" || return 1
             runtime_config="$(_octopus_openai_compatible_runtime_config "$agent_type")" || return 1
             IFS=$'\t' read -r base_url api_key_env <<<"$runtime_config"
-            echo "${PLUGIN_DIR}/scripts/helpers/openai-compatible-agent.py --provider generic --base-url ${base_url} --api-key-env ${api_key_env} --model ${model} ${reasoning_fragment} --cwd ${PWD}"
+            echo "${PLUGIN_DIR}/scripts/helpers/openai-compatible-agent.sh --provider generic --base-url ${base_url} --api-key-env ${api_key_env} --model ${model} ${reasoning_fragment} --cwd ${PWD}"
             ;;
         atlascloud-agent)  # Atlas Cloud via the OpenAI-compatible tool-loop agent
             model="${ATLASCLOUD_MODEL:-${OCTOPUS_ATLASCLOUD_MODEL:-${OPENAI_COMPAT_MODEL:-}}}"
@@ -352,7 +364,7 @@ get_agent_command() {
                 log ERROR "Invalid Atlas Cloud cwd: ${PWD}"
                 return 1
             fi
-            echo "${PLUGIN_DIR}/scripts/helpers/openai-compatible-agent.py --provider atlascloud --model ${model} --cwd ${PWD}"
+            echo "${PLUGIN_DIR}/scripts/helpers/openai-compatible-agent.sh --provider atlascloud --model ${model} --cwd ${PWD}"
             ;;
         perplexity|perplexity-fast)  # v8.24.0: Perplexity Sonar — web-grounded research (Issue #22)
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then

--- a/scripts/lib/error-tracking.sh
+++ b/scripts/lib/error-tracking.sh
@@ -250,6 +250,11 @@ classify_agent_output() {
         return 0
     fi
 
+    if [[ "$agent" == openrouter* ]] && grep -qiE '<[[:space:]]*(tool_call|function_call|function_calls)\b' "$output_file" 2>/dev/null; then
+        echo "failed:Unevaluated OpenRouter tool call"
+        return 0
+    fi
+
     if grep -q 'OUTPUT TRUNCATED' "$output_file" 2>/dev/null; then
         echo "degraded:Output truncated"
         return 0

--- a/scripts/lib/events.sh
+++ b/scripts/lib/events.sh
@@ -10,33 +10,31 @@
 # Normal command output is unchanged when OCTO_EVENT_LOG is unset.
 
 octo_event_log_path() {
+    local output_var="${1:-}"
+    local path=""
     case "${OCTO_EVENT_LOG:-}" in
         "") return 1 ;;
-        auto) printf '%s\n' "${WORKSPACE_DIR:-$PWD}/.octo/events.jsonl" ;;
-        *) printf '%s\n' "$OCTO_EVENT_LOG" ;;
+        auto) path="${WORKSPACE_DIR:-$PWD}/.octo/events.jsonl" ;;
+        *) path="$OCTO_EVENT_LOG" ;;
     esac
+    if [[ -n "$output_var" ]]; then
+        printf -v "$output_var" '%s' "$path"
+    else
+        printf '%s\n' "$path"
+    fi
 }
 
 octo_event_enabled() {
-    octo_event_log_path >/dev/null 2>&1
+    local path=""
+    octo_event_log_path path
 }
 
 _octo_json_string() {
     local value="$1"
+    local output_var="${2:-}"
 
-    if command -v python3 >/dev/null 2>&1; then
-        python3 - "$value" <<'PY' 2>/dev/null && return 0
-import json
-import sys
-
-print(json.dumps(sys.argv[1]))
-PY
-    fi
-
-    if command -v jq >/dev/null 2>&1; then
-        jq -Rn --arg value "$value" '$value' 2>/dev/null && return 0
-    fi
-
+    # Keep event serialization shell-native. Spawning an encoder once per field
+    # is expensive on Windows, and probing WindowsApps/python3 can open Store.
     local out="" ch ord esc
     local i
     value=${value//\\/\\\\}
@@ -60,24 +58,67 @@ PY
                 ;;
         esac
     done
-    printf '"%s"\n' "$out"
+    if [[ -n "$output_var" ]]; then
+        printf -v "$output_var" '"%s"' "$out"
+    else
+        printf '"%s"\n' "$out"
+    fi
 }
 
 # Portable best-effort exclusive lock. flock is Linux-only; mkdir is atomic on
 # every POSIX filesystem. Bounded spin (~1s) so a dead lock holder degrades to a
 # lockless write rather than hanging the caller. Returns 0 if acquired, 1 if not.
+_octo_event_epoch() {
+    local output_var="$1"
+    local epoch=""
+    if ! TZ=UTC printf -v epoch '%(%s)T' -1 2>/dev/null; then
+        epoch=$(date +%s 2>/dev/null || true)
+    fi
+    printf -v "$output_var" '%s' "$epoch"
+}
+
+_octo_event_reclaim_stale_lock() {
+    local lockdir="$1"
+    local stale_seconds="${OCTO_EVENT_LOCK_STALE_SECONDS:-30}"
+    [[ "$stale_seconds" =~ ^[1-9][0-9]*$ ]] || stale_seconds=30
+
+    local modified="" now=""
+    read -r modified 2>/dev/null < "$lockdir/created" || true
+    if ! [[ "$modified" =~ ^[0-9]+$ ]]; then
+        modified=$(stat -c %Y "$lockdir" 2>/dev/null || stat -f %m "$lockdir" 2>/dev/null || true)
+    fi
+    [[ "$modified" =~ ^[0-9]+$ ]] || return 1
+    _octo_event_epoch now
+    [[ "$now" =~ ^[0-9]+$ ]] || return 1
+    (( now - modified >= stale_seconds )) || return 1
+
+    # Rename first so a concurrent unlock or reclaimer cannot make us remove a
+    # newly acquired lock at the original path.
+    local stale_dir="${lockdir}.stale.${BASHPID:-$$}.${RANDOM:-0}"
+    mv "$lockdir" "$stale_dir" 2>/dev/null || return 1
+    rm -rf "$stale_dir" 2>/dev/null || true
+    return 0
+}
+
 _octo_event_lock() {
     local lockdir="$1.lock"
     local tries=0
     while ! mkdir "$lockdir" 2>/dev/null; do
         tries=$((tries + 1))
+        if _octo_event_reclaim_stale_lock "$lockdir"; then
+            continue
+        fi
         [[ "$tries" -ge 50 ]] && return 1
         sleep 0.02 2>/dev/null || return 1
     done
+    local created=""
+    _octo_event_epoch created
+    printf '%s\n' "$created" > "$lockdir/created" 2>/dev/null || true
     return 0
 }
 
 _octo_event_unlock() {
+    rm -f "$1.lock/created" 2>/dev/null || true
     rmdir "$1.lock" 2>/dev/null || true
 }
 
@@ -89,13 +130,32 @@ _octo_event_trim() {
     [[ "$max_lines" -gt 0 ]] || return 0
     [[ -f "$file" ]] || return 0
 
-    local count
-    count=$(wc -l < "$file" 2>/dev/null | tr -d ' ')
-    [[ "$count" =~ ^[0-9]+$ ]] || return 0
+    if ! type mapfile >/dev/null 2>&1; then
+        # macOS Bash 3.2 compatibility; modern Bash uses the no-fork path below.
+        local legacy_count
+        legacy_count=$(wc -l < "$file" 2>/dev/null | tr -d ' ')
+        [[ "$legacy_count" =~ ^[0-9]+$ ]] || return 0
+        [[ "$legacy_count" -le "$max_lines" ]] && return 0
+        local legacy_tmp="${file}.tmp.$$"
+        tail -n "$max_lines" "$file" > "$legacy_tmp" && mv "$legacy_tmp" "$file" || {
+            rm -f "$legacy_tmp"
+            return 1
+        }
+        return 0
+    fi
+
+    local -a lines=()
+    mapfile -t lines < "$file" 2>/dev/null || return 0
+    local count="${#lines[@]}"
     [[ "$count" -le "$max_lines" ]] && return 0
 
     local tmp="${file}.tmp.$$"
-    tail -n "$max_lines" "$file" > "$tmp" && mv "$tmp" "$file" || {
+    local first=$((count - max_lines)) i
+    : > "$tmp" || return 1
+    for ((i = first; i < count; i++)); do
+        printf '%s\n' "${lines[$i]}" >> "$tmp" || return 1
+    done
+    mv "$tmp" "$file" || {
         rm -f "$tmp"
         return 1
     }
@@ -108,36 +168,49 @@ octo_event_emit() {
     local event="${1:-}"
     shift || true
 
-    local log_file
-    log_file=$(octo_event_log_path 2>/dev/null) || return 0
+    local log_file=""
+    octo_event_log_path log_file || return 0
 
     [[ "$event" =~ ^[A-Za-z0-9_.:-]+$ ]] || return 2
 
     local attrs="" sep=""
-    local pair key value
+    local pair key value key_json value_json
     for pair in "$@"; do
         key="${pair%%=*}"
         value="${pair#*=}"
         [[ "$pair" == *=* ]] || return 2
         [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_.:-]*$ ]] || return 2
-        attrs="${attrs}${sep}$(_octo_json_string "$key"):$(_octo_json_string "$value")"
+        _octo_json_string "$key" key_json
+        _octo_json_string "$value" value_json
+        attrs="${attrs}${sep}${key_json}:${value_json}"
         sep=","
     done
 
-    local timestamp
-    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date +%s)
+    local timestamp=""
+    if ! TZ=UTC printf -v timestamp '%(%Y-%m-%dT%H:%M:%SZ)T' -1 2>/dev/null; then
+        timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date +%s)
+    fi
 
     local dir
-    dir="$(dirname "$log_file")"
+    if [[ "$log_file" == */* ]]; then
+        dir="${log_file%/*}"
+        [[ -n "$dir" ]] || dir="/"
+    else
+        dir="."
+    fi
     mkdir -p "$dir" 2>/dev/null || return 0
 
-    local record
+    local record timestamp_json event_json source_json session_json
+    _octo_json_string "$timestamp" timestamp_json
+    _octo_json_string "$event" event_json
+    _octo_json_string "${OCTO_EVENT_SOURCE:-octopus}" source_json
+    _octo_json_string "${OCTOPUS_SESSION_ID:-}" session_json
     printf -v record '{"timestamp":%s,"event":%s,"source":%s,"pid":%s,"session_id":%s,"attributes":{%s}}\n' \
-        "$(_octo_json_string "$timestamp")" \
-        "$(_octo_json_string "$event")" \
-        "$(_octo_json_string "${OCTO_EVENT_SOURCE:-octopus}")" \
+        "$timestamp_json" \
+        "$event_json" \
+        "$source_json" \
         "$$" \
-        "$(_octo_json_string "${OCTOPUS_SESSION_ID:-}")" \
+        "$session_json" \
         "$attrs"
 
     # Serialize append+trim under one lock so a concurrent emit can never have

--- a/scripts/lib/execution-profile.sh
+++ b/scripts/lib/execution-profile.sh
@@ -124,7 +124,12 @@ octopus_resolve_reasoning_level() {
   value="$(_octopus_profile_field "$phase" "$role" reasoning 2>/dev/null || true)"
   if [[ -z "$value" ]]; then
     cfg="$(_octopus_profile_config_file)"
-    [[ -f "$cfg" ]] && value=$(jq -r --arg p "$provider" '.providers[$p].reasoning.default // empty' "$cfg" 2>/dev/null || true)
+    [[ -f "$cfg" ]] && value=$(jq -r --arg p "$provider" '
+      (.providers[$p] // {}) as $provider
+      | (if ($provider.reasoning | type) == "object" then $provider.reasoning.default else empty end)
+        // $provider.reasoning_effort
+        // empty
+    ' "$cfg" 2>/dev/null || true)
   fi
   octopus_normalize_reasoning_level "$value"
 }

--- a/scripts/lib/fable5.sh
+++ b/scripts/lib/fable5.sh
@@ -30,7 +30,14 @@ FABLE5_MODEL_ID="claude-fable-5"
 FABLE5_REROUTE_MODEL="claude-opus-4.8"
 
 fable5_opus_pinned() {
-    [[ "${OCTOPUS_OPUS_MODEL:-}" == "$FABLE5_MODEL_ID" ]]
+    if [[ "${OCTOPUS_OPUS_MODEL:-}" == "$FABLE5_MODEL_ID" ]]; then
+        return 0
+    fi
+    local config_file="${OCTOPUS_PROVIDERS_CONFIG:-${HOME}/.claude-octopus/config/providers.json}"
+    [[ -f "$config_file" ]] || return 1
+    command -v jq >/dev/null 2>&1 || return 1
+    jq -e --arg model "$FABLE5_MODEL_ID" \
+        '.providers.claude.default == $model' "$config_file" >/dev/null 2>&1
 }
 
 fable5_sdk_pinned() {

--- a/scripts/lib/fable5.sh
+++ b/scripts/lib/fable5.sh
@@ -6,14 +6,13 @@
 # is detected, orchestration auto-enables three guards (auto-detect + banner,
 # no user action needed):
 #
-#   1. Security reroute — security-audit dispatches never target Fable 5; its
-#      safety classifiers can refuse offensive-security phrasing even in
-#      authorized audits. Rerouted to Opus 4.8.
+#   1. Availability fallback — a Fable 5 dispatch falls back to Opus 4.8 only
+#      when the provider explicitly rejects the model or reports it unavailable.
 #   2. Effort clamp — xhigh/max clamp to high for Fable dispatches. Fable 5
 #      effort applies per tool call; higher settings widen scope at 2x cost
 #      without extending runs.
-#   3. Refusal retry — the claude-sdk shim retries a failed/empty Fable 5
-#      dispatch once on Opus 4.8 (see helpers/claude-sdk-exec.sh).
+#   3. Refusal handling remains provider-owned; an ordinary content refusal is
+#      not treated as model unavailability and does not silently upgrade cost.
 #
 # Detection is env-pin based only (deterministic; host session model ignored):
 #   OCTOPUS_OPUS_MODEL=claude-fable-5        — opus seats run Fable 5
@@ -65,30 +64,32 @@ fable5_clamp_effort() {
     echo "$effort"
 }
 
-# fable5_is_security_dispatch <role> <agent_type> <phase> — true when any of
-# the dispatch identifiers indicate security work (security-auditor persona,
-# squeeze red/blue workflow, red-team roles).
-fable5_is_security_dispatch() {
-    local combined="${1:-} ${2:-} ${3:-}"
-    case "$combined" in
-        *security*|*squeeze*|*red-team*|*redteam*) return 0 ;;
-        *) return 1 ;;
-    esac
-}
-
-# fable5_maybe_reroute <model> <role> <agent_type> <phase> — echo the model to
-# dispatch. Swaps Fable 5 for Opus 4.8 on security dispatches.
+# Compatibility hook for model resolution. Fable remains primary for every
+# role; spawn.sh performs the availability-only retry after provider failure.
 fable5_maybe_reroute() {
     local model="${1:-}"
-    if [[ "$model" == "$FABLE5_MODEL_ID" ]] && fable5_mode_active \
-        && fable5_is_security_dispatch "${2:-}" "${3:-}" "${4:-}"; then
-        if declare -f log >/dev/null 2>&1; then
-            log "WARN" "Fable 5 security reroute: ${FABLE5_MODEL_ID} → ${FABLE5_REROUTE_MODEL} (safety classifiers can refuse adversarial security phrasing)"
-        fi
-        echo "$FABLE5_REROUTE_MODEL"
-        return 0
-    fi
     echo "$model"
+}
+
+# True only for errors proving that Fable itself cannot currently be served.
+# Generic failures and content refusals deliberately do not match.
+fable5_model_unavailable() {
+    local stderr_file="${1:-}"
+    local stdout_file="${2:-}"
+    local error_text=""
+    [[ -n "$stderr_file" && -f "$stderr_file" ]] && error_text+=$(<"$stderr_file")
+    [[ -n "$stdout_file" && -f "$stdout_file" ]] && error_text+=$'\n'$(<"$stdout_file")
+    error_text="${error_text,,}"
+    [[ "$error_text" == *"model not found"* || \
+       "$error_text" == *"unknown model"* || \
+       "$error_text" == *"model does not exist"* || \
+       "$error_text" == *"model unavailable"* || \
+       "$error_text" == *"model is unavailable"* || \
+       "$error_text" == *"not available"* || \
+       "$error_text" == *"capacity"* || \
+       "$error_text" == *"overloaded"* || \
+       "$error_text" == *"rate limit"* || \
+       "$error_text" == *"429"* ]]
 }
 
 # fable5_banner — one-line stderr banner, once per process tree (guarded by an
@@ -97,5 +98,5 @@ fable5_banner() {
     fable5_mode_active || return 0
     [[ -n "${_OCTO_FABLE5_BANNER_SHOWN:-}" ]] && return 0
     export _OCTO_FABLE5_BANNER_SHOWN=1
-    echo "🐙 Fable 5 mode active — security passes reroute to Opus 4.8, effort clamps to high, refusal retry on (OCTOPUS_FABLE5_MODE=off to disable)" >&2
+    echo "🐙 Fable 5 mode active — Opus 4.8 fallback only when Fable is unavailable, effort high (OCTOPUS_FABLE5_MODE=off to disable)" >&2
 }

--- a/scripts/lib/interactive.sh
+++ b/scripts/lib/interactive.sh
@@ -57,7 +57,7 @@ ERROR_CODES=(
     "E006:Agent spawn failed:Check API keys and network connection:help troubleshoot"
     "E007:Quality gate failed:Review output and retry with lower threshold (-q 60):help quality"
     "E008:Timeout exceeded:Increase timeout with -t 600 or break into smaller tasks:help timeout"
-    "E009:Invalid agent type:Use codex, codex-standard, codex-max, codex-mini, codex-general, codex-spark, codex-reasoning, codex-large-context, codex-review, gemini, gemini-fast, gemini-image, claude, claude-sonnet, claude-opus, claude-opus-fast, openrouter, openrouter-glm5, openrouter-kimi, openrouter-deepseek, perplexity, perplexity-fast, ollama, copilot, copilot-research, qwen, qwen-research, opencode, opencode-fast, opencode-research, cursor-agent:help agents"
+    "E009:Invalid agent type:Use codex, codex-standard, codex-max, codex-mini, codex-general, codex-spark, codex-reasoning, codex-large-context, codex-review, gemini, gemini-fast, gemini-image, claude, claude-sonnet, claude-opus, claude-opus-fast, openrouter, openrouter-glm5, openrouter-glm52, openrouter-kimi, openrouter-kimi-k3, openrouter-deepseek, perplexity, perplexity-fast, ollama, copilot, copilot-research, qwen, qwen-research, opencode, opencode-fast, opencode-research, cursor-agent:help agents"
     "E010:Task file parse error:Check JSON syntax with: jq . tasks.json:help tasks"
 )
 

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -150,6 +150,23 @@ resolve_octopus_model() {
         return 0
     fi
 
+    # OCTOPUS_OPUS_MODEL is the agent-specific override for claude-opus seats.
+    # It must bypass both memory and persistent caches just like the generic
+    # provider override above; otherwise a cache primed with Opus can conceal a
+    # later Fable pin in telemetry and policy checks.
+    if [[ "$canonical_provider" == "claude" && "$agent_type" == claude-opus* && -n "${OCTOPUS_OPUS_MODEL:-}" ]]; then
+        if ! validate_model_name_for_provider "$canonical_provider" "$OCTOPUS_OPUS_MODEL"; then
+            log ERROR "Invalid model name in OCTOPUS_OPUS_MODEL"
+            return 1
+        fi
+        if declare -f fable5_maybe_reroute >/dev/null 2>&1; then
+            fable5_maybe_reroute "$OCTOPUS_OPUS_MODEL" "$role" "$agent_type" "$phase"
+        else
+            echo "$OCTOPUS_OPUS_MODEL"
+        fi
+        return 0
+    fi
+
     # 0. Session Cache (v8.53.0)
     # Uses a process-local memory cache + optional file-based cache for cross-process speed
     local cache_key

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -375,7 +375,7 @@ resolve_octopus_model() {
     # Fallback to hard-coded defaults (Priority 7)
     if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
         case "$agent_type" in
-            codex*)          resolved_model="gpt-5.5" ;;
+            codex*)          resolved_model="gpt-5.6-sol" ;;
             gemini-image)    resolved_model="gemini-3-pro-image" ;;  # image, not text — must precede gemini* (codex review)
             gemini-fast|gemini-flash) resolved_model="gemini-3-flash-preview" ;;
             gemini*)         resolved_model="gemini-3.1-pro-preview" ;;
@@ -399,7 +399,7 @@ resolve_octopus_model() {
             opencode-research*) resolved_model="opencode/glm-5.1" ;;
             opencode-fast*)  resolved_model="opencode/deepseek-v4-flash-free" ;;
             opencode*)       resolved_model="opencode/deepseek-v4-flash-free" ;;
-            *)              resolved_model="gpt-5.5" ;; # Safest universal fallback
+            *)              resolved_model="gpt-5.6-sol" ;; # Safest universal fallback
         esac
         [[ -n "$_trace" ]] && echo "[model-trace] Tier 7 (hardcoded fallback): $resolved_model ← SELECTED" >&2
     fi

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -369,6 +369,8 @@ resolve_octopus_model() {
             claude*)         resolved_model="claude-sonnet-4.6" ;;
             perplexity-fast)  resolved_model="sonar" ;;
             perplexity*)       resolved_model="sonar-pro" ;;
+            openrouter-glm52*) resolved_model="z-ai/glm-5.2" ;;
+            openrouter-kimi-k3*) resolved_model="moonshotai/kimi-k3" ;;
             openrouter-glm*)  resolved_model="z-ai/glm-5" ;;
             openrouter-kimi*) resolved_model="moonshotai/kimi-k2.5" ;;
             openrouter-deepseek*) resolved_model="deepseek/deepseek-r1-0528" ;;
@@ -583,7 +585,7 @@ get_fallback_agent() {
                 echo "$preferred"
             fi
             ;;
-        openrouter-glm5|openrouter-kimi|openrouter-deepseek)
+        openrouter-*)
             # v8.11.0: Model-specific OpenRouter → generic openrouter → codex → gemini
             if is_agent_available "openrouter"; then
                 [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: $preferred -> openrouter (model-specific unavailable)" || true

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -56,7 +56,9 @@ get_model_catalog() {
         composer-2)             echo "200|yes|no|no|cursor-agent|premium|active" ;;
         # OpenRouter
         z-ai/glm-5)             echo "203|yes|no|no|openrouter|standard|active" ;;
+        z-ai/glm-5.2)           echo "1000|yes|no|yes|openrouter|premium|active" ;;
         moonshotai/kimi-k2.5)   echo "262|yes|yes|no|openrouter|standard|active" ;;
+        moonshotai/kimi-k3)     echo "1000|yes|yes|yes|openrouter|premium|active" ;;
         deepseek/deepseek-r1-0528) echo "164|yes|no|yes|openrouter|standard|active" ;;
         # OpenCode (multi-provider router — models use opencode/<model> namespace)
         opencode/deepseek-v4-flash-free) echo "128|yes|no|no|opencode|budget|active" ;;
@@ -125,7 +127,7 @@ list_models() {
         agy/default
         claude-sonnet-4.6 claude-fable-5 claude-opus-4.8 claude-opus-4.8-fast claude-opus-4.7 claude-opus-4.6 claude-opus-4.6-fast
         grok-4-20 grok-4-20-thinking composer-2-fast composer-2
-        z-ai/glm-5 moonshotai/kimi-k2.5 deepseek/deepseek-r1-0528
+        z-ai/glm-5 z-ai/glm-5.2 moonshotai/kimi-k2.5 moonshotai/kimi-k3 deepseek/deepseek-r1-0528
         opencode/deepseek-v4-flash-free opencode/gpt-5.4 opencode/gpt-5.4-mini opencode/glm-5.1
         sonar-pro sonar
     )

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -18,6 +18,7 @@ get_model_catalog() {
     local model="$1"
     case "$model" in
         # OpenAI GPT-5.x
+        gpt-5.6-sol)            echo "400|yes|yes|yes|codex|premium|active" ;;
         gpt-5.5)                echo "400|yes|yes|no|codex|premium|active" ;;
         gpt-5.5-pro)            echo "400|yes|yes|no|codex|premium|active" ;;
         gpt-5.4)                echo "400|yes|yes|no|codex|premium|active" ;;
@@ -120,7 +121,7 @@ list_models() {
     done
 
     local -a all_models=(
-        gpt-5.5 gpt-5.5-pro gpt-5.4 gpt-5.4-pro gpt-5.3-codex gpt-5.2-codex
+        gpt-5.6-sol gpt-5.5 gpt-5.5-pro gpt-5.4 gpt-5.4-pro gpt-5.3-codex gpt-5.2-codex
         gpt-5.4-mini gpt-5.1-codex-max
         o3 o3-pro o3-mini
         gemini-3.1-pro-preview gemini-3.5-flash gemini-3.1-flash-lite gemini-3-flash-preview gemini-3-pro-image gemini-3.1-flash-image gemini-3-pro-image-preview

--- a/scripts/lib/path-runtime.sh
+++ b/scripts/lib/path-runtime.sh
@@ -114,10 +114,10 @@ pathrt_within_target() {
     _pathrt_within_canonical "$root" "$candidate"
 }
 
-# Native Windows Git cannot consume /c/... when MSYS argument conversion is
-# explicitly disabled. Convert only at the execution boundary; containment
-# always uses the canonical runtime form above.
-pathrt_for_git() {
+# Native Windows executables cannot consume /c/... when MSYS argument
+# conversion is explicitly disabled. Convert only at the execution boundary;
+# containment always uses the canonical runtime form above.
+pathrt_for_native() {
     local canonical
     canonical=$(pathrt_canon_existing "${1:-}") || return 2
     if pathrt_is_windows; then
@@ -126,4 +126,8 @@ pathrt_for_git() {
         return 0
     fi
     printf '%s\n' "$canonical"
+}
+
+pathrt_for_git() {
+    pathrt_for_native "${1:-}"
 }

--- a/scripts/lib/path-runtime.sh
+++ b/scripts/lib/path-runtime.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# path-runtime.sh — shared cross-platform canonicalization and containment.
+
+[[ -n "${_OCTOPUS_PATH_RUNTIME_LOADED:-}" ]] && return 0
+_OCTOPUS_PATH_RUNTIME_LOADED=1
+
+pathrt_is_windows() {
+    case "$(uname -s 2>/dev/null || true)" in
+        MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    esac
+    return 1
+}
+
+_pathrt_validate_input() {
+    local path="${1:-}"
+    [[ -n "$path" ]] || return 2
+    [[ "$path" != *$'\n'* && "$path" != *$'\r'* ]] || return 2
+
+    # UNC/device paths and drive-relative paths do not have an unambiguous
+    # workspace meaning in the Git/MSYS runtime and are denied.
+    [[ "$path" != \\\\* && "$path" != //* ]] || return 2
+    if [[ "$path" =~ ^[A-Za-z]:$ || "$path" =~ ^[A-Za-z]:[^/\\] ]]; then
+        return 2
+    fi
+    return 0
+}
+
+_pathrt_runtime_input() {
+    local path="$1"
+    _pathrt_validate_input "$path" || return 2
+
+    if [[ "$path" =~ ^[A-Za-z]:[/\\] ]]; then
+        pathrt_is_windows || return 2
+        command -v cygpath >/dev/null 2>&1 || return 2
+        cygpath -u "$path" 2>/dev/null || return 2
+        return 0
+    fi
+
+    # Backslashes outside an absolute drive path are ambiguous and are not
+    # silently reinterpreted as separators.
+    [[ "$path" != *\\* ]] || return 2
+    printf '%s\n' "$path"
+}
+
+_pathrt_format_canonical() {
+    local path="$1"
+    if pathrt_is_windows; then
+        path=$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]')
+    fi
+    while [[ "$path" != "/" && ! "$path" =~ ^/[a-z]$ && "$path" == */ ]]; do
+        path="${path%/}"
+    done
+    printf '%s\n' "$path"
+}
+
+pathrt_canon_existing() {
+    local input runtime_path canonical
+    input="${1:-}"
+    runtime_path=$(_pathrt_runtime_input "$input") || return 2
+    canonical=$(realpath -e -- "$runtime_path" 2>/dev/null) || return 2
+    _pathrt_format_canonical "$canonical"
+}
+
+pathrt_canon_target() {
+    local input runtime_path parent base canonical_parent candidate
+    input="${1:-}"
+    runtime_path=$(_pathrt_runtime_input "$input") || return 2
+
+    if [[ -e "$runtime_path" || -L "$runtime_path" ]]; then
+        pathrt_canon_existing "$runtime_path"
+        return $?
+    fi
+
+    while [[ "$runtime_path" != "/" && "$runtime_path" == */ ]]; do
+        runtime_path="${runtime_path%/}"
+    done
+    parent=$(dirname -- "$runtime_path" 2>/dev/null) || return 2
+    base=$(basename -- "$runtime_path" 2>/dev/null) || return 2
+    [[ -n "$base" && "$base" != "." && "$base" != ".." ]] || return 2
+    canonical_parent=$(pathrt_canon_existing "$parent") || return 2
+    [[ -d "$canonical_parent" ]] || return 2
+
+    if [[ "$canonical_parent" == "/" ]]; then
+        candidate="/$base"
+    else
+        candidate="$canonical_parent/$base"
+    fi
+    _pathrt_format_canonical "$candidate"
+}
+
+_pathrt_within_canonical() {
+    local root="$1" candidate="$2"
+    if [[ "$root" == "/" ]]; then
+        [[ "$candidate" == /* ]] && return 0
+        return 1
+    fi
+    case "$candidate" in
+        "$root"|"$root"/*) return 0 ;;
+    esac
+    return 1
+}
+
+pathrt_within_existing() {
+    local root candidate
+    root=$(pathrt_canon_existing "${1:-}") || return 2
+    candidate=$(pathrt_canon_existing "${2:-}") || return 2
+    _pathrt_within_canonical "$root" "$candidate"
+}
+
+pathrt_within_target() {
+    local root candidate
+    root=$(pathrt_canon_existing "${1:-}") || return 2
+    candidate=$(pathrt_canon_target "${2:-}") || return 2
+    _pathrt_within_canonical "$root" "$candidate"
+}
+
+# Native Windows Git cannot consume /c/... when MSYS argument conversion is
+# explicitly disabled. Convert only at the execution boundary; containment
+# always uses the canonical runtime form above.
+pathrt_for_git() {
+    local canonical
+    canonical=$(pathrt_canon_existing "${1:-}") || return 2
+    if pathrt_is_windows; then
+        command -v cygpath >/dev/null 2>&1 || return 2
+        cygpath -m "$canonical" 2>/dev/null || return 2
+        return 0
+    fi
+    printf '%s\n' "$canonical"
+}

--- a/scripts/lib/perplexity.sh
+++ b/scripts/lib/perplexity.sh
@@ -134,12 +134,10 @@ EOF
         log WARN "Empty response from OpenRouter ($model)"
         echo "$response"
     else
-        local result
-        result=$(echo "$content" | sed 's/\\n/\n/g; s/\\t/\t/g; s/\\"/"/g')
         if [[ -n "$output_file" ]]; then
-            echo "$result" > "$output_file"
+            printf '%s\n' "$content" > "$output_file"
         else
-            echo "$result"
+            printf '%s\n' "$content"
         fi
     fi
 }

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -398,7 +398,8 @@ EOF
 
 # Pre-flight dependency validation
 # Performance: Uses 1-hour cache to avoid repeated CLI checks
-# v7.9.1: Supports single-provider mode (only need ONE of Codex or Gemini or Cursor Agent)
+# Uses the configured review roster when present. This keeps preflight and its
+# paid smoke test from probing installed providers that are not workflow seats.
 preflight_check() {
     local force_check="${1:-false}"
 
@@ -417,12 +418,41 @@ preflight_check() {
     local has_codex=false
     local has_gemini=false
     local has_cursor_agent=false
+    local has_claude=false
+    local has_openrouter=false
     local codex_auth=false
     local gemini_auth=false
     local cursor_agent_auth=false
+    local claude_auth=false
+    local openrouter_auth=false
+
+    local want_codex=true want_gemini=true want_cursor_agent=true
+    local want_claude=true want_openrouter=true
+    local configured_fleet=""
+    if declare -f _review_fleet_from_config >/dev/null 2>&1; then
+        configured_fleet=$(_review_fleet_from_config)
+    fi
+    if [[ -n "$configured_fleet" ]]; then
+        want_codex=false; want_gemini=false; want_cursor_agent=false
+        want_claude=false; want_openrouter=false
+        local configured_agent _configured_role _configured_specialty
+        while IFS=':' read -r configured_agent _configured_role _configured_specialty; do
+            configured_agent=${configured_agent//$'\r'/}
+            case "$configured_agent" in
+                codex|codex-*) want_codex=true ;;
+                gemini|gemini-*) want_gemini=true ;;
+                cursor-agent|cursor-agent-*) want_cursor_agent=true ;;
+                claude|claude-*) want_claude=true ;;
+                openrouter|openrouter-*) want_openrouter=true ;;
+            esac
+        done <<< "$configured_fleet"
+        log INFO "Preflight roster: configured review fleet"
+    fi
 
     # Check Codex CLI
-    if command -v codex &>/dev/null; then
+    if [[ "$want_codex" == "true" ]] && \
+       { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed codex; } && \
+       command -v codex &>/dev/null; then
         has_codex=true
         log DEBUG "Codex CLI: $(command -v codex)"
         if [[ -f "$HOME/.codex/auth.json" ]] || [[ -n "${OPENAI_API_KEY:-}" ]]; then
@@ -431,7 +461,9 @@ preflight_check() {
     fi
 
     # Check Gemini CLI
-    if command -v gemini &>/dev/null; then
+    if [[ "$want_gemini" == "true" ]] && \
+       { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed gemini; } && \
+       command -v gemini &>/dev/null; then
         has_gemini=true
         log DEBUG "Gemini CLI: $(command -v gemini)"
         if [[ -f "$HOME/.gemini/oauth_creds.json" ]] || [[ -n "${GEMINI_API_KEY:-}" ]] || [[ -n "${GOOGLE_API_KEY:-}" ]]; then
@@ -440,7 +472,9 @@ preflight_check() {
     fi
 
     # Check Cursor Agent CLI
-    if declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
+    if [[ "$want_cursor_agent" == "true" ]] && \
+       { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed cursor-agent; } && \
+       declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
         has_cursor_agent=true
         log DEBUG "Cursor Agent CLI: $(command -v agent)"
         if [[ -n "${CURSOR_API_KEY:-}" ]] || grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; then
@@ -448,22 +482,58 @@ preflight_check() {
         fi
     fi
 
+    # Claude subscription route. Claude Code owns its own login state, so a
+    # callable CLI is the non-interactive readiness signal used by dispatch.
+    if [[ "$want_claude" == "true" ]] && \
+       { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed claude; } && \
+       command -v claude &>/dev/null; then
+        has_claude=true
+        claude_auth=true
+        log DEBUG "Claude CLI: $(command -v claude)"
+    fi
+
+    # OpenRouter seats share one credential but keep their exact model aliases
+    # for the smoke test. Do not substitute an installed Gemini CLI here.
+    if [[ "$want_openrouter" == "true" ]] && \
+       { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed openrouter; }; then
+        if [[ -z "${OPENROUTER_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
+            resolve_provider_env "OPENROUTER_API_KEY" 2>/dev/null || true
+        fi
+        if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+            has_openrouter=true
+            openrouter_auth=true
+        fi
+    fi
+
     # v7.9.1: Only need ONE provider to work
-    if [[ "$has_codex" == "false" && "$has_gemini" == "false" && "$has_cursor_agent" == "false" ]]; then
+    if [[ "$has_codex" == "false" && "$has_gemini" == "false" && \
+          "$has_cursor_agent" == "false" && "$has_claude" == "false" && \
+          "$has_openrouter" == "false" ]]; then
         echo ""
         echo -e "${RED}╔═══════════════════════════════════════════════════════════════╗${NC}"
         echo -e "${RED}║  ❌ NO AI PROVIDERS FOUND                                     ║${NC}"
         echo -e "${RED}╚═══════════════════════════════════════════════════════════════╝${NC}"
         echo ""
-        echo -e "Claude Octopus needs at least ${YELLOW}ONE${NC} external AI provider."
+        echo -e "Claude Octopus needs at least ${YELLOW}ONE${NC} configured AI provider."
         echo ""
         echo -e "${CYAN}Option 1: Install Codex CLI (OpenAI)${NC}"
         echo -e "  npm install -g @openai/codex"
         echo -e "  codex login  ${DIM}# OAuth recommended${NC}"
         echo ""
-        echo -e "${CYAN}Option 2: Install Gemini CLI (Google)${NC}"
-        echo -e "  npm install -g @google/gemini-cli"
-        echo -e "  gemini       ${DIM}# OAuth recommended${NC}"
+        if [[ "$want_claude" == "true" ]]; then
+            echo -e "${CYAN}Claude seat: install/login to Claude Code${NC}"
+            echo -e "  claude"
+            echo ""
+        fi
+        if [[ "$want_openrouter" == "true" ]]; then
+            echo -e "${CYAN}OpenRouter seats: configure OPENROUTER_API_KEY${NC}"
+            echo ""
+        fi
+        if [[ "$want_gemini" == "true" ]]; then
+            echo -e "${CYAN}Gemini seat: install/login to Gemini CLI${NC}"
+            echo -e "  gemini"
+            echo ""
+        fi
         echo ""
         echo -e "${CYAN}Option 3: Install Cursor Agent CLI${NC}"
         echo -e "  curl -fsSL https://cursor.com/install | bash"
@@ -476,7 +546,9 @@ preflight_check() {
     fi
 
     # Check if at least one provider is authenticated
-    if [[ "$codex_auth" == "false" && "$gemini_auth" == "false" && "$cursor_agent_auth" == "false" ]]; then
+    if [[ "$codex_auth" == "false" && "$gemini_auth" == "false" && \
+          "$cursor_agent_auth" == "false" && "$claude_auth" == "false" && \
+          "$openrouter_auth" == "false" ]]; then
         echo ""
         echo -e "${YELLOW}╔═══════════════════════════════════════════════════════════════╗${NC}"
         echo -e "${YELLOW}║  ⚠️  PROVIDERS FOUND BUT NOT AUTHENTICATED                    ║${NC}"
@@ -500,6 +572,14 @@ preflight_check() {
             echo -e "  ${DIM}OR export CURSOR_API_KEY=\"...\"${NC}"
             echo ""
         fi
+        if [[ "$want_claude" == "true" && "$has_claude" == "false" ]]; then
+            echo -e "${CYAN}Claude CLI is required by the configured fleet.${NC}"
+            echo ""
+        fi
+        if [[ "$want_openrouter" == "true" && "$has_openrouter" == "false" ]]; then
+            echo -e "${CYAN}OpenRouter is required by the configured fleet; set OPENROUTER_API_KEY.${NC}"
+            echo ""
+        fi
         echo -e "Run ${GREEN}/octo:setup${NC} for guided configuration."
         echo ""
         preflight_cache_write "1"
@@ -511,6 +591,8 @@ preflight_check() {
     [[ "$codex_auth" == "true" ]] && available_providers="${available_providers}Codex "
     [[ "$gemini_auth" == "true" ]] && available_providers="${available_providers}Gemini "
     [[ "$cursor_agent_auth" == "true" ]] && available_providers="${available_providers}Cursor-Agent "
+    [[ "$claude_auth" == "true" ]] && available_providers="${available_providers}Claude "
+    [[ "$openrouter_auth" == "true" ]] && available_providers="${available_providers}OpenRouter "
     log INFO "Available providers: $available_providers"
 
     # v8.48: Codex OAuth token freshness check (P1-A)
@@ -518,14 +600,9 @@ preflight_check() {
     if [[ "$codex_auth" == "true" ]]; then
         if ! check_codex_auth_freshness; then
             # Token expired but another authenticated provider may still work — degrade gracefully
-            if [[ "$gemini_auth" == "true" ]] || [[ "$cursor_agent_auth" == "true" ]]; then
-                if [[ "$gemini_auth" == "true" && "$cursor_agent_auth" == "true" ]]; then
-                    log WARN "Codex OAuth expired; continuing with Gemini/Cursor Agent only"
-                elif [[ "$gemini_auth" == "true" ]]; then
-                    log WARN "Codex OAuth expired; continuing with Gemini only"
-                else
-                    log WARN "Codex OAuth expired; continuing with Cursor Agent only"
-                fi
+            if [[ "$gemini_auth" == "true" || "$cursor_agent_auth" == "true" || \
+                  "$claude_auth" == "true" || "$openrouter_auth" == "true" ]]; then
+                log WARN "Codex OAuth expired; continuing with other configured providers only"
             else
                 log ERROR "Codex OAuth expired and no other authenticated provider"
                 preflight_cache_write "1"

--- a/scripts/lib/provider-allowlist.sh
+++ b/scripts/lib/provider-allowlist.sh
@@ -113,6 +113,11 @@ octo_provider_allowed() {
                     codex|codex-*) return 0 ;;
                 esac
                 ;;
+            openrouter)
+                case "$provider" in
+                    openrouter|openrouter-*) return 0 ;;
+                esac
+                ;;
             gemini)
                 case "$provider" in
                     gemini|gemini-*) return 0 ;;

--- a/scripts/lib/provider-allowlist.sh
+++ b/scripts/lib/provider-allowlist.sh
@@ -13,7 +13,15 @@ set -eo pipefail
 # present, then the session file, then the global config file.
 
 octo_normalize_provider_name() {
-    printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ','
+    local value="${1:-}"
+    value="${value//_/-}"
+    value="${value//,/}"
+    # Provider aliases are normally already lowercase. Avoid three external
+    # processes per check on Windows; only pay for `tr` on unusual mixed case.
+    case "$value" in
+        *[A-Z]*) value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')" ;;
+    esac
+    printf '%s' "$value"
 }
 
 octo_provider_allowlist_config_dir() {
@@ -21,10 +29,21 @@ octo_provider_allowlist_config_dir() {
 }
 
 octo_provider_allowlist_session_id() {
-    local raw
+    local raw sanitized="" char index
     raw="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_CODE_SESSION:-${OCTOPUS_SESSION_ID:-${CLAUDE_SESSION_ID:-global}}}}"
-    raw="$(printf '%s' "$raw" | tr -c 'A-Za-z0-9_.-' '-' | sed 's/--*/-/g;s/^-//;s/-$//')"
-    printf '%s\n' "${raw:-global}"
+    for ((index = 0; index < ${#raw}; index++)); do
+        char="${raw:index:1}"
+        case "$char" in
+            [A-Za-z0-9_.-]) sanitized+="$char" ;;
+            *) sanitized+="-" ;;
+        esac
+    done
+    while [[ "$sanitized" == *--* ]]; do
+        sanitized="${sanitized//--/-}"
+    done
+    sanitized="${sanitized#-}"
+    sanitized="${sanitized%-}"
+    printf '%s\n' "${sanitized:-global}"
 }
 
 octo_provider_allowlist_session_file() {

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -26,6 +26,58 @@
 # Populates PROVIDER_ENV_ARRAY with argv tokens that limit environment
 # variables to essentials only. This stays safe when PATH contains spaces.
 # ═══════════════════════════════════════════════════════════════════════════════
+
+octopus_codex_home_isolation_enabled() {
+    case "${OCTOPUS_CODEX_ISOLATE_HOME:-auto}" in
+        1|true|yes|on) return 0 ;;
+        0|false|no|off) return 1 ;;
+    esac
+
+    case "$(uname -s 2>/dev/null || true)" in
+        MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    esac
+    return 1
+}
+
+# Codex Desktop and the separately installed Codex CLI can be different
+# versions on Windows. Sharing models_cache.json across those versions can make
+# the CLI fail before dispatch. Keep auth/config synchronized while letting the
+# Octopus runtime own its model cache independently.
+octopus_prepare_codex_runtime_home() {
+    octopus_codex_home_isolation_enabled || return 0
+
+    local source_home="${OCTOPUS_CODEX_SOURCE_HOME:-$HOME/.codex}"
+    local runtime_home="${OCTOPUS_CODEX_HOME:-${WORKSPACE_DIR:-$HOME/.claude-octopus}/codex-home}"
+    local source_file target_file name
+
+    if [[ -n "${CODEX_HOME:-}" && -z "${OCTOPUS_CODEX_HOME:-}" \
+        && "$CODEX_HOME" != "$source_home" && "$CODEX_HOME" != "$runtime_home" ]]; then
+        return 0
+    fi
+    [[ "$runtime_home" != "$source_home" ]] || return 0
+
+    mkdir -p "$runtime_home" || {
+        echo "codex runtime home: cannot create $runtime_home" >&2
+        return 1
+    }
+    chmod 700 "$runtime_home" 2>/dev/null || true
+
+    for name in auth.json config.toml; do
+        source_file="$source_home/$name"
+        target_file="$runtime_home/$name"
+        [[ -f "$source_file" ]] || continue
+        if [[ ! -f "$target_file" ]] || ! cmp -s "$source_file" "$target_file"; then
+            cp -p "$source_file" "$target_file" || {
+                echo "codex runtime home: cannot synchronize $name" >&2
+                return 1
+            }
+            chmod 600 "$target_file" 2>/dev/null || true
+        fi
+    done
+
+    export CODEX_HOME="$runtime_home"
+}
+
 build_provider_env() {
     local provider="$1"
     PROVIDER_ENV_ARRAY=()
@@ -49,6 +101,7 @@ build_provider_env() {
     # v9.2.1: Try resolving env vars before building isolated env (Issue #177)
     case "$provider" in
         codex*)
+            octopus_prepare_codex_runtime_home || return 1
             if [[ -z "${OPENAI_API_KEY:-}" ]]; then
                 resolve_provider_env "OPENAI_API_KEY" 2>/dev/null || true
             fi

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -283,6 +283,31 @@ resolve_provider_env() {
     # Already set — nothing to do
     [[ -n "${!var_name:-}" ]] && return 0
 
+    # Parse simple KEY=value / export KEY=value declarations without evaluating
+    # their files. ~/.bashrc is especially important on Windows, where the
+    # desktop app may predate a newly-set user environment variable and
+    # non-interactive Git Bash deliberately skips interactive startup files.
+    local direct_env_file direct_env_line direct_env_value
+    for direct_env_file in "$PWD/.env" "$HOME/.env" "$HOME/.bashrc"; do
+        [[ -f "$direct_env_file" ]] || continue
+        while IFS= read -r direct_env_line || [[ -n "$direct_env_line" ]]; do
+            direct_env_line=${direct_env_line%$'\r'}
+            if [[ "$direct_env_line" =~ ^[[:space:]]*(export[[:space:]]+)?${var_name}= ]]; then
+                direct_env_value=${direct_env_line#*=}
+                if [[ "$direct_env_value" == \"*\" && "$direct_env_value" == *\" ]]; then
+                    direct_env_value=${direct_env_value:1:${#direct_env_value}-2}
+                elif [[ "$direct_env_value" == \'*\' && "$direct_env_value" == *\' ]]; then
+                    direct_env_value=${direct_env_value:1:${#direct_env_value}-2}
+                fi
+                if [[ -n "$direct_env_value" ]]; then
+                    export "$var_name=$direct_env_value"
+                    log DEBUG "Resolved $var_name from $direct_env_file (non-interactive shell fallback)"
+                    return 0
+                fi
+            fi
+        done < "$direct_env_file"
+    done
+
     # Try sourcing from ~/.profile (login shell config, no interactive guard)
     # Use a sentinel to isolate the var value from any stdout the profile may emit
     if [[ -f "$HOME/.profile" ]]; then

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -15,7 +15,7 @@
 
 # Agent configurations
 # Models (Mar 2026) - Premium defaults for Design Thinking workflows:
-# - OpenAI GPT-5.x: gpt-5.5 (premium, OAuth+API), gpt-5.4-pro (API-key only), gpt-5.3-codex, gpt-5.3-codex-spark (fast),
+# - OpenAI GPT-5.x: gpt-5.6-sol (ChatGPT subscription default), gpt-5.5, gpt-5.4-pro (API-key only),
 # [EXTRACTED to lib/dispatch.sh in v9.7.7]
 
 # NOTE: get_agent_command_array() removed in v9.7.7 — was dead code with broken
@@ -78,6 +78,27 @@ octopus_prepare_codex_runtime_home() {
     export CODEX_HOME="$runtime_home"
 }
 
+# A Codex CLI logged in through ChatGPT must not receive OPENAI_API_KEY from
+# Octopus's provider environment. Passing the key can silently change the
+# billing path from the user's subscription to metered API usage.
+octopus_codex_uses_chatgpt_auth() {
+    case "${OCTOPUS_CODEX_AUTH_MODE:-auto}" in
+        chatgpt|subscription|oauth) return 0 ;;
+        api|api-key|apikey) return 1 ;;
+    esac
+
+    local auth_file="${CODEX_HOME:-$HOME/.codex}/auth.json"
+    [[ -r "$auth_file" ]] || return 1
+    if command -v jq >/dev/null 2>&1; then
+        jq -e '.auth_mode == "chatgpt"' "$auth_file" >/dev/null 2>&1 && return 0
+        local jq_status=$?
+        # Native Windows jq cannot always open an MSYS /tmp path. A valid JSON
+        # false is definitive; parser/path failures fall through to grep.
+        [[ "$jq_status" -eq 1 ]] && return 1
+    fi
+    grep -Eq '"auth_mode"[[:space:]]*:[[:space:]]*"chatgpt"' "$auth_file" 2>/dev/null
+}
+
 build_provider_env() {
     local provider="$1"
     PROVIDER_ENV_ARRAY=()
@@ -102,7 +123,10 @@ build_provider_env() {
     case "$provider" in
         codex*)
             octopus_prepare_codex_runtime_home || return 1
-            if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+            local _codex_subscription_auth=false
+            if octopus_codex_uses_chatgpt_auth; then
+                _codex_subscription_auth=true
+            elif [[ -z "${OPENAI_API_KEY:-}" ]]; then
                 resolve_provider_env "OPENAI_API_KEY" 2>/dev/null || true
             fi
 
@@ -120,7 +144,10 @@ build_provider_env() {
                 fi
             fi
 
-            PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "OPENAI_API_KEY=${OPENAI_API_KEY:-}" "TMPDIR=${TMPDIR:-/tmp}")
+            PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "TMPDIR=${TMPDIR:-/tmp}")
+            if [[ "$_codex_subscription_auth" != "true" && -n "${OPENAI_API_KEY:-}" ]]; then
+                PROVIDER_ENV_ARRAY+=("OPENAI_API_KEY=${OPENAI_API_KEY}")
+            fi
             if [[ -n "${CODEX_HOME:-}" ]]; then
                 PROVIDER_ENV_ARRAY+=("CODEX_HOME=${CODEX_HOME}")
             fi
@@ -310,7 +337,7 @@ migrate_provider_config() {
         
         # Extract existing model preferences to seed v3.0
         local codex_model gemini_model
-        codex_model=$(jq -r '.providers.codex.model // .providers.codex.default // "gpt-5.5"' "$config_file")
+        codex_model=$(jq -r '.providers.codex.model // .providers.codex.default // "gpt-5.6-sol"' "$config_file")
         gemini_model=$(jq -r '.providers.gemini.model // .providers.gemini.default // "gemini-3.1-pro-preview"' "$config_file")
         
         cat > "$tmp_file" << EOF
@@ -319,11 +346,11 @@ migrate_provider_config() {
   "providers": {
     "codex": {
       "default": "$codex_model",
-      "fallback": "gpt-5.5",
-      "spark": "gpt-5.5",
-      "mini": "gpt-5.4-mini",
-      "reasoning": "o3",
-      "large_context": "gpt-5.5"
+      "fallback": "gpt-5.6-sol",
+      "spark": "gpt-5.6-sol",
+      "mini": "gpt-5.6-sol",
+      "reasoning": "gpt-5.6-sol",
+      "large_context": "gpt-5.6-sol"
     },
     "gemini": {
       "default": "$gemini_model",
@@ -391,7 +418,7 @@ EOF
         local replacement=""
         case "$current_val" in
             claude-sonnet-4-5|claude-sonnet-4-5-20250514|claude-3-5-sonnet*|claude-sonnet-4*)
-                if [[ "$path" == *codex* ]]; then replacement="gpt-5.5"; fi ;;
+                if [[ "$path" == *codex* ]]; then replacement="gpt-5.6-sol"; fi ;;
             gemini-2.0-flash-thinking*|gemini-2.0-flash-exp*|gemini-exp-*)
                 replacement="gemini-3-flash-preview" ;;
             gemini-2.0-pro*|gemini-1.5-pro*|gemini-pro)
@@ -399,7 +426,7 @@ EOF
             gemini-3-pro-image-preview)
                 replacement="gemini-3-pro-image" ;;  # shutdown 2026-06-25 (codex review)
             gpt-4o*|gpt-4-turbo*|gpt-4-*|o1-*|chatgpt-*)
-                replacement="gpt-5.5" ;;
+                replacement="gpt-5.6-sol" ;;
         esac
 
         if [[ -n "$replacement" ]]; then
@@ -447,7 +474,7 @@ set_provider_model() {
     if ! validate_model_name "$model"; then
         echo "ERROR: Invalid model name: '$model'" >&2
         echo "  Model names must not contain shell metacharacters (spaces, ;, |, &, \$, \`, quotes)" >&2
-        echo "  Examples: gpt-5.5, gemini-3.1-pro-preview, claude-opus-4.6" >&2
+        echo "  Examples: gpt-5.6-sol, gemini-3.1-pro-preview, claude-opus-4.6" >&2
         return 1
     fi
 
@@ -459,12 +486,12 @@ set_provider_model() {
   "version": "3.0",
   "providers": {
     "codex": {
-      "default": "gpt-5.5",
-      "fallback": "gpt-5.5",
-      "spark": "gpt-5.5",
-      "mini": "gpt-5.4-mini",
-      "reasoning": "o3",
-      "large_context": "gpt-5.5"
+      "default": "gpt-5.6-sol",
+      "fallback": "gpt-5.6-sol",
+      "spark": "gpt-5.6-sol",
+      "mini": "gpt-5.6-sol",
+      "reasoning": "gpt-5.6-sol",
+      "large_context": "gpt-5.6-sol"
     },
     "gemini": {
       "default": "gemini-3.1-pro-preview",

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -766,6 +766,9 @@ check_provider_health() {
             ;;
         openrouter)
             if [[ -z "${OPENROUTER_API_KEY:-}" ]]; then
+                resolve_provider_env "OPENROUTER_API_KEY" 2>/dev/null
+            fi
+            if [[ -z "${OPENROUTER_API_KEY:-}" ]]; then
                 echo "openrouter: OPENROUTER_API_KEY not set" >&2
                 return 1
             fi

--- a/scripts/lib/python-runtime.sh
+++ b/scripts/lib/python-runtime.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Source-safe Python resolver for Windows hook processes.
+# Windows App Execution Aliases report as executables but launch Microsoft
+# Store instead of an interpreter. Redirect python3 to a real python/py binary,
+# or remove the alias directory from PATH so availability checks fail safely.
+
+if [[ -z "${_OCTOPUS_PYTHON_RUNTIME_READY:-}" ]]; then
+    _OCTOPUS_PYTHON_RUNTIME_READY=1
+    _octopus_python3_path=$(type -P python3 2>/dev/null || true)
+
+    case "$_octopus_python3_path" in
+        */WindowsApps/*|*\\WindowsApps\\*)
+            _octopus_real_python=$(type -P python 2>/dev/null || true)
+            case "$_octopus_real_python" in
+                */WindowsApps/*|*\\WindowsApps\\*) _octopus_real_python="" ;;
+            esac
+
+            if [[ -n "$_octopus_real_python" ]]; then
+                _OCTOPUS_REAL_PYTHON="$_octopus_real_python"
+                export _OCTOPUS_REAL_PYTHON
+                python3() { "$_OCTOPUS_REAL_PYTHON" "$@"; }
+            else
+                _octopus_py_launcher=$(type -P py 2>/dev/null || true)
+                case "$_octopus_py_launcher" in
+                    */WindowsApps/*|*\\WindowsApps\\*) _octopus_py_launcher="" ;;
+                esac
+                if [[ -n "$_octopus_py_launcher" ]]; then
+                    _OCTOPUS_PY_LAUNCHER="$_octopus_py_launcher"
+                    export _OCTOPUS_PY_LAUNCHER
+                    python3() { "$_OCTOPUS_PY_LAUNCHER" -3 "$@"; }
+                else
+                    _octopus_alias_dir=${_octopus_python3_path%/*}
+                    _octopus_clean_path=""
+                    _octopus_old_ifs=$IFS
+                    IFS=:
+                    for _octopus_path_entry in $PATH; do
+                        [[ "$_octopus_path_entry" == "$_octopus_alias_dir" ]] && continue
+                        _octopus_clean_path="${_octopus_clean_path:+${_octopus_clean_path}:}${_octopus_path_entry}"
+                    done
+                    IFS=$_octopus_old_ifs
+                    PATH=$_octopus_clean_path
+                    export PATH
+                    hash -r 2>/dev/null || true
+                fi
+            fi
+            ;;
+    esac
+fi
+
+# Orchestrator subprocesses and helper scripts inherit the safe resolver.
+if declare -F python3 >/dev/null 2>&1; then
+    export -f python3 2>/dev/null || true
+fi

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -502,6 +502,7 @@ Be concise and specific. This is a planning exercise, not implementation."
     local design_synthesis_agent="${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}"
     local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-0}"
     local design_synth_timeout="${OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT:-0}"
+    local design_retries="${OCTOPUS_DESIGN_REVIEW_RETRIES:-1}"
     if [[ ! "$design_timeout" =~ ^[0-9]+$ ]]; then
         log WARN "Invalid OCTOPUS_DESIGN_REVIEW_TIMEOUT='${design_timeout}', defaulting to no wall timeout"
         design_timeout=0
@@ -509,6 +510,10 @@ Be concise and specific. This is a planning exercise, not implementation."
     if [[ ! "$design_synth_timeout" =~ ^[0-9]+$ ]]; then
         log WARN "Invalid OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT='${design_synth_timeout}', defaulting to no wall timeout"
         design_synth_timeout=0
+    fi
+    if [[ ! "$design_retries" =~ ^[0-9]+$ ]]; then
+        log WARN "Invalid OCTOPUS_DESIGN_REVIEW_RETRIES='${design_retries}', defaulting to 1"
+        design_retries=1
     fi
 
     local _design_timeout_label="none"
@@ -534,13 +539,26 @@ Be concise and specific. This is a planning exercise, not implementation."
 
     local design_agents=""
     local design_approaches=""
-    local design_agent design_role design_specialty design_approach
+    local design_agent design_role design_specialty design_approach design_attempt design_succeeded
     while IFS=':' read -r design_agent design_role design_specialty; do
         design_agent=${design_agent//$'\r'/}
         [[ -z "$design_agent" ]] && continue
         design_role="${design_role:-code-reviewer}"
         design_agents+="${design_agents:+, }${design_agent}"
-        design_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_agent" "$ceremony_prompt" "$design_timeout" "$design_role" "ceremony" 2>/dev/null) || true
+        design_approach=""
+        design_succeeded=false
+        for ((design_attempt = 0; design_attempt <= design_retries; design_attempt++)); do
+            if design_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_agent" "$ceremony_prompt" "$design_timeout" "$design_role" "ceremony" 2>/dev/null); then
+                design_succeeded=true
+                break
+            fi
+            if (( design_attempt < design_retries )); then
+                log WARN "Design review provider $design_agent failed; retrying ($((design_attempt + 1))/$design_retries)"
+            fi
+        done
+        if [[ "$design_succeeded" != "true" ]]; then
+            log WARN "Design review provider $design_agent unavailable after $((design_retries + 1)) attempts"
+        fi
         design_approaches+=$'\n\n'"${design_agent} APPROACH:"$'\n'"${design_approach:-[unavailable]}"
     done <<< "$design_fleet"
 

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -494,12 +494,11 @@ State your HIGH-LEVEL approach in 3-5 bullet points:
 
 Be concise and specific. This is a planning exercise, not implementation."
 
-    # Gather approaches from available providers. Keep these configurable so
-    # operators can pick cheaper/faster review models without patching code.
-    local codex_approach="" gemini_approach="" sonnet_approach=""
+    # Configured review participants are the ceremony roster. Explicit legacy
+    # environment overrides remain supported for operators who set them.
     local design_codex_agent="${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-codex-mini}"
     local design_agy_agent="${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-agy}}"
-    local design_claude_agent="${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}"
+    local design_claude_agent="${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-opus}"
     local design_synthesis_agent="${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}"
     local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-0}"
     local design_synth_timeout="${OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT:-0}"
@@ -517,27 +516,43 @@ Be concise and specific. This is a planning exercise, not implementation."
     local _synth_timeout_label="none"
     [[ "$design_synth_timeout" != "0" ]] && _synth_timeout_label="${design_synth_timeout}s"
 
-    log INFO "Design review: gathering provider approaches..."
-    log INFO "Design review agents: codex=${design_codex_agent}, agy=${design_agy_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${_design_timeout_label}, synth_timeout=${_synth_timeout_label}"
+    local design_fleet=""
+    if [[ -n "${OCTOPUS_DESIGN_REVIEW_FLEET:-}" ]]; then
+        design_fleet="$OCTOPUS_DESIGN_REVIEW_FLEET"
+    elif [[ -n "${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-}${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-}${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-}${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-}" ]]; then
+        design_fleet="${design_codex_agent}:implementer:implementation approach"$'\n'
+        design_fleet+="${design_agy_agent}:researcher:independent architecture approach"$'\n'
+        design_fleet+="${design_claude_agent}:code-reviewer:integration and risk approach"$'\n'
+    elif declare -f build_review_fleet >/dev/null 2>&1; then
+        design_fleet=$(build_review_fleet)
+    fi
+    if [[ -z "$design_fleet" ]]; then
+        design_fleet="${design_codex_agent}:implementer:implementation approach"$'\n'
+        design_fleet+="${design_agy_agent}:researcher:independent architecture approach"$'\n'
+        design_fleet+="${design_claude_agent}:code-reviewer:integration and risk approach"$'\n'
+    fi
 
-    codex_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
-    gemini_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
-    sonnet_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony" 2>/dev/null) || true
+    local design_agents=""
+    local design_approaches=""
+    local design_agent design_role design_specialty design_approach
+    while IFS=':' read -r design_agent design_role design_specialty; do
+        design_agent=${design_agent//$'\r'/}
+        [[ -z "$design_agent" ]] && continue
+        design_role="${design_role:-code-reviewer}"
+        design_agents+="${design_agents:+, }${design_agent}"
+        design_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_agent" "$ceremony_prompt" "$design_timeout" "$design_role" "ceremony" 2>/dev/null) || true
+        design_approaches+=$'\n\n'"${design_agent} APPROACH:"$'\n'"${design_approach:-[unavailable]}"
+    done <<< "$design_fleet"
+
+    log INFO "Design review: gathered configured provider approaches"
+    log INFO "Design review agents: ${design_agents:-none}; synthesis=${design_synthesis_agent}, timeout=${_design_timeout_label}, synth_timeout=${_synth_timeout_label}"
 
     # Synthesize conflicts and resolution
     local synthesis
     synthesis=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_synthesis_agent" "You are synthesizing a design review ceremony.
 
-Three providers stated their approach to this task:
-
-CODEX APPROACH:
-${codex_approach:-[unavailable]}
-
-GEMINI APPROACH:
-${gemini_approach:-[unavailable]}
-
-SONNET APPROACH:
-${sonnet_approach:-[unavailable]}
+The configured providers stated their approaches to this task:
+${design_approaches:-[all providers unavailable]}
 
 Identify:
 1. CONFLICTS: Where do the approaches disagree?

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -11,6 +11,11 @@
 # parse_review_md: reads REVIEW.md from repo root, outputs directive vars
 # WHY: CC Code Review supports REVIEW.md for customization; we match that
 # convention so repos already configured for CC work with /octo:review too.
+if ! type pathrt_canon_existing >/dev/null 2>&1; then
+    _octo_path_runtime_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/path-runtime.sh"
+    [[ -f "$_octo_path_runtime_lib" ]] && source "$_octo_path_runtime_lib"
+fi
+
 parse_review_md() {
     local repo_root="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
     local review_md="$repo_root/REVIEW.md"
@@ -731,8 +736,8 @@ review_run() {
         local review_root=""
         local context_file_resolved=""
         review_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)
-        review_root=$(cd "$review_root" 2>/dev/null && pwd -P || printf '%s' "$review_root")
-        context_file_resolved=$(realpath "$context_file" 2>/dev/null || true)
+        review_root=$(pathrt_canon_existing "$review_root" 2>/dev/null || true)
+        context_file_resolved=$(pathrt_canon_existing "$context_file" 2>/dev/null || true)
         if [[ -z "$context_file_resolved" || ! -r "$context_file_resolved" ]]; then
             log ERROR "review_run: contextFile is not readable: $context_file"
             echo '{"findings":[],"warning":"contextFile is not readable"}' > "$findings_file"
@@ -745,9 +750,7 @@ review_run() {
             render_terminal_report "$findings_file"
             return 1
         fi
-        case "$context_file_resolved" in
-            "$review_root"|"$review_root"/*) ;;
-            *)
+        if [[ -z "$review_root" ]] || ! pathrt_within_existing "$review_root" "$context_file"; then
                 log ERROR "review_run: contextFile escapes workspace root: $context_file"
                 echo '{"findings":[],"warning":"contextFile escapes workspace root"}' > "$findings_file"
                 if [[ -n "$proof_dir" ]]; then
@@ -758,8 +761,7 @@ review_run() {
                 rm -f "$provider_status_file"
                 render_terminal_report "$findings_file"
                 return 1
-                ;;
-        esac
+        fi
         context_file="$context_file_resolved"
         local context_file_bytes="0"
         context_file_bytes=$(wc -c < "$context_file" 2>/dev/null | tr -d '[:space:]' || echo 0)

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -634,64 +634,76 @@ print_provider_report() {
         return 0
     fi
 
-    # Determine status per provider
-    local codex_status="not used" gemini_status="not used" claude_status="✓ OK" perplexity_status="not used"
-    local codex_detail="" gemini_detail="" perplexity_detail=""
-    local had_fallback=false
+    # Collapse repeated round entries per exact executor alias. Preserve the
+    # configured fleet rather than projecting it onto the legacy four-provider
+    # dashboard, which hid OpenRouter GLM/Kimi successes.
+    local rows
+    rows=$(awk -F'|' '
+        function rank(s) {
+            if (s == "auth-failed" || s == "not-installed") return 4
+            if (s == "fallback" || s == "failed") return 3
+            if (s == "ok") return 1
+            return 2
+        }
+        {
+            provider = $1
+            detail = $3
+            for (i = 4; i <= NF; i++) detail = detail FS $i
+            if (!(provider in seen)) {
+                seen[provider] = 1
+                order[++count] = provider
+            }
+            if (!(provider in status) || rank($2) >= rank(status[provider])) {
+                status[provider] = $2
+                details[provider] = detail
+            }
+        }
+        END {
+            for (i = 1; i <= count; i++) {
+                provider = order[i]
+                print provider "|" status[provider] "|" details[provider]
+            }
+        }
+    ' "$status_file")
+    [[ -n "$rows" ]] || { rm -f "$status_file"; return 0; }
 
-    while IFS='|' read -r provider status detail; do
-        case "$provider" in
-            codex)
-                if [[ "$status" == "ok" ]]; then
-                    codex_status="✓ OK"
-                elif [[ "$status" == "fallback" ]]; then
-                    codex_status="✗ FALLBACK"
-                    codex_detail="$detail"
-                    had_fallback=true
-                elif [[ "$status" == "auth-failed" ]]; then
-                    codex_status="✗ AUTH FAILED"
-                    codex_detail="$detail"
-                    had_fallback=true
-                fi
-                ;;
-            gemini)
-                if [[ "$status" == "ok" ]]; then
-                    gemini_status="✓ OK"
-                elif [[ "$status" == "fallback" ]]; then
-                    gemini_status="✗ FALLBACK"
-                    gemini_detail="$detail"
-                    had_fallback=true
-                fi
-                ;;
-            perplexity)
-                if [[ "$status" == "ok" ]]; then
-                    perplexity_status="✓ OK"
-                elif [[ "$status" == "fallback" ]]; then
-                    perplexity_status="✗ FALLBACK"
-                    perplexity_detail="$detail"
-                    had_fallback=true
-                fi
-                ;;
-        esac
-    done < "$status_file"
+    local had_fallback=false
+    local provider status detail label display
 
     # Always print the report card
     echo ""
-    echo "┌─────────────────────────────────────────────┐"
-    echo "│ 🐙 Provider Status                          │"
-    echo "│                                             │"
-    printf "│ 🔴 Codex:      %-28s│\n" "$codex_status"
-    [[ -n "$codex_detail" ]] && printf "│    → %-38s│\n" "$codex_detail"
-    printf "│ 🟡 Gemini:     %-28s│\n" "$gemini_status"
-    [[ -n "$gemini_detail" ]] && printf "│    → %-38s│\n" "$gemini_detail"
-    printf "│ 🔵 Claude:     %-28s│\n" "$claude_status"
-    printf "│ 🟣 Perplexity: %-28s│\n" "$perplexity_status"
-    [[ -n "$perplexity_detail" ]] && printf "│    → %-38s│\n" "$perplexity_detail"
+    echo "+-----------------------------------------------------------------+"
+    echo "|  Octopus configured provider status                             |"
+    echo "+-----------------------------------------------------------------+"
+    while IFS='|' read -r provider status detail; do
+        case "$provider" in
+            codex)                 label="Codex" ;;
+            claude-opus)           label="Claude / Fable" ;;
+            claude*)               label="Claude / ${provider#claude-}" ;;
+            openrouter-glm52)      label="OpenRouter / GLM 5.2" ;;
+            openrouter-kimi-k3)    label="OpenRouter / Kimi K3" ;;
+            openrouter-*)          label="OpenRouter / ${provider#openrouter-}" ;;
+            gemini*)               label="Gemini" ;;
+            perplexity*)           label="Perplexity" ;;
+            *)                     label="$provider" ;;
+        esac
+        case "$status" in
+            ok)            display="OK" ;;
+            fallback)      display="FAILED / FALLBACK"; had_fallback=true ;;
+            auth-failed)   display="AUTH FAILED"; had_fallback=true ;;
+            not-installed) display="NOT INSTALLED"; had_fallback=true ;;
+            *)             display="${status:-UNKNOWN}"; had_fallback=true ;;
+        esac
+        printf "| %-29.29s %-31.31s |\n" "$label" "$display"
+        if [[ "$status" != "ok" && -n "$detail" ]]; then
+            printf "|   -> %-57.57s |\n" "$detail"
+        fi
+    done <<< "$rows"
     if [[ "$had_fallback" == "true" ]]; then
-        echo "│                                             │"
-        echo "│ ⚠ Some providers failed — run /octo:doctor  │"
+        echo "|                                                                 |"
+        echo "| Some providers failed - run /octo:doctor                       |"
     fi
-    echo "└─────────────────────────────────────────────┘"
+    echo "+-----------------------------------------------------------------+"
 
     # Persist failures for /octo:doctor
     if [[ "$had_fallback" == "true" ]]; then
@@ -1084,7 +1096,7 @@ ${round1_prompts[$retry_idx]}"
         local provider_key="${atype%%[-_]*}"
         if [[ ! -f "$f" ]]; then
             ((round1_partial_count++)) || true
-            echo "${provider_key}|fallback|Round 1 agent missing result" >> "$provider_status_file"
+            echo "${atype}|fallback|Round 1 agent missing result" >> "$provider_status_file"
             ((idx++)) || true
             continue
         fi
@@ -1113,9 +1125,9 @@ ${round1_prompts[$retry_idx]}"
         fi
         if ! review_result_completed_successfully "$f"; then
             ((round1_partial_count++)) || true
-            echo "${provider_key}|fallback|Round 1 agent did not complete successfully" >> "$provider_status_file"
+            echo "${atype}|fallback|Round 1 agent did not complete successfully" >> "$provider_status_file"
         else
-            echo "${provider_key}|ok|Round 1 completed" >> "$provider_status_file"
+            echo "${atype}|ok|Round 1 completed" >> "$provider_status_file"
         fi
         ((idx++)) || true
     done

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -64,82 +64,58 @@ _review_fleet_from_config() {
     local has_logic=false has_security=false has_arch=false has_cve=false has_diversity=false
 
     while IFS= read -r provider; do
+        # jq preserves CRLF from the host config on Windows. Normalize before
+        # exact matching so configured participants are not silently dropped.
+        provider=${provider//$'\r'/}
         [[ -z "$provider" ]] && continue
         case "$provider" in
             codex|codex-*)
-                if [[ "$has_logic" == "false" ]]; then
-                    fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
-                    has_logic=true
-                fi
+                fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+                has_logic=true
                 ;;
             opencode|opencode-*)
-                if [[ "$has_logic" == "false" ]]; then
-                    fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
-                    has_logic=true
-                fi
+                fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+                has_logic=true
                 ;;
             gemini|gemini-*)
-                if [[ "$has_security" == "false" ]]; then
-                    fleet+="${provider}:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
-                    has_security=true
-                fi
+                fleet+="${provider}:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+                has_security=true
                 ;;
             claude|claude-sonnet|claude-opus)
-                if [[ "$has_arch" == "false" ]]; then
-                    local agent="${provider}"
-                    [[ "$provider" == "claude" ]] && agent="claude-sonnet"
-                    fleet+="${agent}:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
-                    has_arch=true
-                fi
+                local agent="${provider}"
+                [[ "$provider" == "claude" ]] && agent="claude-opus"
+                fleet+="${agent}:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
+                has_arch=true
                 ;;
             perplexity|perplexity-*)
-                if [[ "$has_cve" == "false" ]]; then
-                    fleet+="${provider}:cve-reviewer:known CVEs, library advisories, live web search"$'\n'
-                    has_cve=true
-                fi
+                fleet+="${provider}:cve-reviewer:known CVEs, library advisories, live web search"$'\n'
+                has_cve=true
                 ;;
             openrouter|openrouter-*)
-                if [[ "$has_diversity" == "false" ]]; then
-                    fleet+="${provider}:diversity-reviewer:cross-family perspective on logic, missed assumptions, training-data divergence from primary providers"$'\n'
-                    has_diversity=true
-                fi
+                fleet+="${provider}:diversity-reviewer:cross-family perspective on logic, missed assumptions, training-data divergence from primary providers"$'\n'
+                has_diversity=true
                 ;;
             openai-compatible|openai-tools|openai-compatible-agent)
-                if [[ "$has_logic" == "false" ]]; then
-                    fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
-                    has_logic=true
-                elif [[ "$has_diversity" == "false" ]]; then
-                    fleet+="${provider}:diversity-reviewer:OpenAI-compatible independent review path"$'\n'
-                    has_diversity=true
-                fi
+                fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+                has_logic=true
                 ;;
             qwen|qwen-*)
-                if [[ "$has_security" == "false" ]]; then
-                    fleet+="${provider}:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
-                    has_security=true
-                elif [[ "$has_diversity" == "false" ]]; then
-                    fleet+="${provider}:diversity-reviewer:cross-family perspective on logic and assumptions"$'\n'
-                    has_diversity=true
-                fi
+                fleet+="${provider}:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+                has_security=true
                 ;;
             copilot|copilot-*)
-                if [[ "$has_cve" == "false" ]]; then
-                    fleet+="${provider}:cve-reviewer:known CVEs via web search, library advisories"$'\n'
-                    has_cve=true
-                elif [[ "$has_diversity" == "false" ]]; then
-                    fleet+="${provider}:diversity-reviewer:cross-perspective review"$'\n'
-                    has_diversity=true
-                fi
+                fleet+="${provider}:cve-reviewer:known CVEs via web search, library advisories"$'\n'
+                has_cve=true
                 ;;
         esac
     done <<< "$participants"
 
     [[ -z "$fleet" ]] && return 0
 
-    # Anchor: always include arch-reviewer (claude-sonnet) if config didn't supply one.
+    # Anchor: always include Claude's Fable-primary route if config omitted one.
     # Architecture context bridges per-finding noise from the specialist agents.
     if [[ "$has_arch" == "false" ]]; then
-        fleet+="claude-sonnet:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
+        fleet+="claude-opus:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
     fi
 
     log INFO "review fleet: config-driven (.routing.features.review)"
@@ -187,8 +163,8 @@ build_review_fleet() {
         fleet+="claude-sonnet:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
     fi
 
-    # arch-reviewer: claude-sonnet (always available — best at holistic analysis)
-    fleet+="claude-sonnet:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
+    # arch-reviewer: Fable 5 primary, Opus 4.8 only on model unavailability.
+    fleet+="claude-opus:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
 
     # cve-reviewer: Perplexity → Gemini search → Copilot → Qwen → claude WebSearch
     if command -v perplexity >/dev/null 2>&1 || [[ -n "${PERPLEXITY_API_KEY:-}" ]]; then

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -342,18 +342,31 @@ review_openai_compat_empty_output_retryable() {
     [[ "${reconnect_count%%$'\n'*}" -gt 0 ]] || return 1
 }
 
+review_openrouter_transport_retryable() {
+    local result_file="$1"
+    local agent_type="$2"
+    [[ "$agent_type" == openrouter-* ]] || return 1
+    review_result_has_terminal_status "$result_file" || return 1
+    review_result_completed_successfully "$result_file" && return 1
+    grep -Fq 'OpenRouter curl failed (timeout or network error' "$result_file" 2>/dev/null
+}
+
 review_result_has_terminal_status() {
     local result_file="$1"
-    local terminal_count
+    local terminal_count final_line
     [[ -f "$result_file" ]] || return 1
+    final_line=$(awk 'NF { line = $0 } END { print line }' "$result_file" 2>/dev/null || true)
+    [[ "$final_line" == '# Completed:'* ]] || return 1
     terminal_count=$(grep -cE '^## Status: (SUCCESS|FAILED|TIMEOUT)([[:space:](]|$)' "$result_file" 2>/dev/null || true)
     [[ "${terminal_count:-0}" -gt 0 ]]
 }
 
 review_result_completed_successfully() {
     local result_file="$1"
-    local final_status
+    local final_status final_line
     [[ -f "$result_file" ]] || return 1
+    final_line=$(awk 'NF { line = $0 } END { print line }' "$result_file" 2>/dev/null || true)
+    [[ "$final_line" == '# Completed:'* ]] || return 1
     final_status=$(awk '
         /^## Status: (SUCCESS|FAILED|TIMEOUT)([[:space:](]|$)/ {
             status = $0
@@ -491,7 +504,7 @@ review_supervise_round1() {
 # for the last JSON object with a findings array.
 review_extract_findings_array() {
     local review_md="$1"
-    local output_text direct_json
+    local output_text direct_json native_review_md
     [[ -f "$review_md" ]] || { echo "[]"; return 1; }
 
     output_text=$(awk '/^## Output$/{found=1;next} /^## /{if(found)exit} found && !/^```(json|JSON)?$/{print}' "$review_md" 2>/dev/null || true)
@@ -504,7 +517,8 @@ review_extract_findings_array() {
     fi
 
     if command -v python3 >/dev/null 2>&1; then
-        python3 - "$review_md" <<'PYEXTRACT'
+        native_review_md=$(pathrt_for_native "$review_md") || { echo "[]"; return 1; }
+        python3 - "$native_review_md" <<'PYEXTRACT'
 import json, sys
 from pathlib import Path
 path = Path(sys.argv[1])
@@ -975,28 +989,42 @@ ${agent_prompt_base}"
     # after a short pause.
     local openai_compat_empty_retry_max="${OCTOPUS_REVIEW_OPENAI_COMPAT_EMPTY_RETRY_MAX:-1}"
     local openai_compat_empty_retry_backoff="${OCTOPUS_REVIEW_OPENAI_COMPAT_EMPTY_RETRY_BACKOFF_SECS:-90}"
+    local openrouter_retry_max="${OCTOPUS_REVIEW_OPENROUTER_RETRY_MAX:-1}"
+    local openrouter_retry_backoff="${OCTOPUS_REVIEW_OPENROUTER_RETRY_BACKOFF_SECS:-5}"
     [[ "$openai_compat_empty_retry_max" =~ ^[0-9]+$ ]] || openai_compat_empty_retry_max=1
     [[ "$openai_compat_empty_retry_backoff" =~ ^[0-9]+$ ]] || openai_compat_empty_retry_backoff=90
+    [[ "$openrouter_retry_max" =~ ^[0-9]+$ ]] || openrouter_retry_max=1
+    [[ "$openrouter_retry_backoff" =~ ^[0-9]+$ ]] || openrouter_retry_backoff=5
     openai_compat_empty_retry_max=$((10#$openai_compat_empty_retry_max))
     openai_compat_empty_retry_backoff=$((10#$openai_compat_empty_retry_backoff))
-    if [[ "$openai_compat_empty_retry_max" -gt 0 ]]; then
+    openrouter_retry_max=$((10#$openrouter_retry_max))
+    openrouter_retry_backoff=$((10#$openrouter_retry_backoff))
+    if [[ "$openai_compat_empty_retry_max" -gt 0 || "$openrouter_retry_max" -gt 0 ]]; then
         local retry_idx=0
         while [[ "$retry_idx" -lt "${#round1_files[@]}" ]]; do
             local retry_file="${round1_files[$retry_idx]}"
             local retry_agent_type="${round1_agent_types[$retry_idx]}"
-            if review_openai_compat_empty_output_retryable "$retry_file" "$retry_agent_type"; then
-                local reconnect_count retry_role retry_task_id retry_prompt retry_result_file retry_pid archived_file
+            local retry_reason="" retry_backoff=0 reconnect_count=0
+            if [[ "$openai_compat_empty_retry_max" -gt 0 ]] && review_openai_compat_empty_output_retryable "$retry_file" "$retry_agent_type"; then
                 reconnect_count=$(grep -c 'Reconnecting' "$retry_file" 2>/dev/null || true)
                 reconnect_count=${reconnect_count:-0}
                 reconnect_count=${reconnect_count%%$'\n'*}
+                retry_reason="Empty output after ${reconnect_count} reconnect(s)"
+                retry_backoff="$openai_compat_empty_retry_backoff"
+            elif [[ "$openrouter_retry_max" -gt 0 ]] && review_openrouter_transport_retryable "$retry_file" "$retry_agent_type"; then
+                retry_reason="a transient OpenRouter transport failure"
+                retry_backoff="$openrouter_retry_backoff"
+            fi
+            if [[ -n "$retry_reason" ]]; then
+                local retry_role retry_task_id retry_prompt retry_result_file retry_pid archived_file
                 retry_role="${round1_roles[$retry_idx]}"
                 retry_task_id="${round1_task_ids[$retry_idx]}-retry1"
                 retry_result_file="${RESULTS_DIR}/${retry_agent_type}-${retry_task_id}.md"
                 archived_file="${retry_file}.attempt1"
                 mv "$retry_file" "$archived_file" 2>/dev/null || true
-                log WARN "review_run: ${retry_agent_type}/${retry_role} ended Empty output after ${reconnect_count} reconnect(s); retrying once after ${openai_compat_empty_retry_backoff}s (artifact=$(basename "$archived_file"))"
-                sleep "$openai_compat_empty_retry_backoff"
-                retry_prompt="RETRY NOTICE: the previous ${retry_agent_type}/${retry_role} review attempt ended with Empty output after adapter reconnects. Review only the supplied diff/context; do not inspect the workspace unless strictly necessary. Return ONLY the required JSON object.
+                log WARN "review_run: ${retry_agent_type}/${retry_role} ended with ${retry_reason}; retrying once after ${retry_backoff}s (artifact=$(basename "$archived_file"))"
+                sleep "$retry_backoff"
+                retry_prompt="RETRY NOTICE: the previous ${retry_agent_type}/${retry_role} review attempt ended with ${retry_reason}. Review only the supplied diff/context; do not inspect the workspace unless strictly necessary. Return ONLY the required JSON object.
 
 ${round1_prompts[$retry_idx]}"
                 spawn_agent "$retry_agent_type" "$retry_prompt" "$retry_task_id" "$retry_role" "review" &

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -387,11 +387,14 @@ review_wait_for_result_status() {
     local results_dir="${4:-${RESULTS_DIR:-${HOME}/.claude-octopus/results}}"
     local stall_window="${5:-${OCTOPUS_REVIEW_STALL_WINDOW:-1800}}"
     local poll_secs="${6:-${OCTOPUS_REVIEW_POLL_SECS:-30}}"
-    local poll_start last_progress last_fp current_fp
+    local poll_start last_progress last_fp current_fp exit_seen=0 now
+    local result_flush_grace="${OCTOPUS_REVIEW_RESULT_FLUSH_GRACE_SECS:-90}"
     [[ "$stall_window" =~ ^[0-9]+$ ]] || stall_window=1800
     [[ "$poll_secs" =~ ^[0-9]+$ ]] || poll_secs=30
+    [[ "$result_flush_grace" =~ ^[0-9]+$ ]] || result_flush_grace=90
     stall_window=$((10#$stall_window))
     poll_secs=$((10#$poll_secs))
+    result_flush_grace=$((10#$result_flush_grace))
     [[ "$poll_secs" -lt 1 ]] && poll_secs=1
     poll_start=$(date +%s)
     last_progress="$poll_start"
@@ -403,9 +406,18 @@ review_wait_for_result_status() {
             break
         fi
         if ! review_process_is_running "$pid"; then
-            log WARN "review_run: ${label} exited without a terminal status"
-            break
+            now=$(date +%s)
+            if [[ "$exit_seen" -eq 0 ]]; then
+                exit_seen="$now"
+                log INFO "review_run: ${label} provider exited; waiting up to ${result_flush_grace}s for result footer flush"
+            elif [[ $((now - exit_seen)) -ge "$result_flush_grace" ]]; then
+                log WARN "review_run: ${label} exited without a terminal status after ${result_flush_grace}s flush grace"
+                break
+            fi
+            sleep "$poll_secs"
+            continue
         fi
+        exit_seen=0
         current_fp=$(review_progress_fingerprint_since "$poll_start" "$results_dir" "$own_pattern")
         if [[ "$current_fp" != "$last_fp" ]]; then
             last_fp="$current_fp"
@@ -431,14 +443,18 @@ review_supervise_round1() {
     local review_poll_secs="$2"
     local results_dir="$3"
     local _poll_start _now _idx _rf _pid _current_fp _round1_active
+    local result_flush_grace="${OCTOPUS_REVIEW_RESULT_FLUSH_GRACE_SECS:-90}"
     local round1_last_progress=()
     local round1_last_fp=()
     local round1_settled=()
+    local round1_exit_seen=()
 
     [[ "$review_stall_window" =~ ^[0-9]+$ ]] || review_stall_window=1800
     [[ "$review_poll_secs" =~ ^[0-9]+$ ]] || review_poll_secs=30
+    [[ "$result_flush_grace" =~ ^[0-9]+$ ]] || result_flush_grace=90
     review_stall_window=$((10#$review_stall_window))
     review_poll_secs=$((10#$review_poll_secs))
+    result_flush_grace=$((10#$result_flush_grace))
     [[ "$review_poll_secs" -lt 1 ]] && review_poll_secs=1
 
     _poll_start=$(date +%s)
@@ -448,6 +464,7 @@ review_supervise_round1() {
         round1_last_progress[$_idx]="$_poll_start"
         round1_last_fp[$_idx]=$(review_progress_fingerprint_since "$_poll_start" "$results_dir" "$(basename "$_rf")*")
         round1_settled[$_idx]=false
+        round1_exit_seen[$_idx]=0
         ((_idx++)) || true
     done
 
@@ -469,11 +486,20 @@ review_supervise_round1() {
                 continue
             fi
             if ! review_process_is_running "$_pid"; then
-                log WARN "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} exited without a terminal status"
-                round1_settled[$_idx]=true
+                if [[ "${round1_exit_seen[$_idx]:-0}" -eq 0 ]]; then
+                    round1_exit_seen[$_idx]="$_now"
+                    log INFO "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} provider exited; waiting up to ${result_flush_grace}s for result footer flush"
+                elif [[ $((_now - ${round1_exit_seen[$_idx]})) -ge "$result_flush_grace" ]]; then
+                    log WARN "review_run: Round 1 ${round1_agent_types[$_idx]}/${round1_roles[$_idx]} exited without a terminal status after ${result_flush_grace}s flush grace"
+                    round1_settled[$_idx]=true
+                fi
+                if [[ "${round1_settled[$_idx]:-false}" != "true" ]]; then
+                    _round1_active=true
+                fi
                 ((_idx++)) || true
                 continue
             fi
+            round1_exit_seen[$_idx]=0
 
             _current_fp=$(review_progress_fingerprint_since "$_poll_start" "$results_dir" "$(basename "$_rf")*")
             if [[ "$_current_fp" != "${round1_last_fp[$_idx]}" ]]; then

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -497,7 +497,7 @@ review_extract_findings_array() {
     output_text=$(awk '/^## Output$/{found=1;next} /^## /{if(found)exit} found && !/^```(json|JSON)?$/{print}' "$review_md" 2>/dev/null || true)
     if [[ -n "$output_text" ]]; then
         direct_json=$(printf '%s' "$output_text" | jq -cs '[.[] | objects | .findings | select(type == "array" and length > 0)] | last // []' 2>/dev/null || true)
-        if [[ -n "$direct_json" && "$direct_json" != "null" ]]; then
+        if [[ -n "$direct_json" && "$direct_json" != "null" && "$direct_json" != "[]" ]]; then
             printf '%s\n' "$direct_json"
             return 0
         fi

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -445,6 +445,51 @@ review_wait_for_result_status() {
     wait "$pid" 2>/dev/null || true
 }
 
+# Launch all Round 1 provider setup paths concurrently. Each
+# spawn_agent_capture_pid call performs model/auth/context setup before it can
+# return the actual provider PID; doing those calls serially made a four-seat
+# "parallel" review spend minutes launching one provider at a time on Windows.
+# The round1_* arrays are owned by review_run and resolved through Bash dynamic
+# scope, matching review_supervise_round1 below.
+# shellcheck disable=SC2154
+review_launch_round1_fleet() {
+    local setup_pids=() pid_receipts=()
+    local idx receipt setup_status captured_pid
+
+    round1_pids=()
+    idx=0
+    while [[ "$idx" -lt "${#round1_agent_types[@]}" ]]; do
+        receipt=$(mktemp "${TMPDIR:-/tmp}/octo-review-spawn.XXXXXX") || return 1
+        pid_receipts[$idx]="$receipt"
+        (
+            spawn_agent_capture_pid \
+                "${round1_agent_types[$idx]}" \
+                "${round1_prompts[$idx]}" \
+                "${round1_task_ids[$idx]}" \
+                "${round1_roles[$idx]}" \
+                "review" > "$receipt"
+        ) &
+        setup_pids[$idx]=$!
+        round1_pids[$idx]=""
+        ((idx++)) || true
+    done
+
+    idx=0
+    while [[ "$idx" -lt "${#setup_pids[@]}" ]]; do
+        setup_status=0
+        wait "${setup_pids[$idx]}" || setup_status=$?
+        captured_pid=$(awk '/^[0-9]+$/ { value=$1 } END { print value }' \
+            "${pid_receipts[$idx]}" 2>/dev/null || true)
+        rm -f "${pid_receipts[$idx]}"
+        if [[ "$setup_status" -eq 0 && "$captured_pid" =~ ^[0-9]+$ ]]; then
+            round1_pids[$idx]="$captured_pid"
+        else
+            log ERROR "review_run: Round 1 ${round1_agent_types[$idx]}/${round1_roles[$idx]} failed to launch"
+        fi
+        ((idx++)) || true
+    done
+}
+
 # review_supervise_round1: monitor each Round 1 provider independently so
 # progress from one provider cannot keep a stalled peer alive. The round1_*
 # arrays are intentionally resolved through Bash's dynamic function scope;
@@ -1022,10 +1067,9 @@ CRITICAL OUTPUT FORMAT: Return ONLY a valid JSON object. No markdown, no prose, 
 ${agent_prompt_base}"
         round1_prompts+=("$agent_prompt")
 
-        local round1_pid
-        round1_pid=$(spawn_agent_capture_pid "$agent_type" "$agent_prompt" "$task_id" "$role" "review")
-        round1_pids+=("$round1_pid")
     done <<< "$fleet"
+
+    review_launch_round1_fleet
 
     fleet_dispatch_end
 

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -67,12 +67,22 @@ _review_fleet_from_config() {
 
     local fleet=""
     local has_logic=false has_security=false has_arch=false has_cve=false has_diversity=false
+    local configured_allowlist=""
+    if declare -f octo_provider_allowlist_value >/dev/null 2>&1; then
+        configured_allowlist="$(octo_provider_allowlist_value)"
+    fi
 
     while IFS= read -r provider; do
         # jq preserves CRLF from the host config on Windows. Normalize before
         # exact matching so configured participants are not silently dropped.
         provider=${provider//$'\r'/}
         [[ -z "$provider" ]] && continue
+        if [[ -n "$configured_allowlist" ]] && \
+           declare -f octo_provider_allowed >/dev/null 2>&1 && \
+           ! OCTO_ALLOWED_PROVIDERS="$configured_allowlist" octo_provider_allowed "$provider"; then
+            log WARN "review fleet: configured provider '$provider' excluded by provider allowlist"
+            continue
+        fi
         case "$provider" in
             codex|codex-*)
                 fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
@@ -119,7 +129,9 @@ _review_fleet_from_config() {
 
     # Anchor: always include Claude's Fable-primary route if config omitted one.
     # Architecture context bridges per-finding noise from the specialist agents.
-    if [[ "$has_arch" == "false" ]]; then
+    if [[ "$has_arch" == "false" ]] && \
+       { [[ -z "$configured_allowlist" ]] || \
+         OCTO_ALLOWED_PROVIDERS="$configured_allowlist" octo_provider_allowed claude; }; then
         fleet+="claude-opus:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
     fi
 
@@ -757,8 +769,8 @@ review_run() {
     # v9.0: Preflight — check Codex auth before review pipeline
     if command -v codex >/dev/null 2>&1; then
         if ! check_codex_auth_freshness 2>/dev/null; then
-            log "WARN" "review_run: Codex auth may be stale — review fleet may fall back to claude-sonnet"
-            log "USER" "⚠ Codex auth check failed. Run 'codex auth' or /octo:doctor to fix. Falling back to claude-sonnet for Codex roles."
+            log "WARN" "review_run: Codex auth may be stale — configured Codex rounds may fail"
+            log "USER" "⚠ Codex auth check failed. Run 'codex auth' or /octo:doctor to fix. No unconfigured or fast alias will be substituted."
             echo "codex|auth-failed|Run: codex auth" >> "$provider_status_file"
         fi
     else
@@ -1196,10 +1208,10 @@ Return ONLY valid JSON with 'findings' array including verdict field."
     verified_findings=$(review_run_agent_sync_progress "codex" "$verifier_prompt" "code-reviewer" "review" "verifier-codex") && {
         echo "codex|ok|Round 2 verification" >> "$provider_status_file"
     } || {
-        log WARN "review_run: codex verifier failed, falling back to claude-sonnet"
-        log "USER" "⚠ Round 2: Codex unavailable → claude-sonnet (fallback). Codex API usage will NOT change."
-        echo "codex|fallback|Round 2 → claude-sonnet" >> "$provider_status_file"
-        verified_findings=$(review_run_agent_sync_progress "claude-sonnet" "$verifier_prompt" "code-reviewer" "review" "verifier-claude-sonnet") || {
+        log WARN "review_run: codex verifier failed, using configured Claude Fable/Opus route"
+        log "USER" "⚠ Round 2: Codex unavailable → configured claude-opus route. No fast alias is used."
+        echo "codex|fallback|Round 2 → configured claude-opus" >> "$provider_status_file"
+        verified_findings=$(review_run_agent_sync_progress "claude-opus" "$verifier_prompt" "code-reviewer" "review" "verifier-claude-opus") || {
             log WARN "review_run: verification failed entirely, using all findings as confirmed"
             verified_findings="{\"findings\":$(echo "$all_findings" | \
                 jq 'map(. + {"verdict":"confirmed"})' 2>/dev/null || echo "[]")}"
@@ -1259,7 +1271,7 @@ Findings: $(echo "$confirmed_findings" | jq -c '.')
 Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
 
     local final_json synth_ok="true"
-    final_json=$(review_run_agent_sync_progress "claude-sonnet" "$synthesis_prompt" "code-reviewer" "review" "synthesis-claude-sonnet") || {
+    final_json=$(review_run_agent_sync_progress "claude-opus" "$synthesis_prompt" "code-reviewer" "review" "synthesis-claude-opus") || {
         synth_ok="false"
         log WARN "review_run: synthesis failed, using confirmed findings sorted as-is"
         final_json="$(review_local_synthesis_json "$confirmed_findings" "$round1_warning")"
@@ -1286,7 +1298,7 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
     if [[ "$synth_ok" == "true" ]] && declare -f octo_event_emit >/dev/null 2>&1; then
         local _synth_count
         _synth_count=$(printf '%s' "$final_json" | jq '.findings | length' 2>/dev/null || echo 0)
-        octo_event_emit "synthesis" phase="review" provider="claude-sonnet" provider_label_kind="legacy-alias" executor_alias="claude-sonnet" configured_provider="$(octo_provider_identity_from_agent_type "claude-sonnet")" configured_model="$(get_agent_model "claude-sonnet" "review" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="review" count="${_synth_count:-0}" || true
+        octo_event_emit "synthesis" phase="review" provider="claude-opus" provider_label_kind="configured-alias" executor_alias="claude-opus" configured_provider="$(octo_provider_identity_from_agent_type "claude-opus")" configured_model="$(get_agent_model "claude-opus" "review" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="review" count="${_synth_count:-0}" || true
     fi
 
     if [[ -n "$proof_dir" ]]; then
@@ -1501,6 +1513,6 @@ render_review_summary() {
     echo "| Nit | $nit_count |"
     echo "| Pre-existing | $preexisting_count |"
     echo ""
-    echo "_Reviewed by Codex + Gemini + Claude + Perplexity fleet_"
+    echo "_Reviewed by the configured multi-provider fleet_"
     echo "_See inline comments for details_"
 }

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -643,7 +643,15 @@ PYEXTRACT
 review_local_synthesis_json() {
     local findings_json="$1"
     local warning="${2:-}"
-    local sort_filter='def severity_rank: if .severity == "normal" then 0 elif .severity == "nit" then 1 elif .severity == "pre-existing" then 2 else 3 end; sort_by(severity_rank)'
+    local sort_filter='def severity_rank: if .severity == "normal" then 0 elif .severity == "nit" then 1 elif .severity == "pre-existing" then 2 else 3 end;
+        def dedupe_findings:
+          group_by([(.file // ""), (.line // 0), (.category // ""), (.severity // "")])
+          | map(.[0] as $base
+              | $base + {
+                  detail: (map(.detail // empty) | unique | join("\n\nCorroborating provider perspective: ")),
+                  confidence: (map(.confidence // 0) | max)
+                });
+        dedupe_findings | sort_by(severity_rank)'
     if [[ -n "$warning" ]]; then
         printf '%s' "$findings_json" | jq -c --arg warning "$warning" "{findings:(. // [] | ${sort_filter}), warning:\$warning}" 2>/dev/null \
             || printf '{"findings":[],"warning":%s}\n' "$(printf '%s' "$warning" | jq -R .)"
@@ -1054,7 +1062,11 @@ CRITICAL OUTPUT FORMAT: Return ONLY a valid JSON object. No markdown, no prose, 
     fleet_dispatch_begin
     while IFS=: read -r agent_type role specialty; do
         [[ -z "$agent_type" ]] && continue
-        local task_id="review-r1-${role}-${timestamp}"
+        # Include the executor alias because multiple configured seats can share
+        # one role (for example GLM and Kimi are both diversity reviewers).
+        # spawn_agent derives raw/temp filenames from task_id alone, so a
+        # role-only ID lets concurrent providers overwrite each other's output.
+        local task_id="review-r1-${agent_type}-${role}-${timestamp}"
         # Use spawn_agent's actual output path convention: ${RESULTS_DIR}/${agent_type}-${task_id}.md
         local result_file="${RESULTS_DIR}/${agent_type}-${task_id}.md"
         round1_files+=("$result_file")

--- a/scripts/lib/routing.sh
+++ b/scripts/lib/routing.sh
@@ -41,7 +41,7 @@ resolve_provider_to_agent() {
                                 agent="$provider" ;;
         agy|agy-research|antigravity)
                                 agent="$provider" ;;
-        openrouter|openrouter-glm5|openrouter-kimi|openrouter-deepseek)
+        openrouter|openrouter-*)
                                 agent="$provider" ;;
         openai-compatible|openai-tools|openai-compatible-agent)
                                 agent="$provider" ;;

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -842,6 +842,72 @@ select_provider() {
 
 # Display provider status with subscription tiers
 show_provider_status() {
+    local configured_fleet=""
+    if declare -f _review_fleet_from_config >/dev/null 2>&1; then
+        configured_fleet=$(_review_fleet_from_config)
+    fi
+    if [[ -n "$configured_fleet" ]]; then
+        echo ""
+        echo -e "${CYAN:-}Configured provider status:${NC:-}"
+        # Status is display-only. Resolve the configured roster's common aliases
+        # with one jq process instead of invoking the full migration/model stack
+        # once per seat (very slow under Git Bash on Windows).
+        local configured_models="" configured_model_agent configured_model_value
+        local provider_config="${HOME}/.claude-octopus/config/providers.json"
+        if command -v jq >/dev/null 2>&1 && [[ -f "$provider_config" ]]; then
+            configured_models=$(jq -r '
+                .providers as $p
+                | [
+                    ["codex", ($p.codex.default // "gpt-5.6-sol")],
+                    ["codex-standard", ($p.codex.default // "gpt-5.6-sol")],
+                    ["codex-mini", ($p.codex.mini // $p.codex.default // "gpt-5.6-sol")],
+                    ["codex-spark", ($p.codex.spark // $p.codex.default // "gpt-5.6-sol")],
+                    ["codex-reasoning", ($p.codex.reasoning // $p.codex.default // "gpt-5.6-sol")],
+                    ["codex-large-context", ($p.codex.large_context // $p.codex.default // "gpt-5.6-sol")],
+                    ["claude-opus", ($p.claude.default // "claude-fable-5")],
+                    ["openrouter-glm52", ($p.openrouter.glm52 // "z-ai/glm-5.2")],
+                    ["openrouter-kimi-k3", ($p.openrouter["kimi-k3"] // "moonshotai/kimi-k3")],
+                    ["openrouter", ($p.openrouter.default // "unresolved")]
+                  ]
+                | .[] | @tsv
+            ' "$provider_config" 2>/dev/null || true)
+        fi
+        local configured_agent configured_role configured_specialty family model status billing
+        while IFS=':' read -r configured_agent configured_role configured_specialty; do
+            configured_agent=${configured_agent//$'\r'/}
+            [[ -z "$configured_agent" ]] && continue
+            case "$configured_agent" in
+                codex|codex-*) family="codex"; billing="ChatGPT subscription" ;;
+                claude|claude-*) family="claude"; billing="Claude subscription" ;;
+                openrouter|openrouter-*) family="openrouter"; billing="OpenRouter metered" ;;
+                gemini|gemini-*) family="gemini"; billing="Gemini route" ;;
+                cursor-agent|cursor-agent-*) family="cursor-agent"; billing="Cursor subscription" ;;
+                agy|agy-*|antigravity) family="agy"; billing="Antigravity subscription" ;;
+                *) family="${configured_agent%%-*}"; billing="configured route" ;;
+            esac
+            status="${RED:-}unavailable${NC:-}"
+            if declare -f check_provider_health >/dev/null 2>&1 && \
+               check_provider_health "$family" >/dev/null 2>&1; then
+                status="${GREEN:-}ready${NC:-}"
+            fi
+            model=""
+            while IFS=$'\t' read -r configured_model_agent configured_model_value; do
+                configured_model_value=${configured_model_value//$'\r'/}
+                if [[ "$configured_model_agent" == "$configured_agent" ]]; then
+                    model="$configured_model_value"
+                    break
+                fi
+            done <<< "$configured_models"
+            if [[ -z "$model" ]]; then
+                model="$(get_agent_model "$configured_agent" review "$configured_role" 2>/dev/null || echo unresolved)"
+            fi
+            echo -e "  ${configured_agent}: ${status} | ${model} | ${billing}"
+        done <<< "$configured_fleet"
+        echo -e "  Fast aliases: ${GREEN:-}disabled${NC:-} (none configured)"
+        echo ""
+        return 0
+    fi
+
     load_providers_config
 
     echo ""
@@ -1082,6 +1148,21 @@ _smoke_test_provider() {
         return 0
     fi
 
+    # Exercise the same credential-isolated command path as real dispatch.
+    # In particular, ChatGPT-authenticated Codex must not inherit a metered
+    # OPENAI_API_KEY merely because the parent desktop process has one.
+    local -a smoke_cmd_array=() smoke_provider_env=() smoke_external_command=()
+    if declare -f build_provider_env >/dev/null 2>&1; then
+        build_provider_env "$agent_type" || {
+            echo "AUTH:${model}" > "$result_file"
+            rm -f "$stderr_file" 2>/dev/null
+            return 0
+        }
+        smoke_provider_env=("${PROVIDER_ENV_ARRAY[@]}")
+    fi
+    read -ra smoke_cmd_array <<< "$cmd_str"
+    smoke_external_command=("${smoke_provider_env[@]}" "${smoke_cmd_array[@]}")
+
     # Send trivial prompt with timeout
     local smoke_exit=0
     if [[ "$provider" == codex || "$provider" == codex-* ]]; then
@@ -1092,19 +1173,19 @@ _smoke_test_provider() {
         pushd "$smoke_dir" >/dev/null 2>&1
         # codex cmd_str ends with `-` (stdin prompt); arg form is rejected.
         echo "Reply with exactly: ok" | run_with_timeout "$smoke_timeout" \
-            $cmd_str \
+            "${smoke_external_command[@]}" \
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
         popd >/dev/null 2>&1
         rm -rf "$smoke_dir" 2>/dev/null
     elif [[ "$provider" == gemini || "$provider" == gemini-* ]]; then
         # Gemini: prompt via stdin with -p "" for headless trigger
         echo "Reply with exactly: ok" | run_with_timeout "$smoke_timeout" \
-            $cmd_str -p "" \
+            "${smoke_external_command[@]}" -p "" \
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
     elif [[ "$provider" == cursor-agent || "$provider" == cursor-agent-* ]]; then
         # --trust required for untrusted workspaces; matches cursor-agent.sh:143 dispatch path
         echo "Reply with exactly: ok" | run_with_timeout "$smoke_timeout" \
-            $cmd_str -p "" --trust --output-format text \
+            "${smoke_external_command[@]}" -p "" --trust --output-format text \
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
     elif [[ "$provider" == agy || "$provider" == agy-* || "$provider" == "antigravity" ]]; then
         # agy-exec.sh is a stdin adapter that builds its own argv and execs agy
@@ -1114,11 +1195,11 @@ _smoke_test_provider() {
         # web-search tool call, which hangs with no sandbox network permission.
         echo "Reply with exactly: ok. Answer from your own knowledge only — do not use web search or any tools." \
             | run_with_timeout "$smoke_timeout" \
-            $cmd_str \
+            "${smoke_external_command[@]}" \
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
     elif [[ "$provider" == claude || "$provider" == claude-* ]]; then
         echo "Reply with exactly: ok" | run_with_timeout "$smoke_timeout" \
-            $cmd_str \
+            "${smoke_external_command[@]}" \
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
     elif [[ "$provider" == openrouter || "$provider" == openrouter-* ]]; then
         run_with_timeout "$smoke_timeout" \
@@ -1126,7 +1207,7 @@ _smoke_test_provider() {
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
     else
         run_with_timeout "$smoke_timeout" \
-            $cmd_str -p "Reply with exactly: ok" \
+            "${smoke_external_command[@]}" -p "Reply with exactly: ok" \
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
     fi
 

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -1059,10 +1059,12 @@ _smoke_test_provider() {
 
     # Determine agent type and get model
     case "$provider" in
-        codex) agent_type="codex" ;;
-        gemini) agent_type="gemini" ;;
-        cursor-agent) agent_type="cursor-agent" ;;
-        agy) agent_type="agy" ;;
+        codex|codex-*) agent_type="$provider" ;;
+        gemini|gemini-*) agent_type="$provider" ;;
+        cursor-agent|cursor-agent-*) agent_type="$provider" ;;
+        agy|agy-*|antigravity) agent_type="$provider" ;;
+        claude|claude-*) agent_type="$provider" ;;
+        openrouter|openrouter-*) agent_type="$provider" ;;
         *) echo "SKIP" > "$result_file"; return 0 ;;
     esac
 
@@ -1082,7 +1084,7 @@ _smoke_test_provider() {
 
     # Send trivial prompt with timeout
     local smoke_exit=0
-    if [[ "$provider" == "codex" ]]; then
+    if [[ "$provider" == codex || "$provider" == codex-* ]]; then
         # Codex requires a git repo — use a temp one to avoid false negatives (#202)
         local smoke_dir
         smoke_dir=$(mktemp -d 2>/dev/null || mktemp -d -t 'octo-smoke')
@@ -1094,17 +1096,17 @@ _smoke_test_provider() {
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
         popd >/dev/null 2>&1
         rm -rf "$smoke_dir" 2>/dev/null
-    elif [[ "$provider" == "gemini" ]]; then
+    elif [[ "$provider" == gemini || "$provider" == gemini-* ]]; then
         # Gemini: prompt via stdin with -p "" for headless trigger
         echo "Reply with exactly: ok" | run_with_timeout "$smoke_timeout" \
             $cmd_str -p "" \
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
-    elif [[ "$provider" == "cursor-agent" ]]; then
+    elif [[ "$provider" == cursor-agent || "$provider" == cursor-agent-* ]]; then
         # --trust required for untrusted workspaces; matches cursor-agent.sh:143 dispatch path
         echo "Reply with exactly: ok" | run_with_timeout "$smoke_timeout" \
             $cmd_str -p "" --trust --output-format text \
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
-    elif [[ "$provider" == "agy" ]]; then
+    elif [[ "$provider" == agy || "$provider" == agy-* || "$provider" == "antigravity" ]]; then
         # agy-exec.sh is a stdin adapter that builds its own argv and execs agy
         # directly — any argv appended here would be silently discarded, so the
         # prompt must go via stdin (like codex/gemini above). Explicitly forbid
@@ -1113,6 +1115,14 @@ _smoke_test_provider() {
         echo "Reply with exactly: ok. Answer from your own knowledge only — do not use web search or any tools." \
             | run_with_timeout "$smoke_timeout" \
             $cmd_str \
+            >/dev/null 2>"$stderr_file" || smoke_exit=$?
+    elif [[ "$provider" == claude || "$provider" == claude-* ]]; then
+        echo "Reply with exactly: ok" | run_with_timeout "$smoke_timeout" \
+            $cmd_str \
+            >/dev/null 2>"$stderr_file" || smoke_exit=$?
+    elif [[ "$provider" == openrouter || "$provider" == openrouter-* ]]; then
+        run_with_timeout "$smoke_timeout" \
+            $cmd_str "Reply with exactly: ok" \
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
     else
         run_with_timeout "$smoke_timeout" \
@@ -1161,108 +1171,97 @@ provider_smoke_test() {
 
     log INFO "Running provider smoke test... 🐙"
 
-    # Determine which providers are available (from preflight state)
-    local has_codex=false has_gemini=false has_cursor_agent=false has_agy=false
-    command -v codex &>/dev/null && has_codex=true
-    command -v gemini &>/dev/null && has_gemini=true
-    if command -v agent &>/dev/null && _is_cursor_agent_binary && \
-       { [[ -n "${CURSOR_API_KEY:-}" ]] || grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; }; then
-        has_cursor_agent=true
+    # Use the exact configured review aliases when present. An installed CLI is
+    # not permission to probe it, and two OpenRouter seats are two distinct
+    # model checks even though they share one API key.
+    local configured_fleet="" require_all=false smoke_agents=""
+    if declare -f _review_fleet_from_config >/dev/null 2>&1; then
+        configured_fleet=$(_review_fleet_from_config)
     fi
-    command -v agy &>/dev/null && has_agy=true
+    if [[ -n "$configured_fleet" ]]; then
+        require_all=true
+        local configured_agent _configured_role _configured_specialty
+        while IFS=':' read -r configured_agent _configured_role _configured_specialty; do
+            configured_agent=${configured_agent//$'\r'/}
+            [[ -n "$configured_agent" ]] && smoke_agents+="${configured_agent}"$'\n'
+        done <<< "$configured_fleet"
+    else
+        local candidate family
+        for candidate in codex gemini cursor-agent agy claude-opus openrouter; do
+            case "$candidate" in
+                codex*) family=codex ;;
+                gemini*) family=gemini ;;
+                cursor-agent*) family=cursor-agent ;;
+                agy*) family=agy ;;
+                claude*) family=claude ;;
+                openrouter*) family=openrouter ;;
+            esac
+            if declare -f octo_provider_allowed >/dev/null 2>&1 && ! octo_provider_allowed "$family"; then
+                continue
+            fi
+            if declare -f check_provider_health >/dev/null 2>&1 && check_provider_health "$family" >/dev/null 2>&1; then
+                smoke_agents+="${candidate}"$'\n'
+            fi
+        done
+    fi
 
-    if [[ "$has_codex" == "false" && "$has_gemini" == "false" && "$has_cursor_agent" == "false" && "$has_agy" == "false" ]]; then
+    if [[ -z "$smoke_agents" ]]; then
         log WARN "Smoke test: no providers to test"
         return 0
     fi
 
-    # Launch parallel smoke tests
-    local codex_result_file gemini_result_file cursor_agent_result_file agy_result_file
-    codex_result_file=$(secure_tempfile "smoke-codex")
-    gemini_result_file=$(secure_tempfile "smoke-gemini")
-    cursor_agent_result_file=$(secure_tempfile "smoke-cursor-agent")
-    agy_result_file=$(secure_tempfile "smoke-agy")
-    local pids=()
-
-    if [[ "$has_codex" == "true" ]]; then
-        _smoke_test_provider "codex" "${OCTOPUS_CODEX_SMOKE_TIMEOUT:-45}" "$codex_result_file" &
+    # Launch exact model aliases in parallel.
+    local agents=() result_files=() pids=()
+    local agent result_file smoke_timeout
+    while IFS= read -r agent; do
+        [[ -z "$agent" ]] && continue
+        result_file=$(secure_tempfile "smoke-${agent}")
+        case "$agent" in
+            codex|codex-*) smoke_timeout="${OCTOPUS_CODEX_SMOKE_TIMEOUT:-45}" ;;
+            gemini|gemini-*) smoke_timeout="${OCTOPUS_GEMINI_SMOKE_TIMEOUT:-30}" ;;
+            cursor-agent|cursor-agent-*) smoke_timeout="${OCTOPUS_CURSOR_AGENT_TIMEOUT:-120}" ;;
+            agy|agy-*|antigravity) smoke_timeout="${OCTOPUS_AGY_SMOKE_TIMEOUT:-45}" ;;
+            claude|claude-*) smoke_timeout="${OCTOPUS_CLAUDE_SMOKE_TIMEOUT:-60}" ;;
+            openrouter|openrouter-*) smoke_timeout="${OCTOPUS_OPENROUTER_SMOKE_TIMEOUT:-75}" ;;
+            *) smoke_timeout="${OCTOPUS_PROVIDER_SMOKE_TIMEOUT:-60}" ;;
+        esac
+        agents+=("$agent")
+        result_files+=("$result_file")
+        _smoke_test_provider "$agent" "$smoke_timeout" "$result_file" &
         pids+=($!)
-    else
-        echo "SKIP" > "$codex_result_file"
-    fi
-
-    if [[ "$has_gemini" == "true" ]]; then
-        _smoke_test_provider "gemini" "${OCTOPUS_GEMINI_SMOKE_TIMEOUT:-30}" "$gemini_result_file" &
-        pids+=($!)
-    else
-        echo "SKIP" > "$gemini_result_file"
-    fi
-
-    if [[ "$has_cursor_agent" == "true" ]]; then
-        _smoke_test_provider "cursor-agent" "${OCTOPUS_CURSOR_AGENT_TIMEOUT:-120}" "$cursor_agent_result_file" &
-        pids+=($!)
-    else
-        echo "SKIP" > "$cursor_agent_result_file"
-    fi
-
-    if [[ "$has_agy" == "true" ]]; then
-        _smoke_test_provider "agy" "${OCTOPUS_AGY_SMOKE_TIMEOUT:-45}" "$agy_result_file" &
-        pids+=($!)
-    else
-        echo "SKIP" > "$agy_result_file"
-    fi
+    done <<< "$smoke_agents"
 
     # Wait for all background tests
     for pid in "${pids[@]}"; do
         wait "$pid" 2>/dev/null || true
     done
 
-    # Collect results
-    local codex_result gemini_result cursor_agent_result agy_result
-    codex_result=$(cat "$codex_result_file" 2>/dev/null || echo "SKIP")
-    gemini_result=$(cat "$gemini_result_file" 2>/dev/null || echo "SKIP")
-    cursor_agent_result=$(cat "$cursor_agent_result_file" 2>/dev/null || echo "SKIP")
-    agy_result=$(cat "$agy_result_file" 2>/dev/null || echo "SKIP")
-    rm -f "$codex_result_file" "$gemini_result_file" "$cursor_agent_result_file" "$agy_result_file" 2>/dev/null
-
     local pass_count=0 fail_count=0 skip_count=0
-
-    for result in "$codex_result" "$gemini_result" "$cursor_agent_result" "$agy_result"; do
+    local index result result_agent
+    for index in "${!agents[@]}"; do
+        result_agent="${agents[$index]}"
+        result=$(cat "${result_files[$index]}" 2>/dev/null || echo "SKIP")
+        rm -f "${result_files[$index]}" 2>/dev/null
         case "${result%%:*}" in
             PASS) ((++pass_count)) ;;
             SKIP) ((++skip_count)) ;;
-            *) ((++fail_count)) ;;
+            *)
+                ((++fail_count))
+                local smoke_error="${result%%:*}"
+                local smoke_model="${result#*:}"
+                _display_smoke_test_error "$result_agent" "$smoke_error" "$smoke_model"
+                ;;
         esac
     done
 
-    # Display results
     if [[ $fail_count -gt 0 ]]; then
-        echo ""
-        if [[ "$codex_result" != "PASS" && "$codex_result" != "SKIP" ]]; then
-            local codex_error="${codex_result%%:*}"
-            local codex_model="${codex_result#*:}"
-            _display_smoke_test_error "Codex" "$codex_error" "$codex_model"
-        fi
-        if [[ "$gemini_result" != "PASS" && "$gemini_result" != "SKIP" ]]; then
-            local gemini_error="${gemini_result%%:*}"
-            local gemini_model="${gemini_result#*:}"
-            _display_smoke_test_error "Gemini" "$gemini_error" "$gemini_model"
-        fi
-        if [[ "$cursor_agent_result" != "PASS" && "$cursor_agent_result" != "SKIP" ]]; then
-            local cursor_agent_error="${cursor_agent_result%%:*}"
-            local cursor_agent_model="${cursor_agent_result#*:}"
-            _display_smoke_test_error "Cursor Agent" "$cursor_agent_error" "$cursor_agent_model"
-        fi
-        if [[ "$agy_result" != "PASS" && "$agy_result" != "SKIP" ]]; then
-            local agy_error="${agy_result%%:*}"
-            local agy_model="${agy_result#*:}"
-            _display_smoke_test_error "Antigravity" "$agy_error" "$agy_model"
-        fi
         echo ""
     fi
 
-    # Pass if at least one provider succeeds (consistent with v7.9.1 single-provider mode)
-    if [[ $pass_count -gt 0 ]]; then
+    # A configured multi-provider roster is fail-closed: never claim success
+    # because one seat answered while GLM, Kimi, Claude, or Codex silently failed.
+    if [[ $pass_count -gt 0 ]] && \
+       { [[ "$require_all" != "true" ]] || [[ $fail_count -eq 0 ]]; }; then
         if [[ $fail_count -gt 0 ]]; then
             log WARN "Smoke test: degraded mode ($pass_count/$((pass_count + fail_count)) providers passed)"
         else
@@ -1272,14 +1271,22 @@ provider_smoke_test() {
         return 0
     fi
 
-    # All providers failed
-    log ERROR "Smoke test failed: no providers responded successfully"
+    if [[ "$require_all" == "true" && $fail_count -gt 0 ]]; then
+        log ERROR "Configured smoke test failed: $fail_count/${#agents[@]} exact seats failed"
+    else
+        log ERROR "Smoke test failed: no providers responded successfully"
+    fi
     echo -e "${RED}╔═══════════════════════════════════════════════════════════════╗${NC}"
     echo -e "${RED}║  ❌ PROVIDER SMOKE TEST FAILED                                ║${NC}"
     echo -e "${RED}╚═══════════════════════════════════════════════════════════════╝${NC}"
     echo ""
-    echo -e "No AI providers could process a test request."
-    echo -e "This means workflows will produce ${YELLOW}empty results${NC}."
+    if [[ "$require_all" == "true" && $fail_count -gt 0 ]]; then
+        echo -e "At least one configured provider/model route failed its exact test request."
+        echo -e "The workflow is blocked; no unconfigured fallback will be selected."
+    else
+        echo -e "No AI providers could process a test request."
+        echo -e "This means workflows will produce ${YELLOW}empty results${NC}."
+    fi
     echo ""
     echo -e "${DIM}Skip with: --skip-smoke-test  (not recommended)${NC}"
     echo -e "${DIM}Re-test:   bash orchestrate.sh doctor smoke${NC}"

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -691,6 +691,7 @@ ${heuristic_ctx}"
         fi
 
         local auth_attempt=0
+        local fable5_fallback_attempt=0
         local exit_code=0
         while true; do
             exit_code=0
@@ -736,6 +737,32 @@ ${heuristic_ctx}"
             fi
 
             stop_quota_watcher "$_quota_watcher_pid"
+
+            # Fable 5 is primary. Retry once on Opus 4.8 only when the provider
+            # explicitly reports that the Fable model is unavailable.
+            if [[ $exit_code -ne 0 ]] && [[ "$fable5_fallback_attempt" -eq 0 ]] \
+                && [[ "$agent_type" == "claude-opus" ]] \
+                && [[ "${OCTOPUS_OPUS_MODEL:-}" == "claude-fable-5" ]] \
+                && declare -f fable5_model_unavailable >/dev/null 2>&1 \
+                && fable5_model_unavailable "$temp_errors" "$temp_output"; then
+                local fable5_model_index=-1
+                local fable5_cmd_index
+                for fable5_cmd_index in "${!cmd_array[@]}"; do
+                    if [[ "${cmd_array[$fable5_cmd_index]}" == "claude-fable-5" ]]; then
+                        fable5_model_index="$fable5_cmd_index"
+                        break
+                    fi
+                done
+                if [[ "$fable5_model_index" -ge 0 ]]; then
+                    cmd_array[$fable5_model_index]="claude-opus-4-8"
+                    fable5_fallback_attempt=1
+                    log "WARN" "[$agent_type] Fable 5 unavailable; retrying once on Opus 4.8"
+                    > "$temp_output"
+                    > "$temp_errors"
+                    > "$raw_output"
+                    continue
+                fi
+            fi
 
             # v8.16: Check if failure is auth-related and retryable
             if [[ $exit_code -ne 0 ]] && [[ $auth_attempt -lt $max_auth_retries ]]; then

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -136,8 +136,15 @@ write_agent_result_header() {
     } > "$result_file"
 }
 
+# Second-resolution timestamps collide when several independent orchestrate.sh
+# processes start together. Include process and random entropy while keeping the
+# leading epoch for operator readability and chronological sorting.
+octopus_new_task_id() {
+    printf '%s-%s-%s\n' "$(date +%s)" "${BASHPID:-$$}" "${RANDOM:-0}"
+}
+
 spawn_agent() {
-    local _ts; _ts=$(date +%s)
+    local _ts; _ts=$(octopus_new_task_id)
     local agent_type="$1"
     local prompt="$2"
     local task_id="${3:-$_ts}"
@@ -640,9 +647,12 @@ ${heuristic_ctx}"
 
         # IMPROVED: Use temp files for reliable output capture (v7.13.2 - Issue #10)
         # v7.19.0 P0.1: Real-time output streaming to result file
-        local temp_output="${RESULTS_DIR}/.tmp-${task_id}.out"
-        local temp_errors="${RESULTS_DIR}/.tmp-${task_id}.err"
-        local raw_output="${RESULTS_DIR}/.raw-${task_id}.out"  # Backup of unfiltered output
+        # A caller may deliberately reuse a group/task ID across providers. Keep
+        # provider subprocess capture isolated even in that case.
+        local capture_id="${agent_type}-${task_id}"
+        local temp_output="${RESULTS_DIR}/.tmp-${capture_id}.out"
+        local temp_errors="${RESULTS_DIR}/.tmp-${capture_id}.err"
+        local raw_output="${RESULTS_DIR}/.raw-${capture_id}.out"  # Backup of unfiltered output
 
         # Update task progress with context-aware spinner verb (v7.16.0 Feature 1)
         if [[ -n "$CLAUDE_TASK_ID" ]]; then
@@ -1151,7 +1161,7 @@ ${heuristic_ctx}"
 spawn_agent_capture_pid() {
     local agent_type="$1"
     local prompt="$2"
-    local task_id="${3:-$(date +%s)}"
+    local task_id="${3:-$(octopus_new_task_id)}"
     local role="${4:-}"
     local phase="${5:-}"
     local use_fork="${6:-false}"

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -402,7 +402,8 @@ ${heuristic_ctx}"
     # Opus 4.8 fast is 2x standard ($10/$50 vs $5/$25 per MTok); legacy 4.6
     # fast remains 6x standard.
     # Only used for interactive single-shot tasks, never for multi-phase workflows
-    if [[ "$agent_type" == "claude-opus" ]] && [[ "$SUPPORTS_FAST_OPUS" == "true" ]]; then
+    if [[ "$agent_type" == "claude-opus" ]] && [[ "$SUPPORTS_FAST_OPUS" == "true" ]] \
+        && [[ "${OCTOPUS_OPUS_MODEL:-}" != "claude-fable-5" ]]; then
         local opus_tier
         opus_tier=$(get_agent_config "${curated_agent:-}" "tier" 2>/dev/null) || opus_tier="premium"
         local session_autonomy

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -398,11 +398,11 @@ ${heuristic_ctx}"
         return "$_budget_rc"
     fi
 
-    # v8.4/v9.42: Auto-route claude-opus to fast mode when appropriate.
-    # Opus 4.8 fast is 2x standard ($10/$50 vs $5/$25 per MTok); legacy 4.6
-    # fast remains 6x standard.
-    # Only used for interactive single-shot tasks, never for multi-phase workflows
+    # Opus Fast is a distinct, more expensive tier. Never select it as an
+    # automatic fallback: callers must opt in explicitly with
+    # OCTOPUS_OPUS_MODE=fast (or request claude-opus-fast directly).
     if [[ "$agent_type" == "claude-opus" ]] && [[ "$SUPPORTS_FAST_OPUS" == "true" ]] \
+        && [[ "${OCTOPUS_OPUS_MODE:-auto}" == "fast" ]] \
         && [[ "${OCTOPUS_OPUS_MODEL:-}" != "claude-fable-5" ]]; then
         local opus_tier
         opus_tier=$(get_agent_config "${curated_agent:-}" "tier" 2>/dev/null) || opus_tier="premium"
@@ -412,7 +412,7 @@ ${heuristic_ctx}"
         opus_mode=$(select_opus_mode "$phase" "$opus_tier" "$session_autonomy")
         if [[ "$opus_mode" == "fast" ]]; then
             agent_type="claude-opus-fast"
-            log "INFO" "Auto-routing to Opus Fast mode (phase=$phase, tier=$opus_tier, autonomy=$session_autonomy)"
+            log "INFO" "Using explicitly requested Opus Fast mode (phase=$phase, tier=$opus_tier, autonomy=$session_autonomy)"
             if [[ "${SUPPORTS_OPUS_4_8:-false}" == "true" && "${OCTOPUS_OPUS_MODEL:-}" != "claude-opus-4.6" ]]; then
                 log "WARN" "Opus 4.8 fast is 2x standard: \$10/\$50 per MTok vs \$5/\$25 standard"
             else

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -847,7 +847,9 @@ ${heuristic_ctx}"
             else
                 # Clean stdout (e.g. codex exec) — pass through with noise filtering
                 # v9.15.1: Filter Gemini MCP status messages and CLI preamble from stdout
-                grep -v \
+                # Treat provider output as text and remove any embedded NULs so
+                # GNU grep never replaces a valid verdict with "Binary file ... matches".
+                LC_ALL=C tr -d '\000' < "$temp_output" | grep -a -v \
                     -e '^MCP issues detected' \
                     -e '^Loading extension:' \
                     -e '^YOLO mode is enabled' \

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -403,7 +403,7 @@ ${heuristic_ctx}"
     # OCTOPUS_OPUS_MODE=fast (or request claude-opus-fast directly).
     if [[ "$agent_type" == "claude-opus" ]] && [[ "$SUPPORTS_FAST_OPUS" == "true" ]] \
         && [[ "${OCTOPUS_OPUS_MODE:-auto}" == "fast" ]] \
-        && [[ "${OCTOPUS_OPUS_MODEL:-}" != "claude-fable-5" ]]; then
+        && { ! declare -f fable5_opus_pinned >/dev/null 2>&1 || ! fable5_opus_pinned; }; then
         local opus_tier
         opus_tier=$(get_agent_config "${curated_agent:-}" "tier" 2>/dev/null) || opus_tier="premium"
         local session_autonomy
@@ -743,7 +743,8 @@ ${heuristic_ctx}"
             # explicitly reports that the Fable model is unavailable.
             if [[ $exit_code -ne 0 ]] && [[ "$fable5_fallback_attempt" -eq 0 ]] \
                 && [[ "$agent_type" == "claude-opus" ]] \
-                && [[ "${OCTOPUS_OPUS_MODEL:-}" == "claude-fable-5" ]] \
+                && declare -f fable5_opus_pinned >/dev/null 2>&1 \
+                && fable5_opus_pinned \
                 && declare -f fable5_model_unavailable >/dev/null 2>&1 \
                 && fable5_model_unavailable "$temp_errors" "$temp_output"; then
                 local fable5_model_index=-1

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -64,18 +64,39 @@ check_explicit_file_coverage() {
     printf '%s' "$missing"
 }
 
+testing_git_compatible_path() {
+    local path="$1"
+    if declare -f tangle_git_compatible_path >/dev/null 2>&1; then
+        tangle_git_compatible_path "$path"
+        return $?
+    fi
+    case "$(uname -s 2>/dev/null || true)" in
+        MINGW*|MSYS*|CYGWIN*)
+            if [[ "$path" == /* ]] && command -v cygpath >/dev/null 2>&1; then
+                cygpath -m "$path"
+                return 0
+            fi
+            ;;
+    esac
+    printf '%s\n' "$path"
+}
+
 snapshot_tangle_worktree_paths() {
     local repo_root=""
+    local repo_candidate=""
 
     if [[ -n "${PROJECT_ROOT:-}" ]]; then
         if [[ -d "$PROJECT_ROOT" ]]; then
-            repo_root=$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null || true)
+            repo_candidate=$(testing_git_compatible_path "$PROJECT_ROOT")
+            repo_root=$(git -C "$repo_candidate" rev-parse --show-toplevel 2>/dev/null || true)
             [[ -n "$repo_root" ]] || return 0
         else
-            repo_root=$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || true)
+            repo_candidate=$(testing_git_compatible_path "$(pwd)")
+            repo_root=$(git -C "$repo_candidate" rev-parse --show-toplevel 2>/dev/null || true)
         fi
     else
-        repo_root=$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || true)
+        repo_candidate=$(testing_git_compatible_path "$(pwd)")
+        repo_root=$(git -C "$repo_candidate" rev-parse --show-toplevel 2>/dev/null || true)
     fi
     [[ -n "$repo_root" ]] || return 0
 

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -5,6 +5,11 @@
 # Validate tangle results with quality gate
 # v3.0: Supports configurable threshold and loop-until-approved retry logic
 
+if ! type pathrt_canon_existing >/dev/null 2>&1; then
+    _octo_path_runtime_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/path-runtime.sh"
+    [[ -f "$_octo_path_runtime_lib" ]] && source "$_octo_path_runtime_lib"
+fi
+
 extract_explicit_file_refs() {
     local text="$1"
 
@@ -65,20 +70,7 @@ check_explicit_file_coverage() {
 }
 
 testing_git_compatible_path() {
-    local path="$1"
-    if declare -f tangle_git_compatible_path >/dev/null 2>&1; then
-        tangle_git_compatible_path "$path"
-        return $?
-    fi
-    case "$(uname -s 2>/dev/null || true)" in
-        MINGW*|MSYS*|CYGWIN*)
-            if [[ "$path" == /* ]] && command -v cygpath >/dev/null 2>&1; then
-                cygpath -m "$path"
-                return 0
-            fi
-            ;;
-    esac
-    printf '%s\n' "$path"
+    pathrt_for_git "$1"
 }
 
 snapshot_tangle_worktree_paths() {

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -376,10 +376,16 @@ $challenge_result
 
         # Write validation report before branching so abort/escalate/retry paths
         # still leave an actionable artifact for embrace and post-run diagnosis.
+        local gate_workspace gate_session
+        gate_workspace=$(pwd -P)
+        gate_session="${CLAUDE_SESSION_ID:-${OCTOPUS_SESSION_ID:-unknown}}"
         cat > "$validation_file" << EOF
 # TANGLE Phase Validation Report
 ## Task: $original_prompt
 ## Generated: $(date)
+## Gate ID: tangle-${task_group}
+## Workspace: ${gate_workspace}
+## Session: ${gate_session}
 
 ### Quality Gate: ${gate_status}
 - Success Rate: ${success_rate}% (threshold: ${tangle_threshold}%)

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -238,6 +238,15 @@ _validate_openai_compatible_agent_command() {
 # Only allows whitelisted command prefixes
 validate_agent_command() {
     local cmd="$1"
+
+    # Claude effort is passed through `env` because spawn.sh executes a parsed
+    # argv rather than shell assignment syntax. Strip only this exact,
+    # allowlisted assignment, then validate the underlying command normally.
+    # Any additional assignment remains at argv[0] and is rejected below.
+    if [[ "$cmd" =~ ^env[[:space:]]+CLAUDE_CODE_EFFORT_LEVEL=(low|medium|high|xhigh|max)[[:space:]]+(.+)$ ]]; then
+        cmd="${BASH_REMATCH[2]}"
+    fi
+
     local cmd_executable="${cmd%%[[:space:]]*}"
 
     # Allow helper shims only when they are the executable token, not when they

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -239,11 +239,14 @@ _validate_openai_compatible_agent_command() {
 validate_agent_command() {
     local cmd="$1"
 
-    # Claude effort is passed through `env` because spawn.sh executes a parsed
-    # argv rather than shell assignment syntax. Strip only this exact,
-    # allowlisted assignment, then validate the underlying command normally.
-    # Any additional assignment remains at argv[0] and is rejected below.
-    if [[ "$cmd" =~ ^env[[:space:]]+CLAUDE_CODE_EFFORT_LEVEL=(low|medium|high|xhigh|max)[[:space:]]+(.+)$ ]]; then
+    # Claude model/effort pins are passed through `env` because spawn.sh
+    # executes parsed argv rather than shell assignment syntax. Strip only the
+    # exact allowlisted assignments emitted by dispatch.sh, then validate the
+    # underlying Claude command normally. Any extra assignment remains at
+    # argv[0] and is rejected below.
+    if [[ "$cmd" =~ ^env[[:space:]]+OCTOPUS_OPUS_MODEL=(claude-fable-5|claude-opus-4\.6|claude-opus-4\.7|claude-opus-4\.8|opus)([[:space:]]+CLAUDE_CODE_EFFORT_LEVEL=(low|medium|high|xhigh|max))?[[:space:]]+(.+)$ ]]; then
+        cmd="${BASH_REMATCH[4]}"
+    elif [[ "$cmd" =~ ^env[[:space:]]+CLAUDE_CODE_EFFORT_LEVEL=(low|medium|high|xhigh|max)[[:space:]]+(.+)$ ]]; then
         cmd="${BASH_REMATCH[2]}"
     fi
 

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -181,13 +181,19 @@ _validate_openai_compatible_agent_command() {
     read -r -a parts <<< "$cmd"
 
     [[ "${#parts[@]}" -ge 7 ]] || return 1
-    [[ "${parts[0]}" == */scripts/helpers/openai-compatible-agent.py ]] || return 1
+    case "${parts[0]}" in
+        */scripts/helpers/openai-compatible-agent.py|*/scripts/helpers/openai-compatible-agent.sh) ;;
+        *) return 1 ;;
+    esac
 
     local provider=""
+    local base_url=""
+    local api_key_env=""
     local model=""
     local cwd=""
     local reasoning_effort=""
     local reasoning_policy=""
+    local tool_mode=""
     local i=1
 
     while [[ $i -lt ${#parts[@]} ]]; do
@@ -196,8 +202,25 @@ _validate_openai_compatible_agent_command() {
         local value="${parts[$((i + 1))]}"
         case "$flag" in
             --provider)
-                [[ -z "$provider" && "$value" == "generic" ]] || return 1
+                [[ -z "$provider" ]] || return 1
+                case "$value" in
+                    generic|openrouter|atlascloud) ;;
+                    *) return 1 ;;
+                esac
                 provider="$value"
+                ;;
+            --base-url)
+                [[ -z "$base_url" ]] || return 1
+                _octopus_is_safe_openai_compatible_value "$value" || return 1
+                case "$value" in
+                    http://*|https://*) ;;
+                    *) return 1 ;;
+                esac
+                base_url="$value"
+                ;;
+            --api-key-env)
+                [[ -z "$api_key_env" && "$value" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+                api_key_env="$value"
                 ;;
             --model)
                 [[ -z "$model" ]] || return 1
@@ -221,6 +244,13 @@ _validate_openai_compatible_agent_command() {
                 [[ -z "$reasoning_policy" ]] || return 1
                 case "$value" in
                     strict|best_effort) reasoning_policy="$value" ;;
+                    *) return 1 ;;
+                esac
+                ;;
+            --tool-mode)
+                [[ -z "$tool_mode" ]] || return 1
+                case "$value" in
+                    full|readonly) tool_mode="$value" ;;
                     *) return 1 ;;
                 esac
                 ;;
@@ -256,7 +286,7 @@ validate_agent_command() {
     # appear later in the command string. OpenAI-compatible helper arguments are
     # validated strictly because model and cwd values are interpolated into the
     # command returned by dispatch.
-    if [[ "$cmd_executable" == */scripts/helpers/openai-compatible-agent.py ]]; then
+    if [[ "$cmd_executable" == */scripts/helpers/openai-compatible-agent.py || "$cmd_executable" == */scripts/helpers/openai-compatible-agent.sh ]]; then
         _validate_openai_compatible_agent_command "$cmd"
         return $?
     fi

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1051,6 +1051,68 @@ tangle_parseable_coding_subtask_count() {
     echo "$count"
 }
 
+tangle_configured_decomposition_agents() {
+    local config_file="${OCTOPUS_PROVIDERS_CONFIG:-${HOME}/.claude-octopus/config/providers.json}"
+    [[ -f "$config_file" ]] || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+
+    # Prefer a decomposition/develop-specific fleet when configured. Fall back
+    # to the general parallel fleet and finally the review fleet so installations
+    # with an explicit multi-provider roster do not silently dispatch to unrelated
+    # legacy seats.
+    jq -r '
+        [
+            .routing.features.tangle_decompose,
+            .routing.features.develop,
+            .routing.features.parallel,
+            .routing.features.review
+        ]
+        | map(select(type == "array" and length > 0))
+        | (first // [])[]
+    ' "$config_file" 2>/dev/null || true
+}
+
+tangle_decomposition_agents() {
+    local tangle_decompose_agent="agy" tangle_decompose_fallback_agent="codex"
+    if declare -f octopus_agent_override >/dev/null 2>&1; then
+        tangle_decompose_agent=$(octopus_execution_profile_provider "tangle" "decompose" "researcher" "agy")
+        tangle_decompose_fallback_agent=$(octopus_execution_profile_provider "tangle" "decompose_fallback" "implementer" "codex")
+    fi
+
+    local candidates="${tangle_decompose_agent}"$'\n'"${tangle_decompose_fallback_agent}"$'\n'
+    candidates+="$(tangle_configured_decomposition_agents)"$'\n'
+    candidates+="claude-opus"$'\n'"codex"$'\n'"agy"$'\n'"openrouter"
+
+    local candidate normalized seen=""
+    while IFS= read -r candidate; do
+        candidate=${candidate//$'\r'/}
+        [[ -n "$candidate" ]] || continue
+        normalized=$(printf '%s' "$candidate" | tr '[:upper:]_' '[:lower:]-')
+        [[ " $seen " == *" $normalized "* ]] && continue
+        seen="${seen:+$seen }$normalized"
+        if ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "$candidate"; then
+            printf '%s\n' "$candidate"
+        fi
+    done <<< "$candidates"
+}
+
+tangle_run_decomposition() {
+    local prompt="$1"
+    local supervision_label="${2:-tangle-dispatch-watcher}"
+    local agent output
+
+    while IFS= read -r agent; do
+        [[ -n "$agent" ]] || continue
+        if output=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="$supervision_label" run_agent_sync "$agent" "$prompt" 0 "researcher" "tangle"); then
+            printf '%s\n' "$output"
+            return 0
+        fi
+        log WARN "Tangle decomposition provider '$agent' failed; trying the next allowed candidate"
+    done < <(tangle_decomposition_agents)
+
+    return 1
+}
+
 tangle_reformat_decomposition() {
     local original_task="$1"
     local previous_decomposition="$2"
@@ -1083,14 +1145,7 @@ Previous decomposition:
 ${previous_decomposition}
 "
 
-    local tangle_decompose_agent="agy" tangle_decompose_fallback_agent="codex"
-    if declare -f octopus_agent_override >/dev/null 2>&1; then
-        tangle_decompose_agent=$(octopus_execution_profile_provider "tangle" "decompose" "researcher" "agy")
-        tangle_decompose_fallback_agent=$(octopus_execution_profile_provider "tangle" "decompose_fallback" "implementer" "codex")
-    fi
-
-    OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-reformat-validation" run_agent_sync "$tangle_decompose_agent" "$reformat_prompt" 0 "researcher" "tangle" || \
-    OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-reformat-validation" run_agent_sync "$tangle_decompose_fallback_agent" "$reformat_prompt" 0 "researcher" "tangle"
+    tangle_run_decomposition "$reformat_prompt" "tangle-reformat-validation"
 }
 
 tangle_validate_parallel_write_scopes() {
@@ -1864,18 +1919,8 @@ Required format:
 2. [REASONING] Short title — Task: specific reasoning work
 Every [CODING] line must include a same-line Files: clause."
 
-    # Tangle decomposition agents are overridable (OCTOPUS_TANGLE_DECOMPOSE_AGENT,
-    # OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT, OCTOPUS_TANGLE_AGENT). Override only
-    # selects the dispatch agent; the fail-closed contract below is unchanged.
-    local tangle_decompose_agent="agy" tangle_decompose_fallback_agent="codex"
-    if declare -f octopus_agent_override >/dev/null 2>&1; then
-        tangle_decompose_agent=$(octopus_execution_profile_provider "tangle" "decompose" "researcher" "agy")
-        tangle_decompose_fallback_agent=$(octopus_execution_profile_provider "tangle" "decompose_fallback" "implementer" "codex")
-    fi
-
     local subtasks
-    subtasks=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-dispatch-watcher" run_agent_sync "$tangle_decompose_agent" "$decompose_prompt" 0 "researcher" "tangle") || \
-    subtasks=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-dispatch-watcher" run_agent_sync "$tangle_decompose_fallback_agent" "$decompose_prompt" 0 "researcher" "tangle") || {
+    subtasks=$(tangle_run_decomposition "$decompose_prompt" "tangle-dispatch-watcher") || {
         log ERROR "Decomposition failed with all providers; refusing monolithic direct fallback"
         return 1
     }

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -156,9 +156,10 @@ IMPORTANT: If you find yourself searching or grepping more than 3 times in a row
         cmd_array=("${inner_cmd_array[@]}")
     fi
 
-    local temp_output="${RESULTS_DIR}/.tmp-${task_id}.out"
-    local temp_errors="${RESULTS_DIR}/.tmp-${task_id}.err"
-    local raw_output="${RESULTS_DIR}/.raw-${task_id}.out"
+    local capture_id="${agent_type}-${task_id}"
+    local temp_output="${RESULTS_DIR}/.tmp-${capture_id}.out"
+    local temp_errors="${RESULTS_DIR}/.tmp-${capture_id}.err"
+    local raw_output="${RESULTS_DIR}/.raw-${capture_id}.out"
 
     # Write result file header
     echo "# Agent: $agent_type" > "$result_file"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -873,23 +873,37 @@ tangle_scopes_overlap() {
     return 1
 }
 
+tangle_git_compatible_path() {
+    local path="$1"
+    case "$(uname -s 2>/dev/null || true)" in
+        MINGW*|MSYS*|CYGWIN*)
+            if [[ "$path" == /* ]] && command -v cygpath >/dev/null 2>&1; then
+                cygpath -m "$path"
+                return 0
+            fi
+            ;;
+    esac
+    printf '%s\n' "$path"
+}
+
 tangle_resolve_repo_root() {
     local repo_root
     local resolved_root
 
     if [[ -n "${PROJECT_ROOT:-}" ]]; then
         if [[ -d "$PROJECT_ROOT" ]]; then
-            resolved_root=$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null || true)
+            repo_root=$(tangle_git_compatible_path "$PROJECT_ROOT")
+            resolved_root=$(git -C "$repo_root" rev-parse --show-toplevel 2>/dev/null || true)
             if [[ -z "$resolved_root" ]]; then
-                printf '%s\n' "$PROJECT_ROOT"
+                printf '%s\n' "$repo_root"
                 return 0
             fi
             printf '%s\n' "$resolved_root"
             return 0
         fi
-        repo_root="$(pwd)"
+        repo_root=$(tangle_git_compatible_path "$(pwd)")
     else
-        repo_root="$(pwd)"
+        repo_root=$(tangle_git_compatible_path "$(pwd)")
     fi
 
     resolved_root=$(git -C "$repo_root" rev-parse --show-toplevel 2>/dev/null || true)

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -8,6 +8,11 @@ if ! type probe_result_file_status >/dev/null 2>&1; then
     [[ -f "$_octo_probe_results_lib" ]] && source "$_octo_probe_results_lib"
 fi
 
+if ! type pathrt_canon_existing >/dev/null 2>&1; then
+    _octo_path_runtime_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/path-runtime.sh"
+    [[ -f "$_octo_path_runtime_lib" ]] && source "$_octo_path_runtime_lib"
+fi
+
 # v8.54.0: Single-agent probe for multi-agentic skill dispatch
 # Runs one probe perspective synchronously and writes result to RESULTS_DIR.
 # Called by Claude's Agent tool (one per perspective) instead of probe_discover().
@@ -874,16 +879,7 @@ tangle_scopes_overlap() {
 }
 
 tangle_git_compatible_path() {
-    local path="$1"
-    case "$(uname -s 2>/dev/null || true)" in
-        MINGW*|MSYS*|CYGWIN*)
-            if [[ "$path" == /* ]] && command -v cygpath >/dev/null 2>&1; then
-                cygpath -m "$path"
-                return 0
-            fi
-            ;;
-    esac
-    printf '%s\n' "$path"
+    pathrt_for_git "$1"
 }
 
 tangle_resolve_repo_root() {

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -12,6 +12,7 @@ set -eo pipefail
 # at itself (ELOOP). See #371.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+source "${SCRIPT_DIR}/lib/python-runtime.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/plugin-root.sh" 2>/dev/null || true
 
 # Self-heal: ensure the stable symlink exists for LLM Bash tool access.
@@ -601,7 +602,7 @@ CODEX_SUBAGENT_PREAMBLE="IMPORTANT: You are running as a non-interactive subagen
 
 "
 
-AVAILABLE_AGENTS="codex codex-standard codex-max codex-mini codex-general codex-spark codex-reasoning codex-large-context gemini gemini-fast gemini-image agy agy-research antigravity codex-review claude claude-sonnet claude-opus claude-opus-fast openrouter openrouter-glm5 openrouter-kimi openrouter-deepseek openai-compatible openai-tools openai-compatible-agent perplexity perplexity-fast ollama copilot copilot-research qwen qwen-research cursor-agent vibe vibe-research"
+AVAILABLE_AGENTS="codex codex-standard codex-max codex-mini codex-general codex-spark codex-reasoning codex-large-context gemini gemini-fast gemini-image agy agy-research antigravity codex-review claude claude-sonnet claude-opus claude-opus-fast openrouter openrouter-glm5 openrouter-glm52 openrouter-kimi openrouter-kimi-k3 openrouter-deepseek openai-compatible openai-tools openai-compatible-agent perplexity perplexity-fast ollama copilot copilot-research qwen qwen-research cursor-agent vibe vibe-research"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # USAGE TRACKING & COST REPORTING (v4.1)

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -103,6 +103,7 @@ source "${SCRIPT_DIR}/agent-teams-bridge.sh"
 source "${SCRIPT_DIR}/lib/common.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/utils.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/state-root.sh"
+source "${SCRIPT_DIR}/lib/path-runtime.sh"
 source "${SCRIPT_DIR}/lib/session-id.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/similarity.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/models.sh" 2>/dev/null || true
@@ -2783,13 +2784,23 @@ case "$COMMAND" in
         ;;
     spawn)
         [[ $# -lt 2 ]] && { log ERROR "Usage: spawn <agent> <prompt>"; exit 1; }
-        case "$1" in
+        _spawn_agent="$1"
+        _spawn_role=""
+        if [[ -n "$(get_agent_config "$1" "file" 2>/dev/null)" ]]; then
+            _spawn_role="$1"
+            if ! _spawn_agent=$(resolve_curated_agent_executor "$1"); then
+                log ERROR "No allowed and available provider for curated agent: $1"
+                exit 1
+            fi
+            log INFO "Resolved curated agent $1 to provider executor $_spawn_agent"
+        fi
+        case "$_spawn_agent" in
             agy|agy-*|antigravity)
-                log INFO "Running $1 synchronously because Antigravity CLI print mode does not emit output from background jobs"
-                run_agent_sync "$1" "$2" "$TIMEOUT" "none" "spawn"
+                log INFO "Running $_spawn_agent synchronously because Antigravity CLI print mode does not emit output from background jobs"
+                run_agent_sync "$_spawn_agent" "$2" "$TIMEOUT" "${_spawn_role:-none}" "spawn"
                 ;;
             *)
-                spawn_agent "$1" "$2"
+                spawn_agent "$_spawn_agent" "$2" "" "$_spawn_role" "spawn"
                 ;;
         esac
         ;;

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -2063,6 +2063,7 @@ show_status() {
 
     local running=0
     local total=0
+    local completed=0
 
     echo -e "${BLUE}Active Agents:${NC}"
     while IFS=: read -r pid agent task_id; do
@@ -2071,12 +2072,13 @@ show_status() {
             echo -e "  ${GREEN}●${NC} PID $pid - $agent ($task_id) - RUNNING"
             ((running++)) || true
         else
-            echo -e "  ${RED}○${NC} PID $pid - $agent ($task_id) - COMPLETED"
+            ((completed++)) || true
         fi
     done < "$PID_FILE"
 
     echo ""
-    echo -e "${BLUE}Summary:${NC} $running running / $total total"
+    [[ "$running" -eq 0 ]] && echo -e "  ${DIM}No agents currently running.${NC}"
+    echo -e "${BLUE}Summary:${NC} $running running / $completed completed ($total tracked)"
     echo ""
 
     if [[ -d "$RESULTS_DIR" ]]; then
@@ -2728,7 +2730,10 @@ case "$COMMAND" in
         fi
         ;;
     preflight)
-        preflight_check
+        case "${1:-}" in
+            --force|force|true) preflight_check true ;;
+            *) preflight_check ;;
+        esac
         ;;
     release)
         do_release

--- a/skills/flow-develop/SKILL.md
+++ b/skills/flow-develop/SKILL.md
@@ -112,48 +112,33 @@ orchestrate.sh develop "<user prompt>\n\nQuality requirements for this deliverab
 
 ### STEP 2: Display Visual Indicators (MANDATORY - BLOCKING)
 
-**MANDATORY: You MUST use the native shell command tool to run this provider check BEFORE displaying the banner. Do NOT skip it. Do NOT assume availability.**
+**MANDATORY: Use the native shell command tool to resolve the exact configured fleet and provider health before displaying the banner. Do not infer a fleet from installed CLIs.**
 
 ```bash
-bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
+provider_status=$(bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh")
+fleet_output=$(bash "${HOME}/.claude-octopus/plugin/scripts/helpers/build-fleet.sh" develop standard "${PROMPT}")
 ```
 
-**Use the ACTUAL results below. PROHIBITED: Showing only "🔵 Claude: Available ✓" without listing all providers.**
+`fleet_output` is the roster; `provider_status` is health evidence. List every exact alias in `fleet_output` and no others. If a configured seat is unavailable, report it and stop before dispatch instead of substituting another provider.
 
 If `OCTO_ALLOWED_PROVIDERS` is set, treat it as the source of truth for which providers may participate. Providers filtered out by that allowlist are intentionally reported as unavailable; do not invoke or recommend them in the workflow.
 
 
 **Display this banner BEFORE orchestrate.sh execution:**
 
-**For Dev Context:**
+**For either context:**
 ```
 🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider implementation mode
-🛠️ [Dev] Develop Phase: [Brief description of what you're building]
+🛠️ [Dev or Knowledge] Develop Phase: [Brief description]
 
-Provider Availability:
-🔴 Codex CLI: ${codex_status} - Code generation and patterns
-🟡 Gemini CLI: ${gemini_status} - Alternative approaches
-🧭 Antigravity CLI: ${agy_status} - Additional external-model challenge
-🔵 Claude: Available ✓ - Integration and quality gates
+Configured fleet:
+[one line per exact alias from fleet_output, with health from provider_status]
 
-💰 Estimated Cost: $0.02-0.10
-⏱️  Estimated Time: 3-7 minutes
+Billing: [subscription-backed seats] + [metered API models actually present]
+No unconfigured fallback is enabled.
 ```
 
-**For Knowledge Context:**
-```
-🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider implementation mode
-🛠️ [Knowledge] Develop Phase: [Brief description of deliverable]
-
-Provider Availability:
-🔴 Codex CLI: ${codex_status} - Structure and framework application
-🟡 Gemini CLI: ${gemini_status} - Content and narrative development
-🧭 Antigravity CLI: ${agy_status} - Additional external-model challenge
-🔵 Claude: Available ✓ - Integration and quality review
-
-💰 Estimated Cost: $0.02-0.10
-⏱️  Estimated Time: 3-7 minutes
-```
+Never print a generic dollar estimate. Codex and Claude may be subscription-backed; OpenRouter models are metered. Report the actual routes without guessing token usage. Never select an alias containing `fast`. The Claude seat uses Fable 5 when available and Opus 4.8 only when Fable is unavailable.
 
 **DO NOT PROCEED TO STEP 3 until banner displayed.** The banner shows users which providers will run and what costs they'll incur — starting API calls without this visibility violates cost transparency.
 
@@ -223,8 +208,7 @@ ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh develop "<user's implement
 If running in Claude Code v2.1.16+, users will see **real-time progress indicators** in the task spinner:
 
 **Phase 1 - External Provider Execution (Parallel):**
-- 🔴 Generating code and patterns (Codex)...
-- 🟡 Exploring alternative approaches (Gemini)...
+- One progress item per exact alias in `fleet_output`.
 
 **Phase 2 - Synthesis (Sequential):**
 - 🔵 Integrating and applying quality gates...
@@ -332,29 +316,7 @@ Analyze the user's prompt and project to determine context:
 
 ### Step 2: Output Context-Aware Banner
 
-**For Dev Context:**
-```
-🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider implementation mode
-🛠️ [Dev] Develop Phase: [Brief description of what you're building]
-📋 Session: ${CLAUDE_SESSION_ID}
-
-Providers:
-🔴 Codex CLI - Code generation and patterns
-🟡 Gemini CLI - Alternative approaches
-🔵 Claude - Integration and quality gates
-```
-
-**For Knowledge Context:**
-```
-🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider implementation mode
-🛠️ [Knowledge] Develop Phase: [Brief description of deliverable]
-📋 Session: ${CLAUDE_SESSION_ID}
-
-Providers:
-🔴 Codex CLI - Structure and framework application
-🟡 Gemini CLI - Content and narrative development
-🔵 Claude - Integration and quality review
-```
+Use the mandatory configured-fleet banner from EXECUTION CONTRACT Step 2. Do not duplicate or hand-author provider names.
 
 {{VISUAL_INDICATORS}}
 
@@ -376,11 +338,7 @@ Providers:
 
 ## What This Workflow Does
 
-The **develop** phase generates multiple implementation approaches using external CLI providers:
-
-1. **🔴 Codex CLI** - Implementation-focused, code generation, technical patterns
-2. **🟡 Gemini CLI** - Alternative approaches, edge cases, best practices
-3. **🔵 Claude (You)** - Integration, refinement, and final implementation
+The **develop** phase generates multiple implementation approaches from the exact aliases returned by `build-fleet.sh develop`. Configuration, not installed-CLI discovery, owns participation.
 
 This is the **divergent** phase for solutions - we explore different implementation paths before converging on the best approach.
 
@@ -413,17 +371,7 @@ Use develop when you need:
 
 ## Visual Indicators
 
-Before execution, you'll see:
-
-```
-🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider implementation
-🛠️ Develop Phase: Building and developing solutions
-
-Providers:
-🔴 Codex CLI - Code generation and patterns
-🟡 Gemini CLI - Alternative approaches
-🔵 Claude - Integration and refinement
-```
+Before execution, show the configured-fleet banner defined above.
 
 
 ## How It Works
@@ -436,11 +384,7 @@ ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh develop "<user's implement
 
 ### Step 2: Multi-Provider Implementation
 
-The orchestrate.sh script will:
-1. Call **Codex CLI** with the implementation task
-2. Call **Gemini CLI** with the implementation task
-3. You (Claude) contribute implementation analysis
-4. Synthesize approaches and recommend best path
+The orchestrate.sh script will dispatch every configured alias, preserve exact model routing, and synthesize their approaches. It must not add an installed provider that is absent from the roster.
 
 ### Step 3: Review Quality Gates
 
@@ -530,11 +474,8 @@ After successful execution, present implementation plan with:
 
    ## Code Overview
 
-   ### Codex Approach
-   [Key implementation details from Codex]
-
-   ### Gemini Approach
-   [Alternative considerations from Gemini]
+   ### Configured Provider Approaches
+   [One subsection per exact alias that returned evidence]
 
    ### Final Implementation
    [Your integrated solution]
@@ -590,17 +531,9 @@ Based on multi-provider analysis, I recommend a layered approach:
 
 ## Code Overview
 
-### Codex Approach
-- Modern TypeScript with strict types
-- Express middleware pattern
-- Redis for token blacklisting
-- Comprehensive error handling
-
-### Gemini Approach
-- Passport.js integration suggestion
-- Rate limiting on auth endpoints
-- Multi-factor auth consideration
-- Session management alternatives
+### Configured Provider Approaches
+- Summarize each exact configured alias separately.
+- Mark unavailable or failed seats explicitly; do not invent their output.
 
 ### Final Implementation
 - Hybrid: Modern TypeScript + Express patterns
@@ -675,52 +608,9 @@ Before writing code, ensure:
 - [ ] Tests planned (if applicable)
 
 
-## After Implementation: Auto Code Review & E2E Verification (MANDATORY)
+## After Implementation: Configured Review & E2E Verification (MANDATORY)
 
-**After implementation completes and before presenting results to the user, you MUST launch two verification agents in parallel.** Do NOT skip this step or ask the user whether to run it — it is automatic.
-
-### Launch both agents simultaneously:
-
-**Agent 1 — Code Review (Sonnet):**
-```
-Agent(
-  model: "sonnet",
-  subagent_type: "feature-dev:code-reviewer",
-  background execution: true,
-  description: "Code review: post-develop",
-  prompt: "Review the code changes from this development session. Focus on:
-1. Bugs, logic errors, security vulnerabilities
-2. Hidden dependencies or coupling issues
-3. Whether error handling covers failure modes
-4. Adherence to project conventions (check CLAUDE.md)
-
-Check git diff for the changed files. Report only high-confidence issues."
-)
-```
-
-**Agent 2 — E2E Verification (Sonnet):**
-```
-Agent(
-  model: "sonnet",
-  background execution: true,
-  description: "E2E test: post-develop",
-  prompt: "Run end-to-end verification of the development changes:
-1. Run the project's test suite (detect from package.json scripts, Makefile, or pyproject.toml)
-2. Verify no regressions in existing tests
-3. Check that new files are properly integrated (imported, registered, sourced)
-4. Verify the implementation matches the original task requirements
-
-Report: tests passed/failed, any integration issues found."
-)
-```
-
-**After both agents complete:**
-- Present their findings to the user as part of the results
-- If the code reviewer found HIGH-confidence issues, flag them prominently
-- If tests failed, flag before the "what next?" prompt
-- Do NOT block on the review — present findings alongside results
-
-WHY: The user should never have to manually request a code review after development work. Fresh-eyes review from a different model (Sonnet vs Opus) catches issues the implementer is blind to. Running tests automatically catches regressions before the user discovers them.
+After implementation, run the canonical review pipeline so it reuses `.routing.features.review`; do not launch a hardcoded model. Run the project's own E2E/test commands separately and report both sets of evidence. A failed configured seat is a visible partial failure, not permission to select an unconfigured or `fast` alias.
 
 
 ## After Implementation Checklist
@@ -735,20 +625,15 @@ After writing code, ensure:
 - [ ] Tests written (if applicable)
 - [ ] Lint/typecheck commands run (detect from package.json, pyproject.toml, Cargo.toml, Makefile; if not found, ask the user)
 - [ ] If lint/test commands were discovered and not documented in CLAUDE.md, suggest adding them
-- [ ] **Auto code review completed** (Sonnet agent)
-- [ ] **E2E verification completed** (Sonnet agent)
+- [ ] **Configured multi-provider code review completed**
+- [ ] **E2E verification completed with project-native tests**
 - [ ] User notified of completion with review findings
 - [ ] Suggest running ink-workflow for validation
 
 
 ## Cost Awareness
 
-**External API Usage:**
-- 🔴 Codex CLI uses your OPENAI_API_KEY (costs apply)
-- 🟡 Gemini CLI uses your GEMINI_API_KEY (costs apply)
-- 🔵 Claude analysis included with Claude Code
-
-Tangle workflows typically cost $0.02-0.10 per task depending on complexity and code length.
+**Billing:** Report only the exact configured routes. Distinguish subscription-backed CLI seats from metered API seats. Do not claim Codex uses an API key when it is configured for ChatGPT subscription auth, and do not print a generic dollar range before token usage is known.
 
 
 ## Post-Development: Checkpoint

--- a/tests/fixtures/review-four-provider-config.json
+++ b/tests/fixtures/review-four-provider-config.json
@@ -1,6 +1,16 @@
 {
   "version": "3.0",
   "providers": {
+    "codex": {
+      "default": "gpt-5.6-sol",
+      "fallback": "gpt-5.6-sol",
+      "reasoning_effort": "high"
+    },
+    "claude": {
+      "default": "claude-fable-5",
+      "fallback": "claude-opus-4.8",
+      "reasoning_effort": "high"
+    },
     "openrouter": {
       "default": "z-ai/glm-5.2",
       "glm52": "z-ai/glm-5.2",

--- a/tests/fixtures/review-four-provider-config.json
+++ b/tests/fixtures/review-four-provider-config.json
@@ -1,0 +1,20 @@
+{
+  "version": "3.0",
+  "providers": {
+    "openrouter": {
+      "default": "z-ai/glm-5.2",
+      "glm52": "z-ai/glm-5.2",
+      "kimi-k3": "moonshotai/kimi-k3"
+    }
+  },
+  "routing": {
+    "features": {
+      "review": [
+        "codex",
+        "claude-opus",
+        "openrouter-glm52",
+        "openrouter-kimi-k3"
+      ]
+    }
+  }
+}

--- a/tests/helpers/test-framework.sh
+++ b/tests/helpers/test-framework.sh
@@ -3,6 +3,9 @@
 # Comprehensive test framework for Claude Octopus
 # Provides assertions, mocks, fixtures, hooks, and reporting
 
+_TEST_FRAMEWORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_TEST_FRAMEWORK_DIR/../../scripts/lib/python-runtime.sh" 2>/dev/null || true
+
 set -euo pipefail
 
 # Colors for output

--- a/tests/test-provider-activation.sh
+++ b/tests/test-provider-activation.sh
@@ -157,9 +157,9 @@ echo ""
 echo -e "\033[0;34mTest Group 4: Model name consistency — no stale defaults (P1-B)\033[0m"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-# 4.1: resolve_octopus_model uses gpt-5.5 for codex default
-if grep -rA 10 "case \"\$agent_type\" in" $SCRIPTS_ALL | grep -A 1 "codex\*)" | grep -q 'gpt-5\.5'; then
-    pass "4.1 resolve_octopus_model returns gpt-5.5 for codex default"
+# 4.1: resolve_octopus_model uses GPT-5.6 Sol for codex default
+if grep -rA 10 "case \"\$agent_type\" in" $SCRIPTS_ALL | grep -A 1 "codex\*)" | grep -q 'gpt-5\.6-sol'; then
+    pass "4.1 resolve_octopus_model returns GPT-5.6 Sol for codex default"
 else
     fail "4.1 resolve_octopus_model uses stale model for codex default"
 fi
@@ -192,9 +192,9 @@ else
     fail "4.4 resolve_octopus_model missing role routing"
 fi
 
-# 4.5: codex fallbacks use gpt-5.5
-if grep -rA 20 "Fallback to hard-coded defaults" $SCRIPTS_ALL | grep -A 1 "codex\*)" | grep -q 'gpt-5\.5'; then
-    pass "4.5 codex fallback uses gpt-5.5"
+# 4.5: codex fallbacks use GPT-5.6 Sol
+if grep -rA 20 "Fallback to hard-coded defaults" $SCRIPTS_ALL | grep -A 1 "codex\*)" | grep -q 'gpt-5\.6-sol'; then
+    pass "4.5 codex fallback uses GPT-5.6 Sol"
 else
     fail "4.5 codex fallback uses stale model"
 fi

--- a/tests/test-resolve-model.sh
+++ b/tests/test-resolve-model.sh
@@ -67,7 +67,7 @@ clear_model_cache() {
 
 # Test 1: Hard-coded defaults
 clear_model_cache
-assert_eq "$(resolve_octopus_model "codex" "codex")" "gpt-5.5" "Default codex"
+assert_eq "$(resolve_octopus_model "codex" "codex")" "gpt-5.6-sol" "Default codex"
 clear_model_cache
 assert_eq "$(resolve_octopus_model "gemini" "gemini")" "gemini-3.1-pro-preview" "Default gemini"
 

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -40,6 +40,20 @@ else
     test_fail "expected allowlisted Claude effort prefix to be accepted"
 fi
 
+test_case "validate_agent_command allows constrained Fable model and effort prefixes"
+if validate_agent_command "env OCTOPUS_OPUS_MODEL=claude-fable-5 CLAUDE_CODE_EFFORT_LEVEL=high claude --print --model claude-fable-5 --effort high --allowed-tools Read,Glob,Grep"; then
+    test_pass
+else
+    test_fail "expected the dispatched Fable model/effort prefix to be accepted"
+fi
+
+test_case "validate_agent_command rejects unapproved Claude model prefix"
+if validate_agent_command "env OCTOPUS_OPUS_MODEL=claude-fast CLAUDE_CODE_EFFORT_LEVEL=high claude --print --model claude-fast" >/dev/null 2>&1; then
+    test_fail "expected an unapproved Claude model prefix to be rejected"
+else
+    test_pass
+fi
+
 test_case "validate_agent_command rejects invalid Claude effort value"
 if validate_agent_command "env CLAUDE_CODE_EFFORT_LEVEL=extreme claude --print --model claude-fable-5" >/dev/null 2>&1; then
     test_fail "expected invalid Claude effort value to be rejected"

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -33,6 +33,27 @@ else
     test_pass
 fi
 
+test_case "validate_agent_command allows constrained Claude effort prefix"
+if validate_agent_command "env CLAUDE_CODE_EFFORT_LEVEL=high claude --print --model claude-fable-5 --allowed-tools Read,Glob,Grep"; then
+    test_pass
+else
+    test_fail "expected allowlisted Claude effort prefix to be accepted"
+fi
+
+test_case "validate_agent_command rejects invalid Claude effort value"
+if validate_agent_command "env CLAUDE_CODE_EFFORT_LEVEL=extreme claude --print --model claude-fable-5" >/dev/null 2>&1; then
+    test_fail "expected invalid Claude effort value to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects extra environment assignments"
+if validate_agent_command "env CLAUDE_CODE_EFFORT_LEVEL=high UNSAFE=1 claude --print --model claude-fable-5" >/dev/null 2>&1; then
+    test_fail "expected extra environment assignment to be rejected"
+else
+    test_pass
+fi
+
 
 test_case "validate_agent_command allows openai-compatible helper path"
 if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --model minimax/minimax-m3 --cwd /tmp/test"; then

--- a/tests/unit/test-agent-predicates.sh
+++ b/tests/unit/test-agent-predicates.sh
@@ -50,6 +50,40 @@ else
     test_fail "should_use_agent_teams does not use is_claude_agent_type"
 fi
 
+test_case "Agent Teams dispatch is disabled on a Codex host"
+# shellcheck source=/dev/null
+source "$AGENT_SYNC"
+log() { :; }
+unset OCTOPUS_FORCE_LEGACY_DISPATCH
+OCTOPUS_HOST=codex
+OCTOPUS_AGENT_TEAMS=auto
+SUPPORTS_STABLE_AGENT_TEAMS=true
+if should_use_agent_teams "claude-opus"; then
+    test_fail "Codex-hosted spawn emitted an Agent Teams stub instead of invoking Claude CLI"
+else
+    test_pass
+fi
+
+test_case "Agent Teams native override cannot bypass non-Claude host safety"
+OCTOPUS_HOST=codex
+OCTOPUS_AGENT_TEAMS=native
+SUPPORTS_STABLE_AGENT_TEAMS=true
+if should_use_agent_teams "claude-opus"; then
+    test_fail "native override enabled an unconsumable Agent Teams instruction on Codex"
+else
+    test_pass
+fi
+
+test_case "Agent Teams remains available on a Claude host"
+OCTOPUS_HOST=claude
+OCTOPUS_AGENT_TEAMS=auto
+SUPPORTS_STABLE_AGENT_TEAMS=true
+if should_use_agent_teams "claude-opus"; then
+    test_pass
+else
+    test_fail "Claude host lost supported native Agent Teams dispatch"
+fi
+
 test_case "Claude agent availability uses the shared predicate for fast variants"
 # shellcheck source=/dev/null
 source "$MODEL_RESOLVER"

--- a/tests/unit/test-agent-skill-context-safety.sh
+++ b/tests/unit/test-agent-skill-context-safety.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$TEST_ROOT/.claude/skills/host-only" "$TEST_ROOT/.claude/skills/domain-only"
+
+cat > "$TEST_ROOT/.claude/skills/host-only/SKILL.md" <<'EOF'
+---
+name: host-only
+execution_mode: enforced
+validation_gates:
+  - orchestrate_sh_executed
+---
+You MUST execute orchestrate.sh spawn and launch another provider.
+EOF
+
+cat > "$TEST_ROOT/.claude/skills/domain-only/SKILL.md" <<'EOF'
+---
+name: domain-only
+---
+Inspect boundary handling and report concrete findings.
+EOF
+
+PLUGIN_DIR="$TEST_ROOT"
+source "$ROOT_DIR/scripts/lib/agents.sh"
+get_agent_skills() { echo "host-only,domain-only"; }
+
+context="$(build_skill_context reviewer)"
+if [[ "$context" == *"orchestrate.sh"* || "$context" == *"launch another provider"* ]]; then
+    echo "FAIL: host orchestration skill leaked into a provider prompt" >&2
+    exit 1
+fi
+if [[ "$context" != *"Inspect boundary handling"* ]]; then
+    echo "FAIL: safe domain skill was removed with host-only skill" >&2
+    exit 1
+fi
+
+echo "PASS: provider skill context excludes host-only orchestration contracts"

--- a/tests/unit/test-agent-sync-parallel-tempfiles.sh
+++ b/tests/unit/test-agent-sync-parallel-tempfiles.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Regression: concurrent run_agent_sync calls must not share capture files.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-sync-parallel.XXXXXX")"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+export RESULTS_DIR="$TEST_DIR/results"
+mkdir -p "$RESULTS_DIR"
+RUNNER="$TEST_DIR/provider.sh"
+cat > "$RUNNER" <<'RUNNER'
+#!/usr/bin/env bash
+read -r prompt
+case "$1" in
+  claude-sonnet) sleep 0.2 ;;
+  claude-opus) sleep 0.8 ;;
+esac
+printf '%s:%s\n' "$1" "$prompt"
+RUNNER
+chmod +x "$RUNNER"
+
+export RUNNER
+export OCTOPUS_PERSISTENCE_AVAILABLE=true
+export OCTOPUS_AGENT_MAX_OUTPUT_BYTES=262144
+
+log() { :; }
+classify_task() { echo standard; }
+compute_dynamic_timeout() { echo 5; }
+get_role_for_context() { echo reviewer; }
+apply_persona() { printf '%s\n' "$2"; }
+get_persona_override() { :; }
+load_earned_skills() { :; }
+build_provider_context() { :; }
+enforce_context_budget() { printf '%s\n' "$1"; }
+get_agent_model() { echo test-model; }
+check_provider_health() { return 0; }
+record_agent_call() { :; }
+get_agent_command() { printf 'bash %s %s\n' "$RUNNER" "$1"; }
+build_provider_env() { PROVIDER_ENV_ARRAY=(); }
+run_with_timeout() { shift; "$@"; }
+stop_quota_watcher() { :; }
+classify_agent_output() { echo completed:ok; }
+write_agent_status() { :; }
+octo_estimate_tokens_for_file() { echo 1; }
+
+source "$ROOT_DIR/scripts/lib/agent-sync.sh"
+
+run_agent_sync claude-sonnet ALPHA 5 reviewer review > "$TEST_DIR/alpha.out" &
+alpha_pid=$!
+run_agent_sync claude-opus BETA 5 reviewer review > "$TEST_DIR/beta.out" &
+beta_pid=$!
+
+wait "$alpha_pid"
+wait "$beta_pid"
+
+grep -Fqx 'claude-sonnet:ALPHA' "$TEST_DIR/alpha.out" || {
+  echo "FAIL: first concurrent provider lost or mixed its output" >&2
+  cat "$TEST_DIR/alpha.out" >&2
+  exit 1
+}
+grep -Fqx 'claude-opus:BETA' "$TEST_DIR/beta.out" || {
+  echo "FAIL: second concurrent provider lost or mixed its output" >&2
+  cat "$TEST_DIR/beta.out" >&2
+  exit 1
+}
+
+if find "$RESULTS_DIR" -maxdepth 1 -name '.tmp-agent-*' -print -quit | grep -q .; then
+  echo "FAIL: synchronous dispatch left capture files behind" >&2
+  exit 1
+fi
+
+echo "PASS: concurrent synchronous agents use isolated capture files"

--- a/tests/unit/test-codex-runtime-home-isolation.sh
+++ b/tests/unit/test-codex-runtime-home-isolation.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Regression: Octopus Codex subagents must not share a newer desktop model cache.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/octo-codex-home.XXXXXX")"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+export HOME="$TEST_HOME"
+export WORKSPACE_DIR="$HOME/.claude-octopus"
+export OCTOPUS_CODEX_ISOLATE_HOME=true
+export OPENAI_API_KEY="test-key"
+unset CODEX_HOME
+
+mkdir -p "$HOME/.codex"
+printf '%s\n' '{"tokens":{"access_token":"test"}}' > "$HOME/.codex/auth.json"
+printf '%s\n' 'model = "gpt-5.4"' > "$HOME/.codex/config.toml"
+printf '%s\n' '{"client_version":"newer-desktop"}' > "$HOME/.codex/models_cache.json"
+
+resolve_provider_env() { :; }
+source "$ROOT_DIR/scripts/lib/provider-routing.sh"
+
+octopus_prepare_codex_runtime_home
+
+expected="$WORKSPACE_DIR/codex-home"
+[[ "$CODEX_HOME" == "$expected" ]] || {
+    echo "FAIL: isolated CODEX_HOME was not selected" >&2
+    exit 1
+}
+cmp -s "$HOME/.codex/auth.json" "$CODEX_HOME/auth.json" || {
+    echo "FAIL: Codex authentication was not synchronized" >&2
+    exit 1
+}
+cmp -s "$HOME/.codex/config.toml" "$CODEX_HOME/config.toml" || {
+    echo "FAIL: Codex configuration was not synchronized" >&2
+    exit 1
+}
+[[ ! -e "$CODEX_HOME/models_cache.json" ]] || {
+    echo "FAIL: incompatible shared model cache leaked into runtime home" >&2
+    exit 1
+}
+
+printf '%s\n' '{"client_version":"runtime-owned"}' > "$CODEX_HOME/models_cache.json"
+printf '%s\n' 'model = "gpt-5.5"' > "$HOME/.codex/config.toml"
+octopus_prepare_codex_runtime_home
+grep -Fq 'gpt-5.5' "$CODEX_HOME/config.toml" || {
+    echo "FAIL: updated Codex configuration was not synchronized" >&2
+    exit 1
+}
+grep -Fq 'runtime-owned' "$CODEX_HOME/models_cache.json" || {
+    echo "FAIL: runtime-owned model cache was overwritten" >&2
+    exit 1
+}
+
+build_provider_env codex
+[[ " ${PROVIDER_ENV_ARRAY[*]} " == *" CODEX_HOME=$expected "* ]] || {
+    echo "FAIL: isolated CODEX_HOME was not propagated to Codex" >&2
+    exit 1
+}
+
+echo "PASS: Codex subagents use an isolated runtime home and model cache"

--- a/tests/unit/test-codex-runtime-home-isolation.sh
+++ b/tests/unit/test-codex-runtime-home-isolation.sh
@@ -13,7 +13,7 @@ export OPENAI_API_KEY="test-key"
 unset CODEX_HOME
 
 mkdir -p "$HOME/.codex"
-printf '%s\n' '{"tokens":{"access_token":"test"}}' > "$HOME/.codex/auth.json"
+printf '%s\n' '{"auth_mode":"chatgpt","tokens":{"access_token":"test"}}' > "$HOME/.codex/auth.json"
 printf '%s\n' 'model = "gpt-5.4"' > "$HOME/.codex/config.toml"
 printf '%s\n' '{"client_version":"newer-desktop"}' > "$HOME/.codex/models_cache.json"
 
@@ -55,6 +55,18 @@ grep -Fq 'runtime-owned' "$CODEX_HOME/models_cache.json" || {
 build_provider_env codex
 [[ " ${PROVIDER_ENV_ARRAY[*]} " == *" CODEX_HOME=$expected "* ]] || {
     echo "FAIL: isolated CODEX_HOME was not propagated to Codex" >&2
+    exit 1
+}
+[[ " ${PROVIDER_ENV_ARRAY[*]} " != *" OPENAI_API_KEY="* ]] || {
+    echo "FAIL: ChatGPT subscription dispatch forwarded a metered API key" >&2
+    exit 1
+}
+
+printf '%s\n' '{"auth_mode":"apikey"}' > "$HOME/.codex/auth.json"
+octopus_prepare_codex_runtime_home
+build_provider_env codex
+[[ " ${PROVIDER_ENV_ARRAY[*]} " == *" OPENAI_API_KEY=test-key "* ]] || {
+    echo "FAIL: explicit API-key authentication lost its API key" >&2
     exit 1
 }
 

--- a/tests/unit/test-codex-sol-subscription-routing.sh
+++ b/tests/unit/test-codex-sol-subscription-routing.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Regression: every Codex capability routes to GPT-5.6 Sol through Codex CLI.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/octo-codex-sol.XXXXXX")"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+mkdir -p "$TEST_HOME/.claude-octopus/config"
+cat > "$TEST_HOME/.claude-octopus/config/providers.json" <<'EOF'
+{
+  "version": "3.0",
+  "providers": {
+    "codex": {
+      "default": "gpt-5.6-sol",
+      "fallback": "gpt-5.6-sol",
+      "spark": "gpt-5.6-sol",
+      "mini": "gpt-5.6-sol",
+      "reasoning": "gpt-5.6-sol",
+      "large_context": "gpt-5.6-sol"
+    }
+  },
+  "routing": {"phases": {}, "roles": {}},
+  "tiers": {},
+  "overrides": {}
+}
+EOF
+
+export HOME="$TEST_HOME"
+export PLUGIN_DIR="$ROOT_DIR"
+export CLAUDE_CODE_SESSION="codex-sol-test-$$"
+log() { :; }
+source "$ROOT_DIR/scripts/lib/models.sh"
+source "$ROOT_DIR/scripts/lib/model-resolver.sh"
+source "$ROOT_DIR/scripts/lib/dispatch.sh"
+migrate_provider_config() { :; }
+validate_model_allowed() { return 0; }
+octopus_resolve_reasoning_level() { echo high; }
+octopus_resolve_reasoning_policy() { echo best_effort; }
+octopus_reasoning_cli_fragment() { :; }
+
+for alias in codex codex-spark codex-mini codex-reasoning codex-large-context; do
+    [[ "$(get_agent_model "$alias" review reviewer)" == "gpt-5.6-sol" ]] || {
+        echo "FAIL: $alias did not resolve to GPT-5.6 Sol" >&2
+        exit 1
+    }
+done
+
+command_line=$(get_agent_command codex review reviewer)
+[[ "$command_line" == "codex exec --skip-git-repo-check --model gpt-5.6-sol --sandbox workspace-write -" ]] || {
+    echo "FAIL: Codex dispatch does not use the subscription CLI with Sol: $command_line" >&2
+    exit 1
+}
+
+[[ "$(get_model_capability gpt-5.6-sol provider)" == "codex" ]] || {
+    echo "FAIL: GPT-5.6 Sol is absent from the Codex model catalog" >&2
+    exit 1
+}
+
+[[ "$(find_capable_fallback gpt-5.4 codex)" == "gpt-5.6-sol" ]] || {
+    echo "FAIL: legacy Codex models do not converge on GPT-5.6 Sol" >&2
+    exit 1
+}
+if find_capable_fallback gpt-5.6-sol codex >/dev/null 2>&1; then
+    echo "FAIL: unavailable GPT-5.6 Sol silently falls back to another Codex model" >&2
+    exit 1
+fi
+
+rm -f "$TEST_HOME/.claude-octopus/config/providers.json"
+[[ "$(resolve_octopus_model codex codex fallback-test fallback-test)" == "gpt-5.6-sol" ]] || {
+    echo "FAIL: hardcoded Codex fallback is not GPT-5.6 Sol" >&2
+    exit 1
+}
+
+default_count=$(grep -c '"gpt-5.6-sol"' "$ROOT_DIR/scripts/helpers/octo-model-config.sh" || true)
+[[ "$default_count" -ge 6 ]] || {
+    echo "FAIL: setup/model-config defaults do not fully pin GPT-5.6 Sol" >&2
+    exit 1
+}
+
+echo "PASS: Codex aliases and defaults route to GPT-5.6 Sol via Codex CLI"

--- a/tests/unit/test-curated-agent-dispatch.sh
+++ b/tests/unit/test-curated-agent-dispatch.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Regression: explicit persona names must resolve to an available provider CLI.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+export PLUGIN_DIR="$ROOT_DIR"
+export AGENTS_DIR="$ROOT_DIR/agents"
+export AGENTS_CONFIG="$ROOT_DIR/agents/config.yaml"
+export WORKSPACE_DIR="${TMPDIR:-/tmp}/octo-curated-agent-dispatch"
+export SUPPORTS_PERSISTENT_MEMORY=false
+export SUPPORTS_NATIVE_AUTO_MEMORY=false
+export AVAILABLE_AGENTS="agy codex"
+
+source "$ROOT_DIR/scripts/lib/agents.sh"
+
+[[ "$(get_agent_config backend-architect cli)" == "agy" ]] || {
+    echo "FAIL: inline YAML comment leaked into the configured CLI" >&2
+    exit 1
+}
+
+octo_provider_allowed() { return 0; }
+is_agent_available_v2() { [[ "$1" == "codex" ]]; }
+
+[[ "$(resolve_curated_agent_executor backend-architect)" == "codex" ]] || {
+    echo "FAIL: unavailable persona primary did not resolve to fallback_cli" >&2
+    exit 1
+}
+
+is_agent_available_v2() { [[ "$1" == "agy" || "$1" == "codex" ]]; }
+[[ "$(resolve_curated_agent_executor backend-architect)" == "agy" ]] || {
+    echo "FAIL: available persona primary was not preferred" >&2
+    exit 1
+}
+
+if resolve_curated_agent_executor missing-persona >/dev/null 2>&1; then
+    echo "FAIL: unknown persona unexpectedly resolved" >&2
+    exit 1
+fi
+
+grep -Fq 'resolve_curated_agent_executor "$1"' "$ROOT_DIR/scripts/orchestrate.sh" || {
+    echo "FAIL: spawn command does not resolve explicit curated personas" >&2
+    exit 1
+}
+
+echo "PASS: explicit curated personas resolve through available provider CLIs"

--- a/tests/unit/test-design-review-configured-fleet.sh
+++ b/tests/unit/test-design-review-configured-fleet.sh
@@ -24,6 +24,10 @@ write_structured_decision() { :; }
 run_agent_sync() {
   local agent="$1" role="${4:-}" phase="${5:-}"
   printf '%s|%s|%s\n' "$agent" "$role" "$phase" >> "$CAPTURE_FILE"
+  if [[ "$agent" == "openrouter-kimi-k3" && ! -f "$TEST_HOME/kimi-failed-once" ]]; then
+    : > "$TEST_HOME/kimi-failed-once"
+    return 1
+  fi
   printf 'Approach from %s\n' "$agent"
 }
 
@@ -44,6 +48,12 @@ for expected in \
     exit 1
   }
 done
+
+[[ "$(grep -c '^openrouter-kimi-k3|' "$CAPTURE_FILE")" == "2" ]] || {
+  echo "FAIL: transient design-review failure was not retried once" >&2
+  cat "$CAPTURE_FILE" >&2
+  exit 1
+}
 
 if grep -Eq '^(agy|claude-sonnet)\|' "$CAPTURE_FILE"; then
   echo "FAIL: hardcoded legacy design-review seat was dispatched" >&2

--- a/tests/unit/test-design-review-configured-fleet.sh
+++ b/tests/unit/test-design-review-configured-fleet.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Regression: flow-develop's ceremony must consume the configured review fleet.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/octo-design-fleet.XXXXXX")"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+mkdir -p "$TEST_HOME/.claude-octopus/config"
+cp "$ROOT_DIR/tests/fixtures/review-four-provider-config.json" \
+   "$TEST_HOME/.claude-octopus/config/providers.json"
+
+export HOME="$TEST_HOME"
+export WORKSPACE_DIR="$TEST_HOME/.claude-octopus"
+export DRY_RUN=false
+export OCTOPUS_CEREMONIES=true
+export OCTOPUS_DESIGN_REVIEW_TIMEOUT=1
+export OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT=1
+CAPTURE_FILE="$TEST_HOME/dispatches.txt"
+
+CYAN=""; GREEN=""; NC=""; _BOX_TOP=""; _BOX_BOT=""
+log() { :; }
+write_structured_decision() { :; }
+run_agent_sync() {
+  local agent="$1" role="${4:-}" phase="${5:-}"
+  printf '%s|%s|%s\n' "$agent" "$role" "$phase" >> "$CAPTURE_FILE"
+  printf 'Approach from %s\n' "$agent"
+}
+
+source "$ROOT_DIR/scripts/lib/review.sh"
+source "$ROOT_DIR/scripts/lib/quality.sh"
+
+design_review_ceremony "verify configured fleet" >/dev/null
+
+for expected in \
+  "codex|logic-reviewer|ceremony" \
+  "claude-opus|arch-reviewer|ceremony" \
+  "openrouter-glm52|diversity-reviewer|ceremony" \
+  "openrouter-kimi-k3|diversity-reviewer|ceremony" \
+  "claude-opus|synthesizer|ceremony"; do
+  grep -Fqx "$expected" "$CAPTURE_FILE" || {
+    echo "FAIL: missing design-review dispatch: $expected" >&2
+    cat "$CAPTURE_FILE" >&2
+    exit 1
+  }
+done
+
+if grep -Eq '^(agy|claude-sonnet)\|' "$CAPTURE_FILE"; then
+  echo "FAIL: hardcoded legacy design-review seat was dispatched" >&2
+  cat "$CAPTURE_FILE" >&2
+  exit 1
+fi
+
+echo "PASS: design review consumes configured provider fleet"

--- a/tests/unit/test-fable5-mode.sh
+++ b/tests/unit/test-fable5-mode.sh
@@ -10,6 +10,7 @@ test_suite "fable5 mode"
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+export OCTOPUS_PROVIDERS_CONFIG="$TMP_DIR/no-providers.json"
 
 # Quiet logger for sourced libs
 log() { :; }
@@ -97,20 +98,20 @@ fi
 
 # ── Security reroute ───────────────────────────────────────────────────────
 
-test_case "reroutes security role off Fable 5"
+test_case "keeps Fable 5 primary for security role"
 out=$(OCTOPUS_OPUS_MODEL=claude-fable-5 bash -c "log(){ :; }; source '$PROJECT_ROOT/scripts/lib/fable5.sh'; fable5_maybe_reroute claude-fable-5 security-auditor claude-opus ink" 2>/dev/null)
-if [[ "$out" == "claude-opus-4.8" ]]; then
+if [[ "$out" == "claude-fable-5" ]]; then
     test_pass
 else
-    test_fail "expected claude-opus-4.8, got '$out'"
+    test_fail "expected claude-fable-5, got '$out'"
 fi
 
-test_case "reroutes squeeze phase off Fable 5"
+test_case "keeps Fable 5 primary for squeeze phase"
 out=$(OCTOPUS_OPUS_MODEL=claude-fable-5 bash -c "log(){ :; }; source '$PROJECT_ROOT/scripts/lib/fable5.sh'; fable5_maybe_reroute claude-fable-5 '' claude-opus squeeze" 2>/dev/null)
-if [[ "$out" == "claude-opus-4.8" ]]; then
+if [[ "$out" == "claude-fable-5" ]]; then
     test_pass
 else
-    test_fail "expected claude-opus-4.8, got '$out'"
+    test_fail "expected claude-fable-5, got '$out'"
 fi
 
 test_case "non-security dispatch keeps Fable 5"
@@ -139,17 +140,17 @@ fi
 
 # ── Resolver integration ───────────────────────────────────────────────────
 
-test_case "resolve_octopus_model reroutes security role under opus pin"
+test_case "resolve_octopus_model keeps Fable for security role under opus pin"
 out=$(cd "$TMP_DIR" && TMPDIR="$TMP_DIR" CLAUDE_CODE_SESSION="fable5-test-$$" \
     OCTOPUS_OPUS_MODEL=claude-fable-5 HOME="$TMP_DIR" bash -c "
     log(){ :; }
     source '$PROJECT_ROOT/scripts/lib/fable5.sh'
     source '$PROJECT_ROOT/scripts/lib/model-resolver.sh'
     resolve_octopus_model claude claude-opus ink security-auditor" 2>/dev/null)
-if [[ "$out" == "claude-opus-4.8" ]]; then
+if [[ "$out" == "claude-fable-5" ]]; then
     test_pass
 else
-    test_fail "expected claude-opus-4.8 from resolver, got '$out'"
+    test_fail "expected claude-fable-5 from resolver, got '$out'"
 fi
 
 test_case "resolve_octopus_model keeps Fable 5 for non-security role"
@@ -167,8 +168,8 @@ fi
 
 # ── Dispatch wiring ────────────────────────────────────────────────────────
 
-test_case "dispatch honors Fable 5 pin in claude-opus model flag"
-if grep -q 'opus_model_flag="claude-fable-5"' "$PROJECT_ROOT/scripts/lib/dispatch.sh"; then
+test_case "dispatch honors the configured claude-opus model flag"
+if grep -q 'configured_opus_model="$(get_agent_model' "$PROJECT_ROOT/scripts/lib/dispatch.sh"; then
     test_pass
 else
     test_fail "dispatch.sh claude-opus case does not honor the Fable 5 pin"

--- a/tests/unit/test-fable5-routing.sh
+++ b/tests/unit/test-fable5-routing.sh
@@ -60,4 +60,9 @@ grep -Fq '[[ "${OCTOPUS_OPUS_MODEL:-}" != "claude-fable-5" ]]' "$ROOT_DIR/script
     exit 1
 }
 
+grep -Fq '[[ "${OCTOPUS_OPUS_MODE:-auto}" == "fast" ]]' "$ROOT_DIR/scripts/lib/spawn.sh" || {
+    echo "FAIL: claude-opus can still auto-route to the more expensive Fast tier" >&2
+    exit 1
+}
+
 echo "PASS: Fable 5 primary routing and availability-only Opus fallback"

--- a/tests/unit/test-fable5-routing.sh
+++ b/tests/unit/test-fable5-routing.sh
@@ -55,7 +55,7 @@ export OCTOPUS_OPUS_MODEL="claude-fable-5"
     exit 1
 }
 
-grep -Fq '[[ "${OCTOPUS_OPUS_MODEL:-}" != "claude-fable-5" ]]' "$ROOT_DIR/scripts/lib/spawn.sh" || {
+grep -Fq '! fable5_opus_pinned' "$ROOT_DIR/scripts/lib/spawn.sh" || {
     echo "FAIL: Fable 5 can be eagerly replaced by the Opus --fast alias" >&2
     exit 1
 }

--- a/tests/unit/test-fable5-routing.sh
+++ b/tests/unit/test-fable5-routing.sh
@@ -31,4 +31,28 @@ grep -Fq 'fable5_model_unavailable "$temp_errors" "$temp_output"' "$ROOT_DIR/scr
     exit 1
 }
 
+# A user pin must outrank a model value cached before the pin was exported.
+# Otherwise dispatch can execute Fable while telemetry still reports Opus 4.8.
+export HOME="$TMP_DIR/home"
+export TMPDIR="$TMP_DIR/cache"
+mkdir -p "$HOME" "$TMPDIR"
+log() { :; }
+migrate_provider_config() { :; }
+source "$ROOT_DIR/scripts/lib/models.sh"
+source "$ROOT_DIR/scripts/lib/model-resolver.sh"
+source "$ROOT_DIR/scripts/lib/dispatch.sh"
+
+unset OCTOPUS_OPUS_MODEL
+export SUPPORTS_OPUS_4_8=true
+[[ "$(get_agent_model claude-opus review code-reviewer)" == "claude-opus-4.8" ]] || {
+    echo "FAIL: could not prime Opus 4.8 model cache" >&2
+    exit 1
+}
+
+export OCTOPUS_OPUS_MODEL="claude-fable-5"
+[[ "$(get_agent_model claude-opus review code-reviewer)" == "claude-fable-5" ]] || {
+    echo "FAIL: OCTOPUS_OPUS_MODEL did not bypass the stale model cache" >&2
+    exit 1
+}
+
 echo "PASS: Fable 5 primary routing and availability-only Opus fallback"

--- a/tests/unit/test-fable5-routing.sh
+++ b/tests/unit/test-fable5-routing.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Regression: Fable 5 stays primary and only model-unavailability errors use Opus.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-fable5-routing.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+source "$ROOT_DIR/scripts/lib/fable5.sh"
+
+[[ "$(fable5_maybe_reroute "claude-fable-5" "security" "claude-opus" "review")" == "claude-fable-5" ]] || {
+    echo "FAIL: security routing eagerly rerouted away from Fable 5" >&2
+    exit 1
+}
+
+printf '%s\n' 'model unavailable' > "$TMP_DIR/unavailable.err"
+: > "$TMP_DIR/empty.out"
+fable5_model_unavailable "$TMP_DIR/unavailable.err" "$TMP_DIR/empty.out" || {
+    echo "FAIL: model-unavailability classifier missed an unavailable model" >&2
+    exit 1
+}
+
+printf '%s\n' 'content refused' > "$TMP_DIR/refusal.err"
+if fable5_model_unavailable "$TMP_DIR/refusal.err" "$TMP_DIR/empty.out"; then
+    echo "FAIL: content refusal incorrectly triggered paid Opus fallback" >&2
+    exit 1
+fi
+
+grep -Fq 'fable5_model_unavailable "$temp_errors" "$temp_output"' "$ROOT_DIR/scripts/lib/spawn.sh" || {
+    echo "FAIL: spawn path does not use availability-only Fable fallback" >&2
+    exit 1
+}
+
+echo "PASS: Fable 5 primary routing and availability-only Opus fallback"

--- a/tests/unit/test-fable5-routing.sh
+++ b/tests/unit/test-fable5-routing.sh
@@ -55,4 +55,9 @@ export OCTOPUS_OPUS_MODEL="claude-fable-5"
     exit 1
 }
 
+grep -Fq '[[ "${OCTOPUS_OPUS_MODEL:-}" != "claude-fable-5" ]]' "$ROOT_DIR/scripts/lib/spawn.sh" || {
+    echo "FAIL: Fable 5 can be eagerly replaced by the Opus --fast alias" >&2
+    exit 1
+}
+
 echo "PASS: Fable 5 primary routing and availability-only Opus fallback"

--- a/tests/unit/test-octo-events.sh
+++ b/tests/unit/test-octo-events.sh
@@ -33,20 +33,14 @@ test_emit_jsonl_event() {
         return
     fi
 
-    if command -v python3 >/dev/null 2>&1; then
-        python3 - "$OCTO_EVENT_LOG" <<'PY' || { test_fail "event JSON did not parse"; return; }
-import json
-import sys
-
-with open(sys.argv[1], "r", encoding="utf-8") as fh:
-    row = json.loads(fh.readline())
-
-assert row["event"] == "provider.status"
-assert row["source"] == "unit-test"
-assert row["session_id"] == "session-1"
-assert row["attributes"]["provider"] == "qwen"
-assert row["attributes"]["status"] == "degraded"
-PY
+    if command -v jq >/dev/null 2>&1; then
+        jq -e 'select(
+            .event == "provider.status" and
+            .source == "unit-test" and
+            .session_id == "session-1" and
+            .attributes.provider == "qwen" and
+            .attributes.status == "degraded"
+        )' < "$OCTO_EVENT_LOG" >/dev/null || { test_fail "event JSON did not parse"; return; }
     else
         grep -q '"event":"provider.status"' "$OCTO_EVENT_LOG" || { test_fail "event name missing"; return; }
     fi
@@ -83,6 +77,50 @@ test_invalid_event_rejected() {
     else test_fail "invalid event name accepted"; fi
 }
 
+test_json_encoding_avoids_windows_python_alias() {
+    test_case "JSON encoding does not probe a Windows Store python3 alias"
+    local fake_bin="$FIXTURE/fake-python-bin"
+    local marker="$FIXTURE/python3-was-invoked"
+    mkdir -p "$fake_bin"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        ": > \"$marker\"" \
+        'exit 99' > "$fake_bin/python3"
+    chmod +x "$fake_bin/python3"
+
+    local encoded
+    encoded=$(PATH="$fake_bin:$PATH" _octo_json_string 'quote " and slash \\')
+    if [[ ! -e "$marker" ]] && printf '%s\n' "$encoded" | jq -e . >/dev/null 2>&1; then
+        test_pass
+    else
+        test_fail "event JSON encoding invoked the python3 App Execution Alias"
+    fi
+}
+
+test_event_encoding_avoids_per_field_shell_forks() {
+    test_case "octo_event_emit avoids Windows-hot-path command substitutions"
+    if grep -Eq '\$\((_octo_json_string|octo_event_log_path|dirname)' "$PROJECT_ROOT/scripts/lib/events.sh"; then
+        test_fail "event serialization still forks helpers on its Windows hot path"
+    else
+        test_pass
+    fi
+}
+
+test_stale_event_lock_recovered() {
+    test_case "octo_event_emit automatically reclaims an abandoned event lock"
+    export OCTO_EVENT_LOG="$FIXTURE/stale-lock-events.jsonl"
+    local lockdir="${OCTO_EVENT_LOG}.lock"
+    mkdir -p "$lockdir"
+    touch -d '5 minutes ago' "$lockdir"
+
+    OCTO_EVENT_LOCK_STALE_SECONDS=1 octo_event_emit "lock.recovered" result=pass
+    if [[ ! -d "$lockdir" ]] && grep -q '"event":"lock.recovered"' "$OCTO_EVENT_LOG"; then
+        test_pass
+    else
+        test_fail "stale event lock remained after emit"
+    fi
+}
+
 test_check_providers_event_hook() {
     test_case "check-providers emits provider.status events when enabled"
     export OCTO_EVENT_LOG="$FIXTURE/providers.jsonl"
@@ -100,9 +138,13 @@ test_concurrent_emit_no_clobber() {
     export OCTO_EVENT_LOG="$FIXTURE/concurrent.jsonl"
     export OCTO_EVENT_MAX_LINES=50
     : > "$OCTO_EVENT_LOG"
+    local workers=12 iterations=60
+    case "$(uname -s 2>/dev/null || true)" in
+        MINGW*|MSYS*|CYGWIN*) workers=4; iterations=20 ;;
+    esac
     local p
-    for p in $(seq 1 12); do
-        ( for i in $(seq 1 60); do octo_event_emit "stress.test" proc="$p" seq="$i"; done ) &
+    for p in $(seq 1 "$workers"); do
+        ( for i in $(seq 1 "$iterations"); do octo_event_emit "stress.test" proc="$p" seq="$i"; done ) &
     done
     wait
     unset OCTO_EVENT_MAX_LINES
@@ -116,14 +158,9 @@ test_concurrent_emit_no_clobber() {
 
     # Every surviving line must be a complete, valid record — a torn line proves
     # an append was clobbered mid-write by a concurrent trim.
-    if command -v python3 >/dev/null 2>&1; then
-        python3 - "$OCTO_EVENT_LOG" <<'PY' || { test_fail "found torn/invalid JSON line under concurrency"; return; }
-import json, sys
-with open(sys.argv[1], encoding="utf-8") as fh:
-    for line in fh:
-        if line.strip():
-            json.loads(line)
-PY
+    if command -v jq >/dev/null 2>&1; then
+        jq -e . < "$OCTO_EVENT_LOG" >/dev/null 2>&1 \
+            || { test_fail "found torn/invalid JSON line under concurrency"; return; }
     else
         local bad
         bad="$(grep -cvE '^\{.*\}$' "$OCTO_EVENT_LOG" || true)"
@@ -199,6 +236,9 @@ test_emit_jsonl_event
 test_auto_log_path
 test_trim_event_log
 test_invalid_event_rejected
+test_json_encoding_avoids_windows_python_alias
+test_event_encoding_avoids_per_field_shell_forks
+test_stale_event_lock_recovered
 test_check_providers_event_hook
 test_concurrent_emit_no_clobber
 test_dispatch_lifecycle_events

--- a/tests/unit/test-openai-compatible-agent.sh
+++ b/tests/unit/test-openai-compatible-agent.sh
@@ -55,7 +55,7 @@ fi
 
 test_case "openai-compatible-agent dispatch uses generic helper and cwd"
 cmd=$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-cmd" PWD="/tmp/octo-cwd" OPENAI_COMPAT_MODEL="vendor/model-fast" get_agent_command openai-compatible-agent 2>/dev/null)
-if assert_contains "$cmd" "scripts/helpers/openai-compatible-agent.py" "helper path" &&
+if assert_contains "$cmd" "scripts/helpers/openai-compatible-agent.sh" "helper path" &&
    assert_contains "$cmd" "--provider generic" "generic provider" &&
    assert_contains "$cmd" "--model vendor/model-fast" "configured model" &&
    assert_contains "$cmd" "--cwd /tmp/octo-cwd" "cwd flag"; then
@@ -216,7 +216,7 @@ fi
 
 test_case "openai-tools alias dispatches through generic helper"
 cmd=$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-tools-alias" PWD="/tmp/octo-cwd" OPENAI_COMPAT_MODEL="vendor/model-fast" get_agent_command openai-tools 2>/dev/null)
-if assert_contains "$cmd" "scripts/helpers/openai-compatible-agent.py" "helper path" &&
+if assert_contains "$cmd" "scripts/helpers/openai-compatible-agent.sh" "helper path" &&
    assert_contains "$cmd" "--provider generic" "generic provider" &&
    assert_contains "$cmd" "--model vendor/model-fast" "configured model"; then
     test_pass

--- a/tests/unit/test-openrouter-content-preservation.sh
+++ b/tests/unit/test-openrouter-content-preservation.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Regression: jq already decodes the outer OpenRouter response; do not decode
+# the model's JSON content a second time and corrupt its escaping.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+export OPENROUTER_API_KEY="test-key"
+export VERBOSE=false
+log() { :; }
+json_escape() { printf '%s' "$1"; }
+curl() {
+    printf '%s' '{"choices":[{"message":{"content":"{\"findings\":[{\"detail\":\"say \\\"hello\\\" and line\\nnext\"}]}"}}]}200'
+}
+
+source "$ROOT_DIR/scripts/lib/perplexity.sh"
+
+result=$(openrouter_execute_model "z-ai/glm-5.2" "review")
+printf '%s' "$result" | jq -e '.findings[0].detail == "say \"hello\" and line\nnext"' >/dev/null || {
+    echo "FAIL: OpenRouter model JSON escaping was corrupted after jq decoding" >&2
+    printf '%s\n' "$result" >&2
+    exit 1
+}
+
+echo "PASS: OpenRouter preserves model-emitted JSON escaping"

--- a/tests/unit/test-openrouter-tool-loop.sh
+++ b/tests/unit/test-openrouter-tool-loop.sh
@@ -16,6 +16,11 @@ source "$ROOT_DIR/scripts/lib/model-resolver.sh"
 source "$ROOT_DIR/scripts/lib/dispatch.sh"
 source "$ROOT_DIR/scripts/lib/utils.sh"
 
+"$ROOT_DIR/scripts/helpers/openai-compatible-agent.sh" --help >/dev/null || {
+    echo "FAIL: Git Bash wrapper did not translate its MSYS helper path for native Python" >&2
+    exit 1
+}
+
 glm_cmd="$(get_agent_command openrouter-glm52 review reviewer)"
 kimi_cmd="$(get_agent_command openrouter-kimi-k3 review reviewer)"
 

--- a/tests/unit/test-openrouter-tool-loop.sh
+++ b/tests/unit/test-openrouter-tool-loop.sh
@@ -117,6 +117,15 @@ assert stdout.getvalue().strip() == "NO FINDINGS"
 assert len(seen_tools) == 3
 assert all("git_status" in names for names in seen_tools)
 assert all("write_file" not in names and "run_command" not in names for names in seen_tools)
+
+# Windows redirected stdout defaults to a legacy code page on some systems.
+# Kimi commonly returns symbols outside cp1252; the helper must emit UTF-8.
+raw = io.BytesIO()
+legacy_stdout = io.TextIOWrapper(raw, encoding="cp1252")
+mod.configure_utf8_stdio(legacy_stdout)
+legacy_stdout.write("Kimi verdict: ❌")
+legacy_stdout.flush()
+assert raw.getvalue().decode("utf-8") == "Kimi verdict: ❌"
 PYTEST
 
 source "$ROOT_DIR/scripts/lib/error-tracking.sh"
@@ -128,5 +137,10 @@ if [[ "$classification" != failed:* ]]; then
     echo "FAIL: unevaluated OpenRouter tool text was classified as $classification" >&2
     exit 1
 fi
+
+grep -q "tr -d '\\\\000'.*grep -a -v" "$ROOT_DIR/scripts/lib/spawn.sh" || {
+    echo "FAIL: spawn output filtering can replace Unicode provider output with a binary-file notice" >&2
+    exit 1
+}
 
 echo "PASS: OpenRouter aliases use a read-only structured tool loop"

--- a/tests/unit/test-openrouter-tool-loop.sh
+++ b/tests/unit/test-openrouter-tool-loop.sh
@@ -136,6 +136,11 @@ mod.configure_utf8_stdio(legacy_stdout)
 legacy_stdout.write("Kimi verdict: ❌")
 legacy_stdout.flush()
 assert raw.getvalue().decode("utf-8") == "Kimi verdict: ❌"
+
+prompt_bytes = io.BytesIO("Prompt marker: ❌".encode("utf-8"))
+legacy_stdin = io.TextIOWrapper(prompt_bytes, encoding="cp1252")
+mod.configure_utf8_stdio(legacy_stdin)
+assert legacy_stdin.read() == "Prompt marker: ❌"
 PYTEST
 
 source "$ROOT_DIR/scripts/lib/error-tracking.sh"

--- a/tests/unit/test-openrouter-tool-loop.sh
+++ b/tests/unit/test-openrouter-tool-loop.sh
@@ -67,6 +67,11 @@ spec.loader.exec_module(mod)
 
 assert mod.PROVIDERS["openrouter"]["base_url"] == "https://openrouter.ai/api/v1"
 assert mod.PROVIDERS["openrouter"]["api_key_env"] == "OPENROUTER_API_KEY"
+if os.name == "nt":
+    assert mod.normalize_cli_path("/c/Users/Wado/project") == r"C:\Users\Wado\project"
+    assert mod.normalize_cli_path("/cygdrive/d/work") == r"D:\work"
+else:
+    assert mod.normalize_cli_path("/c/Users/Wado/project") == "/c/Users/Wado/project"
 
 readonly_names = {
     item["function"]["name"] for item in mod.tools_for_mode("readonly")

--- a/tests/unit/test-openrouter-tool-loop.sh
+++ b/tests/unit/test-openrouter-tool-loop.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$ROOT_DIR/scripts/helpers/openai-compatible-agent.py"
+
+log() { :; }
+migrate_provider_config() { :; }
+validate_model_allowed() { return 0; }
+opus_default_model() { echo "claude-opus-4.8"; }
+PROVIDER_CODEX_INSTALLED=false
+PLUGIN_DIR="$ROOT_DIR"
+PWD="/tmp/octopus-review"
+
+source "$ROOT_DIR/scripts/lib/model-resolver.sh"
+source "$ROOT_DIR/scripts/lib/dispatch.sh"
+source "$ROOT_DIR/scripts/lib/utils.sh"
+
+glm_cmd="$(get_agent_command openrouter-glm52 review reviewer)"
+kimi_cmd="$(get_agent_command openrouter-kimi-k3 review reviewer)"
+
+for spec in \
+    "$glm_cmd|z-ai/glm-5.2" \
+    "$kimi_cmd|moonshotai/kimi-k3"; do
+    cmd="${spec%%|*}"
+    model="${spec#*|}"
+    [[ "$cmd" == *"scripts/helpers/openai-compatible-agent.sh"* ]] || {
+        echo "FAIL: OpenRouter $model does not use the structured tool-loop helper" >&2
+        exit 1
+    }
+    [[ "$cmd" == *"--provider openrouter"* ]] || {
+        echo "FAIL: OpenRouter $model does not select the OpenRouter transport" >&2
+        exit 1
+    }
+    [[ "$cmd" == *"--model $model"* ]] || {
+        echo "FAIL: OpenRouter command lost exact model $model" >&2
+        exit 1
+    }
+    [[ "$cmd" == *"--tool-mode readonly"* ]] || {
+        echo "FAIL: OpenRouter review alias is not fail-closed read-only" >&2
+        exit 1
+    }
+    validate_agent_command "$cmd" || {
+        echo "FAIL: generated OpenRouter tool-loop command is rejected by command validation" >&2
+        exit 1
+    }
+done
+
+case "$(uname -s 2>/dev/null || true)" in
+    MINGW*|MSYS*) PYTHON_BIN=python ;;
+    *) PYTHON_BIN=python3 ;;
+esac
+
+HELPER="$HELPER" "$PYTHON_BIN" - <<'PYTEST'
+import importlib.util
+import os
+
+path = os.environ["HELPER"]
+spec = importlib.util.spec_from_file_location("octopus_openrouter_agent", path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+assert mod.PROVIDERS["openrouter"]["base_url"] == "https://openrouter.ai/api/v1"
+assert mod.PROVIDERS["openrouter"]["api_key_env"] == "OPENROUTER_API_KEY"
+
+readonly_names = {
+    item["function"]["name"] for item in mod.tools_for_mode("readonly")
+}
+assert {"read_file", "list_files", "git_status", "git_diff"} <= readonly_names
+assert "write_file" not in readonly_names
+assert "run_command" not in readonly_names
+
+assert mod.is_unevaluated_tool_text(
+    "I'll inspect the diff now.<tool_call>Bashgit diff --stat"
+)
+assert not mod.is_unevaluated_tool_text(
+    "P1 src/app.py:10: boundary condition is inverted."
+)
+
+# Exercise main's recovery path: plain-text pseudo call -> structured read tool
+# -> visible verdict. This is the exact shape of the live GLM failure.
+import contextlib
+import io
+import sys
+import tempfile
+
+responses = [
+    {"choices": [{"message": {"content": "I'll inspect now.<tool_call>Bashgit status"}, "finish_reason": "stop"}]},
+    {"choices": [{"message": {"content": "", "tool_calls": [{"id": "call-1", "type": "function", "function": {"name": "git_status", "arguments": "{}"}}]}, "finish_reason": "tool_calls"}]},
+    {"choices": [{"message": {"content": "NO FINDINGS"}, "finish_reason": "stop"}]},
+]
+seen_tools = []
+
+def fake_api_call(*args, **kwargs):
+    seen_tools.append({item["function"]["name"] for item in kwargs["tools"]})
+    return responses.pop(0)
+
+mod.api_call = fake_api_call
+os.environ["OPENROUTER_API_KEY"] = "test-key"
+with tempfile.TemporaryDirectory() as cwd:
+    old_argv = sys.argv
+    sys.argv = [
+        "openai-compatible-agent.py", "--provider", "openrouter",
+        "--model", "z-ai/glm-5.2", "--cwd", cwd,
+        "--tool-mode", "readonly", "--max-turns", "4",
+        "--prompt", "Review the current diff.",
+    ]
+    stdout = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(stdout):
+            rc = mod.main()
+    finally:
+        sys.argv = old_argv
+
+assert rc == 0
+assert stdout.getvalue().strip() == "NO FINDINGS"
+assert len(seen_tools) == 3
+assert all("git_status" in names for names in seen_tools)
+assert all("write_file" not in names and "run_command" not in names for names in seen_tools)
+PYTEST
+
+source "$ROOT_DIR/scripts/lib/error-tracking.sh"
+pseudo_output="$(mktemp)"
+trap 'rm -f "$pseudo_output"' EXIT
+printf '%s\n' "I'll inspect the diff now.<tool_call>Bashgit diff --stat" > "$pseudo_output"
+classification="$(classify_agent_output "$pseudo_output" 0 openrouter-glm52)"
+if [[ "$classification" != failed:* ]]; then
+    echo "FAIL: unevaluated OpenRouter tool text was classified as $classification" >&2
+    exit 1
+fi
+
+echo "PASS: OpenRouter aliases use a read-only structured tool loop"

--- a/tests/unit/test-opus-48-routing.sh
+++ b/tests/unit/test-opus-48-routing.sh
@@ -20,6 +20,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 
 test_suite "Opus 4.8 Routing (v9.42)"
+export HOME="$TEST_TMP_DIR/opus-home"
+mkdir -p "$HOME"
 
 # dispatch.sh calls log() on its sandbox-validation error path; stub it so the
 # functions can run outside orchestrate.sh. _BARE_OPT is empty in normal runs.
@@ -172,10 +174,10 @@ test_effort_omitted_when_unsupported() {
     reset_env
     export SUPPORTS_EFFORT_COMMAND=false SUPPORTS_XHIGH_EFFORT=false
     local got; got="$(get_agent_command claude-opus develop)"
-    if [[ "$got" != *"CLAUDE_CODE_EFFORT_LEVEL="* && "$got" == *"--model opus"* ]]; then
+    if [[ "$got" != *"CLAUDE_CODE_EFFORT_LEVEL="* && "$got" == *"--model claude-opus-4-6"* ]]; then
         test_pass
     else
-        test_fail "expected plain '--model opus' with no effort prefix, got: $got"
+        test_fail "expected resolved 4.6 model with no effort prefix, got: $got"
     fi
 }
 

--- a/tests/unit/test-path-runtime.sh
+++ b/tests/unit/test-path-runtime.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression: all path consumers share strict cross-platform canonicalization.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PATH_RUNTIME="$ROOT_DIR/scripts/lib/path-runtime.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/octo-path-runtime.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$TEST_ROOT/repo/src" "$TEST_ROOT/repo2" "$TEST_ROOT/outside"
+printf '%s\n' ok > "$TEST_ROOT/repo/src/context.md"
+printf '%s\n' outside > "$TEST_ROOT/repo2/context.md"
+git -C "$TEST_ROOT/repo" init -q
+
+source "$PATH_RUNTIME"
+
+repo_posix="$(cd "$TEST_ROOT/repo" && pwd -P)"
+context_posix="$repo_posix/src/context.md"
+
+if pathrt_is_windows; then
+    repo_native="$(cygpath -m "$repo_posix")"
+    context_native="$(cygpath -w "$context_posix")"
+    [[ "$(pathrt_canon_existing "$repo_posix")" == "$(pathrt_canon_existing "$repo_native")" ]] || {
+        echo "FAIL: Windows native and MSYS roots did not canonicalize equally" >&2
+        exit 1
+    }
+    pathrt_within_existing "$repo_posix" "$context_native" || {
+        echo "FAIL: Windows native context was rejected under MSYS root" >&2
+        exit 1
+    }
+    git_root="$(pathrt_for_git "$repo_posix")"
+    [[ "$git_root" =~ ^[A-Za-z]:/ ]] || {
+        echo "FAIL: Git execution path was not converted to drive form" >&2
+        exit 1
+    }
+    MSYS2_ARG_CONV_EXCL='*' git -C "$git_root" rev-parse --show-toplevel >/dev/null || {
+        echo "FAIL: native Windows Git rejected shared execution path" >&2
+        exit 1
+    }
+else
+    [[ "$(pathrt_canon_existing "$repo_posix")" == "$repo_posix" ]] || {
+        echo "FAIL: POSIX canonical path changed unexpectedly" >&2
+        exit 1
+    }
+fi
+
+pathrt_within_existing "$repo_posix" "$context_posix" || {
+    echo "FAIL: existing child was rejected" >&2
+    exit 1
+}
+if pathrt_within_existing "$repo_posix" "$TEST_ROOT/repo2/context.md"; then
+    echo "FAIL: prefix sibling was accepted without a separator boundary" >&2
+    exit 1
+fi
+if pathrt_within_existing "$repo_posix" "$repo_posix/../repo2/context.md"; then
+    echo "FAIL: traversal outside the root was accepted" >&2
+    exit 1
+fi
+
+pathrt_within_target "$repo_posix" "$repo_posix/src/new.md" || {
+    echo "FAIL: target with existing parent was rejected" >&2
+    exit 1
+}
+set +e
+pathrt_within_target "$repo_posix" "$repo_posix/missing/new.md"
+missing_rc=$?
+pathrt_canon_existing 'C:relative-path'
+drive_relative_rc=$?
+pathrt_canon_existing '\\server\share\file.md'
+unc_rc=$?
+set -e
+[[ "$missing_rc" -eq 2 && "$drive_relative_rc" -eq 2 && "$unc_rc" -eq 2 ]] || {
+    echo "FAIL: invalid paths did not fail closed with status 2" >&2
+    exit 1
+}
+
+ln -s "$TEST_ROOT/outside" "$TEST_ROOT/repo/escape-link" 2>/dev/null || true
+if [[ -L "$TEST_ROOT/repo/escape-link" ]] \
+    && pathrt_within_existing "$repo_posix" "$TEST_ROOT/repo/escape-link"; then
+    echo "FAIL: symlink escape was accepted" >&2
+    exit 1
+fi
+
+grep -Fq 'pathrt_within_existing "$review_root" "$context_file"' "$ROOT_DIR/scripts/lib/review.sh" || {
+    echo "FAIL: review context guard does not use shared containment" >&2
+    exit 1
+}
+grep -Fq 'pathrt_for_git' "$ROOT_DIR/scripts/lib/workflows.sh" || {
+    echo "FAIL: workflows do not use shared Git path conversion" >&2
+    exit 1
+}
+grep -Fq 'pathrt_for_git' "$ROOT_DIR/scripts/lib/testing.sh" || {
+    echo "FAIL: testing does not use shared Git path conversion" >&2
+    exit 1
+}
+
+echo "PASS: shared path runtime canonicalizes, contains, and fails closed"

--- a/tests/unit/test-path-runtime.sh
+++ b/tests/unit/test-path-runtime.sh
@@ -37,6 +37,11 @@ if pathrt_is_windows; then
         echo "FAIL: native Windows Git rejected shared execution path" >&2
         exit 1
     }
+    native_context="$(pathrt_for_native "$context_posix")"
+    [[ "$native_context" =~ ^[A-Za-z]:/ ]] || {
+        echo "FAIL: native execution path was not converted to drive form" >&2
+        exit 1
+    }
 else
     [[ "$(pathrt_canon_existing "$repo_posix")" == "$repo_posix" ]] || {
         echo "FAIL: POSIX canonical path changed unexpectedly" >&2
@@ -83,6 +88,10 @@ fi
 
 grep -Fq 'pathrt_within_existing "$review_root" "$context_file"' "$ROOT_DIR/scripts/lib/review.sh" || {
     echo "FAIL: review context guard does not use shared containment" >&2
+    exit 1
+}
+grep -Fq 'pathrt_for_native "$review_md"' "$ROOT_DIR/scripts/lib/review.sh" || {
+    echo "FAIL: review extractor does not use shared native path conversion" >&2
     exit 1
 }
 grep -Fq 'pathrt_for_git' "$ROOT_DIR/scripts/lib/workflows.sh" || {

--- a/tests/unit/test-provider-allowlist.sh
+++ b/tests/unit/test-provider-allowlist.sh
@@ -153,4 +153,21 @@ else
     test_fail "preflight ignored the provider allowlist or omitted OpenRouter"
 fi
 
+test_case "provider env resolver reads a simple bashrc export without evaluation"
+resolver_home="$TEST_TMP_DIR/provider-env-home"
+mkdir -p "$resolver_home"
+printf '%s\n' 'export OPENROUTER_API_KEY="test-router-key"' > "$resolver_home/.bashrc"
+if HOME="$resolver_home" PROJECT_ROOT="$PROJECT_ROOT" bash -c '
+    set -euo pipefail
+    log() { :; }
+    source "$PROJECT_ROOT/scripts/lib/provider-routing.sh"
+    unset OPENROUTER_API_KEY
+    resolve_provider_env OPENROUTER_API_KEY
+    [[ "$OPENROUTER_API_KEY" == "test-router-key" ]]
+'; then
+    test_pass
+else
+    test_fail "resolver did not recover OPENROUTER_API_KEY from .bashrc"
+fi
+
 test_summary

--- a/tests/unit/test-provider-allowlist.sh
+++ b/tests/unit/test-provider-allowlist.sh
@@ -15,6 +15,7 @@ ALLOWLIST_LIB="$PROJECT_ROOT/scripts/lib/provider-allowlist.sh"
 CHECK_PROVIDERS="$PROJECT_ROOT/scripts/helpers/check-providers.sh"
 BUILD_FLEET="$PROJECT_ROOT/scripts/helpers/build-fleet.sh"
 MODEL_CONFIG="$PROJECT_ROOT/scripts/helpers/octo-model-config.sh"
+PREFLIGHT_LIB="$PROJECT_ROOT/scripts/lib/preflight.sh"
 
 test_case "allowlist helper has valid bash syntax"
 if bash -n "$ALLOWLIST_LIB"; then
@@ -116,6 +117,40 @@ if assert_contains "$fleet" "gemini|" "gemini should be eligible" &&
    assert_contains "$fleet" "claude-sonnet|" "claude alias should allow claude-sonnet" &&
    assert_not_contains "$fleet" "codex|" "codex should not be emitted"; then
     test_pass
+fi
+
+test_case "preflight excludes disallowed Gemini and accepts configured OpenRouter"
+preflight_home="$TEST_TMP_DIR/preflight-home"
+preflight_bin="$TEST_TMP_DIR/preflight-bin"
+mkdir -p "$preflight_home/.claude-octopus" "$preflight_bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$preflight_bin/gemini"
+chmod +x "$preflight_bin/gemini"
+set +e
+preflight_output=$(
+    export HOME="$preflight_home"
+    export WORKSPACE_DIR="$preflight_home/.claude-octopus"
+    export PATH="$preflight_bin:/usr/bin:/bin"
+    export OCTO_ALLOWED_PROVIDERS="openrouter"
+    export OPENROUTER_API_KEY="test-only-placeholder"
+    RED=""; YELLOW=""; CYAN=""; GREEN=""; DIM=""; NC=""
+    source "$ALLOWLIST_LIB"
+    source "$PREFLIGHT_LIB"
+    preflight_cache_valid() { return 1; }
+    preflight_cache_write() { :; }
+    provider_smoke_test() { return 0; }
+    detect_enterprise_backend() { :; }
+    init_workspace() { mkdir -p "$WORKSPACE_DIR"; }
+    log() { printf '%s\n' "$*"; }
+    preflight_check true
+)
+preflight_status=$?
+set -e
+if [[ $preflight_status -eq 0 ]] &&
+   assert_contains "$preflight_output" "OpenRouter" "configured OpenRouter should satisfy preflight" &&
+   assert_not_contains "$preflight_output" "Gemini" "disallowed Gemini must not appear in preflight"; then
+    test_pass
+else
+    test_fail "preflight ignored the provider allowlist or omitted OpenRouter"
 fi
 
 test_summary

--- a/tests/unit/test-python-runtime-windows-alias.sh
+++ b/tests/unit/test-python-runtime-windows-alias.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Regression: Windows Store App Execution Alias must never be invoked as Python.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-python-runtime.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+WINDOWS_APPS="$TMP_DIR/WindowsApps"
+REAL_BIN="$TMP_DIR/RealPython"
+mkdir -p "$WINDOWS_APPS" "$REAL_BIN"
+
+cat > "$WINDOWS_APPS/python3" <<EOF
+#!/usr/bin/env bash
+touch "$TMP_DIR/store-alias-invoked"
+exit 49
+EOF
+cat > "$REAL_BIN/python" <<'EOF'
+#!/usr/bin/env bash
+printf 'REAL_PYTHON:%s\n' "$*"
+EOF
+chmod +x "$WINDOWS_APPS/python3" "$REAL_BIN/python"
+
+ORIGINAL_PATH="$PATH"
+PATH="$WINDOWS_APPS:$REAL_BIN:$ORIGINAL_PATH"
+source "$ROOT_DIR/scripts/lib/python-runtime.sh"
+
+output="$(python3 -c 'probe')"
+[[ "$output" == "REAL_PYTHON:-c probe" ]] || {
+    echo "FAIL: python3 was not redirected to the real interpreter" >&2
+    exit 1
+}
+
+child_output="$(bash -c "python3 -c child-probe")"
+[[ "$child_output" == "REAL_PYTHON:-c child-probe" ]] || {
+    echo "FAIL: child Bash process lost the safe Python resolver" >&2
+    exit 1
+}
+[[ ! -e "$TMP_DIR/store-alias-invoked" ]] || {
+    echo "FAIL: Windows Store alias was invoked" >&2
+    exit 1
+}
+
+while IFS= read -r hook; do
+    grep -Fq 'scripts/lib/python-runtime.sh' "$hook" || {
+        echo "FAIL: hook uses python3 without runtime guard: $hook" >&2
+        exit 1
+    }
+done < <(rg -l '(^|[^[:alnum:]_])python3([^[:alnum:]_]|$)' "$ROOT_DIR/hooks" -g '*.sh')
+
+echo "PASS: Windows Store Python alias is rejected by hook runtime"

--- a/tests/unit/test-quality-gate-lifecycle.sh
+++ b/tests/unit/test-quality-gate-lifecycle.sh
@@ -41,6 +41,13 @@ other_session_output="$(cd "$WORKSPACE_A" && HOME="$TEST_HOME" CLAUDE_SESSION_ID
   exit 1
 }
 
+other_workspace_status="$(cd "$WORKSPACE_B" && HOME="$TEST_HOME" CLAUDE_SESSION_ID=session-a bash "$HOOK" --status)"
+grep -Fq 'No active quality gate for this workspace/session.' <<<"$other_workspace_status" || {
+  echo "FAIL: gate status displayed an unrelated report as active" >&2
+  printf '%s\n' "$other_workspace_status" >&2
+  exit 1
+}
+
 ack_output="$(cd "$WORKSPACE_A" && HOME="$TEST_HOME" CLAUDE_SESSION_ID=session-a bash "$HOOK" --ack "$REPORT")"
 grep -Fq 'Acknowledged quality gate tangle-test' <<<"$ack_output" || {
   echo "FAIL: acknowledgement command failed" >&2

--- a/tests/unit/test-quality-gate-lifecycle.sh
+++ b/tests/unit/test-quality-gate-lifecycle.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Regression: failed tangle gates are scoped and explicitly acknowledgeable.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$ROOT_DIR/hooks/quality-gate.sh"
+TEST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/octo-quality-gate.XXXXXX")"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+WORKSPACE_A="$TEST_HOME/workspace-a"
+WORKSPACE_B="$TEST_HOME/workspace-b"
+RESULTS="$TEST_HOME/.claude-octopus/results"
+mkdir -p "$WORKSPACE_A" "$WORKSPACE_B" "$RESULTS"
+WORKSPACE_A="$(cd "$WORKSPACE_A" && pwd -P)"
+WORKSPACE_B="$(cd "$WORKSPACE_B" && pwd -P)"
+REPORT="$RESULTS/tangle-validation-test.md"
+
+cat > "$REPORT" <<EOF
+# TANGLE Phase Validation Report
+## Gate ID: tangle-test
+## Workspace: $WORKSPACE_A
+## Session: session-a
+### Quality Gate: FAILED
+EOF
+
+matching_output="$(cd "$WORKSPACE_A" && HOME="$TEST_HOME" CLAUDE_SESSION_ID=session-a bash "$HOOK")"
+grep -Fq '"decision": "block"' <<<"$matching_output" || {
+  echo "FAIL: matching failed gate did not block" >&2
+  exit 1
+}
+
+other_workspace_output="$(cd "$WORKSPACE_B" && HOME="$TEST_HOME" CLAUDE_SESSION_ID=session-a bash "$HOOK")"
+[[ -z "$other_workspace_output" ]] || {
+  echo "FAIL: gate leaked into another workspace" >&2
+  exit 1
+}
+
+other_session_output="$(cd "$WORKSPACE_A" && HOME="$TEST_HOME" CLAUDE_SESSION_ID=session-b bash "$HOOK")"
+[[ -z "$other_session_output" ]] || {
+  echo "FAIL: gate leaked into another session" >&2
+  exit 1
+}
+
+ack_output="$(cd "$WORKSPACE_A" && HOME="$TEST_HOME" CLAUDE_SESSION_ID=session-a bash "$HOOK" --ack "$REPORT")"
+grep -Fq 'Acknowledged quality gate tangle-test' <<<"$ack_output" || {
+  echo "FAIL: acknowledgement command failed" >&2
+  exit 1
+}
+
+acknowledged_output="$(cd "$WORKSPACE_A" && HOME="$TEST_HOME" CLAUDE_SESSION_ID=session-a bash "$HOOK")"
+[[ -z "$acknowledged_output" ]] || {
+  echo "FAIL: acknowledged gate continued blocking" >&2
+  exit 1
+}
+
+printf '\nChanged after review.\n' >> "$REPORT"
+changed_output="$(cd "$WORKSPACE_A" && HOME="$TEST_HOME" CLAUDE_SESSION_ID=session-a bash "$HOOK")"
+grep -Fq '"decision": "block"' <<<"$changed_output" || {
+  echo "FAIL: changed report incorrectly reused stale acknowledgement" >&2
+  exit 1
+}
+
+grep -Fq '## Gate ID:' "$ROOT_DIR/scripts/lib/testing.sh" || {
+  echo "FAIL: validation reports do not record a gate ID" >&2
+  exit 1
+}
+grep -Fq '## Workspace:' "$ROOT_DIR/scripts/lib/testing.sh" || {
+  echo "FAIL: validation reports do not record workspace scope" >&2
+  exit 1
+}
+grep -Fq '## Session:' "$ROOT_DIR/scripts/lib/testing.sh" || {
+  echo "FAIL: validation reports do not record session scope" >&2
+  exit 1
+}
+
+echo "PASS: quality gate lifecycle is scoped and acknowledgeable"

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -201,10 +201,10 @@ if ! declare -F review_result_completed_successfully >/dev/null 2>&1; then
     test_fail "missing terminal success classifier"
 else
     printf '{"findings":[{"title":"partial"}]}\n' > "$TEST_TMP_DIR/partial.md"
-    printf '## Status: FAILED (exit code: 1)\n' > "$TEST_TMP_DIR/failed.md"
-    printf '## Status: SUCCESS\n' > "$TEST_TMP_DIR/success.md"
-    printf '## Status: SUCCESS\n## Status: FAILED (exit code: 1)\n' > "$TEST_TMP_DIR/success-then-failed.md"
-    printf '## Status: SUCCESS\n## Status: TIMEOUT\n' > "$TEST_TMP_DIR/success-then-timeout.md"
+    printf '## Status: FAILED (exit code: 1)\n# Completed: now\n' > "$TEST_TMP_DIR/failed.md"
+    printf '## Status: SUCCESS\n# Completed: now\n' > "$TEST_TMP_DIR/success.md"
+    printf '## Status: SUCCESS\n## Status: FAILED (exit code: 1)\n# Completed: now\n' > "$TEST_TMP_DIR/success-then-failed.md"
+    printf '## Status: SUCCESS\n## Status: TIMEOUT\n# Completed: now\n' > "$TEST_TMP_DIR/success-then-timeout.md"
     if ! review_result_completed_successfully "$TEST_TMP_DIR/partial.md" &&
        ! review_result_completed_successfully "$TEST_TMP_DIR/failed.md" &&
        ! review_result_completed_successfully "$TEST_TMP_DIR/success-then-failed.md" &&
@@ -214,6 +214,14 @@ else
     else
         test_fail "terminal success classifier accepted a partial or failed result"
     fi
+fi
+
+test_case "embedded prompt status is not a terminal result"
+printf 'Prompt context:\n## Status: SUCCESS\nprovider still running\n' > "$TEST_TMP_DIR/embedded-status.md"
+if ! review_result_has_terminal_status "$TEST_TMP_DIR/embedded-status.md"; then
+    test_pass
+else
+    test_fail "embedded prompt status ended supervision before provider completion"
 fi
 
 test_case "Round 1 supervisor accepts leading-zero decimal timing values"
@@ -269,7 +277,7 @@ bash -c '
         printf "%s\n" "$tick" >> "$1.progress"
         sleep 1
     done
-    printf "## Status: SUCCESS\n" > "$1"
+    printf "## Status: SUCCESS\n# Completed: now\n" > "$1"
     touch "$2"
 ' _ "$healthy_result" "$healthy_completed" &
 healthy_pid=$!

--- a/tests/unit/test-review-findings-extraction.sh
+++ b/tests/unit/test-review-findings-extraction.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Regression: echoed context may contain an earlier empty ## Output block.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-review-extract.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+RESULT="$TMP_DIR/result.md"
+
+cat > "$RESULT" <<'EOF'
+# Prompt
+Embedded prior result:
+## Output
+```
+{"findings": []}
+```
+## Status: SUCCESS
+
+## Output
+```
+{"findings":[{"title":"real final finding","severity":"normal"}]}
+```
+## Status: SUCCESS
+EOF
+
+source "$ROOT_DIR/scripts/lib/python-runtime.sh"
+source "$ROOT_DIR/scripts/lib/review.sh"
+
+findings=$(review_extract_findings_array "$RESULT")
+[[ "$(printf '%s' "$findings" | jq -r '.[0].title')" == "real final finding" ]] || {
+    echo "FAIL: earlier empty output masked the provider's final findings" >&2
+    printf '%s\n' "$findings" >&2
+    exit 1
+}
+
+echo "PASS: review extraction falls through to the final non-empty findings"

--- a/tests/unit/test-review-findings-extraction.sh
+++ b/tests/unit/test-review-findings-extraction.sh
@@ -26,6 +26,9 @@ EOF
 source "$ROOT_DIR/scripts/lib/python-runtime.sh"
 source "$ROOT_DIR/scripts/lib/review.sh"
 
+# Reproduce Codex Desktop's Windows hook environment, where automatic MSYS
+# argument conversion is disabled for native executables such as python.exe.
+export MSYS2_ARG_CONV_EXCL='*'
 findings=$(review_extract_findings_array "$RESULT")
 [[ "$(printf '%s' "$findings" | jq -r '.[0].title')" == "real final finding" ]] || {
     echo "FAIL: earlier empty output masked the provider's final findings" >&2

--- a/tests/unit/test-review-four-provider-fleet.sh
+++ b/tests/unit/test-review-four-provider-fleet.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Regression: configured review must preserve Codex, Claude, GLM 5.2, and Kimi K3.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/octo-review-four-provider.XXXXXX")"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+mkdir -p "$TEST_HOME/.claude-octopus/config"
+cp "$ROOT_DIR/tests/fixtures/review-four-provider-config.json" \
+   "$TEST_HOME/.claude-octopus/config/providers.json"
+
+export HOME="$TEST_HOME"
+export PLUGIN_DIR="$ROOT_DIR"
+export USER_AGENTS_DIR="$ROOT_DIR/agents/personas"
+export RESULTS_DIR="$TEST_HOME/.claude-octopus/results"
+export LOGS_DIR="$TEST_HOME/.claude-octopus/logs"
+
+log() { :; }
+source "$ROOT_DIR/scripts/lib/review.sh"
+source "$ROOT_DIR/scripts/lib/models.sh"
+source "$ROOT_DIR/scripts/lib/model-resolver.sh"
+source "$ROOT_DIR/scripts/lib/dispatch.sh"
+migrate_provider_config() { :; }
+validate_model_allowed() { return 0; }
+
+fleet="$(build_review_fleet)"
+
+for expected in \
+  "codex:logic-reviewer" \
+  "claude-opus:arch-reviewer" \
+  "openrouter-glm52:diversity-reviewer" \
+  "openrouter-kimi-k3:diversity-reviewer"; do
+  grep -Fq "$expected" <<<"$fleet" || {
+    echo "FAIL: missing configured review seat: $expected" >&2
+    printf '%s\n' "$fleet" >&2
+    exit 1
+  }
+done
+
+[[ "$(get_agent_command openrouter-glm52 review review)" == *"z-ai/glm-5.2"* ]] || {
+  echo "FAIL: GLM 5.2 dispatch target missing" >&2
+  exit 1
+}
+[[ "$(get_agent_command openrouter-kimi-k3 review review)" == *"moonshotai/kimi-k3"* ]] || {
+  echo "FAIL: Kimi K3 dispatch target missing" >&2
+  exit 1
+}
+[[ "$(get_agent_model openrouter-glm52 review review)" == "z-ai/glm-5.2" ]] || {
+  echo "FAIL: GLM 5.2 model resolver target missing" >&2
+  exit 1
+}
+[[ "$(get_agent_model openrouter-kimi-k3 review review)" == "moonshotai/kimi-k3" ]] || {
+  echo "FAIL: Kimi K3 model resolver target missing" >&2
+  exit 1
+}
+
+echo "PASS: four-provider review fleet and model dispatch"

--- a/tests/unit/test-review-four-provider-fleet.sh
+++ b/tests/unit/test-review-four-provider-fleet.sh
@@ -54,5 +54,13 @@ done
   echo "FAIL: Kimi K3 model resolver target missing" >&2
   exit 1
 }
+[[ "$(get_agent_model codex review reviewer)" == "gpt-5.6-sol" ]] || {
+  echo "FAIL: Codex review seat is not GPT-5.6 Sol" >&2
+  exit 1
+}
+[[ "$(get_agent_command codex review reviewer)" == *"--model gpt-5.6-sol"* ]] || {
+  echo "FAIL: Codex review dispatch does not invoke GPT-5.6 Sol" >&2
+  exit 1
+}
 
 echo "PASS: four-provider review fleet and model dispatch"

--- a/tests/unit/test-review-four-provider-fleet.sh
+++ b/tests/unit/test-review-four-provider-fleet.sh
@@ -21,6 +21,7 @@ source "$ROOT_DIR/scripts/lib/review.sh"
 source "$ROOT_DIR/scripts/lib/models.sh"
 source "$ROOT_DIR/scripts/lib/model-resolver.sh"
 source "$ROOT_DIR/scripts/lib/dispatch.sh"
+SUPPORTS_EFFORT_COMMAND=true
 migrate_provider_config() { :; }
 validate_model_allowed() { return 0; }
 
@@ -37,6 +38,64 @@ for expected in \
     exit 1
   }
 done
+
+# The skill-facing helper must consume the same configured roster. Historically
+# it did not recognize "develop" and silently rebuilt a generic research fleet.
+helper_fleet="$(
+  OCTO_ALLOWED_PROVIDERS="codex claude openrouter" \
+    "$ROOT_DIR/scripts/helpers/build-fleet.sh" develop standard "review target" 2>/dev/null
+)"
+for expected in \
+  "codex|" \
+  "claude-opus|" \
+  "openrouter-glm52|" \
+  "openrouter-kimi-k3|"; do
+  grep -Fq "$expected" <<<"$helper_fleet" || {
+    echo "FAIL: skill-facing fleet omitted configured seat: $expected" >&2
+    printf '%s\n' "$helper_fleet" >&2
+    exit 1
+  }
+done
+if grep -Eq '^(gemini|agy|claude-sonnet)\|' <<<"$helper_fleet"; then
+  echo "FAIL: skill-facing fleet synthesized a provider outside configuration" >&2
+  printf '%s\n' "$helper_fleet" >&2
+  exit 1
+fi
+
+# Paid preflight probes must use those same exact aliases and require all four.
+source "$ROOT_DIR/scripts/lib/smoke.sh"
+SKIP_SMOKE_TEST=false
+OCTOPUS_SKIP_PROVIDER_PROBES=false
+OCTOPUS_REMOTE_SESSION=false
+CLAUDE_CODE_REMOTE=false
+VERBOSE=false
+RED=""; YELLOW=""; DIM=""; NC=""
+smoke_test_cache_valid() { return 1; }
+smoke_test_cache_write() { :; }
+secure_tempfile() { mktemp "$TEST_HOME/smoke.XXXXXX"; }
+SMOKE_CAPTURE="$TEST_HOME/smoke-agents.txt"
+_smoke_test_provider() {
+  printf '%s\n' "$1" >> "$SMOKE_CAPTURE"
+  printf 'PASS\n' > "$3"
+}
+provider_smoke_test true >/dev/null
+for expected in codex claude-opus openrouter-glm52 openrouter-kimi-k3; do
+  grep -Fqx "$expected" "$SMOKE_CAPTURE" || {
+    echo "FAIL: smoke test omitted configured alias: $expected" >&2
+    cat "$SMOKE_CAPTURE" >&2
+    exit 1
+  }
+done
+if grep -Eq '^(gemini|agy|claude-sonnet)$' "$SMOKE_CAPTURE"; then
+  echo "FAIL: smoke test probed a provider outside configuration" >&2
+  cat "$SMOKE_CAPTURE" >&2
+  exit 1
+fi
+[[ "$(wc -l < "$SMOKE_CAPTURE" | tr -d ' ')" == "4" ]] || {
+  echo "FAIL: smoke test did not probe exactly four configured aliases" >&2
+  cat "$SMOKE_CAPTURE" >&2
+  exit 1
+}
 
 [[ "$(get_agent_command openrouter-glm52 review review)" == *"z-ai/glm-5.2"* ]] || {
   echo "FAIL: GLM 5.2 dispatch target missing" >&2
@@ -60,6 +119,41 @@ done
 }
 [[ "$(get_agent_command codex review reviewer)" == *"--model gpt-5.6-sol"* ]] || {
   echo "FAIL: Codex review dispatch does not invoke GPT-5.6 Sol" >&2
+  exit 1
+}
+[[ "$(get_agent_command codex review reviewer)" == *'model_reasoning_effort="high"'* ]] || {
+  echo "FAIL: Codex review dispatch is not using high reasoning effort" >&2
+  exit 1
+}
+claude_command="$(get_agent_command claude-opus review arch-reviewer)"
+[[ "$claude_command" == *"--model claude-fable-5"* ]] || {
+  echo "FAIL: configured Claude route is not Fable 5 primary" >&2
+  printf '%s\n' "$claude_command" >&2
+  exit 1
+}
+[[ "$claude_command" == *"--effort high"* && "$claude_command" != *"--fast"* ]] || {
+  echo "FAIL: configured Claude route is not standard high effort" >&2
+  printf '%s\n' "$claude_command" >&2
+  exit 1
+}
+[[ "$(get_agent_model claude-opus review arch-reviewer)" == "claude-fable-5" ]] || {
+  echo "FAIL: Claude model resolver did not preserve Fable 5 primary" >&2
+  exit 1
+}
+
+if grep -Eq 'review_run_agent_sync_progress "claude-sonnet"|synthesis-claude-sonnet|Round 2.*claude-sonnet' \
+    "$ROOT_DIR/scripts/lib/review.sh"; then
+  echo "FAIL: configured review rounds still contain a Claude Sonnet fallback" >&2
+  exit 1
+fi
+
+if grep -Eiq 'Gemini|Antigravity|Claude Sonnet|model: "sonnet"' \
+    "$ROOT_DIR/skills/flow-develop/SKILL.md"; then
+  echo "FAIL: flow-develop still advertises a hardcoded legacy provider" >&2
+  exit 1
+fi
+grep -Fq 'build-fleet.sh" develop' "$ROOT_DIR/skills/flow-develop/SKILL.md" || {
+  echo "FAIL: flow-develop does not resolve its configured develop fleet" >&2
   exit 1
 }
 

--- a/tests/unit/test-review-four-provider-fleet.sh
+++ b/tests/unit/test-review-four-provider-fleet.sh
@@ -97,6 +97,47 @@ fi
   exit 1
 }
 
+check_provider_health() { return 0; }
+status_output="$(show_provider_status)"
+for expected in \
+  'codex: ' \
+  'claude-opus: ' \
+  'openrouter-glm52: ' \
+  'openrouter-kimi-k3: '; do
+  grep -Fq "$expected" <<<"$status_output" || {
+    echo "FAIL: configured status omitted $expected" >&2
+    printf '%s\n' "$status_output" >&2
+    exit 1
+  }
+done
+if grep -Eiq 'Gemini|Antigravity|claude-sonnet' <<<"$status_output"; then
+  echo "FAIL: configured status advertised an unconfigured provider" >&2
+  printf '%s\n' "$status_output" >&2
+  exit 1
+fi
+
+# The live smoke path must use provider credential isolation too. This protects
+# a ChatGPT-subscription Codex seat from inheriting a metered OpenAI key.
+(
+  source "$ROOT_DIR/scripts/lib/smoke.sh"
+  fake_codex="$TEST_HOME/fake-codex"
+  command_capture="$TEST_HOME/codex-smoke-command.txt"
+  smoke_result="$TEST_HOME/codex-smoke-result.txt"
+  export OPENAI_API_KEY=metered-parent-key
+  get_agent_model() { echo gpt-5.6-sol; }
+  get_agent_command() { echo "$fake_codex -"; }
+  build_provider_env() { PROVIDER_ENV_ARRAY=(env -u OPENAI_API_KEY); }
+  run_with_timeout() { shift; printf '%s\n' "$@" > "$command_capture"; }
+  secure_tempfile() { mktemp "$TEST_HOME/smoke-env.XXXXXX"; }
+  _smoke_test_provider codex 5 "$smoke_result"
+  grep -Fqx PASS "$smoke_result"
+  [[ "$(tr '\n' ' ' < "$command_capture")" == \
+     "env -u OPENAI_API_KEY $fake_codex - " ]]
+) || {
+  echo "FAIL: Codex smoke bypassed subscription credential isolation" >&2
+  exit 1
+}
+
 [[ "$(get_agent_command openrouter-glm52 review review)" == *"z-ai/glm-5.2"* ]] || {
   echo "FAIL: GLM 5.2 dispatch target missing" >&2
   exit 1

--- a/tests/unit/test-review-provider-report.sh
+++ b/tests/unit/test-review-provider-report.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Regression: the terminal report must show the configured four-provider fleet.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-review-report.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+STATUS_FILE="$TMP_DIR/status"
+
+log() { :; }
+source "$ROOT_DIR/scripts/lib/review.sh"
+
+cat > "$STATUS_FILE" <<'EOF'
+codex|ok|Round 1 completed
+claude-opus|ok|Round 1 completed
+openrouter-glm52|ok|Round 1 completed
+openrouter-kimi-k3|ok|Round 1 completed
+codex|ok|Round 2 verification
+EOF
+
+report=$(print_provider_report "$STATUS_FILE")
+for label in 'Codex' 'Claude / Fable' 'OpenRouter / GLM 5.2' 'OpenRouter / Kimi K3'; do
+    grep -Fq "$label" <<< "$report" || {
+        echo "FAIL: report omitted $label" >&2
+        printf '%s\n' "$report" >&2
+        exit 1
+    }
+done
+if grep -Fq 'Gemini' <<< "$report"; then
+    echo "FAIL: report listed an unused legacy provider" >&2
+    exit 1
+fi
+
+grep -Fq 'echo "${atype}|ok|Round 1 completed"' "$ROOT_DIR/scripts/lib/review.sh" || {
+    echo "FAIL: Round 1 status still collapses configured aliases" >&2
+    exit 1
+}
+
+echo "PASS: provider report shows the exact configured review fleet"

--- a/tests/unit/test-review-run.sh
+++ b/tests/unit/test-review-run.sh
@@ -125,6 +125,9 @@ assert_contains "$(grep -c 'attempt1' "$ALL_SRC" 2>/dev/null || true)" \
 assert_contains "$(grep -c 'OCTOPUS_REVIEW_OPENROUTER_RETRY_BACKOFF_SECS' "$ALL_SRC" 2>/dev/null || true)" \
   "[1-9]" "review_run: OpenRouter transport retry has configurable backoff"
 
+assert_contains "$(grep 'local task_id="review-r1-' "$PROJECT_ROOT/scripts/lib/review.sh" 2>/dev/null)" \
+  'review-r1-\$\{agent_type\}-\$\{role\}' "review_run: concurrent seats receive provider-unique task IDs"
+
 # ── diff target file support ─────────────────────────────────────────────────
 
 source "$PROJECT_ROOT/scripts/lib/review.sh"
@@ -154,6 +157,21 @@ if (
 else
   fail "review_run: Round 1 provider setup launches concurrently" \
     "four two-second setup paths did not overlap or PID ordering changed"
+fi
+
+local_synthesis=$(review_local_synthesis_json '[
+  {"file":"calc.js","line":2,"severity":"normal","category":"correctness","title":"wrong operation","detail":"first perspective","confidence":0.8},
+  {"file":"calc.js","line":2,"severity":"normal","category":"correctness","title":"subtracts instead of adds","detail":"second perspective","confidence":0.9},
+  {"file":"other.js","line":1,"severity":"nit","category":"style","title":"minor","detail":"third finding","confidence":0.7}
+]')
+if [[ "$(printf '%s' "$local_synthesis" | jq '.findings | length')" == "2" ]] &&
+   [[ "$(printf '%s' "$local_synthesis" | jq -r '.findings[0].confidence')" == "0.9" ]] &&
+   [[ "$(printf '%s' "$local_synthesis" | jq -r '.findings[0].detail')" == *"first perspective"* ]] &&
+   [[ "$(printf '%s' "$local_synthesis" | jq -r '.findings[0].detail')" == *"second perspective"* ]]; then
+  pass "review_run: local synthesis deduplicates corroborating provider findings"
+else
+  fail "review_run: local synthesis deduplicates corroborating provider findings" \
+    "fallback did not merge same-location/category findings deterministically"
 fi
 
 DIFF_TARGET="$TMPDIR_TEST/review-target.diff"

--- a/tests/unit/test-review-run.sh
+++ b/tests/unit/test-review-run.sh
@@ -122,6 +122,9 @@ assert_contains "$(grep -c 'OCTOPUS_REVIEW_OPENAI_COMPAT_EMPTY_RETRY_BACKOFF_SEC
 assert_contains "$(grep -c 'attempt1' "$ALL_SRC" 2>/dev/null || true)" \
   "[1-9]" "review_run: OpenAI-compatible Empty output retry preserves first artifact"
 
+assert_contains "$(grep -c 'OCTOPUS_REVIEW_OPENROUTER_RETRY_BACKOFF_SECS' "$ALL_SRC" 2>/dev/null || true)" \
+  "[1-9]" "review_run: OpenRouter transport retry has configurable backoff"
+
 # ── diff target file support ─────────────────────────────────────────────────
 
 source "$PROJECT_ROOT/scripts/lib/review.sh"
@@ -168,6 +171,27 @@ if review_openai_compat_empty_output_retryable "$OPENAI_COMPAT_EMPTY_RETRYABLE" 
   fail "review_run: non-OpenAI-compatible Empty output is not retried by adapter policy"
 else
   pass "review_run: non-OpenAI-compatible Empty output is not retried by adapter policy"
+fi
+
+OPENROUTER_TRANSPORT_RETRYABLE="$TMPDIR_TEST/openrouter-transport-retryable.md"
+cat > "$OPENROUTER_TRANSPORT_RETRYABLE" <<'EOF'
+# Agent: openrouter-kimi-k3
+## Status: FAILED (exit code: 1)
+## Error Log
+OpenRouter curl failed (timeout or network error, model=moonshotai/kimi-k3)
+# Completed: now
+EOF
+
+if review_openrouter_transport_retryable "$OPENROUTER_TRANSPORT_RETRYABLE" "openrouter-kimi-k3"; then
+  pass "review_run: transient OpenRouter transport failure is retryable"
+else
+  fail "review_run: transient OpenRouter transport failure is retryable"
+fi
+
+if review_openrouter_transport_retryable "$OPENROUTER_TRANSPORT_RETRYABLE" "codex"; then
+  fail "review_run: OpenRouter transport retry is provider-scoped"
+else
+  pass "review_run: OpenRouter transport retry is provider-scoped"
 fi
 
 # ── MCP schema ───────────────────────────────────────────────────────────────

--- a/tests/unit/test-review-run.sh
+++ b/tests/unit/test-review-run.sh
@@ -129,6 +129,33 @@ assert_contains "$(grep -c 'OCTOPUS_REVIEW_OPENROUTER_RETRY_BACKOFF_SECS' "$ALL_
 
 source "$PROJECT_ROOT/scripts/lib/review.sh"
 
+if (
+  log() { :; }
+  round1_agent_types=(codex claude-opus openrouter-glm52 openrouter-kimi-k3)
+  round1_prompts=(one two three four)
+  round1_task_ids=(task-1 task-2 task-3 task-4)
+  round1_roles=(logic architecture diversity diversity)
+  round1_pids=()
+  spawn_agent_capture_pid() {
+    sleep 2
+    case "$1" in
+      codex) echo 9001 ;;
+      claude-opus) echo 9002 ;;
+      openrouter-glm52) echo 9003 ;;
+      openrouter-kimi-k3) echo 9004 ;;
+    esac
+  }
+  SECONDS=0
+  review_launch_round1_fleet
+  [[ "$SECONDS" -lt 5 ]] &&
+    [[ "${round1_pids[*]}" == "9001 9002 9003 9004" ]]
+); then
+  pass "review_run: Round 1 provider setup launches concurrently"
+else
+  fail "review_run: Round 1 provider setup launches concurrently" \
+    "four two-second setup paths did not overlap or PID ordering changed"
+fi
+
 DIFF_TARGET="$TMPDIR_TEST/review-target.diff"
 cat > "$DIFF_TARGET" <<'EOF'
 diff --git a/foo.txt b/foo.txt

--- a/tests/unit/test-review-terminal-status.sh
+++ b/tests/unit/test-review-terminal-status.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression: embedded status text must not end provider supervision early.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-review-terminal.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+source "$ROOT_DIR/scripts/lib/review.sh"
+
+cat > "$TMP_DIR/running.md" <<'EOF'
+# Prompt
+Prior context:
+## Status: SUCCESS
+# Completed: yesterday
+
+## Output
+provider still writing
+EOF
+
+cat > "$TMP_DIR/success.md" <<'EOF'
+# Prompt
+## Status: FAILED (exit code: 1)
+# Completed: yesterday
+
+## Output
+{"findings":[]}
+## Status: SUCCESS
+# Completed: now
+EOF
+
+cat > "$TMP_DIR/failed.md" <<'EOF'
+# Prompt
+## Status: SUCCESS
+# Completed: yesterday
+
+## Output
+(no output)
+## Status: FAILED (exit code: 1)
+# Completed: now
+EOF
+
+! review_result_has_terminal_status "$TMP_DIR/running.md" || {
+    echo "FAIL: embedded completion text ended a running provider" >&2
+    exit 1
+}
+review_result_has_terminal_status "$TMP_DIR/success.md" || {
+    echo "FAIL: completed success was not terminal" >&2
+    exit 1
+}
+review_result_completed_successfully "$TMP_DIR/success.md" || {
+    echo "FAIL: completed success was classified as failed" >&2
+    exit 1
+}
+! review_result_completed_successfully "$TMP_DIR/failed.md" || {
+    echo "FAIL: embedded success masked the final failure" >&2
+    exit 1
+}
+
+echo "PASS: review supervision requires the final completion footer"

--- a/tests/unit/test-review-terminal-status.sh
+++ b/tests/unit/test-review-terminal-status.sh
@@ -6,6 +6,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-review-terminal.XXXXXX")"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
+log() { :; }
 source "$ROOT_DIR/scripts/lib/review.sh"
 
 cat > "$TMP_DIR/running.md" <<'EOF'
@@ -54,6 +55,41 @@ review_result_completed_successfully "$TMP_DIR/success.md" || {
 }
 ! review_result_completed_successfully "$TMP_DIR/failed.md" || {
     echo "FAIL: embedded success masked the final failure" >&2
+    exit 1
+}
+
+export OCTOPUS_REVIEW_RESULT_FLUSH_GRACE_SECS=3
+delayed="$TMP_DIR/delayed.md"
+(
+    sleep 1
+    printf '## Status: SUCCESS\n# Completed: now\n' > "$delayed"
+) &
+delayed_writer=$!
+delayed_start=$(date +%s)
+review_wait_for_result_status "$delayed" 999999 "delayed wrapper" "$TMP_DIR" 5 1
+delayed_elapsed=$(( $(date +%s) - delayed_start ))
+wait "$delayed_writer"
+[[ "$delayed_elapsed" -ge 1 ]] && review_result_completed_successfully "$delayed" || {
+    echo "FAIL: retry waiter did not allow wrapper footer flush" >&2
+    exit 1
+}
+
+round_delayed="$TMP_DIR/round-delayed.md"
+(
+    sleep 1
+    printf '## Status: SUCCESS\n# Completed: now\n' > "$round_delayed"
+) &
+round_writer=$!
+round1_files=("$round_delayed")
+round1_pids=(999998)
+round1_agent_types=(openrouter-kimi-k3)
+round1_roles=(diversity-reviewer)
+round_start=$(date +%s)
+review_supervise_round1 5 1 "$TMP_DIR"
+round_elapsed=$(( $(date +%s) - round_start ))
+wait "$round_writer"
+[[ "$round_elapsed" -ge 1 ]] && review_result_completed_successfully "$round_delayed" || {
+    echo "FAIL: Round 1 supervisor did not allow wrapper footer flush" >&2
     exit 1
 }
 

--- a/tests/unit/test-role-mapping-v929.sh
+++ b/tests/unit/test-role-mapping-v929.sh
@@ -49,14 +49,14 @@ test_architect_is_opus() {
 }
 
 test_code_reviewer_is_gpt_54() {
-    test_case "code-reviewer → codex-review:gpt-5.5"
+    test_case "code-reviewer → codex-review:gpt-5.6-sol"
     unset OCTOPUS_LEGACY_ROLES
     local mapping
     mapping=$(get_role_mapping "code-reviewer")
-    if [[ "$mapping" == "codex-review:gpt-5.5" ]]; then
+    if [[ "$mapping" == "codex-review:gpt-5.6-sol" ]]; then
         test_pass
     else
-        test_fail "expected codex-review:gpt-5.5, got $mapping"
+        test_fail "expected codex-review:gpt-5.6-sol, got $mapping"
     fi
 }
 
@@ -86,14 +86,14 @@ test_security_reviewer_is_opus() {
 }
 
 test_implementer_stays_gpt_54() {
-    test_case "implementer → codex:gpt-5.5 (unchanged from v9.28)"
+    test_case "implementer → codex:gpt-5.6-sol"
     unset OCTOPUS_LEGACY_ROLES
     local mapping
     mapping=$(get_role_mapping "implementer")
-    if [[ "$mapping" == "codex:gpt-5.5" ]]; then
+    if [[ "$mapping" == "codex:gpt-5.6-sol" ]]; then
         test_pass
     else
-        test_fail "expected codex:gpt-5.5, got $mapping"
+        test_fail "expected codex:gpt-5.6-sol, got $mapping"
     fi
 }
 
@@ -138,28 +138,28 @@ test_synthesizer_is_sonnet() {
 # ═══════════════════════════════════════════════════════════════════════════════
 
 test_legacy_architect_is_gpt_54() {
-    test_case "OCTOPUS_LEGACY_ROLES=1: architect → codex:gpt-5.5 (v9.28 behavior)"
+    test_case "OCTOPUS_LEGACY_ROLES=1: architect → codex:gpt-5.6-sol"
     export OCTOPUS_LEGACY_ROLES=1
     local mapping
     mapping=$(get_role_mapping "architect")
     unset OCTOPUS_LEGACY_ROLES
-    if [[ "$mapping" == "codex:gpt-5.5" ]]; then
+    if [[ "$mapping" == "codex:gpt-5.6-sol" ]]; then
         test_pass
     else
-        test_fail "expected codex:gpt-5.5 under legacy, got $mapping"
+        test_fail "expected codex:gpt-5.6-sol under legacy, got $mapping"
     fi
 }
 
 test_legacy_security_reviewer_falls_back() {
-    test_case "OCTOPUS_LEGACY_ROLES=1: security-reviewer → codex-review:gpt-5.5 (unified v9.28 reviewer)"
+    test_case "OCTOPUS_LEGACY_ROLES=1: security-reviewer → codex-review:gpt-5.6-sol"
     export OCTOPUS_LEGACY_ROLES=1
     local mapping
     mapping=$(get_role_mapping "security-reviewer")
     unset OCTOPUS_LEGACY_ROLES
-    if [[ "$mapping" == "codex-review:gpt-5.5" ]]; then
+    if [[ "$mapping" == "codex-review:gpt-5.6-sol" ]]; then
         test_pass
     else
-        test_fail "expected codex-review:gpt-5.5 under legacy, got $mapping"
+        test_fail "expected codex-review:gpt-5.6-sol under legacy, got $mapping"
     fi
 }
 
@@ -193,14 +193,14 @@ test_get_role_agent_for_architect() {
 }
 
 test_get_role_model_for_code_reviewer() {
-    test_case "get_role_model code-reviewer → gpt-5.5"
+    test_case "get_role_model code-reviewer → gpt-5.6-sol"
     unset OCTOPUS_LEGACY_ROLES
     local model
     model=$(get_role_model "code-reviewer")
-    if [[ "$model" == "gpt-5.5" ]]; then
+    if [[ "$model" == "gpt-5.6-sol" ]]; then
         test_pass
     else
-        test_fail "expected gpt-5.5, got $model"
+        test_fail "expected gpt-5.6-sol, got $model"
     fi
 }
 

--- a/tests/unit/test-spawn-task-isolation.sh
+++ b/tests/unit/test-spawn-task-isolation.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SPAWN="$ROOT_DIR/scripts/lib/spawn.sh"
+
+source "$SPAWN"
+
+if ! declare -f octopus_new_task_id >/dev/null 2>&1; then
+    echo "FAIL: spawn runtime has no collision-resistant task ID generator" >&2
+    exit 1
+fi
+
+declare -A seen=()
+for _ in $(seq 1 16); do
+    task_id="$(octopus_new_task_id)"
+    if [[ -n "${seen[$task_id]:-}" ]]; then
+        echo "FAIL: duplicate generated task ID: $task_id" >&2
+        exit 1
+    fi
+    seen[$task_id]=1
+done
+
+if ! grep -Fq 'local capture_id="${agent_type}-${task_id}"' "$SPAWN"; then
+    echo "FAIL: spawn scratch artifacts are not provider-qualified" >&2
+    exit 1
+fi
+
+for suffix in out err; do
+    if ! grep -Fq ".tmp-\${capture_id}.${suffix}" "$SPAWN"; then
+        echo "FAIL: .tmp scratch ${suffix} does not use provider-qualified capture ID" >&2
+        exit 1
+    fi
+done
+
+if ! grep -Fq '.raw-${capture_id}.out' "$SPAWN"; then
+    echo "FAIL: raw scratch output does not use provider-qualified capture ID" >&2
+    exit 1
+fi
+
+echo "PASS: spawn defaults and scratch artifacts are collision-resistant"

--- a/tests/unit/test-tangle-decompose-allowlist-routing.sh
+++ b/tests/unit/test-tangle-decompose-allowlist-routing.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Regression: tangle decomposition must not dispatch only to providers excluded
+# by the active provider allowlist.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/octo-tangle-routing.XXXXXX")"
+trap 'rm -rf "$TEST_HOME"' EXIT INT TERM
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "tangle decomposition allowlist routing"
+
+export HOME="$TEST_HOME"
+export OCTOPUS_CONFIG_DIR="$TEST_HOME/.claude-octopus/config"
+export OCTOPUS_PROVIDERS_CONFIG="$OCTOPUS_CONFIG_DIR/providers.json"
+export PLUGIN_DIR="$PROJECT_ROOT"
+mkdir -p "$OCTOPUS_CONFIG_DIR"
+
+cat > "$OCTOPUS_PROVIDERS_CONFIG" <<'JSON'
+{
+  "routing": {
+    "features": {
+      "review": [
+        "codex",
+        "claude-opus",
+        "openrouter-glm52",
+        "openrouter-kimi-k3"
+      ]
+    }
+  }
+}
+JSON
+
+source "$PROJECT_ROOT/scripts/lib/provider-allowlist.sh"
+source "$PROJECT_ROOT/scripts/lib/execution-profile.sh"
+source "$PROJECT_ROOT/scripts/lib/agent-utils.sh"
+source "$PROJECT_ROOT/scripts/lib/workflows.sh"
+
+CALL_LOG="$TEST_HOME/decompose-calls.log"
+log() { :; }
+
+run_agent_sync() {
+    local agent="$1"
+    printf '%s\n' "$agent" >> "$CALL_LOG"
+    octo_provider_allowed "$agent" || return 1
+    case "$agent" in
+        claude-opus|openrouter-glm52)
+            printf '1. [CODING] Routed task - Files: scripts/lib/workflows.sh - Task: use an allowed configured provider\n'
+            return 0
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+test_case "Claude-only session routes decomposition to the configured Fable/Opus seat"
+if (
+    rm -f "$CALL_LOG"
+    export OCTO_ALLOWED_PROVIDERS="claude"
+    result=$(tangle_reformat_decomposition "task" "bad decomposition" "provider failure" "")
+    [[ "$result" == *"Routed task"* ]] &&
+    [[ "$(sed -n '1p' "$CALL_LOG")" == "claude-opus" ]] &&
+    [[ "$(wc -l < "$CALL_LOG")" -eq 1 ]]
+); then
+    test_pass
+else
+    test_fail "Claude-only decomposition did not select claude-opus from the configured fleet"
+fi
+
+test_case "OpenRouter family allowlist routes decomposition to a configured model alias"
+if (
+    rm -f "$CALL_LOG"
+    export OCTO_ALLOWED_PROVIDERS="openrouter"
+    result=$(tangle_reformat_decomposition "task" "bad decomposition" "provider failure" "")
+    [[ "$result" == *"Routed task"* ]] &&
+    [[ "$(sed -n '1p' "$CALL_LOG")" == "openrouter-glm52" ]] &&
+    [[ "$(wc -l < "$CALL_LOG")" -eq 1 ]]
+); then
+    test_pass
+else
+    test_fail "OpenRouter decomposition did not select the first configured OpenRouter model"
+fi
+
+test_case "initial and reformat decomposition share the allowlist-aware candidate chain"
+if [[ "$(grep -c 'tangle_run_decomposition' "$PROJECT_ROOT/scripts/lib/workflows.sh" || true)" -ge 3 ]]; then
+    test_pass
+else
+    test_fail "tangle_develop and reformat are not wired to one decomposition dispatcher"
+fi
+
+test_summary

--- a/tests/unit/test-tangle-windows-repo-root.sh
+++ b/tests/unit/test-tangle-windows-repo-root.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Regression: Git for Windows cannot consume /c/... paths when MSYS argument
+# conversion is disabled by the host environment.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT_SOURCE="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "tangle Windows repository root normalization"
+
+source "$PROJECT_ROOT_SOURCE/scripts/lib/workflows.sh"
+
+repo="$TEST_TMP_DIR/tangle-windows-root/repo"
+mkdir -p "$repo"
+git -C "$repo" init -q
+printf 'tracked\n' > "$repo/README.md"
+git -C "$repo" add README.md
+
+test_case "resolved repository root remains valid for git -C with MSYS conversion disabled"
+if [[ "$(uname -s)" == MINGW* ]] && command -v cygpath >/dev/null 2>&1; then
+    if (
+        export PROJECT_ROOT="$repo"
+        export MSYS2_ARG_CONV_EXCL='*'
+        resolved=$(tangle_resolve_repo_root)
+        [[ "$resolved" =~ ^[A-Za-z]:/ ]] &&
+        [[ "$(git -C "$resolved" ls-files)" == "README.md" ]]
+    ); then
+        test_pass
+    else
+        test_fail "tangle_resolve_repo_root returned a Git-incompatible MSYS path"
+    fi
+else
+    if (
+        export PROJECT_ROOT="$repo"
+        resolved=$(tangle_resolve_repo_root)
+        [[ "$(git -C "$resolved" ls-files)" == "README.md" ]]
+    ); then
+        test_pass
+    else
+        test_fail "tangle_resolve_repo_root did not preserve a usable repository root"
+    fi
+fi
+
+test_summary

--- a/tests/unit/test-tangle-windows-repo-root.sh
+++ b/tests/unit/test-tangle-windows-repo-root.sh
@@ -9,6 +9,7 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "tangle Windows repository root normalization"
 
 source "$PROJECT_ROOT_SOURCE/scripts/lib/workflows.sh"
+source "$PROJECT_ROOT_SOURCE/scripts/lib/testing.sh"
 
 repo="$TEST_TMP_DIR/tangle-windows-root/repo"
 mkdir -p "$repo"
@@ -38,6 +39,32 @@ else
         test_pass
     else
         test_fail "tangle_resolve_repo_root did not preserve a usable repository root"
+    fi
+fi
+
+printf 'new artifact\n' > "$repo/PROOF.txt"
+
+test_case "worktree snapshot sees untracked files with MSYS conversion disabled"
+if [[ "$(uname -s)" == MINGW* ]] && command -v cygpath >/dev/null 2>&1; then
+    if (
+        export PROJECT_ROOT="$repo"
+        export MSYS2_ARG_CONV_EXCL='*'
+        snapshot=$(snapshot_tangle_worktree_paths)
+        grep -Fxq 'PROOF.txt' <<< "$snapshot"
+    ); then
+        test_pass
+    else
+        test_fail "snapshot_tangle_worktree_paths lost the Windows repository root"
+    fi
+else
+    if (
+        export PROJECT_ROOT="$repo"
+        snapshot=$(snapshot_tangle_worktree_paths)
+        grep -Fxq 'PROOF.txt' <<< "$snapshot"
+    ); then
+        test_pass
+    else
+        test_fail "snapshot_tangle_worktree_paths did not report the untracked artifact"
     fi
 fi
 


### PR DESCRIPTION
## Summary

- preserve the configured Codex/GPT-5.4, Claude/Fable 5, OpenRouter GLM 5.2, and OpenRouter Kimi K3 review seats
- keep Fable 5 primary with standard Opus 4.8 only as a model-unavailability fallback
- prohibit automatic routing to the more expensive Opus Fast tier; Fast now requires an explicit request
- make architecture/tangle/review personas resolve through available providers instead of hardcoded unavailable aliases
- unify Windows/MSYS path containment and native execution boundaries for Git and Python
- isolate Codex's spawned runtime cache, concurrent agent captures, and hook Python resolution
- wait for real provider completion footers, preserve OpenRouter JSON, recover embedded findings, and retry transient OpenRouter transport failures once
- report the exact configured fleet in the terminal instead of hiding GLM/Kimi behind the legacy provider card
- keep prompt-routing and initialization hooks enabled without visible terminal or Microsoft Store launches

## Verification

- focused active-cache matrix passed: curated dispatch, isolated Codex runtime, four-provider fleet, configured design fleet, Windows paths, Fable routing, OpenRouter content, findings extraction, terminal supervision, exact provider report, command validation, and 30/30 review-pipeline checks
- live code-review task 1784583281 completed with exit 0 for GPT-5.4, Claude Fable 5 high, z-ai/glm-5.2, and moonshotai/kimi-k3
- live synthesis produced 3 findings with no partial-provider warning
- active Windows runtime resolved Python 3.13 without launching Microsoft Store; no provider worker remained after completion
- all 53 changed branch files match the active 9.54.1 plugin cache byte-for-byte
- Bash syntax and git diff checks passed

## Notes

- the older aggregation robustness script retains a pre-existing long-running timeout; focused regression tests for every changed runtime path pass

### Codex GPT-5.6 Sol subscription routing

- Pins every Codex capability and fallback slot to `gpt-5.6-sol`.
- Uses the Codex CLI with ChatGPT subscription authentication and strips `OPENAI_API_KEY` from ChatGPT-authenticated provider environments.
- Removes fast, mini, and alternate-model Codex fallback candidates; unavailable Sol now fails closed.
- Adds regression coverage for model resolution, command construction, subscription isolation, role mapping, and the four-provider review fleet.
- Live installed-runtime proof returned `OCTOPUS_SOL_OCTOPUS_OK` with executor `codex`, configured model `gpt-5.6-sol`, and `SUCCESS`.
