### PR TITLE
docs: keep release guidance synchronized

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -2,7 +2,7 @@
 
 # Claude Octopus
 
-**One prompt. Up to nine AI providers checking each other's work.** Claude Octopus turns Claude Code into a multi-LLM orchestration engine — Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, and OpenCode all contribute perspectives, then a 75% consensus gate catches disagreements before they ship.
+**One prompt. Up to ten external AI integrations checking each other's work.** Claude Octopus turns Claude Code into a multi-LLM orchestration engine — Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok all contribute perspectives, then a 75% consensus gate catches disagreements before they ship.
 
 **Claude-native first, Octopus for escalation.** Use Claude-native `/init`, `/review`, and `/security-review` when Claude is enough. Use Octopus when you want multiple model opinions, adversarial review, or stricter multi-LLM workflows.
 
@@ -58,8 +58,8 @@ Don't know the command? Describe what you need — `/octo:auto <anything>` route
 
 - Claude Code v2.1.14+
 - Zero external providers needed (Claude is built in)
-- Optional: Codex CLI, Gemini CLI, Antigravity CLI (`agy`), Copilot, Qwen, Ollama, Perplexity API key, OpenRouter API key
-- Six of nine providers cost nothing extra when you already have the relevant subscriptions or local runtime (OAuth, free tiers, or local)
+- Optional: Codex CLI, Gemini CLI, Antigravity CLI (`agy`), Copilot, Qwen, Ollama, Perplexity API key, OpenRouter API key, OpenCode CLI, and xAI API key (Grok)
+- Five external integrations cost nothing extra when you already have the relevant subscriptions or local runtime (OAuth or local)
 
 ## One Limitation
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -50,6 +50,11 @@ cheaper model tiers, user overrides, and legacy compatibility.
   contract is council, debate, parallel, or multi-provider research.
 - Tests and runtime evidence remain mandatory; redundant prompt-only
   self-verification is removed.
+- Release summaries, model defaults, component counts, runtime compatibility,
+  and provider counts in the public README surfaces are generated from
+  repository sources rather than maintained as duplicated prose.
+- `make sync` repairs README drift and `make sync-check` rejects it. Release
+  preparation updates the changelog first, then runs the same synchronization.
 - `.octo-continue.md` predates this work and is preserved as user-owned state.
 
 ## Tracking Blocker
@@ -77,6 +82,12 @@ could not be claimed or recorded as a new Beads issue.
 - Fresh configs adopt the frontier roster; existing v3 configs and explicit
   model pins remain unchanged.
 - `make sync-check` passes with no script mode changes.
+- `scripts/sync-readme.py` keeps `README.md`, `.claude-plugin/README.md`, and
+  `PRODUCT.md` aligned with plugin metadata, runtime capability gates, model
+  resolver defaults, and the current changelog release.
+- The README release-sync regression suite passes 7/7, including deliberate
+  fixture drift detection and repair; current public model guidance names
+  Opus 5, GPT-5.6 Sol/Terra/Luna, Sonnet 5, and opt-in Fable 5 consistently.
 - The final integrated `make ci-local` passed 16 smoke, 183 unit, and 7
   integration suites, including the live plugin lifecycle test.
 - PRs #678 and #681 passed protected/review checks, including Ubuntu and macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Fixed
 
 - **A council `agy` seat that dies demanding a TTY is salvaged under a pseudo-terminal instead of silently failing.** agy is a bubbletea TUI app; in `--print` mode it is headless, but when it must render an interactive screen anyway — a folder-trust prompt on a brand-new worktree, or an auth flow — it opens `/dev/tty` and, in a session with no controlling terminal, dies with `bubbletea: could not open TTY` before producing an answer, sinking the seat. `agy-exec.sh` now detects that specific failure and retries once under a pseudo-terminal via `script`, so the auto-dismissed (`--dangerously-skip-permissions`) TUI has a terminal to draw on. The fallback is gated on the real error — a blanket no-TTY wrap would fire on every autonomous dispatch (which never has a TTY) and leak the pseudo-terminal's caret-notation echo into the answer — and the salvaged output is stripped of that echo (CR / backspace / EOT / leading caret-notation) so it stays byte-clean for the council response parser. Portable across BSD (`script … command`) and util-linux (`script -c`) `script`; opt out with `OCTOPUS_AGY_NO_PTY_FALLBACK=1`.
+- **Public release guidance now stays synchronized with repository truth.**
+  `make sync` updates the root and plugin READMEs plus `PRODUCT.md` from plugin
+  metadata, model resolver defaults, runtime capability gates, and the
+  changelog; `make sync-check` and release preparation reject future drift.
 
 ## [9.55.1] - 2026-07-27
 

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@ test: test-smoke test-unit
 # Regenerate ALL derived artifacts (run after changing commands/skills/agents or plugin.json)
 # See RELEASING.md step 3 for the artifact-to-generator map.
 sync:
+	@./scripts/sync-readme.py
 	@./scripts/sync-marketplace.sh
 	@./scripts/build-openclaw.sh
 
 # Verify derived artifacts are current (what CI enforces)
 sync-check:
+	@./scripts/sync-readme.py --check
 	@./scripts/sync-marketplace.sh --check
 	@./scripts/build-openclaw.sh --check
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,12 +1,12 @@
 ---
-last_reviewed: 2026-05-25
+last_reviewed: 2026-07-27
 ---
 
 # PRODUCT.md
 
 ## Mission
 
-Put up to 9 AI models on every task so blind spots surface before you ship — not after.
+Put up to 10 external AI integrations on every task so blind spots surface before you ship — not after.
 
 ## Vision
 
@@ -35,17 +35,17 @@ Claude Octopus is a **multi-runtime orchestration plugin** with three architectu
 
 | Layer | What it does | Gap it closes |
 |-------|-------------|---------------|
-| **Provider adapters** (`scripts/orchestrate.sh`, `bin/check-providers.sh`) | Detects, authenticates, and dispatches to up to 9 AI CLIs | Eliminates manual per-provider boilerplate |
+| **Provider adapters** (`scripts/orchestrate.sh`, `bin/check-providers.sh`) | Detects, authenticates, and dispatches to up to 10 external AI integrations | Eliminates manual per-provider boilerplate |
 | **Workflow engine** (`skills/`) | Structures every task into Discover → Define → Develop → Deliver with quality gates | Stops ad-hoc "just ask Claude" from shipping low-confidence output |
 | **Consensus layer** | 75% gate: flags disagreements across providers before code is finalized | The actual blind-spot catcher — surfaces the 1-in-5 case where Claude was wrong |
 
-49 slash commands, 54 skills, 32 specialized personas activate the right layer for the right job.
+50 slash commands, 58 skills, 32 specialized personas activate the right layer for the right job.
 
 ## Core Value Propositions
 
-- **Blind spot elimination:** Any model can be wrong; 9 providers rarely agree on the same wrong answer
+- **Blind spot elimination:** Any model can be wrong; 10 external integrations rarely agree on the same wrong answer
 - **Zero-friction escalation:** Claude-native for ordinary tasks, Octopus for anything that deserves a second opinion
-- **Six providers can cost nothing extra when you already have access:** Codex (OAuth), Gemini (OAuth), Antigravity CLI, Qwen (1K-2K free/day), Copilot (GitHub subscription), Ollama (local) — pay only when you add metered providers such as Perplexity or OpenRouter
+- **Five providers can cost nothing extra when you already have access:** Codex (OAuth), Gemini (OAuth), Antigravity CLI, Copilot (GitHub subscription), and Ollama (local) — Qwen now requires API-key or Coding-Plan auth, while Perplexity and OpenRouter are metered
 - **Dark Factory autonomy:** Spec in, software out — full Discover→Define→Develop→Deliver pipeline without step-by-step prompting
 - **Opinionated four-phase methodology:** Infrastructure plus the workflow that uses it correctly
 
@@ -74,17 +74,17 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 
 ## Evidence
 
-**Traction (as of 2026-05-25):**
-- GitHub stars: 3,410
-- GitHub forks: 302
-- Test suites passing: 117
-- Version: 9.40.3 (active release cadence)
+**Traction (as of 2026-07-27):**
+- GitHub stars: 3,889
+- GitHub forks: 365
+- Local CI parity: 16 smoke, 183 unit, and 7 integration suites
+- Version: 9.55.1 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Cursor (MCP), Gemini CLI
 
 **Measured Impact:**
 - 75% consensus gate: quantifiable disagreement detection before production
 - Token compression (`bin/octo-compress`): ~7,300 tokens saved per session
-- 170+ Claude Code feature flags tracked through v2.1.132
+- 182 Claude Code capability flags tracked through v2.1.219
 
 ## Claude Code 2026 Compatibility Layer (v9.50.0)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Version-9.55.1-blue" alt="Version 9.55.1">
-  <img src="https://img.shields.io/badge/Claude_Code-v2.1.50+_required-blueviolet" alt="Requires Claude Code v2.1.50+">
+  <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
 
@@ -34,12 +34,16 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 
 ## What's New
 
-> 🆕 **v9.50 — Claude Code 2026 compatibility layer.** Routine manifest for scheduled and GitHub-event automations, a SubagentStop quality/cost gate, `/octo:usage` per-provider cost attribution in Claude Code's `/usage` schema, a `worktree.bgIsolation` opt-out for fast direct-edit runs, a Claude Agent SDK seat (`CLAUDE_SDK_API_KEY`, Opus 4.8, 1M context), a four-skill starter pack, and a `/plugin browse` manifest with projected context cost.
-> 🧭 **Frontier routing update.** Opus 5 is the premium lead, GPT-5.6 Sol is the independent implementation/review peer, Sonnet 5 is the standard Claude seat, and Fable 5 remains an opt-in judgment escalation. Existing pins win. See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md).
+<!-- BEGIN CURRENT RELEASE -->
+> 🆕 **v9.55.1 — Opus 5 default routing with GPT-5.6 Codex peer review, opt-in Fable 5 escalation, isolated Tangle verification, and resilient multi-provider councils.**
+>
+> **Default roster:** Claude Opus 5 leads architecture, planning, security reasoning, and final judgment; GPT-5.6 Sol is the independent implementation/review peer; Claude Sonnet 5 is the standard Claude seat; Fable 5 remains an opt-in judgment escalation. Existing model pins and provider configuration still win. See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md).
+<!-- END CURRENT RELEASE -->
 >
 > ```bash
-> /octo:usage --format table        # who spent what, per provider/skill/MCP server
-> OCTOPUS_WORKTREE_BG_ISOLATION=false   # skip worktree cloning for fast runs
+> /octo:model-config                         # inspect or override the frontier roster
+> OCTOPUS_OPUS5_AUTO_XHIGH=1                 # opt in to automatic xhigh Opus 5 phases
+> OCTOPUS_OPUS_MODEL=claude-fable-5          # explicitly opt in to Fable 5
 > ```
 
 > 🆕 **v9.41 — Multi-LLM Council.** `/octo:council` runs a structured 3/5/7-persona deliberation across Claude, Codex, Gemini, and OpenCode with goal modes (`advice`, `decision`, `plan`, `implement`, `review`), styles (`balanced`, `adversarial`, `red-team`, `executive`, `implementation`), benchmark-aware role routing, quorum + critical-veto gates, budget caps, and gated worktree handoff for approved plans. Use it when one model's opinion isn't enough.
@@ -51,9 +55,10 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 
 | Version | Best Features |
 |---------|--------------|
-| **v9.50** (new) | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (Opus 4.8, 1M context), starter skills pack, `/plugin browse` manifest with projected context cost. |
+| **v9.55.1** (new) | Opus 5 default routing with GPT-5.6 Codex peer review, opt-in Fable 5 escalation, isolated Tangle verification, and resilient multi-provider councils. |
+| **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
-| **v9** (current) | Up to 10 external provider integrations (Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 175+ CC feature flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |
+| **v9** (current) | Up to 10 external provider integrations (Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |
 | **v8** | Multi-LLM code review with inline PR comments. Parallel workstreams in isolated git worktrees. Reaction engine — auto-responds to CI failures. 32 specialized personas. Dark Factory autonomous pipeline. |
 | **v7** | Double Diamond workflow. Multi-provider dispatch. Quality gates and consensus scoring. Configurable sandbox modes. |
 
@@ -62,7 +67,9 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 <details>
 <summary>Upgrading to 9.5x</summary>
 
-- The Codex seat's premium default moved from GPT-5.4 to **GPT-5.5** (v9.44+). Pin the old model with `OCTOPUS_CODEX_MODEL=gpt-5.4` if needed.
+<!-- BEGIN CURRENT MODEL DEFAULTS -->
+- Current fresh configurations use **GPT-5.6 Sol** for Codex implementation/review, **Claude Opus 5** for premium Claude work, and **Claude Sonnet 5** for the standard Claude seat. Existing environment, session, and `providers.json` pins remain unchanged; `OCTOPUS_LEGACY_ROLES=1` restores the pre-frontier role mapping.
+<!-- END CURRENT MODEL DEFAULTS -->
 - New claude-sdk seat env vars (v9.50): `CLAUDE_SDK_API_KEY`, `OCTOPUS_CLAUDE_SDK_MODEL`, `OCTOPUS_CLAUDE_SDK_MAX_TOKENS`, `OCTOPUS_CLAUDE_SDK_ALLOWED_MODELS`, `OCTOPUS_CLAUDE_SDK_CONTEXT_BUDGET`.
 - New Fable 5 guard env vars (v9.51): `OCTOPUS_FABLE5_MODE` (auto/off/on), `OCTOPUS_FABLE5_NO_RETRY`. Guards auto-enable only when you pin `claude-fable-5`.
 - Premium Claude role routing (architect, strategist, security-reviewer to Opus) landed in v9.29; restore the older mapping with `OCTOPUS_LEGACY_ROLES=1`.
@@ -82,7 +89,7 @@ claude plugin install octo@nyldn-plugins
 
 That's it. Setup detects installed providers, shows what's missing, and walks you through configuration. You need **zero** external providers to start — Claude is built in.
 
-Claude Code **v2.1.50+** is the minimum supported runtime. Newer Claude Code releases unlock additional Octopus diagnostics and release checks automatically; the current plugin tracks feature flags through **Claude Code v2.1.157**.
+Claude Code **v2.1.14+** is the minimum supported runtime. Newer Claude Code releases unlock additional Octopus diagnostics and release checks automatically; the current plugin tracks 182 Claude Code capability flags through **Claude Code v2.1.219**.
 
 <details>
 <summary>Install for Codex CLI</summary>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,7 +25,9 @@ Run `scripts/release.sh <version> "<summary>"` — it bumps every location below
 | `.cursor-plugin/plugin.json` | `version` |
 | `.factory-plugin/plugin.json` | `version` |
 | `.factory-plugin/marketplace.json` | `metadata.version`, plugin entry `version` + `description` |
-| `README.md` | version badge (line ~15) |
+| `README.md` | version badge, current-release highlight/table row, component counts, model defaults, Claude Code capability floor/ceiling |
+| `.claude-plugin/README.md` | public provider roster, minimum runtime, component counts |
+| `PRODUCT.md` | current release, provider/component counts, Claude Code capability count/ceiling |
 | `CHANGELOG.md` | new `## [X.Y.Z] - YYYY-MM-DD` section (fold Unreleased into it) |
 
 ## 3. Regenerate derived artifacts (`make sync`)
@@ -34,14 +36,17 @@ Do NOT hand-edit these; CI diffs them against their generators:
 
 | Generated artifact | Generator | CI check that fails if stale |
 |--------------------|-----------|------------------------------|
+| `README.md`, `.claude-plugin/README.md`, `PRODUCT.md` mechanical release facts | `./scripts/sync-readme.py` | `tests/unit/test-readme-release-sync.sh` and `make sync-check` |
 | `.claude-plugin/marketplace.json` (octo entry description + counts) | `./scripts/sync-marketplace.sh` | Smoke job step "Verify marketplace.json is up to date" |
 | `openclaw/src/tools/index.ts` | `./scripts/build-openclaw.sh` | `tests/unit/test-openclaw-compat.sh` |
 
 Rules learned the hard way:
 - The marketplace generator derives the feature summary from `plugin.json`'s `description` and appends its own component counts ("32 personas, N commands, N skills"). To change the marketplace blurb, edit `plugin.json`'s description and run `make sync` — never edit `marketplace.json` directly. Never hand-write counts into `plugin.json`'s description; the generator appends them and `--check` will fail on the collision (the v9.50 description did this and shipped doubled counts until v9.51).
-- README body prose counts must match `plugin.json`: the "**N commands** ... **N skills**" sentence (README ~line 28) and the "[All N skills]" link (~line 367) are asserted by `tests/unit/test-docs-sync.sh`.
+- The README generator derives the current release copy from `plugin.json`, model defaults from `scripts/lib/model-resolver.sh`, and Claude Code floor/ceiling facts from `scripts/orchestrate.sh` plus `scripts/lib/providers.sh`. Keep the `CURRENT RELEASE` and `CURRENT MODEL DEFAULTS` markers intact, plus exactly one version-table row marked `(new)`.
+- README body prose counts must match `plugin.json`: the "**N commands** ... **N skills**" sentence and the "[All N skills]" link are asserted by `tests/unit/test-docs-sync.sh`.
 
-`make sync` runs both generators; `make sync-check` runs both `--check` modes.
+`make sync` runs all generators; `make sync-check` runs every corresponding
+check mode.
 
 ## 4. Validate locally with CI parity
 

--- a/commands/model-config.md
+++ b/commands/model-config.md
@@ -72,7 +72,7 @@ Then display a compact dashboard:
 
 Providers                          Status
   🔵 Claude (Sonnet/Opus)          Built-in ✓
-  🔴 Codex (GPT-5.4)              [Installed ✓ / Missing ✗]  → current: <model>
+  🔴 Codex (GPT-5.6 Sol)          [Installed ✓ / Missing ✗]  → current: <model>
   🟡 Gemini                        [Installed ✓ / Missing ✗]  → current: <model>
   🧭 Antigravity (`agy`)           [Installed ✓ / Missing ✗]  → current: <model>
   🟣 Perplexity                    [Configured ✓ / Not set]
@@ -92,7 +92,7 @@ Only show providers that are installed or configured. Don't show rows for provid
 
 ## STEP 2: Route by Arguments
 
-**If arguments were provided** (e.g., `/octo:model-config codex gpt-5.4`), skip the interactive flow and execute the CLI-style command directly per the EXECUTION CONTRACT at the bottom.
+**If arguments were provided** (e.g., `/octo:model-config codex gpt-5.6-sol`), skip the interactive flow and execute the CLI-style command directly per the EXECUTION CONTRACT at the bottom.
 
 **If no arguments**, proceed to the interactive wizard:
 
@@ -157,9 +157,9 @@ AskUserQuestion({
     header: "Codex Model",
     multiSelect: false,
     options: [
-      {label: "gpt-5.4", description: "Flagship — 400K context, $2.50/$15 MTok, best for complex tasks"},
-      {label: "gpt-5.4 (fast/spark)", description: "1000+ tok/s — 128K context, Pro-only, best for reviews & iteration"},
-      {label: "gpt-5.4-mini", description: "Budget — 400K context, $0.25/$2 MTok, great for simple tasks"},
+      {label: "gpt-5.6-sol", description: "Frontier — 1M context, $5/$30 MTok, best for implementation and independent review"},
+      {label: "gpt-5.6-terra", description: "Balanced — 1M context, $2.50/$15 MTok, strong general-purpose Codex seat"},
+      {label: "gpt-5.6-luna", description: "Budget — 1M context, $1/$6 MTok, best for quick checks and prototypes"},
       {label: "o3", description: "Reasoning — 200K context, $2/$8 MTok, deep analysis & trade-offs"},
       {label: "Custom", description: "Enter a custom model name"}
     ]
@@ -245,8 +245,8 @@ AskUserQuestion({
     multiSelect: false,
     options: [
       // Show cross-provider options
-      {label: "codex:default (gpt-5.4)", description: "Deep reasoning, complex tasks"},
-      {label: "codex:spark (gpt-5.4 fast)", description: "15x faster, good for iteration"},
+      {label: "codex:default (gpt-5.6-sol)", description: "Frontier implementation and independent review"},
+      {label: "codex:spark (gpt-5.6-luna)", description: "Budget-friendly quick checks and iteration"},
       {label: "codex:reasoning (o3)", description: "Deep analysis with chain-of-thought"},
       {label: "gemini:default", description: "Broad research, creative approaches"},
       {label: "gemini:flash", description: "Fast, low-cost"},
@@ -297,7 +297,7 @@ AskUserQuestion({
     options: [
       // Only show installed/configured providers
       {label: "🔵 Claude (Sonnet 5 / Opus 5)", description: "Moderator — instruction-following, synthesis"},
-      {label: "🔴 Codex (GPT-5.4)", description: "Technical depth — architecture, implementation"},
+      {label: "🔴 Codex (GPT-5.6 Sol)", description: "Independent implementation and edge-case review"},
       {label: "🟡 Gemini", description: "Ecosystem perspective — alternatives, trends"},
       {label: "🧭 Antigravity (agy)", description: "Alternate model perspective via Antigravity CLI"},
       {label: "🟠 OpenRouter: GLM-5", description: "Code review specialist — quality focus"},
@@ -344,7 +344,7 @@ AskUserQuestion({
     header: "Cost Mode",
     multiSelect: false,
     options: [
-      {label: "💰 Budget", description: "Use cheapest models: gpt-5.4-mini, gemini-flash — best for prototyping"},
+      {label: "💰 Budget", description: "Use cheapest models: gpt-5.6-luna, gemini-flash — best for prototyping"},
       {label: "⚖️ Standard (current default)", description: "Balanced: use your configured defaults"},
       {label: "🚀 Premium", description: "Use best available models for every task — higher cost, best quality"}
     ]
@@ -438,7 +438,7 @@ AskUserQuestion({
     multiSelect: false,
     options: [
       {label: "Reset all", description: "Restore all providers and routing to defaults"},
-      {label: "Reset Codex only", description: "Reset Codex to gpt-5.4 default"},
+      {label: "Reset Codex only", description: "Reset Codex to gpt-5.6-sol default"},
       {label: "Reset Gemini only", description: "Reset Gemini to gemini-3.1-pro-preview default"},
       {label: "Reset phase routing only", description: "Restore default phase-to-model mapping"},
       {label: "Cancel", description: "Go back without changing anything"}
@@ -470,7 +470,7 @@ AskUserQuestion({
 
 ## CLI-STYLE EXECUTION CONTRACT (for direct arguments)
 
-When invoked WITH arguments (e.g., `/octo:model-config codex gpt-5.4`), skip the interactive flow and execute directly:
+When invoked WITH arguments (e.g., `/octo:model-config codex gpt-5.6-sol`), skip the interactive flow and execute directly:
 
 1. **Parse arguments** to determine action:
    - `show phases` → Display formatted phase routing table

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This document explains how Claude Octopus orchestrates multiple AI providers and
 
 ## Overview
 
-Claude Octopus coordinates **nine AI providers** to give you multi-perspective analysis:
+Claude Octopus coordinates **ten external AI integrations** alongside its built-in Claude host to give you multi-perspective analysis. The diagram shows the representative execution path; the full roster follows it.
 
 ```
     +------------------+
@@ -42,8 +42,9 @@ Claude Octopus coordinates **nine AI providers** to give you multi-perspective a
 | **Copilot** *(optional)* | `copilot -p` | GitHub models (Claude/GPT/Gemini) | GitHub Copilot subscription |
 | **Qwen** *(optional)* | `qwen -p` | Qwen3-Coder | `QWEN_API_KEY` or Coding-Plan auth |
 | **OpenCode** *(optional)* | `opencode run` | Multi-provider router | Your OpenCode auth |
+| **Grok** *(optional)* | OpenAI-compatible API | Grok models | Your `XAI_API_KEY` |
 
-> **Note:** Models are as of April 2026. The orchestrate.sh script uses the latest available models. Only Claude is required — all others are optional and auto-detected.
+> **Note:** Models are as of July 2026. The orchestrate.sh script uses the latest supported models. Only Claude is required — all others are optional and auto-detected.
 
 ### Role → Model Mapping (v9.29+)
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -236,10 +236,12 @@ with open(path, 'w') as f:
 print(f'   {path}')
 "
 
-# Regenerate marketplace and OpenClaw artifacts from their source files.
-make sync
-
 octo_release_update_changelog CHANGELOG.md "$VERSION" "$DATE" "$SUMMARY"
+
+# Regenerate README, marketplace, and OpenClaw artifacts from their source
+# files. The changelog entry must exist first so README sync can derive the
+# release date for PRODUCT.md.
+make sync
 
 echo ""
 
@@ -249,7 +251,7 @@ echo "2/8 Committing..."
 if [[ "$ON_RELEASE_BRANCH" == "false" ]]; then
     git checkout -b "$BRANCH" --quiet
 fi
-git add package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .claude-plugin/plugin-manifest.json .claude-plugin/routines.json .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json .factory-plugin/marketplace.json README.md CHANGELOG.md
+git add package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .claude-plugin/plugin-manifest.json .claude-plugin/routines.json .claude-plugin/README.md .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json .factory-plugin/marketplace.json README.md PRODUCT.md CHANGELOG.md
 git commit --quiet -m "chore: release v${VERSION} — ${SUMMARY}
 
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"

--- a/scripts/sync-readme.py
+++ b/scripts/sync-readme.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Synchronize mechanical release facts across public README surfaces.
+
+The plugin manifest and runtime capability/model resolvers are the source of
+truth. Run without arguments to update files, or with --check to fail when a
+tracked surface has drifted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+CURRENT_RELEASE_START = "<!-- BEGIN CURRENT RELEASE -->"
+CURRENT_RELEASE_END = "<!-- END CURRENT RELEASE -->"
+CURRENT_MODELS_START = "<!-- BEGIN CURRENT MODEL DEFAULTS -->"
+CURRENT_MODELS_END = "<!-- END CURRENT MODEL DEFAULTS -->"
+
+PUBLIC_EXTERNAL_PROVIDERS = (
+    ("Codex", "Codex CLI"),
+    ("Gemini", "Gemini CLI"),
+    ("Antigravity CLI", "Antigravity CLI (`agy`)"),
+    ("Copilot", "Copilot"),
+    ("Qwen", "Qwen"),
+    ("Ollama", "Ollama"),
+    ("Perplexity", "Perplexity API key"),
+    ("OpenRouter", "OpenRouter API key"),
+    ("OpenCode", "OpenCode CLI"),
+    ("Grok", "xAI API key (Grok)"),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repository root (defaults to the script's parent repository)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report drift without writing files",
+    )
+    return parser.parse_args()
+
+
+def require_match(pattern: str, text: str, label: str, flags: int = 0) -> re.Match[str]:
+    match = re.search(pattern, text, flags)
+    if not match:
+        raise ValueError(f"unable to derive {label}")
+    return match
+
+
+def replace_marker_block(
+    text: str,
+    start: str,
+    end: str,
+    body: str,
+    label: str,
+) -> str:
+    pattern = rf"{re.escape(start)}.*?{re.escape(end)}"
+    replacement = f"{start}\n{body.rstrip()}\n{end}"
+    updated, count = re.subn(pattern, replacement, text, count=1, flags=re.DOTALL)
+    if count != 1:
+        raise ValueError(f"{label} markers are missing or duplicated")
+    return updated
+
+
+def function_echo_values(shell_text: str, function_name: str) -> list[str]:
+    block = require_match(
+        rf"^{re.escape(function_name)}\(\) \{{\n(.*?)^\}}",
+        shell_text,
+        function_name,
+        re.MULTILINE | re.DOTALL,
+    ).group(1)
+    return re.findall(r'echo "([^"$]+)"', block)
+
+
+def display_model(model: str) -> str:
+    if model.startswith("claude-"):
+        words = model.removeprefix("claude-").split("-")
+        return "Claude " + " ".join(word.capitalize() for word in words)
+    if model.startswith("gpt-"):
+        words = model.split("-")
+        return "GPT-" + words[1] + "".join(
+            f" {word.capitalize()}" for word in words[2:]
+        )
+    return model
+
+
+def semver_key(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in value.split("."))
+
+
+def release_summary(description: str, version: str) -> str:
+    summary = re.sub(
+        rf"^v{re.escape(version)}\s*[-—]\s*",
+        "",
+        description.strip(),
+    )
+    summary = re.sub(r"\s*Run /octo:setup\.\s*$", "", summary)
+    return summary.rstrip().rstrip(".")
+
+
+def markdown_table_text(value: str) -> str:
+    return value.replace("|", r"\|")
+
+
+def human_join(values: tuple[str, ...]) -> str:
+    if len(values) < 2:
+        return "".join(values)
+    return f"{', '.join(values[:-1])}, and {values[-1]}"
+
+
+def number_word(value: int) -> str:
+    words = {
+        0: "zero",
+        1: "one",
+        2: "two",
+        3: "three",
+        4: "four",
+        5: "five",
+        6: "six",
+        7: "seven",
+        8: "eight",
+        9: "nine",
+        10: "ten",
+        11: "eleven",
+        12: "twelve",
+    }
+    return words.get(value, str(value))
+
+
+def derive_facts(root: Path) -> dict[str, object]:
+    plugin = json.loads((root / ".claude-plugin/plugin.json").read_text())
+    version = plugin["version"]
+    summary = release_summary(plugin["description"], version)
+    command_count = len(plugin.get("commands", []))
+    skill_count = len(plugin.get("skills", []))
+    persona_count = len(list((root / "agents/personas").glob("*.md")))
+
+    orchestrate = (root / "scripts/orchestrate.sh").read_text()
+    providers = (root / "scripts/lib/providers.sh").read_text()
+    resolver = (root / "scripts/lib/model-resolver.sh").read_text()
+
+    minimum_version = require_match(
+        r'local min_version="([0-9]+\.[0-9]+\.[0-9]+)"',
+        orchestrate,
+        "minimum Claude Code version",
+    ).group(1)
+    capability_flags = set(
+        re.findall(r"^(SUPPORTS_[A-Z0-9_]+)=(?:false|true)\b", orchestrate, re.MULTILINE)
+    )
+    capability_versions = re.findall(
+        r'version_compare "\$CLAUDE_CODE_VERSION" "([0-9]+\.[0-9]+\.[0-9]+)"',
+        providers,
+    )
+    if not capability_flags or not capability_versions:
+        raise ValueError("unable to derive Claude Code capability facts")
+    capability_ceiling = max(capability_versions, key=semver_key)
+
+    opus_models = function_echo_values(resolver, "opus_default_model")
+    sonnet_models = function_echo_values(resolver, "sonnet_default_model")
+    codex_models = function_echo_values(resolver, "codex_default_model")
+    if not opus_models or not sonnet_models or not codex_models:
+        raise ValueError("current model resolver functions have no model values")
+
+    changelog = (root / "CHANGELOG.md").read_text()
+    release_date = require_match(
+        rf"^## \[{re.escape(version)}\] - ([0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}})$",
+        changelog,
+        f"release date for {version}",
+        re.MULTILINE,
+    ).group(1)
+
+    return {
+        "version": version,
+        "summary": summary,
+        "command_count": command_count,
+        "skill_count": skill_count,
+        "persona_count": persona_count,
+        "minimum_version": minimum_version,
+        "capability_count": len(capability_flags),
+        "capability_ceiling": capability_ceiling,
+        "opus_model": opus_models[0],
+        "sonnet_model": sonnet_models[0],
+        "codex_model": codex_models[0],
+        "release_date": release_date,
+        "provider_count": len(PUBLIC_EXTERNAL_PROVIDERS),
+        "provider_names": human_join(tuple(item[0] for item in PUBLIC_EXTERNAL_PROVIDERS)),
+        "provider_prerequisites": human_join(
+            tuple(item[1] for item in PUBLIC_EXTERNAL_PROVIDERS)
+        ),
+    }
+
+
+def sync_main_readme(text: str, facts: dict[str, object]) -> str:
+    version = str(facts["version"])
+    summary = str(facts["summary"])
+    command_count = int(facts["command_count"])
+    skill_count = int(facts["skill_count"])
+    persona_count = int(facts["persona_count"])
+    minimum = str(facts["minimum_version"])
+    capability_count = int(facts["capability_count"])
+    ceiling = str(facts["capability_ceiling"])
+    opus = display_model(str(facts["opus_model"]))
+    sonnet = display_model(str(facts["sonnet_model"]))
+    codex = display_model(str(facts["codex_model"]))
+    provider_count = int(facts["provider_count"])
+    provider_names = str(facts["provider_names"])
+    provider_word = number_word(provider_count)
+
+    text = re.sub(r"Version-[0-9]+\.[0-9]+\.[0-9]+-blue", f"Version-{version}-blue", text)
+    text = re.sub(r"Version [0-9]+\.[0-9]+\.[0-9]+", f"Version {version}", text)
+    text = re.sub(
+        r"Claude_Code-v[0-9]+\.[0-9]+\.[0-9]+\+_required",
+        f"Claude_Code-v{minimum}+_required",
+        text,
+    )
+    text = re.sub(
+        r"Requires Claude Code v[0-9]+\.[0-9]+\.[0-9]+\+",
+        f"Requires Claude Code v{minimum}+",
+        text,
+    )
+    text = re.sub(
+        r"\*\*\d+ specialized personas\*\*",
+        f"**{persona_count} specialized personas**",
+        text,
+    )
+    text = re.sub(r"\*\*\d+ commands\*\*", f"**{command_count} commands**", text)
+    text = re.sub(r"\*\*\d+ skills\*\*", f"**{skill_count} skills**", text)
+    text = re.sub(r"\[All \d+ skills\]", f"[All {skill_count} skills]", text)
+    provider_intro = (
+        f"Every AI model has blind spots. Claude Octopus supports {provider_word} external "
+        f"provider integrations — {provider_names} — alongside the built-in Claude Code "
+        "host, with consensus gates that flag disagreements before you ship."
+    )
+    text, provider_intro_count = re.subn(
+        r"^Every AI model has blind spots\..*$",
+        provider_intro,
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if provider_intro_count != 1:
+        raise ValueError("main README provider introduction is missing")
+    text = re.sub(
+        r"with (?:[a-z]+|\d+) external providers checking the host's work",
+        f"with {provider_word} external providers checking the host's work",
+        text,
+    )
+    text = re.sub(
+        r"Adds up to (?:[a-z]+|\d+) external provider integrations\.",
+        f"Adds up to {provider_word} external provider integrations.",
+        text,
+    )
+    text = re.sub(
+        r"Up to \d+ external provider integrations \(.*?\) alongside the Claude Code host",
+        (
+            f"Up to {provider_count} external provider integrations "
+            f"({provider_names}) alongside the Claude Code host"
+        ),
+        text,
+    )
+
+    release_body = (
+        f"> 🆕 **v{version} — {summary}.**\n"
+        ">\n"
+        f"> **Default roster:** {opus} leads architecture, planning, security reasoning, "
+        f"and final judgment; {codex} is the independent implementation/review peer; "
+        f"{sonnet} is the standard Claude seat; Fable 5 remains an opt-in judgment "
+        "escalation. Existing model pins and provider configuration still win. "
+        "See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md)."
+    )
+    text = replace_marker_block(
+        text,
+        CURRENT_RELEASE_START,
+        CURRENT_RELEASE_END,
+        release_body,
+        "current release",
+    )
+    text, release_row_count = re.subn(
+        r"^\| \*\*v[0-9]+\.[0-9]+\.[0-9]+\*\* \(new\) \|.*\|$",
+        f"| **v{version}** (new) | {markdown_table_text(summary)}. |",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if release_row_count != 1:
+        raise ValueError("current release table row is missing or duplicated")
+
+    model_body = (
+        f"- Current fresh configurations use **{codex}** for Codex implementation/review, "
+        f"**{opus}** for premium Claude work, and **{sonnet}** for the standard Claude "
+        "seat. Existing environment, session, and `providers.json` pins remain unchanged; "
+        "`OCTOPUS_LEGACY_ROLES=1` restores the pre-frontier role mapping."
+    )
+    text = replace_marker_block(
+        text,
+        CURRENT_MODELS_START,
+        CURRENT_MODELS_END,
+        model_body,
+        "current model defaults",
+    )
+
+    text = re.sub(
+        r"\d+\+ (?:CC|Claude Code) (?:feature|capability) flags through v[0-9]+\.[0-9]+\.[0-9]+",
+        f"{capability_count} Claude Code capability flags through v{ceiling}",
+        text,
+    )
+    text = re.sub(
+        (
+            r"current plugin tracks(?: \d+ Claude Code capability flags| feature flags) "
+            r"through \*\*Claude Code v[0-9]+\.[0-9]+\.[0-9]+\*\*"
+        ),
+        (
+            f"current plugin tracks {capability_count} Claude Code capability flags "
+            f"through **Claude Code v{ceiling}**"
+        ),
+        text,
+    )
+    text = re.sub(
+        r"Claude Code \*\*v[0-9]+\.[0-9]+\.[0-9]+\+\*\* is the minimum supported runtime",
+        f"Claude Code **v{minimum}+** is the minimum supported runtime",
+        text,
+    )
+    return text
+
+
+def sync_plugin_readme(text: str, facts: dict[str, object]) -> str:
+    command_count = int(facts["command_count"])
+    skill_count = int(facts["skill_count"])
+    persona_count = int(facts["persona_count"])
+    minimum = str(facts["minimum_version"])
+    provider_count = int(facts["provider_count"])
+    providers = str(facts["provider_names"])
+    prerequisites = str(facts["provider_prerequisites"])
+
+    provider_word = number_word(provider_count)
+    first_paragraph = (
+        f"**One prompt. Up to {provider_word} external AI integrations checking each "
+        "other's work.** Claude Octopus turns Claude Code into a multi-LLM orchestration "
+        f"engine — {providers} all contribute perspectives, then a 75% consensus gate "
+        "catches disagreements before they ship."
+    )
+    text, count = re.subn(
+        r"\*\*One prompt\..*?before they ship\.",
+        first_paragraph,
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+    if count != 1:
+        raise ValueError("plugin README provider introduction is missing")
+    text = re.sub(r"\b\d+ commands\b", f"{command_count} commands", text)
+    text = re.sub(r"\b\d+ skills\b", f"{skill_count} skills", text)
+    text = re.sub(r"\b\d+ specialized personas\b", f"{persona_count} specialized personas", text)
+    text = re.sub(r"\ball \d+ commands\b", f"all {command_count} commands", text)
+    text = re.sub(
+        r"Claude Code v[0-9]+\.[0-9]+\.[0-9]+\+",
+        f"Claude Code v{minimum}+",
+        text,
+    )
+    text, prerequisite_count = re.subn(
+        r"^- Optional: .*$",
+        f"- Optional: {prerequisites}",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if prerequisite_count != 1:
+        raise ValueError("plugin README optional provider list is missing")
+    return text
+
+
+def sync_product(text: str, facts: dict[str, object]) -> str:
+    version = str(facts["version"])
+    command_count = int(facts["command_count"])
+    skill_count = int(facts["skill_count"])
+    persona_count = int(facts["persona_count"])
+    capability_count = int(facts["capability_count"])
+    ceiling = str(facts["capability_ceiling"])
+    release_date = str(facts["release_date"])
+    provider_count = int(facts["provider_count"])
+
+    text = re.sub(r"^last_reviewed: [0-9-]+$", f"last_reviewed: {release_date}", text, flags=re.MULTILINE)
+    text = re.sub(
+        r"\bup to \d+ (?:AI models|AI CLIs|external AI integrations)\b",
+        f"up to {provider_count} external AI integrations",
+        text,
+    )
+    text = re.sub(
+        r"\b\d+ slash commands, \d+ skills, \d+ specialized personas\b",
+        f"{command_count} slash commands, {skill_count} skills, {persona_count} specialized personas",
+        text,
+    )
+    text = re.sub(
+        r"\b\d+ (?:providers|external integrations) rarely agree\b",
+        f"{provider_count} external integrations rarely agree",
+        text,
+    )
+    text = re.sub(
+        r"^- Version: [0-9]+\.[0-9]+\.[0-9]+ \(active release cadence\)$",
+        f"- Version: {version} (active release cadence)",
+        text,
+        flags=re.MULTILINE,
+    )
+    text = re.sub(
+        r"^- \d+\+ Claude Code feature flags tracked through v[0-9]+\.[0-9]+\.[0-9]+$",
+        f"- {capability_count} Claude Code capability flags tracked through v{ceiling}",
+        text,
+        flags=re.MULTILINE,
+    )
+    return text
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.resolve()
+
+    try:
+        facts = derive_facts(root)
+        transforms = {
+            root / "README.md": sync_main_readme,
+            root / ".claude-plugin/README.md": sync_plugin_readme,
+            root / "PRODUCT.md": sync_product,
+        }
+        drifted: list[Path] = []
+        updates: dict[Path, str] = {}
+        for path, transform in transforms.items():
+            original = path.read_text()
+            expected = transform(original, facts)
+            if expected != original:
+                drifted.append(path)
+                updates[path] = expected
+    except (FileNotFoundError, KeyError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: README sync failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.check:
+        if drifted:
+            for path in drifted:
+                print(f"STALE: {path.relative_to(root)}", file=sys.stderr)
+            print("Run ./scripts/sync-readme.py", file=sys.stderr)
+            return 1
+        print(
+            "OK: README release facts are synchronized "
+            f"(v{facts['version']}, {facts['capability_count']} capabilities through "
+            f"v{facts['capability_ceiling']})"
+        )
+        return 0
+
+    for path, expected in updates.items():
+        path.write_text(expected)
+        print(f"UPDATED: {path.relative_to(root)}")
+    if not updates:
+        print("OK: README release facts already synchronized")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/skill-parallel-agents/SKILL.md
+++ b/skills/skill-parallel-agents/SKILL.md
@@ -594,13 +594,13 @@ The `tangle` phase enforces quality gates:
 
 | Agent | Model | Best For |
 |-------|-------|----------|
-| `codex` | gpt-5.3-codex | Complex code, deep refactoring (premium default) |
-| `codex-standard` | gpt-5.2-codex | Standard tier implementation |
-| `codex-mini` | gpt-5.4-mini | Quick fixes, simple tasks |
-| `gemini` | gemini-3-pro-preview | Deep analysis, 1M context |
+| `codex` | gpt-5.6-sol | Frontier implementation and independent review |
+| `codex-standard` | gpt-5.6-terra | Balanced implementation and review |
+| `codex-mini` | gpt-5.6-luna | Quick fixes, simple tasks |
+| `gemini` | gemini-3.1-pro-preview | Deep analysis, 1M context |
 | `gemini-fast` | gemini-3-flash-preview | Speed-critical tasks |
 | `gemini-image` | gemini-3-pro-image-preview | Image generation |
-| `codex-review` | gpt-5.2-codex | Code review mode |
+| `codex-review` | gpt-5.6-sol | Code review mode |
 | `openrouter` | Various | Universal fallback (400+ models) |
 
 ## Provider-Aware Routing (v4.8)

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -759,8 +759,8 @@ test_agy_slash_command_visibility() {
        grep -q 'Antigravity CLI' "$PROJECT_ROOT/.claude/skills/skill-debate/SKILL.md" && \
        grep -q 'Antigravity CLI' "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md" && \
        grep -q 'Antigravity CLI' "$PROJECT_ROOT/SECURITY.md" && \
-       grep -q 'up to 9 AI CLIs' "$PROJECT_ROOT/PRODUCT.md" && \
-       grep -q 'Six providers can cost nothing extra' "$PROJECT_ROOT/PRODUCT.md" && \
+       grep -q 'up to 10 external AI integrations' "$PROJECT_ROOT/PRODUCT.md" && \
+       grep -q 'Five providers can cost nothing extra' "$PROJECT_ROOT/PRODUCT.md" && \
        grep -q 'codex gemini agy' "$PROJECT_ROOT/tests/test-fleet-diversity.sh" && \
        grep -q 'codex, gemini, agy' "$PROJECT_ROOT/tests/unit/test-research-fanout-static.sh"; then
         test_pass

--- a/tests/unit/test-readme-release-sync.sh
+++ b/tests/unit/test-readme-release-sync.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=tests/helpers/test-framework.sh
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "README Release Sync"
+
+SYNC_SCRIPT="$PROJECT_ROOT/scripts/sync-readme.py"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-readme-sync-test.XXXXXX")"
+CURRENT_VERSION="$(jq -r '.version' "$PROJECT_ROOT/.claude-plugin/plugin.json")"
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+make_fixture() {
+    local root="$1"
+
+    mkdir -p \
+        "$root/.claude-plugin" \
+        "$root/agents/personas" \
+        "$root/scripts/lib"
+
+    cp "$PROJECT_ROOT/README.md" "$root/README.md"
+    cp "$PROJECT_ROOT/PRODUCT.md" "$root/PRODUCT.md"
+    cp "$PROJECT_ROOT/CHANGELOG.md" "$root/CHANGELOG.md"
+    cp "$PROJECT_ROOT/.claude-plugin/plugin.json" "$root/.claude-plugin/plugin.json"
+    cp "$PROJECT_ROOT/.claude-plugin/README.md" "$root/.claude-plugin/README.md"
+    cp "$PROJECT_ROOT/scripts/orchestrate.sh" "$root/scripts/orchestrate.sh"
+    cp "$PROJECT_ROOT/scripts/lib/model-resolver.sh" "$root/scripts/lib/model-resolver.sh"
+    cp "$PROJECT_ROOT/scripts/lib/providers.sh" "$root/scripts/lib/providers.sh"
+    cp "$PROJECT_ROOT/agents/personas/"*.md "$root/agents/personas/"
+}
+
+if [[ -x "$SYNC_SCRIPT" ]]; then
+    test_case "sync-readme.py exists and is executable"
+    test_pass
+else
+    test_case "sync-readme.py exists and is executable"
+    test_fail "missing executable README sync helper"
+fi
+
+test_case "tracked README surfaces are synchronized"
+if "$SYNC_SCRIPT" --check >/tmp/octo-readme-sync-check.out 2>&1; then
+    test_pass
+else
+    test_fail "README sync check failed: $(cat /tmp/octo-readme-sync-check.out 2>/dev/null)"
+fi
+
+fixture="$TMP_DIR/fixture"
+make_fixture "$fixture"
+
+python3 - "$fixture" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1])
+readme = root / "README.md"
+text = readme.read_text()
+text = re.sub(r"Version-\d+\.\d+\.\d+-blue", "Version-0.0.0-blue", text)
+text = re.sub(r"Version \d+\.\d+\.\d+", "Version 0.0.0", text)
+text = text.replace(
+    "supports ten external provider integrations",
+    "supports nine external provider integrations",
+    1,
+)
+text = text.replace(
+    "<!-- BEGIN CURRENT RELEASE -->",
+    "<!-- BEGIN CURRENT RELEASE -->\n> stale release copy",
+    1,
+)
+text = re.sub(
+    r"current plugin tracks \d+ Claude Code capability flags through "
+    r"\*\*Claude Code v\d+\.\d+\.\d+\*\*",
+    "current plugin tracks feature flags through **Claude Code v2.1.157**",
+    text,
+)
+readme.write_text(text)
+
+plugin_readme = root / ".claude-plugin/README.md"
+plugin_text = plugin_readme.read_text()
+plugin_text = re.sub(
+    r"^- Optional: .*$",
+    "- Optional: Codex CLI and Gemini CLI",
+    plugin_text,
+    count=1,
+    flags=re.MULTILINE,
+)
+plugin_readme.write_text(plugin_text)
+
+product = root / "PRODUCT.md"
+product_text = product.read_text()
+product_text = product_text.replace(
+    "up to 10 external AI integrations",
+    "up to 9 AI CLIs",
+)
+product.write_text(product_text)
+PY
+
+test_case "--check rejects deliberately stale README facts"
+if "$SYNC_SCRIPT" --root "$fixture" --check >/tmp/octo-readme-sync-stale.out 2>&1; then
+    test_fail "stale fixture unexpectedly passed"
+else
+    test_pass
+fi
+
+test_case "sync repairs release, model, count, and capability facts"
+if "$SYNC_SCRIPT" --root "$fixture" >/tmp/octo-readme-sync-update.out 2>&1 &&
+   "$SYNC_SCRIPT" --root "$fixture" --check >/tmp/octo-readme-sync-recheck.out 2>&1 &&
+   grep -q "Version-${CURRENT_VERSION}-blue" "$fixture/README.md" &&
+   grep -q "v${CURRENT_VERSION}.*(new)" "$fixture/README.md" &&
+   grep -q 'supports ten external provider integrations.*Grok' "$fixture/README.md" &&
+   grep -q 'GPT-5.6 Sol' "$fixture/README.md" &&
+   grep -q 'Claude Opus 5' "$fixture/README.md" &&
+   grep -q 'Claude Sonnet 5' "$fixture/README.md" &&
+   grep -qE '[0-9]+ Claude Code capability flags through.*v[0-9]+\.[0-9]+\.[0-9]+' "$fixture/README.md" &&
+   grep -q 'OpenCode CLI, and xAI API key (Grok)' "$fixture/.claude-plugin/README.md" &&
+   grep -q 'up to 10 external AI integrations' "$fixture/PRODUCT.md" &&
+   ! grep -qE 'Version-0\.0\.0-blue|stale release copy|v2\.1\.157' "$fixture/README.md"; then
+    test_pass
+else
+    test_fail "sync did not restore the expected README facts"
+fi
+
+test_case "release workflow regenerates and stages synchronized docs"
+release_commit_block="$(sed -n '/^echo "2\/8 Committing\.\.\."/,/^git commit /p' "$PROJECT_ROOT/scripts/release.sh")"
+changelog_line="$(grep -n '^octo_release_update_changelog ' "$PROJECT_ROOT/scripts/release.sh" | cut -d: -f1)"
+sync_line="$(grep -n '^make sync$' "$PROJECT_ROOT/scripts/release.sh" | cut -d: -f1)"
+if grep -q 'scripts/sync-readme.py' "$PROJECT_ROOT/Makefile" &&
+   grep -q 'scripts/sync-readme.py --check' "$PROJECT_ROOT/Makefile" &&
+   grep -q 'PRODUCT.md' <<<"$release_commit_block" &&
+   grep -q '\.claude-plugin/README.md' <<<"$release_commit_block" &&
+   [[ -n "$changelog_line" && -n "$sync_line" && "$changelog_line" -lt "$sync_line" ]]; then
+    test_pass
+else
+    test_fail "release workflow does not regenerate and stage every synchronized doc surface"
+fi
+
+test_case "current model configuration guidance uses the frontier roster"
+if grep -q 'gpt-5.6-sol' "$PROJECT_ROOT/commands/model-config.md" &&
+   grep -q 'gpt-5.6-terra' "$PROJECT_ROOT/commands/model-config.md" &&
+   grep -q 'gpt-5.6-luna' "$PROJECT_ROOT/commands/model-config.md" &&
+   ! grep -qE 'GPT-5\.4|gpt-5\.4' "$PROJECT_ROOT/commands/model-config.md"; then
+    test_pass
+else
+    test_fail "model-config command still presents pre-GPT-5.6 defaults"
+fi
+
+test_case "public documentation names all ten external integrations"
+if grep -q 'ten external provider integrations' "$PROJECT_ROOT/README.md" &&
+   grep -q 'Up to ten external AI integrations' "$PROJECT_ROOT/.claude-plugin/README.md" &&
+   grep -q 'Grok' "$PROJECT_ROOT/.claude-plugin/README.md" &&
+   grep -q 'ten external AI integrations' "$PROJECT_ROOT/docs/ARCHITECTURE.md"; then
+    test_pass
+else
+    test_fail "provider count/list differs across public documentation"
+fi
+
+test_summary


### PR DESCRIPTION
## Description

Updates every public README/product surface to the v9.55.1 frontier roster and adds a source-driven synchronizer so future releases update mechanical facts automatically. Release preparation now updates the changelog before synchronization and stages every generated documentation surface.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring

## Documentation consistency
- Root README, plugin README, PRODUCT, architecture, model-config, and parallel-agent model guidance now agree on Opus 5, GPT-5.6 Sol/Terra/Luna, Sonnet 5, opt-in Fable 5, ten external integrations, and current component/capability counts.
- `scripts/sync-readme.py` derives release/model/runtime/count facts from repository sources.
- `make sync`, `make sync-check`, and `scripts/release.sh` enforce the same generated state.
- `AI_AGENT_HANDOFF.md` records the decision and resume path for Claude Code, Codex, and other harnesses.

## Checklist
- [x] Shell scripts pass syntax/static checks
- [x] OpenClaw registry and marketplace are in sync
- [x] Documentation updated
- [x] CHANGELOG updated
- [x] No existing script mode changes

## Testing
- `make sync-check`
- `tests/unit/test-readme-release-sync.sh` (7/7)
- `tests/unit/test-agy-provider.sh` (40/40)
- `tests/unit/test-docs-sync.sh` (135/135)
- `tests/unit/test-shared-marketplace-sync.sh` (13/13)
- `make test-integration` (7/7 suites)
- full local matrix: 16/16 smoke; 183/184 unit suites before correcting the sole stale PRODUCT assertion, then corrected suite 40/40

## Related Issues

Beads write tracking is blocked by the repository schema migration gate; no migration was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support and documentation to **up to ten** external AI integrations, including **Grok** and **OpenCode**.
  * Updated **Codex** model defaults/options to the **GPT-5.6** lineup.

* **Documentation**
  * Refreshed product/architecture guidance and provider/prerequisite details (including updated timing/scope and revised cost/no-cost integration counts).
  * Enhanced release notes guidance so public docs stay consistent across the main release documents.

* **Tests**
  * Added automated coverage for release/doc synchronization and drift detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->