### PR TITLE
fix: preserve gemini-cli .env fallback and forward NODE_EXTRA_CA_CERTS

### DIFF
--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -97,7 +97,17 @@ build_provider_env() {
             if [[ -z "${GOOGLE_API_KEY:-}" ]]; then
                 resolve_provider_env "GOOGLE_API_KEY" 2>/dev/null || true
             fi
-            PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "GEMINI_API_KEY=${GEMINI_API_KEY:-}" "GOOGLE_API_KEY=${GOOGLE_API_KEY:-}" "GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-}" "GOOGLE_CLOUD_PROJECT_ID=${GOOGLE_CLOUD_PROJECT_ID:-}" "NODE_NO_WARNINGS=1" "TMPDIR=${TMPDIR:-/tmp}" "GEMINI_CLI_TRUST_WORKSPACE=${GEMINI_CLI_TRUST_WORKSPACE:-true}")
+            # v9.55: Don't preset GEMINI_API_KEY/GOOGLE_API_KEY as empty-but-set —
+            # gemini-cli's dotenv loader won't override an already-set var, so an
+            # empty preset silently defeats ~/.gemini/.env when the parent shell
+            # doesn't export the key (#660). Only forward vars that are non-empty,
+            # and pass through NODE_EXTRA_CA_CERTS/GOOGLE_GEMINI_BASE_URL so relay
+            # setups (extra CA root, custom base URL) survive env isolation.
+            PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "NODE_NO_WARNINGS=1" "TMPDIR=${TMPDIR:-/tmp}" "GEMINI_CLI_TRUST_WORKSPACE=${GEMINI_CLI_TRUST_WORKSPACE:-true}")
+            local _gemini_var
+            for _gemini_var in GEMINI_API_KEY GOOGLE_API_KEY GOOGLE_CLOUD_PROJECT GOOGLE_CLOUD_PROJECT_ID GOOGLE_GEMINI_BASE_URL NODE_EXTRA_CA_CERTS; do
+                [[ -n "${!_gemini_var:-}" ]] && PROVIDER_ENV_ARRAY+=("${_gemini_var}=${!_gemini_var}")
+            done
             if [[ ${#_trace_env[@]} -gt 0 ]]; then
                 PROVIDER_ENV_ARRAY+=("${_trace_env[@]}")
             fi

--- a/tests/smoke/test-preflight-json.sh
+++ b/tests/smoke/test-preflight-json.sh
@@ -17,7 +17,11 @@ PREFLIGHT="$PROJECT_ROOT/scripts/helpers/preflight.sh"
 # (the latter trip on Windows python wrappers).
 _has_key() {
     local out="$1" key="$2"
-    echo "$out" | grep -qE "\"${key}\"[[:space:]]*:"
+    # grep -c (not -q) — -q exits on first match, closing the pipe before
+    # echo finishes writing, which under this script's inherited
+    # `set -o pipefail` (from test-framework.sh) can fail the whole
+    # pipeline on a SIGPIPE write error even though the key was found.
+    echo "$out" | grep -cE "\"${key}\"[[:space:]]*:" >/dev/null
 }
 
 test_preflight_exists() {

--- a/tests/test-credential-isolation.sh
+++ b/tests/test-credential-isolation.sh
@@ -114,7 +114,13 @@ rm -rf "$CODEX_RUNTIME_HOME" "$CODEX_RUNTIME_HOME-home"
 GEMINI_ENV=$(awk '/GEMINI_CLI_TRUST_WORKSPACE/{flag=1} flag{print; if (/^[[:space:]]*;;[[:space:]]*$/) exit}' "$ALL_SRC")
 if [[ -z "$GEMINI_ENV" ]]; then
   fail "Gemini env block not found (GEMINI_CLI_TRUST_WORKSPACE marker missing)"
-elif echo "$GEMINI_ENV" | grep -q 'GEMINI_API_KEY'; then
+elif echo "$GEMINI_ENV" | grep -qE 'for _gemini_var in [^;]*\bGEMINI_API_KEY\b'; then
+  # Full case-arm text now also includes resolve_provider_env calls and the
+  # for-loop's own variable list, both of which mention GEMINI_API_KEY
+  # unconditionally — a bare substring grep would trivially match even if
+  # forwarding were broken. Anchor on the allowlist for-loop itself, since
+  # that's the actual mechanism that decides whether GEMINI_API_KEY gets
+  # forwarded into PROVIDER_ENV_ARRAY.
   pass "Gemini env includes GEMINI_API_KEY"
 else
   fail "Gemini env missing GEMINI_API_KEY"

--- a/tests/test-credential-isolation.sh
+++ b/tests/test-credential-isolation.sh
@@ -104,8 +104,11 @@ if [[ -n "$OLD_ROUTER_API_KEY" ]]; then export ROUTER_API_KEY="$OLD_ROUTER_API_K
 if [[ -n "$OLD_GEMINI_API_KEY" ]]; then export GEMINI_API_KEY="$OLD_GEMINI_API_KEY"; else unset GEMINI_API_KEY; fi
 rm -rf "$CODEX_RUNTIME_HOME" "$CODEX_RUNTIME_HOME-home"
 
-# 1.3 Gemini scoping — only GEMINI_API_KEY + GOOGLE_API_KEY
-GEMINI_ENV=$(grep -A16 'gemini\*)' "$ALL_SRC" | grep 'PROVIDER_ENV_ARRAY=.*env -i' | head -1 || true)
+# 1.3 Gemini scoping — only GEMINI_API_KEY + GOOGLE_API_KEY (conditionally
+# forwarded via a loop as of #660, so anchor on the isolated-env line's
+# unique GEMINI_CLI_TRUST_WORKSPACE marker and include the loop after it,
+# rather than the PROVIDER_ENV_ARRAY=(...) line alone)
+GEMINI_ENV=$(grep -A5 'GEMINI_CLI_TRUST_WORKSPACE' "$ALL_SRC" | head -5 || true)
 if echo "$GEMINI_ENV" | grep -q 'GEMINI_API_KEY'; then
   pass "Gemini env includes GEMINI_API_KEY"
 else
@@ -171,6 +174,42 @@ for provider in codex gemini perplexity openrouter; do
   fi
   rm -rf "$tmp_home" "$tmp_pwd"
 done
+
+# 1.7 Gemini: unset GEMINI_API_KEY must not become an empty-but-set var,
+# or gemini-cli's own ~/.gemini/.env dotenv loading is silently defeated (#660)
+test_case "Gemini env omits GEMINI_API_KEY entirely when unset (not empty-but-set)"
+tmp_home=$(mktemp -d)
+gemini_env_output=$(HOME="$tmp_home" bash -c '
+    set -eo pipefail
+    unset GEMINI_API_KEY GOOGLE_API_KEY
+    source "$1/scripts/lib/provider-routing.sh"
+    build_provider_env gemini
+    printf "%s\n" "${PROVIDER_ENV_ARRAY[@]}"
+  ' _ "$PLUGIN_DIR" 2>&1)
+if echo "$gemini_env_output" | grep -qx 'GEMINI_API_KEY='; then
+  test_fail "GEMINI_API_KEY present as empty-but-set, blocks gemini-cli's own .env loading"
+else
+  test_pass
+fi
+rm -rf "$tmp_home"
+
+# 1.8 Gemini: NODE_EXTRA_CA_CERTS and GOOGLE_GEMINI_BASE_URL survive isolation
+# when set, so TLS-relay setups don't die with "fetch failed" (#660)
+test_case "Gemini env forwards NODE_EXTRA_CA_CERTS and GOOGLE_GEMINI_BASE_URL when set"
+tmp_home=$(mktemp -d)
+gemini_env_output=$(HOME="$tmp_home" NODE_EXTRA_CA_CERTS="/tmp/extra-ca.pem" GOOGLE_GEMINI_BASE_URL="https://relay.example/v1" bash -c '
+    set -eo pipefail
+    source "$1/scripts/lib/provider-routing.sh"
+    build_provider_env gemini
+    printf "%s\n" "${PROVIDER_ENV_ARRAY[@]}"
+  ' _ "$PLUGIN_DIR" 2>&1)
+if echo "$gemini_env_output" | grep -qx 'NODE_EXTRA_CA_CERTS=/tmp/extra-ca.pem' \
+  && echo "$gemini_env_output" | grep -qx 'GOOGLE_GEMINI_BASE_URL=https://relay.example/v1'; then
+  test_pass
+else
+  test_fail "NODE_EXTRA_CA_CERTS/GOOGLE_GEMINI_BASE_URL not forwarded: $gemini_env_output"
+fi
+rm -rf "$tmp_home"
 
 # ─────────────────────────────────────────────────────────────────────
 # Suite 2: build_provider_env() is wired into spawn_agent()

--- a/tests/test-credential-isolation.sh
+++ b/tests/test-credential-isolation.sh
@@ -13,10 +13,11 @@ test_suite "for credential isolation (v8.32.0)"
 PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROJECT_ROOT="$PLUGIN_DIR"
 ORCH="$PLUGIN_DIR/scripts/orchestrate.sh"
-# v9.12: Search orchestrate.sh + lib/*.sh for decomposed functions
-ALL_SRC=$(mktemp)
+# v9.12: Search orchestrate.sh + lib/*.sh for decomposed functions.
+# Keep all suite temporaries under the test framework's TEST_TMP_DIR so its
+# existing EXIT/INT/TERM cleanup remains authoritative.
+ALL_SRC="$TEST_TMP_DIR/all-src"
 cat "$ORCH" "$PLUGIN_DIR/scripts/lib/"*.sh > "$ALL_SRC" 2>/dev/null
-trap 'rm -f "$ALL_SRC"' EXIT
 
 PASS=0
 FAIL=0
@@ -58,7 +59,8 @@ else
 fi
 
 # 1.2b Codex CLI config preservation — CODEX_HOME + configured env_key
-CODEX_RUNTIME_HOME=$(mktemp -d)
+CODEX_RUNTIME_HOME="$TEST_TMP_DIR/codex-runtime"
+mkdir -p "$CODEX_RUNTIME_HOME"
 cat > "$CODEX_RUNTIME_HOME/config.toml" <<'EOF'
 model_provider = "router"
 model = "example/model"
@@ -124,7 +126,7 @@ fi
 # 1.4 Perplexity — shell function provider, env -i skipped (#300)
 # perplexity_execute is a bash function dispatched by get_agent_command();
 # env -i cannot exec shell functions, so build_provider_env returns empty.
-PERP_CASE=$(grep -A70 'build_provider_env()' "$ALL_SRC" | grep -A10 'perplexity\*)' | head -11 || true)
+PERP_CASE=$(grep -A10 '^[[:space:]]*perplexity\*)' "$PLUGIN_DIR/scripts/lib/provider-routing.sh" | head -11 || true)
 PERP_ENV=$(echo "$PERP_CASE" | grep 'env -i' | head -1 || true)
 if echo "$PERP_CASE" | grep -q 'resolve_provider_env.*PERPLEXITY_API_KEY'; then
   pass "Perplexity resolves PERPLEXITY_API_KEY before dispatch"
@@ -153,8 +155,9 @@ fi
 # 1.6 Missing API keys are tolerated under set -e (#336)
 for provider in codex gemini perplexity openrouter; do
   test_case "build_provider_env $provider tolerates absent API keys under set -e"
-  tmp_home=$(mktemp -d)
-  tmp_pwd=$(mktemp -d)
+  tmp_home="$TEST_TMP_DIR/missing-${provider}-home"
+  tmp_pwd="$TEST_TMP_DIR/missing-${provider}-pwd"
+  mkdir -p "$tmp_home" "$tmp_pwd"
   case_output=""
   if case_output=$(HOME="$tmp_home" bash -c '
       set -eo pipefail
@@ -172,13 +175,13 @@ for provider in codex gemini perplexity openrouter; do
   else
     test_fail "build_provider_env $provider exited under set -e: $case_output"
   fi
-  rm -rf "$tmp_home" "$tmp_pwd"
 done
 
 # 1.7 Gemini: unset GEMINI_API_KEY must not become an empty-but-set var,
 # or gemini-cli's own ~/.gemini/.env dotenv loading is silently defeated (#660)
 test_case "Gemini env omits GEMINI_API_KEY entirely when unset (not empty-but-set)"
-tmp_home=$(mktemp -d)
+tmp_home="$TEST_TMP_DIR/gemini-unset-home"
+mkdir -p "$tmp_home"
 gemini_env_output=$(HOME="$tmp_home" bash -c '
     set -eo pipefail
     unset GEMINI_API_KEY GOOGLE_API_KEY
@@ -192,12 +195,12 @@ if echo "$gemini_env_output" | grep -qE '^(GEMINI_API_KEY|GOOGLE_API_KEY)='; the
 else
   test_pass
 fi
-rm -rf "$tmp_home"
 
 # 1.8 Gemini: NODE_EXTRA_CA_CERTS and GOOGLE_GEMINI_BASE_URL survive isolation
 # when set, so TLS-relay setups don't die with "fetch failed" (#660)
 test_case "Gemini env forwards NODE_EXTRA_CA_CERTS and GOOGLE_GEMINI_BASE_URL when set"
-tmp_home=$(mktemp -d)
+tmp_home="$TEST_TMP_DIR/gemini-forward-home"
+mkdir -p "$tmp_home"
 gemini_env_output=$(HOME="$tmp_home" NODE_EXTRA_CA_CERTS="/tmp/extra-ca.pem" GOOGLE_GEMINI_BASE_URL="https://relay.example/v1" bash -c '
     set -eo pipefail
     source "$1/scripts/lib/provider-routing.sh"
@@ -210,7 +213,6 @@ if echo "$gemini_env_output" | grep -qx 'NODE_EXTRA_CA_CERTS=/tmp/extra-ca.pem' 
 else
   test_fail "NODE_EXTRA_CA_CERTS/GOOGLE_GEMINI_BASE_URL not forwarded: $gemini_env_output"
 fi
-rm -rf "$tmp_home"
 
 # ─────────────────────────────────────────────────────────────────────
 # Suite 2: build_provider_env() is wired into spawn_agent()

--- a/tests/test-credential-isolation.sh
+++ b/tests/test-credential-isolation.sh
@@ -182,12 +182,13 @@ tmp_home=$(mktemp -d)
 gemini_env_output=$(HOME="$tmp_home" bash -c '
     set -eo pipefail
     unset GEMINI_API_KEY GOOGLE_API_KEY
-    source "$1/scripts/lib/provider-routing.sh"
+    cd "$1"
+    source "$2/scripts/lib/provider-routing.sh"
     build_provider_env gemini
     printf "%s\n" "${PROVIDER_ENV_ARRAY[@]}"
-  ' _ "$PLUGIN_DIR" 2>&1)
-if echo "$gemini_env_output" | grep -qx 'GEMINI_API_KEY='; then
-  test_fail "GEMINI_API_KEY present as empty-but-set, blocks gemini-cli's own .env loading"
+  ' _ "$tmp_home" "$PLUGIN_DIR" 2>&1)
+if echo "$gemini_env_output" | grep -qE '^(GEMINI_API_KEY|GOOGLE_API_KEY)='; then
+  test_fail "Gemini credentials present as empty-but-set, blocks gemini-cli's own .env loading: $gemini_env_output"
 else
   test_pass
 fi

--- a/tests/test-credential-isolation.sh
+++ b/tests/test-credential-isolation.sh
@@ -108,10 +108,13 @@ rm -rf "$CODEX_RUNTIME_HOME" "$CODEX_RUNTIME_HOME-home"
 
 # 1.3 Gemini scoping — only GEMINI_API_KEY + GOOGLE_API_KEY (conditionally
 # forwarded via a loop as of #660, so anchor on the isolated-env line's
-# unique GEMINI_CLI_TRUST_WORKSPACE marker and include the loop after it,
-# rather than the PROVIDER_ENV_ARRAY=(...) line alone)
-GEMINI_ENV=$(grep -A5 'GEMINI_CLI_TRUST_WORKSPACE' "$ALL_SRC" | head -5 || true)
-if echo "$GEMINI_ENV" | grep -q 'GEMINI_API_KEY'; then
+# unique GEMINI_CLI_TRUST_WORKSPACE marker and read through to the case
+# arm's closing `;;` rather than a fixed line count, so this doesn't
+# silently truncate if the block grows.
+GEMINI_ENV=$(awk '/GEMINI_CLI_TRUST_WORKSPACE/{flag=1} flag{print; if (/^[[:space:]]*;;[[:space:]]*$/) exit}' "$ALL_SRC")
+if [[ -z "$GEMINI_ENV" ]]; then
+  fail "Gemini env block not found (GEMINI_CLI_TRUST_WORKSPACE marker missing)"
+elif echo "$GEMINI_ENV" | grep -q 'GEMINI_API_KEY'; then
   pass "Gemini env includes GEMINI_API_KEY"
 else
   fail "Gemini env missing GEMINI_API_KEY"


### PR DESCRIPTION
## Description
`build_provider_env()`'s Gemini branch (`scripts/lib/provider-routing.sh:93-104`) built the isolated `env -i` array with `"GEMINI_API_KEY=${GEMINI_API_KEY:-}"` and `"GOOGLE_API_KEY=${GOOGLE_API_KEY:-}"` unconditionally. When the parent shell doesn't export these keys, that presets them as *empty-but-set* in the child environment. gemini-cli's own dotenv loader does not override an already-set variable, so `~/.gemini/.env` (where the CLI normally finds `GEMINI_API_KEY`/`GOOGLE_GEMINI_BASE_URL`) is silently ignored and the CLI aborts with "you must specify the GEMINI_API_KEY environment variable" — even though a plain `gemini -p "..."` from the same shell works fine.

Separately, `NODE_EXTRA_CA_CERTS` was stripped by `env -i` with no passthrough. Node only reads that variable at process startup, so users routing Gemini through a relay/proxy whose TLS chain needs an extra root CA have no way to recover it — every request dies with `fetch failed` after a TLS handshake failure.

## Change
- Only forward `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_PROJECT_ID`, `GOOGLE_GEMINI_BASE_URL`, `NODE_EXTRA_CA_CERTS` into the isolated env when each is actually non-empty, instead of presetting empty values.
- Added `GOOGLE_GEMINI_BASE_URL` and `NODE_EXTRA_CA_CERTS` to the allowlist so relay/custom-endpoint setups survive env isolation.
- Scope is intentionally limited to the `gemini*` branch reported in #660; the analogous `codex*` branch has the same empty-preset pattern for `OPENAI_API_KEY` but that's untouched here since it isn't what was reported.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check (`bash -n scripts/lib/provider-routing.sh tests/test-credential-isolation.sh`)
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (32/32, unrelated to this change but green)
- [ ] OpenClaw registry in sync — n/a, no skill/command changes
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` — n/a
- [ ] Version bump — n/a, patch-level bugfix, no release cut in this PR
- [ ] Documentation updated — n/a, internal env-isolation logic only
- [ ] CHANGELOG.md updated — left to release PR per repo convention

## Testing
- `bash tests/test-credential-isolation.sh` — 28/30 passing. The 2 remaining failures (`Perplexity missing PERPLEXITY_API_KEY resolve`, `Perplexity should return 0`) are pre-existing and reproduce identically on unmodified `origin/main` — confirmed by stashing this change and re-running; unrelated to the Gemini branch touched here.
- Added two new regression cases to `tests/test-credential-isolation.sh`:
  - `Gemini env omits GEMINI_API_KEY entirely when unset (not empty-but-set)`
  - `Gemini env forwards NODE_EXTRA_CA_CERTS and GOOGLE_GEMINI_BASE_URL when set`
  - Verified both actually catch the bug: reverted just `provider-routing.sh` locally, re-ran, confirmed both new cases fail with the exact symptoms from the report; restored the fix and they're green again.
- Updated one pre-existing static-source-grep assertion (`Gemini env includes GEMINI_API_KEY`, section 1.3) whose anchor line no longer contains a literal `GEMINI_API_KEY=` token now that the value is forwarded conditionally via a loop — re-anchored on the isolated-env line's unique `GEMINI_CLI_TRUST_WORKSPACE` marker instead of the `PROVIDER_ENV_ARRAY=(env -i ...)` line, so it still asserts the same intent.
- Full `make test-unit` (all ~150 suites) was launched in the background; if it surfaces anything I missed I'll follow up on this PR.

## Related Issues
Closes #660

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjApZuk2KPjNcKpBrzzVzo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini credential isolation so API-related variables are omitted when unset, avoiding empty-value dotenv suppression.
  * Forwarded optional settings (certificate path and Gemini base URL) when provided, while keeping existing runtime defaults intact.
* **Tests**
  * Centralized temporary directory creation under the test framework for more consistent setup/cleanup.
  * Tightened Gemini environment parsing and updated test assertions for “unset vs empty” and forwarded environment values.
  * Adjusted JSON required-key detection to avoid pipefail/SIGPIPE false negatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->