### PR TITLE
chore: release v9.55.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.54.2"
+    "version": "9.55.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.54.2 - Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
-      "version": "9.54.2",
+      "description": "v9.55.0 - Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
+      "version": "9.55.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": "2026-06",
   "name": "octo",
   "displayName": "Claude Octopus",
-  "version": "9.54.2",
+  "version": "9.55.0",
   "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
   "author": {
     "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.54.2",
-  "description": "v9.54.2 \u2014 Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. Run /octo:setup.",
+  "version": "9.55.0",
+  "description": "v9.55.0 \u2014 Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Claude Octopus routine manifest (v9.54.2). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "$comment": "Claude Octopus routine manifest (v9.55.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
   "schemaVersion": 1,
   "routines": [
     {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.54.2",
+  "version": "9.55.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.54.2",
+  "version": "9.55.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.54.2"
+    "version": "9.55.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.54.2 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 50 commands, 58 skills. Run /octo:setup after install.",
-      "version": "9.54.2",
+      "description": "v9.55.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 50 commands, 58 skills. Run /octo:setup after install.",
+      "version": "9.55.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.54.2",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.54.2. 32 expert personas, 50 commands, 58 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.55.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.55.0. 32 expert personas, 50 commands, 58 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,9 +1,9 @@
 # AI Agent Handoff
 
 Last updated: 2026-07-27
-Status: prerequisites merged; final integrated verification passed
-Branch: `feat/opus-5-default-routing`
-Pull request: https://github.com/nyldn/claude-octopus/pull/678
+Status: v9.55.0 released; no open delivery work
+Branch: `main`
+Release: https://github.com/nyldn/claude-octopus/releases/tag/v9.55.0
 
 ## Start Here
 
@@ -20,9 +20,9 @@ Read in order:
 5. `git status --short --branch`
 6. the latest commits on the current branch
 
-## Current Goal
+## Delivered Goal
 
-Make Opus 5 the default complex-work owner in Claude Octopus while keeping
+Opus 5 is the default complex-work owner in Claude Octopus while keeping
 Fable 5 as a capability escalation, Codex/GPT-5.6 as an independent peer,
 cheaper model tiers, user overrides, and legacy compatibility.
 
@@ -61,13 +61,9 @@ could not be claimed or recorded as a new Beads issue.
 
 ## Current Evidence
 
-- Public `main` is complete through the Council reliability queue and Tangle
-  PRs #673, #674, and #675 (`f3d7b276`).
-- This branch includes that exact `main` squash stack; the only remaining
-  public feature PR is #678.
-- Core implementation commit: `6e0e6863` (`feat: adopt Opus 5 frontier model
-  routing`); latest compliance fix: `4b96a2cf` (`fix: enforce Claude allowlists
-  for Opus routing`).
+- Public `main` includes the Council reliability queue, Tangle PRs #672-#675,
+  and the Opus 5 routing squash from PR #678 (`972d9597`).
+- Release v9.55.0 contains the complete integration and is the resume baseline.
 - Installed Claude Code: 2.1.220.
 - Installed Codex CLI: 0.145.0.
 - Upstream model policy: `nyldn/fable5-optimizer` v2.0.0.
@@ -82,19 +78,21 @@ could not be claimed or recorded as a new Beads issue.
 - `make sync-check` passes with no script mode changes.
 - The final integrated `make ci-local` passed 16 smoke, 183 unit, and 7
   integration suites, including the live plugin lifecycle test.
+- PR #678 passed 13 protected/review checks, including Ubuntu and macOS unit
+  matrices; the v9.55.0 release PR passed its required protected gates.
 
 ## Merge Queue
 
 - Merged: #656, #658, #664, #666, #667, #668, #669, #670, #672, #673, #674,
-  #675, and release PR #677 (v9.54.2).
-- In progress: #678 (Opus 5 routing), followed by the v9.55.0 minor release.
+  #675, #678, release PR #677 (v9.54.2), and release PR #680 (v9.55.0).
+- No public or private pull requests or issues remained open at release.
 - Private E2E issue classification fix merged in
   `nyldn/claude-octopus-dev#4`; the target VPS remains unreachable over SSH, so
   the repository fix is complete but the live script has not been refreshed.
 
 ## Next Action
 
-Commit and push the integrated head to both remotes. Merge #678 only after
-required review and protected verification gates pass. Finish the v9.55.0
-minor release workflow, tag the squash-merge commit on `main`, publish the
-GitHub release, and update this handoff to the released state.
+No delivery action remains. Future sessions should start from current `main`,
+read this file and the routing strategy, then use `bd ready` for new work. The
+private E2E repository fix is complete; retry the VPS refresh separately when
+the host is reachable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [9.55.0] - 2026-07-27
+
+
 ### Changed
 
 - **Real Tangle implementation runs now require a clean Git baseline by default** (#674). Modified tracked files, untracked files, and non-Git workspaces fail before provider dispatch with each blocking status entry reported; ignored files remain allowed and direct library consumers may explicitly opt out with `OCTOPUS_TANGLE_REQUIRE_CLEAN_BASELINE=false`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@
 
 ## [9.55.0] - 2026-07-27
 
-
-### Changed
-
-- **Real Tangle implementation runs now require a clean Git baseline by default** (#674). Modified tracked files, untracked files, and non-Git workspaces fail before provider dispatch with each blocking status entry reported; ignored files remain allowed and direct library consumers may explicitly opt out with `OCTOPUS_TANGLE_REQUIRE_CLEAN_BASELINE=false`.
-
 ### Added
 
 - **Frontier model routing strategy and prompt policy** (`docs/MODEL-ROUTING-STRATEGY.md`, `docs/GPT-5.6-PROMPTING.md`, `skills/blocks/frontier-model-routing.md`): defines Opus 5 as the premium lead, GPT-5.6 Sol as the independent implementation/review peer, Sonnet 5 as the standard Claude seat, and Fable 5 as an explicit capability escalation rather than an automatic default.
@@ -21,6 +16,7 @@
 
 ### Changed
 
+- **Real Tangle implementation runs now require a clean Git baseline by default** (#674). Modified tracked files, untracked files, and non-Git workspaces fail before provider dispatch with each blocking status entry reported; ignored files remain allowed and direct library consumers may explicitly opt out with `OCTOPUS_TANGLE_REQUIRE_CLEAN_BASELINE=false`.
 - **Current-model defaults now prefer Opus 5, Sonnet 5, and GPT-5.6** when the installed Claude Code and Codex versions support them. Fresh provider configurations use GPT-5.6 Sol/Terra/Luna and Opus 5/Sonnet 5/Haiku 4.5; existing environment, session, and `providers.json` pins retain precedence.
 - **Fable 5 remains opt-in and falls back to Opus 5** for security routing or a refusal/empty response. `OCTOPUS_FABLE5_FALLBACK_MODEL` can select another fallback, and automatic Opus 5 `xhigh` phase routing is now opt-in through `OCTOPUS_OPUS5_AUTO_XHIGH=1`.
 - **Provider capability gates and cost reporting recognize the new roster**: Sonnet 5 requires Claude Code v2.1.197+, Opus 5 requires v2.1.219+, and GPT-5.6 routing requires Codex CLI v0.144.0+.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 <p align="center">
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/Version-9.54.2-blue" alt="Version 9.54.2">
+  <img src="https://img.shields.io/badge/Version-9.55.0-blue" alt="Version 9.55.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.50+_required-blueviolet" alt="Requires Claude Code v2.1.50+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.54.2",
+  "version": "9.55.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Release v9.55.0

Opus 5 default routing and resilient Council/Tangle workflows

---
🤖 Generated with release.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Release**
  * Released version **9.55.0** across supported plugin integrations and the published package.
  * Updated version metadata/branding in plugin manifests and marketplace entries.
  * Updated the README version badge to **v9.55.0**.
* **Documentation**
  * Updated **CHANGELOG.md** to include a new **9.55.0** release section and organize the latest items under it.
* **Project Docs**
  * Refreshed **AI_AGENT_HANDOFF.md** to reflect the completed **v9.55.0** baseline and next steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->