### PR TITLE
fix: consume provider health in fleet building; per-signature quota-dead TTL

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -77,7 +77,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 **Traction (as of 2026-07-27):**
 - GitHub stars: 3,889
 - GitHub forks: 365
-- Local CI parity: 16 smoke, 185 unit, and 7 integration suites
+- Local CI parity: 16 smoke, 186 unit, and 7 integration suites
 - Version: 9.56.1 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Cursor (MCP), Gemini CLI
 

--- a/scripts/helpers/agy-exec.sh
+++ b/scripts/helpers/agy-exec.sh
@@ -237,6 +237,25 @@ _agy_quota_reset_window() {
     LC_ALL=C grep -hoiE 'resets in [0-9]+h[0-9]+m([0-9]+s)?' "$stderr_file" "$stdout_file" 2>/dev/null | head -1
 }
 
+# Convert agy's "Resets in 156h13m[45s]" into seconds, so the quota-dead marker
+# expires when the quota actually resets. Without this the marker inherits the
+# generic 1h default and a ~156h window is re-tried roughly 156 times, each retry
+# dispatching into the same instant failure. Echoes nothing when unparseable, and
+# the caller then falls back to the default TTL.
+_agy_reset_window_seconds() {
+    local w h m s
+    w="$(_agy_quota_reset_window)"
+    [[ -n "$w" ]] || return 0
+    h="$(printf '%s\n' "$w" | LC_ALL=C sed -nE 's/.*[^0-9]([0-9]+)h.*/\1/p')"
+    m="$(printf '%s\n' "$w" | LC_ALL=C sed -nE 's/.*h([0-9]+)m.*/\1/p')"
+    s="$(printf '%s\n' "$w" | LC_ALL=C sed -nE 's/.*m([0-9]+)s.*/\1/p')"
+    [[ "$h" =~ ^[0-9]+$ ]] || h=0
+    [[ "$m" =~ ^[0-9]+$ ]] || m=0
+    [[ "$s" =~ ^[0-9]+$ ]] || s=0
+    (( h == 0 && m == 0 && s == 0 )) && return 0
+    printf '%s\n' "$(( h * 3600 + m * 60 + s ))"
+}
+
 _agy_tty_error() {
     # Match only TTY-specific phrasing. A bare "bubbletea" would also catch unrelated
     # TUI failures a pseudo-terminal can't fix; the real error ("bubbletea: could not
@@ -320,7 +339,10 @@ if (( rc != 0 )) && _agy_quota_error; then
         # shellcheck source=/dev/null
         source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/quota-watcher.sh" 2>/dev/null || true
     fi
-    declare -f octo_quota_mark_dead >/dev/null 2>&1 && octo_quota_mark_dead "agy" || true
+    # Expire the marker when the quota actually resets, not on the generic
+    # default. An unparseable window yields an empty ttl and mark_dead falls back.
+    _agy_reset_ttl="$(_agy_reset_window_seconds)"
+    declare -f octo_quota_mark_dead >/dev/null 2>&1 && octo_quota_mark_dead "agy" "${_agy_reset_ttl}" || true
 fi
 
 # Surface agy's own stderr (folder-trust notes, diagnostics) that used to flow straight

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -24,6 +24,13 @@ source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/auth.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/qwen.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/grok.sh" 2>/dev/null || true
+# Provider liveness. check-providers.sh reports a quota/auth-dead seat as
+# `degraded`, but nothing downstream consumed that: this script built its fleet
+# from `command -v` plus the allowlist alone, so a seat known to be dead was
+# still handed a role and dispatched into an immediate failure. For gemini that
+# also means launching the CLI, which triggers a macOS keychain prompt for
+# gemini-cli-workspace-oauth on every review.
+source "${SCRIPT_DIR}/../lib/quota-watcher.sh" 2>/dev/null || true
 
 WORKFLOW="${1:-research}"
 INTENSITY="${2:-standard}"
@@ -72,6 +79,29 @@ if octo_provider_allowed cursor-agent && declare -f _is_cursor_agent_binary >/de
 fi
 octo_provider_allowed perplexity && [[ -n "${PERPLEXITY_API_KEY:-}" ]] && AVAILABLE_CLI+=(perplexity)
 octo_provider_allowed openrouter && [[ -n "${OPENROUTER_API_KEY:-}" ]] && AVAILABLE_CLI+=(openrouter)
+
+# Drop seats already known quota/auth-dead this session. Applied as a filter over
+# the assembled list rather than as another condition on each detection line: the
+# detection conditions differ per provider (binary, API key, health function), and
+# adding a 13th variant of the same check to each was how the original omission
+# happened. One choke point, same as provider_status() in check-providers.sh.
+if declare -f octo_quota_is_dead >/dev/null 2>&1 && [[ -n "${AVAILABLE_CLI[*]:-}" ]]; then
+    _LIVE_CLI=()
+    for _p in "${AVAILABLE_CLI[@]}"; do
+        if octo_quota_is_dead "$_p"; then
+            [[ "${OCTOPUS_FLEET_DEBUG:-0}" == "1" ]] && \
+                echo "build-fleet: skipping ${_p} (quota/auth-dead this session)" >&2
+            continue
+        fi
+        _LIVE_CLI+=("$_p")
+    done
+    AVAILABLE_CLI=("${_LIVE_CLI[@]:-}")
+    # An all-dead list collapses to a single empty element under bash 3.2's
+    # ${arr[@]:-} expansion; normalise so CLI_COUNT does not report a phantom seat.
+    if [[ ${#AVAILABLE_CLI[@]} -eq 1 && -z "${AVAILABLE_CLI[0]}" ]]; then
+        AVAILABLE_CLI=()
+    fi
+fi
 
 CLI_COUNT=0
 if [[ -n "${AVAILABLE_CLI[*]:-}" ]]; then

--- a/scripts/helpers/gemini-exec.sh
+++ b/scripts/helpers/gemini-exec.sh
@@ -70,7 +70,10 @@ _gemini_mark_dead() {
         # shellcheck source=/dev/null
         source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/quota-watcher.sh" 2>/dev/null || true
     fi
-    declare -f octo_quota_mark_dead >/dev/null 2>&1 && octo_quota_mark_dead "gemini" || true
+    # ttl 0 = permanent. IneligibleTierError is not a quota window: Google sunset
+    # Gemini Code Assist free-tier OAuth, so the seat cannot recover on its own and
+    # expiring the marker only re-launches the CLI (and its keychain prompt).
+    declare -f octo_quota_mark_dead >/dev/null 2>&1 && octo_quota_mark_dead "gemini" 0 || true
 }
 
 last_exit=0

--- a/scripts/lib/quota-watcher.sh
+++ b/scripts/lib/quota-watcher.sh
@@ -25,13 +25,57 @@ octo_quota_dead_file() {
     printf '%s\n' "${WORKSPACE_DIR:-$HOME/.claude-octopus}/state/.provider-quota-dead"
 }
 
+# Per-provider expiry metadata, kept in a sidecar so the main marker file stays a
+# plain list of provider names (its on-disk format is depended on by callers and
+# tests that grep it directly).
+# Format: one "provider<TAB>marked_at_epoch<TAB>ttl_seconds" line per provider.
+# ttl_seconds of 0 means "never expires".
+octo_quota_dead_meta_file() {
+    printf '%s\n' "$(octo_quota_dead_file).meta"
+}
+
+# octo_quota_mark_dead <provider> [ttl_seconds]
+# ttl_seconds: omit for the OCTOPUS_QUOTA_DEAD_TTL default, 0 for permanent, or a
+# provider-supplied window (e.g. agy's "Resets in 156h13m").
 octo_quota_mark_dead() {
-    local provider="$1"
+    local provider="$1" ttl="${2:-}"
     [[ -n "$provider" ]] || return 0
-    local f dir
+    local f dir meta now tmp
     f="$(octo_quota_dead_file)"; dir="$(dirname "$f")"
     mkdir -p "$dir" 2>/dev/null || return 0
     grep -qxF "$provider" "$f" 2>/dev/null || printf '%s\n' "$provider" >> "$f"
+
+    [[ "$ttl" =~ ^[0-9]+$ ]] || return 0
+    meta="$(octo_quota_dead_meta_file)"
+    now="$(date +%s 2>/dev/null)" || return 0
+    [[ "$now" =~ ^[0-9]+$ ]] || return 0
+    tmp="$(mktemp "${meta}.XXXXXX")" 2>/dev/null || return 0
+    if [[ -f "$meta" ]]; then
+        grep -v "^${provider}	" "$meta" > "$tmp" 2>/dev/null || true
+    fi
+    printf '%s\t%s\t%s\n' "$provider" "$now" "$ttl" >> "$tmp"
+    mv "$tmp" "$meta" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    return 0
+}
+
+# _octo_quota_meta_expired <provider> — 0 when a recorded per-provider window has
+# elapsed, 1 when it is still in force, 2 when no metadata exists (caller falls
+# back to the file-mtime default).
+_octo_quota_meta_expired() {
+    local provider="$1" meta line marked ttl now
+    meta="$(octo_quota_dead_meta_file)"
+    [[ -f "$meta" ]] || return 2
+    line="$(grep "^${provider}	" "$meta" 2>/dev/null | tail -1)" || return 2
+    [[ -n "$line" ]] || return 2
+    marked="$(printf '%s\n' "$line" | cut -f2)"
+    ttl="$(printf '%s\n' "$line" | cut -f3)"
+    [[ "$marked" =~ ^[0-9]+$ && "$ttl" =~ ^[0-9]+$ ]] || return 2
+    # ttl 0 = permanent (e.g. gemini's IneligibleTierError, which is not a quota
+    # window at all but the sunset of an auth mode).
+    (( ttl == 0 )) && return 1
+    now="$(date +%s 2>/dev/null)"
+    [[ "$now" =~ ^[0-9]+$ ]] || return 1
+    (( now - marked > ttl ))
 }
 
 # How long a quota-dead mark stays in force, in seconds. The marker was
@@ -66,6 +110,19 @@ octo_quota_is_dead() {
     f="$(octo_quota_dead_file)"
     [[ -f "$f" ]] || return 1
 
+    # Per-provider window first. The single global TTL below is wrong for both
+    # signatures that motivated this cache: gemini's IneligibleTierError is
+    # permanent for that auth mode, and agy's window is ~156h, so a 1h default
+    # expired it roughly 156 times before the quota actually reset — putting a
+    # known-dead seat straight back into dispatch.
+    _octo_quota_meta_expired "$provider"
+    case $? in
+        0) return 1 ;;   # recorded window elapsed
+        1) grep -qxF "$provider" "$f" 2>/dev/null; return $? ;;   # still in force
+    esac
+
+    # No metadata (marked by an older version, or a signature with no known
+    # window): fall back to the coarse file-mtime default.
     if [[ "$OCTOPUS_QUOTA_DEAD_TTL" =~ ^[0-9]+$ ]] && (( OCTOPUS_QUOTA_DEAD_TTL > 0 )); then
         local mtime now
         mtime="$(_octo_quota_file_mtime "$f")"

--- a/tests/unit/test-provider-health-fleet.sh
+++ b/tests/unit/test-provider-health-fleet.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Unit tests for provider-health-aware fleet building and per-signature
+# quota-dead expiry.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Provider health and fleet"
+
+QUOTA_LIB="$PROJECT_ROOT/scripts/lib/quota-watcher.sh"
+BUILD_FLEET="$PROJECT_ROOT/scripts/helpers/build-fleet.sh"
+
+export WORKSPACE_DIR="$TEST_TMP_DIR/health-workspace"
+mkdir -p "$WORKSPACE_DIR/state"
+DEAD_FILE="$WORKSPACE_DIR/state/.provider-quota-dead"
+
+reset_markers() { rm -f "$DEAD_FILE" "$DEAD_FILE.meta"; }
+
+# Mock CLIs so fleet composition does not depend on what the developer has installed.
+mock_bin="$TEST_TMP_DIR/health-bin"
+mkdir -p "$mock_bin"
+for cmd in codex gemini; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$mock_bin/$cmd"
+    chmod +x "$mock_bin/$cmd"
+done
+
+test_case "quota-watcher has valid bash syntax"
+if bash -n "$QUOTA_LIB"; then test_pass; else test_fail "quota-watcher.sh syntax error"; fi
+
+# ── Per-signature expiry ─────────────────────────────────────────────────────
+
+# gemini's IneligibleTierError is the sunset of an auth mode, not a quota window.
+# A marker that expires only relaunches the CLI (and its keychain prompt).
+test_case "ttl 0 marks a seat dead permanently"
+reset_markers
+out=$(WORKSPACE_DIR="$WORKSPACE_DIR" OCTOPUS_QUOTA_DEAD_TTL=1 bash -c "
+    source '$QUOTA_LIB'
+    octo_quota_mark_dead gemini 0
+    # Backdate far beyond any plausible default TTL.
+    touch -t 202001010000 '$DEAD_FILE'
+    octo_quota_is_dead gemini && echo DEAD || echo ALIVE
+")
+if [[ "$out" == "DEAD" ]]; then
+    test_pass
+else
+    test_fail "a permanent mark must survive an elapsed default TTL, got '$out'"
+fi
+
+test_case "a recorded window still in force keeps the seat dead"
+reset_markers
+out=$(WORKSPACE_DIR="$WORKSPACE_DIR" OCTOPUS_QUOTA_DEAD_TTL=1 bash -c "
+    source '$QUOTA_LIB'
+    octo_quota_mark_dead agy 100000
+    touch -t 202001010000 '$DEAD_FILE'
+    octo_quota_is_dead agy && echo DEAD || echo ALIVE
+")
+if [[ "$out" == "DEAD" ]]; then
+    test_pass
+else
+    test_fail "a ~28h window must outlast a 1s default TTL, got '$out'"
+fi
+
+test_case "a recorded window that has elapsed revives the seat"
+reset_markers
+out=$(WORKSPACE_DIR="$WORKSPACE_DIR" bash -c "
+    source '$QUOTA_LIB'
+    octo_quota_mark_dead agy 1
+    # Rewrite the metadata timestamp to two hours ago.
+    meta=\"\$(octo_quota_dead_meta_file)\"
+    now=\$(date +%s)
+    printf 'agy\t%s\t1\n' \"\$((now - 7200))\" > \"\$meta\"
+    octo_quota_is_dead agy && echo DEAD || echo ALIVE
+")
+if [[ "$out" == "ALIVE" ]]; then
+    test_pass
+else
+    test_fail "an elapsed window must revive the seat, got '$out'"
+fi
+
+test_case "per-provider windows are independent"
+reset_markers
+out=$(WORKSPACE_DIR="$WORKSPACE_DIR" bash -c "
+    source '$QUOTA_LIB'
+    octo_quota_mark_dead gemini 0
+    octo_quota_mark_dead agy 1
+    meta=\"\$(octo_quota_dead_meta_file)\"
+    now=\$(date +%s)
+    printf 'gemini\t%s\t0\nagy\t%s\t1\n' \"\$now\" \"\$((now - 7200))\" > \"\$meta\"
+    octo_quota_is_dead gemini && echo GEMINI_DEAD
+    octo_quota_is_dead agy || echo AGY_ALIVE
+")
+if grep -qx "GEMINI_DEAD" <<<"$out" && grep -qx "AGY_ALIVE" <<<"$out"; then
+    test_pass
+else
+    test_fail "expiry must be per provider, got '$out'"
+fi
+
+# Markers written by an older version have no sidecar entry and must keep working.
+test_case "a marker with no metadata falls back to the default TTL"
+reset_markers
+printf 'perplexity\n' > "$DEAD_FILE"
+in_force=$(WORKSPACE_DIR="$WORKSPACE_DIR" OCTOPUS_QUOTA_DEAD_TTL=3600 bash -c "
+    source '$QUOTA_LIB'; octo_quota_is_dead perplexity && echo DEAD || echo ALIVE")
+touch -t 202001010000 "$DEAD_FILE"
+expired=$(WORKSPACE_DIR="$WORKSPACE_DIR" OCTOPUS_QUOTA_DEAD_TTL=3600 bash -c "
+    source '$QUOTA_LIB'; octo_quota_is_dead perplexity && echo DEAD || echo ALIVE")
+if [[ "$in_force" == "DEAD" && "$expired" == "ALIVE" ]]; then
+    test_pass
+else
+    test_fail "legacy fallback broken: fresh='$in_force' stale='$expired'"
+fi
+
+test_case "the marker file keeps its bare-provider-name format"
+reset_markers
+WORKSPACE_DIR="$WORKSPACE_DIR" bash -c "source '$QUOTA_LIB'; octo_quota_mark_dead agy 500"
+if [[ "$(cat "$DEAD_FILE")" == "agy" ]]; then
+    test_pass
+else
+    test_fail "main marker file must stay a plain name list, got '$(cat "$DEAD_FILE")'"
+fi
+
+# ── agy reset-window parsing ─────────────────────────────────────────────────
+
+test_case "agy 'Resets in 156h13m' parses to seconds"
+got=$(bash -c '
+    stderr_file=$(mktemp); stdout_file=$(mktemp)
+    echo "Individual quota reached. Resets in 156h13m" > "$stderr_file"
+    _agy_quota_reset_window() { LC_ALL=C grep -hoiE "resets in [0-9]+h[0-9]+m([0-9]+s)?" "$stderr_file" "$stdout_file" 2>/dev/null | head -1; }
+    '"$(sed -n '/^_agy_reset_window_seconds() {/,/^}/p' "$PROJECT_ROOT/scripts/helpers/agy-exec.sh")"'
+    _agy_reset_window_seconds
+    rm -f "$stderr_file" "$stdout_file"
+')
+if [[ "$got" == "562380" ]]; then
+    test_pass
+else
+    test_fail "expected 562380 (156h13m), got '$got'"
+fi
+
+test_case "an unparseable reset window yields an empty ttl"
+got=$(bash -c '
+    stderr_file=$(mktemp); stdout_file=$(mktemp)
+    echo "Individual quota reached." > "$stderr_file"
+    _agy_quota_reset_window() { LC_ALL=C grep -hoiE "resets in [0-9]+h[0-9]+m([0-9]+s)?" "$stderr_file" "$stdout_file" 2>/dev/null | head -1; }
+    '"$(sed -n '/^_agy_reset_window_seconds() {/,/^}/p' "$PROJECT_ROOT/scripts/helpers/agy-exec.sh")"'
+    _agy_reset_window_seconds
+    rm -f "$stderr_file" "$stdout_file"
+')
+if [[ -z "$got" ]]; then
+    test_pass
+else
+    test_fail "no window should mean no ttl (caller falls back), got '$got'"
+fi
+
+# ── Fleet excludes dead seats ────────────────────────────────────────────────
+
+test_case "a healthy gemini seat is assigned a fleet role"
+reset_markers
+fleet=$(PATH="$mock_bin:/usr/bin:/bin" WORKSPACE_DIR="$WORKSPACE_DIR" \
+    OCTO_ALLOWED_PROVIDERS="codex gemini" "$BUILD_FLEET" review standard "x" 2>/dev/null)
+if grep -q "^gemini|" <<<"$fleet"; then
+    test_pass
+else
+    test_fail "gemini should be in the fleet when healthy: $fleet"
+fi
+
+# This is the defect that made every /octo:review launch the dead gemini CLI and
+# raise a macOS keychain prompt for gemini-cli-workspace-oauth.
+test_case "a quota-dead gemini seat is excluded from the fleet"
+reset_markers
+WORKSPACE_DIR="$WORKSPACE_DIR" bash -c "source '$QUOTA_LIB'; octo_quota_mark_dead gemini 0"
+fleet=$(PATH="$mock_bin:/usr/bin:/bin" WORKSPACE_DIR="$WORKSPACE_DIR" \
+    OCTO_ALLOWED_PROVIDERS="codex gemini" "$BUILD_FLEET" review standard "x" 2>/dev/null)
+if ! grep -q "^gemini|" <<<"$fleet"; then
+    test_pass
+else
+    test_fail "a dead seat must not be dispatched: $fleet"
+fi
+
+test_case "excluding a dead seat leaves the rest of the fleet intact"
+if grep -q "^codex|" <<<"$fleet"; then
+    test_pass
+else
+    test_fail "codex should still be assigned: $fleet"
+fi
+
+test_case "fleet building survives every CLI seat being dead"
+reset_markers
+WORKSPACE_DIR="$WORKSPACE_DIR" bash -c "
+    source '$QUOTA_LIB'
+    octo_quota_mark_dead gemini 0
+    octo_quota_mark_dead codex 0"
+if fleet=$(PATH="$mock_bin:/usr/bin:/bin" WORKSPACE_DIR="$WORKSPACE_DIR" \
+    OCTO_ALLOWED_PROVIDERS="codex gemini" "$BUILD_FLEET" review standard "x" 2>/dev/null); then
+    if ! grep -qE "^(gemini|codex)\|" <<<"$fleet"; then
+        test_pass
+    else
+        test_fail "dead seats leaked into an all-dead fleet: $fleet"
+    fi
+else
+    test_fail "build-fleet must not crash when all CLI seats are dead"
+fi
+
+test_summary


### PR DESCRIPTION
Two defects in the provider-liveness path. **One of them I introduced in #690**, and it is live on `main`.

## build-fleet.sh never read provider health

`#690` made `check-providers.sh` report a quota/auth-dead seat as `degraded`. Nothing downstream consumed it. `build-fleet.sh` assembled `AVAILABLE_CLI` from `command -v` plus the allowlist alone, so a seat known to be dead was still handed a fleet role and dispatched into an immediate failure:

```
check-providers.sh  →  gemini:degraded
build-fleet.sh      →  gemini|Security Reviewer|...     ← still dispatched
```

For gemini this also launches the CLI, which is what raises the macOS keychain prompt for `gemini-cli-workspace-oauth` on every `/octo:review`.

Applied as **one filter over the assembled list**, not as another condition on each detection line. The per-provider conditions differ (binary presence, API key, health function), and adding a 13th variant of the same check to each is precisely how the original omission happened. Same single-choke-point shape as `provider_status()`.

## The 1h TTL was wrong for both signatures it was built for

`OCTOPUS_QUOTA_DEAD_TTL` defaulted to 3600s for everything. Both signatures that motivated the cache in #690 need something else:

| Signature | Reality | Old behaviour |
|---|---|---|
| gemini `IneligibleTierError` | Sunset of an auth mode. Cannot recover. | Expired hourly, relaunching the CLI and its keychain prompt |
| agy `Individual quota reached` | ~156h window, stated in the error text | Expired ~156 times before the quota actually reset |

Observed on a live marker: 18.9h old against a 1h TTL, so **both seats had reverted to `available`** and were being dispatched into instant failure. Pre-#690 gemini at least stayed suppressed, because the marker was permanent. I traded "permanent suppression risk" for "suppression that never lasts long enough to matter," which is worse for exactly these two cases.

Now: per-provider `marked_at` + `ttl` in a sidecar file, `ttl 0` meaning permanent. gemini marks permanent; agy parses its own `Resets in 156h13m` into 562380s via `_agy_reset_window_seconds` and passes that, falling back to the default when unparseable.

**Backward compatible by design.** The main marker file keeps its bare-provider-name format, because callers and tests grep it directly. A marker written by an older version has no sidecar entry and falls back to the existing mtime default; that path has its own test.

## Verification

- `make ci-local` exit 0; `PASS: unit/test-provider-health-fleet.sh`; no mode changes
- 13 new assertions covering permanent ttl, in-force window, elapsed window, per-provider independence, legacy fallback, on-disk format stability, window parsing (`156h13m` → `562380`), unparseable windows, fleet inclusion when healthy, fleet exclusion when dead, remaining fleet intact, and an all-seats-dead fleet not crashing
- No regressions: `test-quota-fast-fail` (9), `test-provider-allowlist` (13), `test-fleet-diversity` (36)
- **Mutation-tested**: removing the fleet health filter, breaking permanent ttl, and breaking the in-force window each make the matching test fail

## Merge note

`PRODUCT.md` records the unit-suite count and both this PR (186) and #691 (187) bump that line. Whichever merges second will conflict there and needs `./scripts/sync-readme.py` rerun rather than a hand-edited number.

Related: #690 (introduced the TTL), #691 (unrelated features, same `PRODUCT.md` line).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Provider availability now reflects individual quota and authentication status with more precise recovery timing.
  * Fleet creation automatically excludes providers that are temporarily unavailable, while continuing to use healthy options.
  * Certain terminal access restrictions remain unavailable for the rest of the session instead of being retried unnecessarily.
* **Documentation**
  * Updated local CI metrics to reflect 186 unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->