### PR TITLE
fix: refresh release marketplace summary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.55.0 - Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
+      "description": "v9.55.0 - Opus 5 default routing with GPT-5.6 Codex peer review, opt-in Fable 5 escalation, isolated Tangle verification, and resilient multi-provider councils. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
       "version": "9.55.0",
       "author": {
         "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
   "version": "9.55.0",
-  "description": "v9.55.0 \u2014 Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. Run /octo:setup.",
+  "description": "v9.55.0 \u2014 Opus 5 default routing with GPT-5.6 Codex peer review, opt-in Fable 5 escalation, isolated Tangle verification, and resilient multi-provider councils. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release metadata now describes the release being shipped.** `release.sh` uses its summary argument as the plugin description source and regenerates derived artifacts before committing, preventing a prior release's marketplace summary from carrying into the next version.
+
 ## [9.55.0] - 2026-07-27
 
 ### Added

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -88,17 +88,19 @@ json.dump(p, open('package.json', 'w'), indent=2)
 print('   package.json')
 "
 
-# plugin.json — strip old version prefix, prepend new one from version field
-python3 -c "
-import json, re
+# plugin.json — use the release summary as the new marketplace source text
+python3 - "$VERSION" "$SUMMARY" <<'PY'
+import json
+import sys
+
+version, summary = sys.argv[1:]
+summary = summary.strip().rstrip(".")
 p = json.load(open('.claude-plugin/plugin.json'))
-p['version'] = '${VERSION}'
-# Strip any existing version prefix, then prepend the new one
-desc = re.sub(r'^v\d+\.\d+\.\d+\s*[\u2014\-]\s*', '', p['description'])
-p['description'] = 'v${VERSION} \u2014 ' + desc
+p['version'] = version
+p['description'] = f'v{version} \u2014 {summary}. Run /octo:setup.'
 json.dump(p, open('.claude-plugin/plugin.json', 'w'), indent=2)
 print('   .claude-plugin/plugin.json')
-"
+PY
 
 # marketplace.json — strip old version prefix, prepend new one
 python3 -c "
@@ -233,6 +235,9 @@ with open(path, 'w') as f:
     f.write('\\n')
 print(f'   {path}')
 "
+
+# Regenerate marketplace and OpenClaw artifacts from their source files.
+make sync
 
 octo_release_update_changelog CHANGELOG.md "$VERSION" "$DATE" "$SUMMARY"
 

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -158,6 +158,18 @@ test_release_file_updates_are_portable() {
     fi
 }
 
+test_release_description_uses_current_summary() {
+    test_case "release.sh replaces stale plugin summary and regenerates derived artifacts"
+
+    if grep -q "version, summary = sys.argv\\[1:\\]" "$RELEASE_SCRIPT" &&
+       grep -q "p\\['description'\\] = f'v{version}" "$RELEASE_SCRIPT" &&
+       grep -q '^make sync$' "$RELEASE_SCRIPT"; then
+        test_pass
+    else
+        test_fail "release.sh does not derive plugin metadata from the current release summary"
+    fi
+}
+
 test_readme_provider_and_cost_contract() {
     test_case "README defines provider counting and auditable cost assumptions"
 
@@ -303,6 +315,7 @@ test_release_script_invokes_shared_marketplace_sync
 test_release_stages_routines_manifest
 test_release_updates_and_stages_browse_manifest
 test_release_file_updates_are_portable
+test_release_description_uses_current_summary
 test_readme_provider_and_cost_contract
 test_marketplace_description_error_uses_logger
 test_release_promotes_unreleased_changelog_notes


### PR DESCRIPTION
## Summary

- describe v9.55 with the Opus 5, GPT-5.6 Codex, Fable 5, Tangle, and Council roster instead of the prior release summary
- make `release.sh` replace plugin metadata from its current summary argument
- regenerate derived marketplace/OpenClaw artifacts before release commits
- add a regression assertion for the release metadata contract

## Verification

- `make ci-local` (16 smoke, 183 unit, 7 integration suites)
- `bash tests/unit/test-shared-marketplace-sync.sh` (13/13)
- `shellcheck -x scripts/release.sh`
- `make sync-check`
- no executable-mode changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated plugin metadata for v9.55.0, highlighting default Opus 5 routing, GPT-5.6 Codex peer review, optional escalation, isolated verification, and multi-provider councils.
  * Added updated persona, command, and skill availability details.
  * Included the `/octo:setup` setup instruction in plugin descriptions.

* **Bug Fixes**
  * Corrected release metadata generation so each release uses its current summary and refreshed derived artifacts before publication.

* **Tests**
  * Added coverage to verify release descriptions use the current release summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->