### PR TITLE
fix: stop Tangle after failed validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- **Tangle now stops immediately when its validation gate fails** (#672). A failed validation no longer falls through into contextual review and correction agents, preventing additional writes after the run has already been declared invalid while preserving the generated validation report for diagnosis.
 - **An oversized council prompt to `agy` now degrades to a structured skip instead of OOM-killing the seat** (#2077). The adapter's existing file-path fallback sidesteps the argv `MAX_ARG_STRLEN` limit but not agy itself — a multi-megabyte prompt is loaded whole into agy's context and OOM-kills the headless process (or is rejected by the backend for context length), leaving the seat dead with an opaque exit code or a silent-empty result the retry cannot recover. `agy-exec.sh` now enforces a configurable payload ceiling (`OCTOPUS_AGY_MAX_PAYLOAD_BYTES`, default 1 MiB): above it, the adapter refuses to dispatch, exits 0, and emits a provider-rejection marker that `classify_agent_output` already recognizes, so dispatch records a structured `skipped:oversize` seat and the council keeps its remaining seats rather than crashing on this one. The ceiling is measured in bytes on the exact prompt content agy would read.
 
 ## [9.54.2] - 2026-07-27

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -2160,6 +2160,11 @@ Every [CODING] line must include a same-line Files: clause."
     local validation_rc=0
     validate_tangle_results "$task_group" "$resolved_prompt" "$worktree_before_file" || validation_rc=$?
 
+    if [[ "$validation_rc" -ne 0 ]]; then
+        log ERROR "Tangle validation failed with status ${validation_rc}; stopping before contextual review and corrections"
+        return "$validation_rc"
+    fi
+
     tangle_contextual_review_gate "$task_group" "$resolved_prompt" "$context" "$subtasks" \
         "$validation_file" "$worktree_before_file" "$validation_rc" "$tangle_coding_agent"
     return $?

--- a/tests/unit/test-tangle-validation-abort.sh
+++ b/tests/unit/test-tangle-validation-abort.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Regression test: failed tangle validation must stop before contextual review.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKFLOWS="$PROJECT_ROOT/scripts/lib/workflows.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "tangle validation hard abort"
+
+source "$WORKFLOWS"
+
+CYAN=""
+GREEN=""
+MAGENTA=""
+NC=""
+TMUX_MODE=false
+DRY_RUN=false
+SUPPORTS_PARALLEL_FILE_SAFETY=false
+RESULTS_DIR="$TEST_TMP_DIR/tangle-validation-abort"
+LOGS_DIR="$RESULTS_DIR/logs"
+WORKSPACE_DIR="$RESULTS_DIR/workspace"
+rm -rf "$RESULTS_DIR"
+mkdir -p "$WORKSPACE_DIR/.octo/agents"
+trap 'rm -rf "$RESULTS_DIR"' EXIT
+
+REVIEW_CALLS=0
+VALIDATION_CALLS=0
+
+log() { :; }
+octopus_phase_banner() { :; }
+display_workflow_cost_estimate() { return 0; }
+reset_provider_lockouts() { :; }
+design_review_ceremony() { :; }
+fleet_dispatch_begin() { :; }
+fleet_dispatch_end() { :; }
+record_agents_batch_complete() { :; }
+
+run_agent_sync() {
+    printf '%s\n' '1. [CODING] Verify the existing fix. Files: apps/web/tests/setup.js'
+}
+
+spawn_agent_capture_pid() {
+    local task_id="$3"
+    printf '0\n' > "$WORKSPACE_DIR/.octo/agents/${task_id}.done"
+    printf '12345\n'
+}
+
+validate_tangle_results() {
+    VALIDATION_CALLS=$((VALIDATION_CALLS + 1))
+    return 1
+}
+
+tangle_contextual_review_gate() {
+    REVIEW_CALLS=$((REVIEW_CALLS + 1))
+    return 0
+}
+
+status=0
+tangle_develop "Verify the existing React.act fix without unrelated edits." >/dev/null 2>&1 || status=$?
+
+test_case "failed validation returns non-zero"
+if [[ "$status" -ne 0 ]]; then
+    test_pass
+else
+    test_fail "expected tangle_develop to return non-zero after validation failure"
+fi
+
+test_case "validation runs exactly once"
+if [[ "$VALIDATION_CALLS" -eq 1 ]]; then
+    test_pass
+else
+    test_fail "expected one validation call, got $VALIDATION_CALLS"
+fi
+
+test_case "contextual review is not called after validation abort"
+if [[ "$REVIEW_CALLS" -eq 0 ]]; then
+    test_pass
+else
+    test_fail "contextual review ran $REVIEW_CALLS time(s) after validation abort"
+fi
+
+test_summary

--- a/tests/unit/test-tangle-validation-abort.sh
+++ b/tests/unit/test-tangle-validation-abort.sh
@@ -20,12 +20,13 @@ NC=""
 TMUX_MODE=false
 DRY_RUN=false
 SUPPORTS_PARALLEL_FILE_SAFETY=false
+TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
 RESULTS_DIR="$TEST_TMP_DIR/tangle-validation-abort"
 LOGS_DIR="$RESULTS_DIR/logs"
 WORKSPACE_DIR="$RESULTS_DIR/workspace"
 rm -rf "$RESULTS_DIR"
 mkdir -p "$WORKSPACE_DIR/.octo/agents"
-trap 'rm -rf "$RESULTS_DIR"' EXIT
+trap 'rm -rf "$RESULTS_DIR"' EXIT INT TERM
 
 REVIEW_CALLS=0
 VALIDATION_CALLS=0

--- a/tests/unit/test-tangle-validation-abort.sh
+++ b/tests/unit/test-tangle-validation-abort.sh
@@ -20,13 +20,13 @@ NC=""
 TMUX_MODE=false
 DRY_RUN=false
 SUPPORTS_PARALLEL_FILE_SAFETY=false
-TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
 RESULTS_DIR="$TEST_TMP_DIR/tangle-validation-abort"
 LOGS_DIR="$RESULTS_DIR/logs"
 WORKSPACE_DIR="$RESULTS_DIR/workspace"
-rm -rf "$RESULTS_DIR"
+rm -rf "$TEST_TMP_DIR"
 mkdir -p "$WORKSPACE_DIR/.octo/agents"
-trap 'rm -rf "$RESULTS_DIR"' EXIT INT TERM
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
 
 REVIEW_CALLS=0
 VALIDATION_CALLS=0


### PR DESCRIPTION
## Problem

`tangle_develop` captured the non-zero status from `validate_tangle_results`, but always continued into `tangle_contextual_review_gate`.

That meant a quality-gate decision of `abort` could still launch contextual review and correction agents, allowing additional writes after the workflow had already declared the run failed.

This was reproduced in a supervised Memory Keeper run: validation reported `Decision: abort`, then the workflow continued into contextual review and corrections.

## Change

Return immediately from `tangle_develop` when validation returns non-zero, before contextual review or corrections can start.

The validation report remains available because `validate_tangle_results` writes it before returning on abort.

## Tests

Added a behavioral regression test that drives `tangle_develop` with stubbed decomposition, dispatch, validation, and contextual review, then asserts:

- failed validation returns non-zero;
- validation runs exactly once;
- contextual review is never called.

Focused validation:

- new hard-abort suite: 3/3;
- correction loop behavior: 7/7;
- contextual review loop: 54/54;
- shell syntax;
- `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tangle development now hard-stops immediately when the validation gate fails.
  * Prevents subsequent contextual review/correction steps from running, avoiding any unintended follow-up actions while still keeping the validation report available for diagnosis.
* **Tests**
  * Added a regression test to confirm the workflow aborts with a non-zero exit status on validation failure and that contextual review is not triggered afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->