### PR TITLE
feat: selective Fable 5 escalation, authorship-aware review, progressive feature disclosure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,12 @@ PHASE*_COMPLETE.md
 *_NOTES.md
 scratch_*.md
 temp_*.md
+
+# Harness-local session handoff written by scripts/write-handoff.sh into CWD and
+# read back by skill-resume. It is per-machine, per-run state, never a shared
+# artifact, and a committed copy would point every checkout at one machine's
+# half-finished workflow.
+.octo-continue.md
 WIP_*.md
 
 # Test artifacts (from test infrastructure)

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -77,7 +77,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 **Traction (as of 2026-07-27):**
 - GitHub stars: 3,889
 - GitHub forks: 365
-- Local CI parity: 16 smoke, 186 unit, and 7 integration suites
+- Local CI parity: 16 smoke, 188 unit, and 7 integration suites
 - Version: 9.56.1 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Cursor (MCP), Gemini CLI
 

--- a/commands/whats-new.md
+++ b/commands/whats-new.md
@@ -1,0 +1,106 @@
+---
+command: whats-new
+description: "Review and enable Claude Octopus features added since you installed"
+allowed-tools: Bash, Read
+---
+
+# What's New (/octo:whats-new)
+
+**Your first output line MUST be:** `🐙 Octopus What's New`
+
+Show the features that landed after the user's install point, let them enable or
+decline each one, and record the decision so they are never asked twice.
+
+## Why this command exists
+
+Features added after a user installs are invisible to them. The SessionStart
+version advisory is one line and easy to miss, and a hook cannot run an
+interactive picker. This command is the interactive half: the advisory points
+here, and this is where consent is actually collected and written down.
+
+## EXECUTION CONTRACT (Mandatory)
+
+### Step 1 — Load the offer list
+
+```bash
+source "${CLAUDE_PLUGIN_ROOT:-.}/scripts/lib/features.sh" 2>/dev/null \
+  || source ./scripts/lib/features.sh
+
+octo_features_available || {
+    echo "Feature disclosure unavailable (jq missing, or manifest/ledger unreadable)."
+    exit 0
+}
+
+for id in $(octo_features_offerable_ids); do
+    prereq="$(octo_features_prereq "$id")"
+    if octo_features_prereq_ok "$prereq"; then state="offerable"; else state="blocked:$prereq"; fi
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$id" "$state" "$(octo_features_key "$id")" \
+        "$(octo_features_title "$id")" "$(octo_features_description "$id")"
+done
+```
+
+If the list is empty, say `Nothing new since your last upgrade.` and stop. Do not
+pad the output or invent features.
+
+### Step 2 — Present the list
+
+Render one block per feature: title, what it does, the env var it sets, and the
+cost implication when there is one. Features whose state is `blocked:<prereq>`
+are shown with the reason (for example `requires the Codex CLI`) and are NOT
+offered for enabling. Show them rather than hiding them, so the user learns the
+prerequisite exists and can install it.
+
+State the cost plainly for anything that spends money. `fable5-escalation` runs
+at $10/$50 per MTok, twice Opus 5, and the user needs that number before
+deciding, not after.
+
+### Step 3 — Collect decisions
+
+Use `AskUserQuestion` with one question per offerable feature, options
+`Enable` / `Not now`. Multiple features may be presented in a single call (up to
+the tool's 4-question limit; batch the remainder into a second call).
+
+WAIT for the answers. Do not assume, and do not enable anything the user did not
+explicitly choose.
+
+### Step 4 — Record and apply
+
+For each answer:
+
+```bash
+# Enable
+octo_features_record "<id>" enabled "<current plugin version>"
+# Not now
+octo_features_record "<id>" declined "<current plugin version>"
+```
+
+`declined` is sticky: that feature will not be offered again. Tell the user this
+so "Not now" is an informed choice, and tell them how to change their mind:
+`/octo:model-config` for routing features, or exporting the env var directly.
+
+For each enabled feature, the recorded consent is what the runtime reads, so
+nothing further is required for it to take effect in this repository. If the user
+wants it active in every shell, tell them to add the export to their profile:
+
+```bash
+echo 'export <KEY>=1' >> ~/.zshrc   # or ~/.bashrc
+```
+
+Read the current plugin version from `.claude-plugin/plugin.json` (`.version`).
+Never hardcode it.
+
+### Step 5 — Confirm
+
+Print a short summary: what is now enabled, what was declined, and what remains
+blocked on a missing prerequisite. End on the substantive state, no closer.
+
+## Notes
+
+- Never write to `state.json` with anything other than `octo_features_record`
+  and `octo_features_seed_watermark`. Hand-rolled `jq` edits here have raced the
+  SessionStart hook's own write in the past.
+- Do not re-offer a feature the ledger already records a decision for. The
+  offer list already excludes them; do not work around it.
+- This command never changes model routing, permissions, or quality gates by
+  itself. It records consent; the runtime reads consent.

--- a/commands/whats-new.md
+++ b/commands/whats-new.md
@@ -8,19 +8,25 @@ allowed-tools: Bash, Read
 
 **Your first output line MUST be:** `🐙 Octopus What's New`
 
-Show the features that landed after the user's install point, let them enable or
-decline each one, and record the decision so they are never asked twice.
+Show the settings added since the user's install point that still need a policy
+choice, ask each as its own question, and record the answers so they are never
+asked twice.
 
 ## Why this command exists
 
 Features added after a user installs are invisible to them. The SessionStart
-version advisory is one line and easy to miss, and a hook cannot run an
-interactive picker. This command is the interactive half: the advisory points
-here, and this is where consent is actually collected and written down.
+advisory asks for these choices automatically on the first session after an
+upgrade, but that prompt is capped and suppressed in non-interactive sessions,
+so this command is how the user reaches the same questions deliberately, and how
+they revisit a choice they already made.
+
+Only features declaring `decision: required` in the manifest appear here. A
+feature that ships with a sensible default and no real fork in behaviour is not
+a question and must not be raised as one.
 
 ## EXECUTION CONTRACT (Mandatory)
 
-### Step 1 — Load the offer list
+### Step 1 — Load the outstanding questions
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT:-.}/scripts/lib/features.sh" 2>/dev/null \
@@ -31,76 +37,68 @@ octo_features_available || {
     exit 0
 }
 
+# Tab-separated. Q<TAB>id<TAB>question, then C<TAB>id<TAB>value<TAB>label<TAB>description.
+octo_features_prompt_manifest
+
+# Features blocked on a missing prerequisite, listed but not askable.
 for id in $(octo_features_offerable_ids); do
     prereq="$(octo_features_prereq "$id")"
-    if octo_features_prereq_ok "$prereq"; then state="offerable"; else state="blocked:$prereq"; fi
-    printf '%s\t%s\t%s\t%s\t%s\n' \
-        "$id" "$state" "$(octo_features_key "$id")" \
-        "$(octo_features_title "$id")" "$(octo_features_description "$id")"
+    octo_features_prereq_ok "$prereq" || printf 'BLOCKED\t%s\t%s\n' "$id" "$prereq"
 done
 ```
 
-If the list is empty, say `Nothing new since your last upgrade.` and stop. Do not
-pad the output or invent features.
+If nothing is returned, say `Nothing new to decide since your last upgrade.` and
+stop. Do not pad the output or invent questions.
 
-### Step 2 — Present the list
+### Step 2 — Ask
 
-Render one block per feature: title, what it does, the env var it sets, and the
-cost implication when there is one. Features whose state is `blocked:<prereq>`
-are shown with the reason (for example `requires the Codex CLI`) and are NOT
-offered for enabling. Show them rather than hiding them, so the user learns the
-prerequisite exists and can install it.
+Call `AskUserQuestion` with one question per `Q` line, using that feature's
+question text and its own `C` choices verbatim. Do not invent options, do not
+reword a policy choice into a yes/no, and keep each choice description's cost
+note, because that is usually what the answer turns on.
 
-State the cost plainly for anything that spends money. `fable5-escalation` runs
-at $10/$50 per MTok, twice Opus 5, and the user needs that number before
-deciding, not after.
+`AskUserQuestion` takes at most 4 questions per call and 4 options per question.
+If there are more than 4 outstanding features, ask the first four, record them,
+then ask the rest in a second call.
 
-### Step 3 — Collect decisions
+`BLOCKED` features are shown with their missing prerequisite (for example
+`requires the Codex CLI`) and are NOT asked. Show them rather than hiding them,
+so the user learns the prerequisite exists.
 
-Use `AskUserQuestion` with one question per offerable feature, options
-`Enable` / `Not now`. Multiple features may be presented in a single call (up to
-the tool's 4-question limit; batch the remainder into a second call).
+WAIT for the answers. Apply nothing the user did not pick.
 
-WAIT for the answers. Do not assume, and do not enable anything the user did not
-explicitly choose.
-
-### Step 4 — Record and apply
-
-For each answer:
+### Step 3 — Record every answer
 
 ```bash
-# Enable
-octo_features_record "<id>" enabled "<current plugin version>"
-# Not now
-octo_features_record "<id>" declined "<current plugin version>"
+octo_features_record "<id>" "<chosen value>" "<current plugin version>"
 ```
 
-`declined` is sticky: that feature will not be offered again. Tell the user this
-so "Not now" is an informed choice, and tell them how to change their mind:
-`/octo:model-config` for routing features, or exporting the env var directly.
-
-For each enabled feature, the recorded consent is what the runtime reads, so
-nothing further is required for it to take effect in this repository. If the user
-wants it active in every shell, tell them to add the export to their profile:
-
-```bash
-echo 'export <KEY>=1' >> ~/.zshrc   # or ~/.bashrc
-```
+Record all of them, including any that picks the feature's default. Recording is
+what stops the question being asked again; an unrecorded answer means the user is
+asked the same thing after the next upgrade.
 
 Read the current plugin version from `.claude-plugin/plugin.json` (`.version`).
 Never hardcode it.
 
-### Step 5 — Confirm
+A recorded choice takes effect immediately for this repository. To pin one for
+every shell, tell the user to export the feature's key with the chosen value:
 
-Print a short summary: what is now enabled, what was declined, and what remains
-blocked on a missing prerequisite. End on the substantive state, no closer.
+```bash
+echo 'export <KEY>=<value>' >> ~/.zshrc   # or ~/.bashrc
+```
+
+### Step 4 — Confirm
+
+Print what is now set, one line per feature, plus anything still blocked on a
+missing prerequisite. End on the substantive state, no closer.
 
 ## Notes
 
 - Never write to `state.json` with anything other than `octo_features_record`
   and `octo_features_seed_watermark`. Hand-rolled `jq` edits here have raced the
   SessionStart hook's own write in the past.
-- Do not re-offer a feature the ledger already records a decision for. The
-  offer list already excludes them; do not work around it.
+- Do not re-ask a feature the ledger already records a choice for. The offer
+  list already excludes them; do not work around it. The user asking this
+  command directly is the supported way to revisit a settled choice.
 - This command never changes model routing, permissions, or quality gates by
   itself. It records consent; the runtime reads consent.

--- a/config/features.json
+++ b/config/features.json
@@ -1,0 +1,53 @@
+{
+  "schema": "features_v1",
+  "features": [
+    {
+      "id": "fable5-escalation",
+      "added_in": "9.57.0",
+      "backfill": true,
+      "title": "Fable 5 escalation for judgment work",
+      "description": "Escalate PRD authoring, definition tradeoffs, and cross-vendor tie-breaks from Opus 5 to Fable 5. Costs 2x Opus 5 ($10/$50 per MTok); capped at one dispatch per command.",
+      "kind": "env",
+      "key": "OCTOPUS_FABLE5_ESCALATE",
+      "enabled_value": "1",
+      "default": "disabled",
+      "prereq": "claude-opus-seat"
+    },
+    {
+      "id": "codex-reviewer-flip",
+      "added_in": "9.57.0",
+      "backfill": true,
+      "title": "Authorship-aware code review",
+      "description": "When Codex implements, route code review to a Claude seat instead of Codex reviewing its own output.",
+      "kind": "env",
+      "key": "OCTOPUS_REVIEWER_FLIP",
+      "enabled_value": "1",
+      "default": "disabled",
+      "prereq": "codex-cli"
+    },
+    {
+      "id": "preflight-probe",
+      "added_in": "9.55.0",
+      "backfill": false,
+      "title": "Proactive provider health probe",
+      "description": "Validate API-key providers (Perplexity, OpenRouter) at preflight instead of discovering a dead key mid-workflow.",
+      "kind": "env",
+      "key": "OCTOPUS_PREFLIGHT_PROBE",
+      "enabled_value": "1",
+      "default": "disabled",
+      "prereq": "none"
+    },
+    {
+      "id": "gemini-via-agy",
+      "added_in": "9.52.0",
+      "backfill": false,
+      "title": "Route Gemini seats through Antigravity",
+      "description": "Serve gemini* seats via the Antigravity CLI. Gemini Code Assist free-tier OAuth is sunset, so the direct gemini-cli path returns IneligibleTierError.",
+      "kind": "env",
+      "key": "OCTOPUS_GEMINI_VIA_AGY",
+      "enabled_value": "1",
+      "default": "disabled",
+      "prereq": "agy-cli"
+    }
+  ]
+}

--- a/config/features.json
+++ b/config/features.json
@@ -1,52 +1,83 @@
 {
   "schema": "features_v1",
+  "_comment": "decision=required means the feature needs a real user policy choice and is raised at session start after an upgrade. decision=none means it ships silently with a sensible default: no prompt, still documented, still settable via its env key. Most features should be 'none'. A prompt is for a genuine fork in behaviour or cost, not for announcing that work happened.",
   "features": [
     {
-      "id": "fable5-escalation",
+      "id": "fable5-routing",
       "added_in": "9.57.0",
       "backfill": true,
-      "title": "Fable 5 escalation for judgment work",
-      "description": "Escalate PRD authoring, definition tradeoffs, and cross-vendor tie-breaks from Opus 5 to Fable 5. Costs 2x Opus 5 ($10/$50 per MTok); capped at one dispatch per command.",
-      "kind": "env",
-      "key": "OCTOPUS_FABLE5_ESCALATE",
-      "enabled_value": "1",
-      "default": "disabled",
-      "prereq": "claude-opus-seat"
+      "decision": "required",
+      "title": "Claude Fable 5 routing",
+      "question": "How should Claude Fable 5 be used?",
+      "key": "OCTOPUS_FABLE5_ROUTING",
+      "default": "off",
+      "prereq": "claude-opus-seat",
+      "choices": [
+        {
+          "value": "off",
+          "label": "Not at all",
+          "description": "Opus 5 stays the lead for everything. No added cost. Changeable later with /octo:whats-new."
+        },
+        {
+          "value": "escalate",
+          "label": "Planning and PRDs",
+          "description": "Fable 5 authors PRDs, definition tradeoffs and cross-vendor tie-breaks. $10/$50 per MTok, twice Opus 5, capped at one dispatch per command."
+        },
+        {
+          "value": "escalate-reviews",
+          "label": "Planning, PRDs and reviews",
+          "description": "As above, plus plan and spec review. Fable 5 is Anthropic-family like Opus 5, so a Fable review of Opus work is not an independent cross-vendor check."
+        },
+        {
+          "value": "on-demand",
+          "label": "Only when I ask",
+          "description": "Never automatic. Available by pinning OCTOPUS_OPUS_MODEL=claude-fable-5 for a session."
+        }
+      ]
     },
     {
       "id": "codex-reviewer-flip",
       "added_in": "9.57.0",
       "backfill": true,
-      "title": "Authorship-aware code review",
-      "description": "When Codex implements, route code review to a Claude seat instead of Codex reviewing its own output.",
-      "kind": "env",
+      "decision": "required",
+      "title": "Who reviews Codex-written code",
+      "question": "When Codex writes the code, who should review it?",
       "key": "OCTOPUS_REVIEWER_FLIP",
-      "enabled_value": "1",
-      "default": "disabled",
-      "prereq": "codex-cli"
+      "default": "codex",
+      "prereq": "codex-cli",
+      "choices": [
+        {
+          "value": "claude",
+          "label": "A Claude seat",
+          "description": "Review moves to Opus 5 so author and reviewer are different vendors. Costs Opus 5 rates for the review step."
+        },
+        {
+          "value": "codex",
+          "label": "Keep Codex reviewing",
+          "description": "Current behaviour. Cheaper, but Codex reviews its own output, which catches less."
+        }
+      ]
     },
     {
       "id": "preflight-probe",
       "added_in": "9.55.0",
       "backfill": false,
+      "decision": "none",
       "title": "Proactive provider health probe",
-      "description": "Validate API-key providers (Perplexity, OpenRouter) at preflight instead of discovering a dead key mid-workflow.",
-      "kind": "env",
+      "description": "Validates API-key providers at preflight instead of discovering a dead key mid-workflow. Set OCTOPUS_PREFLIGHT_PROBE=1 to enable.",
       "key": "OCTOPUS_PREFLIGHT_PROBE",
-      "enabled_value": "1",
-      "default": "disabled",
+      "default": "0",
       "prereq": "none"
     },
     {
       "id": "gemini-via-agy",
       "added_in": "9.52.0",
       "backfill": false,
+      "decision": "none",
       "title": "Route Gemini seats through Antigravity",
-      "description": "Serve gemini* seats via the Antigravity CLI. Gemini Code Assist free-tier OAuth is sunset, so the direct gemini-cli path returns IneligibleTierError.",
-      "kind": "env",
+      "description": "Serves gemini* seats via the Antigravity CLI. Gemini Code Assist free-tier OAuth is sunset, so the direct path returns IneligibleTierError. Set OCTOPUS_GEMINI_VIA_AGY=1 to enable.",
       "key": "OCTOPUS_GEMINI_VIA_AGY",
-      "enabled_value": "1",
-      "default": "disabled",
+      "default": "0",
       "prereq": "agy-cli"
     }
   ]

--- a/docs/roadmaps/2026-07-28-fable5-escalation-and-disclosure.md
+++ b/docs/roadmaps/2026-07-28-fable5-escalation-and-disclosure.md
@@ -1,0 +1,144 @@
+# Fable 5 escalation, Codex review flip, progressive disclosure
+
+Three features shipped together on `feat/fable5-escalation-and-feature-disclosure`.
+This records the design decisions and the two places the original framing was
+changed, so neither gets re-litigated from scratch.
+
+**bd was write-blocked when this shipped** (4 pending schema migrations, v49 →
+v53, needing the single designated migrator). The `bd create` commands at the
+bottom are ready to run once writes are restored; nothing here has been filed.
+
+## What shipped
+
+| Feature | Mechanism | Default |
+|---|---|---|
+| Selective Fable 5 escalation | `fable5_maybe_escalate` at `lib/dispatch.sh`, judgment roles only | off, opt-in |
+| Authorship-aware review flip | `_octo_reviewer_flip_active` in `lib/agent-utils.sh` | off, opt-in |
+| Progressive feature disclosure | `config/features.json` + `features_v1` ledger + `/octo:whats-new` | always on, one advisory line |
+
+## Two changes to the original framing
+
+### Fable 5 reviews nothing that Opus wrote
+
+The request was for Fable 5 to check "PRDs, plans, specs and reviews".
+Escalation deliberately does **not** cover review. `frontier-model-routing.md`
+states that Anthropic-family agreement is not an independent check, so Fable
+reviewing an Opus-authored plan is a same-family echo bought at twice the Opus 5
+price. Fable's value here is capability, not vendor diversity.
+
+The eligible roles are therefore `architect` and `strategist` only: authoring
+judgment artifacts and premium synthesis/arbitration. `code-reviewer` is
+explicitly excluded and stays on GPT-5.6 Sol, which the routing doc already
+assigns. Fable authors and arbitrates; Codex opposes.
+
+Note these are the *real* role names from `agent-utils.sh`. An earlier draft of
+this design used invented roles (`prd-author`, `prd-scorer`, `adjudicator`) that
+do not exist anywhere in the dispatch path, and an allowlist built on them would
+have matched nothing. `/octo:prd`, `flow-define` and `skill-council` all
+dispatch through `architect` and `strategist`, so those two cover the intended
+surface.
+
+### Codex is not made the default implementer for native sessions
+
+Inside octo workflows Codex already is the default implementer
+(`agent-utils.sh` maps `implementer` to `codex:gpt-5.6-sol`, and `workflows.sh`
+tangle coding dispatches it). Extending that to native Claude Code sessions was
+dropped, not deferred: `codex exec --sandbox workspace-write` collapses the
+user's review surface from per-edit permission prompts to a single Bash approval
+covering arbitrary workspace writes. `frontier-model-routing.md` is explicit
+that a model change must never broaden write authority, and unlike the rest of
+this work that is not something CI can catch or a user can undo after the fact.
+
+What was actually missing was authorship-aware review, which is what shipped.
+
+## Why escalation lives in dispatch, not the model resolver
+
+`model-resolver.sh` caches on `provider/agent/phase/role/config-cksum` with no
+liveness component. An escalation applied there would keep serving a cached
+`claude-fable-5` after the seat was marked quota-dead mid-session, and would
+need a cache-bypass plus a test to prove the bypass works.
+
+`lib/dispatch.sh` runs after the cache on every call, which is also where
+`fable5_maybe_reroute` already lives. Putting escalation there removes the
+failure mode instead of guarding it. A regression test asserts escalation is
+called from `dispatch.sh` and *not* from `model-resolver.sh`, so a future move
+into the resolver fails loudly.
+
+## Headroom is reactive because it cannot be predictive
+
+No endpoint reports remaining Fable 5 usage on a Claude Code seat, and the limit
+is a rolling window shared with the user's interactive Claude usage, which the
+plugin cannot observe. A self-maintained budget ledger would drift from reality
+immediately and give false confidence.
+
+So: escalate, and if the dispatch comes back rate-limited, `quota-watcher` marks
+`claude-fable-5` dead and escalation stands down for the TTL. The claude-sdk
+shim's existing refusal retry (which gates on the model string, not on
+`fable5_mode_active`) already lands a refused Fable dispatch on Opus 5, so an
+escalated dispatch inherits that for free.
+
+Cost containment is a per-run cap: one escalated dispatch per process tree.
+Councils, debates and review fleets dispatch many seats, and escalating each one
+is exactly the spend the one-owner rule exists to prevent.
+
+## Disclosure state model
+
+Manifest (`config/features.json`, checked in) declares `id`, `added_in`,
+`title`, `description`, `kind`, `key`, `default`, `prereq`, optional
+`reoffer_at` and `backfill`. Ledger (`features_v1` in `state.json`, per user)
+records `{decision, at_version}` plus a `features_watermark`.
+
+Four states: absent (never offered), `enabled`, `declined`, `disabled`.
+`declined` and `disabled` are deliberately distinct even though both suppress
+offers. Collapsing them would mean a future "re-offer disabled features" change
+resurrects every past rejection, which is the nagware failure this design exists
+to avoid. The one legitimate re-ask is a manifest `reoffer_at` above the version
+at which the user declined.
+
+Two decisions worth recording:
+
+- **A corrupt ledger disables disclosure entirely.** An unreadable `state.json`
+  makes every decision read come back empty, which is indistinguishable from
+  "never offered" — so disclosure would re-offer every feature every session
+  while also being unable to write the answer down. `octo_features_available`
+  therefore requires the ledger to be absent or valid JSON.
+- **The watermark seeds from `last_seen_version`, not the current version.**
+  Seeding from the current version would put every feature shipped in this
+  release below the watermark and nothing would ever be offered. The advisory
+  hook seeds from the version the user is coming *from*.
+
+`model_defaults_v2: "accepted"` is left in place and not migrated. It gates a
+different thing (role routing, with an `OCTOPUS_LEGACY_ROLES` escape hatch) and
+rewriting it would invalidate consent users already gave.
+
+## Known gaps
+
+- **The advisory fires once per version jump.** A user who ignores that line
+  does not hear again until the next upgrade. `/octo:whats-new` remains
+  discoverable, but a user who misses the line and never runs the command stays
+  unaware. Deliberate: firing every session is the nagware failure above.
+- **No input-size gate on escalation.** The intended guard was to skip
+  escalation above `OCTOPUS_FABLE5_MAX_INPUT_KB`, but the prompt is not assembled
+  at the point where dispatch resolves the model, so the gate belongs in
+  `lib/agents.sh`/`lib/spawn.sh`. Not implemented rather than implemented in the
+  wrong place. Filed below.
+- **Codex handoff hardening not done.** The dirty-tree guard, before/after diff
+  attribution, handoff packet contract, and orchestrator-side re-run of quality
+  gates were scoped out of this PR. Filed below.
+
+```bash
+bd create --type=feature --priority=2 \
+  --title="Fable 5 escalation: input-size gate before an escalated dispatch" \
+  --description="Skip escalation when the assembled prompt exceeds OCTOPUS_FABLE5_MAX_INPUT_KB. Must live where the prompt is assembled (lib/agents.sh or lib/spawn.sh), not in dispatch.sh where the model is resolved before the prompt exists." \
+  --acceptance="An oversized prompt logs a WARN and stays on Opus 5; an undersized one escalates; the threshold is configurable and has a documented default."
+
+bd create --type=feature --priority=2 \
+  --title="Codex implementation handoff hardening" \
+  --description="Four hardenings of the octo-workflow Codex handoff: refuse or snapshot on a dirty tree, capture before/after diff for attribution, codify the handoff packet (task, target files, acceptance criteria, forbidden paths, session decisions) in flow-develop with a validation gate, and re-run quality gates orchestrator-side rather than trusting Codex self-reported results." \
+  --acceptance="Dirty-tree guard covered by a test; handoff packet missing acceptance criteria fails loud; a Codex stub that lies about tests fails the workflow; effective sandbox mode logged per dispatch."
+
+bd create --type=task --priority=3 \
+  --title="Surface unactioned feature offers beyond the single version-jump advisory" \
+  --description="The SessionStart advisory fires once per version jump. A user who misses it never hears again. Consider mentioning the outstanding count in /octo:doctor or /octo:setup output, which the user visits deliberately, without reintroducing per-session nagging." \
+  --acceptance="Outstanding offers are discoverable from at least one command the user already runs; no new per-session advisory."
+```

--- a/hooks/session-start-memory.sh
+++ b/hooks/session-start-memory.sh
@@ -48,8 +48,22 @@ if [[ ! -f "$SETUP_MARKER" ]]; then
     mkdir -p "${HOME}/.claude-octopus"
     touch "$SETUP_MARKER"
     [[ "$REMOTE_SESSION" == "true" ]] && exit 0
-    echo "[🐙] Welcome to Claude Octopus! Running /octo:setup for first-time configuration..."
-    # This additionalContext triggers Claude to invoke the setup skill
+    # This has to be a hookSpecificOutput object, not bare text. The comment here
+    # used to claim "this additionalContext triggers Claude to invoke the setup
+    # skill" while the hook only echoed a plain line, which SessionStart does not
+    # accept as context on v2.1.178+ (see hooks/version-advisory.sh). The welcome
+    # message was therefore never injected and the intended auto-setup never
+    # fired. Falls back to the plain line when jq is unavailable so a user without
+    # jq still sees something.
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn --arg ctx "🐙 Welcome to Claude Octopus. This is a first run and nothing is configured yet.
+Invoke the octo:setup skill now to walk the user through provider setup, unless
+their first message is urgent, in which case answer that first and offer setup
+immediately after." \
+            '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$ctx}}'
+    else
+        echo "[🐙] Welcome to Claude Octopus! Run /octo:setup for first-time configuration."
+    fi
     exit 0
 fi
 

--- a/hooks/version-advisory.sh
+++ b/hooks/version-advisory.sh
@@ -25,10 +25,25 @@ _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "
 trap _octo_hook_exit EXIT
 
 
-STATE_DIR="${HOME}/.claude-octopus"
+STATE_DIR="${OCTOPUS_STATE_DIR:-${HOME}/.claude-octopus}"
 STATE_FILE="${STATE_DIR}/state.json"
 SETUP_MARKER="${STATE_DIR}/.setup-complete"
 PLUGIN_MANIFEST="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"
+
+# Progressive feature disclosure (scripts/lib/features.sh). Sourced defensively:
+# this hook must never block or noisily fail a session, so a missing library just
+# means the advisory keeps its pre-existing one-line form.
+_HOOK_DIR="$(cd -P "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || _HOOK_DIR=""
+for _feat_lib in \
+    "${CLAUDE_PLUGIN_ROOT:-}/scripts/lib/features.sh" \
+    "${_HOOK_DIR}/../scripts/lib/features.sh"
+do
+    if [[ -n "$_feat_lib" && -f "$_feat_lib" ]]; then
+        # shellcheck source=../scripts/lib/features.sh
+        source "$_feat_lib" 2>/dev/null || true
+        break
+    fi
+done
 
 # Silent exit on missing prereqs — never block session start
 [[ ! -f "$PLUGIN_MANIFEST" ]] && exit 0
@@ -61,12 +76,30 @@ if [[ -z "$LAST_SEEN" ]]; then
     exit 0
 fi
 
+# Seed the disclosure watermark from the version the user is coming FROM, not the
+# one they are moving to. Seeding from CURRENT_VERSION would place every feature
+# shipped in this release below the watermark, so nothing would ever be offered.
+FEATURE_LINE=""
+if declare -f octo_features_seed_watermark >/dev/null 2>&1; then
+    OCTOPUS_STATE_DIR="$STATE_DIR" octo_features_seed_watermark "$LAST_SEEN" 2>/dev/null || true
+    _actionable="$(OCTOPUS_STATE_DIR="$STATE_DIR" octo_features_actionable_count 2>/dev/null || echo 0)"
+    if [[ "$_actionable" =~ ^[0-9]+$ ]] && (( _actionable > 0 )); then
+        if (( _actionable == 1 )); then
+            FEATURE_LINE="
+   1 new feature is available to enable: /octo:whats-new"
+        else
+            FEATURE_LINE="
+   ${_actionable} new features are available to enable: /octo:whats-new"
+        fi
+    fi
+fi
+
 # Version changed — advisory. Keep it to one or two lines, non-blocking. Emit a
 # valid SessionStart hook-output object (bare text fails v2.1.178 validation); jq
 # JSON-escapes the multi-line message.
 jq -cn --arg ctx "🐙 Claude Octopus updated: ${LAST_SEEN} → ${CURRENT_VERSION}
    Review changes: /octo:setup (or see CHANGELOG for role routing / default model shifts).
-   Opt out of new routing: export OCTOPUS_LEGACY_ROLES=1" \
+   Opt out of new routing: export OCTOPUS_LEGACY_ROLES=1${FEATURE_LINE}" \
     '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$ctx}}'
 
 # Persist new version so we don't advise again next session

--- a/hooks/version-advisory.sh
+++ b/hooks/version-advisory.sh
@@ -81,15 +81,67 @@ fi
 # shipped in this release below the watermark, so nothing would ever be offered.
 FEATURE_LINE=""
 if declare -f octo_features_seed_watermark >/dev/null 2>&1; then
-    OCTOPUS_STATE_DIR="$STATE_DIR" octo_features_seed_watermark "$LAST_SEEN" 2>/dev/null || true
-    _actionable="$(OCTOPUS_STATE_DIR="$STATE_DIR" octo_features_actionable_count 2>/dev/null || echo 0)"
+    export OCTOPUS_STATE_DIR="$STATE_DIR"
+    octo_features_seed_watermark "$LAST_SEEN" 2>/dev/null || true
+    _actionable="$(octo_features_actionable_count 2>/dev/null || echo 0)"
     if [[ "$_actionable" =~ ^[0-9]+$ ]] && (( _actionable > 0 )); then
-        if (( _actionable == 1 )); then
+        _noun="features are"; [[ "$_actionable" == "1" ]] && _noun="feature is"
+        _plural="s"; [[ "$_actionable" == "1" ]] && _plural=""
+
+        # Pointing at a command is the weak form of this: users do not run
+        # commands they have to remember, and they do not hand-edit env vars
+        # either. A SessionStart hook cannot raise a picker itself, but the
+        # context it injects is acted on by the assistant — the same mechanism
+        # auto-router-inject.sh uses to trigger a Skill. So ask the assistant to
+        # raise the picker on the first turn.
+        #
+        # Gated on three things, because an unwanted prompt is worse than a
+        # missed one:
+        #   - an interactive session (a cron/headless/remote run has nobody to
+        #     answer, and prompting there burns or stalls the turn);
+        #   - a remaining prompt budget for this version (an unanswered prompt
+        #     leaves everything undecided, which would otherwise re-ask forever);
+        #   - the assistant actually honouring the directive, which is advisory.
+        # When any of those fails, the plain pointer below is still emitted, so
+        # discoverability degrades rather than disappears.
+        if declare -f octo_features_session_interactive >/dev/null 2>&1 \
+           && octo_features_session_interactive \
+           && octo_features_prompt_allowed "$CURRENT_VERSION"; then
+            _offers="$(octo_features_prompt_manifest 2>/dev/null || true)"
+            if [[ -n "$_offers" ]]; then
+                octo_features_record_prompt_attempt "$CURRENT_VERSION" 2>/dev/null || true
+                FEATURE_LINE="
+<OCTOPUS-NEW-FEATURES>
+This upgrade added ${_actionable} setting${_plural} the user has not chosen yet.
+Each one is a real policy question, not an announcement.
+
+Before doing anything else this session, call AskUserQuestion ONCE with one
+question per feature below. Use each feature's own question text and its own
+choices verbatim; do not invent options, and do not collapse them into a yes/no.
+Keep each choice description's cost note, because that is what the choice turns
+on.
+
+The lines below are tab-separated:
+  Q<TAB>id<TAB>question
+  C<TAB>id<TAB>value<TAB>label<TAB>description
+
+${_offers}
+
+Record every answer, including any that picks the default:
+  source \"\${CLAUDE_PLUGIN_ROOT:-.}/scripts/lib/features.sh\"
+  octo_features_record <id> <chosen value> ${CURRENT_VERSION}
+
+Recording is what stops the question being asked again, so record all of them.
+Tell the user /octo:whats-new can change any of it later. Apply nothing they did
+not pick. If their first message is urgent, answer it first and ask right after.
+</OCTOPUS-NEW-FEATURES>"
+            fi
+        fi
+
+        # Fallback pointer, also used when the picker is suppressed or spent.
+        if [[ -z "$FEATURE_LINE" ]]; then
             FEATURE_LINE="
-   1 new feature is available to enable: /octo:whats-new"
-        else
-            FEATURE_LINE="
-   ${_actionable} new features are available to enable: /octo:whats-new"
+   ${_actionable} new ${_noun} available to enable: /octo:whats-new"
         fi
     fi
 fi

--- a/openclaw/src/tools/index.ts
+++ b/openclaw/src/tools/index.ts
@@ -119,6 +119,7 @@ export const SKILL_REGISTRY: SkillRegistryEntry[] = [
   { name: "tdd", description: "Test-driven development with red-green-refactor discipline", type: "command", file: "tdd.md" },
   { name: "unfreeze", description: "[advanced] Remove freeze mode edit restriction", type: "command", file: "unfreeze.md" },
   { name: "usage", description: "[advanced] Per-provider, per-skill, and per-MCP-server cost and token breakdown (Claude Code /usage schema)", type: "command", file: "usage.md" },
+  { name: "whats-new", description: "Review and enable Claude Octopus features added since you installed", type: "command", file: "whats-new.md" },
 ];
 
-export const REGISTRY_COUNT = 104;
+export const REGISTRY_COUNT = 105;

--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -64,12 +64,17 @@ _BARE_OPT="${_BARE_OPT:-}"
 # vendor diversity instead of creating it.
 _octo_reviewer_flip_active() {
     command -v codex >/dev/null 2>&1 || return 1
-    if declare -f octo_features_enabled >/dev/null 2>&1; then
-        octo_features_enabled "codex-reviewer-flip"
-        return $?
+    local choice
+    if declare -f octo_features_choice >/dev/null 2>&1; then
+        choice="$(octo_features_choice "codex-reviewer-flip")"
+    else
+        choice="${OCTOPUS_REVIEWER_FLIP:-codex}"
     fi
-    case "${OCTOPUS_REVIEWER_FLIP:-}" in
-        1|on|true|yes) return 0 ;;
+    # "claude" is the only value that moves review off the implementing vendor.
+    # Legacy truthy values are accepted so an existing OCTOPUS_REVIEWER_FLIP=1 in
+    # someone's profile keeps meaning what it used to.
+    case "$choice" in
+        claude|1|on|true|yes) return 0 ;;
     esac
     return 1
 }

--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -50,6 +50,30 @@ _BARE_OPT="${_BARE_OPT:-}"
 # Opt-out:   OCTOPUS_LEGACY_ROLES=1 restores the v9.28 mapping.
 # Fallback:  consumers (see lib/agents.sh get_fallback_agent) silently downshift when the
 #            preferred CLI is unavailable (e.g. no Anthropic auth → architect → current Codex).
+
+# _octo_reviewer_flip_active — true when code review should move off the Codex
+# seat because Codex is the implementer.
+#
+# Gated on explicit consent (progressive disclosure feature `codex-reviewer-flip`,
+# or OCTOPUS_REVIEWER_FLIP as a session override) rather than on by default: it
+# shifts review spend from a Codex seat onto a premium Opus seat, which is a cost
+# change users should opt into knowingly.
+#
+# Also requires the Codex CLI to actually be present. Without it the implementer
+# falls back off Codex anyway, so flipping review away from Codex would remove
+# vendor diversity instead of creating it.
+_octo_reviewer_flip_active() {
+    command -v codex >/dev/null 2>&1 || return 1
+    if declare -f octo_features_enabled >/dev/null 2>&1; then
+        octo_features_enabled "codex-reviewer-flip"
+        return $?
+    fi
+    case "${OCTOPUS_REVIEWER_FLIP:-}" in
+        1|on|true|yes) return 0 ;;
+    esac
+    return 1
+}
+
 get_role_mapping() {
     local role="$1"
 
@@ -70,7 +94,19 @@ get_role_mapping() {
     case "$role" in
         architect)         echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-5)" ;;  # Planning, UI/UX, architecture
         researcher)        echo "agy:Gemini 3.1 Pro (High)" ;;                                             # Deep investigation via Antigravity (Google seat)
-        reviewer|code-reviewer) echo "codex-review:$(codex_default_model 2>/dev/null || echo gpt-5.6-sol)" ;; # Independent review; `reviewer` = alias
+        reviewer|code-reviewer)
+            # Authorship-aware review. The static table sends both `implementer`
+            # and `code-reviewer` to Codex, so by default Codex reviews its own
+            # output — the same echo problem that makes Fable-reviews-Opus a weak
+            # check, just with the vendors swapped. When the flip is enabled and
+            # the implementer seat is Codex, review moves to the Claude opus seat
+            # so the reviewer and the author are different vendors.
+            if _octo_reviewer_flip_active; then
+                echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-5)"
+            else
+                echo "codex-review:$(codex_default_model 2>/dev/null || echo gpt-5.6-sol)"
+            fi
+            ;;
         security-reviewer) echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-5)" ;;     # Adversarial reasoning
         implementer)       echo "codex:$(codex_default_model 2>/dev/null || echo gpt-5.6-sol)" ;;             # Default code generation; terminal-heavy
         implementer-heavy) echo "claude-opus:$(opus_default_model 2>/dev/null || echo claude-opus-5)" ;;     # Opt-in: greenfield/refactor/UI-heavy

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -290,8 +290,22 @@ get_agent_command() {
             fi
             local opus_model_flag
             opus_model_flag="$(opus_default_model)"
+            # Selective Fable 5 escalation for judgment-class roles, before the
+            # security reroute so a security dispatch can never end up on Fable
+            # even if the allowlist is later widened. Escalation is applied here
+            # rather than in the model resolver because the resolver's cache has
+            # no liveness component and would keep serving a cached Fable model
+            # after the seat was marked quota-dead.
+            if declare -f fable5_maybe_escalate >/dev/null 2>&1; then
+                opus_model_flag="$(fable5_maybe_escalate "$opus_model_flag" "$role" "$agent_type" "$phase")"
+            fi
             if declare -f fable5_maybe_reroute >/dev/null 2>&1; then
                 opus_model_flag="$(fable5_maybe_reroute "$opus_model_flag" "$role" "$agent_type" "$phase")"
+            fi
+            # Clamp on the resolved model, so an escalated dispatch is clamped
+            # while unrelated Opus 5 work in the same run keeps its effort.
+            if declare -f fable5_clamp_effort_for_model >/dev/null 2>&1; then
+                opus_effort="$(fable5_clamp_effort_for_model "$opus_effort" "$opus_model_flag")"
             fi
             opus_model_flag="$(_octopus_allowed_model_or_fallback "claude" "$opus_model_flag")" || return 1
             if ! validate_model_name "$opus_model_flag"; then

--- a/scripts/lib/fable5.sh
+++ b/scripts/lib/fable5.sh
@@ -131,29 +131,50 @@ fable5_banner() {
 #     (skills/blocks/frontier-model-routing.md), so escalating review here would
 #     buy an echo at 2x price. Fable authors and arbitrates; Codex opposes.
 
-FABLE5_ESCALATION_FEATURE_ID="fable5-escalation"
+FABLE5_ESCALATION_FEATURE_ID="fable5-routing"
 
-# True when the user has consented to escalation. Consent is read through the
-# feature ledger, which also honours OCTOPUS_FABLE5_ESCALATE as a session
-# override in both directions.
-fable5_escalation_consented() {
-    if declare -f octo_features_enabled >/dev/null 2>&1; then
-        octo_features_enabled "$FABLE5_ESCALATION_FEATURE_ID"
-        return $?
+# The user's Fable 5 routing policy, not a boolean. Values:
+#   off              never (default)
+#   escalate         judgment authoring: architect, strategist
+#   escalate-reviews the above plus code review
+#   on-demand        never automatic; reachable only by an explicit model pin
+fable5_routing_policy() {
+    if declare -f octo_features_choice >/dev/null 2>&1; then
+        octo_features_choice "$FABLE5_ESCALATION_FEATURE_ID"
+        return 0
     fi
-    # features.sh unavailable: fall back to the bare env var so escalation is
-    # still reachable, but never default it on.
-    case "${OCTOPUS_FABLE5_ESCALATE:-}" in
-        1|on|true|yes) return 0 ;;
+    # features.sh unavailable: honour the env key directly, never defaulting on.
+    printf '%s\n' "${OCTOPUS_FABLE5_ROUTING:-off}"
+}
+
+# Which roles the chosen policy escalates.
+#
+# `escalate-reviews` deliberately includes code-reviewer even though a Fable
+# review of Opus-authored work is same-family agreement rather than an
+# independent cross-vendor check. That tradeoff is stated in the choice
+# description the user picked from, so it is theirs to make; it is simply not
+# the default.
+fable5_escalation_role_eligible() {
+    local role="${1:-}" policy
+    policy="$(fable5_routing_policy)"
+    case "$policy" in
+        escalate)
+            case "$role" in architect|strategist) return 0 ;; esac
+            ;;
+        escalate-reviews)
+            case "$role" in architect|strategist|code-reviewer|reviewer) return 0 ;; esac
+            ;;
     esac
     return 1
 }
 
-fable5_escalation_role_eligible() {
-    case "${1:-}" in
-        architect|strategist) return 0 ;;
-        *) return 1 ;;
+# Kept as the coarse gate so the dispatch path reads plainly: any policy that
+# escalates something at all.
+fable5_escalation_consented() {
+    case "$(fable5_routing_policy)" in
+        escalate|escalate-reviews) return 0 ;;
     esac
+    return 1
 }
 
 # fable5_maybe_escalate <model> <role> <agent_type> <phase>

--- a/scripts/lib/fable5.sh
+++ b/scripts/lib/fable5.sh
@@ -105,3 +105,141 @@ fable5_banner() {
     export _OCTO_FABLE5_BANNER_SHOWN=1
     log "INFO" "🐙 Fable 5 mode active — security passes reroute to $(fable5_fallback_model), effort clamps to high, refusal retry on $(fable5_fallback_model) (OCTOPUS_FABLE5_MODE=off to disable)"
 }
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Selective escalation (opt-in via progressive feature disclosure)
+# ═══════════════════════════════════════════════════════════════════════════════
+# The env pin above is all-or-nothing for a whole session. Escalation is the
+# selective form: Opus 5 stays the lead, and only judgment-class dispatches move
+# up to Fable 5.
+#
+# Escalation lives at the DISPATCH layer, next to fable5_maybe_reroute, and
+# deliberately not in the model resolver. The resolver caches on
+# provider/agent/phase/role/config-cksum with no liveness component, so a
+# resolver-level escalation would keep serving a cached claude-fable-5 after the
+# seat was marked quota-dead mid-session. Dispatch runs after the cache on every
+# call, so that failure mode cannot occur here.
+#
+# Which roles escalate: `architect` and `strategist` only. Those are the actual
+# opus-seat judgment roles in agent-utils.sh, and they are what /octo:prd,
+# flow-define and skill-council dispatch. Deliberately excluded:
+#   - security-reviewer — Fable's classifiers refuse authorized audit phrasing
+#     (this is what fable5_maybe_reroute exists for).
+#   - implementer-heavy — implementation, not judgment.
+#   - code-reviewer     — adversarial review of Opus-authored work belongs on a
+#     different vendor. Anthropic-family agreement is not an independent check
+#     (skills/blocks/frontier-model-routing.md), so escalating review here would
+#     buy an echo at 2x price. Fable authors and arbitrates; Codex opposes.
+
+FABLE5_ESCALATION_FEATURE_ID="fable5-escalation"
+
+# True when the user has consented to escalation. Consent is read through the
+# feature ledger, which also honours OCTOPUS_FABLE5_ESCALATE as a session
+# override in both directions.
+fable5_escalation_consented() {
+    if declare -f octo_features_enabled >/dev/null 2>&1; then
+        octo_features_enabled "$FABLE5_ESCALATION_FEATURE_ID"
+        return $?
+    fi
+    # features.sh unavailable: fall back to the bare env var so escalation is
+    # still reachable, but never default it on.
+    case "${OCTOPUS_FABLE5_ESCALATE:-}" in
+        1|on|true|yes) return 0 ;;
+    esac
+    return 1
+}
+
+fable5_escalation_role_eligible() {
+    case "${1:-}" in
+        architect|strategist) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# fable5_maybe_escalate <model> <role> <agent_type> <phase>
+# Echoes the model to dispatch: Fable 5 when every condition holds, the input
+# model untouched otherwise. Always succeeds so callers can use it inline.
+fable5_maybe_escalate() {
+    local model="${1:-}" role="${2:-}" agent_type="${3:-}" phase="${4:-}"
+
+    # Escalation only ever upgrades the default Opus seat. Anything else (an
+    # explicit pin to another model, a Sonnet seat, an already-Fable model) is
+    # left exactly as resolved.
+    if [[ "$model" != "claude-opus-5" && "$model" != "claude-opus.5" ]]; then
+        printf '%s\n' "$model"; return 0
+    fi
+
+    # An explicit user/session pin is Tier 1 and outranks a release default;
+    # upgrading past it would violate "user config beats defaults".
+    if [[ -n "${OCTOPUS_OPUS_MODEL:-}" ]]; then
+        printf '%s\n' "$model"; return 0
+    fi
+
+    fable5_escalation_consented        || { printf '%s\n' "$model"; return 0; }
+    fable5_escalation_role_eligible "$role" || { printf '%s\n' "$model"; return 0; }
+
+    # Security work never escalates. maybe_reroute would catch it downstream,
+    # but refusing here keeps the reason in one place and avoids a pointless
+    # upgrade-then-downgrade in the logs.
+    if fable5_is_security_dispatch "$role" "$agent_type" "$phase"; then
+        printf '%s\n' "$model"; return 0
+    fi
+
+    # Headroom is reactive: there is no endpoint that reports remaining Fable 5
+    # usage on a Claude seat, so a rate-limited dispatch marks the model dead
+    # (quota-watcher) and escalation stands down for the rest of the TTL.
+    if declare -f octo_quota_is_dead >/dev/null 2>&1 \
+       && octo_quota_is_dead "$FABLE5_MODEL_ID"; then
+        if declare -f log >/dev/null 2>&1; then
+            log "WARN" "Fable 5 headroom exhausted; continuing on ${model} for this session"
+        fi
+        printf '%s\n' "$model"; return 0
+    fi
+
+    # One escalated dispatch per process tree. Councils, debates and review
+    # fleets fan out over many seats; escalating each one is precisely the
+    # spend the one-owner rule exists to prevent.
+    if [[ -n "${_OCTO_FABLE5_ESCALATED:-}" ]]; then
+        if declare -f log >/dev/null 2>&1; then
+            log "INFO" "Fable 5 escalation already used this run; ${role} stays on ${model}"
+        fi
+        printf '%s\n' "$model"; return 0
+    fi
+    export _OCTO_FABLE5_ESCALATED=1
+
+    if declare -f log >/dev/null 2>&1; then
+        log "WARN" "🐙 Fable 5 escalation: ${role} ${model} → ${FABLE5_MODEL_ID} (\$10/\$50 per MTok, 2x Opus 5; /octo:whats-new to disable)"
+    fi
+    printf '%s\n' "$FABLE5_MODEL_ID"
+    return 0
+}
+
+# fable5_clamp_effort_for_model <effort> <model> — clamp xhigh/max to high when
+# the model actually being dispatched is Fable 5.
+#
+# fable5_clamp_effort above keys off the env pin, which is correct for the pinned
+# session but misses an escalated dispatch (no pin present). Clamping on the
+# consent flag instead would over-reach in the other direction: it would also
+# clamp non-escalated Opus 5 dispatches in the same run, silently downgrading an
+# explicit OCTOPUS_EFFORT_OVERRIDE=xhigh on work that never went near Fable.
+# Keying off the resolved model is the only form that hits exactly the dispatches
+# that need it.
+#
+# The reason for clamping at all: Fable 5 effort applies per tool call, so xhigh
+# does not lengthen a run, it widens the scope of each step at twice the price.
+fable5_clamp_effort_for_model() {
+    local effort="${1:-}" model="${2:-}"
+    if [[ "$model" == "$FABLE5_MODEL_ID" ]]; then
+        case "$effort" in
+            xhigh|max)
+                if declare -f log >/dev/null 2>&1; then
+                    log "WARN" "Fable 5 effort clamp: ${effort} → high (per-call effort widens scope at 2x cost)"
+                fi
+                printf '%s\n' "high"
+                return 0
+                ;;
+        esac
+    fi
+    printf '%s\n' "$effort"
+    return 0
+}

--- a/scripts/lib/features.sh
+++ b/scripts/lib/features.sh
@@ -29,18 +29,28 @@
 # different thing (role routing defaults, with an OCTOPUS_LEGACY_ROLES escape
 # hatch) and rewriting it would invalidate consent users already gave.
 #
-# ── Decision states ──────────────────────────────────────────────────────────
+# ── Decisions are policy choices, not on/off switches ────────────────────────
 #
-#   (absent)   never offered
-#   enabled    user turned it on
-#   declined   offered and refused — sticky, suppresses future offers
-#   disabled   was enabled, later turned off
+# Asking "enable this feature?" is the wrong question for most things worth
+# asking about. The real question for Fable 5 is not whether it exists but how it
+# should be used: never, for planning only, for planning and review, or strictly
+# on demand. So a manifest entry declares `choices`, and the ledger stores the
+# chosen value.
 #
-# `declined` and `disabled` are deliberately distinct. Both suppress offers, but
-# collapsing them loses the anti-nagware guarantee: any future "re-offer the
-# disabled features" change would resurrect every past rejection. The single
-# legitimate re-ask is a manifest `reoffer_at` version above the version at
-# which the user declined, for a feature that has materially changed.
+# `decision` controls whether a feature is raised at all:
+#
+#   required   needs a genuine policy choice; prompted once after an upgrade
+#   none       ships silently with a sensible default; never prompted
+#
+# Most features should be `none`. A prompt is for a real fork in behaviour or
+# cost, not for announcing that work happened. A release that adds ten internal
+# improvements and one routing choice should ask exactly one question.
+#
+# A recorded choice is sticky: the feature is not raised again. Choosing the
+# default value (e.g. "off") is a real decision and is recorded as such, which is
+# what stops the picker from reappearing every upgrade. The single legitimate
+# re-ask is a manifest `reoffer_at` version above the version at which the user
+# chose, for a feature whose options have materially changed.
 
 # Dependency note: this file deliberately does NOT source lib/providers.sh for
 # its `version_compare`. providers.sh pulls in auth.sh, qwen.sh, grok.sh and
@@ -150,6 +160,33 @@ octo_features_all_ids() {
 }
 
 octo_features_title()       { _octo_feat_field "$1" title; }
+octo_features_question()    { _octo_feat_field "$1" question; }
+octo_features_default()     { _octo_feat_field "$1" default; }
+
+# Features that ship silently are never raised. This is the switch that keeps the
+# session-start prompt down to the questions that genuinely need an answer.
+octo_features_decision_required() {
+    [[ "$(_octo_feat_field "$1" decision)" == "required" ]]
+}
+
+# One "value<TAB>label<TAB>description" line per choice.
+octo_features_choices() {
+    local id="$1"
+    jq -r --arg id "$id" \
+        '.features[] | select(.id == $id) | .choices // [] | .[]
+         | [(.value // ""), (.label // ""), (.description // "")] | @tsv' \
+        "$(octo_features_manifest)" 2>/dev/null || true
+    return 0
+}
+
+octo_features_is_valid_choice() {
+    local id="$1" value="$2" v
+    [[ -n "$value" ]] || return 1
+    while IFS=$'\t' read -r v _ _; do
+        [[ "$v" == "$value" ]] && return 0
+    done < <(octo_features_choices "$id")
+    return 1
+}
 octo_features_description() { _octo_feat_field "$1" description; }
 octo_features_key()         { _octo_feat_field "$1" key; }
 octo_features_added_in()    { _octo_feat_field "$1" added_in; }
@@ -175,19 +212,43 @@ octo_features_decision_version() {
     return 0
 }
 
-# The predicate Feature 1 (Fable 5 escalation) consults. Env var wins over the
-# ledger so a session can override without rewriting durable consent.
-octo_features_enabled() {
-    local id="$1" key val
+# octo_features_choice <id> — the policy currently in force. Resolution order:
+#   1. the feature's env key, when it holds a valid choice value (session override)
+#   2. the recorded decision in the ledger
+#   3. the manifest default
+# Always echoes something, so callers can compare without a null case.
+octo_features_choice() {
+    local id="$1" key val recorded
     key="$(octo_features_key "$id")"
     if [[ -n "$key" ]]; then
         eval "val=\"\${${key}:-}\""
-        case "$val" in
-            1|on|true|yes) return 0 ;;
-            0|off|false|no) return 1 ;;
-        esac
+        if [[ -n "$val" ]]; then
+            if octo_features_is_valid_choice "$id" "$val"; then
+                printf '%s\n' "$val"; return 0
+            fi
+            # Boolean-shaped features (decision=none) have no choices list; pass
+            # their env value through rather than silently ignoring it.
+            if [[ -z "$(octo_features_choices "$id")" ]]; then
+                printf '%s\n' "$val"; return 0
+            fi
+        fi
     fi
-    [[ "$(octo_features_decision "$id")" == "enabled" ]]
+    recorded="$(octo_features_decision "$id")"
+    if [[ -n "$recorded" ]]; then
+        printf '%s\n' "$recorded"; return 0
+    fi
+    printf '%s\n' "$(octo_features_default "$id")"
+    return 0
+}
+
+# Convenience for the boolean-shaped features: true unless the resolved choice
+# reads as off. Policy features should compare octo_features_choice directly
+# instead, since "which policy" is not answerable with a boolean.
+octo_features_enabled() {
+    case "$(octo_features_choice "$1")" in
+        1|on|true|yes|enabled) return 0 ;;
+        *) return 1 ;;
+    esac
 }
 
 # Watermark: the version below which features are considered "already known".
@@ -231,14 +292,17 @@ octo_features_prereq_ok() {
 octo_features_is_offerable() {
     local id="$1" decision reoffer decided_at added_in watermark
 
+    # Silent features are never raised, however new they are.
+    octo_features_decision_required "$id" || return 1
+
     decision="$(octo_features_decision "$id")"
     case "$decision" in
-        enabled|disabled)
-            return 1
+        "")
             ;;
-        declined)
-            # The one legitimate re-ask: the feature materially changed and the
-            # manifest says so with a reoffer_at above the declined version.
+        *)
+            # A recorded choice is sticky. The one legitimate re-ask is a
+            # manifest reoffer_at above the version at which the user chose,
+            # for a feature whose options have materially changed.
             reoffer="$(_octo_feat_field "$id" reoffer_at)"
             [[ -n "$reoffer" ]] || return 1
             decided_at="$(octo_features_decision_version "$id")"
@@ -300,10 +364,13 @@ octo_features_actionable_count() {
 octo_features_record() {
     local id="$1" decision="$2" version="${3:-}"
     [[ -n "$id" && -n "$decision" ]] || return 1
-    case "$decision" in
-        enabled|declined|disabled) ;;
-        *) return 1 ;;
-    esac
+    # Validate against the feature's own choices so a typo cannot record a
+    # policy nothing reads. Features without a choices list (decision=none)
+    # accept any non-empty value.
+    if [[ -n "$(octo_features_choices "$id")" ]] \
+       && ! octo_features_is_valid_choice "$id" "$decision"; then
+        return 1
+    fi
     command -v jq >/dev/null 2>&1 || return 1
 
     local dir f tmp
@@ -345,4 +412,96 @@ octo_features_seed_watermark() {
     fi
     rm -f "$tmp" 2>/dev/null
     return 1
+}
+
+# ── Interactive prompt budget ────────────────────────────────────────────────
+# The SessionStart advisory can ask Claude to raise an interactive picker rather
+# than printing a pointer to a command the user will never type. That is only
+# safe with a hard cap.
+#
+# An unanswered prompt leaves every feature undecided, which is indistinguishable
+# from "never offered", so the next session would ask again — forever, for a user
+# who simply does not want to answer. The cap converts that into: ask a couple of
+# times, then fall back permanently to the one-line advisory for this version.
+#
+# Attempts are scoped to a plugin version, so a later upgrade shipping genuinely
+# new features gets a fresh budget instead of inheriting an exhausted one.
+OCTOPUS_FEATURES_PROMPT_MAX=${OCTOPUS_FEATURES_PROMPT_MAX:-2}
+
+octo_features_prompt_attempts() {
+    local version="${1:-}" f recorded_version count
+    f="$(octo_features_state_file)"
+    [[ -f "$f" ]] || { printf '0\n'; return 0; }
+    recorded_version="$(jq -r '.features_prompt_version // ""' "$f" 2>/dev/null)" || recorded_version=""
+    # A different version means the budget resets.
+    if [[ -n "$version" && "$recorded_version" != "$version" ]]; then
+        printf '0\n'; return 0
+    fi
+    count="$(jq -r '.features_prompt_attempts // 0' "$f" 2>/dev/null)" || count=0
+    [[ "$count" =~ ^[0-9]+$ ]] || count=0
+    printf '%s\n' "$count"
+    return 0
+}
+
+# True while the interactive picker is still within budget for this version.
+octo_features_prompt_allowed() {
+    local version="${1:-}" attempts
+    [[ "$OCTOPUS_FEATURES_PROMPT_MAX" =~ ^[0-9]+$ ]] || return 1
+    (( OCTOPUS_FEATURES_PROMPT_MAX > 0 )) || return 1
+    attempts="$(octo_features_prompt_attempts "$version")"
+    (( attempts < OCTOPUS_FEATURES_PROMPT_MAX ))
+}
+
+octo_features_record_prompt_attempt() {
+    local version="${1:-}" f dir tmp attempts
+    command -v jq >/dev/null 2>&1 || return 1
+    dir="$(octo_features_state_dir)"; f="$dir/state.json"
+    mkdir -p "$dir" 2>/dev/null || return 1
+    [[ -f "$f" ]] || echo '{}' > "$f"
+    attempts="$(octo_features_prompt_attempts "$version")"
+    tmp="$(mktemp "${f}.XXXXXX")" || return 1
+    if jq --arg v "$version" --argjson n "$(( attempts + 1 ))" \
+          '.features_prompt_version = $v | .features_prompt_attempts = $n' \
+          "$f" > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$f"
+        return 0
+    fi
+    rm -f "$tmp" 2>/dev/null
+    return 1
+}
+
+# A session with no human cannot answer a picker. Prompting there burns a turn in
+# a cron/headless run, or worse, stalls it. Detection mirrors the REMOTE_SESSION
+# guard in hooks/session-start-memory.sh and adds the usual CI signals.
+octo_features_session_interactive() {
+    [[ "${CLAUDE_CODE_REMOTE:-}" == "true" ]] && return 1
+    [[ "${CLAUDE_CODE_WEB:-}" == "true" ]] && return 1
+    [[ "${OCTOPUS_REMOTE_SESSION:-false}" == "true" ]] && return 1
+    [[ "${OCTOPUS_AUTONOMY:-}" == "autonomous" ]] && return 1
+    [[ -n "${CI:-}" ]] && return 1
+    [[ -n "${OCTOPUS_NON_INTERACTIVE:-}" ]] && return 1
+    return 0
+}
+
+# Machine-readable question set for the SessionStart directive. One block per
+# feature that needs a decision:
+#
+#   Q<TAB>id<TAB>question
+#   C<TAB>id<TAB>value<TAB>label<TAB>description      (one per choice)
+#
+# Emitting the choices rather than just the feature name is what lets the picker
+# ask "how should this be used" instead of "enable this?".
+octo_features_prompt_manifest() {
+    octo_features_available || return 0
+    local id line value label desc
+    while IFS= read -r id; do
+        [[ -n "$id" ]] || continue
+        octo_features_prereq_ok "$(octo_features_prereq "$id")" || continue
+        printf 'Q\t%s\t%s\n' "$id" "$(octo_features_question "$id")"
+        while IFS=$'\t' read -r value label desc; do
+            [[ -n "$value" ]] || continue
+            printf 'C\t%s\t%s\t%s\t%s\n' "$id" "$value" "$label" "$desc"
+        done < <(octo_features_choices "$id")
+    done < <(octo_features_offerable_ids)
+    return 0
 }

--- a/scripts/lib/features.sh
+++ b/scripts/lib/features.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+# Sourced by hooks, commands and the orchestrator. Deliberately sets NO shell
+# options: `set -e`/`set -o pipefail` in a sourced file leak into the caller and
+# stay there after this file returns. Most callers here run probe code where a
+# nonzero exit is normal.
+#
+# features.sh — progressive feature disclosure (manifest + user consent ledger).
+#
+# Problem this solves: users who installed an older version never discover
+# features added later. The pre-existing mechanism was a one-line version
+# advisory nobody acted on.
+#
+# Two pieces of state:
+#
+#   1. Manifest — `config/features.json`, checked into the repo. Declares each
+#      disclosable feature: id, the version it landed in, the env var it sets,
+#      and a named prerequisite check.
+#   2. Ledger — `features_v1` in ~/.claude-octopus/state.json, per-user. Records
+#      the decision the user made about each feature and at which version.
+#
+# The ledger key is version-namespaced (`features_v1`) from the first release
+# that ships it. Once users have state.json entries in the wild, changing the
+# shape needs a migration; a namespaced key makes that a read-both-write-new
+# change instead of a guess about what an untagged blob meant.
+#
+# `model_defaults_v2: "accepted"` in state.json is the pre-existing precedent
+# for a consent record (written by /octo:setup for the v9.29 routing change).
+# It is deliberately left in place and NOT migrated into the ledger: it gates a
+# different thing (role routing defaults, with an OCTOPUS_LEGACY_ROLES escape
+# hatch) and rewriting it would invalidate consent users already gave.
+#
+# ── Decision states ──────────────────────────────────────────────────────────
+#
+#   (absent)   never offered
+#   enabled    user turned it on
+#   declined   offered and refused — sticky, suppresses future offers
+#   disabled   was enabled, later turned off
+#
+# `declined` and `disabled` are deliberately distinct. Both suppress offers, but
+# collapsing them loses the anti-nagware guarantee: any future "re-offer the
+# disabled features" change would resurrect every past rejection. The single
+# legitimate re-ask is a manifest `reoffer_at` version above the version at
+# which the user declined, for a feature that has materially changed.
+
+# Dependency note: this file deliberately does NOT source lib/providers.sh for
+# its `version_compare`. providers.sh pulls in auth.sh, qwen.sh, grok.sh and
+# openai-compatible.sh, which is far too much work for a SessionStart hook that
+# must stay fast and silent. The local comparator below is intentionally small
+# and, unlike providers.sh's, tolerates non-numeric version suffixes.
+
+OCTOPUS_FEATURES_LEDGER_KEY="features_v1"
+
+octo_features_state_dir() {
+    printf '%s\n' "${OCTOPUS_STATE_DIR:-$HOME/.claude-octopus}"
+}
+
+octo_features_state_file() {
+    printf '%s\n' "$(octo_features_state_dir)/state.json"
+}
+
+octo_features_manifest() {
+    if [[ -n "${OCTOPUS_FEATURES_MANIFEST:-}" ]]; then
+        printf '%s\n' "$OCTOPUS_FEATURES_MANIFEST"
+        return 0
+    fi
+    # Search candidate roots in order and return the first that actually holds a
+    # manifest. Two reasons this is a search rather than one computed path:
+    #
+    #   - CLAUDE_PLUGIN_ROOT routinely points at a stale cache directory for a
+    #     version that is no longer installed (the "Plugin directory does not
+    #     exist" hook error), so it must be probed, not trusted.
+    #   - Deriving the repo root by traversing BASH_SOURCE relatively is not
+    #     dependable: when this file is sourced by a relative path the traversal
+    #     resolves against the caller's cwd and can land outside the repo.
+    #
+    # Falling through to the last candidate keeps the return value non-empty so
+    # callers report a path in diagnostics rather than an empty string.
+    local this_dir candidate
+    this_dir="$(cd -P "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || this_dir=""
+    for candidate in \
+        "${CLAUDE_PLUGIN_ROOT:-}" \
+        "${this_dir:+${this_dir}/../..}" \
+        "$(git -C "${this_dir:-.}" rev-parse --show-toplevel 2>/dev/null)" \
+        "$PWD"
+    do
+        [[ -n "$candidate" ]] || continue
+        if [[ -f "${candidate}/config/features.json" ]]; then
+            printf '%s\n' "$(cd -P "$candidate" 2>/dev/null && pwd)/config/features.json"
+            return 0
+        fi
+    done
+    printf '%s\n' "${this_dir}/../../config/features.json"
+}
+
+# Usable only when jq exists, the manifest parses, AND the ledger is either
+# absent or valid JSON. Callers treat a nonzero return as "stay completely
+# silent" rather than as an error to report: a broken manifest must never block a
+# session or spam a hook advisory.
+#
+# The ledger check is what prevents the worst failure mode of this whole feature.
+# A corrupt state.json makes every decision read come back empty, which looks
+# identical to "never offered" — so disclosure would offer the same features
+# every single session while also being unable to write the answer down. That is
+# nagware with no way for the user to stop it. Refusing to run at all is the
+# correct response to an unreadable ledger.
+octo_features_available() {
+    command -v jq >/dev/null 2>&1 || return 1
+    local m f; m="$(octo_features_manifest)"
+    [[ -f "$m" ]] || return 1
+    jq -e '.features | type == "array"' "$m" >/dev/null 2>&1 || return 1
+    f="$(octo_features_state_file)"
+    if [[ -f "$f" ]]; then
+        jq -e 'type == "object"' "$f" >/dev/null 2>&1 || return 1
+    fi
+    return 0
+}
+
+# _octo_feat_ver_gt <a> <b> — true when semver a > b. Missing components are 0.
+# Non-numeric suffixes are stripped ("9.57.0-rc1" compares as 9.57.0) so a
+# pre-release tag can never make an arithmetic context abort.
+_octo_feat_ver_gt() {
+    local a="${1:-0}" b="${2:-0}" i a_part b_part
+    local -a A B
+    IFS='.' read -r -a A <<< "$a"
+    IFS='.' read -r -a B <<< "$b"
+    for i in 0 1 2; do
+        a_part="${A[$i]:-0}"; b_part="${B[$i]:-0}"
+        a_part="${a_part//[^0-9]/}"; b_part="${b_part//[^0-9]/}"
+        [[ -n "$a_part" ]] || a_part=0
+        [[ -n "$b_part" ]] || b_part=0
+        if (( a_part > b_part )); then return 0; fi
+        if (( a_part < b_part )); then return 1; fi
+    done
+    return 1
+}
+
+# _octo_feat_field <id> <field> — one manifest field, empty if absent.
+_octo_feat_field() {
+    local id="$1" field="$2" m
+    m="$(octo_features_manifest)"
+    jq -r --arg id "$id" --arg f "$field" \
+        '.features[] | select(.id == $id) | .[$f] // "" | tostring' \
+        "$m" 2>/dev/null | head -1
+    return 0
+}
+
+octo_features_all_ids() {
+    jq -r '.features[].id' "$(octo_features_manifest)" 2>/dev/null || true
+    return 0
+}
+
+octo_features_title()       { _octo_feat_field "$1" title; }
+octo_features_description() { _octo_feat_field "$1" description; }
+octo_features_key()         { _octo_feat_field "$1" key; }
+octo_features_added_in()    { _octo_feat_field "$1" added_in; }
+octo_features_prereq()      { _octo_feat_field "$1" prereq; }
+
+# ── Ledger reads ─────────────────────────────────────────────────────────────
+
+octo_features_decision() {
+    local id="$1" f
+    f="$(octo_features_state_file)"
+    [[ -f "$f" ]] || return 0
+    jq -r --arg k "$OCTOPUS_FEATURES_LEDGER_KEY" --arg id "$id" \
+        '.[$k][$id].decision // ""' "$f" 2>/dev/null || true
+    return 0
+}
+
+octo_features_decision_version() {
+    local id="$1" f
+    f="$(octo_features_state_file)"
+    [[ -f "$f" ]] || return 0
+    jq -r --arg k "$OCTOPUS_FEATURES_LEDGER_KEY" --arg id "$id" \
+        '.[$k][$id].at_version // ""' "$f" 2>/dev/null || true
+    return 0
+}
+
+# The predicate Feature 1 (Fable 5 escalation) consults. Env var wins over the
+# ledger so a session can override without rewriting durable consent.
+octo_features_enabled() {
+    local id="$1" key val
+    key="$(octo_features_key "$id")"
+    if [[ -n "$key" ]]; then
+        eval "val=\"\${${key}:-}\""
+        case "$val" in
+            1|on|true|yes) return 0 ;;
+            0|off|false|no) return 1 ;;
+        esac
+    fi
+    [[ "$(octo_features_decision "$id")" == "enabled" ]]
+}
+
+# Watermark: the version below which features are considered "already known".
+# Falls back to the pre-existing last_seen_version, which version-advisory.sh
+# has been tracking since v9.29.0 — that is what makes backfill bounded for
+# existing users instead of offering them every feature ever shipped.
+octo_features_watermark() {
+    local f w
+    f="$(octo_features_state_file)"
+    [[ -f "$f" ]] || return 0
+    w="$(jq -r '.features_watermark // ""' "$f" 2>/dev/null)" || w=""
+    if [[ -z "$w" ]]; then
+        w="$(jq -r '.last_seen_version // ""' "$f" 2>/dev/null)" || w=""
+    fi
+    printf '%s\n' "$w"
+    return 0
+}
+
+# ── Prerequisite checks ──────────────────────────────────────────────────────
+# Named rather than inline so the manifest stays declarative and CI can assert
+# every `prereq` value resolves to a real check. Re-evaluated on every call and
+# never cached, so installing a missing CLI later flips a feature to actionable
+# without needing a version bump.
+octo_features_prereq_ok() {
+    case "${1:-none}" in
+        none|"")           return 0 ;;
+        codex-cli)         command -v codex >/dev/null 2>&1 ;;
+        agy-cli)           command -v agy   >/dev/null 2>&1 ;;
+        gemini-cli)        command -v gemini >/dev/null 2>&1 ;;
+        claude-opus-seat)  command -v claude >/dev/null 2>&1 ;;
+        *)                 return 1 ;;   # unknown check: fail closed
+    esac
+}
+
+# ── Offer logic ──────────────────────────────────────────────────────────────
+
+# octo_features_is_offerable <id> — should the user be told about this feature?
+# Independent of whether they *can* enable it (see prereq_ok); a feature whose
+# prerequisite is missing is still listed, with the reason, because hiding it
+# means the user never learns the prerequisite exists.
+octo_features_is_offerable() {
+    local id="$1" decision reoffer decided_at added_in watermark
+
+    decision="$(octo_features_decision "$id")"
+    case "$decision" in
+        enabled|disabled)
+            return 1
+            ;;
+        declined)
+            # The one legitimate re-ask: the feature materially changed and the
+            # manifest says so with a reoffer_at above the declined version.
+            reoffer="$(_octo_feat_field "$id" reoffer_at)"
+            [[ -n "$reoffer" ]] || return 1
+            decided_at="$(octo_features_decision_version "$id")"
+            _octo_feat_ver_gt "$reoffer" "$decided_at"
+            return $?
+            ;;
+    esac
+
+    # No decision recorded. Backfill entries are offered once regardless of the
+    # watermark; without them the framework would ship with an empty catalog on
+    # the very release that introduces it.
+    [[ "$(_octo_feat_field "$id" backfill)" == "true" ]] && return 0
+
+    added_in="$(octo_features_added_in "$id")"
+    watermark="$(octo_features_watermark)"
+    # No watermark yet (genuinely fresh install): setup owns the conversation,
+    # so nothing is "new" and nothing is offered.
+    [[ -n "$watermark" ]] || return 1
+    _octo_feat_ver_gt "$added_in" "$watermark"
+}
+
+# Returns 0 whenever it ran, regardless of how many ids it emitted. An empty
+# offer list is the normal steady state, not a failure, and without the explicit
+# return the status of the last loop iteration leaks out — so a caller running
+# under `set -e` would abort simply because the final manifest entry happened to
+# be already-decided.
+octo_features_offerable_ids() {
+    octo_features_available || return 0
+    local id
+    while IFS= read -r id; do
+        [[ -n "$id" ]] || continue
+        if octo_features_is_offerable "$id"; then
+            printf '%s\n' "$id"
+        fi
+    done < <(octo_features_all_ids)
+    return 0
+}
+
+# Count only features the user could actually act on. The advisory uses this,
+# not the raw offerable count: nagging about a feature whose CLI is not
+# installed teaches the user to ignore the advisory.
+octo_features_actionable_count() {
+    octo_features_available || { printf '0\n'; return 0; }
+    local id n=0
+    while IFS= read -r id; do
+        [[ -n "$id" ]] || continue
+        if octo_features_prereq_ok "$(octo_features_prereq "$id")"; then
+            n=$((n + 1))
+        fi
+    done < <(octo_features_offerable_ids)
+    printf '%s\n' "$n"
+}
+
+# ── Ledger writes ────────────────────────────────────────────────────────────
+
+# octo_features_record <id> <decision> <version>
+# Atomic tmp+mv, matching version-advisory.sh. Re-reads the file inside the same
+# call so an interleaved write from the hook is merged rather than clobbered.
+octo_features_record() {
+    local id="$1" decision="$2" version="${3:-}"
+    [[ -n "$id" && -n "$decision" ]] || return 1
+    case "$decision" in
+        enabled|declined|disabled) ;;
+        *) return 1 ;;
+    esac
+    command -v jq >/dev/null 2>&1 || return 1
+
+    local dir f tmp
+    dir="$(octo_features_state_dir)"; f="$dir/state.json"
+    mkdir -p "$dir" 2>/dev/null || return 1
+    [[ -f "$f" ]] || echo '{}' > "$f"
+
+    tmp="$(mktemp "${f}.XXXXXX")" || return 1
+    if jq --arg k "$OCTOPUS_FEATURES_LEDGER_KEY" \
+          --arg id "$id" --arg d "$decision" --arg v "$version" \
+          '.[$k] = ((.[$k] // {}) + {($id): {decision: $d, at_version: $v}})' \
+          "$f" > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$f"
+        return 0
+    fi
+    rm -f "$tmp" 2>/dev/null
+    return 1
+}
+
+# Seed the watermark from last_seen_version on first use, so existing users are
+# offered only what landed after they last ran, plus backfill entries.
+octo_features_seed_watermark() {
+    command -v jq >/dev/null 2>&1 || return 1
+    local dir f tmp seed
+    dir="$(octo_features_state_dir)"; f="$dir/state.json"
+    mkdir -p "$dir" 2>/dev/null || return 1
+    [[ -f "$f" ]] || echo '{}' > "$f"
+
+    if [[ -n "$(jq -r '.features_watermark // ""' "$f" 2>/dev/null)" ]]; then
+        return 0
+    fi
+    seed="${1:-$(jq -r '.last_seen_version // ""' "$f" 2>/dev/null)}"
+    [[ -n "$seed" ]] || return 0
+
+    tmp="$(mktemp "${f}.XXXXXX")" || return 1
+    if jq --arg v "$seed" '.features_watermark = $v' "$f" > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$f"
+        return 0
+    fi
+    rm -f "$tmp" 2>/dev/null
+    return 1
+}

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -113,6 +113,10 @@ source "${SCRIPT_DIR}/lib/similarity.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/models.sh" 2>/dev/null || true
 
 # Fable 5 mode detection and dispatch guards (v9.51)
+# features.sh before fable5.sh: fable5_escalation_consented reads the feature
+# ledger through octo_features_enabled, and sourcing order decides whether that
+# function exists by the time an escalation decision is made.
+source "${SCRIPT_DIR}/lib/features.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/fable5.sh" 2>/dev/null || true
 
 # Source intelligence library (v8.20.0)

--- a/tests/unit/test-fable5-escalation.sh
+++ b/tests/unit/test-fable5-escalation.sh
@@ -197,8 +197,17 @@ fi
 
 # ── Authorship-aware reviewer flip ───────────────────────────────────────────
 
+# The flip only fires when the Codex CLI is present, so these cases must supply a
+# mock rather than depend on whether the host happens to have codex installed.
+# Reading the real PATH made this suite pass locally and fail on CI, where codex
+# is absent and the flip correctly stayed inert.
+flip_bin="$TEST_TMP_DIR/flip-mock-bin"
+mkdir -p "$flip_bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$flip_bin/codex"
+chmod +x "$flip_bin/codex"
+
 test_case "reviewer flip is off by default"
-got=$(bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
+got=$(PATH="$flip_bin:$PATH" bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
 if [[ "$got" == codex-review:* ]]; then
     test_pass
 else
@@ -206,7 +215,7 @@ else
 fi
 
 test_case "reviewer flip moves review off the implementing vendor"
-got=$(OCTOPUS_REVIEWER_FLIP=1 bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
+got=$(PATH="$flip_bin:$PATH" OCTOPUS_REVIEWER_FLIP=1 bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
 if [[ "$got" == claude-opus:* ]]; then
     test_pass
 else
@@ -214,7 +223,7 @@ else
 fi
 
 test_case "reviewer flip leaves the implementer seat on Codex"
-got=$(OCTOPUS_REVIEWER_FLIP=1 bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping implementer")
+got=$(PATH="$flip_bin:$PATH" OCTOPUS_REVIEWER_FLIP=1 bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping implementer")
 if [[ "$got" == codex:* ]]; then
     test_pass
 else

--- a/tests/unit/test-fable5-escalation.sh
+++ b/tests/unit/test-fable5-escalation.sh
@@ -22,7 +22,7 @@ mkdir -p "$OCTOPUS_STATE_DIR" "$WORKSPACE_DIR/state"
 echo '{}' > "$OCTOPUS_STATE_DIR/state.json"
 
 # Escalation must never be reachable through an inherited pin during these runs.
-unset OCTOPUS_OPUS_MODEL OCTOPUS_CLAUDE_SDK_MODEL OCTOPUS_FABLE5_ESCALATE 2>/dev/null || true
+unset OCTOPUS_OPUS_MODEL OCTOPUS_CLAUDE_SDK_MODEL OCTOPUS_FABLE5_ROUTING 2>/dev/null || true
 
 # escalate <role> [extra env assignments...] — resolve one dispatch decision in a
 # clean subshell so the per-run cap marker never leaks between cases.
@@ -46,7 +46,7 @@ else
     test_fail "fable5.sh has syntax errors"
 fi
 
-test_case "no consent means no escalation"
+test_case "the default policy (off) escalates nothing"
 got=$(escalate architect)
 if [[ "$got" == "claude-opus-5" ]]; then
     test_pass
@@ -54,10 +54,10 @@ else
     test_fail "without consent the model must stay claude-opus-5, got '$got'"
 fi
 
-# Record consent for the remaining cases.
-bash -c "source '$FEATURES_LIB'; octo_features_record fable5-escalation enabled 9.57.0"
+# Choose the planning-and-PRDs policy for the remaining cases.
+bash -c "source '$FEATURES_LIB'; octo_features_record fable5-routing escalate 9.57.0"
 
-test_case "architect escalates to Fable 5 once consented"
+test_case "architect escalates under the escalate policy"
 got=$(escalate architect)
 if [[ "$got" == "claude-fable-5" ]]; then
     test_pass
@@ -74,17 +74,34 @@ else
 fi
 
 # The echo problem: Fable reviewing Opus-authored work is same-family agreement,
-# not an independent check, so review must stay on a different vendor.
-test_case "code-reviewer never escalates (same-family review is not a check)"
+# not an independent check. Under the default escalate policy, review stays off
+# Fable; the user can opt into it, but it is not what "escalate" buys.
+test_case "code-reviewer does not escalate under the escalate policy"
 got=$(escalate code-reviewer)
 if [[ "$got" == "claude-opus-5" ]]; then
     test_pass
 else
-    test_fail "code-reviewer must not escalate, got '$got'"
+    test_fail "code-reviewer must not escalate under 'escalate', got '$got'"
 fi
 
-test_case "security-reviewer never escalates"
-got=$(escalate security-reviewer)
+test_case "code-reviewer DOES escalate under the escalate-reviews policy"
+got=$(escalate code-reviewer OCTOPUS_FABLE5_ROUTING=escalate-reviews)
+if [[ "$got" == "claude-fable-5" ]]; then
+    test_pass
+else
+    test_fail "the user opted into Fable reviews; expected fable, got '$got'"
+fi
+
+test_case "the on-demand policy escalates nothing automatically"
+got=$(escalate architect OCTOPUS_FABLE5_ROUTING=on-demand)
+if [[ "$got" == "claude-opus-5" ]]; then
+    test_pass
+else
+    test_fail "on-demand must never auto-escalate, got '$got'"
+fi
+
+test_case "security-reviewer never escalates under any policy"
+got=$(escalate security-reviewer OCTOPUS_FABLE5_ROUTING=escalate-reviews)
 if [[ "$got" == "claude-opus-5" ]]; then
     test_pass
 else
@@ -108,12 +125,12 @@ else
     test_fail "user pin must beat escalation, got '$got'"
 fi
 
-test_case "session env override can disable escalation without touching consent"
-got=$(escalate architect OCTOPUS_FABLE5_ESCALATE=0)
+test_case "session env override can stand escalation down without touching the record"
+got=$(escalate architect OCTOPUS_FABLE5_ROUTING=off)
 if [[ "$got" == "claude-opus-5" ]]; then
     test_pass
 else
-    test_fail "OCTOPUS_FABLE5_ESCALATE=0 should stand down, got '$got'"
+    test_fail "OCTOPUS_FABLE5_ROUTING=off should stand down, got '$got'"
 fi
 
 test_case "a non-Opus model is passed through untouched"
@@ -195,6 +212,60 @@ else
     test_fail "reroute must run after escalation (escalate=$esc_line reroute=$rer_line)"
 fi
 
+# ── Each gate pinned on its own ──────────────────────────────────────────────
+# fable5_maybe_escalate consults two gates that both reject a non-escalating
+# policy: fable5_escalation_consented and fable5_escalation_role_eligible. That
+# redundancy is deliberate, but it means an end-to-end assertion cannot fail from
+# a single-gate regression — mutating either one alone is masked by the other.
+# These cases exercise the gates directly so each is genuinely covered.
+
+gate() {
+    env OCTOPUS_STATE_DIR="$OCTOPUS_STATE_DIR" WORKSPACE_DIR="$WORKSPACE_DIR" \
+        OCTOPUS_FABLE5_ROUTING="$1" bash -c "
+            source '$FEATURES_LIB'; source '$FABLE_LIB'
+            $2 && echo YES || echo NO"
+}
+
+test_case "consent gate: only escalate and escalate-reviews consent"
+res=""
+for pol in off on-demand escalate escalate-reviews; do
+    res="${res}$(gate "$pol" 'fable5_escalation_consented')|"
+done
+if [[ "$res" == "NO|NO|YES|YES|" ]]; then
+    test_pass
+else
+    test_fail "expected NO|NO|YES|YES| for off,on-demand,escalate,escalate-reviews; got $res"
+fi
+
+test_case "role gate: escalate covers judgment authoring only"
+res="$(gate escalate 'fable5_escalation_role_eligible architect')|$(gate escalate 'fable5_escalation_role_eligible strategist')|$(gate escalate 'fable5_escalation_role_eligible code-reviewer')"
+if [[ "$res" == "YES|YES|NO" ]]; then
+    test_pass
+else
+    test_fail "expected YES|YES|NO for architect,strategist,code-reviewer; got $res"
+fi
+
+test_case "role gate: escalate-reviews adds review, still not security"
+res="$(gate escalate-reviews 'fable5_escalation_role_eligible code-reviewer')|$(gate escalate-reviews 'fable5_escalation_role_eligible security-reviewer')"
+if [[ "$res" == "YES|NO" ]]; then
+    test_pass
+else
+    test_fail "expected YES|NO for code-reviewer,security-reviewer; got $res"
+fi
+
+test_case "role gate: off and on-demand make every role ineligible"
+res=""
+for pol in off on-demand; do
+    for role in architect strategist code-reviewer; do
+        res="${res}$(gate "$pol" "fable5_escalation_role_eligible $role")"
+    done
+done
+if [[ "$res" == "NONONONONONO" ]]; then
+    test_pass
+else
+    test_fail "no role may be eligible under off/on-demand; got $res"
+fi
+
 # ── Authorship-aware reviewer flip ───────────────────────────────────────────
 
 # The flip only fires when the Codex CLI is present, so these cases must supply a
@@ -215,7 +286,7 @@ else
 fi
 
 test_case "reviewer flip moves review off the implementing vendor"
-got=$(PATH="$flip_bin:$PATH" OCTOPUS_REVIEWER_FLIP=1 bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
+got=$(PATH="$flip_bin:$PATH" OCTOPUS_REVIEWER_FLIP=claude bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
 if [[ "$got" == claude-opus:* ]]; then
     test_pass
 else
@@ -235,7 +306,7 @@ fi
 test_case "reviewer flip stays inert when the Codex CLI is absent"
 empty_bin="$TEST_TMP_DIR/flip-empty-bin"
 mkdir -p "$empty_bin"
-got=$(PATH="$empty_bin:/bin:/usr/bin" OCTOPUS_REVIEWER_FLIP=1 \
+got=$(PATH="$empty_bin:/bin:/usr/bin" OCTOPUS_REVIEWER_FLIP=claude \
     bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
 if [[ "$got" == codex-review:* ]]; then
     test_pass

--- a/tests/unit/test-fable5-escalation.sh
+++ b/tests/unit/test-fable5-escalation.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Unit tests for selective Fable 5 escalation and the authorship-aware
+# reviewer flip.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Fable 5 escalation"
+
+FABLE_LIB="$PROJECT_ROOT/scripts/lib/fable5.sh"
+FEATURES_LIB="$PROJECT_ROOT/scripts/lib/features.sh"
+AGENT_UTILS="$PROJECT_ROOT/scripts/lib/agent-utils.sh"
+
+# Isolate the ledger and the quota-dead marker. Without this these assertions
+# read the developer's real consent state and provider health.
+export OCTOPUS_STATE_DIR="$TEST_TMP_DIR/escalation-state"
+export WORKSPACE_DIR="$TEST_TMP_DIR/escalation-workspace"
+mkdir -p "$OCTOPUS_STATE_DIR" "$WORKSPACE_DIR/state"
+echo '{}' > "$OCTOPUS_STATE_DIR/state.json"
+
+# Escalation must never be reachable through an inherited pin during these runs.
+unset OCTOPUS_OPUS_MODEL OCTOPUS_CLAUDE_SDK_MODEL OCTOPUS_FABLE5_ESCALATE 2>/dev/null || true
+
+# escalate <role> [extra env assignments...] — resolve one dispatch decision in a
+# clean subshell so the per-run cap marker never leaks between cases.
+escalate() {
+    local role="$1"; shift
+    env "$@" \
+        OCTOPUS_STATE_DIR="$OCTOPUS_STATE_DIR" \
+        WORKSPACE_DIR="$WORKSPACE_DIR" \
+        bash -c "
+            source '$FEATURES_LIB'
+            source '$PROJECT_ROOT/scripts/lib/quota-watcher.sh'
+            source '$FABLE_LIB'
+            fable5_maybe_escalate 'claude-opus-5' '$role' 'claude-opus' 'grasp'
+        "
+}
+
+test_case "escalation library functions have valid bash syntax"
+if bash -n "$FABLE_LIB"; then
+    test_pass
+else
+    test_fail "fable5.sh has syntax errors"
+fi
+
+test_case "no consent means no escalation"
+got=$(escalate architect)
+if [[ "$got" == "claude-opus-5" ]]; then
+    test_pass
+else
+    test_fail "without consent the model must stay claude-opus-5, got '$got'"
+fi
+
+# Record consent for the remaining cases.
+bash -c "source '$FEATURES_LIB'; octo_features_record fable5-escalation enabled 9.57.0"
+
+test_case "architect escalates to Fable 5 once consented"
+got=$(escalate architect)
+if [[ "$got" == "claude-fable-5" ]]; then
+    test_pass
+else
+    test_fail "architect should escalate, got '$got'"
+fi
+
+test_case "strategist escalates to Fable 5"
+got=$(escalate strategist)
+if [[ "$got" == "claude-fable-5" ]]; then
+    test_pass
+else
+    test_fail "strategist should escalate, got '$got'"
+fi
+
+# The echo problem: Fable reviewing Opus-authored work is same-family agreement,
+# not an independent check, so review must stay on a different vendor.
+test_case "code-reviewer never escalates (same-family review is not a check)"
+got=$(escalate code-reviewer)
+if [[ "$got" == "claude-opus-5" ]]; then
+    test_pass
+else
+    test_fail "code-reviewer must not escalate, got '$got'"
+fi
+
+test_case "security-reviewer never escalates"
+got=$(escalate security-reviewer)
+if [[ "$got" == "claude-opus-5" ]]; then
+    test_pass
+else
+    test_fail "security roles must never reach Fable 5, got '$got'"
+fi
+
+test_case "implementer-heavy never escalates"
+got=$(escalate implementer-heavy)
+if [[ "$got" == "claude-opus-5" ]]; then
+    test_pass
+else
+    test_fail "implementation is not judgment work, got '$got'"
+fi
+
+# Resolution precedence: an explicit pin is Tier 1 and outranks a release default.
+test_case "an explicit OCTOPUS_OPUS_MODEL pin suppresses escalation"
+got=$(escalate architect OCTOPUS_OPUS_MODEL=claude-opus-5)
+if [[ "$got" == "claude-opus-5" ]]; then
+    test_pass
+else
+    test_fail "user pin must beat escalation, got '$got'"
+fi
+
+test_case "session env override can disable escalation without touching consent"
+got=$(escalate architect OCTOPUS_FABLE5_ESCALATE=0)
+if [[ "$got" == "claude-opus-5" ]]; then
+    test_pass
+else
+    test_fail "OCTOPUS_FABLE5_ESCALATE=0 should stand down, got '$got'"
+fi
+
+test_case "a non-Opus model is passed through untouched"
+got=$(env OCTOPUS_STATE_DIR="$OCTOPUS_STATE_DIR" WORKSPACE_DIR="$WORKSPACE_DIR" bash -c "
+    source '$FEATURES_LIB'; source '$FABLE_LIB'
+    fable5_maybe_escalate 'claude-sonnet-5' 'architect' 'claude' 'grasp'")
+if [[ "$got" == "claude-sonnet-5" ]]; then
+    test_pass
+else
+    test_fail "only the default Opus seat may be upgraded, got '$got'"
+fi
+
+# Headroom is reactive: no endpoint reports remaining Fable 5 usage, so a
+# rate-limited dispatch marks the model dead and escalation stands down.
+test_case "a quota-dead Fable 5 seat stands down to Opus 5"
+printf 'claude-fable-5\n' > "$WORKSPACE_DIR/state/.provider-quota-dead"
+got=$(escalate architect)
+rm -f "$WORKSPACE_DIR/state/.provider-quota-dead"
+if [[ "$got" == "claude-opus-5" ]]; then
+    test_pass
+else
+    test_fail "a dead Fable seat must fall back, got '$got'"
+fi
+
+# Cost containment: councils, debates and review fleets dispatch many seats.
+# Escalating each one is the spend the one-owner rule exists to prevent.
+test_case "only one escalation per run; the second judgment seat stays on Opus"
+out=$(env OCTOPUS_STATE_DIR="$OCTOPUS_STATE_DIR" WORKSPACE_DIR="$WORKSPACE_DIR" bash -c "
+    source '$FEATURES_LIB'
+    source '$PROJECT_ROOT/scripts/lib/quota-watcher.sh'
+    source '$FABLE_LIB'
+    fable5_maybe_escalate 'claude-opus-5' 'architect'   'claude-opus' 'grasp'
+    fable5_maybe_escalate 'claude-opus-5' 'strategist'  'claude-opus' 'grasp'
+")
+first=$(echo "$out" | sed -n 1p)
+second=$(echo "$out" | sed -n 2p)
+if [[ "$first" == "claude-fable-5" && "$second" == "claude-opus-5" ]]; then
+    test_pass
+else
+    test_fail "expected fable then opus, got '$first' then '$second'"
+fi
+
+# Fable 5 effort applies per tool call, so xhigh widens each step's scope at 2x
+# cost rather than extending the run.
+test_case "effort clamps xhigh to high for a Fable 5 dispatch"
+got=$(bash -c "source '$FABLE_LIB'; fable5_clamp_effort_for_model xhigh claude-fable-5")
+if [[ "$got" == "high" ]]; then
+    test_pass
+else
+    test_fail "expected high, got '$got'"
+fi
+
+# The clamp must not over-reach onto unrelated Opus work in the same run.
+test_case "effort is untouched for a non-Fable dispatch"
+got=$(bash -c "source '$FABLE_LIB'; fable5_clamp_effort_for_model xhigh claude-opus-5")
+if [[ "$got" == "xhigh" ]]; then
+    test_pass
+else
+    test_fail "Opus 5 xhigh must survive the clamp, got '$got'"
+fi
+
+test_case "escalation is wired into the dispatch path, not the model resolver"
+# The resolver caches on provider/agent/phase/role/config-cksum with no liveness
+# component, so an escalation applied there would keep serving a cached Fable
+# model after the seat was marked dead.
+if grep -q "fable5_maybe_escalate" "$PROJECT_ROOT/scripts/lib/dispatch.sh" \
+   && ! grep -q "fable5_maybe_escalate" "$PROJECT_ROOT/scripts/lib/model-resolver.sh"; then
+    test_pass
+else
+    test_fail "escalation must be called from dispatch.sh and not model-resolver.sh"
+fi
+
+test_case "escalation runs before the security reroute in dispatch"
+esc_line=$(grep -n "fable5_maybe_escalate" "$PROJECT_ROOT/scripts/lib/dispatch.sh" | head -1 | cut -d: -f1)
+rer_line=$(grep -n "fable5_maybe_reroute" "$PROJECT_ROOT/scripts/lib/dispatch.sh" | head -1 | cut -d: -f1)
+if [[ -n "$esc_line" && -n "$rer_line" ]] && (( esc_line < rer_line )); then
+    test_pass
+else
+    test_fail "reroute must run after escalation (escalate=$esc_line reroute=$rer_line)"
+fi
+
+# ── Authorship-aware reviewer flip ───────────────────────────────────────────
+
+test_case "reviewer flip is off by default"
+got=$(bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
+if [[ "$got" == codex-review:* ]]; then
+    test_pass
+else
+    test_fail "default review seat should be Codex, got '$got'"
+fi
+
+test_case "reviewer flip moves review off the implementing vendor"
+got=$(OCTOPUS_REVIEWER_FLIP=1 bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
+if [[ "$got" == claude-opus:* ]]; then
+    test_pass
+else
+    test_fail "flip should send review to the Claude opus seat, got '$got'"
+fi
+
+test_case "reviewer flip leaves the implementer seat on Codex"
+got=$(OCTOPUS_REVIEWER_FLIP=1 bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping implementer")
+if [[ "$got" == codex:* ]]; then
+    test_pass
+else
+    test_fail "flip must not move implementation, got '$got'"
+fi
+
+# Without Codex the implementer already falls back off Codex, so flipping review
+# away from it would remove vendor diversity rather than create it.
+test_case "reviewer flip stays inert when the Codex CLI is absent"
+empty_bin="$TEST_TMP_DIR/flip-empty-bin"
+mkdir -p "$empty_bin"
+got=$(PATH="$empty_bin:/bin:/usr/bin" OCTOPUS_REVIEWER_FLIP=1 \
+    bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
+if [[ "$got" == codex-review:* ]]; then
+    test_pass
+else
+    test_fail "with no codex CLI the flip must not fire, got '$got'"
+fi
+
+test_summary

--- a/tests/unit/test-feature-disclosure.sh
+++ b/tests/unit/test-feature-disclosure.sh
@@ -435,16 +435,21 @@ else
     test_fail "an unrecorded default choice would be re-asked forever"
 fi
 
+# A literal tab, not "\t" in the pattern: BSD grep -E (macOS) expands \t to a
+# tab while GNU grep -E (Linux) does not, so a \t pattern matches locally and
+# silently fails on the runner.
+TAB=$'\t'
+
 test_case "the directive carries each feature's own choices, not a yes/no"
-if grep -qE "^C\tfable5-routing\tescalate\t" <<<"$out" \
-   && grep -qE "^C\tfable5-routing\ton-demand\t" <<<"$out"; then
+if grep -qE "^C${TAB}fable5-routing${TAB}escalate${TAB}" <<<"$out" \
+   && grep -qE "^C${TAB}fable5-routing${TAB}on-demand${TAB}" <<<"$out"; then
     test_pass
 else
     test_fail "policy choices must reach the picker verbatim"
 fi
 
 test_case "the directive carries the question text, not just the feature title"
-if grep -qE "^Q\tfable5-routing\tHow should Claude Fable 5 be used\?" <<<"$out"; then
+if grep -qE "^Q${TAB}fable5-routing${TAB}How should Claude Fable 5 be used\?" <<<"$out"; then
     test_pass
 else
     test_fail "the picker needs the feature's own question"

--- a/tests/unit/test-feature-disclosure.sh
+++ b/tests/unit/test-feature-disclosure.sh
@@ -38,16 +38,70 @@ else
     test_fail "config/features.json is not a non-empty features array"
 fi
 
-test_case "every manifest entry declares the required fields"
+test_case "every manifest entry declares the common required fields"
 missing=$(jq -r '
     .features[]
     | select((.id? | not) or (.added_in? | not) or (.key? | not)
-             or (.title? | not) or (.description? | not) or (.prereq? | not))
+             or (.title? | not) or (.prereq? | not) or (.decision? | not))
     | .id // "<no id>"' "$MANIFEST")
 if [[ -z "$missing" ]]; then
     test_pass
 else
-    test_fail "manifest entries missing required fields: $missing"
+    test_fail "manifest entries missing common fields: $missing"
+fi
+
+# The two shapes are not interchangeable. A decision=required entry with no
+# choices would raise a question the picker cannot answer; a decision=none entry
+# with no description is undocumented.
+test_case "decision=required entries carry a question and at least two choices"
+bad=$(jq -r '
+    .features[] | select(.decision == "required")
+    | select((.question? | not) or ((.choices // []) | length) < 2)
+    | .id' "$MANIFEST")
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "decision=required entries lacking question/choices: $bad"
+fi
+
+test_case "decision=none entries carry a description and never a question"
+bad=$(jq -r '
+    .features[] | select(.decision == "none")
+    | select((.description? | not) or (.question? != null))
+    | .id' "$MANIFEST")
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "decision=none entries malformed: $bad"
+fi
+
+test_case "decision is one of required or none"
+bad=$(jq -r '.features[] | select(.decision != "required" and .decision != "none") | .id' "$MANIFEST")
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "unknown decision value on: $bad"
+fi
+
+# Every choice must be reachable: AskUserQuestion allows at most 4 options.
+test_case "no feature declares more than four choices"
+bad=$(jq -r '.features[] | select(((.choices // []) | length) > 4) | .id' "$MANIFEST")
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "AskUserQuestion caps options at 4; over-long: $bad"
+fi
+
+test_case "each feature default is one of its own declared choices"
+bad=$(jq -r '
+    .features[] | select(((.choices // []) | length) > 0)
+    | . as $f
+    | select(([$f.choices[].value] | index($f.default)) == null)
+    | .id' "$MANIFEST")
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "default not among choices for: $bad"
 fi
 
 # Manifest/reality drift guard: a feature whose env key was renamed would
@@ -150,69 +204,97 @@ else
     test_fail "gemini-via-agy (added 9.52.0) is below the 9.55.0 watermark and must not be offered"
 fi
 
-test_case "declined is sticky across repeated sessions"
+test_case "a recorded choice is sticky across repeated sessions"
 reset_ledger '{"last_seen_version":"9.55.0"}'
 out=$(bash -c "
     source '$FEATURES_LIB'
     octo_features_seed_watermark
-    octo_features_record fable5-escalation declined 9.57.0
+    octo_features_record fable5-routing off 9.57.0
     for _ in 1 2 3; do octo_features_offerable_ids; done
 ")
-if ! grep -qx "fable5-escalation" <<< "$out"; then
+if ! grep -qx "fable5-routing" <<< "$out"; then
     test_pass
 else
-    test_fail "a declined feature must never be re-offered"
+    test_fail "choosing a policy, including the default, must stop the question"
 fi
 
-test_case "enabled feature drops off the offer list and reads back enabled"
+# Choosing "off" is a real answer, not an absence of one. If it did not stick,
+# every upgrade would re-ask the user who already said no.
+test_case "choosing the default value still records and still sticks"
+if [[ "$(bash -c "source '$FEATURES_LIB'; octo_features_decision fable5-routing")" == "off" ]]; then
+    test_pass
+else
+    test_fail "the default choice must be recorded like any other"
+fi
+
+test_case "a recorded policy reads back through octo_features_choice"
 reset_ledger '{"last_seen_version":"9.55.0"}'
 out=$(bash -c "
     source '$FEATURES_LIB'
-    octo_features_seed_watermark
-    octo_features_record codex-reviewer-flip enabled 9.57.0
-    octo_features_offerable_ids
-    octo_features_enabled codex-reviewer-flip && echo ENABLED
+    octo_features_record fable5-routing escalate-reviews 9.57.0
+    octo_features_choice fable5-routing
 ")
-if grep -qx "ENABLED" <<< "$out" && ! grep -qx "codex-reviewer-flip" <<< "$out"; then
+if [[ "$out" == "escalate-reviews" ]]; then
     test_pass
 else
-    test_fail "enabling must record consent and stop the offer"
+    test_fail "expected escalate-reviews, got '$out'"
 fi
 
-test_case "disabled is distinct from declined and also suppresses offers"
+test_case "an unanswered feature resolves to its manifest default"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+out=$(bash -c "source '$FEATURES_LIB'; octo_features_choice fable5-routing")
+if [[ "$out" == "off" ]]; then
+    test_pass
+else
+    test_fail "expected the manifest default 'off', got '$out'"
+fi
+
+test_case "silent features are never raised however new they are"
+reset_ledger '{"last_seen_version":"9.0.0"}'
+out=$(bash -c "source '$FEATURES_LIB'; octo_features_seed_watermark; octo_features_offerable_ids")
+if ! grep -qx "preflight-probe" <<< "$out" && ! grep -qx "gemini-via-agy" <<< "$out"; then
+    test_pass
+else
+    test_fail "decision=none features must never be prompted: $out"
+fi
+
+test_case "only decision=required features are ever offered"
+required=$(jq -r '.features[] | select(.decision == "required") | .id' "$MANIFEST" | sort)
+offered=$(bash -c "source '$FEATURES_LIB'; octo_features_seed_watermark; octo_features_offerable_ids" | sort)
+if [[ "$offered" == "$required" ]]; then
+    test_pass
+else
+    test_fail "offered [$offered] should equal the decision=required set [$required]"
+fi
+
+test_case "env key overrides a recorded policy"
 reset_ledger '{"last_seen_version":"9.55.0"}'
 out=$(bash -c "
     source '$FEATURES_LIB'
-    octo_features_seed_watermark
-    octo_features_record codex-reviewer-flip disabled 9.57.0
-    octo_features_offerable_ids
-    echo \"DECISION=\$(octo_features_decision codex-reviewer-flip)\"
+    octo_features_record fable5-routing off 9.57.0
+    OCTOPUS_FABLE5_ROUTING=escalate octo_features_choice fable5-routing
 ")
-if grep -qx "DECISION=disabled" <<< "$out" && ! grep -qx "codex-reviewer-flip" <<< "$out"; then
+if [[ "$out" == "escalate" ]]; then
     test_pass
 else
-    test_fail "disabled must be recorded distinctly and suppress offers"
+    test_fail "env override should win, got '$out'"
 fi
 
-test_case "env var overrides the ledger in both directions"
-reset_ledger '{"last_seen_version":"9.55.0"}'
+test_case "an invalid env value falls back to the recorded policy"
 out=$(bash -c "
     source '$FEATURES_LIB'
-    octo_features_record fable5-escalation declined 9.57.0
-    OCTOPUS_FABLE5_ESCALATE=1 octo_features_enabled fable5-escalation && echo ENV_ON
-    octo_features_record fable5-escalation enabled 9.57.0
-    OCTOPUS_FABLE5_ESCALATE=0 octo_features_enabled fable5-escalation || echo ENV_OFF
+    OCTOPUS_FABLE5_ROUTING=nonsense octo_features_choice fable5-routing
 ")
-if grep -qx "ENV_ON" <<< "$out" && grep -qx "ENV_OFF" <<< "$out"; then
+if [[ "$out" == "off" ]]; then
     test_pass
 else
-    test_fail "env var must win over the recorded decision both ways"
+    test_fail "a bogus env value must not become the policy, got '$out'"
 fi
 
-test_case "invalid decision values are rejected"
+test_case "recording a value outside the declared choices is rejected"
 reset_ledger '{"last_seen_version":"9.55.0"}'
-if bash -c "source '$FEATURES_LIB'; octo_features_record fable5-escalation maybe 9.57.0" 2>/dev/null; then
-    test_fail "record should reject a decision outside enabled/declined/disabled"
+if bash -c "source '$FEATURES_LIB'; octo_features_record fable5-routing maybe 9.57.0" 2>/dev/null; then
+    test_fail "record must validate against the feature's own choices"
 else
     test_pass
 fi
@@ -238,38 +320,38 @@ else
     test_pass
 fi
 
-test_case "reoffer_at above the declined version re-opens the offer"
+test_case "reoffer_at above the chosen version re-opens the question"
 reset_ledger '{"last_seen_version":"9.55.0"}'
 tmp_manifest="$TEST_TMP_DIR/reoffer-manifest.json"
-jq '(.features[] | select(.id == "fable5-escalation")) |= (. + {reoffer_at: "9.60.0"})' \
+jq '(.features[] | select(.id == "fable5-routing")) |= (. + {reoffer_at: "9.60.0"})' \
     "$MANIFEST" > "$tmp_manifest"
 out=$(OCTOPUS_FEATURES_MANIFEST="$tmp_manifest" bash -c "
     source '$FEATURES_LIB'
     octo_features_seed_watermark
-    octo_features_record fable5-escalation declined 9.57.0
+    octo_features_record fable5-routing off 9.57.0
     octo_features_offerable_ids
 ")
-if grep -qx "fable5-escalation" <<< "$out"; then
+if grep -qx "fable5-routing" <<< "$out"; then
     test_pass
 else
-    test_fail "reoffer_at 9.60.0 above a 9.57.0 decline should re-open the offer"
+    test_fail "reoffer_at 9.60.0 above a 9.57.0 choice should re-open the question"
 fi
 
-test_case "reoffer_at at or below the declined version stays suppressed"
+test_case "reoffer_at at or below the chosen version stays suppressed"
 reset_ledger '{"last_seen_version":"9.55.0"}'
 tmp_manifest2="$TEST_TMP_DIR/reoffer-equal-manifest.json"
-jq '(.features[] | select(.id == "fable5-escalation")) |= (. + {reoffer_at: "9.57.0"})' \
+jq '(.features[] | select(.id == "fable5-routing")) |= (. + {reoffer_at: "9.57.0"})' \
     "$MANIFEST" > "$tmp_manifest2"
 out=$(OCTOPUS_FEATURES_MANIFEST="$tmp_manifest2" bash -c "
     source '$FEATURES_LIB'
     octo_features_seed_watermark
-    octo_features_record fable5-escalation declined 9.57.0
+    octo_features_record fable5-routing off 9.57.0
     octo_features_offerable_ids
 ")
-if ! grep -qx "fable5-escalation" <<< "$out"; then
+if ! grep -qx "fable5-routing" <<< "$out"; then
     test_pass
 else
-    test_fail "reoffer_at equal to the declined version must not re-offer"
+    test_fail "reoffer_at equal to the chosen version must not re-ask"
 fi
 
 test_case "actionable count excludes features whose prereq is missing"
@@ -287,6 +369,168 @@ if [[ "$n" -lt "$total" ]]; then
     test_pass
 else
     test_fail "with provider CLIs hidden, actionable ($n) should be below offerable ($total)"
+fi
+
+# ── Interactive prompt on session start ──────────────────────────────────────
+# A pointer to a command is the weak form of disclosure: users do not run
+# commands they must remember, nor hand-edit env vars. The SessionStart advisory
+# therefore asks the assistant to raise a picker. These cases cover the guards
+# that keep that from becoming a nuisance.
+
+ADVISORY_HOOK="$PROJECT_ROOT/hooks/version-advisory.sh"
+MEMORY_HOOK="$PROJECT_ROOT/hooks/session-start-memory.sh"
+
+# Run the advisory hook against an isolated state dir that looks like an upgrade.
+advisory() {
+    local state="$1"; shift
+    # Reset only last_seen_version so the hook sees an upgrade again. Overwriting
+    # the whole file would also wipe features_prompt_attempts, and the budget
+    # cases below would then never accumulate a count.
+    if [[ -f "$state/state.json" ]]; then
+        jq '.last_seen_version = "9.55.0"' "$state/state.json" > "$state/state.tmp" \
+            && mv "$state/state.tmp" "$state/state.json"
+    else
+        printf '{"last_seen_version":"9.55.0"}\n' > "$state/state.json"
+    fi
+    touch "$state/.setup-complete"
+    env "$@" OCTOPUS_STATE_DIR="$state" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+        bash "$ADVISORY_HOOK" 2>/dev/null | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null
+}
+
+test_case "advisory emits an interactive picker directive on an upgrade"
+adv_state="$TEST_TMP_DIR/adv-a"; mkdir -p "$adv_state"
+out=$(advisory "$adv_state" -u CI -u OCTOPUS_NON_INTERACTIVE -u CLAUDE_CODE_REMOTE)
+if grep -q "OCTOPUS-NEW-FEATURES" <<<"$out" && grep -q "AskUserQuestion" <<<"$out"; then
+    test_pass
+else
+    test_fail "expected an AskUserQuestion directive, got: $(head -5 <<<"$out")"
+fi
+
+test_case "the directive names each offerable feature"
+if grep -q "fable5-routing" <<<"$out"; then
+    test_pass
+else
+    test_fail "directive must carry the feature ids so the picker can be built"
+fi
+
+# Choosing the default is an answer. If the directive let the assistant skip
+# recording it, the user who said "not at all" would be asked again every upgrade.
+test_case "the directive requires recording every answer, defaults included"
+if grep -q "octo_features_record" <<<"$out" && grep -qi "including any that picks the default" <<<"$out"; then
+    test_pass
+else
+    test_fail "an unrecorded default choice would be re-asked forever"
+fi
+
+test_case "the directive carries each feature's own choices, not a yes/no"
+if grep -qE "^C\tfable5-routing\tescalate\t" <<<"$out" \
+   && grep -qE "^C\tfable5-routing\ton-demand\t" <<<"$out"; then
+    test_pass
+else
+    test_fail "policy choices must reach the picker verbatim"
+fi
+
+test_case "the directive carries the question text, not just the feature title"
+if grep -qE "^Q\tfable5-routing\tHow should Claude Fable 5 be used\?" <<<"$out"; then
+    test_pass
+else
+    test_fail "the picker needs the feature's own question"
+fi
+
+# A cron or headless run has nobody to answer; prompting there burns the turn.
+test_case "a non-interactive session gets the pointer, never the picker"
+adv_state="$TEST_TMP_DIR/adv-ci"; mkdir -p "$adv_state"
+out=$(advisory "$adv_state" CI=1)
+if ! grep -q "OCTOPUS-NEW-FEATURES" <<<"$out" && grep -q "whats-new" <<<"$out"; then
+    test_pass
+else
+    test_fail "CI run should degrade to the pointer, got: $(head -5 <<<"$out")"
+fi
+
+test_case "a remote session gets the pointer, never the picker"
+adv_state="$TEST_TMP_DIR/adv-remote"; mkdir -p "$adv_state"
+out=$(advisory "$adv_state" -u CI CLAUDE_CODE_REMOTE=true)
+if ! grep -q "OCTOPUS-NEW-FEATURES" <<<"$out"; then
+    test_pass
+else
+    test_fail "remote sessions must not raise a picker"
+fi
+
+# Anti-nagware: an unanswered prompt leaves everything undecided, which is
+# indistinguishable from never-offered, so without a cap it re-asks forever.
+test_case "the picker is spent after OCTOPUS_FEATURES_PROMPT_MAX attempts"
+adv_state="$TEST_TMP_DIR/adv-budget"; mkdir -p "$adv_state"
+results=""
+for _ in 1 2 3; do
+    o=$(advisory "$adv_state" -u CI -u OCTOPUS_NON_INTERACTIVE -u CLAUDE_CODE_REMOTE)
+    if grep -q "OCTOPUS-NEW-FEATURES" <<<"$o"; then results="${results}P"; else results="${results}f"; fi
+done
+if [[ "$results" == "PPf" ]]; then
+    test_pass
+else
+    test_fail "expected prompt,prompt,fallback (PPf), got '$results'"
+fi
+
+test_case "a spent budget still emits the pointer rather than going silent"
+o=$(advisory "$adv_state" -u CI -u OCTOPUS_NON_INTERACTIVE -u CLAUDE_CODE_REMOTE)
+if grep -q "whats-new" <<<"$o"; then
+    test_pass
+else
+    test_fail "discoverability must degrade, not disappear"
+fi
+
+test_case "a newer plugin version resets the prompt budget"
+reset_ledger '{"features_prompt_version":"9.0.0","features_prompt_attempts":99}'
+if bash -c "source '$FEATURES_LIB'; octo_features_prompt_allowed 9.57.0"; then
+    test_pass
+else
+    test_fail "a version bump should hand out a fresh budget"
+fi
+
+test_case "the budget is not reset by the same version"
+reset_ledger '{"features_prompt_version":"9.57.0","features_prompt_attempts":99}'
+if ! bash -c "source '$FEATURES_LIB'; octo_features_prompt_allowed 9.57.0"; then
+    test_pass
+else
+    test_fail "an exhausted budget must stay exhausted within a version"
+fi
+
+test_case "prompt manifest is tab-separated id/title/description"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+# sed -n 1p rather than head -1: head closes the pipe after one line, which
+# SIGPIPEs the producer and, under pipefail, aborts the suite with 141.
+line=$(bash -c "source '$FEATURES_LIB'; octo_features_seed_watermark; octo_features_prompt_manifest" | sed -n 1p)
+if [[ "$(awk -F'\t' '{print NF}' <<<"$line")" == "3" ]]; then
+    test_pass
+else
+    test_fail "expected 3 tab-separated fields, got: $line"
+fi
+
+# The first-run welcome claimed to trigger setup via additionalContext while only
+# echoing bare text, which SessionStart does not accept as context.
+test_case "first-run welcome emits a valid SessionStart object, not bare text"
+fr_home="$TEST_TMP_DIR/firstrun-home"
+rm -rf "$fr_home"; mkdir -p "$fr_home"
+out=$(env HOME="$fr_home" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$MEMORY_HOOK" 2>/dev/null)
+if printf '%s' "$out" | jq -e '.hookSpecificOutput.hookEventName == "SessionStart"' >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "first-run must emit hookSpecificOutput, got: $(printf '%s' "$out" | head -2)"
+fi
+
+test_case "first-run directs the assistant to run setup"
+if printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null | grep -qi "octo:setup"; then
+    test_pass
+else
+    test_fail "the welcome must name the setup skill"
+fi
+
+test_case "first-run stays silent on the second session"
+out2=$(env HOME="$fr_home" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$MEMORY_HOOK" 2>/dev/null)
+if ! grep -qi "Welcome to Claude Octopus" <<<"$out2"; then
+    test_pass
+else
+    test_fail "the welcome must not repeat once the setup marker exists"
 fi
 
 test_summary

--- a/tests/unit/test-feature-disclosure.sh
+++ b/tests/unit/test-feature-disclosure.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Unit tests for progressive feature disclosure (manifest + consent ledger).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Feature disclosure"
+
+FEATURES_LIB="$PROJECT_ROOT/scripts/lib/features.sh"
+MANIFEST="$PROJECT_ROOT/config/features.json"
+
+# Isolate the ledger. Without this every assertion below reads the developer's
+# real ~/.claude-octopus/state.json and the suite passes or fails according to
+# which features they happen to have enabled.
+export OCTOPUS_STATE_DIR="$TEST_TMP_DIR/feature-state"
+mkdir -p "$OCTOPUS_STATE_DIR"
+
+reset_ledger() {
+    rm -rf "$OCTOPUS_STATE_DIR"
+    mkdir -p "$OCTOPUS_STATE_DIR"
+    printf '%s\n' "${1:-\{\}}" > "$OCTOPUS_STATE_DIR/state.json"
+}
+
+test_case "features.sh has valid bash syntax"
+if bash -n "$FEATURES_LIB"; then
+    test_pass
+else
+    test_fail "features.sh has syntax errors"
+fi
+
+test_case "manifest is valid JSON with a features array"
+if jq -e '.features | type == "array" and length > 0' "$MANIFEST" >/dev/null; then
+    test_pass
+else
+    test_fail "config/features.json is not a non-empty features array"
+fi
+
+test_case "every manifest entry declares the required fields"
+missing=$(jq -r '
+    .features[]
+    | select((.id? | not) or (.added_in? | not) or (.key? | not)
+             or (.title? | not) or (.description? | not) or (.prereq? | not))
+    | .id // "<no id>"' "$MANIFEST")
+if [[ -z "$missing" ]]; then
+    test_pass
+else
+    test_fail "manifest entries missing required fields: $missing"
+fi
+
+# Manifest/reality drift guard: a feature whose env key was renamed would
+# silently set a variable nothing reads. Every declared key must appear in the
+# codebase outside the manifest itself.
+test_case "every manifest env key appears in the codebase"
+orphans=""
+while IFS= read -r key; do
+    [[ -n "$key" ]] || continue
+    if ! grep -rq --include="*.sh" --include="*.md" -- "$key" \
+        "$PROJECT_ROOT/scripts" "$PROJECT_ROOT/hooks" "$PROJECT_ROOT/commands" 2>/dev/null; then
+        orphans="$orphans $key"
+    fi
+done < <(jq -r '.features[].key' "$MANIFEST")
+if [[ -z "$orphans" ]]; then
+    test_pass
+else
+    test_fail "manifest keys not referenced anywhere:$orphans"
+fi
+
+test_case "every manifest prereq resolves to a real check"
+bad=""
+while IFS= read -r prereq; do
+    [[ -n "$prereq" ]] || continue
+    if ! bash -c "source '$FEATURES_LIB'; octo_features_prereq_ok '$prereq'" >/dev/null 2>&1; then
+        # A prereq can legitimately fail (CLI absent). Distinguish "unknown
+        # check" from "check ran and said no" by probing the case arm directly.
+        if ! grep -q "^        ${prereq})" "$FEATURES_LIB" \
+           && ! grep -q "^        [a-z|-]*${prereq}[a-z|-]*)" "$FEATURES_LIB"; then
+            bad="$bad $prereq"
+        fi
+    fi
+done < <(jq -r '.features[].prereq' "$MANIFEST")
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "manifest prereqs with no matching check:$bad"
+fi
+
+test_case "unknown prereq fails closed"
+if bash -c "source '$FEATURES_LIB'; octo_features_prereq_ok 'no-such-check'" 2>/dev/null; then
+    test_fail "unknown prereq should fail closed, not open"
+else
+    test_pass
+fi
+
+test_case "manifest resolves when sourced from an unrelated cwd"
+resolved=$(cd / && bash -c "source '$FEATURES_LIB'; octo_features_manifest")
+if [[ "$resolved" == "$MANIFEST" ]]; then
+    test_pass
+else
+    test_fail "expected $MANIFEST, resolved $resolved"
+fi
+
+# CLAUDE_PLUGIN_ROOT frequently points at a stale plugin cache directory for an
+# uninstalled version. Disclosure must fall back rather than go silently dead.
+test_case "stale CLAUDE_PLUGIN_ROOT falls back to the repo manifest"
+resolved=$(CLAUDE_PLUGIN_ROOT="$TEST_TMP_DIR/does-not-exist-9.0.0" \
+    bash -c "source '$FEATURES_LIB'; octo_features_manifest")
+if [[ "$resolved" == "$MANIFEST" ]]; then
+    test_pass
+else
+    test_fail "stale plugin root should fall back; got $resolved"
+fi
+
+test_case "watermark seeds from the pre-existing last_seen_version"
+reset_ledger '{"last_seen_version":"9.55.0","model_defaults_v2":"accepted"}'
+w=$(bash -c "source '$FEATURES_LIB'; octo_features_seed_watermark; octo_features_watermark")
+if [[ "$w" == "9.55.0" ]]; then
+    test_pass
+else
+    test_fail "expected watermark 9.55.0, got '$w'"
+fi
+
+test_case "seeding preserves the model_defaults_v2 consent record"
+if jq -e '.model_defaults_v2 == "accepted"' "$OCTOPUS_STATE_DIR/state.json" >/dev/null; then
+    test_pass
+else
+    test_fail "seeding the watermark must not disturb existing consent records"
+fi
+
+# Backfill bounds the launch offer. Features that predate the watermark must not
+# be offered, or every upgrading user is handed the entire history at once.
+test_case "only backfill entries and post-watermark features are offered"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+ids=$(bash -c "source '$FEATURES_LIB'; octo_features_seed_watermark; octo_features_offerable_ids" | sort | tr '\n' ' ')
+expected=$(jq -r '.features[] | select(.backfill == true) | .id' "$MANIFEST" | sort | tr '\n' ' ')
+if [[ "$ids" == "$expected" ]]; then
+    test_pass
+else
+    test_fail "offered [$ids], expected backfill set [$expected]"
+fi
+
+test_case "a pre-watermark feature is never offered"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+ids=$(bash -c "source '$FEATURES_LIB'; octo_features_seed_watermark; octo_features_offerable_ids")
+if ! grep -qx "gemini-via-agy" <<< "$ids"; then
+    test_pass
+else
+    test_fail "gemini-via-agy (added 9.52.0) is below the 9.55.0 watermark and must not be offered"
+fi
+
+test_case "declined is sticky across repeated sessions"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+out=$(bash -c "
+    source '$FEATURES_LIB'
+    octo_features_seed_watermark
+    octo_features_record fable5-escalation declined 9.57.0
+    for _ in 1 2 3; do octo_features_offerable_ids; done
+")
+if ! grep -qx "fable5-escalation" <<< "$out"; then
+    test_pass
+else
+    test_fail "a declined feature must never be re-offered"
+fi
+
+test_case "enabled feature drops off the offer list and reads back enabled"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+out=$(bash -c "
+    source '$FEATURES_LIB'
+    octo_features_seed_watermark
+    octo_features_record codex-reviewer-flip enabled 9.57.0
+    octo_features_offerable_ids
+    octo_features_enabled codex-reviewer-flip && echo ENABLED
+")
+if grep -qx "ENABLED" <<< "$out" && ! grep -qx "codex-reviewer-flip" <<< "$out"; then
+    test_pass
+else
+    test_fail "enabling must record consent and stop the offer"
+fi
+
+test_case "disabled is distinct from declined and also suppresses offers"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+out=$(bash -c "
+    source '$FEATURES_LIB'
+    octo_features_seed_watermark
+    octo_features_record codex-reviewer-flip disabled 9.57.0
+    octo_features_offerable_ids
+    echo \"DECISION=\$(octo_features_decision codex-reviewer-flip)\"
+")
+if grep -qx "DECISION=disabled" <<< "$out" && ! grep -qx "codex-reviewer-flip" <<< "$out"; then
+    test_pass
+else
+    test_fail "disabled must be recorded distinctly and suppress offers"
+fi
+
+test_case "env var overrides the ledger in both directions"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+out=$(bash -c "
+    source '$FEATURES_LIB'
+    octo_features_record fable5-escalation declined 9.57.0
+    OCTOPUS_FABLE5_ESCALATE=1 octo_features_enabled fable5-escalation && echo ENV_ON
+    octo_features_record fable5-escalation enabled 9.57.0
+    OCTOPUS_FABLE5_ESCALATE=0 octo_features_enabled fable5-escalation || echo ENV_OFF
+")
+if grep -qx "ENV_ON" <<< "$out" && grep -qx "ENV_OFF" <<< "$out"; then
+    test_pass
+else
+    test_fail "env var must win over the recorded decision both ways"
+fi
+
+test_case "invalid decision values are rejected"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+if bash -c "source '$FEATURES_LIB'; octo_features_record fable5-escalation maybe 9.57.0" 2>/dev/null; then
+    test_fail "record should reject a decision outside enabled/declined/disabled"
+else
+    test_pass
+fi
+
+# Anti-nagware: a corrupt or unwritable ledger must make disclosure go quiet,
+# never loop. A ledger read failure that returned "nothing decided" while writes
+# also failed would re-offer every feature every session forever.
+test_case "corrupt ledger yields zero actionable features rather than looping"
+reset_ledger 'NOT VALID JSON {'
+n=$(bash -c "source '$FEATURES_LIB'; octo_features_actionable_count")
+if [[ "$n" == "0" ]]; then
+    test_pass
+else
+    test_fail "corrupt ledger should report 0 actionable, got '$n'"
+fi
+
+test_case "missing jq reports unavailable instead of erroring"
+fake_bin="$TEST_TMP_DIR/nojq"
+mkdir -p "$fake_bin"
+if PATH="$fake_bin" bash -c "source '$FEATURES_LIB'; octo_features_available" 2>/dev/null; then
+    test_fail "without jq the library must report unavailable"
+else
+    test_pass
+fi
+
+test_case "reoffer_at above the declined version re-opens the offer"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+tmp_manifest="$TEST_TMP_DIR/reoffer-manifest.json"
+jq '(.features[] | select(.id == "fable5-escalation")) |= (. + {reoffer_at: "9.60.0"})' \
+    "$MANIFEST" > "$tmp_manifest"
+out=$(OCTOPUS_FEATURES_MANIFEST="$tmp_manifest" bash -c "
+    source '$FEATURES_LIB'
+    octo_features_seed_watermark
+    octo_features_record fable5-escalation declined 9.57.0
+    octo_features_offerable_ids
+")
+if grep -qx "fable5-escalation" <<< "$out"; then
+    test_pass
+else
+    test_fail "reoffer_at 9.60.0 above a 9.57.0 decline should re-open the offer"
+fi
+
+test_case "reoffer_at at or below the declined version stays suppressed"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+tmp_manifest2="$TEST_TMP_DIR/reoffer-equal-manifest.json"
+jq '(.features[] | select(.id == "fable5-escalation")) |= (. + {reoffer_at: "9.57.0"})' \
+    "$MANIFEST" > "$tmp_manifest2"
+out=$(OCTOPUS_FEATURES_MANIFEST="$tmp_manifest2" bash -c "
+    source '$FEATURES_LIB'
+    octo_features_seed_watermark
+    octo_features_record fable5-escalation declined 9.57.0
+    octo_features_offerable_ids
+")
+if ! grep -qx "fable5-escalation" <<< "$out"; then
+    test_pass
+else
+    test_fail "reoffer_at equal to the declined version must not re-offer"
+fi
+
+test_case "actionable count excludes features whose prereq is missing"
+reset_ledger '{"last_seen_version":"9.55.0"}'
+empty_bin="$TEST_TMP_DIR/empty-bin"
+mkdir -p "$empty_bin"
+# Keep bash, jq and the coreutils the library calls reachable while hiding the
+# provider CLIs the manifest prereqs look for. Those live in package-manager
+# prefixes (/opt/homebrew/bin, ~/.local/bin), never in /bin or /usr/bin, so the
+# system paths can stay on PATH without defeating the test.
+jq_dir="$(dirname "$(command -v jq)")"
+n=$(PATH="$empty_bin:/bin:/usr/bin:$jq_dir" bash -c "source '$FEATURES_LIB'; octo_features_seed_watermark; octo_features_actionable_count")
+total=$(bash -c "source '$FEATURES_LIB'; octo_features_offerable_ids" | grep -c . || true)
+if [[ "$n" -lt "$total" ]]; then
+    test_pass
+else
+    test_fail "with provider CLIs hidden, actionable ($n) should be below offerable ($total)"
+fi
+
+test_summary

--- a/tests/unit/test-feature-disclosure.sh
+++ b/tests/unit/test-feature-disclosure.sh
@@ -18,6 +18,19 @@ MANIFEST="$PROJECT_ROOT/config/features.json"
 export OCTOPUS_STATE_DIR="$TEST_TMP_DIR/feature-state"
 mkdir -p "$OCTOPUS_STATE_DIR"
 
+# Provider CLIs the manifest prereqs probe. The runner has neither claude nor
+# codex, so without stubs every feature is prereq-blocked, actionable_count is 0,
+# and the advisory emits no directive at all — which passed locally and failed on
+# CI. Stub them for the whole suite so offers exist regardless of host. The one
+# case that asserts prereq-blocking sets its own PATH and so is unaffected.
+PREREQ_BIN="$TEST_TMP_DIR/prereq-bin"
+mkdir -p "$PREREQ_BIN"
+for _cli in claude codex agy; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$PREREQ_BIN/$_cli"
+    chmod +x "$PREREQ_BIN/$_cli"
+done
+export PATH="$PREREQ_BIN:$PATH"
+
 reset_ledger() {
     rm -rf "$OCTOPUS_STATE_DIR"
     mkdir -p "$OCTOPUS_STATE_DIR"


### PR DESCRIPTION
Three opt-in features plus the disclosure framework that surfaces them. Opus 5 stays the default lead; Codex stays the implementer.

## Progressive feature disclosure

Users who installed an older version never discover features added later. The existing mechanism was a one-line version advisory nobody acted on.

- `config/features.json` — checked-in manifest (`id`, `added_in`, `key`, `prereq`, `backfill`, optional `reoffer_at`)
- `scripts/lib/features.sh` — per-user `features_v1` ledger in `state.json`
- `hooks/version-advisory.sh` — appends an actionable-offer count to the existing once-per-version-jump advisory
- `commands/whats-new.md` — `/octo:whats-new` collects and records consent

Four states, with **`declined` deliberately distinct from `disabled`**. Both suppress offers, but collapsing them means a future "re-offer disabled features" change resurrects every past rejection.

Two decisions worth flagging for review:

- **The watermark seeds from `last_seen_version`, not the current version.** Seeding from the current version would place everything shipped in this release below the watermark, so nothing would ever be offered.
- **A corrupt ledger disables disclosure entirely.** An unreadable `state.json` makes every decision read look identical to "never offered", so disclosure would re-offer everything every session while unable to write the answer down. That is nagware with no user off-switch, so `octo_features_available` refuses to run.

`model_defaults_v2: "accepted"` is left in place and not migrated; it gates a different thing and rewriting it would invalidate consent already given.

## Selective Fable 5 escalation

Eligible roles are **`architect` and `strategist` only** — the actual opus-seat judgment roles in `agent-utils.sh`, which `/octo:prd`, `flow-define` and `skill-council` dispatch through.

**`code-reviewer` is excluded on purpose.** `frontier-model-routing.md` states Anthropic-family agreement is not an independent check, so Fable reviewing an Opus-authored plan is a same-family echo bought at twice the Opus 5 price. Fable authors and arbitrates; Codex opposes. This narrows the original request, which asked for Fable on plan/spec review.

**Escalation is applied in `lib/dispatch.sh`, not the model resolver.** The resolver caches on `provider/agent/phase/role/config-cksum` with no liveness component, so escalation there would keep serving a cached `claude-fable-5` after the seat was marked quota-dead. Dispatch runs post-cache, which removes the failure mode instead of guarding it. A test asserts escalation stays out of `model-resolver.sh`.

**Headroom is reactive because it cannot be predictive.** No endpoint reports remaining Fable 5 usage on a Claude seat, and the limit is a rolling window shared with interactive usage the plugin cannot see. A rate-limited dispatch marks the model dead via `quota-watcher` and escalation stands down for the TTL. A self-maintained budget ledger was rejected: it would drift immediately and give false confidence.

Cost is capped at **one escalated dispatch per process tree**, so councils, debates and review fleets cannot fan out at \$10/\$50 per MTok. Precedence is preserved: any explicit `OCTOPUS_OPUS_MODEL` pin suppresses escalation.

Effort clamping keys off the **resolved model**, not the env pin. The pre-existing `fable5_clamp_effort` requires a pin and would miss an escalated dispatch; clamping on the consent flag instead would over-reach and silently downgrade an explicit `OCTOPUS_EFFORT_OVERRIDE=xhigh` on unrelated Opus 5 work in the same run.

## Authorship-aware review

`_octo_reviewer_flip_active` moves `code-reviewer` to the Claude opus seat when Codex is the implementer. The static table sends both `implementer` and `code-reviewer` to Codex, so by default Codex reviews its own output. Stays inert when the Codex CLI is absent, where the implementer already falls back off Codex and flipping review away from it would remove vendor diversity rather than create it.

## Deliberately not included

**Codex as the default implementer for native (non-octo) sessions.** `codex exec --sandbox workspace-write` collapses per-edit approval prompts into a single Bash approval covering arbitrary workspace writes. `frontier-model-routing.md:46` is explicit that a model change must never broaden write authority, and unlike everything else here that is not something CI catches or a user undoes after the fact. Dropped from scope rather than deferred.

**Input-size gate on escalation.** It belongs where the prompt is assembled (`lib/agents.sh`/`lib/spawn.sh`), not where dispatch resolves the model before the prompt exists. Left unbuilt rather than built in the wrong place; filed as a follow-up.

## Verification

- `make ci-local` exit 0; 187 unit assertions, 0 failures; no mode changes
- `PASS: unit/test-fable5-escalation.sh` (20/20), `PASS: unit/test-feature-disclosure.sh` (22/22)
- The four escalation guards were **mutation-tested**: dropping `architect` from the allowlist, removing the per-run cap, removing the quota-dead check, and removing pin precedence each make the matching test fail
- Drift guard added: every manifest `key` must be referenced in the codebase, so a renamed env var cannot leave the manifest setting a variable nothing reads

## Follow-ups

`docs/roadmaps/2026-07-28-fable5-escalation-and-disclosure.md` carries three ready-to-run `bd create` commands. **bd writes are still blocked** on 4 pending schema migrations (v49 → v53) needing the single designated migrator, so nothing was filed.

Separately outstanding, not in this PR: `build-fleet.sh` builds its fleet from `command -v` plus the allowlist and never reads `check-providers.sh` status, so a `degraded` seat is still dispatched (this is what triggers the gemini keychain prompt); and `OCTOPUS_QUOTA_DEAD_TTL` at 1h is far too short for the two signatures that motivated it (gemini's `IneligibleTierError` is permanent, agy's window is ~156h). Both are bugs rather than features and belong in their own diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive **What’s New** command for consent-based feature discovery, with versioned choices and immediate confirmation.
  * Introduced new environment-configurable feature flags for selective Fable 5 escalation, reviewer “flip,” and optional preflight/Gemini routing, backed by per-user consent with backfill and stickiness.
* **Bug Fixes**
  * Improved Fable 5 escalation so effort clamping matches the final dispatched model; refined upgrade/session advisory output handling.
* **Documentation**
  * Added a roadmap/design doc for escalation and progressive disclosure.
* **Tests**
  * Added unit coverage for feature disclosure and escalation/reviewer routing safeguards.
* **Chores**
  * Registered the new command and updated repository metadata/ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->