### PR TITLE
fix(agy): salvage a TTY-demanding agy seat under a pseudo-terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **A council `agy` seat that dies demanding a TTY is salvaged under a pseudo-terminal instead of silently failing.** agy is a bubbletea TUI app; in `--print` mode it is headless, but when it must render an interactive screen anyway — a folder-trust prompt on a brand-new worktree, or an auth flow — it opens `/dev/tty` and, in a session with no controlling terminal, dies with `bubbletea: could not open TTY` before producing an answer, sinking the seat. `agy-exec.sh` now detects that specific failure and retries once under a pseudo-terminal via `script`, so the auto-dismissed (`--dangerously-skip-permissions`) TUI has a terminal to draw on. The fallback is gated on the real error — a blanket no-TTY wrap would fire on every autonomous dispatch (which never has a TTY) and leak the pseudo-terminal's caret-notation echo into the answer — and the salvaged output is stripped of that echo (CR / backspace / EOT / leading caret-notation) so it stays byte-clean for the council response parser. Portable across BSD (`script … command`) and util-linux (`script -c`) `script`; opt out with `OCTOPUS_AGY_NO_PTY_FALLBACK=1`.
+
 ## [9.55.1] - 2026-07-27
 
 ### Fixed

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -246,10 +246,15 @@ run_agy_pty() {
         # BSD script: trailing command args preserve argv (safe for a large --print value).
         script -q /dev/null "${cmd[@]}" > "$stdout_file" 2> "$stderr_file" < /dev/null
     else
-        # util-linux script: the command must be one -c string; shell-quote every arg so a
-        # multiline/oversized --print survives intact.
-        local _q="" _a
-        for _a in "${cmd[@]}"; do _q+="$(printf '%q ' "$_a")"; done
+        # util-linux script: the command must be one -c string and may be
+        # interpreted by /bin/sh rather than Bash. Quote every argument with
+        # POSIX single-quote syntax; Bash printf %q can emit $'...' for
+        # multiline values, which is not portable to /bin/sh.
+        local _q="" _a _escaped
+        for _a in "${cmd[@]}"; do
+            _escaped="${_a//\'/\'\\\'\'}"
+            _q+="'${_escaped}' "
+        done
         script -qec "$_q" /dev/null > "$stdout_file" 2> "$stderr_file" < /dev/null
     fi
     local _rc=$?

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -222,8 +222,13 @@ run_agy() {
 # dies with "bubbletea: could not open TTY" before producing any answer. Detect that
 # specific failure so we only pay the pseudo-TTY cost when it actually happens.
 _agy_tty_error() {
-    LC_ALL=C grep -qiE 'could not open( a)? tty|open /dev/tty|bubbletea|inappropriate ioctl|/dev/tty.*(no such device|not a)' \
-        "$stderr_file" "$stdout_file" 2>/dev/null
+    # Match only TTY-specific phrasing. A bare "bubbletea" would also catch unrelated
+    # TUI failures a pseudo-terminal can't fix; the real error ("bubbletea: could not
+    # open TTY") is already covered by the "could not open tty" alternative. Count
+    # matches rather than `grep -q`: -q exits on first match and can SIGPIPE an upstream
+    # writer under pipefail, which the repo's portability lint forbids.
+    LC_ALL=C grep -ciE 'could not open( a)? tty|open /dev/tty|inappropriate ioctl|/dev/tty.*(no such device|not a)' \
+        "$stderr_file" "$stdout_file" >/dev/null 2>&1
 }
 
 # PTY-fallback: re-run agy under a pseudo-terminal via `script` so a TUI it insists on
@@ -232,9 +237,11 @@ _agy_tty_error() {
 # autonomous dispatch (which never has a TTY) and leak the PTY's control-char echo (^D,
 # CR) into the answer. Opt out with OCTOPUS_AGY_NO_PTY_FALLBACK=1.
 run_agy_pty() {
+    # Bail BEFORE truncating the captures: agy's original stderr (the TTY error the
+    # caller matched on) must survive if we can't actually run the fallback.
+    command -v script >/dev/null 2>&1 || return 127
     : > "$stdout_file"
     : > "$stderr_file"
-    command -v script >/dev/null 2>&1 || return 127
     if [[ "$(uname -s 2>/dev/null)" == Darwin* || "$(uname -s 2>/dev/null)" == *BSD ]]; then
         # BSD script: trailing command args preserve argv (safe for a large --print value).
         script -q /dev/null "${cmd[@]}" > "$stdout_file" 2> "$stderr_file" < /dev/null
@@ -272,7 +279,8 @@ fi
 # pseudo-terminal so a first-touch folder-trust TUI on a fresh worktree can't sink an
 # autonomous council seat. Gated on the real error so the working headless path is
 # untouched.
-if [[ "${OCTOPUS_AGY_NO_PTY_FALLBACK:-}" != "1" ]] && (( rc != 0 )) && _agy_tty_error; then
+if [[ "${OCTOPUS_AGY_NO_PTY_FALLBACK:-}" != "1" ]] && (( rc != 0 )) \
+        && command -v script >/dev/null 2>&1 && _agy_tty_error; then
     echo "agy-exec.sh: agy demanded a TTY; retrying once under a pseudo-terminal (disable with OCTOPUS_AGY_NO_PTY_FALLBACK=1)" >&2
     run_agy_pty
     rc=$?

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -93,7 +93,8 @@ fi
 # the --print argument. Buffer stdout to a file to preserve output fidelity.
 prompt_file=""
 stdout_file=$(mktemp -t "octo-agy-stdout.XXXXXX")
-trap 'rm -f "${prompt_file:-}" "${stdout_file:-}"' EXIT
+stderr_file=$(mktemp -t "octo-agy-stderr.XXXXXX")
+trap 'rm -f "${prompt_file:-}" "${stdout_file:-}" "${stderr_file:-}"' EXIT
 # INT/TERM must actually terminate (bash otherwise resumes after the handler);
 # the EXIT trap still runs the cleanup on the way out.
 trap 'exit 130' INT
@@ -211,7 +212,50 @@ fi
 
 run_agy() {
     : > "$stdout_file"
-    "${cmd[@]}" > "$stdout_file" < /dev/null
+    : > "$stderr_file"
+    "${cmd[@]}" > "$stdout_file" 2> "$stderr_file" < /dev/null
+}
+
+# agy is a bubbletea TUI app. In --print mode it is headless, but when it must render
+# an INTERACTIVE screen anyway — a folder-trust prompt on a brand-new worktree, or an
+# auth/login flow — it opens /dev/tty and, in a session with no controlling terminal,
+# dies with "bubbletea: could not open TTY" before producing any answer. Detect that
+# specific failure so we only pay the pseudo-TTY cost when it actually happens.
+_agy_tty_error() {
+    LC_ALL=C grep -qiE 'could not open( a)? tty|open /dev/tty|bubbletea|inappropriate ioctl|/dev/tty.*(no such device|not a)' \
+        "$stderr_file" "$stdout_file" 2>/dev/null
+}
+
+# PTY-fallback: re-run agy under a pseudo-terminal via `script` so a TUI it insists on
+# rendering (already auto-dismissed by --dangerously-skip-permissions) has a TTY to draw
+# on. Only invoked on a confirmed TTY error — a blanket wrap would fire on EVERY
+# autonomous dispatch (which never has a TTY) and leak the PTY's control-char echo (^D,
+# CR) into the answer. Opt out with OCTOPUS_AGY_NO_PTY_FALLBACK=1.
+run_agy_pty() {
+    : > "$stdout_file"
+    : > "$stderr_file"
+    command -v script >/dev/null 2>&1 || return 127
+    if [[ "$(uname -s 2>/dev/null)" == Darwin* || "$(uname -s 2>/dev/null)" == *BSD ]]; then
+        # BSD script: trailing command args preserve argv (safe for a large --print value).
+        script -q /dev/null "${cmd[@]}" > "$stdout_file" 2> "$stderr_file" < /dev/null
+    else
+        # util-linux script: the command must be one -c string; shell-quote every arg so a
+        # multiline/oversized --print survives intact.
+        local _q="" _a
+        for _a in "${cmd[@]}"; do _q+="$(printf '%q ' "$_a")"; done
+        script -qec "$_q" /dev/null > "$stdout_file" 2> "$stderr_file" < /dev/null
+    fi
+    local _rc=$?
+    # Clean the pseudo-terminal's echo artifacts so the captured answer is byte-clean
+    # for the council response parser. Feeding /dev/null as stdin makes the line
+    # discipline echo the EOF as caret-notation "^D" (literal ^ + D) followed by
+    # backspaces to erase it — plus trailing carriage returns. Drop CR/BS/EOT, then
+    # strip any leading run of caret-notation control sequences (^@..^_ ^?) left on the
+    # first line. A real answer never starts with those.
+    LC_ALL=C tr -d '\r\010\004' < "$stdout_file" \
+        | LC_ALL=C sed -E '1s/^(\^[]@-_?])+//' > "${stdout_file}.clean" 2>/dev/null \
+        && mv -f "${stdout_file}.clean" "$stdout_file"
+    return "$_rc"
 }
 
 set +e
@@ -224,7 +268,19 @@ if [[ $rc -eq 0 && -z "${content//[$' \t\r\n']/}" && -n "$prompt_file" && "${OCT
     run_agy
     rc=$?
 fi
+# Hardening (not a live-bug fix): if agy died demanding a TTY, retry once under a
+# pseudo-terminal so a first-touch folder-trust TUI on a fresh worktree can't sink an
+# autonomous council seat. Gated on the real error so the working headless path is
+# untouched.
+if [[ "${OCTOPUS_AGY_NO_PTY_FALLBACK:-}" != "1" ]] && (( rc != 0 )) && _agy_tty_error; then
+    echo "agy-exec.sh: agy demanded a TTY; retrying once under a pseudo-terminal (disable with OCTOPUS_AGY_NO_PTY_FALLBACK=1)" >&2
+    run_agy_pty
+    rc=$?
+fi
 set -e
 
+# Surface agy's own stderr (folder-trust notes, diagnostics) that used to flow straight
+# through, now that we capture it to detect the TTY error.
+[[ -s "$stderr_file" ]] && cat "$stderr_file" >&2
 cat "$stdout_file"
 exit "$rc"

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -271,6 +271,66 @@ MOCK_AGY
     fi
 }
 
+test_agy_pty_fallback_salvages_tty_error() {
+    test_case "agy-exec retries under a pseudo-terminal when agy dies demanding a TTY"
+    command -v script >/dev/null 2>&1 || { test_skip "script (PTY allocator) not available"; return 0; }
+
+    local tmp_bin="$TEST_TMP_DIR/agy-pty-bin"
+    mkdir -p "$tmp_bin"
+    # Mimic agy's bubbletea failure: die 'could not open TTY' with NO controlling
+    # terminal, but produce a real answer once a PTY is present.
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+if [ -t 1 ] || [ -t 0 ]; then
+    printf 'reviewed\nVERDICT: APPROVE\n'
+    exit 0
+fi
+echo "bubbletea: could not open TTY" >&2
+exit 1
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+
+    local out rc=0 err="$TEST_TMP_DIR/agy-pty.err"
+    out="$(printf 'review this diff' | OCTOPUS_AGY_FORCE_INLINE=0 \
+        PATH="$tmp_bin:$PATH" bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" 2>"$err")" || rc=$?
+
+    # Salvaged: real verdict returned, exit 0, PTY path announced, and the answer is
+    # byte-clean (no caret-notation ^D echo leaked from the pseudo-terminal).
+    if [[ $rc -eq 0 ]] && [[ "$out" == *"VERDICT: APPROVE"* ]] &&
+       ! printf '%s' "$out" | grep -q '\^D' &&
+       grep -q 'pseudo-terminal' "$err"; then
+        test_pass
+    else
+        test_fail "PTY fallback did not salvage: rc=$rc out=[$(printf '%s' "$out" | tr '\n' '|')] fired=$(grep -q pseudo-terminal "$err" && echo yes || echo no)"
+    fi
+}
+
+test_agy_pty_fallback_opt_out() {
+    test_case "OCTOPUS_AGY_NO_PTY_FALLBACK=1 disables the pseudo-terminal retry"
+
+    local tmp_bin="$TEST_TMP_DIR/agy-pty-off-bin"
+    mkdir -p "$tmp_bin"
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+if [ -t 1 ] || [ -t 0 ]; then printf 'VERDICT: APPROVE\n'; exit 0; fi
+echo "bubbletea: could not open TTY" >&2
+exit 1
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+
+    local out rc=0 err="$TEST_TMP_DIR/agy-pty-off.err"
+    out="$(printf 'review this diff' | OCTOPUS_AGY_NO_PTY_FALLBACK=1 OCTOPUS_AGY_FORCE_INLINE=0 \
+        PATH="$tmp_bin:$PATH" bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" 2>"$err")" || rc=$?
+
+    # With the fallback off, the TTY failure propagates: non-zero exit, no salvage.
+    if [[ $rc -ne 0 ]] && [[ "$out" != *"VERDICT: APPROVE"* ]] &&
+       ! grep -q 'pseudo-terminal' "$err"; then
+        test_pass
+    else
+        test_fail "opt-out still retried: rc=$rc out=[$(printf '%s' "$out" | tr '\n' '|')]"
+    fi
+}
+
 test_gemini_via_agy_option() {
     test_case "OCTOPUS_GEMINI_VIA_AGY serves gemini seats through agy"
 
@@ -911,6 +971,8 @@ test_agy_oversize_payload_skips_gracefully
 test_agy_oversize_ceiling_is_configurable
 test_agy_oversize_uses_documented_default_ceiling
 test_agy_oversize_default_ceiling_dispatches_at_the_limit
+test_agy_pty_fallback_salvages_tty_error
+test_agy_pty_fallback_opt_out
 test_gemini_via_agy_option
 test_agy_dynamic_model_validation
 test_agy_command_validation

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -279,9 +279,15 @@ test_agy_pty_fallback_salvages_tty_error() {
     mkdir -p "$tmp_bin"
     # Mimic agy's bubbletea failure: die 'could not open TTY' with NO controlling
     # terminal, but produce a real answer once a PTY is present.
-    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+cat > "$tmp_bin/agy" <<'MOCK_AGY'
 #!/usr/bin/env bash
 if [ -t 1 ] || [ -t 0 ]; then
+    expected=$'review this diff\npreserve a '\''quoted'\'' token'
+    actual="${!#}"
+    if [[ "$actual" != "$expected" ]]; then
+        printf 'prompt corrupted: <%s>\n' "$actual" >&2
+        exit 3
+    fi
     printf 'reviewed\nVERDICT: APPROVE\n'
     exit 0
 fi
@@ -291,7 +297,7 @@ MOCK_AGY
     chmod +x "$tmp_bin/agy"
 
     local out rc=0 err="$TEST_TMP_DIR/agy-pty.err"
-    out="$(printf 'review this diff' | OCTOPUS_AGY_FORCE_INLINE=0 \
+    out="$(printf '%s' $'review this diff\npreserve a '\''quoted'\'' token' | OCTOPUS_AGY_FORCE_INLINE=0 \
         PATH="$tmp_bin:$PATH" bash "$PROJECT_ROOT/scripts/helpers/agy-exec.sh" 2>"$err")" || rc=$?
 
     # Salvaged: real verdict returned, exit 0, PTY path announced, and the answer is


### PR DESCRIPTION
## Problem

agy (Antigravity CLI) is a [bubbletea](https://github.com/charmbracelet/bubbletea) TUI app. In `--print` mode it's headless, but when it must render an **interactive** screen anyway — a folder-trust prompt on a brand-new worktree, or an auth/login flow — it opens `/dev/tty`. In a session with **no controlling terminal** (the normal case for an autonomous/background council run), that fails with:

```
bubbletea: could not open TTY
```

…before agy produces any answer, so the council seat silently dies. Observed on a first-touch council dispatch into a fresh git worktree.

`--print` + `--dangerously-skip-permissions` are already passed unconditionally (verified — no branch drops them), and the common headless path works fine; this only bites when agy insists on rendering a TUI it would otherwise auto-dismiss.

## Fix

`agy-exec.sh` now:
- **Detects** the specific `could not open TTY` / bubbletea failure in agy's captured stderr/stdout.
- **Retries once under a pseudo-terminal** via `script`, giving the auto-dismissed TUI a terminal to draw on so agy can proceed to the real answer.
- **Gated on the real error** — a blanket "wrap whenever there's no TTY" would fire on *every* autonomous dispatch (which never has a TTY) and leak the pseudo-terminal's control-char echo into the answer. The direct headless path is completely untouched.
- **Cleans the PTY echo** (`\r` / backspace / EOT / a leading run of caret-notation like `^D`) so the salvaged answer is byte-clean for the council response parser.
- **Portable**: BSD `script /dev/null <command…>` (trailing argv — safe for a large `--print` value) and util-linux `script -c` (shell-quoted argv via `printf %q`).
- **Opt out** with `OCTOPUS_AGY_NO_PTY_FALLBACK=1`.

## Verification

- A stub agy that dies `bubbletea: could not open TTY` with no TTY but answers under one → **salvaged clean** (real `VERDICT: APPROVE`, no `^D` junk, exit 0, PTY path announced).
- `OCTOPUS_AGY_NO_PTY_FALLBACK=1` → the failure propagates (no retry), as expected.
- Direct headless dispatch (the working path) is byte-identical — the fallback never fires without the error.
- **agy suite: 42/42.** No file-mode drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes intermittent failures where the Antigravity flow can’t open a TTY by retrying once via a pseudo-terminal when the specific TTY error is detected.
  * Cleans up recovered output to remove terminal/control artifacts that could break parsing.
  * Captures and surfaces the original stderr for troubleshooting.
  * Adds an opt-out setting: `OCTOPUS_AGY_NO_PTY_FALLBACK=1`.
* **Tests**
  * Adds unit coverage for PTY recovery (including clean output) and the opt-out behavior.
* **Documentation**
  * Updates the unreleased changelog with the terminal-retry fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->