### PR TITLE
fix: let OpenAI-compatible providers choose output limits

### DIFF
--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -70,7 +70,7 @@ def tool_exec(cwd: Path, name: str, args: dict) -> str:
     except Exception as e:
         return f"ERROR: {type(e).__name__}: {e}"
 
-def api_call(base_url, key, model, headers_extra, messages, max_tokens=1400, request_timeout=60.0, max_retries=3, reasoning_effort=None, reasoning_policy="best_effort"):
+def api_call(base_url, key, model, headers_extra, messages, max_tokens=0, request_timeout=60.0, max_retries=3, reasoning_effort=None, reasoning_policy="best_effort"):
     payload = {"model": model, "messages": messages, "tools": TOOLS, "tool_choice": "auto", "temperature": 0}
     if reasoning_effort:
         payload["reasoning_effort"] = reasoning_effort
@@ -148,7 +148,7 @@ def main() -> int:
     key = os.environ.get(key_env)
     if not key:
         print(f"ERROR: missing {key_env}", file=sys.stderr); return 2
-    max_tokens = env_int("OPENAI_COMPAT_MAX_TOKENS", 1400, 0)
+    max_tokens = env_int("OPENAI_COMPAT_MAX_TOKENS", 0, 0)
     request_timeout = env_float("OPENAI_COMPAT_REQUEST_TIMEOUT", 60.0)
     max_retries = env_int("OPENAI_COMPAT_MAX_RETRIES", 3, 1)
     cwd = Path(args.cwd).resolve(); prompt = args.prompt if args.prompt is not None else sys.stdin.read()

--- a/tests/unit/test-openai-compatible-agent.sh
+++ b/tests/unit/test-openai-compatible-agent.sh
@@ -156,6 +156,70 @@ else
     test_fail "expected provider-default and max_tokens=0 to omit max_tokens from request payload"
 fi
 
+
+test_case "openai-compatible-agent main treats unset and zero as provider default"
+if HELPER="$HELPER" python3 - <<'PYTEST'
+import importlib.util, os, pathlib, sys, tempfile
+
+helper_path = os.environ["HELPER"]
+spec = importlib.util.spec_from_file_location("openai_compatible_agent_main_tokens", helper_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+seen = []
+def fake_api_call(*args, **kwargs):
+    seen.append(kwargs.get("max_tokens"))
+    return {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+mod.api_call = fake_api_call
+
+with tempfile.TemporaryDirectory() as cwd:
+    base_argv = [
+        "openai-compatible-agent.py",
+        "--provider", "generic",
+        "--base-url", "https://example.invalid/v1",
+        "--api-key-env", "TEST_PROVIDER_KEY",
+        "--model", "vendor/model",
+        "--cwd", cwd,
+        "--prompt", "verify",
+        "--max-turns", "1",
+    ]
+    old_argv = sys.argv[:]
+    old_key = os.environ.get("TEST_PROVIDER_KEY")
+    old_limit = os.environ.get("OPENAI_COMPAT_MAX_TOKENS")
+    try:
+        os.environ["TEST_PROVIDER_KEY"] = "test-key"
+
+        os.environ.pop("OPENAI_COMPAT_MAX_TOKENS", None)
+        sys.argv = base_argv
+        assert mod.main() == 0
+        assert seen[-1] == 0, seen
+
+        os.environ["OPENAI_COMPAT_MAX_TOKENS"] = "0"
+        sys.argv = base_argv
+        assert mod.main() == 0
+        assert seen[-1] == 0, seen
+
+        os.environ["OPENAI_COMPAT_MAX_TOKENS"] = "4096"
+        sys.argv = base_argv
+        assert mod.main() == 0
+        assert seen[-1] == 4096, seen
+    finally:
+        sys.argv = old_argv
+        if old_key is None:
+            os.environ.pop("TEST_PROVIDER_KEY", None)
+        else:
+            os.environ["TEST_PROVIDER_KEY"] = old_key
+        if old_limit is None:
+            os.environ.pop("OPENAI_COMPAT_MAX_TOKENS", None)
+        else:
+            os.environ["OPENAI_COMPAT_MAX_TOKENS"] = old_limit
+PYTEST
+then
+    test_pass
+else
+    test_fail "expected main() to omit provider limit for unset/0 and forward positive overrides"
+fi
+
 test_case "openai-compatible-agent retries transient HTTP errors"
 if HELPER="$HELPER" python3 - <<'PYTEST'
 import importlib.util, io, os, urllib.error

--- a/tests/unit/test-openai-compatible-agent.sh
+++ b/tests/unit/test-openai-compatible-agent.sh
@@ -143,6 +143,8 @@ def fake_urlopen(req, timeout):
     seen.append(json.loads(req.data.decode()))
     return Response()
 mod.urllib.request.urlopen = fake_urlopen
+mod.api_call("https://example.invalid/v1", "key", "model", {}, [{"role":"user","content":"hi"}], request_timeout=1, max_retries=1)
+assert "max_tokens" not in seen[-1], seen[-1]
 mod.api_call("https://example.invalid/v1", "key", "model", {}, [{"role":"user","content":"hi"}], max_tokens=0, request_timeout=1, max_retries=1)
 assert "max_tokens" not in seen[-1], seen[-1]
 mod.api_call("https://example.invalid/v1", "key", "model", {}, [{"role":"user","content":"hi"}], max_tokens=123, request_timeout=1, max_retries=1)
@@ -151,7 +153,7 @@ PYTEST
 then
     test_pass
 else
-    test_fail "expected max_tokens=0 to omit max_tokens from request payload"
+    test_fail "expected provider-default and max_tokens=0 to omit max_tokens from request payload"
 fi
 
 test_case "openai-compatible-agent retries transient HTTP errors"


### PR DESCRIPTION
## Problem

The native OpenAI-compatible helper imposed `max_tokens=1400` on every request unless overridden by `OPENAI_COMPAT_MAX_TOKENS`.

That arbitrary global cap is too small for reasoning/tool-calling models and can produce successful HTTP responses with:

    finish_reason=length
    content_len=0
    tool_calls=0

In a supervised Tangle decomposition run, the configured DeepSeek model repeatedly exhausted the 1400-token budget before producing visible content, consuming turns and eventually failing without a final answer.

## Change

Use the provider/model default output budget unless an operator explicitly configures a cap:

- `api_call(..., max_tokens=0)` by default;
- `OPENAI_COMPAT_MAX_TOKENS` defaults to `0`;
- values greater than zero continue to send `max_tokens` exactly as before;
- zero omits the field from the request payload.

This preserves the existing override while removing an undocumented global restriction.

## Validation

- default `api_call` omits `max_tokens`;
- explicit `max_tokens=0` omits the field;
- explicit positive values are forwarded;
- OpenAI-compatible tool-loop suite: 17/17;
- Python syntax check;
- git diff --check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OpenAI-compatible requests so that when no maximum token limit is specified, the provider’s default is used.
  * Ensured the request payload omits the token-limit field when the configured limit is unset or set to zero.

* **Tests**
  * Expanded unit coverage to confirm outgoing payloads omit the token limit when using provider defaults.
  * Added verification that the runtime token-limit setting is correctly forwarded by the entry point when the environment variable is unset, `"0"`, or positive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->