### PR TITLE
fix(agy): degrade an oversized council prompt to a structured skip instead of OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **An oversized council prompt to `agy` now degrades to a structured skip instead of OOM-killing the seat** (#2077). The adapter's existing file-path fallback sidesteps the argv `MAX_ARG_STRLEN` limit but not agy itself — a multi-megabyte prompt is loaded whole into agy's context and OOM-kills the headless process (or is rejected by the backend for context length), leaving the seat dead with an opaque exit code or a silent-empty result the retry cannot recover. `agy-exec.sh` now enforces a configurable payload ceiling (`OCTOPUS_AGY_MAX_PAYLOAD_BYTES`, default 1 MiB): above it, the adapter refuses to dispatch, exits 0, and emits a provider-rejection marker that `classify_agent_output` already recognizes, so dispatch records a structured `skipped:oversize` seat and the council keeps its remaining seats rather than crashing on this one. The ceiling is measured in bytes on the exact prompt content agy would read.
+
 ## [9.54.1] - 2026-07-20
 
 ### Fixed

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -171,22 +171,24 @@ byte_length() {
 # bytes agy would read from the file — not the argv the inline branch would build.
 # Tunable; default 1 MiB (~250k tokens), already far larger than any real review.
 max_payload_bytes="${OCTOPUS_AGY_MAX_PAYLOAD_BYTES:-1048576}"
-# Reject non-digits, then canonicalize to base 10. A value like `08` is an all-digit
-# string but Bash arithmetic reads its leading zero as octal, so `(( x > 08 ))` errors
-# and the comparison silently evaluates false — disabling the ceiling entirely and
-# letting an oversized payload through. `10#` forces base 10.
-# Also guard the magnitude first: Bash arithmetic is signed 64-bit and WRAPS on
-# overflow, so a value beyond INT64 could flip negative and make `prompt_bytes > x`
-# always true (refusing every seat) or otherwise misbehave. A ceiling wider than 18
-# digits (~10^18 bytes ≈ an exabyte) is never a real cap, so fall back to the default;
-# capping at 18 digits keeps `10#` strictly within INT64 range.
+# Validate and normalize the ceiling. Reject non-digits, strip leading zeros (so a
+# padded value keeps its true magnitude and `08` isn't read as octal by `10#`), then
+# accept anything up to INT64_MAX and reject only genuine overflow. Bash arithmetic
+# is signed 64-bit and WRAPS on overflow, which could flip a huge ceiling negative and
+# make `prompt_bytes > x` always true (refusing every seat); so a value with more than
+# 19 digits, or a 19-digit value above 9223372036854775807, falls back to the default.
+# For equal-length all-digit strings a lexical `>` is the numeric comparison, which lets
+# us range-check without triggering the very overflow we're guarding against.
 case "$max_payload_bytes" in
-    ''|*[!0-9]*)      max_payload_bytes=1048576 ;;
-    *) if (( ${#max_payload_bytes} > 18 )); then
-           max_payload_bytes=1048576
-       else
-           max_payload_bytes=$((10#$max_payload_bytes))
-       fi ;;
+    ''|*[!0-9]*) max_payload_bytes=1048576 ;;
+    *)
+        _mpb="${max_payload_bytes#"${max_payload_bytes%%[!0]*}"}"; [[ -n "$_mpb" ]] || _mpb=0
+        if (( ${#_mpb} > 19 )) || { (( ${#_mpb} == 19 )) && [[ "$_mpb" > "9223372036854775807" ]]; }; then
+            max_payload_bytes=1048576
+        else
+            max_payload_bytes=$((10#$_mpb))
+        fi
+        ;;
 esac
 prompt_bytes="$(byte_length "$prompt_content")"
 if (( prompt_bytes > max_payload_bytes )); then

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -171,7 +171,15 @@ byte_length() {
 # bytes agy would read from the file — not the argv the inline branch would build.
 # Tunable; default 1 MiB (~250k tokens), already far larger than any real review.
 max_payload_bytes="${OCTOPUS_AGY_MAX_PAYLOAD_BYTES:-1048576}"
-case "$max_payload_bytes" in ''|*[!0-9]*) max_payload_bytes=1048576 ;; esac
+# Reject non-digits, then canonicalize to base 10. A value like `08` is an all-digit
+# string but Bash arithmetic reads its leading zero as octal, so `(( x > 08 ))` errors
+# and the comparison silently evaluates false — disabling the ceiling entirely and
+# letting an oversized payload through. `10#` forces base 10; the case guard above
+# guarantees the operand is all digits, so `10#` can never itself error.
+case "$max_payload_bytes" in
+    ''|*[!0-9]*) max_payload_bytes=1048576 ;;
+    *)           max_payload_bytes=$((10#$max_payload_bytes)) ;;
+esac
 prompt_bytes="$(byte_length "$prompt_content")"
 if (( prompt_bytes > max_payload_bytes )); then
     echo "agy-exec.sh: prompt input is too large (${prompt_bytes} bytes > OCTOPUS_AGY_MAX_PAYLOAD_BYTES=${max_payload_bytes}); refusing to dispatch to avoid exhausting agy memory" >&2

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -174,11 +174,19 @@ max_payload_bytes="${OCTOPUS_AGY_MAX_PAYLOAD_BYTES:-1048576}"
 # Reject non-digits, then canonicalize to base 10. A value like `08` is an all-digit
 # string but Bash arithmetic reads its leading zero as octal, so `(( x > 08 ))` errors
 # and the comparison silently evaluates false — disabling the ceiling entirely and
-# letting an oversized payload through. `10#` forces base 10; the case guard above
-# guarantees the operand is all digits, so `10#` can never itself error.
+# letting an oversized payload through. `10#` forces base 10.
+# Also guard the magnitude first: Bash arithmetic is signed 64-bit and WRAPS on
+# overflow, so a value beyond INT64 could flip negative and make `prompt_bytes > x`
+# always true (refusing every seat) or otherwise misbehave. A ceiling wider than 18
+# digits (~10^18 bytes ≈ an exabyte) is never a real cap, so fall back to the default;
+# capping at 18 digits keeps `10#` strictly within INT64 range.
 case "$max_payload_bytes" in
-    ''|*[!0-9]*) max_payload_bytes=1048576 ;;
-    *)           max_payload_bytes=$((10#$max_payload_bytes)) ;;
+    ''|*[!0-9]*)      max_payload_bytes=1048576 ;;
+    *) if (( ${#max_payload_bytes} > 18 )); then
+           max_payload_bytes=1048576
+       else
+           max_payload_bytes=$((10#$max_payload_bytes))
+       fi ;;
 esac
 prompt_bytes="$(byte_length "$prompt_content")"
 if (( prompt_bytes > max_payload_bytes )); then

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -155,6 +155,29 @@ byte_length() {
     printf '%s' "${#1}"
 }
 
+# Hard payload ceiling. The argv-size fallback below hands agy an OVERSIZED prompt
+# as a file to read, which sidesteps MAX_ARG_STRLEN but not agy itself: a
+# multi-megabyte prompt is loaded whole into agy's context and OOM-kills the
+# headless process (or is rejected by the backend for context length). Either way
+# the seat dies opaquely — an exit-code failure or a silent-empty result the retry
+# can't fix, and #2077's finished-but-timed-out salvage can't recover because no
+# verdict was ever written. Above this ceiling, refuse to dispatch and emit a
+# provider-rejection marker the dispatch classifier already recognizes
+# ("input is too large" -> classify_agent_output -> skipped:oversize), so the
+# council records a STRUCTURED oversize skip and keeps its other seats instead of
+# crashing on this one. Exit 0 (not an error), matching how agent-sync.sh routes
+# around provider oversize rejections (#410): a too-big prompt is an input-size
+# mismatch to skip, not a hard run failure. Measured on prompt_content — the exact
+# bytes agy would read from the file — not the argv the inline branch would build.
+# Tunable; default 1 MiB (~250k tokens), already far larger than any real review.
+max_payload_bytes="${OCTOPUS_AGY_MAX_PAYLOAD_BYTES:-1048576}"
+case "$max_payload_bytes" in ''|*[!0-9]*) max_payload_bytes=1048576 ;; esac
+prompt_bytes="$(byte_length "$prompt_content")"
+if (( prompt_bytes > max_payload_bytes )); then
+    echo "agy-exec.sh: prompt input is too large (${prompt_bytes} bytes > OCTOPUS_AGY_MAX_PAYLOAD_BYTES=${max_payload_bytes}); refusing to dispatch to avoid exhausting agy memory" >&2
+    exit 0
+fi
+
 # Single-argument size ceiling: Linux caps one argv string at MAX_ARG_STRLEN
 # (128 KiB). Oversized prompts stay in the cached temp file and agy is pointed
 # at it via --add-dir with a read-this-file --print instruction, instead of

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -139,6 +139,70 @@ test_agy_file_prompt_directive_permits_reading_prompt_file() {
     fi
 }
 
+test_agy_oversize_payload_skips_gracefully() {
+    test_case "agy-exec refuses an over-ceiling payload as a structured oversize skip, not an OOM"
+
+    local tmp_bin="$TEST_TMP_DIR/agy-oversize-bin"
+    local marker="$TEST_TMP_DIR/agy-oversize.called"
+    local err="$TEST_TMP_DIR/agy-oversize.err"
+    mkdir -p "$tmp_bin"
+    rm -f "$marker"
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+echo called > "${AGY_CALLED_MARKER:?}"
+echo "mock-response"
+exit 0
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+
+    # A tiny ceiling + a payload above it: agy must NOT be invoked (a multi-MB
+    # prompt OOM-kills headless agy), the exit is 0 (route around, don't fail the
+    # council), stdout is empty, and stderr carries a marker the dispatch
+    # classifier recognizes as a provider oversize rejection -> skipped:oversize.
+    local out rc
+    out="$(printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' \
+        | AGY_CALLED_MARKER="$marker" OCTOPUS_AGY_MAX_PAYLOAD_BYTES=10 \
+          PATH="$tmp_bin:$PATH" bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" 2>"$err")"
+    rc=$?
+
+    if [[ $rc -eq 0 ]] && [[ -z "$out" ]] && [[ ! -f "$marker" ]] &&
+       grep -qiE 'input is too large' "$err"; then
+        test_pass
+    else
+        test_fail "oversize skip wrong: rc=$rc out=[$out] agy_called=$([[ -f "$marker" ]] && echo yes || echo no) stderr=[$(tr '\n' ' ' < "$err")]"
+    fi
+}
+
+test_agy_oversize_ceiling_is_configurable() {
+    test_case "OCTOPUS_AGY_MAX_PAYLOAD_BYTES raises the ceiling so the same prompt dispatches"
+
+    local tmp_bin="$TEST_TMP_DIR/agy-ceiling-bin"
+    local marker="$TEST_TMP_DIR/agy-ceiling.called"
+    mkdir -p "$tmp_bin"
+    rm -f "$marker"
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+echo called > "${AGY_CALLED_MARKER:?}"
+echo "mock-response"
+exit 0
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+
+    # The exact prompt refused at a 10-byte ceiling must dispatch once the ceiling
+    # is raised above its size — proving the threshold is env-driven, not fixed.
+    local out rc
+    out="$(printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' \
+        | AGY_CALLED_MARKER="$marker" OCTOPUS_AGY_MAX_PAYLOAD_BYTES=100000 \
+          PATH="$tmp_bin:$PATH" bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" 2>/dev/null)"
+    rc=$?
+
+    if [[ $rc -eq 0 ]] && [[ -f "$marker" ]] && [[ "$out" == *"mock-response"* ]]; then
+        test_pass
+    else
+        test_fail "raised ceiling should dispatch: rc=$rc agy_called=$([[ -f "$marker" ]] && echo yes || echo no) out=[$out]"
+    fi
+}
+
 test_gemini_via_agy_option() {
     test_case "OCTOPUS_GEMINI_VIA_AGY serves gemini seats through agy"
 
@@ -775,6 +839,8 @@ test_agy_dispatch_native_flags
 test_agy_print_receives_prompt_argument
 test_agy_force_inline_directive_prepended_by_default
 test_agy_file_prompt_directive_permits_reading_prompt_file
+test_agy_oversize_payload_skips_gracefully
+test_agy_oversize_ceiling_is_configurable
 test_gemini_via_agy_option
 test_agy_dynamic_model_validation
 test_agy_command_validation

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -238,6 +238,39 @@ MOCK_AGY
     fi
 }
 
+test_agy_oversize_default_ceiling_dispatches_at_the_limit() {
+    test_case "a payload at exactly the 1 MiB default (unset env) dispatches, not refused"
+
+    local tmp_bin="$TEST_TMP_DIR/agy-atlimit-bin"
+    local marker="$TEST_TMP_DIR/agy-atlimit.called"
+    mkdir -p "$tmp_bin"
+    rm -f "$marker"
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+echo called > "${AGY_CALLED_MARKER:?}"
+echo "mock-response"
+exit 0
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+
+    # Exactly 1,048,576 bytes = the documented default. The refusal is strictly
+    # greater-than, so this must DISPATCH. Pairs with the 1-byte-over rejection test:
+    # together they pin the boundary, so a default that is too LOW (would refuse here)
+    # is also caught, not just one that is too high.
+    local out rc
+    out="$( { unset OCTOPUS_AGY_MAX_PAYLOAD_BYTES
+             head -c 1048576 /dev/zero | tr '\0' 'x' \
+               | AGY_CALLED_MARKER="$marker" PATH="$tmp_bin:$PATH" \
+                 bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" 2>/dev/null; } )"
+    rc=$?
+
+    if [[ $rc -eq 0 ]] && [[ -f "$marker" ]] && [[ "$out" == *"mock-response"* ]]; then
+        test_pass
+    else
+        test_fail "at-limit payload should dispatch: rc=$rc agy_called=$([[ -f "$marker" ]] && echo yes || echo no) out=[$out]"
+    fi
+}
+
 test_gemini_via_agy_option() {
     test_case "OCTOPUS_GEMINI_VIA_AGY serves gemini seats through agy"
 
@@ -877,6 +910,7 @@ test_agy_file_prompt_directive_permits_reading_prompt_file
 test_agy_oversize_payload_skips_gracefully
 test_agy_oversize_ceiling_is_configurable
 test_agy_oversize_uses_documented_default_ceiling
+test_agy_oversize_default_ceiling_dispatches_at_the_limit
 test_gemini_via_agy_option
 test_agy_dynamic_model_validation
 test_agy_command_validation

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -203,6 +203,41 @@ MOCK_AGY
     fi
 }
 
+test_agy_oversize_uses_documented_default_ceiling() {
+    test_case "the 1 MiB default ceiling applies when OCTOPUS_AGY_MAX_PAYLOAD_BYTES is unset"
+
+    local tmp_bin="$TEST_TMP_DIR/agy-default-bin"
+    local marker="$TEST_TMP_DIR/agy-default.called"
+    local err="$TEST_TMP_DIR/agy-default.err"
+    mkdir -p "$tmp_bin"
+    rm -f "$marker"
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+echo called > "${AGY_CALLED_MARKER:?}"
+echo "mock-response"
+exit 0
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+
+    # 1,048,577 bytes = 1 byte over the documented 1 MiB default. With no env
+    # override, a broken default/fallback would dispatch instead of refusing — the
+    # two override-based tests could not catch that. `unset` is scoped to the
+    # subshell so it cannot leak into sibling tests.
+    local out rc
+    out="$( { unset OCTOPUS_AGY_MAX_PAYLOAD_BYTES
+             head -c 1048577 /dev/zero | tr '\0' 'x' \
+               | AGY_CALLED_MARKER="$marker" PATH="$tmp_bin:$PATH" \
+                 bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" 2>"$err"; } )"
+    rc=$?
+
+    if [[ $rc -eq 0 ]] && [[ -z "$out" ]] && [[ ! -f "$marker" ]] &&
+       grep -qiE 'input is too large' "$err"; then
+        test_pass
+    else
+        test_fail "default ceiling not enforced: rc=$rc out=[$out] agy_called=$([[ -f "$marker" ]] && echo yes || echo no) stderr=[$(tr '\n' ' ' < "$err")]"
+    fi
+}
+
 test_gemini_via_agy_option() {
     test_case "OCTOPUS_GEMINI_VIA_AGY serves gemini seats through agy"
 
@@ -841,6 +876,7 @@ test_agy_force_inline_directive_prepended_by_default
 test_agy_file_prompt_directive_permits_reading_prompt_file
 test_agy_oversize_payload_skips_gracefully
 test_agy_oversize_ceiling_is_configurable
+test_agy_oversize_uses_documented_default_ceiling
 test_gemini_via_agy_option
 test_agy_dynamic_model_validation
 test_agy_command_validation


### PR DESCRIPTION
## Problem

`agy-exec.sh` already has a file-path fallback (from #609) that hands agy an oversized prompt as a file to read, sidestepping the argv `MAX_ARG_STRLEN` (128 KiB) limit. But that fallback has **no upper bound**, and it doesn't protect agy itself: a multi-megabyte prompt is loaded whole into agy's context and **OOM-kills the headless process** (or is rejected by the backend for context length).

Either way the council seat dies **opaquely**:
- a non-zero exit → recorded as a generic `failed:Exit code N`, or
- a silent-empty result the replay retry can't fix — and the #2077 finished-but-timed-out salvage can't recover it either, because no `VERDICT:` was ever written.

Surfaced by downstream sail-cruisey #2077 on large-diff council reviews.

## Fix

- **Configurable payload ceiling** `OCTOPUS_AGY_MAX_PAYLOAD_BYTES` (default **1 MiB**, ~250k tokens — already far larger than any real review prompt), measured in bytes on the exact `prompt_content` agy would read from the file.
- **Above the ceiling**, the adapter refuses to dispatch, **exits 0**, and emits an `input is too large` provider-rejection marker to stderr. `classify_agent_output` already recognizes that phrase → `failed:Prompt rejected by provider (oversize)` → `agent-sync.sh` records a structured **`skipped:oversize`** seat and returns 0, so the council keeps its remaining seats instead of crashing on this one. Exit 0 (not an error) matches how `agent-sync.sh` already routes around provider oversize rejections (#410): a too-big prompt is an input-size mismatch to skip, not a hard run failure.
- **True chunking is intentionally not attempted.** A single analytical review prompt ("review this diff and return a verdict") can't be split into independent chunks and recombined into one coherent verdict; a bounded, structured skip is the correct degradation.

No change to the normal path or the existing 100 KB inline-vs-file-path branch — the ceiling check sits above it and only fires on pathological payloads.

## Verification

Three payload bands, all confirmed with a stubbed `agy`:
- **≤ 100 KB** → inline `--print` argument (unchanged).
- **100 KB – ceiling** → file-path fallback with `--add-dir` (unchanged).
- **> ceiling** → agy **not invoked**, exit 0, empty stdout, `input is too large` on stderr; `classify_agent_output` → `skipped:oversize`.

End-to-end classifier chain checked (`agy-exec.sh` stderr → `classify_agent_output` → `skipped:oversize`). New unit tests: over-ceiling payload skips gracefully; the ceiling is env-configurable (the same prompt dispatches once the ceiling is raised). **Full agy suite: 38 passed, 0 failed.** No file-mode drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added a configurable hard cap for oversized AI provider prompt payloads (default: 1 MiB) to prevent crashes/OOM and unrecoverable failures.
  - When the payload exceeds the limit, dispatch is refused gracefully (returns success) and emits a recognized “skipped:oversize” outcome instead of failure behavior.

- **Tests**
  - Added unit coverage to ensure oversized payloads are skipped without invoking the provider.
  - Added tests to verify the ceiling is configurable and the documented default limit is enforced exactly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->