### PR TITLE
feat(council): per-seat seats[] in summary.json (machine-checkable quorum)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Council `summary.json` now records a per-seat `seats[]` array**, making quorum integrity machine-checkable without reading `responses/*` by hand. Each advice seat carries `seat` (role), `provider`, `provider_org`, `model`, `response_bytes`, `payload_kind` (currently `full`), `verdict`, `status` (`responded` / `degenerate` / `empty` / `no-response`), and `counted_as_approver`. `distinct_approving_providers` is recomputable as the count of distinct providers among seats where `counted_as_approver` is true — so a chair or degenerate seat can no longer masquerade as a distinct approving vendor. First of the sail-cruisey #2077 council-runner reliability fixes; later fixes extend `payload_kind` (agy chunking) and `status` (timeout/degraded).
+
 ## [9.54.1] - 2026-07-20
 
 ### Fixed

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1699,17 +1699,23 @@ council_run_advice_phase() {
     COUNCIL_RESPONSES_RECEIVED="0"
     COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
     COUNCIL_RESPONDING_PROVIDERS=""
+    COUNCIL_SEAT_RECORDS_JSON="[]"
     local dissenting_providers=""
 
     local index=0 member persona slug output_path seat mprovider verdict
+    local seat_org seat_model resp_bytes seat_status seat_rec
     while IFS= read -r member; do
         persona="$(jq -r '.persona' <<< "$member")"
         seat="$(jq -r '.seat' <<< "$member")"
         mprovider="$(jq -r '.provider' <<< "$member")"
+        seat_org="$(jq -r '.provider_org // ""' <<< "$member")"
+        seat_model="$(jq -r '.model // ""' <<< "$member")"
         slug="$(council_slug "$persona")"
         output_path="${COUNCIL_RUN_DIR}/responses/$(printf '%02d' "$index")-${slug}.md"
+        verdict=""; seat_status="no-response"; resp_bytes=0
         if council_dispatch_member "$member" "independent-advice" > "$output_path"; then
             COUNCIL_RESPONSES_RECEIVED=$((COUNCIL_RESPONSES_RECEIVED + 1))
+            resp_bytes="$(wc -c < "$output_path" 2>/dev/null | tr -d '[:space:]')"; [[ -z "$resp_bytes" ]] && resp_bytes=0
             if [[ "$seat" == "chair" ]]; then
                 COUNCIL_CHAIR_RESPONSE_RECEIVED="true"
             fi
@@ -1723,13 +1729,31 @@ council_run_advice_phase() {
             if council_response_nonempty "$output_path" && council_response_is_substantive "$output_path"; then
                 COUNCIL_RESPONDING_PROVIDERS="${COUNCIL_RESPONDING_PROVIDERS} ${mprovider}"
                 verdict="$(council_response_verdict "$output_path")"
+                seat_status="responded"
                 if [[ "$verdict" != "APPROVE" ]]; then
                     dissenting_providers="${dissenting_providers} ${mprovider}"
                 fi
+            elif council_response_nonempty "$output_path"; then
+                seat_status="degenerate"   # produced bytes but reviewed nothing (host stub / "cannot access")
+            else
+                seat_status="empty"
             fi
         else
             rm -f "$output_path"
+            seat_status="no-response"
         fi
+        # Per-seat record for summary.json — makes quorum integrity machine-checkable
+        # (a chair or degenerate seat can no longer masquerade as a distinct approving
+        # vendor). payload_kind is "full" here; #2 (agy chunking) populates delta/chunk,
+        # and #2/#3 extend `status` with degraded/timed_out. RATIONALE: sail-cruisey #2077.
+        seat_rec="$(jq -cn --argjson idx "$index" --arg persona "$persona" --arg seat "$seat" \
+            --arg provider "$mprovider" --arg org "$seat_org" --arg model "$seat_model" \
+            --argjson bytes "${resp_bytes:-0}" --arg verdict "$verdict" --arg status "$seat_status" \
+            '{index:$idx, persona:$persona, seat:$seat, provider:$provider, provider_org:$org,
+              model:$model, response_bytes:$bytes, payload_kind:"full",
+              verdict:(if $verdict=="" then null else $verdict end),
+              status:$status, counted_as_approver:false}')"
+        COUNCIL_SEAT_RECORDS_JSON="$(jq -c ". + [$seat_rec]" <<< "$COUNCIL_SEAT_RECORDS_JSON")"
         index=$((index + 1))
     done < <(jq -c '.[]' <<< "$COUNCIL_ROSTER_JSON")
 
@@ -1754,6 +1778,14 @@ council_run_advice_phase() {
     COUNCIL_APPROVING_PROVIDERS="$(council_compute_approving_providers "$COUNCIL_RESPONDING_PROVIDERS" "$dissenting_providers")"
     COUNCIL_DISTINCT_APPROVING_PROVIDERS="$(printf '%s' "$COUNCIL_APPROVING_PROVIDERS" | tr ' ' '\n' | sed '/^$/d' | sort -u | wc -l | tr -d '[:space:]')"
     [[ -z "$COUNCIL_DISTINCT_APPROVING_PROVIDERS" ]] && COUNCIL_DISTINCT_APPROVING_PROVIDERS=0
+
+    # Flag which seats' providers made the approving set so distinct_approving_providers
+    # is recomputable from the seats array alone: distinct providers among seats where
+    # counted_as_approver == true equals distinct_approving_providers.
+    COUNCIL_SEAT_RECORDS_JSON="$(jq -c --arg approving " ${COUNCIL_APPROVING_PROVIDERS} " '
+        map(.provider as $p
+            | .counted_as_approver = (.status == "responded" and .verdict == "APPROVE"
+                and ($approving | contains(" " + $p + " "))))' <<< "${COUNCIL_SEAT_RECORDS_JSON:-[]}")"
 
     if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" == "true" ]] && (( received_non_chair >= required )) \
         && { (( required < 2 )) || (( COUNCIL_DISTINCT_APPROVING_PROVIDERS >= required )); }; then
@@ -2372,6 +2404,7 @@ council_write_summary_json() {
         --arg task "$COUNCIL_TASK" \
         --arg personas_requested "$COUNCIL_PERSONAS" \
         --argjson council_roster "$COUNCIL_ROSTER_JSON" \
+        --argjson seat_records "${COUNCIL_SEAT_RECORDS_JSON:-[]}" \
         --arg responses_received "$COUNCIL_RESPONSES_RECEIVED" \
         --arg quorum_met "$COUNCIL_QUORUM_MET" \
         --arg distinct_providers "${COUNCIL_DISTINCT_PROVIDERS:-0}" \
@@ -2447,6 +2480,7 @@ council_write_summary_json() {
             chair_fallback_persona: (if $chair_fallback_persona == "" then null else $chair_fallback_persona end)
           },
           council: $council_roster,
+          seats: $seat_records,
           veto: {
             triggered: ($veto_triggered == "true"),
             severity: (if $veto_severity == "" then null else $veto_severity end),

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1821,6 +1821,7 @@ council_synthesis_capable_persona() {
 
 council_run_chair_fallback() {
     local persona provider member_json slug output_path index
+    local seat_org seat_model resp_bytes verdict seat_status seat_rec
 
     while IFS= read -r persona; do
         [[ -n "$persona" ]] || continue
@@ -1837,13 +1838,41 @@ council_run_chair_fallback() {
         council_provider_is_available "$provider" || continue
 
         member_json="$(council_roster_entry_json "$persona" "$provider" | jq -c '.seat = "chair"')"
-        index="$(find "${COUNCIL_RUN_DIR}/responses" -type f -name '*.md' | wc -l | tr -d ' ')"
+        # Seat-record length is the canonical next index: failed roster seats remove
+        # their response files but remain in seats[], so counting files can reuse an
+        # existing index and make the execution record ambiguous.
+        index="$(jq 'length' <<< "${COUNCIL_SEAT_RECORDS_JSON:-[]}")"
         output_path="${COUNCIL_RUN_DIR}/responses/$(printf '%02d' "$index")-chair-fallback-${slug}.md"
         if council_dispatch_member "$member_json" "independent-advice" > "$output_path"; then
             COUNCIL_RESPONSES_RECEIVED=$((COUNCIL_RESPONSES_RECEIVED + 1))
             COUNCIL_CHAIR_RESPONSE_RECEIVED="true"
             COUNCIL_CHAIR_FALLBACK_USED="true"
             COUNCIL_CHAIR_FALLBACK_PERSONA="$persona"
+            # The fallback is an additional advice dispatch outside the resolved
+            # roster, so persist it as an additional seat execution record. Without
+            # this, summary.json claims to expose every seat while silently omitting
+            # the chair response that actually made synthesis possible.
+            seat_org="$(jq -r '.provider_org // ""' <<< "$member_json")"
+            seat_model="$(jq -r '.model // ""' <<< "$member_json")"
+            resp_bytes="$(wc -c < "$output_path" 2>/dev/null | tr -d '[:space:]')"
+            [[ -z "$resp_bytes" ]] && resp_bytes=0
+            verdict=""
+            seat_status="empty"
+            if council_response_nonempty "$output_path" && council_response_is_substantive "$output_path"; then
+                verdict="$(council_response_verdict "$output_path")"
+                seat_status="responded"
+            elif council_response_nonempty "$output_path"; then
+                seat_status="degenerate"
+            fi
+            seat_rec="$(jq -cn --argjson idx "$index" --arg persona "$persona" \
+                --arg provider "$provider" --arg org "$seat_org" --arg model "$seat_model" \
+                --argjson bytes "${resp_bytes:-0}" --arg verdict "$verdict" --arg status "$seat_status" \
+                '{index:$idx, persona:$persona, seat:"chair", provider:$provider,
+                  provider_org:$org, model:$model, response_bytes:$bytes,
+                  payload_kind:"full",
+                  verdict:(if $verdict=="" then null else $verdict end),
+                  status:$status, counted_as_approver:false}')"
+            COUNCIL_SEAT_RECORDS_JSON="$(jq -c ". + [$seat_rec]" <<< "${COUNCIL_SEAT_RECORDS_JSON:-[]}")"
             return 0
         fi
         rm -f "$output_path"

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1347,12 +1347,17 @@ test_council_seats_array_makes_quorum_inspectable() {
     # and distinct_approving_providers is recomputable from seats[] alone (no reading
     # responses/* by hand).
     if jq -e '
-        (.seats | type == "array" and length >= 1)
+        (.seats | type == "array" and length >= 2)
         and (.seats | all(has("seat") and has("provider") and has("provider_org")
                           and has("model") and has("status") and has("verdict")
                           and has("response_bytes") and has("payload_kind")
                           and has("counted_as_approver")))
         and (.seats | all(.provider_org | type == "string" and length >= 1))
+        and (.seats | all(.seat | type == "string" and length >= 1))
+        and (.seats | all(.status | type == "string" and length >= 1))
+        # counted_as_approver drives quorum, so it must be a real boolean, not a
+        # truthy string that jq would still `select`.
+        and (.seats | all(.counted_as_approver | type == "boolean"))
         and (.seats | all(.response_bytes | type == "number"))
         # verdict is null (no substantive verdict) or a known token — never garbage.
         and (.seats | all((.verdict == null) or (.verdict | test("^(APPROVE|REVISE|BLOCK)$"))))

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1342,19 +1342,29 @@ test_council_seats_array_makes_quorum_inspectable() {
         council_run --depth standard --output-dir "$tmp_dir" "Review X" >/dev/null 2>&1 || true
     rd="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
     s="$rd/summary.json"
-    # Every seat carries the inspectable fields, and distinct_approving_providers is
-    # recomputable from seats[] alone (no reading responses/* by hand).
+    # Every seat carries the FULL documented contract (incl. provider_org, model,
+    # verdict), the fields are well-typed, the counted_as_approver invariant holds,
+    # and distinct_approving_providers is recomputable from seats[] alone (no reading
+    # responses/* by hand).
     if jq -e '
         (.seats | type == "array" and length >= 1)
-        and (.seats | all(has("seat") and has("provider") and has("status")
+        and (.seats | all(has("seat") and has("provider") and has("provider_org")
+                          and has("model") and has("status") and has("verdict")
                           and has("response_bytes") and has("payload_kind")
                           and has("counted_as_approver")))
+        and (.seats | all(.provider_org | type == "string" and length >= 1))
+        and (.seats | all(.response_bytes | type == "number"))
+        # verdict is null (no substantive verdict) or a known token — never garbage.
+        and (.seats | all((.verdict == null) or (.verdict | test("^(APPROVE|REVISE|BLOCK)$"))))
+        # a counted approver is, by construction, a responded APPROVE seat.
+        and (.seats | all((.counted_as_approver | not)
+                          or (.status == "responded" and .verdict == "APPROVE")))
         and (.quorum.distinct_approving_providers
              == ([.seats[] | select(.counted_as_approver) | .provider] | unique | length))
     ' "$s" >/dev/null; then
         test_pass
     else
-        test_fail "seats[] missing/!recomputable: $(jq -c '{q:.quorum.distinct_approving_providers, seats:(.seats|length)}' "$s" 2>/dev/null)"
+        test_fail "seats[] missing/!recomputable: $(jq -c '{q:.quorum.distinct_approving_providers, seats:.seats}' "$s" 2>/dev/null)"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1347,18 +1347,32 @@ test_council_seats_array_makes_quorum_inspectable() {
     # and distinct_approving_providers is recomputable from seats[] alone (no reading
     # responses/* by hand).
     if jq -e '
-        (.seats | type == "array" and length >= 2)
+        . as $summary
+        | ($summary.seats | type == "array" and length >= 2)
+        and ($summary.council | type == "array")
+        and (($summary.seats | length) == ($summary.council | length))
         and (.seats | all(has("seat") and has("provider") and has("provider_org")
                           and has("model") and has("status") and has("verdict")
                           and has("response_bytes") and has("payload_kind")
                           and has("counted_as_approver")))
-        and (.seats | all(.provider_org | type == "string" and length >= 1))
-        and (.seats | all(.seat | type == "string" and length >= 1))
-        and (.seats | all(.status | type == "string" and length >= 1))
+        and (.seats | all(
+            (.index | type == "number" and floor == .)
+            and ([.seat, .persona, .provider, .provider_org, .model, .status, .payload_kind]
+                 | all(type == "string" and length >= 1))
+        ))
+        # The seat list is a one-for-one, ordered execution record for the resolved
+        # council roster; a missing, duplicate, or invented seat must fail the contract.
+        and (all(range(0; ($summary.council | length)); . as $i
+            | ($summary.seats[$i].index == $i)
+            and ($summary.seats[$i].persona == $summary.council[$i].persona)
+            and ($summary.seats[$i].seat == $summary.council[$i].seat)
+            and ($summary.seats[$i].provider == $summary.council[$i].provider)
+            and ($summary.seats[$i].provider_org == $summary.council[$i].provider_org)
+            and ($summary.seats[$i].model == $summary.council[$i].model)))
         # counted_as_approver drives quorum, so it must be a real boolean, not a
         # truthy string that jq would still `select`.
         and (.seats | all(.counted_as_approver | type == "boolean"))
-        and (.seats | all(.response_bytes | type == "number"))
+        and (.seats | all(.response_bytes | type == "number" and . >= 0))
         # verdict is null (no substantive verdict) or a known token — never garbage.
         and (.seats | all((.verdict == null) or (.verdict | test("^(APPROVE|REVISE|BLOCK)$"))))
         # a counted approver is, by construction, a responded APPROVE seat.

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -791,7 +791,26 @@ test_council_chair_fallback_preserves_quorum() {
     summary="$(find "$tmp_dir" -name summary.json -type f | head -1)"
     [[ -n "$summary" ]] || { test_fail "summary.json not written"; return 1; }
 
-    if jq -e '.status == "completed" and .quorum.met == true and .warnings.chair_fallback == true and (.quorum.chair_received == true)' "$summary" >/dev/null; then
+    if jq -e '
+        .status == "completed"
+        and .quorum.met == true
+        and .warnings.chair_fallback == true
+        and (.quorum.chair_received == true)
+        # The failed roster chair remains visible, and the successfully dispatched
+        # fallback is an additional, fully typed execution record.
+        and (.seats[0].seat == "chair" and .seats[0].status == "no-response")
+        and ((.seats | length) == ((.council | length) + 1))
+        and (.seats[-1] as $fallback
+             | $fallback.index == (.council | length)
+             and $fallback.persona == .warnings.chair_fallback_persona
+             and $fallback.seat == "chair"
+             and ([$fallback.provider, $fallback.provider_org, $fallback.model,
+                   $fallback.payload_kind, $fallback.status]
+                  | all(type == "string" and length > 0))
+             and $fallback.response_bytes > 0
+             and $fallback.verdict == "APPROVE"
+             and ($fallback.counted_as_approver | type == "boolean"))
+    ' "$summary" >/dev/null; then
         test_pass
     else
         test_fail "chair fallback did not preserve quorum"
@@ -1350,8 +1369,9 @@ test_council_seats_array_makes_quorum_inspectable() {
         . as $summary
         | ($summary.seats | type == "array" and length >= 2)
         and ($summary.council | type == "array")
-        and (($summary.seats | length) == ($summary.council | length))
-        and (.seats | all(has("seat") and has("provider") and has("provider_org")
+        and (($summary.seats | length) >= ($summary.council | length))
+        and (.seats | all(has("index") and has("persona")
+                          and has("seat") and has("provider") and has("provider_org")
                           and has("model") and has("status") and has("verdict")
                           and has("response_bytes") and has("payload_kind")
                           and has("counted_as_approver")))
@@ -1369,6 +1389,15 @@ test_council_seats_array_makes_quorum_inspectable() {
             and ($summary.seats[$i].provider == $summary.council[$i].provider)
             and ($summary.seats[$i].provider_org == $summary.council[$i].provider_org)
             and ($summary.seats[$i].model == $summary.council[$i].model)))
+        # Any records beyond the roster must be the explicitly reported chair
+        # fallback dispatch; no unrelated extra seats are accepted.
+        and (if (($summary.seats | length) == ($summary.council | length))
+             then true
+             else ($summary.warnings.chair_fallback == true)
+                  and ($summary.seats[($summary.council | length):]
+                       | all(.seat == "chair"
+                             and .persona == $summary.warnings.chair_fallback_persona))
+             end)
         # counted_as_approver drives quorum, so it must be a real boolean, not a
         # truthy string that jq would still `select`.
         and (.seats | all(.counted_as_approver | type == "boolean"))

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1332,6 +1332,33 @@ test_council_all_approve_meets_quorum() {
     fi
 }
 
+test_council_seats_array_makes_quorum_inspectable() {
+    test_case "summary.json seats[] records per-seat state and quorum is recomputable from it"
+    load_council_lib || return 1
+    local tmp_dir rd s
+    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-seats.XXXXXX")"
+    OCTOPUS_COUNCIL_FIXTURE=full-success \
+    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='codex:available,agy:available' \
+        council_run --depth standard --output-dir "$tmp_dir" "Review X" >/dev/null 2>&1 || true
+    rd="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    s="$rd/summary.json"
+    # Every seat carries the inspectable fields, and distinct_approving_providers is
+    # recomputable from seats[] alone (no reading responses/* by hand).
+    if jq -e '
+        (.seats | type == "array" and length >= 1)
+        and (.seats | all(has("seat") and has("provider") and has("status")
+                          and has("response_bytes") and has("payload_kind")
+                          and has("counted_as_approver")))
+        and (.quorum.distinct_approving_providers
+             == ([.seats[] | select(.counted_as_approver) | .provider] | unique | length))
+    ' "$s" >/dev/null; then
+        test_pass
+    else
+        test_fail "seats[] missing/!recomputable: $(jq -c '{q:.quorum.distinct_approving_providers, seats:(.seats|length)}' "$s" 2>/dev/null)"
+        return 1
+    fi
+}
+
 test_council_host_native_detection
 test_council_live_response_host_native_skips_subprocess
 test_council_live_response_host_native_fails_for_synthesis
@@ -1339,4 +1366,5 @@ test_council_verdict_parsing
 test_council_approving_providers_failsafe
 test_council_split_double_seat_fails_quorum
 test_council_all_approve_meets_quorum
+test_council_seats_array_makes_quorum_inspectable
 test_summary


### PR DESCRIPTION
## Summary

Fix **1 of 4** from a downstream 12-round governed council run (sail-cruisey #2077), where the lead couldn't tell a full-diff APPROVE from a partial-payload APPROVE — or a placeholder chair seat from a real vote — without reading `responses/*` by hand, and a degenerate seat could masquerade as a distinct approving vendor in the quorum count.

Makes **quorum integrity inspectable from `summary.json` alone**:

- `council_run_advice_phase` records one entry per advice seat in a new `seats[]` array: `seat` (role), `provider`, `provider_org`, `model`, `response_bytes`, `payload_kind`, `verdict`, `status` (`responded` / `degenerate` / `empty` / `no-response`), and `counted_as_approver`.
- `quorum.distinct_approving_providers` is now recomputable: it equals the count of distinct providers among seats where `counted_as_approver` is true. So a chair or degenerate seat can't inflate the count unnoticed.
- Guarded default `[]` for dry-run / early-abort paths (no schema break).

This is the **foundation** for the other three #2077 runner fixes: `payload_kind` stays `full` until agy chunking (fix #2) populates `delta`/`chunk`, and `status` gains `timed_out`/`degraded` in fixes #2–#3.

## Test plan

- [x] New test: `seats[]` carries the fields **and** `distinct_approving_providers` is recomputable from it
- [x] Verified full-approve (2 approvers, recompute matches) and all-REVISE (0 approvers, met:false, recompute matches)
- [x] `tests/unit/test-council-command.sh` — 57/57 pass; `bash -n` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Council summaries now include a per-seat `seats[]` breakdown with provider details, model, response status/verdict, payload kind, response size, and whether the seat is counted as an approver.
  - `quorum.distinct_approving_providers` is recomputed solely from `seats[]` via `counted_as_approver`.
- **Bug Fixes**
  - Prevents empty/degenerate/no-response seats from being incorrectly treated as distinct approving providers.
  - Chair fallback now adds an inspectable seat record to the summary.
- **Tests**
  - Added unit tests validating `seats[]` shape/type and the `distinct_approving_providers` recomputation invariant.
- **Documentation**
  - Updated the unreleased changelog to reflect the new seat-level quorum details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->