### PR TITLE
fix: validate OpenAI-compatible runtime arguments

### DIFF
--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -204,10 +204,8 @@ _validate_openai_compatible_agent_command() {
             --base-url)
                 [[ -z "$base_url" ]] || return 1
                 _octopus_is_safe_openai_compatible_value "$value" || return 1
-                case "$value" in
-                    http://*|https://*) base_url="$value" ;;
-                    *) return 1 ;;
-                esac
+                [[ "$value" =~ ^https?://[^/?#]+ ]] || return 1
+                base_url="$value"
                 ;;
             --api-key-env)
                 [[ -z "$api_key_env" ]] || return 1

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -188,6 +188,8 @@ _validate_openai_compatible_agent_command() {
     local cwd=""
     local reasoning_effort=""
     local reasoning_policy=""
+    local base_url=""
+    local api_key_env=""
     local i=1
 
     while [[ $i -lt ${#parts[@]} ]]; do
@@ -198,6 +200,19 @@ _validate_openai_compatible_agent_command() {
             --provider)
                 [[ -z "$provider" && "$value" == "generic" ]] || return 1
                 provider="$value"
+                ;;
+            --base-url)
+                [[ -z "$base_url" ]] || return 1
+                _octopus_is_safe_openai_compatible_value "$value" || return 1
+                case "$value" in
+                    http://*|https://*) base_url="$value" ;;
+                    *) return 1 ;;
+                esac
+                ;;
+            --api-key-env)
+                [[ -z "$api_key_env" ]] || return 1
+                [[ "$value" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+                api_key_env="$value"
                 ;;
             --model)
                 [[ -z "$model" ]] || return 1

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -77,6 +77,13 @@ else
     test_pass
 fi
 
+test_case "validate_agent_command rejects duplicate credential env args"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --base-url https://api.pioneer.ai/v1 --api-key-env PIONEER_API_KEY --api-key-env OPENAI_API_KEY --model deepseek-ai/DeepSeek-V4-Pro --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected duplicate credential env args to be rejected"
+else
+    test_pass
+fi
+
 test_case "validate_agent_command rejects non-project openai-compatible helper path"
 if validate_agent_command "/tmp/openai-compatible-agent.py --provider generic --model minimax/minimax-m3 --cwd /tmp/test" >/dev/null 2>&1; then
     test_fail "expected non-project openai-compatible helper path to be rejected"

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -56,6 +56,20 @@ else
     test_pass
 fi
 
+test_case "validate_agent_command rejects http URL without host"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --base-url http:// --api-key-env PIONEER_API_KEY --model deepseek-ai/DeepSeek-V4-Pro --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected http URL without host to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects https URL without host"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --base-url https:// --api-key-env PIONEER_API_KEY --model deepseek-ai/DeepSeek-V4-Pro --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected https URL without host to be rejected"
+else
+    test_pass
+fi
+
 test_case "validate_agent_command rejects unsafe OpenAI-compatible base URL"
 if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --base-url https://api.example/v1;touch --api-key-env PIONEER_API_KEY --model deepseek-ai/DeepSeek-V4-Pro --cwd /tmp/test" >/dev/null 2>&1; then
     test_fail "expected unsafe base URL to be rejected"

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -41,6 +41,42 @@ else
     test_fail "expected openai-compatible helper path to be accepted"
 fi
 
+
+test_case "validate_agent_command allows configured OpenAI-compatible runtime args"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --base-url https://api.pioneer.ai/v1 --api-key-env PIONEER_API_KEY --model deepseek-ai/DeepSeek-V4-Pro --cwd /tmp/test"; then
+    test_pass
+else
+    test_fail "expected configured OpenAI-compatible runtime args to be accepted"
+fi
+
+test_case "validate_agent_command rejects non-http OpenAI-compatible base URL"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --base-url file:///tmp/api --api-key-env PIONEER_API_KEY --model deepseek-ai/DeepSeek-V4-Pro --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected non-http base URL to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects unsafe OpenAI-compatible base URL"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --base-url https://api.example/v1;touch --api-key-env PIONEER_API_KEY --model deepseek-ai/DeepSeek-V4-Pro --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected unsafe base URL to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects invalid credential env name"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --base-url https://api.pioneer.ai/v1 --api-key-env BAD-NAME --model deepseek-ai/DeepSeek-V4-Pro --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected invalid credential env name to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects duplicate OpenAI-compatible runtime args"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --base-url https://api.pioneer.ai/v1 --base-url https://api.example/v1 --api-key-env PIONEER_API_KEY --model deepseek-ai/DeepSeek-V4-Pro --cwd /tmp/test" >/dev/null 2>&1; then
+    test_fail "expected duplicate runtime args to be rejected"
+else
+    test_pass
+fi
+
 test_case "validate_agent_command rejects non-project openai-compatible helper path"
 if validate_agent_command "/tmp/openai-compatible-agent.py --provider generic --model minimax/minimax-m3 --cwd /tmp/test" >/dev/null 2>&1; then
     test_fail "expected non-project openai-compatible helper path to be rejected"


### PR DESCRIPTION
## Problem

PR #646 added explicit OpenAI-compatible runtime arguments to the dispatch command:

    --base-url <http(s) endpoint>
    --api-key-env <credential variable name>

The strict helper-command validator was not updated at the same time. As a result, a supervised Tangle run completed design review and decomposition, then failed at implementation launch with:

    Invalid agent command returned
    spawn_agent produced no provider PID

The generated command was valid and had already passed provider preflight, but `validate_agent_command()` rejected both new flags as unknown.

## Change

Extend the strict OpenAI-compatible helper validator to accept the runtime arguments while preserving the existing injection boundary:

- `--base-url` is optional, unique, safe-token validated, and restricted to `http://` or `https://`;
- `--api-key-env` is optional, unique, and restricted to a valid environment-variable name;
- duplicate flags remain rejected;
- unknown flags and shell metacharacters remain rejected;
- legacy helper commands without these options remain supported.

## Validation

- exact command that failed in the supervised run: accepted;
- configured runtime args: accepted;
- non-HTTP URL: rejected;
- unsafe URL/metacharacters: rejected;
- invalid credential env name: rejected;
- duplicate runtime args: rejected;
- full agent command validation suite: 21/21;
- shell syntax check;
- git diff --check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAI-compatible agents with custom `--base-url` and `--api-key-env`.

* **Bug Fixes**
  * Improved `--base-url` validation to allow only `http`/`https` URLs without unsafe content.
  * Improved `--api-key-env` validation to require a safe environment variable name.
  * Updated validation to reject duplicate `--base-url` and duplicate `--api-key-env` arguments.

* **Tests**
  * Expanded unit coverage for accepted and rejected OpenAI-compatible command invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->