### PR TITLE
fix: re-derive USAGE_FILE after WORKSPACE_DIR is resolved (fixes #693)

### DIFF
--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -221,6 +221,12 @@ fi
 SESSION_FILE="${WORKSPACE_DIR}/session.json"
 PROGRESS_FILE="${WORKSPACE_DIR}/progress.json"
 
+# Re-derive cost tracking paths for the same reason (cost.sh is sourced before
+# WORKSPACE_DIR is defined, which froze USAGE_FILE at "/usage-session.json" and
+# made every record_agent_call append fail — killing dispatches under set -e)
+USAGE_FILE="${WORKSPACE_DIR}/usage-session.json"
+USAGE_HISTORY_DIR="${WORKSPACE_DIR}/usage-history"
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # CLAUDE CODE INTEGRATION: Task Management (v7.16.0)
 # Capture Claude Code v2.1.16+ environment variables for enhanced progress tracking


### PR DESCRIPTION
## Problem

`lib/cost.sh` is sourced at `orchestrate.sh:183`, before `WORKSPACE_DIR` is defined (lines 212-216). `USAGE_FILE` therefore freezes at `/usage-session.json`, and every `record_agent_call` append hits `Permission denied` at the filesystem root. Under `set -eo pipefail` this kills the dispatch subshell, agents are reported `failed with exit code 1`, and standard-depth councils lose quorum.

Reproduced on v9.54.1 (`cost.sh:397`) and a fresh v9.56.1 install (`cost.sh:422`). Full diagnosis in #693.

## Fix

Mirror the existing `SESSION_FILE`/`PROGRESS_FILE` re-derivation pattern right after `WORKSPACE_DIR` is resolved:

```bash
USAGE_FILE="${WORKSPACE_DIR}/usage-session.json"
USAGE_HISTORY_DIR="${WORKSPACE_DIR}/usage-history"
```

Two assignments, no behavior change beyond writing telemetry where it was always intended to go.

## Validation

- `bash -n scripts/orchestrate.sh` clean.
- Before the fix: every council dispatch logs `cost.sh: line 422: /usage-session.json.log: Permission denied` followed by agent failure; after applying the same edit to a local install, the append targets `~/.claude-octopus/usage-session.json.log` as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage and cost tracking during orchestration.
  * Prevented failures when recording usage history in newly determined workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->