### PR TITLE
chore: release v9.56.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.56.0"
+    "version": "9.56.1"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.56.0 - Security, correctness and performance fixes from a full-project code review. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
-      "version": "9.56.0",
+      "description": "v9.56.1 - Harden release guardrails and close review findings. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
+      "version": "9.56.1",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": "2026-06",
   "name": "octo",
   "displayName": "Claude Octopus",
-  "version": "9.56.0",
+  "version": "9.56.1",
   "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
   "author": {
     "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.56.0",
-  "description": "v9.56.0 \u2014 Security, correctness and performance fixes from a full-project code review. Run /octo:setup.",
+  "version": "9.56.1",
+  "description": "v9.56.1 \u2014 Harden release guardrails and close review findings. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Claude Octopus routine manifest (v9.56.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "$comment": "Claude Octopus routine manifest (v9.56.1). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
   "schemaVersion": 1,
   "routines": [
     {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.56.0",
+  "version": "9.56.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.56.0",
+  "version": "9.56.1",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.56.0"
+    "version": "9.56.1"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.56.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 50 commands, 58 skills. Run /octo:setup after install.",
-      "version": "9.56.0",
+      "description": "v9.56.1 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 50 commands, 58 skills. Run /octo:setup after install.",
+      "version": "9.56.1",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.56.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.56.0. 32 expert personas, 50 commands, 58 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.56.1",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.56.1. 32 expert personas, 50 commands, 58 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 - README synchronization derives smoke, unit, and integration suite counts from
   test discovery, keeping `PRODUCT.md` current when coverage grows.
+- Release automation waits for the real macOS CI duration, squash-merges release
+  PRs, and pushes an annotated tag on the post-squash commit before publishing.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@
 
 - README synchronization derives smoke, unit, and integration suite counts from
   test discovery, keeping `PRODUCT.md` current when coverage grows.
-- Release automation waits for the real macOS CI duration, squash-merges release
-  PRs, and pushes an annotated tag on the post-squash commit before publishing.
+- Release automation waits for the real macOS CI duration, fails closed on
+  actionable review state, squash-merges release PRs, verifies the exact
+  post-squash main commit, and only then pushes an annotated tag and publishes.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [9.56.1] - 2026-07-27
+
+
 ### Security
 
 - Destructive-delete guards cover reversed and mixed short/long recursive-force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@
 - README synchronization derives smoke, unit, and integration suite counts from
   test discovery, keeping `PRODUCT.md` current when coverage grows.
 - Release automation waits for the real macOS CI duration, fails closed on
-  actionable review state, squash-merges release PRs, verifies the exact
-  post-squash main commit, and only then pushes an annotated tag and publishes.
+  anything short of explicit approval or on any paginated unresolved thread,
+  squash-merges release PRs, boundedly verifies the exact post-squash main
+  commit, and only then pushes an annotated tag and publishes.
 
 ### Tests
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -78,7 +78,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 - GitHub stars: 3,889
 - GitHub forks: 365
 - Local CI parity: 16 smoke, 185 unit, and 7 integration suites
-- Version: 9.56.0 (active release cadence)
+- Version: 9.56.1 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Cursor (MCP), Gemini CLI
 
 **Measured Impact:**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 <p align="center">
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/Version-9.56.0-blue" alt="Version 9.56.0">
+  <img src="https://img.shields.io/badge/Version-9.56.1-blue" alt="Version 9.56.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -35,7 +35,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 ## What's New
 
 <!-- BEGIN CURRENT RELEASE -->
-> 🆕 **v9.56.0 — Security, correctness and performance fixes from a full-project code review.**
+> 🆕 **v9.56.1 — Harden release guardrails and close review findings.**
 >
 > **Default roster:** Claude Opus 5 leads architecture, planning, security reasoning, and final judgment; GPT-5.6 Sol is the independent implementation/review peer; Claude Sonnet 5 is the standard Claude seat; Fable 5 remains an opt-in judgment escalation. Existing model pins and provider configuration still win. See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md).
 <!-- END CURRENT RELEASE -->
@@ -55,7 +55,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 
 | Version | Best Features |
 |---------|--------------|
-| **v9.56.0** (new) | Security, correctness and performance fixes from a full-project code review. |
+| **v9.56.1** (new) | Harden release guardrails and close review findings. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
 | **v9** (current) | Up to 10 external provider integrations (Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -74,8 +74,8 @@ Must be empty. Shell scripts and Python helpers must stay `100755`; both contrib
 - `scripts/release.sh` waits up to 15 minutes by default so the macOS unit
   matrix can finish. Override only when necessary with
   `OCTO_RELEASE_CI_TIMEOUT_SECONDS=<seconds>`.
-- Automatic merge fails closed while a review requests changes or any review
-  thread is unresolved.
+- Automatic merge requires an explicit approved review and zero unresolved
+  review threads across every paginated result page.
 
 ## 7. Tag AFTER the squash-merge
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -74,6 +74,8 @@ Must be empty. Shell scripts and Python helpers must stay `100755`; both contrib
 - `scripts/release.sh` waits up to 15 minutes by default so the macOS unit
   matrix can finish. Override only when necessary with
   `OCTO_RELEASE_CI_TIMEOUT_SECONDS=<seconds>`.
+- Automatic merge fails closed while a review requests changes or any review
+  thread is unresolved.
 
 ## 7. Tag AFTER the squash-merge
 
@@ -99,4 +101,6 @@ Marketplace consumers pin by release; a bare tag is not enough.
 
 ## 9. Post-merge verification
 
-Watch the main-branch Test Suite run on the merge commit until `completed/success`. A release is not done while main is red.
+`scripts/release.sh` waits for the main-branch Test Suite on the exact squash
+commit before it creates the tag or GitHub release. For manual recovery, watch
+that run until `completed/success`. A release is not done while main is red.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,10 +71,16 @@ Must be empty. Shell scripts and Python helpers must stay `100755`; both contrib
 - Open the PR against `main`. Same-repo branches run CI immediately; **fork PRs stall at `action_required`** until approved: `gh api -X POST repos/nyldn/claude-octopus/actions/runs/<run-id>/approve` (needed after every push to the fork branch).
 - Known flake: macOS runner timing in `tests/unit/test-agent-lifecycle-events.sh` ("hook timeout did not return promptly"). If it hits, `gh run rerun <run-id> --failed` once before investigating.
 - Squash-merge is the repo convention.
+- `scripts/release.sh` waits up to 15 minutes by default so the macOS unit
+  matrix can finish. Override only when necessary with
+  `OCTO_RELEASE_CI_TIMEOUT_SECONDS=<seconds>`.
 
 ## 7. Tag AFTER the squash-merge
 
 The tag must point at the merge commit on `main`, not at the branch head (squash rewrites the SHA):
+
+`scripts/release.sh` creates and pushes this annotated tag automatically. If a
+release is being recovered manually, use:
 
 ```bash
 sha=$(gh pr view <pr> --json mergeCommit --jq .mergeCommit.oid)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -94,7 +94,7 @@ git push origin vX.Y.Z
 ## 8. GitHub Release
 
 ```bash
-gh release create vX.Y.Z --title "vX.Y.Z" --notes-file <(awk '/^## \[X.Y.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)
+gh release create vX.Y.Z --verify-tag --title "vX.Y.Z" --notes-file <(awk '/^## \[X.Y.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)
 ```
 
 Marketplace consumers pin by release; a bare tag is not enough.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.56.0",
+  "version": "9.56.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/scripts/lib/release-ci.sh
+++ b/scripts/lib/release-ci.sh
@@ -57,7 +57,7 @@ octo_release_unresolved_review_threads() {
     local repo_owner="$1"
     local repo_name="$2"
     local pr_number="$3"
-    local query response has_next cursor=""
+    local query response page_unresolved has_next cursor=""
     local unresolved_total=0
 
     query='query($owner:String!, $name:String!, $number:Int!, $cursor:String) {
@@ -88,10 +88,17 @@ octo_release_unresolved_review_threads() {
                 -f cursor="$cursor") || return 1
         fi
 
-        unresolved_total=$((unresolved_total + $(jq \
+        page_unresolved=$(jq -er \
             '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' \
-            <<< "$response")))
-        has_next=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<< "$response")
+            <<< "$response") || return 1
+        [[ "$page_unresolved" =~ ^[0-9]+$ ]] || return 1
+        unresolved_total=$((unresolved_total + page_unresolved))
+
+        has_next=$(jq -r \
+            '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage |
+             if type == "boolean" then . else error("invalid hasNextPage") end' \
+            <<< "$response") || return 1
+        [[ "$has_next" == "true" || "$has_next" == "false" ]] || return 1
         [[ "$has_next" == "true" ]] || break
 
         cursor=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty' <<< "$response")

--- a/scripts/lib/release-ci.sh
+++ b/scripts/lib/release-ci.sh
@@ -43,3 +43,85 @@ else:
     print("pending")
 PY
 }
+
+octo_release_review_gate() {
+    local review_decision="$1"
+    local unresolved_threads="$2"
+
+    [[ "$review_decision" == "APPROVED" ]] || return 1
+    [[ "$unresolved_threads" =~ ^[0-9]+$ ]] || return 1
+    [[ "$unresolved_threads" == "0" ]]
+}
+
+octo_release_unresolved_review_threads() {
+    local repo_owner="$1"
+    local repo_name="$2"
+    local pr_number="$3"
+    local query response has_next cursor=""
+    local unresolved_total=0
+
+    query='query($owner:String!, $name:String!, $number:Int!, $cursor:String) {
+      repository(owner:$owner, name:$name) {
+        pullRequest(number:$number) {
+          reviewThreads(first:100, after:$cursor) {
+            nodes { isResolved }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    }'
+
+    while :; do
+        if [[ -z "$cursor" ]]; then
+            response=$(gh api graphql \
+                -f query="$query" \
+                -f owner="$repo_owner" \
+                -f name="$repo_name" \
+                -F number="$pr_number" \
+                -F cursor=null) || return 1
+        else
+            response=$(gh api graphql \
+                -f query="$query" \
+                -f owner="$repo_owner" \
+                -f name="$repo_name" \
+                -F number="$pr_number" \
+                -f cursor="$cursor") || return 1
+        fi
+
+        unresolved_total=$((unresolved_total + $(jq \
+            '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' \
+            <<< "$response")))
+        has_next=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<< "$response")
+        [[ "$has_next" == "true" ]] || break
+
+        cursor=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty' <<< "$response")
+        [[ -n "$cursor" ]] || return 1
+    done
+
+    printf '%s\n' "$unresolved_total"
+}
+
+octo_release_run_with_timeout() {
+    local timeout_seconds="$1"
+    shift
+
+    python3 - "$timeout_seconds" "$@" <<'PY'
+import subprocess
+import sys
+
+timeout = int(sys.argv[1])
+command = sys.argv[2:]
+process = subprocess.Popen(command)
+try:
+    return_code = process.wait(timeout=timeout)
+except subprocess.TimeoutExpired:
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+    raise SystemExit(124)
+raise SystemExit(return_code)
+PY
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -53,6 +53,13 @@ cd "$PLUGIN_ROOT"
 # clone pointing $REMOTE at the canonical repo (with origin left on a fork)
 # would otherwise create the PR/release against the wrong repo. Pin it.
 REPO_SLUG="$(git remote get-url "$REMOTE" | sed -E 's#^(git@|https://)([^:/]+)[:/]##; s#\.git$##')"
+REPO_OWNER="${REPO_SLUG%%/*}"
+REPO_NAME="${REPO_SLUG#*/}"
+
+if [[ -z "$REPO_OWNER" || -z "$REPO_NAME" || "$REPO_OWNER" == "$REPO_NAME" ]]; then
+    echo "Error: could not parse owner/repository from remote ${REMOTE}: ${REPO_SLUG}"
+    exit 1
+fi
 
 # --- Preflight ---
 
@@ -329,6 +336,36 @@ if [[ $SECONDS -ge $DEADLINE ]]; then
 fi
 echo ""
 
+# Required checks can pass while a review still has actionable findings.
+# Fail closed instead of relying on an owner/admin merge bypass.
+echo "   Checking review gate..."
+if ! REVIEW_DECISION=$(gh pr view "$PR_NUM" -R "$REPO_SLUG" --json reviewDecision --jq '.reviewDecision // ""'); then
+    echo "   ERROR: Could not read the PR review decision."
+    exit 1
+fi
+if ! UNRESOLVED_THREADS=$(gh api graphql \
+    -f query='query($owner:String!, $name:String!, $number:Int!) {
+      repository(owner:$owner, name:$name) {
+        pullRequest(number:$number) {
+          reviewThreads(first:100) { nodes { isResolved } }
+        }
+      }
+    }' \
+    -f owner="$REPO_OWNER" \
+    -f name="$REPO_NAME" \
+    -F number="$PR_NUM" \
+    --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'); then
+    echo "   ERROR: Could not read PR review threads."
+    exit 1
+fi
+if [[ "$REVIEW_DECISION" == "CHANGES_REQUESTED" || "$UNRESOLVED_THREADS" != "0" ]]; then
+    echo "   REVIEW BLOCKED — decision=${REVIEW_DECISION:-none} | unresolved threads=${UNRESOLVED_THREADS}"
+    echo "   Resolve every actionable finding and rerun the release."
+    exit 1
+fi
+echo "   Review: ${REVIEW_DECISION:-no blocking review} | unresolved threads: 0"
+echo ""
+
 # --- 6. Merge + Release ---
 
 echo "6/8 Merging and creating release..."
@@ -345,6 +382,31 @@ else
     git pull --quiet "$REMOTE" main
     git branch -d "$BRANCH" --quiet 2>/dev/null || true
     MERGE_SHA=$(git rev-parse main)
+fi
+
+# Do not publish a tag while the exact post-squash main commit is unverified.
+echo "   Waiting for main Test Suite on ${MERGE_SHA}..."
+MAIN_RUN_ID=""
+MAIN_RUN_DEADLINE=$((SECONDS + 120))
+while [[ -z "$MAIN_RUN_ID" && $SECONDS -lt $MAIN_RUN_DEADLINE ]]; do
+    MAIN_RUN_ID=$(gh run list \
+        -R "$REPO_SLUG" \
+        --workflow "Test Suite" \
+        --branch main \
+        --event push \
+        --limit 20 \
+        --json databaseId,headSha \
+        --jq ".[] | select(.headSha == \"${MERGE_SHA}\") | .databaseId" \
+        | head -n 1)
+    [[ -n "$MAIN_RUN_ID" ]] || sleep 5
+done
+if [[ -z "$MAIN_RUN_ID" ]]; then
+    echo "   ERROR: Main Test Suite run did not appear for ${MERGE_SHA}."
+    exit 1
+fi
+if ! gh run watch "$MAIN_RUN_ID" -R "$REPO_SLUG" --exit-status; then
+    echo "   ERROR: Main Test Suite failed for ${MERGE_SHA}; tag and release were not created."
+    exit 1
 fi
 
 TAG_NAME="v${VERSION}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -369,19 +369,60 @@ echo ""
 # --- 6. Merge + Release ---
 
 echo "6/8 Merging and creating release..."
-gh pr merge "$PR_NUM" -R "$REPO_SLUG" --squash --quiet 2>/dev/null || gh pr merge "$PR_NUM" -R "$REPO_SLUG" --squash
+merge_release_pr() {
+    gh pr merge "$PR_NUM" -R "$REPO_SLUG" --squash "$@"
+}
+
+read_release_pr_state() {
+    gh pr view "$PR_NUM" -R "$REPO_SLUG" --json state --jq '.state'
+}
+
+if ! merge_release_pr --quiet 2>/dev/null; then
+    if ! PR_STATE=$(read_release_pr_state); then
+        echo "   ERROR: Merge failed and the PR state could not be read."
+        exit 1
+    fi
+    if [[ "$PR_STATE" != "MERGED" ]]; then
+        if ! merge_release_pr; then
+            if ! PR_STATE=$(read_release_pr_state); then
+                echo "   ERROR: Merge retry failed and the PR state could not be read."
+                exit 1
+            fi
+            if [[ "$PR_STATE" != "MERGED" ]]; then
+                echo "   ERROR: Release PR is still ${PR_STATE} after the merge retry."
+                exit 1
+            fi
+        fi
+    fi
+fi
+
+if ! MERGE_SHA=$(gh pr view "$PR_NUM" \
+    -R "$REPO_SLUG" \
+    --json state,mergeCommit \
+    --jq 'select(.state == "MERGED") | .mergeCommit.oid // empty'); then
+    echo "   ERROR: Could not read the merged PR commit."
+    exit 1
+fi
+if [[ ! "$MERGE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "   ERROR: Merged PR returned an invalid merge commit: ${MERGE_SHA:-empty}"
+    exit 1
+fi
+
+git fetch --quiet "$REMOTE" main
+if ! git merge-base --is-ancestor "$MERGE_SHA" FETCH_HEAD; then
+    echo "   ERROR: PR merge commit ${MERGE_SHA} is not present on ${REMOTE}/main."
+    exit 1
+fi
 
 if [[ "$ON_RELEASE_BRANCH" == "true" ]]; then
     # main is normally still checked out in the worktree this release branch
-    # was cut from; don't touch this worktree's checkout or delete the
-    # branch we're standing on. Just fetch the merge commit to tag it.
-    git fetch --quiet "$REMOTE" main
-    MERGE_SHA=$(git rev-parse FETCH_HEAD)
+    # was cut from; don't touch this worktree's checkout or delete the branch
+    # we're standing on. The PR API above is the release SHA source of truth.
+    :
 else
     git checkout main --quiet
     git pull --quiet "$REMOTE" main
     git branch -d "$BRANCH" --quiet 2>/dev/null || true
-    MERGE_SHA=$(git rev-parse main)
 fi
 
 # Do not publish a tag while the exact post-squash main commit is unverified.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -40,6 +40,12 @@ SUMMARY="$2"
 DATE=$(date +%Y-%m-%d)
 BRANCH="release/v${VERSION}"
 REMOTE="${OCTO_RELEASE_REMOTE:-origin}"
+CI_TIMEOUT_SECONDS="${OCTO_RELEASE_CI_TIMEOUT_SECONDS:-900}"
+
+if [[ ! "$CI_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: OCTO_RELEASE_CI_TIMEOUT_SECONDS must be a positive integer."
+    exit 1
+fi
 
 cd "$PLUGIN_ROOT"
 
@@ -292,8 +298,9 @@ echo ""
 # --- 5. Wait for CI ---
 
 echo "5/8 Waiting for CI..."
-# Poll until required checks finish (max 5 minutes)
-DEADLINE=$((SECONDS + 300))
+# macOS unit jobs routinely take around 10 minutes, so leave enough headroom
+# while keeping the wait configurable for slower or faster repositories.
+DEADLINE=$((SECONDS + CI_TIMEOUT_SECONDS))
 while [[ $SECONDS -lt $DEADLINE ]]; do
     CHECKS=$(gh pr checks "$PR_NUM" -R "$REPO_SLUG" --json name,state 2>&1 || true)
     SMOKE=$(octo_pr_check_state "$CHECKS" "Smoke Tests")
@@ -307,7 +314,7 @@ while [[ $SECONDS -lt $DEADLINE ]]; do
 
     if [[ "$SMOKE" == "fail" || "$UNIT" == "fail" || "$INTEG" == "fail" ]]; then
         echo "   CI FAILED — Smoke: ${SMOKE} | Unit: ${UNIT} | Integration: ${INTEG}"
-        echo "   Fix failures, then run: gh pr merge ${PR_NUM} --merge -R ${REPO_SLUG}"
+        echo "   Fix failures, then run: gh pr merge ${PR_NUM} --squash -R ${REPO_SLUG}"
         exit 1
     fi
 
@@ -315,9 +322,9 @@ while [[ $SECONDS -lt $DEADLINE ]]; do
 done
 
 if [[ $SECONDS -ge $DEADLINE ]]; then
-    echo "   CI timed out after 5 minutes."
+    echo "   CI timed out after ${CI_TIMEOUT_SECONDS} seconds."
     echo "   Check manually: gh pr checks ${PR_NUM} -R ${REPO_SLUG}"
-    echo "   Then merge: gh pr merge ${PR_NUM} --merge -R ${REPO_SLUG}"
+    echo "   Then merge: gh pr merge ${PR_NUM} --squash -R ${REPO_SLUG}"
     exit 1
 fi
 echo ""
@@ -325,7 +332,7 @@ echo ""
 # --- 6. Merge + Release ---
 
 echo "6/8 Merging and creating release..."
-gh pr merge "$PR_NUM" -R "$REPO_SLUG" --merge --quiet 2>/dev/null || gh pr merge "$PR_NUM" -R "$REPO_SLUG" --merge
+gh pr merge "$PR_NUM" -R "$REPO_SLUG" --squash --quiet 2>/dev/null || gh pr merge "$PR_NUM" -R "$REPO_SLUG" --squash
 
 if [[ "$ON_RELEASE_BRANCH" == "true" ]]; then
     # main is normally still checked out in the worktree this release branch
@@ -340,9 +347,13 @@ else
     MERGE_SHA=$(git rev-parse main)
 fi
 
+TAG_NAME="v${VERSION}"
+git tag -a "$TAG_NAME" "$MERGE_SHA" -m "${TAG_NAME}: ${SUMMARY}"
+git push --quiet "$REMOTE" "$TAG_NAME"
+
 gh release create "v${VERSION}" \
     -R "$REPO_SLUG" \
-    --target "$MERGE_SHA" \
+    --verify-tag \
     --title "v${VERSION} — ${SUMMARY}" \
     --notes "### Changed
 - ${SUMMARY}
@@ -351,7 +362,7 @@ gh release create "v${VERSION}" \
     --quiet 2>/dev/null || \
 gh release create "v${VERSION}" \
     -R "$REPO_SLUG" \
-    --target "$MERGE_SHA" \
+    --verify-tag \
     --title "v${VERSION} — ${SUMMARY}" \
     --notes "### Changed
 - ${SUMMARY}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -343,27 +343,17 @@ if ! REVIEW_DECISION=$(gh pr view "$PR_NUM" -R "$REPO_SLUG" --json reviewDecisio
     echo "   ERROR: Could not read the PR review decision."
     exit 1
 fi
-if ! UNRESOLVED_THREADS=$(gh api graphql \
-    -f query='query($owner:String!, $name:String!, $number:Int!) {
-      repository(owner:$owner, name:$name) {
-        pullRequest(number:$number) {
-          reviewThreads(first:100) { nodes { isResolved } }
-        }
-      }
-    }' \
-    -f owner="$REPO_OWNER" \
-    -f name="$REPO_NAME" \
-    -F number="$PR_NUM" \
-    --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'); then
+if ! UNRESOLVED_THREADS=$(octo_release_unresolved_review_threads \
+    "$REPO_OWNER" "$REPO_NAME" "$PR_NUM"); then
     echo "   ERROR: Could not read PR review threads."
     exit 1
 fi
-if [[ "$REVIEW_DECISION" == "CHANGES_REQUESTED" || "$UNRESOLVED_THREADS" != "0" ]]; then
+if ! octo_release_review_gate "$REVIEW_DECISION" "$UNRESOLVED_THREADS"; then
     echo "   REVIEW BLOCKED — decision=${REVIEW_DECISION:-none} | unresolved threads=${UNRESOLVED_THREADS}"
-    echo "   Resolve every actionable finding and rerun the release."
+    echo "   An explicit approval and zero unresolved threads are required."
     exit 1
 fi
-echo "   Review: ${REVIEW_DECISION:-no blocking review} | unresolved threads: 0"
+echo "   Review: ${REVIEW_DECISION} | unresolved threads: 0"
 echo ""
 
 # --- 6. Merge + Release ---
@@ -445,7 +435,8 @@ if [[ -z "$MAIN_RUN_ID" ]]; then
     echo "   ERROR: Main Test Suite run did not appear for ${MERGE_SHA}."
     exit 1
 fi
-if ! gh run watch "$MAIN_RUN_ID" -R "$REPO_SLUG" --exit-status; then
+if ! octo_release_run_with_timeout "$CI_TIMEOUT_SECONDS" \
+    gh run watch "$MAIN_RUN_ID" -R "$REPO_SLUG" --exit-status; then
     echo "   ERROR: Main Test Suite failed for ${MERGE_SHA}; tag and release were not created."
     exit 1
 fi

--- a/tests/unit/test-release-sh-worktree-flow.sh
+++ b/tests/unit/test-release-sh-worktree-flow.sh
@@ -103,6 +103,36 @@ test_release_ci_timeout_covers_macos() {
     fi
 }
 
+test_release_requires_clean_review_state() {
+    test_case "release fails closed on requested changes or unresolved review threads"
+
+    if grep -q -- '--json reviewDecision' "$RELEASE_SH" \
+        && grep -q 'reviewThreads(first:100)' "$RELEASE_SH" \
+        && grep -q 'REVIEW_DECISION" == "CHANGES_REQUESTED"' "$RELEASE_SH" \
+        && grep -q 'UNRESOLVED_THREADS" != "0"' "$RELEASE_SH"; then
+        test_pass
+    else
+        test_fail "release.sh does not enforce the PR review gate"
+    fi
+}
+
+test_release_verifies_main_before_tag() {
+    test_case "release verifies the post-squash main commit before tagging"
+
+    local merge_block watch_line tag_line
+    merge_block=$(awk '/# --- 6\. Merge \+ Release/,/^# --- 7\. Sync shared marketplace/' "$RELEASE_SH")
+    watch_line=$(grep -n 'gh run watch "\$MAIN_RUN_ID"' <<< "$merge_block" | cut -d: -f1)
+    tag_line=$(grep -n 'git tag -a "\$TAG_NAME"' <<< "$merge_block" | cut -d: -f1)
+
+    if grep -q -- '--workflow "Test Suite"' <<< "$merge_block" \
+        && grep -q 'headSha == \\"${MERGE_SHA}\\"' <<< "$merge_block" \
+        && [[ -n "$watch_line" && -n "$tag_line" && "$watch_line" -lt "$tag_line" ]]; then
+        test_pass
+    else
+        test_fail "release.sh does not verify the exact main merge SHA before tagging"
+    fi
+}
+
 # Functional: reproduce the exact worktree scenario from RELEASING.md §0
 # (main checked out in one worktree, release/vX.Y.Z cut in another) and prove
 # the fetch+FETCH_HEAD approach release.sh now uses succeeds there, while the
@@ -174,6 +204,8 @@ test_post_merge_skips_checkout_on_release_branch
 test_release_tags_merge_sha
 test_release_uses_squash_merge
 test_release_ci_timeout_covers_macos
+test_release_requires_clean_review_state
+test_release_verifies_main_before_tag
 test_fetch_head_approach_works_when_main_checked_out_elsewhere
 
 test_summary

--- a/tests/unit/test-release-sh-worktree-flow.sh
+++ b/tests/unit/test-release-sh-worktree-flow.sh
@@ -63,13 +63,43 @@ test_post_merge_skips_checkout_on_release_branch() {
     fi
 }
 
-test_release_targets_merge_sha() {
-    test_case "gh release create targets the resolved merge SHA"
+test_release_tags_merge_sha() {
+    test_case "release creates and pushes an annotated tag on the resolved merge SHA"
 
-    if grep -q -- '--target "\$MERGE_SHA"' "$RELEASE_SH"; then
+    local merge_block
+    merge_block=$(awk '/# --- 6\. Merge \+ Release/,/^# --- 7\. Sync shared marketplace/' "$RELEASE_SH")
+
+    if grep -q 'git tag -a "\$TAG_NAME" "\$MERGE_SHA"' <<< "$merge_block" \
+        && grep -q 'git push --quiet "\$REMOTE" "\$TAG_NAME"' <<< "$merge_block" \
+        && grep -q -- '--verify-tag' <<< "$merge_block"; then
         test_pass
     else
-        test_fail "gh release create does not pin --target to MERGE_SHA"
+        test_fail "release does not push and verify an annotated tag on MERGE_SHA"
+    fi
+}
+
+test_release_uses_squash_merge() {
+    test_case "release PR follows the repository squash-merge convention"
+
+    local merge_commands
+    merge_commands=$(grep 'gh pr merge' "$RELEASE_SH" || true)
+
+    if grep -q -- '--squash' <<< "$merge_commands" \
+        && ! grep -q -- '--merge' <<< "$merge_commands"; then
+        test_pass
+    else
+        test_fail "release.sh merge commands must use --squash exclusively"
+    fi
+}
+
+test_release_ci_timeout_covers_macos() {
+    test_case "release CI timeout has configurable 15-minute headroom"
+
+    if grep -q 'CI_TIMEOUT_SECONDS="${OCTO_RELEASE_CI_TIMEOUT_SECONDS:-900}"' "$RELEASE_SH" \
+        && grep -q 'DEADLINE=\$((SECONDS + CI_TIMEOUT_SECONDS))' "$RELEASE_SH"; then
+        test_pass
+    else
+        test_fail "release.sh does not use the configurable 900-second CI timeout"
     fi
 }
 
@@ -141,7 +171,9 @@ test_remote_configurable
 test_preflight_accepts_release_branch
 test_plugin_manifest_staged
 test_post_merge_skips_checkout_on_release_branch
-test_release_targets_merge_sha
+test_release_tags_merge_sha
+test_release_uses_squash_merge
+test_release_ci_timeout_covers_macos
 test_fetch_head_approach_works_when_main_checked_out_elsewhere
 
 test_summary

--- a/tests/unit/test-release-sh-worktree-flow.sh
+++ b/tests/unit/test-release-sh-worktree-flow.sh
@@ -6,8 +6,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 RELEASE_SH="$PROJECT_ROOT/scripts/release.sh"
+CI_LIB="$PROJECT_ROOT/scripts/lib/release-ci.sh"
 
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
+# shellcheck source=scripts/lib/release-ci.sh
+source "$CI_LIB"
 
 test_suite "release.sh worktree/branch/remote flow"
 
@@ -123,15 +126,28 @@ test_release_ci_timeout_covers_macos() {
 }
 
 test_release_requires_clean_review_state() {
-    test_case "release fails closed on requested changes or unresolved review threads"
+    test_case "release requires explicit approval and paginates every review thread"
 
-    if grep -q -- '--json reviewDecision' "$RELEASE_SH" \
-        && grep -q 'reviewThreads(first:100)' "$RELEASE_SH" \
-        && grep -q 'REVIEW_DECISION" == "CHANGES_REQUESTED"' "$RELEASE_SH" \
-        && grep -q 'UNRESOLVED_THREADS" != "0"' "$RELEASE_SH"; then
+    local unresolved
+    gh() {
+        if [[ " $* " == *" cursor=NEXT_PAGE "* ]]; then
+            printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}'
+        else
+            printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true},{"isResolved":false}],"pageInfo":{"hasNextPage":true,"endCursor":"NEXT_PAGE"}}}}}}'
+        fi
+    }
+    unresolved=$(octo_release_unresolved_review_threads owner repo 687)
+    unset -f gh
+
+    if octo_release_review_gate APPROVED 0 \
+        && ! octo_release_review_gate "" 0 \
+        && ! octo_release_review_gate REVIEW_REQUIRED 0 \
+        && ! octo_release_review_gate CHANGES_REQUESTED 0 \
+        && ! octo_release_review_gate APPROVED 1 \
+        && [[ "$unresolved" == "2" ]]; then
         test_pass
     else
-        test_fail "release.sh does not enforce the PR review gate"
+        test_fail "release review gate accepted an unapproved or unresolved state"
     fi
 }
 
@@ -144,11 +160,31 @@ test_release_verifies_main_before_tag() {
     tag_line=$(grep -n 'git tag -a "\$TAG_NAME"' <<< "$merge_block" | cut -d: -f1)
 
     if grep -q -- '--workflow "Test Suite"' <<< "$merge_block" \
-        && grep -q 'headSha == \\"${MERGE_SHA}\\"' <<< "$merge_block" \
+        && grep -q 'headSha' <<< "$merge_block" \
+        && grep -q 'MERGE_SHA' <<< "$merge_block" \
+        && grep -q 'octo_release_run_with_timeout "\$CI_TIMEOUT_SECONDS"' <<< "$merge_block" \
         && [[ -n "$watch_line" && -n "$tag_line" && "$watch_line" -lt "$tag_line" ]]; then
         test_pass
     else
         test_fail "release.sh does not verify the exact main merge SHA before tagging"
+    fi
+}
+
+test_release_timeout_is_bounded() {
+    test_case "release timeout helper terminates a stuck main-run watch"
+
+    local started elapsed
+    started=$(date +%s)
+    if octo_release_run_with_timeout 1 sleep 5 >/dev/null 2>&1; then
+        test_fail "timeout helper accepted a command that exceeded its budget"
+        return
+    fi
+    elapsed=$(( $(date +%s) - started ))
+
+    if [[ "$elapsed" -lt 5 ]] && octo_release_run_with_timeout 2 true; then
+        test_pass
+    else
+        test_fail "timeout helper did not bound the command or rejected a fast command"
     fi
 }
 
@@ -225,6 +261,7 @@ test_release_uses_squash_merge
 test_release_ci_timeout_covers_macos
 test_release_requires_clean_review_state
 test_release_verifies_main_before_tag
+test_release_timeout_is_bounded
 test_fetch_head_approach_works_when_main_checked_out_elsewhere
 
 test_summary

--- a/tests/unit/test-release-sh-worktree-flow.sh
+++ b/tests/unit/test-release-sh-worktree-flow.sh
@@ -55,7 +55,7 @@ test_post_merge_skips_checkout_on_release_branch() {
 
     if grep -q 'ON_RELEASE_BRANCH" == "true"' <<< "$merge_block" \
         && grep -q 'git fetch --quiet "\$REMOTE" main' <<< "$merge_block" \
-        && grep -q 'MERGE_SHA=\$(git rev-parse FETCH_HEAD)' <<< "$merge_block" \
+        && grep -q -- '--json state,mergeCommit' <<< "$merge_block" \
         && ! grep -q 'ON_RELEASE_BRANCH" == "true"' <<< "$checkout_context"; then
         test_pass
     else
@@ -69,7 +69,11 @@ test_release_tags_merge_sha() {
     local merge_block
     merge_block=$(awk '/# --- 6\. Merge \+ Release/,/^# --- 7\. Sync shared marketplace/' "$RELEASE_SH")
 
-    if grep -q 'git tag -a "\$TAG_NAME" "\$MERGE_SHA"' <<< "$merge_block" \
+    if grep -q -- '--json state,mergeCommit' <<< "$merge_block" \
+        && grep -q 'mergeCommit\.oid // empty' <<< "$merge_block" \
+        && grep -q 'MERGE_SHA" =~ \^\[0-9a-fA-F\]' <<< "$merge_block" \
+        && grep -q 'git merge-base --is-ancestor "\$MERGE_SHA" FETCH_HEAD' <<< "$merge_block" \
+        && grep -q 'git tag -a "\$TAG_NAME" "\$MERGE_SHA"' <<< "$merge_block" \
         && grep -q 'git push --quiet "\$REMOTE" "\$TAG_NAME"' <<< "$merge_block" \
         && grep -q -- '--verify-tag' <<< "$merge_block"; then
         test_pass
@@ -82,10 +86,11 @@ test_release_uses_squash_merge() {
     test_case "release PR follows the repository squash-merge convention"
 
     local merge_commands
-    merge_commands=$(grep 'gh pr merge' "$RELEASE_SH" || true)
+    merge_commands=$(grep -E '^[[:space:]]*gh pr merge "\$PR_NUM"' "$RELEASE_SH" || true)
 
     if grep -q -- '--squash' <<< "$merge_commands" \
-        && ! grep -q -- '--merge' <<< "$merge_commands"; then
+        && ! grep -q -- '--merge' <<< "$merge_commands" \
+        && ! grep -q -- '--rebase' <<< "$merge_commands"; then
         test_pass
     else
         test_fail "release.sh merge commands must use --squash exclusively"
@@ -93,13 +98,27 @@ test_release_uses_squash_merge() {
 }
 
 test_release_ci_timeout_covers_macos() {
-    test_case "release CI timeout has configurable 15-minute headroom"
+    test_case "release CI timeout defaults to 900, accepts overrides, and rejects invalid values"
 
-    if grep -q 'CI_TIMEOUT_SECONDS="${OCTO_RELEASE_CI_TIMEOUT_SECONDS:-900}"' "$RELEASE_SH" \
-        && grep -q 'DEADLINE=\$((SECONDS + CI_TIMEOUT_SECONDS))' "$RELEASE_SH"; then
+    local default_trace override_trace invalid_output
+    default_trace=$(OCTO_RELEASE_REMOTE=__missing_release_test_remote__ \
+        bash -x "$RELEASE_SH" 9.99.0 "test release" 2>&1 || true)
+    override_trace=$(OCTO_RELEASE_REMOTE=__missing_release_test_remote__ \
+        OCTO_RELEASE_CI_TIMEOUT_SECONDS=1200 \
+        bash -x "$RELEASE_SH" 9.99.0 "test release" 2>&1 || true)
+
+    if invalid_output=$(OCTO_RELEASE_CI_TIMEOUT_SECONDS=invalid \
+        bash "$RELEASE_SH" 9.99.0 "test release" 2>&1); then
+        test_fail "release.sh accepted an invalid CI timeout"
+        return
+    fi
+
+    if grep -q '^+ CI_TIMEOUT_SECONDS=900$' <<< "$default_trace" \
+        && grep -q '^+ CI_TIMEOUT_SECONDS=1200$' <<< "$override_trace" \
+        && grep -q 'must be a positive integer' <<< "$invalid_output"; then
         test_pass
     else
-        test_fail "release.sh does not use the configurable 900-second CI timeout"
+        test_fail "release.sh timeout default, override, or validation behavior is incorrect"
     fi
 }
 


### PR DESCRIPTION
## Release v9.56.1

Harden release guardrails and close all review findings from v9.56.0.

### Included
- promote the verified review/security follow-ups into a patch release
- synchronize README.md, PRODUCT.md, manifests, marketplace metadata, and changelog to v9.56.1
- make release automation wait 15 minutes, require explicit approval, paginate every review thread, squash-merge, pin the PR merge SHA, boundedly verify exact main, and only then push an annotated tag and publish

### Verification
- `make ci-local`: 16 smoke, 185 unit, 7 integration suites passed
- focused release flow: 11/11, including behavioral approval, pagination, and timeout cases
- shared marketplace sync: 13/13
- README release sync: 7/7
- live GraphQL pagination check: 0 unresolved threads
- ShellCheck, `make sync-check`, and `git diff --check` passed
- parent squash `70062ae4` passed the full main matrix, including E2E

The tag and GitHub release will be created only after this PR passes review and protected checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * CI wait window is now configurable via `OCTO_RELEASE_CI_TIMEOUT_SECONDS` (positive-integer; default 900s).
  * Added a fails-closed PR review gate that blocks releases when reviews aren’t exactly approved or unresolved threads exist.
  * Release now uses squash-only merges, verifies the post-squash main Test Suite on the merge commit, and publishes using annotated tags with tag verification.
* **Documentation**
  * Updated release docs, README, and changelog for the 9.56.1 process and version.
* **Chores**
  * Bumped plugin/package versions to **9.56.1** across manifests.
* **Tests**
  * Expanded coverage for merge, CI waiting, tag verification, and review-gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->