### PR TITLE
fix: resolve v9.56.0 review follow-ups

### DIFF
--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,9 +1,9 @@
 # AI Agent Handoff
 
 Last updated: 2026-07-27
-Status: v9.55.1 released; no open delivery work
+Status: v9.56.0 released; no open delivery work
 Branch: `main`
-Release: https://github.com/nyldn/claude-octopus/releases/tag/v9.55.1
+Release: https://github.com/nyldn/claude-octopus/releases/tag/v9.56.0
 
 ## Start Here
 
@@ -55,6 +55,11 @@ cheaper model tiers, user overrides, and legacy compatibility.
   repository sources rather than maintained as duplicated prose.
 - `make sync` repairs README drift and `make sync-check` rejects it. Release
   preparation updates the changelog first, then runs the same synchronization.
+- Public test-suite counts are derived from the same `test-*.sh` discovery used
+  by the smoke, unit, and integration runners.
+- Review findings are fixed on the release branch before merge; review comments
+  marked addressed are still checked against the actual head rather than
+  accepted as evidence.
 - `.octo-continue.md` predates this work and is preserved as user-owned state.
 
 ## Tracking Blocker
@@ -68,8 +73,9 @@ could not be claimed or recorded as a new Beads issue.
 
 - Public `main` includes the Council reliability queue, Tangle PRs #672-#675,
   and the Opus 5 routing squash from PR #678 (`972d9597`).
-- Release v9.55.1 contains the complete integration and corrected marketplace
-  metadata; it is the resume baseline.
+- Release v9.56.0 contains the complete Opus 5/GPT-5.6 documentation sync,
+  agy PTY salvage, and full-project security/correctness/performance review; it
+  is the resume baseline.
 - Installed Claude Code: 2.1.220.
 - Installed Codex CLI: 0.145.0.
 - Upstream model policy: `nyldn/fable5-optimizer` v2.0.0.
@@ -78,27 +84,27 @@ could not be claimed or recorded as a new Beads issue.
 - Latest focused evidence: Opus routing 21/21, Fable mode 27/27,
   SubagentStop 8/8, Tangle run-worktree 13/13, and verification-only 10/10.
 - The final #675 head passed protected smoke, unit, and integration gates on
-  Ubuntu and macOS; the complete local unit matrix passed 183/183.
+  Ubuntu and macOS.
 - Fresh configs adopt the frontier roster; existing v3 configs and explicit
   model pins remain unchanged.
 - `make sync-check` passes with no script mode changes.
 - `scripts/sync-readme.py` keeps `README.md`, `.claude-plugin/README.md`, and
   `PRODUCT.md` aligned with plugin metadata, runtime capability gates, model
-  resolver defaults, and the current changelog release.
+  resolver defaults, test discovery, and the current changelog release.
 - The README release-sync regression suite passes 7/7, including deliberate
   fixture drift detection and repair; current public model guidance names
   Opus 5, GPT-5.6 Sol/Terra/Luna, Sonnet 5, and opt-in Fable 5 consistently.
-- The final integrated `make ci-local` passed 16 smoke, 183 unit, and 7
+- The final integrated `make ci-local` passed 16 smoke, 185 unit, and 7
   integration suites, including the live plugin lifecycle test.
-- PRs #678 and #681 passed protected/review checks, including Ubuntu and macOS
-  unit matrices; the v9.55.0 and v9.55.1 release PRs passed their required
-  protected gates.
+- PRs #683, #684, and #685 passed protected/review checks, including Ubuntu and
+  macOS unit matrices; the v9.56.0 release PR passed its required protected
+  gates after all CodeRabbit findings were verified against the rebased head.
 
 ## Merge Queue
 
 - Merged: #656, #658, #664, #666, #667, #668, #669, #670, #672, #673, #674,
-  #675, #678, #681, release PR #677 (v9.54.2), release PR #680 (v9.55.0), and
-  release PR #682 (v9.55.1).
+  #675, #678, #681, #683, #684, release PR #677 (v9.54.2), release PR #680
+  (v9.55.0), release PR #682 (v9.55.1), and release PR #685 (v9.56.0).
 - No public or private pull requests or issues remained open at release.
 - Private E2E issue classification fix merged in
   `nyldn/claude-octopus-dev#4`; the target VPS remains unreachable over SSH, so

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-27
 Status: v9.56.0 released; no open delivery work
 Branch: `main`
 Release: https://github.com/nyldn/claude-octopus/releases/tag/v9.56.0
+Release squash: `7a5d44e5d46efd3e906b21de83ef9c3e8e6e1d1b` (pushed to
+`upstream/main`)
+Tag target: `v9.56.0` resolves to the same post-squash commit and is pushed
 
 ## Start Here
 
@@ -76,6 +79,9 @@ could not be claimed or recorded as a new Beads issue.
 - Release v9.56.0 contains the complete Opus 5/GPT-5.6 documentation sync,
   agy PTY salvage, and full-project security/correctness/performance review; it
   is the resume baseline.
+- The release squash and `v9.56.0` tag both resolve to
+  `7a5d44e5d46efd3e906b21de83ef9c3e8e6e1d1b` on public `main`. The commit,
+  tag, and GitHub release were verified after the squash merge.
 - Installed Claude Code: 2.1.220.
 - Installed Codex CLI: 0.145.0.
 - Upstream model policy: `nyldn/fable5-optimizer` v2.0.0.
@@ -88,6 +94,8 @@ could not be claimed or recorded as a new Beads issue.
 - Fresh configs adopt the frontier roster; existing v3 configs and explicit
   model pins remain unchanged.
 - `make sync-check` passes with no script mode changes.
+- The primary checkout's tracked working tree is clean and its only local item
+  is the preserved, user-owned untracked `.octo-continue.md`.
 - `scripts/sync-readme.py` keeps `README.md`, `.claude-plugin/README.md`, and
   `PRODUCT.md` aligned with plugin metadata, runtime capability gates, model
   resolver defaults, test discovery, and the current changelog release.
@@ -104,7 +112,8 @@ could not be claimed or recorded as a new Beads issue.
 
 - Merged: #656, #658, #664, #666, #667, #668, #669, #670, #672, #673, #674,
   #675, #678, #681, #683, #684, release PR #677 (v9.54.2), release PR #680
-  (v9.55.0), release PR #682 (v9.55.1), and release PR #685 (v9.56.0).
+  (v9.55.0), release PR #682 (v9.55.1), release PR #685 (v9.56.0), and review
+  follow-up PR #686.
 - No public or private pull requests or issues remained open at release.
 - Private E2E issue classification fix merged in
   `nyldn/claude-octopus-dev#4`; the target VPS remains unreachable over SSH, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## [Unreleased]
 
+### Security
+
+- Destructive-delete guards cover reversed `rm -fr` / `--force --recursive`
+  flag order and quoted home prefixes with unquoted suffixes such as
+  `"$HOME"/cache`.
+
+### Fixed
+
+- Factory session metadata validates exactly one maturity JSON value, numeric
+  ratios, retry counts, and satisfaction targets, and persists the effective
+  holdout/retry overrides used by `factory_run`.
+- HTTP telemetry setup fails closed when an installed Claude CLI returns no
+  parseable numeric version.
+- The codex smoke probe removes its diagnostic tempfile on every early-return
+  path.
+- Standalone context, agent, and intelligence libraries fail immediately if
+  their shared word-count helper cannot be loaded.
+- Word and provider-recommendation splitting disables globbing and uses a fixed
+  whitespace `IFS`.
+- `set_provider_model` and `reset_provider_model` accept the canonical `agy`
+  provider key used by generated configurations.
+
+### Changed
+
+- README synchronization derives smoke, unit, and integration suite counts from
+  test discovery, keeping `PRODUCT.md` current when coverage grows.
+
+### Tests
+
+- Dedicated regression coverage now exercises factory metadata, destructive
+  delete flag/path forms, telemetry version parsing, fixed-IFS word splitting,
+  `agy` model configuration, and README suite-count drift.
+
 ## [9.56.0] - 2026-07-27
 
 
@@ -11,7 +44,6 @@
 - **`enable-http-telemetry.sh` no longer accepts the bearer token on the command line.** A token in argv lands in shell history and is readable via `ps` by every local process. The token is read from `OCTOPUS_TELEMETRY_BEARER_TOKEN`, and writing it into the Git-tracked `hooks/hooks.json` now requires `--allow-plaintext-token`. **Breaking:** the second positional argument is rejected with an explanatory error.
 - **The sysadmin safety gate covers macOS home paths.** Its `rm -rf` path list was Linux-only (`/home`), so `rm -rf /Users/<you>/...` passed unchallenged on the project's primary platform. `/Users`, `/Library`, `/System`, `/Applications` and a bare `rm -rf /` are now caught.
 - **`run_command` in the OpenAI-compatible agent has guardrails.** `read_file`/`write_file` were confined to the working directory while the shell tool could reach anything the invoking user could. Privilege escalation, download-and-execute, credential-file reads, raw device writes and absolute-path recursive deletes are refused. Set `OPENAI_COMPAT_UNSAFE_COMMANDS=1` to opt out inside a disposable container. This is a guardrail, not a sandbox.
-- Destructive-delete guards also cover reversed `rm -fr` / `--force --recursive` flag order and quoted or braced home paths such as `"$HOME"` and `"${HOME}"`.
 - `resolve_provider_env` validates the variable name before it reaches `bash -c` and `export`.
 - `detect_project_quality_commands` shell-quotes the project path in the strings later passed to `eval`.
 
@@ -27,14 +59,11 @@
 - **`json_extract_multi` returned nothing on macOS.** It used a `local -n` nameref, which needs bash 4.3+, while the project supports bash 3.2 — still `/bin/bash` on macOS. Audit-log and pending-review output rendered with every field blank. Reimplemented with `printf -v`.
 - **`tangle_verify` leaked a temp directory on every run.** Cleanup cleared the caller's `EXIT` trap instead of restoring it, discarding `orchestrate.sh`'s own `$OCTOPUS_TMP_DIR` removal.
 - **Sourced libraries no longer leak shell options.** `provider-allowlist.sh`, `doctor.sh` and `user-config.sh` set `-eo pipefail` at file scope, which persisted in the sourcing shell — including `providers.sh`, which documents itself as source-safe and is full of probes where a nonzero exit is normal.
-- **Factory session metadata is valid and matches the effective run.** `parse_factory_spec` no longer reads `maturity_json` through dynamic scoping, validates JSON, ratios, retry counts, and satisfaction targets before writing, and persists the positional holdout/retry overrides actually used by `factory_run`.
+- **`parse_factory_spec` no longer depends on dynamic scoping.** `maturity_json` was read out of the caller's frame, so any other caller wrote invalid JSON into `session.json`. It is now an explicit argument with a valid default.
 - **Careful mode stopped flagging ordinary pushes.** `git push .*-f` matched any branch name containing `-f` (`release-final`), and patterns were matched against the entire hook payload rather than the extracted command.
 - The `enable-http-telemetry.sh` version guard compares the major component, so a future Claude Code v3.0.0 is no longer rejected as older than v2.1.63.
 - The codex smoke probe skips rather than reporting a false negative when it cannot enter its temporary git repository.
-- The codex smoke probe removes its diagnostic tempfile on every early-return path.
-- Standalone context, agent, and intelligence libraries fail immediately if their shared word-count helper cannot be loaded.
-- Word and provider-recommendation splitting now disables globbing and uses a fixed whitespace `IFS`, so wildcard input or a caller-modified `IFS` cannot change the result.
-- `set_provider_model` and `reset_provider_model` accept the canonical `agy` provider key used by generated configurations.
+- Word-count splitting disables globbing, so a value containing `*` no longer expands to matching filenames.
 
 ### Changed
 
@@ -42,7 +71,6 @@
 - **ShellCheck is an enforcing CI gate.** The step ended in `|| true` and had accumulated 406 unread warnings, two of which pinpointed the allowlist and jq defects above. The codebase is at zero with `SC2034`, `SC2155`, `SC1090` and `SC1091` excluded as stylistic.
 - **One source of truth for the model-resolution cache path** (`scripts/lib/model-cache-path.sh`). `model-resolver.sh` honoured `$TMPDIR` while `provider-routing.sh` and `octo-model-config.sh` hardcoded `/tmp`, so on macOS the writer and the invalidating `rm -f` addressed different files.
 - `set_provider_model` and `reset_provider_model` derive their matchers and messages from a single `OCTO_MODEL_CONFIG_PROVIDERS` list; the reset message had already drifted, omitting `openai-compatible` and `openai-tools`.
-- README synchronization derives the smoke, unit, and integration suite counts from test discovery, keeping `PRODUCT.md` current when coverage grows.
 
 ### Performance
 
@@ -54,7 +82,6 @@
 - `test-review-run.sh` exercises the retry classifier's behaviour instead of grepping the source for its name.
 - `test-pr-review-state.sh` fixture variables are renamed so a name collision can no longer mask a broken jq filter.
 - `test-openclaw-compat.sh` scans the shipped `skills/` tree as well as `.claude/skills/`.
-- Factory metadata, destructive-delete flag ordering, quoted home paths, fixed-IFS word splitting, `agy` model configuration, and README suite-count drift have dedicated regression coverage.
 
 ## [9.55.1] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Security
 
 - Destructive-delete guards cover reversed and mixed short/long recursive-force
-  options (including uppercase `-R`) and quoted home prefixes with unquoted
-  suffixes such as `"$HOME"/cache`.
+  options (including uppercase `-R`), long options with attached values such as
+  `--preserve-root=all`, and quoted home prefixes with unquoted suffixes such as
+  `"$HOME"/cache`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Security
 
-- Destructive-delete guards cover reversed `rm -fr` / `--force --recursive`
-  flag order and quoted home prefixes with unquoted suffixes such as
-  `"$HOME"/cache`.
+- Destructive-delete guards cover reversed and mixed short/long recursive-force
+  options (including uppercase `-R`) and quoted home prefixes with unquoted
+  suffixes such as `"$HOME"/cache`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **`enable-http-telemetry.sh` no longer accepts the bearer token on the command line.** A token in argv lands in shell history and is readable via `ps` by every local process. The token is read from `OCTOPUS_TELEMETRY_BEARER_TOKEN`, and writing it into the Git-tracked `hooks/hooks.json` now requires `--allow-plaintext-token`. **Breaking:** the second positional argument is rejected with an explanatory error.
 - **The sysadmin safety gate covers macOS home paths.** Its `rm -rf` path list was Linux-only (`/home`), so `rm -rf /Users/<you>/...` passed unchallenged on the project's primary platform. `/Users`, `/Library`, `/System`, `/Applications` and a bare `rm -rf /` are now caught.
 - **`run_command` in the OpenAI-compatible agent has guardrails.** `read_file`/`write_file` were confined to the working directory while the shell tool could reach anything the invoking user could. Privilege escalation, download-and-execute, credential-file reads, raw device writes and absolute-path recursive deletes are refused. Set `OPENAI_COMPAT_UNSAFE_COMMANDS=1` to opt out inside a disposable container. This is a guardrail, not a sandbox.
+- Destructive-delete guards also cover reversed `rm -fr` / `--force --recursive` flag order and quoted or braced home paths such as `"$HOME"` and `"${HOME}"`.
 - `resolve_provider_env` validates the variable name before it reaches `bash -c` and `export`.
 - `detect_project_quality_commands` shell-quotes the project path in the strings later passed to `eval`.
 
@@ -26,11 +27,14 @@
 - **`json_extract_multi` returned nothing on macOS.** It used a `local -n` nameref, which needs bash 4.3+, while the project supports bash 3.2 — still `/bin/bash` on macOS. Audit-log and pending-review output rendered with every field blank. Reimplemented with `printf -v`.
 - **`tangle_verify` leaked a temp directory on every run.** Cleanup cleared the caller's `EXIT` trap instead of restoring it, discarding `orchestrate.sh`'s own `$OCTOPUS_TMP_DIR` removal.
 - **Sourced libraries no longer leak shell options.** `provider-allowlist.sh`, `doctor.sh` and `user-config.sh` set `-eo pipefail` at file scope, which persisted in the sourcing shell — including `providers.sh`, which documents itself as source-safe and is full of probes where a nonzero exit is normal.
-- **`parse_factory_spec` no longer depends on dynamic scoping.** `maturity_json` was read out of the caller's frame, so any other caller wrote invalid JSON into `session.json`. It is now an explicit argument with a valid default.
+- **Factory session metadata is valid and matches the effective run.** `parse_factory_spec` no longer reads `maturity_json` through dynamic scoping, validates JSON, ratios, retry counts, and satisfaction targets before writing, and persists the positional holdout/retry overrides actually used by `factory_run`.
 - **Careful mode stopped flagging ordinary pushes.** `git push .*-f` matched any branch name containing `-f` (`release-final`), and patterns were matched against the entire hook payload rather than the extracted command.
 - The `enable-http-telemetry.sh` version guard compares the major component, so a future Claude Code v3.0.0 is no longer rejected as older than v2.1.63.
 - The codex smoke probe skips rather than reporting a false negative when it cannot enter its temporary git repository.
-- Word-count splitting disables globbing, so a value containing `*` no longer expands to matching filenames.
+- The codex smoke probe removes its diagnostic tempfile on every early-return path.
+- Standalone context, agent, and intelligence libraries fail immediately if their shared word-count helper cannot be loaded.
+- Word and provider-recommendation splitting now disables globbing and uses a fixed whitespace `IFS`, so wildcard input or a caller-modified `IFS` cannot change the result.
+- `set_provider_model` and `reset_provider_model` accept the canonical `agy` provider key used by generated configurations.
 
 ### Changed
 
@@ -38,6 +42,7 @@
 - **ShellCheck is an enforcing CI gate.** The step ended in `|| true` and had accumulated 406 unread warnings, two of which pinpointed the allowlist and jq defects above. The codebase is at zero with `SC2034`, `SC2155`, `SC1090` and `SC1091` excluded as stylistic.
 - **One source of truth for the model-resolution cache path** (`scripts/lib/model-cache-path.sh`). `model-resolver.sh` honoured `$TMPDIR` while `provider-routing.sh` and `octo-model-config.sh` hardcoded `/tmp`, so on macOS the writer and the invalidating `rm -f` addressed different files.
 - `set_provider_model` and `reset_provider_model` derive their matchers and messages from a single `OCTO_MODEL_CONFIG_PROVIDERS` list; the reset message had already drifted, omitting `openai-compatible` and `openai-tools`.
+- README synchronization derives the smoke, unit, and integration suite counts from test discovery, keeping `PRODUCT.md` current when coverage grows.
 
 ### Performance
 
@@ -49,6 +54,7 @@
 - `test-review-run.sh` exercises the retry classifier's behaviour instead of grepping the source for its name.
 - `test-pr-review-state.sh` fixture variables are renamed so a name collision can no longer mask a broken jq filter.
 - `test-openclaw-compat.sh` scans the shipped `skills/` tree as well as `.claude/skills/`.
+- Factory metadata, destructive-delete flag ordering, quoted home paths, fixed-IFS word splitting, `agy` model configuration, and README suite-count drift have dedicated regression coverage.
 
 ## [9.55.1] - 2026-07-27
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -77,7 +77,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 **Traction (as of 2026-07-27):**
 - GitHub stars: 3,889
 - GitHub forks: 365
-- Local CI parity: 16 smoke, 183 unit, and 7 integration suites
+- Local CI parity: 16 smoke, 185 unit, and 7 integration suites
 - Version: 9.56.0 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Cursor (MCP), Gemini CLI
 

--- a/hooks/sysadmin-safety-gate.sh
+++ b/hooks/sysadmin-safety-gate.sh
@@ -47,7 +47,7 @@ fi
 # /Users is the macOS home root — this list was Linux-only (/home) even though
 # macOS is a primary platform. The trailing alternation also catches a bare
 # root target (`rm -rf /`, `rm -rf /*`), which previously matched nothing.
-RM_OPTION_RE='-[a-zA-Z-]+'
+RM_OPTION_RE='(-[a-zA-Z]+|--[a-zA-Z][a-zA-Z-]*(=[^[:space:]]+)?)'
 RM_RECURSIVE_RE='(-[rR]|--recursive)'
 RM_FORCE_RE='(-f|--force)'
 RM_COMBINED_RE='(-[a-zA-Z]*[rR][a-zA-Z]*f[a-zA-Z]*|-[a-zA-Z]*f[a-zA-Z]*[rR][a-zA-Z]*)'

--- a/hooks/sysadmin-safety-gate.sh
+++ b/hooks/sysadmin-safety-gate.sh
@@ -47,7 +47,13 @@ fi
 # /Users is the macOS home root — this list was Linux-only (/home) even though
 # macOS is a primary platform. The trailing alternation also catches a bare
 # root target (`rm -rf /`, `rm -rf /*`), which previously matched nothing.
-if echo "$COMMAND" | grep -qE '(rm\s+-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|rm\s+-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*|rm\s+--recursive\s+--force|rm\s+--force\s+--recursive|rm\s+-r\s+-f|rm\s+-f\s+-r)\s+([^|;&]*\s)?(/(etc|var|usr|boot|sys|proc|home|Users|Library|System|Applications|opt|bin|sbin)\b|~|\$HOME|\$\{HOME\}|"\$HOME"(/[^[:space:]|;&]*)?|"\$\{HOME\}"(/[^[:space:]|;&]*)?|/(\s|\*|$))'; then
+RM_OPTION_RE='-[a-zA-Z-]+'
+RM_RECURSIVE_RE='(-[rR]|--recursive)'
+RM_FORCE_RE='(-f|--force)'
+RM_COMBINED_RE='(-[a-zA-Z]*[rR][a-zA-Z]*f[a-zA-Z]*|-[a-zA-Z]*f[a-zA-Z]*[rR][a-zA-Z]*)'
+RM_DESTRUCTIVE_RE="rm[[:space:]]+(${RM_COMBINED_RE}|(${RM_OPTION_RE}[[:space:]]+)*${RM_RECURSIVE_RE}[[:space:]]+(${RM_OPTION_RE}[[:space:]]+)*${RM_FORCE_RE}|(${RM_OPTION_RE}[[:space:]]+)*${RM_FORCE_RE}[[:space:]]+(${RM_OPTION_RE}[[:space:]]+)*${RM_RECURSIVE_RE})"
+RM_PROTECTED_PATH_RE='(/(etc|var|usr|boot|sys|proc|home|Users|Library|System|Applications|opt|bin|sbin)\b|~|\$HOME|\$\{HOME\}|"\$HOME"(/[^[:space:]|;&]*)?|"\$\{HOME\}"(/[^[:space:]|;&]*)?|/([[:space:]]|\*|$))'
+if echo "$COMMAND" | grep -qE "${RM_DESTRUCTIVE_RE}[[:space:]]+(${RM_OPTION_RE}[[:space:]]+)*${RM_PROTECTED_PATH_RE}"; then
     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Sysadmin safety gate: destructive rm -rf on system path blocked"}}'
     exit 0
 fi

--- a/hooks/sysadmin-safety-gate.sh
+++ b/hooks/sysadmin-safety-gate.sh
@@ -47,7 +47,7 @@ fi
 # /Users is the macOS home root — this list was Linux-only (/home) even though
 # macOS is a primary platform. The trailing alternation also catches a bare
 # root target (`rm -rf /`, `rm -rf /*`), which previously matched nothing.
-if echo "$COMMAND" | grep -qE '(rm\s+-[a-zA-Z]*r[a-zA-Z]*f|rm\s+--recursive\s+--force|rm\s+-r\s+-f|rm\s+-f\s+-r)\s+([^|;&]*\s)?(/(etc|var|usr|boot|sys|proc|home|Users|Library|System|Applications|opt|bin|sbin)\b|~|\$HOME|/(\s|\*|$))'; then
+if echo "$COMMAND" | grep -qE '(rm\s+-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|rm\s+-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*|rm\s+--recursive\s+--force|rm\s+--force\s+--recursive|rm\s+-r\s+-f|rm\s+-f\s+-r)\s+([^|;&]*\s)?(/(etc|var|usr|boot|sys|proc|home|Users|Library|System|Applications|opt|bin|sbin)\b|~|\$HOME|/(\s|\*|$))'; then
     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Sysadmin safety gate: destructive rm -rf on system path blocked"}}'
     exit 0
 fi

--- a/hooks/sysadmin-safety-gate.sh
+++ b/hooks/sysadmin-safety-gate.sh
@@ -47,7 +47,7 @@ fi
 # /Users is the macOS home root — this list was Linux-only (/home) even though
 # macOS is a primary platform. The trailing alternation also catches a bare
 # root target (`rm -rf /`, `rm -rf /*`), which previously matched nothing.
-if echo "$COMMAND" | grep -qE '(rm\s+-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|rm\s+-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*|rm\s+--recursive\s+--force|rm\s+--force\s+--recursive|rm\s+-r\s+-f|rm\s+-f\s+-r)\s+([^|;&]*\s)?(/(etc|var|usr|boot|sys|proc|home|Users|Library|System|Applications|opt|bin|sbin)\b|~|\$HOME|/(\s|\*|$))'; then
+if echo "$COMMAND" | grep -qE '(rm\s+-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|rm\s+-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*|rm\s+--recursive\s+--force|rm\s+--force\s+--recursive|rm\s+-r\s+-f|rm\s+-f\s+-r)\s+([^|;&]*\s)?(/(etc|var|usr|boot|sys|proc|home|Users|Library|System|Applications|opt|bin|sbin)\b|~|\$HOME|\$\{HOME\}|"\$HOME"(/[^[:space:]|;&]*)?|"\$\{HOME\}"(/[^[:space:]|;&]*)?|/(\s|\*|$))'; then
     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Sysadmin safety gate: destructive rm -rf on system path blocked"}}'
     exit 0
 fi

--- a/scripts/enable-http-telemetry.sh
+++ b/scripts/enable-http-telemetry.sh
@@ -86,8 +86,15 @@ fi
 
 # Version guard: HTTP hooks require Claude Code v2.1.63+
 CC_VERSION=""
+CC_VERSION_OUTPUT=""
 if command -v claude &>/dev/null; then
-    CC_VERSION=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+    CC_VERSION_OUTPUT=$(claude --version 2>&1 || true)
+    CC_VERSION=$(printf '%s\n' "$CC_VERSION_OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+    if [[ -z "$CC_VERSION" ]]; then
+        echo "ERROR: HTTP hooks require a numeric Claude Code version (x.y.z)," >&2
+        echo "  but 'claude --version' returned no parseable version: ${CC_VERSION_OUTPUT:-<empty>}" >&2
+        exit 1
+    fi
 fi
 
 if [[ -n "$CC_VERSION" ]]; then

--- a/scripts/enable-http-telemetry.sh
+++ b/scripts/enable-http-telemetry.sh
@@ -40,7 +40,7 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-BEARER_TOKEN="${OCTOPUS_TELEMETRY_BEARER_TOKEN:-}"
+BEARER_TOKEN=${OCTOPUS_TELEMETRY_BEARER_TOKEN:-}
 
 usage() {
     echo "Usage: enable-http-telemetry.sh <webhook-url> [--allow-plaintext-token]"
@@ -87,10 +87,14 @@ fi
 # Version guard: HTTP hooks require Claude Code v2.1.63+
 CC_VERSION=""
 if command -v claude &>/dev/null; then
-    CC_VERSION=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    CC_VERSION=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
 fi
 
 if [[ -n "$CC_VERSION" ]]; then
+    if [[ ! "$CC_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "ERROR: HTTP hooks require a numeric Claude Code version (x.y.z). Detected: v${CC_VERSION}" >&2
+        exit 1
+    fi
     # Compare all three components. An earlier version of this guard read only
     # minor/patch, so any future major (v3.0.0) was misread as "older than
     # 2.1.63" and rejected outright.

--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -64,8 +64,8 @@ _BLOCKED_COMMAND_PATTERNS = [
     # Destructive recursive deletes outside the working tree
     (r'\brm\s+(?:(?:(?:-[A-Za-z]+|--[A-Za-z-]+)\s+)*(?:-[A-Za-z]*[rR][A-Za-z]*|--recursive)'
      r'(?:\s+(?:-[A-Za-z]+|--[A-Za-z-]+))*)\s+(?:[^\s|;&]+\s+)*'
-     r'(?:"(?:/[^"]*|\$(?:\{HOME\}|HOME)(?:/[^"]*)?)"|'
-     r"'(?:/[^']*|\$(?:\{HOME\}|HOME)(?:/[^']*)?)'|"
+     r'(?:"(?:/[^"]*|\$(?:\{HOME\}|HOME)(?:/[^"]*)?)"(?:/[^\s|;&]*)?|'
+     r"'(?:/[^']*|\$(?:\{HOME\}|HOME)(?:/[^']*)?)'(?:/[^\s|;&]*)?|"
      r'(?:/[^\s|;&]*|~(?:/[^\s|;&]*)?|\$(?:\{HOME\}|HOME)(?:/[^\s|;&]*)?))(?:\s|$)',
      "recursive delete targeting an absolute or home path"),
     # Privilege escalation

--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -62,7 +62,11 @@ def resolve_path(cwd: Path, rel: str) -> Path:
 # container where the blast radius is already bounded).
 _BLOCKED_COMMAND_PATTERNS = [
     # Destructive recursive deletes outside the working tree
-    (r'\brm\s+(-[a-zA-Z]*\s+)*-?[a-zA-Z]*[rR][a-zA-Z]*f?[a-zA-Z]*\s+[^|;&]*(/|~|\$HOME)(\s|$|/)',
+    (r'\brm\s+(?:(?:(?:-[A-Za-z]+|--[A-Za-z-]+)\s+)*(?:-[A-Za-z]*[rR][A-Za-z]*|--recursive)'
+     r'(?:\s+(?:-[A-Za-z]+|--[A-Za-z-]+))*)\s+(?:[^\s|;&]+\s+)*'
+     r'(?:"(?:/[^"]*|\$(?:\{HOME\}|HOME)(?:/[^"]*)?)"|'
+     r"'(?:/[^']*|\$(?:\{HOME\}|HOME)(?:/[^']*)?)'|"
+     r'(?:/[^\s|;&]*|~(?:/[^\s|;&]*)?|\$(?:\{HOME\}|HOME)(?:/[^\s|;&]*)?))(?:\s|$)',
      "recursive delete targeting an absolute or home path"),
     # Privilege escalation
     (r'(^|[|;&]\s*)sudo\s', "sudo"),

--- a/scripts/lib/agents.sh
+++ b/scripts/lib/agents.sh
@@ -15,7 +15,9 @@
 # count_words() lives in lib/utils.sh; pull it in when this file is sourced
 # standalone (tests do) rather than through orchestrate.sh's load order.
 if ! declare -f count_words >/dev/null 2>&1; then
-    source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/utils.sh" 2>/dev/null || true
+    if ! source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/utils.sh"; then
+        return 1 2>/dev/null || exit 1
+    fi
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -655,6 +657,7 @@ show_agent_recommendations() {
     local _had_noglob=false
     case "$-" in *f*) _had_noglob=true ;; esac
     set -f
+    local IFS=$' \t\n'
     # shellcheck disable=SC2206 # deliberate word splitting; globbing disabled above
     local rec_array=($recommendations)
     [[ "$_had_noglob" == "true" ]] || set +f

--- a/scripts/lib/audit.sh
+++ b/scripts/lib/audit.sh
@@ -58,9 +58,8 @@ format_audit_entry() {
     local line="$1"
 
     # Performance: Single-pass JSON extraction using bash regex (no subprocesses).
-    # json_extract_multi writes each field into _<field> via a nameref, so the
-    # targets must be declared here — otherwise the nameref assignment lands in
-    # the global scope and leaks between entries.
+    # json_extract_multi uses Bash 3.x-safe printf -v assignments into each
+    # dynamically named _<field> target, so declare those targets locally.
     local _timestamp="" _action="" _phase="" _decision="" _reviewer=""
     json_extract_multi "$line" timestamp action phase decision reviewer
 
@@ -128,8 +127,8 @@ list_pending_reviews() {
     echo "$pending" | while read -r line; do
         ((count++)) || true
         # Performance: Single-pass JSON extraction (no subprocesses).
-        # Declare the nameref targets so json_extract_multi assigns into this
-        # scope rather than creating globals that persist across iterations.
+        # Declare the printf -v targets locally so dynamically named assignments
+        # do not create globals that persist across iterations.
         local _id="" _phase="" _status="" _output_file="" _created_at=""
         json_extract_multi "$line" id phase status output_file created_at
 

--- a/scripts/lib/context.sh
+++ b/scripts/lib/context.sh
@@ -9,7 +9,9 @@
 # count_words() lives in lib/utils.sh; pull it in when this file is sourced
 # standalone (tests do) rather than through orchestrate.sh's load order.
 if ! declare -f count_words >/dev/null 2>&1; then
-    source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/utils.sh" 2>/dev/null || true
+    if ! source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/utils.sh"; then
+        return 1 2>/dev/null || exit 1
+    fi
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/scripts/lib/factory-spec.sh
+++ b/scripts/lib/factory-spec.sh
@@ -88,7 +88,7 @@ parse_factory_spec() {
         log ERROR "jq is required to validate factory session metadata"
         return 1
     fi
-    if ! printf '%s' "$maturity_json_in" | jq empty >/dev/null 2>&1; then
+    if ! printf '%s' "$maturity_json_in" | jq -e -s 'length == 1' >/dev/null 2>&1; then
         log ERROR "Factory maturity metadata is not valid JSON"
         return 1
     fi

--- a/scripts/lib/factory-spec.sh
+++ b/scripts/lib/factory-spec.sh
@@ -71,15 +71,33 @@ MATEOF
 parse_factory_spec() {
     local spec_path="$1"
     local run_dir="$2"
-    # Maturity JSON from the caller's E27 pre-flight. Previously this was read
-    # straight off the caller's `local maturity_json` via dynamic scoping, so
-    # any other caller silently wrote `"maturity": ,` — invalid JSON — into
-    # session.json. Take it as an argument and keep a valid-JSON default.
-    local maturity_json_in="${3:-${maturity_json:-}}"
+    # Maturity JSON and the effective run parameters come from factory_run.
+    # Keep them explicit so Bash dynamic scoping and environment defaults cannot
+    # make session.json disagree with the run that produced it.
+    local maturity_json_in="${3:-}"
+    local holdout_ratio="${4:-${OCTOPUS_FACTORY_HOLDOUT_RATIO:-0.20}}"
+    local max_retries="${5:-${OCTOPUS_FACTORY_MAX_RETRIES:-1}}"
     [[ -n "$maturity_json_in" ]] || maturity_json_in='{}'
 
     if [[ ! -f "$spec_path" ]]; then
         log ERROR "Factory spec not found: $spec_path"
+        return 1
+    fi
+
+    if ! command -v jq >/dev/null 2>&1; then
+        log ERROR "jq is required to validate factory session metadata"
+        return 1
+    fi
+    if ! printf '%s' "$maturity_json_in" | jq empty >/dev/null 2>&1; then
+        log ERROR "Factory maturity metadata is not valid JSON"
+        return 1
+    fi
+    if [[ ! "$holdout_ratio" =~ ^(0([.][0-9]+)?|1([.]0+)?)$ ]]; then
+        log ERROR "Factory holdout ratio must be numeric and between 0 and 1: $holdout_ratio"
+        return 1
+    fi
+    if [[ ! "$max_retries" =~ ^[0-9]+$ ]]; then
+        log ERROR "Factory max retries must be a non-negative integer: $max_retries"
         return 1
     fi
 
@@ -117,6 +135,10 @@ parse_factory_spec() {
         satisfaction_target="$OCTOPUS_FACTORY_SATISFACTION_TARGET"
         log INFO "Satisfaction target overridden by env: $satisfaction_target"
     fi
+    if [[ ! "$satisfaction_target" =~ ^(0([.][0-9]+)?|1([.]0+)?)$ ]]; then
+        log ERROR "Factory satisfaction target must be numeric and between 0 and 1: $satisfaction_target"
+        return 1
+    fi
 
     # Extract behaviors (lines starting with "### " under Behaviors section, or numbered items)
     local behavior_count
@@ -135,8 +157,8 @@ parse_factory_spec() {
   "satisfaction_target": $satisfaction_target,
   "complexity": "$complexity",
   "behavior_count": $behavior_count,
-  "holdout_ratio": ${OCTOPUS_FACTORY_HOLDOUT_RATIO:-0.20},
-  "max_retries": ${OCTOPUS_FACTORY_MAX_RETRIES:-1},
+  "holdout_ratio": $holdout_ratio,
+  "max_retries": $max_retries,
   "maturity": $maturity_json_in,
   "status": "initialized",
   "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/scripts/lib/factory.sh
+++ b/scripts/lib/factory.sh
@@ -258,8 +258,11 @@ factory_run() {
     # ── Phase 1: Parse spec ──────────────────────────────────────────────
     echo -e "${YELLOW}[1/7]${NC} Parsing factory spec..."
     local satisfaction_target
-    satisfaction_target=$(parse_factory_spec "$spec_path" "$run_dir" "$maturity_json")
-    if [[ $? -ne 0 || -z "$satisfaction_target" ]]; then
+    if ! satisfaction_target=$(parse_factory_spec "$spec_path" "$run_dir" "$maturity_json" "$holdout_ratio" "$max_retries"); then
+        log ERROR "Failed to parse factory spec"
+        return 1
+    fi
+    if [[ -z "$satisfaction_target" ]]; then
         log ERROR "Failed to parse factory spec"
         return 1
     fi

--- a/scripts/lib/intelligence.sh
+++ b/scripts/lib/intelligence.sh
@@ -9,7 +9,9 @@
 # count_words() lives in lib/utils.sh; pull it in when this file is sourced
 # standalone (tests do) rather than through orchestrate.sh's load order.
 if ! declare -f count_words >/dev/null 2>&1; then
-    source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/utils.sh" 2>/dev/null || true
+    if ! source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/utils.sh"; then
+        return 1 2>/dev/null || exit 1
+    fi
 fi
 
 # Source guard — prevent double-loading

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -17,7 +17,7 @@
 # matchers plus two user-facing messages) and they had drifted: the reset error
 # message omitted openai-compatible and openai-tools even though the matcher
 # accepted them. Add a provider here and every site follows.
-OCTO_MODEL_CONFIG_PROVIDERS="codex gemini claude claude-sdk perplexity opencode openrouter atlascloud openai-compatible openai-tools openai-compatible-agent cursor-agent"
+OCTO_MODEL_CONFIG_PROVIDERS="codex gemini agy claude claude-sdk perplexity opencode openrouter atlascloud openai-compatible openai-tools openai-compatible-agent cursor-agent"
 
 octo_model_config_provider_valid() {
     case " ${OCTO_MODEL_CONFIG_PROVIDERS} " in

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -1077,6 +1077,7 @@ _smoke_test_provider() {
 
     if [[ -z "$cmd_str" ]]; then
         echo "SKIP" > "$result_file"
+        rm -f "$stderr_file" 2>/dev/null || true
         return 0
     fi
 
@@ -1094,6 +1095,7 @@ _smoke_test_provider() {
             log DEBUG "Smoke test codex: could not enter temp repo $smoke_dir; skipping"
             rm -rf "$smoke_dir" 2>/dev/null
             echo "SKIP" > "$result_file"
+            rm -f "$stderr_file" 2>/dev/null || true
             return 0
         fi
         # codex cmd_str ends with `-` (stdin prompt); arg form is rejected.

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -117,6 +117,7 @@ count_words() {
     local _cw_had_noglob=false
     case "$-" in *f*) _cw_had_noglob=true ;; esac
     set -f
+    local IFS=$' \t\n'
     # shellcheck disable=SC2206 # deliberate word splitting; globbing disabled above
     local _cw_words=($_cw_str)
     [[ "$_cw_had_noglob" == "true" ]] || set +f

--- a/scripts/sync-readme.py
+++ b/scripts/sync-readme.py
@@ -144,6 +144,12 @@ def derive_facts(root: Path) -> dict[str, object]:
     command_count = len(plugin.get("commands", []))
     skill_count = len(plugin.get("skills", []))
     persona_count = len(list((root / "agents/personas").glob("*.md")))
+    test_suite_counts = {
+        category: len(list((root / "tests" / category).glob("test-*.sh")))
+        for category in ("smoke", "unit", "integration")
+    }
+    if not all(test_suite_counts.values()):
+        raise ValueError("unable to derive local CI suite counts")
 
     orchestrate = (root / "scripts/orchestrate.sh").read_text()
     providers = (root / "scripts/lib/providers.sh").read_text()
@@ -185,6 +191,9 @@ def derive_facts(root: Path) -> dict[str, object]:
         "command_count": command_count,
         "skill_count": skill_count,
         "persona_count": persona_count,
+        "smoke_suite_count": test_suite_counts["smoke"],
+        "unit_suite_count": test_suite_counts["unit"],
+        "integration_suite_count": test_suite_counts["integration"],
         "minimum_version": minimum_version,
         "capability_count": len(capability_flags),
         "capability_ceiling": capability_ceiling,
@@ -388,6 +397,9 @@ def sync_product(text: str, facts: dict[str, object]) -> str:
     ceiling = str(facts["capability_ceiling"])
     release_date = str(facts["release_date"])
     provider_count = int(facts["provider_count"])
+    smoke_suite_count = int(facts["smoke_suite_count"])
+    unit_suite_count = int(facts["unit_suite_count"])
+    integration_suite_count = int(facts["integration_suite_count"])
 
     text = re.sub(r"^last_reviewed: [0-9-]+$", f"last_reviewed: {release_date}", text, flags=re.MULTILINE)
     text = re.sub(
@@ -408,6 +420,15 @@ def sync_product(text: str, facts: dict[str, object]) -> str:
     text = re.sub(
         r"^- Version: [0-9]+\.[0-9]+\.[0-9]+ \(active release cadence\)$",
         f"- Version: {version} (active release cadence)",
+        text,
+        flags=re.MULTILINE,
+    )
+    text = re.sub(
+        r"^- Local CI parity: \d+ smoke, \d+ unit, and \d+ integration suites$",
+        (
+            f"- Local CI parity: {smoke_suite_count} smoke, "
+            f"{unit_suite_count} unit, and {integration_suite_count} integration suites"
+        ),
         text,
         flags=re.MULTILINE,
     )

--- a/tests/smoke/test-safety-hooks.sh
+++ b/tests/smoke/test-safety-hooks.sh
@@ -176,6 +176,12 @@ test_sysadmin_rm_flag_order() {
         'rm -fr /Users/example' \
         'rm --recursive --force /home/example' \
         'rm --force --recursive /home/example' \
+        'rm -r --force /etc' \
+        'rm --force -r /etc' \
+        'rm --recursive -f /etc' \
+        'rm -f --recursive /etc' \
+        'rm -R -f /etc' \
+        'rm -i -R --force /etc' \
         'rm -rf "$HOME"/cache' \
         'rm -rf "${HOME}"/cache'; do
         output=$(jq -cn --arg command "$command" \

--- a/tests/smoke/test-safety-hooks.sh
+++ b/tests/smoke/test-safety-hooks.sh
@@ -175,7 +175,9 @@ test_sysadmin_rm_flag_order() {
         'rm -rf /Users/example' \
         'rm -fr /Users/example' \
         'rm --recursive --force /home/example' \
-        'rm --force --recursive /home/example'; do
+        'rm --force --recursive /home/example' \
+        'rm -rf "$HOME"/cache' \
+        'rm -rf "${HOME}"/cache'; do
         output=$(jq -cn --arg command "$command" \
             '{tool_name:"Bash",tool_input:{command:$command}}' | bash "$SYSADMIN_HOOK")
         if [[ "$output" != *'"permissionDecision":"deny"'* ]]; then

--- a/tests/smoke/test-safety-hooks.sh
+++ b/tests/smoke/test-safety-hooks.sh
@@ -12,6 +12,7 @@ test_suite "Safety Hooks (careful/freeze/guard)"
 
 CAREFUL_HOOK="$PROJECT_ROOT/hooks/careful-check.sh"
 FREEZE_HOOK="$PROJECT_ROOT/hooks/freeze-check.sh"
+SYSADMIN_HOOK="$PROJECT_ROOT/hooks/sysadmin-safety-gate.sh"
 PLUGIN_JSON="$PROJECT_ROOT/.claude-plugin/plugin.json"
 HOOKS_JSON="$PROJECT_ROOT/hooks/hooks.json"
 COMMANDS_DIR="$PROJECT_ROOT/commands"
@@ -167,6 +168,24 @@ test_careful_returns_ask_decision() {
     fi
 }
 
+test_sysadmin_rm_flag_order() {
+    test_case "sysadmin safety gate blocks destructive rm flags in either order"
+    local command output
+    for command in \
+        'rm -rf /Users/example' \
+        'rm -fr /Users/example' \
+        'rm --recursive --force /home/example' \
+        'rm --force --recursive /home/example'; do
+        output=$(jq -cn --arg command "$command" \
+            '{tool_name:"Bash",tool_input:{command:$command}}' | bash "$SYSADMIN_HOOK")
+        if [[ "$output" != *'"permissionDecision":"deny"'* ]]; then
+            test_fail "failed to block: $command"
+            return
+        fi
+    done
+    test_pass
+}
+
 # ── Freeze hook: boundary enforcement ────────────────────────────────
 
 test_freeze_reads_state_file() {
@@ -318,6 +337,7 @@ test_careful_kubectl_delete
 test_careful_docker_destructive
 test_careful_reads_state_file
 test_careful_returns_ask_decision
+test_sysadmin_rm_flag_order
 
 test_freeze_reads_state_file
 test_freeze_checks_file_path

--- a/tests/smoke/test-safety-hooks.sh
+++ b/tests/smoke/test-safety-hooks.sh
@@ -182,6 +182,9 @@ test_sysadmin_rm_flag_order() {
         'rm -f --recursive /etc' \
         'rm -R -f /etc' \
         'rm -i -R --force /etc' \
+        'rm --preserve-root=all -r --force /etc' \
+        'rm -r --preserve-root=all --force /etc' \
+        'rm -rf --preserve-root=all /etc' \
         'rm -rf "$HOME"/cache' \
         'rm -rf "${HOME}"/cache'; do
         output=$(jq -cn --arg command "$command" \

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -32,6 +32,19 @@ test_agy_available_agent() {
     fi
 }
 
+test_agy_model_config_provider() {
+    test_case "model configuration accepts the canonical agy provider key"
+
+    if (
+        source "$PROJECT_ROOT/scripts/lib/provider-routing.sh"
+        octo_model_config_provider_valid agy
+    ) >/dev/null 2>&1; then
+        test_pass
+    else
+        test_fail "agy should be accepted by set/reset model configuration"
+    fi
+}
+
 test_agy_dispatch_native_flags() {
     test_case "dispatch.sh uses native agy helper"
 
@@ -969,6 +982,7 @@ test_provider_workflow_review_regressions() {
 
 test_agy_config_exists
 test_agy_available_agent
+test_agy_model_config_provider
 test_agy_dispatch_native_flags
 test_agy_print_receives_prompt_argument
 test_agy_force_inline_directive_prepended_by_default

--- a/tests/unit/test-cc-version-detection.sh
+++ b/tests/unit/test-cc-version-detection.sh
@@ -556,6 +556,28 @@ else
     fail "Version compare block count: $block_count" "expected >= 29 blocks"
 fi
 
+# The telemetry opt-in script has its own minimum-version gate. An installed
+# CLI with unexpected output must fail closed rather than silently bypassing it.
+telemetry_test_root="$TEST_TMP_DIR/telemetry-version"
+telemetry_mock_bin="$telemetry_test_root/mock-bin"
+mkdir -p "$telemetry_test_root/scripts" "$telemetry_mock_bin"
+cp "$PROJECT_ROOT/scripts/enable-http-telemetry.sh" "$telemetry_test_root/scripts/"
+printf '%s\n' '#!/usr/bin/env bash' 'echo "Claude Code development build"' \
+    > "$telemetry_mock_bin/claude"
+chmod +x "$telemetry_mock_bin/claude"
+telemetry_output="$telemetry_test_root/output.txt"
+if PATH="$telemetry_mock_bin:$PATH" \
+    bash "$telemetry_test_root/scripts/enable-http-telemetry.sh" \
+        "https://example.invalid/hook" >"$telemetry_output" 2>&1; then
+    fail "Telemetry rejects unparseable installed Claude versions" \
+        "unparseable claude --version output bypassed the minimum-version gate"
+elif grep -q "returned no parseable version" "$telemetry_output"; then
+    pass "Telemetry rejects unparseable installed Claude versions"
+else
+    fail "Telemetry rejects unparseable installed Claude versions" \
+        "the version failure was not reported explicitly"
+fi
+
 # ╔══════════════════════════════════════════════════════════════════════╗
 # ║  Summary                                                            ║
 # ╚══════════════════════════════════════════════════════════════════════╝

--- a/tests/unit/test-factory-metadata.sh
+++ b/tests/unit/test-factory-metadata.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=tests/helpers/test-framework.sh
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Factory Session Metadata"
+
+log() { :; }
+OCTOPUS_FACTORY_HOLDOUT_RATIO=0.20
+OCTOPUS_FACTORY_MAX_RETRIES=1
+OCTOPUS_FACTORY_SATISFACTION_TARGET=""
+
+# shellcheck source=scripts/lib/factory-spec.sh
+source "$PROJECT_ROOT/scripts/lib/factory-spec.sh"
+
+SPEC="$TEST_TMP_DIR/factory-spec.md"
+cat > "$SPEC" <<'SPEC'
+# Factory specification
+
+Complexity: complicated
+Satisfaction Target: 0.90
+
+## Behaviors
+### Produce the requested artifact
+SPEC
+
+test_case "session metadata persists effective positional factory parameters"
+RUN_DIR="$TEST_TMP_DIR/effective"
+mkdir -p "$RUN_DIR"
+if target=$(parse_factory_spec "$SPEC" "$RUN_DIR" '{"level":"Mature"}' 0.35 3) &&
+   [[ "$target" == "0.90" ]] &&
+   jq -e '.holdout_ratio == 0.35 and .max_retries == 3 and .maturity.level == "Mature"' \
+       "$RUN_DIR/session.json" >/dev/null; then
+    test_pass
+else
+    test_fail "session.json did not preserve the effective run parameters"
+fi
+
+test_case "invalid maturity JSON is rejected before session metadata is written"
+RUN_DIR="$TEST_TMP_DIR/invalid-maturity"
+mkdir -p "$RUN_DIR"
+if parse_factory_spec "$SPEC" "$RUN_DIR" '{bad json' 0.20 1 >/dev/null 2>&1 ||
+   [[ -e "$RUN_DIR/session.json" ]]; then
+    test_fail "malformed maturity metadata should fail without writing session.json"
+else
+    test_pass
+fi
+
+test_case "invalid ratios and retries are rejected before session metadata is written"
+invalid_values_rejected=true
+for values in '1.5 1' 'word 1' '0.20 -1' '0.20 1.5'; do
+    read -r ratio retries <<<"$values"
+    RUN_DIR="$TEST_TMP_DIR/invalid-${ratio//[^A-Za-z0-9]/_}-${retries//[^A-Za-z0-9]/_}"
+    mkdir -p "$RUN_DIR"
+    if parse_factory_spec "$SPEC" "$RUN_DIR" '{}' "$ratio" "$retries" >/dev/null 2>&1 ||
+       [[ -e "$RUN_DIR/session.json" ]]; then
+        invalid_values_rejected=false
+    fi
+done
+if [[ "$invalid_values_rejected" == "true" ]]; then
+    test_pass
+else
+    test_fail "invalid holdout ratio or retry count reached session.json"
+fi
+
+test_case "omitted maturity data no longer reads a dynamically scoped caller variable"
+RUN_DIR="$TEST_TMP_DIR/no-dynamic-scope"
+mkdir -p "$RUN_DIR"
+call_without_maturity_argument() {
+    local maturity_json='{bad json'
+    parse_factory_spec "$SPEC" "$RUN_DIR"
+}
+if call_without_maturity_argument >/dev/null &&
+   jq -e '.maturity == {}' "$RUN_DIR/session.json" >/dev/null; then
+    test_pass
+else
+    test_fail "parse_factory_spec still inherited maturity_json from its caller"
+fi
+
+test_summary

--- a/tests/unit/test-factory-metadata.sh
+++ b/tests/unit/test-factory-metadata.sh
@@ -49,6 +49,16 @@ else
     test_pass
 fi
 
+test_case "multiple top-level maturity JSON values are rejected"
+RUN_DIR="$TEST_TMP_DIR/multiple-maturity-values"
+mkdir -p "$RUN_DIR"
+if parse_factory_spec "$SPEC" "$RUN_DIR" '{} {}' 0.20 1 >/dev/null 2>&1 ||
+   [[ -e "$RUN_DIR/session.json" ]]; then
+    test_fail "multiple JSON documents should fail without writing session.json"
+else
+    test_pass
+fi
+
 test_case "invalid ratios and retries are rejected before session metadata is written"
 invalid_values_rejected=true
 for values in '1.5 1' 'word 1' '0.20 -1' '0.20 1.5'; do

--- a/tests/unit/test-intelligence.sh
+++ b/tests/unit/test-intelligence.sh
@@ -72,6 +72,16 @@ test_db_append_cap() {
     fi
 }
 
+test_count_words_uses_whitespace_ifs() {
+    test_case "count_words ignores a caller-provided non-whitespace IFS"
+
+    local result
+    result=$(IFS=x count_words $'alpha\tbeta gamma')
+    if assert_equals "3" "$result" "Should always split on shell whitespace"; then
+        test_pass
+    fi
+}
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Provider Intelligence Tests
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -713,6 +723,7 @@ test_persona_packs_off() {
 test_db_set_get
 test_db_get_default
 test_db_append_cap
+test_count_words_uses_whitespace_ifs
 
 # Provider Intelligence
 test_record_outcome

--- a/tests/unit/test-openai-compatible-agent.sh
+++ b/tests/unit/test-openai-compatible-agent.sh
@@ -43,6 +43,8 @@ blocked = (
     'rm -rf "$HOME"',
     "rm -rf '${HOME}'",
     'rm -fr "${HOME}/cache"',
+    'rm -rf "$HOME"/cache',
+    'rm -rf "${HOME}"/cache',
     "rm --recursive --force /Users/example",
 )
 assert all(module.command_is_blocked(command) for command in blocked)

--- a/tests/unit/test-openai-compatible-agent.sh
+++ b/tests/unit/test-openai-compatible-agent.sh
@@ -28,6 +28,32 @@ else
     fail "agent scripts have valid syntax" "syntax error"
 fi
 
+test_case "openai-compatible agent blocks quoted home-directory deletes"
+if python3 - "$HELPER" <<'PY'
+import importlib.util
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("openai_compatible_agent", path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+blocked = (
+    'rm -rf "$HOME"',
+    "rm -rf '${HOME}'",
+    'rm -fr "${HOME}/cache"',
+    "rm --recursive --force /Users/example",
+)
+assert all(module.command_is_blocked(command) for command in blocked)
+assert module.command_is_blocked("rm -rf relative-cache") is None
+PY
+then
+    test_pass
+else
+    test_fail "quoted or braced home-directory delete bypassed the command guardrail"
+fi
+
 TEST_HOME="$TEST_TMP_DIR/home"
 mkdir -p "$TEST_HOME"
 

--- a/tests/unit/test-openclaw-compat.sh
+++ b/tests/unit/test-openclaw-compat.sh
@@ -440,10 +440,12 @@ test_no_openclaw_in_skills() {
     local _skill_dir
     for _skill_dir in "$PROJECT_ROOT/skills/" "$PROJECT_ROOT/.claude/skills/"; do
         [[ -d "$_skill_dir" ]] || continue
+        local _skill_label="${_skill_dir#"$PROJECT_ROOT/"}"
+        _skill_label="${_skill_label%/}"
         # Exclude the whole skill-claw/ tree, not just its SKILL.md: sibling
         # files (agents/*.yaml) are equally and intentionally OpenClaw-specific.
         if grep -rl 'openclaw\|OpenClaw' "$_skill_dir" 2>/dev/null | grep -Ev 'skill-claw(\.md$|/)' | head -1 | grep -q .; then
-            found="skills"
+            found="${found:+$found }$_skill_label"
         fi
     done
     if grep -rl 'openclaw\|OpenClaw' "$PROJECT_ROOT/commands/" 2>/dev/null | grep -v 'claw\.md' | head -1 | grep -q .; then

--- a/tests/unit/test-readme-release-sync.sh
+++ b/tests/unit/test-readme-release-sync.sh
@@ -12,6 +12,9 @@ test_suite "README Release Sync"
 SYNC_SCRIPT="$PROJECT_ROOT/scripts/sync-readme.py"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-readme-sync-test.XXXXXX")"
 CURRENT_VERSION="$(jq -r '.version' "$PROJECT_ROOT/.claude-plugin/plugin.json")"
+SMOKE_SUITE_COUNT="$(find "$PROJECT_ROOT/tests/smoke" -maxdepth 1 -name 'test-*.sh' | wc -l | tr -d ' ')"
+UNIT_SUITE_COUNT="$(find "$PROJECT_ROOT/tests/unit" -maxdepth 1 -name 'test-*.sh' | wc -l | tr -d ' ')"
+INTEGRATION_SUITE_COUNT="$(find "$PROJECT_ROOT/tests/integration" -maxdepth 1 -name 'test-*.sh' | wc -l | tr -d ' ')"
 
 cleanup() {
     rm -rf "$TMP_DIR"
@@ -24,7 +27,10 @@ make_fixture() {
     mkdir -p \
         "$root/.claude-plugin" \
         "$root/agents/personas" \
-        "$root/scripts/lib"
+        "$root/scripts/lib" \
+        "$root/tests/smoke" \
+        "$root/tests/unit" \
+        "$root/tests/integration"
 
     cp "$PROJECT_ROOT/README.md" "$root/README.md"
     cp "$PROJECT_ROOT/PRODUCT.md" "$root/PRODUCT.md"
@@ -35,6 +41,12 @@ make_fixture() {
     cp "$PROJECT_ROOT/scripts/lib/model-resolver.sh" "$root/scripts/lib/model-resolver.sh"
     cp "$PROJECT_ROOT/scripts/lib/providers.sh" "$root/scripts/lib/providers.sh"
     cp "$PROJECT_ROOT/agents/personas/"*.md "$root/agents/personas/"
+    local category test_file
+    for category in smoke unit integration; do
+        for test_file in "$PROJECT_ROOT/tests/$category"/test-*.sh; do
+            : > "$root/tests/$category/$(basename "$test_file")"
+        done
+    done
 }
 
 if [[ -x "$SYNC_SCRIPT" ]]; then
@@ -100,6 +112,11 @@ product_text = product_text.replace(
     "up to 10 external AI integrations",
     "up to 9 AI CLIs",
 )
+product_text = re.sub(
+    r"Local CI parity: \d+ smoke, \d+ unit, and \d+ integration suites",
+    "Local CI parity: 1 smoke, 1 unit, and 1 integration suites",
+    product_text,
+)
 product.write_text(product_text)
 PY
 
@@ -122,6 +139,7 @@ if "$SYNC_SCRIPT" --root "$fixture" >/tmp/octo-readme-sync-update.out 2>&1 &&
    grep -qE '[0-9]+ Claude Code capability flags through.*v[0-9]+\.[0-9]+\.[0-9]+' "$fixture/README.md" &&
    grep -q 'OpenCode CLI, and xAI API key (Grok)' "$fixture/.claude-plugin/README.md" &&
    grep -q 'up to 10 external AI integrations' "$fixture/PRODUCT.md" &&
+   grep -q "Local CI parity: ${SMOKE_SUITE_COUNT} smoke, ${UNIT_SUITE_COUNT} unit, and ${INTEGRATION_SUITE_COUNT} integration suites" "$fixture/PRODUCT.md" &&
    ! grep -qE 'Version-0\.0\.0-blue|stale release copy|v2\.1\.157' "$fixture/README.md"; then
     test_pass
 else

--- a/tests/unit/test-review-run.sh
+++ b/tests/unit/test-review-run.sh
@@ -31,7 +31,7 @@ assert_not_contains() {
 # ── parse_review_md fixture ───────────────────────────────────────────────────
 
 TMPDIR_TEST=$(mktemp -d)
-trap 'rm -rf "$TMPDIR_TEST"' EXIT
+trap 'rm -f "$ALL_SRC"; rm -rf "$TMPDIR_TEST"' EXIT
 
 TEST_REVIEW_MD="$TMPDIR_TEST/REVIEW.md"
 cat > "$TEST_REVIEW_MD" <<'EOF'
@@ -115,7 +115,7 @@ assert_contains "$(grep -A2 'commit_id.*headRefOid' "$ALL_SRC" 2>/dev/null | hea
 
 # Behavioural test for the retry classifier, not a grep for its name: the
 # grep passed whether or not the function actually classified anything.
-source "$PROJECT_ROOT/scripts/lib/review.sh" 2>/dev/null || true
+source "$PROJECT_ROOT/scripts/lib/review.sh"
 
 _retry_fixture_dir="$(mktemp -d)"
 _retry_both="$_retry_fixture_dir/both.md"
@@ -126,33 +126,33 @@ _retry_clean="$_retry_fixture_dir/clean.md"
 printf '## Status: OK\nall good\n' > "$_retry_clean"
 
 if review_openai_compat_empty_output_retryable "$_retry_both" "codex"; then
-  assert_contains "retryable" "retryable" "review_run: empty-output + reconnect is retryable"
+  assert_contains "retryable" "^retryable$" "review_run: empty-output + reconnect is retryable"
 else
-  assert_contains "not-retryable" "retryable" "review_run: empty-output + reconnect is retryable"
+  assert_contains "not-retryable" "^retryable$" "review_run: empty-output + reconnect is retryable"
 fi
 
 if review_openai_compat_empty_output_retryable "$_retry_empty_only" "codex"; then
-  assert_contains "retryable" "not-retryable" "review_run: empty output without reconnect is not retryable"
+  assert_contains "retryable" "^not-retryable$" "review_run: empty output without reconnect is not retryable"
 else
-  assert_contains "not-retryable" "not-retryable" "review_run: empty output without reconnect is not retryable"
+  assert_contains "not-retryable" "^not-retryable$" "review_run: empty output without reconnect is not retryable"
 fi
 
 if review_openai_compat_empty_output_retryable "$_retry_clean" "codex"; then
-  assert_contains "retryable" "not-retryable" "review_run: clean output is not retryable"
+  assert_contains "retryable" "^not-retryable$" "review_run: clean output is not retryable"
 else
-  assert_contains "not-retryable" "not-retryable" "review_run: clean output is not retryable"
+  assert_contains "not-retryable" "^not-retryable$" "review_run: clean output is not retryable"
 fi
 
 if review_openai_compat_empty_output_retryable "$_retry_both" "gemini"; then
-  assert_contains "retryable" "not-retryable" "review_run: retry classifier only applies to codex seats"
+  assert_contains "retryable" "^not-retryable$" "review_run: retry classifier only applies to codex seats"
 else
-  assert_contains "not-retryable" "not-retryable" "review_run: retry classifier only applies to codex seats"
+  assert_contains "not-retryable" "^not-retryable$" "review_run: retry classifier only applies to codex seats"
 fi
 
 if review_openai_compat_empty_output_retryable "$_retry_fixture_dir/missing.md" "codex"; then
-  assert_contains "retryable" "not-retryable" "review_run: missing result file is not retryable"
+  assert_contains "retryable" "^not-retryable$" "review_run: missing result file is not retryable"
 else
-  assert_contains "not-retryable" "not-retryable" "review_run: missing result file is not retryable"
+  assert_contains "not-retryable" "^not-retryable$" "review_run: missing result file is not retryable"
 fi
 
 rm -rf "$_retry_fixture_dir"


### PR DESCRIPTION
## Summary

Resolves every actionable follow-up from the v9.56.0 CodeRabbit review that was not present in the squash merge.

- hardens safety and telemetry validation, including flag-order and quoted-path cases
- validates factory session metadata and persists effective run settings
- makes helper sourcing failures explicit and preserves portable word splitting
- keeps README/PRODUCT suite counts derived from the test tree
- adds focused regression coverage for all fixes
- refreshes the durable agent handoff with release decisions and verification evidence

## Verification

- `make sync-check`
- `make ci-local` — 16 smoke, 185 unit, 7 integration suites
- focused safety, telemetry, factory, agy, intelligence, OpenAI-compatible, OpenClaw, README-sync, and review tests
- `git diff --check`
- no unintended executable mode changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Expanded safeguards against destructive recursive delete commands across more flag/order permutations and quoted/home-path target forms (including sysadmin and agent command guards).
  - Telemetry enabling now fails closed when Claude version parsing is not valid.
  - Added stricter validation for factory session metadata inputs.
- **Bug Fixes**
  - Made word splitting/counting independent of caller `IFS`, and tightened whitespace-based recommendation parsing.
  - Improved fail-fast behavior when shared utilities can’t be loaded; ensured temporary stderr files are cleaned up on early exits.
  - Tightened model configuration validation to accept the canonical `agy` provider key.
- **Documentation**
  - README/product evidence “Local CI parity” now reflects derived local smoke/unit/integration counts.
- **Tests**
  - Added/expanded regression tests covering safety hooks, factory metadata, telemetry parsing, whitespace handling, `agy` configuration, and README parity synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->