### PR TITLE
refactor: unify consultative agent dispatch

### DIFF
--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -76,6 +76,47 @@ should_use_agent_teams() {
     return 1
 }
 
+# Run a synchronous agent in a strictly consultative context.
+#
+# Council seats and pre-implementation design reviews are advisory: they may
+# inspect the workspace and execute read-only diagnostics, but must not mutate
+# project files. Keep the policy here so every consultative caller gets the same
+# sandbox/autonomy isolation and exact environment restoration on success or
+# failure.
+run_agent_sync_consultative() {
+    local old_security_set="${OCTOPUS_SECURITY_V870+x}"
+    local old_security="${OCTOPUS_SECURITY_V870:-}"
+    local old_gemini_sandbox_set="${OCTOPUS_GEMINI_SANDBOX+x}"
+    local old_gemini_sandbox="${OCTOPUS_GEMINI_SANDBOX:-}"
+    local old_codex_sandbox_set="${OCTOPUS_CODEX_SANDBOX+x}"
+    local old_codex_sandbox="${OCTOPUS_CODEX_SANDBOX:-}"
+    local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
+    local old_autonomy="${CLAUDE_OCTOPUS_AUTONOMY:-}"
+    local rc
+
+    unset OCTOPUS_SECURITY_V870
+    unset OCTOPUS_GEMINI_SANDBOX
+    unset CLAUDE_OCTOPUS_AUTONOMY
+    export OCTOPUS_CODEX_SANDBOX="read-only"
+
+    if run_agent_sync "$@"; then
+        rc=0
+    else
+        rc=$?
+    fi
+
+    if [[ -n "$old_security_set" ]]; then export OCTOPUS_SECURITY_V870="$old_security"; else unset OCTOPUS_SECURITY_V870; fi
+    if [[ -n "$old_gemini_sandbox_set" ]]; then export OCTOPUS_GEMINI_SANDBOX="$old_gemini_sandbox"; else unset OCTOPUS_GEMINI_SANDBOX; fi
+    if [[ -n "$old_autonomy_set" ]]; then export CLAUDE_OCTOPUS_AUTONOMY="$old_autonomy"; else unset CLAUDE_OCTOPUS_AUTONOMY; fi
+    if [[ -n "$old_codex_sandbox_set" ]]; then
+        export OCTOPUS_CODEX_SANDBOX="$old_codex_sandbox"
+    else
+        unset OCTOPUS_CODEX_SANDBOX
+    fi
+
+    return "$rc"
+}
+
 # Synchronous agent execution (for sequential steps within phases)
 run_agent_sync() {
     local agent_type="$1"

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -78,8 +78,8 @@ should_use_agent_teams() {
 
 # Prepare an isolated copy-on-write workspace for advisory agents.
 # GNU cp uses reflinks when the backing filesystem supports them; otherwise it
-# falls back to an ordinary private copy. The original checkout is never used as
-# the agent cwd.
+# falls back to an ordinary private copy. This protects the source checkout from
+# incidental relative-path mutations by keeping advisory work in a throwaway cwd.
 _octopus_prepare_consultative_workspace() {
     local source_root="$1"
     local temp_root workspace
@@ -101,8 +101,10 @@ _octopus_prepare_consultative_workspace() {
 # Council seats and pre-implementation design reviews are advisory. Native
 # read-only sandboxing is not portable across all Codex runtimes (notably
 # Landlock-restricted hosts), so advisory agents run with the functional
-# danger-full-access mode inside a private disposable workspace. Any writes are
-# discarded with that workspace and never reach the real checkout.
+# danger-full-access mode inside a private disposable workspace. Relative-path
+# writes made during normal advisory work are discarded with that workspace.
+# This is mutation isolation for accidental workspace edits, not a security
+# boundary against deliberate access to absolute paths outside the workspace.
 run_agent_sync_consultative() {
     local old_security_set="${OCTOPUS_SECURITY_V870+x}"
     local old_security="${OCTOPUS_SECURITY_V870:-}"
@@ -114,9 +116,10 @@ run_agent_sync_consultative() {
     local old_codex_sandbox="${OCTOPUS_CODEX_SANDBOX:-}"
     local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
     local old_autonomy="${CLAUDE_OCTOPUS_AUTONOMY:-}"
-    local source_root workspace temp_root rc original_prompt isolated_prompt
+    local source_root source_root_logical workspace temp_root rc original_prompt isolated_prompt
     local -a consultative_args
 
+    source_root_logical="$PWD"
     source_root="$(pwd -P)"
     workspace="$(_octopus_prepare_consultative_workspace "$source_root")" || {
         log ERROR "Failed to prepare disposable consultative workspace from: $source_root"
@@ -127,11 +130,14 @@ run_agent_sync_consultative() {
     consultative_args=("$@")
     original_prompt="${consultative_args[1]:-}"
     isolated_prompt="${original_prompt//$source_root/$workspace}"
+    if [[ "$source_root_logical" != "$source_root" ]]; then
+        isolated_prompt="${isolated_prompt//$source_root_logical/$workspace}"
+    fi
     isolated_prompt="${isolated_prompt}
 
 ## Consultative Workspace Boundary
 Work only inside this disposable workspace: ${workspace}
-Do not access or modify the source checkout at ${source_root}. Any workspace changes are exploratory and will be discarded. Return analysis and recommendations only."
+Treat ${workspace} as the working copy for this advisory task. Any relative-path workspace changes are exploratory and will be discarded. Return analysis and recommendations only."
     consultative_args[1]="$isolated_prompt"
 
     unset OCTOPUS_SECURITY_V870
@@ -146,7 +152,7 @@ Do not access or modify the source checkout at ${source_root}. Any workspace cha
         rc=$?
     fi
 
-    rm -rf "$temp_root"
+    rm -rf "$temp_root" 2>/dev/null || true
 
     if [[ -n "$old_security_set" ]]; then export OCTOPUS_SECURITY_V870="$old_security"; else unset OCTOPUS_SECURITY_V870; fi
     if [[ -n "$old_gemini_sandbox_set" ]]; then export OCTOPUS_GEMINI_SANDBOX="$old_gemini_sandbox"; else unset OCTOPUS_GEMINI_SANDBOX; fi

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -76,13 +76,33 @@ should_use_agent_teams() {
     return 1
 }
 
+# Prepare an isolated copy-on-write workspace for advisory agents.
+# GNU cp uses reflinks when the backing filesystem supports them; otherwise it
+# falls back to an ordinary private copy. The original checkout is never used as
+# the agent cwd.
+_octopus_prepare_consultative_workspace() {
+    local source_root="$1"
+    local temp_root workspace
+    temp_root="$(mktemp -d "${TMPDIR:-/tmp}/octopus-consultative.XXXXXX")" || return 1
+    workspace="${temp_root}/workspace"
+    mkdir -p "$workspace" || { rm -rf "$temp_root"; return 1; }
+
+    if ! cp -a --reflink=auto "${source_root}/." "${workspace}/" 2>/dev/null; then
+        rm -rf "$workspace"
+        mkdir -p "$workspace" || { rm -rf "$temp_root"; return 1; }
+        cp -a "${source_root}/." "${workspace}/" || { rm -rf "$temp_root"; return 1; }
+    fi
+
+    printf '%s\n' "$workspace"
+}
+
 # Run a synchronous agent in a strictly consultative context.
 #
-# Council seats and pre-implementation design reviews are advisory: they may
-# inspect the workspace and execute read-only diagnostics, but must not mutate
-# project files. Keep the policy here so every consultative caller gets the same
-# sandbox/autonomy isolation and exact environment restoration on success or
-# failure.
+# Council seats and pre-implementation design reviews are advisory. Native
+# read-only sandboxing is not portable across all Codex runtimes (notably
+# Landlock-restricted hosts), so advisory agents run with the functional
+# danger-full-access mode inside a private disposable workspace. Any writes are
+# discarded with that workspace and never reach the real checkout.
 run_agent_sync_consultative() {
     local old_security_set="${OCTOPUS_SECURITY_V870+x}"
     local old_security="${OCTOPUS_SECURITY_V870:-}"
@@ -94,19 +114,39 @@ run_agent_sync_consultative() {
     local old_codex_sandbox="${OCTOPUS_CODEX_SANDBOX:-}"
     local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
     local old_autonomy="${CLAUDE_OCTOPUS_AUTONOMY:-}"
-    local rc
+    local source_root workspace temp_root rc original_prompt isolated_prompt
+    local -a consultative_args
+
+    source_root="$(pwd -P)"
+    workspace="$(_octopus_prepare_consultative_workspace "$source_root")" || {
+        log ERROR "Failed to prepare disposable consultative workspace from: $source_root"
+        return 1
+    }
+    temp_root="$(dirname "$workspace")"
+
+    consultative_args=("$@")
+    original_prompt="${consultative_args[1]:-}"
+    isolated_prompt="${original_prompt//$source_root/$workspace}"
+    isolated_prompt="${isolated_prompt}
+
+## Consultative Workspace Boundary
+Work only inside this disposable workspace: ${workspace}
+Do not access or modify the source checkout at ${source_root}. Any workspace changes are exploratory and will be discarded. Return analysis and recommendations only."
+    consultative_args[1]="$isolated_prompt"
 
     unset OCTOPUS_SECURITY_V870
     unset OCTOPUS_GEMINI_SANDBOX
     unset OCTOPUS_AGY_SANDBOX
     unset CLAUDE_OCTOPUS_AUTONOMY
-    export OCTOPUS_CODEX_SANDBOX="read-only"
+    export OCTOPUS_CODEX_SANDBOX="danger-full-access"
 
-    if run_agent_sync "$@"; then
+    if (cd "$workspace" && run_agent_sync "${consultative_args[@]}"); then
         rc=0
     else
         rc=$?
     fi
+
+    rm -rf "$temp_root"
 
     if [[ -n "$old_security_set" ]]; then export OCTOPUS_SECURITY_V870="$old_security"; else unset OCTOPUS_SECURITY_V870; fi
     if [[ -n "$old_gemini_sandbox_set" ]]; then export OCTOPUS_GEMINI_SANDBOX="$old_gemini_sandbox"; else unset OCTOPUS_GEMINI_SANDBOX; fi

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -152,7 +152,13 @@ Treat ${workspace} as the working copy for this advisory task. Any relative-path
         rc=$?
     fi
 
-    rm -rf "$temp_root" 2>/dev/null || true
+    if ! rm -rf "$temp_root" 2>/dev/null; then
+        if declare -F log >/dev/null 2>&1; then
+            log WARN "Failed to remove consultative workspace: $temp_root"
+        else
+            printf 'WARN: failed to remove consultative workspace: %s\n' "$temp_root" >&2
+        fi
+    fi
 
     if [[ -n "$old_security_set" ]]; then export OCTOPUS_SECURITY_V870="$old_security"; else unset OCTOPUS_SECURITY_V870; fi
     if [[ -n "$old_gemini_sandbox_set" ]]; then export OCTOPUS_GEMINI_SANDBOX="$old_gemini_sandbox"; else unset OCTOPUS_GEMINI_SANDBOX; fi

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -88,6 +88,8 @@ run_agent_sync_consultative() {
     local old_security="${OCTOPUS_SECURITY_V870:-}"
     local old_gemini_sandbox_set="${OCTOPUS_GEMINI_SANDBOX+x}"
     local old_gemini_sandbox="${OCTOPUS_GEMINI_SANDBOX:-}"
+    local old_agy_sandbox_set="${OCTOPUS_AGY_SANDBOX+x}"
+    local old_agy_sandbox="${OCTOPUS_AGY_SANDBOX:-}"
     local old_codex_sandbox_set="${OCTOPUS_CODEX_SANDBOX+x}"
     local old_codex_sandbox="${OCTOPUS_CODEX_SANDBOX:-}"
     local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
@@ -96,6 +98,7 @@ run_agent_sync_consultative() {
 
     unset OCTOPUS_SECURITY_V870
     unset OCTOPUS_GEMINI_SANDBOX
+    unset OCTOPUS_AGY_SANDBOX
     unset CLAUDE_OCTOPUS_AUTONOMY
     export OCTOPUS_CODEX_SANDBOX="read-only"
 
@@ -107,6 +110,7 @@ run_agent_sync_consultative() {
 
     if [[ -n "$old_security_set" ]]; then export OCTOPUS_SECURITY_V870="$old_security"; else unset OCTOPUS_SECURITY_V870; fi
     if [[ -n "$old_gemini_sandbox_set" ]]; then export OCTOPUS_GEMINI_SANDBOX="$old_gemini_sandbox"; else unset OCTOPUS_GEMINI_SANDBOX; fi
+    if [[ -n "$old_agy_sandbox_set" ]]; then export OCTOPUS_AGY_SANDBOX="$old_agy_sandbox"; else unset OCTOPUS_AGY_SANDBOX; fi
     if [[ -n "$old_autonomy_set" ]]; then export CLAUDE_OCTOPUS_AUTONOMY="$old_autonomy"; else unset CLAUDE_OCTOPUS_AUTONOMY; fi
     if [[ -n "$old_codex_sandbox_set" ]]; then
         export OCTOPUS_CODEX_SANDBOX="$old_codex_sandbox"

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -60,6 +60,7 @@ _council_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=scripts/lib/benchmark-routing.sh
 source "${_council_lib_dir}/benchmark-routing.sh" 2>/dev/null || true
 source "${_council_lib_dir}/openai-compatible.sh" 2>/dev/null || true
+source "${_council_lib_dir}/agent-sync.sh" 2>/dev/null || true
 unset _council_lib_dir
 
 council_usage() {

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1517,39 +1517,8 @@ EOF
 
     if declare -f run_agent_sync >/dev/null 2>&1; then
         local agent_type="$provider"
-        local old_security_set="${OCTOPUS_SECURITY_V870+x}"
-        local old_security="${OCTOPUS_SECURITY_V870:-}"
-        local old_gemini_sandbox_set="${OCTOPUS_GEMINI_SANDBOX+x}"
-        local old_gemini_sandbox="${OCTOPUS_GEMINI_SANDBOX:-}"
-        local old_codex_sandbox="${OCTOPUS_CODEX_SANDBOX:-}"
-        local old_codex_sandbox_set="${OCTOPUS_CODEX_SANDBOX+x}"
-        local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
-        local old_autonomy="${CLAUDE_OCTOPUS_AUTONOMY:-}"
-
-        unset OCTOPUS_SECURITY_V870
-        unset OCTOPUS_GEMINI_SANDBOX
-        unset CLAUDE_OCTOPUS_AUTONOMY
-        export OCTOPUS_CODEX_SANDBOX="read-only"
-        run_agent_sync "$agent_type" "$prompt" "${OCTOPUS_COUNCIL_AGENT_TIMEOUT:-120}" "$persona" "council" || {
-            if [[ -n "$old_security_set" ]]; then export OCTOPUS_SECURITY_V870="$old_security"; else unset OCTOPUS_SECURITY_V870; fi
-            if [[ -n "$old_gemini_sandbox_set" ]]; then export OCTOPUS_GEMINI_SANDBOX="$old_gemini_sandbox"; else unset OCTOPUS_GEMINI_SANDBOX; fi
-            if [[ -n "$old_autonomy_set" ]]; then export CLAUDE_OCTOPUS_AUTONOMY="$old_autonomy"; else unset CLAUDE_OCTOPUS_AUTONOMY; fi
-            if [[ -n "$old_codex_sandbox_set" ]]; then
-                export OCTOPUS_CODEX_SANDBOX="$old_codex_sandbox"
-            else
-                unset OCTOPUS_CODEX_SANDBOX
-            fi
-            return 1
-        }
-        if [[ -n "$old_security_set" ]]; then export OCTOPUS_SECURITY_V870="$old_security"; else unset OCTOPUS_SECURITY_V870; fi
-        if [[ -n "$old_gemini_sandbox_set" ]]; then export OCTOPUS_GEMINI_SANDBOX="$old_gemini_sandbox"; else unset OCTOPUS_GEMINI_SANDBOX; fi
-        if [[ -n "$old_autonomy_set" ]]; then export CLAUDE_OCTOPUS_AUTONOMY="$old_autonomy"; else unset CLAUDE_OCTOPUS_AUTONOMY; fi
-        if [[ -n "$old_codex_sandbox_set" ]]; then
-            export OCTOPUS_CODEX_SANDBOX="$old_codex_sandbox"
-        else
-            unset OCTOPUS_CODEX_SANDBOX
-        fi
-        return 0
+        run_agent_sync_consultative "$agent_type" "$prompt" "${OCTOPUS_COUNCIL_AGENT_TIMEOUT:-120}" "$persona" "council"
+        return $?
     fi
 
     return 1

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -520,13 +520,13 @@ Be concise and specific. This is a planning exercise, not implementation."
     log INFO "Design review: gathering provider approaches..."
     log INFO "Design review agents: codex=${design_codex_agent}, agy=${design_agy_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${_design_timeout_label}, synth_timeout=${_synth_timeout_label}"
 
-    codex_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
-    gemini_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
-    sonnet_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony" 2>/dev/null) || true
+    codex_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
+    gemini_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
+    sonnet_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony" 2>/dev/null) || true
 
     # Synthesize conflicts and resolution
     local synthesis
-    synthesis=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync "$design_synthesis_agent" "You are synthesizing a design review ceremony.
+    synthesis=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_synthesis_agent" "You are synthesizing a design review ceremony.
 
 Three providers stated their approach to this task:
 

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -11,6 +11,11 @@
 # Source-safe: no main execution block.
 
 
+_quality_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/lib/agent-sync.sh
+source "${_quality_lib_dir}/agent-sync.sh" 2>/dev/null || true
+unset _quality_lib_dir
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONDITIONAL BRANCHING - Tentacle path selection based on task analysis
 # Enables decision trees for workflow routing

--- a/tests/unit/test-consultative-agent-dispatch.sh
+++ b/tests/unit/test-consultative-agent-dispatch.sh
@@ -40,10 +40,11 @@ fi
 test_case "consultative dispatch restores unset variables after failure"
 unset OCTOPUS_SECURITY_V870 OCTOPUS_GEMINI_SANDBOX OCTOPUS_AGY_SANDBOX OCTOPUS_CODEX_SANDBOX CLAUDE_OCTOPUS_AUTONOMY
 STUB_RC=7
-set +e
-run_agent_sync_consultative codex prompt 120 implementer ceremony >/dev/null
-rc=$?
-set -e
+if run_agent_sync_consultative codex prompt 120 implementer ceremony >/dev/null; then
+    rc=0
+else
+    rc=$?
+fi
 if [[ "$rc" -eq 7 && -z "${OCTOPUS_SECURITY_V870+x}" && -z "${OCTOPUS_GEMINI_SANDBOX+x}" && -z "${OCTOPUS_AGY_SANDBOX+x}" && -z "${OCTOPUS_CODEX_SANDBOX+x}" && -z "${CLAUDE_OCTOPUS_AUTONOMY+x}" ]]; then
     test_pass
 else

--- a/tests/unit/test-consultative-agent-dispatch.sh
+++ b/tests/unit/test-consultative-agent-dispatch.sh
@@ -11,13 +11,14 @@ OBSERVED_FILE="/tmp/octopus-consultative-observed-$$"
 trap 'rm -f "$OBSERVED_FILE"' EXIT
 STUB_RC=0
 run_agent_sync() {
-    printf '%s\n' "codex=${OCTOPUS_CODEX_SANDBOX-unset};security=${OCTOPUS_SECURITY_V870-unset};gemini=${OCTOPUS_GEMINI_SANDBOX-unset};autonomy=${CLAUDE_OCTOPUS_AUTONOMY-unset};args=$*" > "$OBSERVED_FILE"
+    printf '%s\n' "codex=${OCTOPUS_CODEX_SANDBOX-unset};security=${OCTOPUS_SECURITY_V870-unset};gemini=${OCTOPUS_GEMINI_SANDBOX-unset};agy=${OCTOPUS_AGY_SANDBOX-unset};autonomy=${CLAUDE_OCTOPUS_AUTONOMY-unset};args=$*" > "$OBSERVED_FILE"
     return "$STUB_RC"
 }
 
 test_case "consultative dispatch enforces read-only and disables write-enabling overrides"
 export OCTOPUS_SECURITY_V870="enabled"
 export OCTOPUS_GEMINI_SANDBOX="workspace-write"
+export OCTOPUS_AGY_SANDBOX="off"
 export OCTOPUS_CODEX_SANDBOX="danger-full-access"
 export CLAUDE_OCTOPUS_AUTONOMY="autonomous"
 STUB_RC=0
@@ -30,20 +31,20 @@ else
 fi
 
 test_case "consultative dispatch restores existing environment after success"
-if [[ "$OCTOPUS_SECURITY_V870" == "enabled" && "$OCTOPUS_GEMINI_SANDBOX" == "workspace-write" && "$OCTOPUS_CODEX_SANDBOX" == "danger-full-access" && "$CLAUDE_OCTOPUS_AUTONOMY" == "autonomous" ]]; then
+if [[ "$OCTOPUS_SECURITY_V870" == "enabled" && "$OCTOPUS_GEMINI_SANDBOX" == "workspace-write" && "$OCTOPUS_AGY_SANDBOX" == "off" && "$OCTOPUS_CODEX_SANDBOX" == "danger-full-access" && "$CLAUDE_OCTOPUS_AUTONOMY" == "autonomous" ]]; then
     test_pass
 else
     test_fail "existing environment was not restored"
 fi
 
 test_case "consultative dispatch restores unset variables after failure"
-unset OCTOPUS_SECURITY_V870 OCTOPUS_GEMINI_SANDBOX OCTOPUS_CODEX_SANDBOX CLAUDE_OCTOPUS_AUTONOMY
+unset OCTOPUS_SECURITY_V870 OCTOPUS_GEMINI_SANDBOX OCTOPUS_AGY_SANDBOX OCTOPUS_CODEX_SANDBOX CLAUDE_OCTOPUS_AUTONOMY
 STUB_RC=7
 set +e
 run_agent_sync_consultative codex prompt 120 implementer ceremony >/dev/null
 rc=$?
 set -e
-if [[ "$rc" -eq 7 && -z "${OCTOPUS_SECURITY_V870+x}" && -z "${OCTOPUS_GEMINI_SANDBOX+x}" && -z "${OCTOPUS_CODEX_SANDBOX+x}" && -z "${CLAUDE_OCTOPUS_AUTONOMY+x}" ]]; then
+if [[ "$rc" -eq 7 && -z "${OCTOPUS_SECURITY_V870+x}" && -z "${OCTOPUS_GEMINI_SANDBOX+x}" && -z "${OCTOPUS_AGY_SANDBOX+x}" && -z "${OCTOPUS_CODEX_SANDBOX+x}" && -z "${CLAUDE_OCTOPUS_AUTONOMY+x}" ]]; then
     test_pass
 else
     test_fail "failure rc/environment restoration incorrect: rc=$rc"
@@ -56,6 +57,14 @@ if grep -q 'run_agent_sync_consultative "$design_codex_agent"' "$PROJECT_ROOT/sc
     test_pass
 else
     test_fail "consultative callers do not share the primitive"
+fi
+
+test_case "council and quality load the consultative dependency when sourced standalone"
+if bash -c 'source "$1/scripts/lib/council.sh"; declare -F run_agent_sync_consultative >/dev/null' _ "$PROJECT_ROOT" && \
+   bash -c 'source "$1/scripts/lib/quality.sh"; declare -F run_agent_sync_consultative >/dev/null' _ "$PROJECT_ROOT"; then
+    test_pass
+else
+    test_fail "standalone libraries did not load consultative dependency"
 fi
 
 test_summary

--- a/tests/unit/test-consultative-agent-dispatch.sh
+++ b/tests/unit/test-consultative-agent-dispatch.sh
@@ -7,16 +7,17 @@ source "$PROJECT_ROOT/scripts/lib/agent-sync.sh"
 
 test_suite "Consultative Agent Dispatch"
 
-TEST_ROOT="/tmp/octopus-consultative-test-$$"
-SOURCE_ROOT="$TEST_ROOT/source"
-OBSERVED_FILE="$TEST_ROOT/observed"
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
+SOURCE_ROOT="$TEST_TMP_DIR/source"
+OBSERVED_FILE="$TEST_TMP_DIR/observed"
 mkdir -p "$SOURCE_ROOT"
 printf '%s\n' original > "$SOURCE_ROOT/protected.txt"
-trap 'rm -rf "$TEST_ROOT"' EXIT
+cleanup() { rm -rf "$TEST_TMP_DIR"; }
+trap cleanup EXIT INT TERM HUP
 
 _octopus_prepare_consultative_workspace() {
     local source_root="$1" temp_root workspace
-    temp_root="$(mktemp -d "$TEST_ROOT/workspace.XXXXXX")"
+    temp_root="$(mktemp -d "$TEST_TMP_DIR/workspace.XXXXXX")"
     workspace="$temp_root/workspace"
     mkdir -p "$workspace"
     cp -a "$source_root/." "$workspace/"
@@ -47,7 +48,7 @@ else
     test_fail "consultative isolation policy was not enforced: $output"
 fi
 
-test_case "consultative writes do not reach the source checkout"
+test_case "relative consultative writes remain in the disposable workspace"
 if [[ "$(cat "$SOURCE_ROOT/protected.txt")" == "original" ]]; then
     test_pass
 else
@@ -55,7 +56,8 @@ else
 fi
 
 test_case "prompt paths are rewritten to the disposable workspace"
-if [[ "$output" != *"prompt=inspect $SOURCE_ROOT/protected.txt"* && "$output" == *"prompt=inspect "*"/workspace/protected.txt"* ]]; then
+physical_source_root="$(cd "$SOURCE_ROOT" && pwd -P)"
+if [[ "$output" != *"prompt=inspect $SOURCE_ROOT/protected.txt"* && "$output" != *"prompt=inspect $physical_source_root/protected.txt"* && "$output" == *"prompt=inspect "*"/workspace/protected.txt"* ]]; then
     test_pass
 else
     test_fail "source checkout path remained in the agent task: $output"
@@ -76,7 +78,7 @@ if run_agent_sync_consultative codex "inspect $SOURCE_ROOT/protected.txt" 120 im
 else
     rc=$?
 fi
-if [[ "$rc" -eq 7 && "$(pwd -P)" == "$SOURCE_ROOT" && "$(cat "$SOURCE_ROOT/protected.txt")" == "original" && -z "${OCTOPUS_SECURITY_V870+x}" && -z "${OCTOPUS_GEMINI_SANDBOX+x}" && -z "${OCTOPUS_AGY_SANDBOX+x}" && -z "${OCTOPUS_CODEX_SANDBOX+x}" && -z "${CLAUDE_OCTOPUS_AUTONOMY+x}" ]]; then
+if [[ "$rc" -eq 7 && "$(pwd -P)" == "$physical_source_root" && "$(cat "$SOURCE_ROOT/protected.txt")" == "original" && -z "${OCTOPUS_SECURITY_V870+x}" && -z "${OCTOPUS_GEMINI_SANDBOX+x}" && -z "${OCTOPUS_AGY_SANDBOX+x}" && -z "${OCTOPUS_CODEX_SANDBOX+x}" && -z "${CLAUDE_OCTOPUS_AUTONOMY+x}" ]]; then
     test_pass
 else
     test_fail "failure cleanup/restoration incorrect: rc=$rc pwd=$(pwd -P)"

--- a/tests/unit/test-consultative-agent-dispatch.sh
+++ b/tests/unit/test-consultative-agent-dispatch.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+source "$PROJECT_ROOT/scripts/lib/agent-sync.sh"
+
+test_suite "Consultative Agent Dispatch"
+
+OBSERVED_FILE="/tmp/octopus-consultative-observed-$$"
+trap 'rm -f "$OBSERVED_FILE"' EXIT
+STUB_RC=0
+run_agent_sync() {
+    printf '%s\n' "codex=${OCTOPUS_CODEX_SANDBOX-unset};security=${OCTOPUS_SECURITY_V870-unset};gemini=${OCTOPUS_GEMINI_SANDBOX-unset};autonomy=${CLAUDE_OCTOPUS_AUTONOMY-unset};args=$*" > "$OBSERVED_FILE"
+    return "$STUB_RC"
+}
+
+test_case "consultative dispatch enforces read-only and disables write-enabling overrides"
+export OCTOPUS_SECURITY_V870="enabled"
+export OCTOPUS_GEMINI_SANDBOX="workspace-write"
+export OCTOPUS_CODEX_SANDBOX="danger-full-access"
+export CLAUDE_OCTOPUS_AUTONOMY="autonomous"
+STUB_RC=0
+run_agent_sync_consultative codex prompt 120 implementer ceremony
+output=$(cat "$OBSERVED_FILE")
+if [[ "$output" == *"codex=read-only"* && "$output" == *"security=unset"* && "$output" == *"gemini=unset"* && "$output" == *"autonomy=unset"* ]]; then
+    test_pass
+else
+    test_fail "consultative policy was not enforced: $output"
+fi
+
+test_case "consultative dispatch restores existing environment after success"
+if [[ "$OCTOPUS_SECURITY_V870" == "enabled" && "$OCTOPUS_GEMINI_SANDBOX" == "workspace-write" && "$OCTOPUS_CODEX_SANDBOX" == "danger-full-access" && "$CLAUDE_OCTOPUS_AUTONOMY" == "autonomous" ]]; then
+    test_pass
+else
+    test_fail "existing environment was not restored"
+fi
+
+test_case "consultative dispatch restores unset variables after failure"
+unset OCTOPUS_SECURITY_V870 OCTOPUS_GEMINI_SANDBOX OCTOPUS_CODEX_SANDBOX CLAUDE_OCTOPUS_AUTONOMY
+STUB_RC=7
+set +e
+run_agent_sync_consultative codex prompt 120 implementer ceremony >/dev/null
+rc=$?
+set -e
+if [[ "$rc" -eq 7 && -z "${OCTOPUS_SECURITY_V870+x}" && -z "${OCTOPUS_GEMINI_SANDBOX+x}" && -z "${OCTOPUS_CODEX_SANDBOX+x}" && -z "${CLAUDE_OCTOPUS_AUTONOMY+x}" ]]; then
+    test_pass
+else
+    test_fail "failure rc/environment restoration incorrect: rc=$rc"
+fi
+
+test_case "design review and council use the shared consultative primitive"
+if grep -q 'run_agent_sync_consultative "$design_codex_agent"' "$PROJECT_ROOT/scripts/lib/quality.sh" && \
+   grep -q 'run_agent_sync_consultative "$design_synthesis_agent"' "$PROJECT_ROOT/scripts/lib/quality.sh" && \
+   grep -q 'run_agent_sync_consultative "$agent_type"' "$PROJECT_ROOT/scripts/lib/council.sh"; then
+    test_pass
+else
+    test_fail "consultative callers do not share the primitive"
+fi
+
+test_summary

--- a/tests/unit/test-consultative-agent-dispatch.sh
+++ b/tests/unit/test-consultative-agent-dispatch.sh
@@ -7,60 +7,82 @@ source "$PROJECT_ROOT/scripts/lib/agent-sync.sh"
 
 test_suite "Consultative Agent Dispatch"
 
-OBSERVED_FILE="/tmp/octopus-consultative-observed-$$"
-trap 'rm -f "$OBSERVED_FILE"' EXIT
+TEST_ROOT="/tmp/octopus-consultative-test-$$"
+SOURCE_ROOT="$TEST_ROOT/source"
+OBSERVED_FILE="$TEST_ROOT/observed"
+mkdir -p "$SOURCE_ROOT"
+printf '%s\n' original > "$SOURCE_ROOT/protected.txt"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+_octopus_prepare_consultative_workspace() {
+    local source_root="$1" temp_root workspace
+    temp_root="$(mktemp -d "$TEST_ROOT/workspace.XXXXXX")"
+    workspace="$temp_root/workspace"
+    mkdir -p "$workspace"
+    cp -a "$source_root/." "$workspace/"
+    printf '%s\n' "$workspace"
+}
+
 STUB_RC=0
 run_agent_sync() {
-    printf '%s\n' "codex=${OCTOPUS_CODEX_SANDBOX-unset};security=${OCTOPUS_SECURITY_V870-unset};gemini=${OCTOPUS_GEMINI_SANDBOX-unset};agy=${OCTOPUS_AGY_SANDBOX-unset};autonomy=${CLAUDE_OCTOPUS_AUTONOMY-unset};args=$*" > "$OBSERVED_FILE"
+    printf '%s\n' "pwd=$PWD;codex=${OCTOPUS_CODEX_SANDBOX-unset};security=${OCTOPUS_SECURITY_V870-unset};gemini=${OCTOPUS_GEMINI_SANDBOX-unset};agy=${OCTOPUS_AGY_SANDBOX-unset};autonomy=${CLAUDE_OCTOPUS_AUTONOMY-unset};prompt=$2" > "$OBSERVED_FILE"
+    printf '%s\n' changed > protected.txt
     return "$STUB_RC"
 }
 
-test_case "consultative dispatch enforces read-only and disables write-enabling overrides"
+cd "$SOURCE_ROOT"
+
+test_case "consultative dispatch uses dangerous mode inside a disposable workspace"
 export OCTOPUS_SECURITY_V870="enabled"
 export OCTOPUS_GEMINI_SANDBOX="workspace-write"
 export OCTOPUS_AGY_SANDBOX="off"
-export OCTOPUS_CODEX_SANDBOX="danger-full-access"
+export OCTOPUS_CODEX_SANDBOX="read-only"
 export CLAUDE_OCTOPUS_AUTONOMY="autonomous"
 STUB_RC=0
-run_agent_sync_consultative codex prompt 120 implementer ceremony
+run_agent_sync_consultative codex "inspect $SOURCE_ROOT/protected.txt" 120 implementer ceremony
 output=$(cat "$OBSERVED_FILE")
-if [[ "$output" == *"codex=read-only"* && "$output" == *"security=unset"* && "$output" == *"gemini=unset"* && "$output" == *"autonomy=unset"* ]]; then
+if [[ "$output" == *"codex=danger-full-access"* && "$output" == *"security=unset"* && "$output" == *"gemini=unset"* && "$output" == *"agy=unset"* && "$output" == *"autonomy=unset"* && "$output" == *"/workspace"* ]]; then
     test_pass
 else
-    test_fail "consultative policy was not enforced: $output"
+    test_fail "consultative isolation policy was not enforced: $output"
+fi
+
+test_case "consultative writes do not reach the source checkout"
+if [[ "$(cat "$SOURCE_ROOT/protected.txt")" == "original" ]]; then
+    test_pass
+else
+    test_fail "consultative write escaped into source checkout"
+fi
+
+test_case "prompt paths are rewritten to the disposable workspace"
+if [[ "$output" != *"prompt=inspect $SOURCE_ROOT/protected.txt"* && "$output" == *"prompt=inspect "*"/workspace/protected.txt"* ]]; then
+    test_pass
+else
+    test_fail "source checkout path remained in the agent task: $output"
 fi
 
 test_case "consultative dispatch restores existing environment after success"
-if [[ "$OCTOPUS_SECURITY_V870" == "enabled" && "$OCTOPUS_GEMINI_SANDBOX" == "workspace-write" && "$OCTOPUS_AGY_SANDBOX" == "off" && "$OCTOPUS_CODEX_SANDBOX" == "danger-full-access" && "$CLAUDE_OCTOPUS_AUTONOMY" == "autonomous" ]]; then
+if [[ "$OCTOPUS_SECURITY_V870" == "enabled" && "$OCTOPUS_GEMINI_SANDBOX" == "workspace-write" && "$OCTOPUS_AGY_SANDBOX" == "off" && "$OCTOPUS_CODEX_SANDBOX" == "read-only" && "$CLAUDE_OCTOPUS_AUTONOMY" == "autonomous" ]]; then
     test_pass
 else
     test_fail "existing environment was not restored"
 fi
 
-test_case "consultative dispatch restores unset variables after failure"
+test_case "consultative dispatch restores unset variables and source checkout after failure"
 unset OCTOPUS_SECURITY_V870 OCTOPUS_GEMINI_SANDBOX OCTOPUS_AGY_SANDBOX OCTOPUS_CODEX_SANDBOX CLAUDE_OCTOPUS_AUTONOMY
 STUB_RC=7
-if run_agent_sync_consultative codex prompt 120 implementer ceremony >/dev/null; then
+if run_agent_sync_consultative codex "inspect $SOURCE_ROOT/protected.txt" 120 implementer ceremony >/dev/null; then
     rc=0
 else
     rc=$?
 fi
-if [[ "$rc" -eq 7 && -z "${OCTOPUS_SECURITY_V870+x}" && -z "${OCTOPUS_GEMINI_SANDBOX+x}" && -z "${OCTOPUS_AGY_SANDBOX+x}" && -z "${OCTOPUS_CODEX_SANDBOX+x}" && -z "${CLAUDE_OCTOPUS_AUTONOMY+x}" ]]; then
+if [[ "$rc" -eq 7 && "$(pwd -P)" == "$SOURCE_ROOT" && "$(cat "$SOURCE_ROOT/protected.txt")" == "original" && -z "${OCTOPUS_SECURITY_V870+x}" && -z "${OCTOPUS_GEMINI_SANDBOX+x}" && -z "${OCTOPUS_AGY_SANDBOX+x}" && -z "${OCTOPUS_CODEX_SANDBOX+x}" && -z "${CLAUDE_OCTOPUS_AUTONOMY+x}" ]]; then
     test_pass
 else
-    test_fail "failure rc/environment restoration incorrect: rc=$rc"
+    test_fail "failure cleanup/restoration incorrect: rc=$rc pwd=$(pwd -P)"
 fi
 
-test_case "design review and council use the shared consultative primitive"
-if grep -q 'run_agent_sync_consultative "$design_codex_agent"' "$PROJECT_ROOT/scripts/lib/quality.sh" && \
-   grep -q 'run_agent_sync_consultative "$design_synthesis_agent"' "$PROJECT_ROOT/scripts/lib/quality.sh" && \
-   grep -q 'run_agent_sync_consultative "$agent_type"' "$PROJECT_ROOT/scripts/lib/council.sh"; then
-    test_pass
-else
-    test_fail "consultative callers do not share the primitive"
-fi
-
-test_case "council and quality load the consultative dependency when sourced standalone"
+test_case "council and quality load the shared consultative primitive"
 if bash -c 'source "$1/scripts/lib/council.sh"; declare -F run_agent_sync_consultative >/dev/null' _ "$PROJECT_ROOT" && \
    bash -c 'source "$1/scripts/lib/quality.sh"; declare -F run_agent_sync_consultative >/dev/null' _ "$PROJECT_ROOT"; then
     test_pass

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1116,8 +1116,8 @@ EOF
     test_pass
 }
 
-test_council_dispatch_strips_blocked_env_but_sets_readonly() {
-    test_case "Council dispatch strips blocked caller env while setting read-only sandbox"
+test_council_dispatch_strips_blocked_env_but_sets_disposable_mode() {
+    test_case "Council dispatch strips blocked caller env while setting disposable-workspace mode"
     load_council_lib || return 1
 
     local tmp_dir env_capture
@@ -1136,7 +1136,7 @@ test_council_dispatch_strips_blocked_env_but_sets_readonly() {
     OCTOPUS_COUNCIL_PROVIDER_FIXTURE='codex:available' \
         council_run --providers codex --depth quick --members 3 --output-dir "$tmp_dir" "Review auth"
 
-    if grep -q '^OCTOPUS_CODEX_SANDBOX=read-only$' "$env_capture" &&
+    if grep -q '^OCTOPUS_CODEX_SANDBOX=danger-full-access$' "$env_capture" &&
        ! grep -q '^OCTOPUS_SECURITY_V870=' "$env_capture" &&
        ! grep -q '^OCTOPUS_GEMINI_SANDBOX=' "$env_capture" &&
        ! grep -q '^CLAUDE_OCTOPUS_AUTONOMY=' "$env_capture"; then
@@ -1144,7 +1144,7 @@ test_council_dispatch_strips_blocked_env_but_sets_readonly() {
         test_pass
     else
         unset -f run_agent_sync
-        test_fail "blocked env forwarding or read-only sandbox mismatch"
+        test_fail "blocked env forwarding or disposable-workspace mode mismatch"
         return 1
     fi
 }
@@ -1197,7 +1197,7 @@ test_council_prompt_task_block_is_authoritative
 test_council_scans_artifact_critical_veto
 test_council_structured_veto_requires_veto_role
 test_council_veto_scan_ignores_discussed_token
-test_council_dispatch_strips_blocked_env_but_sets_readonly
+test_council_dispatch_strips_blocked_env_but_sets_disposable_mode
 
 test_council_host_native_detection() {
     test_case "council_detect_providers marks host provider as host-native (issue #444)"


### PR DESCRIPTION
## Problem

Design review and council are consultative, but the historical design-review path inherited writable execution against the real checkout. A supervised Tangle run showed a design-review Codex seat making incidental project edits before decomposition.

## Historical context

The design review predates the modern council implementation. Council later added consultative execution safeguards, but the older design-review path was never migrated, leaving duplicate behavior and inconsistent handling.

## Refactor

This PR introduces one shared `run_agent_sync_consultative` primitive used by both council and design review.

Native Codex `read-only` sandboxing is not portable in all supported runtimes: on a Landlock-restricted host it failed before basic read commands could run. The shared primitive therefore uses the runtime-compatible model:

1. create a private disposable copy of the current workspace;
2. use copy-on-write reflinks when supported, with a normal private-copy fallback;
3. normalize and rewrite logical/physical source paths in the task to the disposable workspace;
4. run Codex with `danger-full-access` from the disposable workspace;
5. clear write-enabling security/autonomy overrides during dispatch;
6. discard the complete workspace after the advisory call;
7. restore the exact previous environment and return code on success or failure.

## Scope of the protection

This is protection against incidental relative-path workspace mutations during advisory work. Such changes land in the disposable copy and are discarded.

It is not presented as a security sandbox against a deliberately malicious agent using absolute paths outside its working copy. Strong filesystem confinement is outside this PR's scope and would require a separate runtime/container boundary.

## Validation

- disposable consultative behavior and cleanup: 6/6
- pre-work ceremonies: 7/7
- council model selection: 10/10
- Qwen council provider: 6/6
- agent command validation: 16/16
- execution-profile dispatch: pass
- shell syntax checks
- git diff --check

The tests deliberately perform a relative write in the advisory cwd and verify that the source fixture remains unchanged. macOS logical `/tmp` and physical `/private/tmp` path normalization is covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consultative agent execution in a disposable workspace, protecting the original checkout from agent changes.
  * Updated Council and design review workflows to use isolated consultative execution.
  * Prompts now direct agents to work within the temporary workspace.

* **Bug Fixes**
  * Improved execution cleanup and restoration of environment settings after successful or failed agent runs.
  * Preserved agent exit statuses while preventing unintended source modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->