### PR TITLE
fix: orchestrate.sh bash/zsh portability + custom model routing

### DIFF
--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -172,7 +172,7 @@ ${provider_ctx}"
 
     # SECURITY: Use array-based execution to prevent word-splitting vulnerabilities
     local -a cmd_array
-    read -ra cmd_array <<< "$cmd"
+    eval "cmd_array=( $cmd )"
 
     # Capture output and exit code separately
     local output

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -78,10 +78,10 @@ get_agent_command() {
             esac
             ;;
         codex-review) echo "codex exec review" ;; # Code review mode (no sandbox support)
-        claude) echo "claude${_BARE_OPT} --print" ;;                         # Claude Sonnet 4.6
-        claude-sonnet) echo "claude${_BARE_OPT} --print --model sonnet" ;;        # Claude Sonnet explicit
-        claude-opus) echo "claude${_BARE_OPT} --print --model opus" ;;            # Claude Opus 4.6 (v8.0)
-        claude-opus-fast) echo "claude${_BARE_OPT} --print --model opus --fast" ;; # Claude Opus 4.6 Fast (v8.4: v2.1.36+)
+        claude) echo "claude --print" ;;                         # Claude Sonnet 4.6
+        claude-sonnet) echo "claude --print --model sonnet" ;;        # Claude Sonnet explicit
+        claude-opus) echo "claude --print --model opus" ;;            # Claude Opus 4.6 (v8.0)
+        claude-opus-fast) echo "claude --print --model opus --fast" ;; # Claude Opus 4.6 Fast (v8.4: v2.1.36+)
         openrouter) echo "openrouter_execute" ;;                 # OpenRouter API (v4.8)
         openrouter-glm5) echo "openrouter_execute_model z-ai/glm-5" ;;           # v8.11.0: GLM-5 via OpenRouter
         openrouter-kimi) echo "openrouter_execute_model moonshotai/kimi-k2.5" ;; # v8.11.0: Kimi K2.5 via OpenRouter

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -51,6 +51,45 @@ resolve_octopus_model() {
     local _trace="${OCTOPUS_TRACE_MODELS:-}"
     [[ -n "$_trace" ]] && echo "[model-trace] Resolving: provider=$provider type=$agent_type phase=${phase:-<none>} role=${role:-<none>}" >&2
 
+    # Priority 0.25: Code reviewer role ALWAYS uses Gemini 3.1-pro
+    if [[ "$role" == "code-reviewer" ]]; then
+        resolved_model="gemini-3.1-pro-preview"
+        [[ -n "$_trace" ]] && echo "[model-trace] Tier 0.25 (code-reviewer role): $resolved_model ← SELECTED" >&2
+        eval "_OCTO_MODEL_CACHE_${cache_key}=\"$resolved_model\""
+        echo "$resolved_model"
+        return 0
+    fi
+
+    # Priority 0.26: Phase-based provider routing (custom embrace workflow)
+    if [[ -z "$resolved_model" ]]; then
+        case "$phase" in
+            probe)
+                # Discover phase → Gemini 3.1-pro
+                resolved_model="gemini-3.1-pro-preview"
+                [[ -n "$_trace" ]] && echo "[model-trace] Tier 0.26 (probe phase): $resolved_model ← SELECTED" >&2
+                eval "_OCTO_MODEL_CACHE_${cache_key}=\"$resolved_model\""
+                echo "$resolved_model"
+                return 0
+                ;;
+            grasp)
+                # Define phase → Claude Opus 4.8
+                resolved_model="claude-opus-4.8"
+                [[ -n "$_trace" ]] && echo "[model-trace] Tier 0.26 (grasp phase): $resolved_model ← SELECTED" >&2
+                eval "_OCTO_MODEL_CACHE_${cache_key}=\"$resolved_model\""
+                echo "$resolved_model"
+                return 0
+                ;;
+            ink)
+                # Deliver phase → Gemini 3.1-pro
+                resolved_model="gemini-3.1-pro-preview"
+                [[ -n "$_trace" ]] && echo "[model-trace] Tier 0.26 (ink phase): $resolved_model ← SELECTED" >&2
+                eval "_OCTO_MODEL_CACHE_${cache_key}=\"$resolved_model\""
+                echo "$resolved_model"
+                return 0
+                ;;
+        esac
+    fi
+
     # 1. Force/Session Overrides (Env vars)
     local env_var="OCTOPUS_$(echo "$provider" | tr '[:lower:]' '[:upper:]' | tr '-' '_')_MODEL"
     if [[ -n "${!env_var:-}" ]]; then
@@ -163,7 +202,26 @@ resolve_octopus_model() {
     # Fallback to hard-coded defaults (Priority 7)
     if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
         case "$agent_type" in
-            codex*)          resolved_model="gpt-5.4" ;;
+            codex*)
+                # Detect complexity: env var OR smart-route by phase
+                local complexity="${OCTOPUS_COMPLEXITY:-}"
+                if [[ -z "$complexity" ]]; then
+                    case "$phase" in
+                        probe)              complexity="+" ;;    # Discover = trivial
+                        grasp|tangle|ink)   complexity="++" ;;   # Define/Develop/Deliver = normal
+                        *)                  complexity="++" ;;    # Default = normal
+                    esac
+                fi
+
+                # Map complexity to model
+                case "$complexity" in
+                    +++)  resolved_model="gpt-5.6-sol" ;;    # Robust
+                    ++)   resolved_model="gpt-5.6-terra" ;;  # Normal
+                    +)    resolved_model="gpt-5.6-luna" ;;   # Trivial
+                    *)    resolved_model="gpt-5.6-terra" ;;  # Default to normal
+                esac
+                ;;
+
             gemini-fast|gemini-flash) resolved_model="gemini-3-flash-preview" ;;
             gemini*)         resolved_model="gemini-3.1-pro-preview" ;;
             claude-opus*)    resolved_model="claude-opus-4.6" ;;

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -14,8 +14,8 @@ version_compare() {
     local operator="$3"
 
     # Split versions into components
-    IFS='.' read -ra V1 <<< "$version1"
-    IFS='.' read -ra V2 <<< "$version2"
+    IFS='.' eval "V1=( $version1 )"
+    IFS='.' eval "V2=( $version2 )"
 
     # Compare major.minor.patch
     for i in 0 1 2; do

--- a/scripts/lib/similarity.sh
+++ b/scripts/lib/similarity.sh
@@ -82,7 +82,7 @@ generate_bigrams() {
     words=$(echo "$text" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' ' ' | tr -s ' ')
 
     local -a word_arr
-    read -ra word_arr <<< "$words"
+    eval "word_arr=( $words )"
 
     local i
     for (( i=0; i < ${#word_arr[@]} - 1; i++ )); do

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -466,10 +466,10 @@ ${heuristic_ctx}"
         local env_prefix
         env_prefix=$(build_provider_env "$agent_type")
         if [[ -n "$env_prefix" ]]; then
-            read -ra cmd_array <<< "$env_prefix $cmd"
+            eval "cmd_array=( $env_prefix $cmd )"
             log "DEBUG" "Credential isolation active for $agent_type"
         else
-            read -ra cmd_array <<< "$cmd"
+            eval "cmd_array=( $cmd )"
         fi
 
         # IMPROVED: Use temp files for reliable output capture (v7.13.2 - Issue #10)

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -124,9 +124,9 @@ IMPORTANT: If you find yourself searching or grepping more than 3 times in a row
     local env_prefix
     env_prefix=$(build_provider_env "$agent_type")
     if [[ -n "$env_prefix" ]]; then
-        read -ra cmd_array <<< "$env_prefix $cmd"
+        eval "cmd_array=( $env_prefix $cmd )"
     else
-        read -ra cmd_array <<< "$cmd"
+        eval "cmd_array=( $cmd )"
     fi
 
     local temp_output="${RESULTS_DIR}/.tmp-${task_id}.out"
@@ -358,7 +358,7 @@ probe_discover() {
 
     # Build agent rotation from dispatch strategy
     local IFS_OLD="$IFS"
-    IFS=',' read -ra _strategy_providers <<< "$dispatch_providers"
+    IFS=',' eval "_strategy_providers=( $dispatch_providers )"
     IFS="$IFS_OLD"
     local probe_agents=()
     local _sp_count=${#_strategy_providers[@]}


### PR DESCRIPTION
## Summary
- Fix bash/zsh portability issues (read -ra → eval word-splitting)
- Remove --bare flag that breaks auth in stdin mode
- Add custom embrace workflow routing (discover→gemini, define→opus, deliver→gemini)
- Implement complexity-based Codex model selection (gpt-5.6-sol/terra/luna)

## Changes
1. **Bashism fixes**: read -ra in 5 files → eval for portable word-splitting
2. **dispatch.sh**: Remove ${_BARE_OPT} from Claude commands
3. **model-resolver.sh**: Priority 0.26 phase routing + OCTOPUS_COMPLEXITY support

## Testing
- orchestrate.sh auto runs without errors
- Custom routing validated with test_custom_routing
- All 3 commits pass pre-commit hooks

## Commits
- 3e8889a fix(orchestrate.sh): bash/zsh portability
- 78d89e7 fix(dispatch.sh): remove --bare flag
- 16df736 feat(model-resolver.sh): custom routing + complexity

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved handling of agent commands and provider settings for more reliable execution.
  * Updated model selection to route code review and workflow phases to optimized models.
  * Added complexity-aware model selection for Codex tasks, adapting choices to task difficulty.
  * Improved provider and version parsing for more consistent compatibility checks.
  * Refined similarity and dispatch processing to support more dependable workflow decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->