### PR TITLE
docs: align cross-harness resume order

### DIFF
--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -17,12 +17,12 @@ harnesses. It is a context packet, not the task tracker.
 Read in order:
 
 1. `AGENTS.md` and `RTK.md`
-2. the relevant `bd` issue before editing; if Beads is blocked, read
+2. `git status --short --branch`
+3. the latest commits on the current branch
+4. the relevant `bd` issue before editing; if Beads is blocked, read
    `Tracking Blocker` below and do not migrate the database
-3. `docs/MODEL-ROUTING-STRATEGY.md`
-4. `docs/GPT-5.6-PROMPTING.md`
-5. `git status --short --branch`
-6. the latest commits on the current branch
+5. `docs/MODEL-ROUTING-STRATEGY.md`
+6. `docs/GPT-5.6-PROMPTING.md`
 
 ## Delivered Goal
 

--- a/tests/unit/test-readme-release-sync.sh
+++ b/tests/unit/test-readme-release-sync.sh
@@ -161,10 +161,10 @@ else
 fi
 
 test_case "cross-harness controller preserves the README sync contract"
-handoff_git_line="$(grep -n -m1 'git status --short --branch' "$PROJECT_ROOT/AI_AGENT_HANDOFF.md" | cut -d: -f1)"
-handoff_bd_line="$(grep -n -m1 'relevant `bd` issue' "$PROJECT_ROOT/AI_AGENT_HANDOFF.md" | cut -d: -f1)"
-rtk_git_line="$(grep -n -m1 'git status --short --branch' "$PROJECT_ROOT/RTK.md" | cut -d: -f1)"
-rtk_bd_line="$(grep -n -m1 'relevant `bd` issue' "$PROJECT_ROOT/RTK.md" | cut -d: -f1)"
+handoff_git_line="$(awk '/^## Start Here$/{section=1; next} section && /^## /{exit} section && /git status --short --branch/{print NR; exit}' "$PROJECT_ROOT/AI_AGENT_HANDOFF.md")"
+handoff_bd_line="$(awk '/^## Start Here$/{section=1; next} section && /^## /{exit} section && /relevant `bd` issue/{print NR; exit}' "$PROJECT_ROOT/AI_AGENT_HANDOFF.md")"
+rtk_git_line="$(awk '/^## Start a Session$/{section=1; next} section && /^## /{exit} section && /git status --short --branch/{print NR; exit}' "$PROJECT_ROOT/RTK.md")"
+rtk_bd_line="$(awk '/^## Start a Session$/{section=1; next} section && /^## /{exit} section && /relevant `bd` issue/{print NR; exit}' "$PROJECT_ROOT/RTK.md")"
 if [[ -f "$PROJECT_ROOT/RTK.md" ]] &&
    [[ -n "$handoff_git_line" && -n "$handoff_bd_line" && "$handoff_git_line" -lt "$handoff_bd_line" ]] &&
    [[ -n "$rtk_git_line" && -n "$rtk_bd_line" && "$rtk_git_line" -lt "$rtk_bd_line" ]] &&

--- a/tests/unit/test-readme-release-sync.sh
+++ b/tests/unit/test-readme-release-sync.sh
@@ -161,7 +161,13 @@ else
 fi
 
 test_case "cross-harness controller preserves the README sync contract"
+handoff_git_line="$(grep -n -m1 'git status --short --branch' "$PROJECT_ROOT/AI_AGENT_HANDOFF.md" | cut -d: -f1)"
+handoff_bd_line="$(grep -n -m1 'relevant `bd` issue' "$PROJECT_ROOT/AI_AGENT_HANDOFF.md" | cut -d: -f1)"
+rtk_git_line="$(grep -n -m1 'git status --short --branch' "$PROJECT_ROOT/RTK.md" | cut -d: -f1)"
+rtk_bd_line="$(grep -n -m1 'relevant `bd` issue' "$PROJECT_ROOT/RTK.md" | cut -d: -f1)"
 if [[ -f "$PROJECT_ROOT/RTK.md" ]] &&
+   [[ -n "$handoff_git_line" && -n "$handoff_bd_line" && "$handoff_git_line" -lt "$handoff_bd_line" ]] &&
+   [[ -n "$rtk_git_line" && -n "$rtk_bd_line" && "$rtk_git_line" -lt "$rtk_bd_line" ]] &&
    grep -q 'scripts/sync-readme.py.*owns' "$PROJECT_ROOT/RTK.md" &&
    grep -q 'scripts/sync-readme.py.*owns' "$PROJECT_ROOT/AGENTS.md" &&
    grep -q 'scripts/sync-readme.py' "$PROJECT_ROOT/CLAUDE.md" &&

--- a/tests/unit/test-readme-release-sync.sh
+++ b/tests/unit/test-readme-release-sync.sh
@@ -162,12 +162,16 @@ fi
 
 test_case "cross-harness controller preserves the README sync contract"
 handoff_git_line="$(awk '/^## Start Here$/{section=1; next} section && /^## /{exit} section && /git status --short --branch/{print NR; exit}' "$PROJECT_ROOT/AI_AGENT_HANDOFF.md")"
+handoff_commits_line="$(awk '/^## Start Here$/{section=1; next} section && /^## /{exit} section && /latest commits/{print NR; exit}' "$PROJECT_ROOT/AI_AGENT_HANDOFF.md")"
 handoff_bd_line="$(awk '/^## Start Here$/{section=1; next} section && /^## /{exit} section && /relevant `bd` issue/{print NR; exit}' "$PROJECT_ROOT/AI_AGENT_HANDOFF.md")"
 rtk_git_line="$(awk '/^## Start a Session$/{section=1; next} section && /^## /{exit} section && /git status --short --branch/{print NR; exit}' "$PROJECT_ROOT/RTK.md")"
+rtk_commits_line="$(awk '/^## Start a Session$/{section=1; next} section && /^## /{exit} section && /latest commits/{print NR; exit}' "$PROJECT_ROOT/RTK.md")"
 rtk_bd_line="$(awk '/^## Start a Session$/{section=1; next} section && /^## /{exit} section && /relevant `bd` issue/{print NR; exit}' "$PROJECT_ROOT/RTK.md")"
 if [[ -f "$PROJECT_ROOT/RTK.md" ]] &&
-   [[ -n "$handoff_git_line" && -n "$handoff_bd_line" && "$handoff_git_line" -lt "$handoff_bd_line" ]] &&
-   [[ -n "$rtk_git_line" && -n "$rtk_bd_line" && "$rtk_git_line" -lt "$rtk_bd_line" ]] &&
+   [[ -n "$handoff_git_line" && -n "$handoff_commits_line" && -n "$handoff_bd_line" ]] &&
+   [[ "$handoff_git_line" -lt "$handoff_bd_line" && "$handoff_commits_line" -lt "$handoff_bd_line" ]] &&
+   [[ -n "$rtk_git_line" && -n "$rtk_commits_line" && -n "$rtk_bd_line" ]] &&
+   [[ "$rtk_git_line" -lt "$rtk_bd_line" && "$rtk_commits_line" -lt "$rtk_bd_line" ]] &&
    grep -q 'scripts/sync-readme.py.*owns' "$PROJECT_ROOT/RTK.md" &&
    grep -q 'scripts/sync-readme.py.*owns' "$PROJECT_ROOT/AGENTS.md" &&
    grep -q 'scripts/sync-readme.py' "$PROJECT_ROOT/CLAUDE.md" &&


### PR DESCRIPTION
## Summary

- align `AI_AGENT_HANDOFF.md` with the canonical `RTK.md`/`AGENTS.md` resume order
- inspect repository status and recent commits before selecting Beads work
- make the ordering contract machine-checked in the existing README/cross-harness regression suite

## Verification

- `make ci-local` (16 smoke, 185 unit, 7 integration suites)
- `./tests/unit/test-readme-release-sync.sh` (8/8)
- `make sync-check`
- `git diff --check`
- no script mode changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Start Here” read-in-order guidance to reorder key prerequisites (git status, latest commits, and relevant tracking-blocker guidance) for clearer setup and workflow flow.

* **Tests**
  * Strengthened documentation consistency checks by validating line-number presence and ordering constraints between the corresponding sections in the handoff guide and the related RTK guide before running the existing README sync contract assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->