### PR TITLE
feat: add native Command Code CLI provider

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -77,7 +77,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 **Traction (as of 2026-07-27):**
 - GitHub stars: 3,889
 - GitHub forks: 365
-- Local CI parity: 16 smoke, 187 unit, and 7 integration suites
+- Local CI parity: 16 smoke, 189 unit, and 7 integration suites
 - Version: 9.56.1 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Gemini CLI
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -77,9 +77,9 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 **Traction (as of 2026-07-27):**
 - GitHub stars: 3,889
 - GitHub forks: 365
-- Local CI parity: 16 smoke, 188 unit, and 7 integration suites
+- Local CI parity: 16 smoke, 187 unit, and 7 integration suites
 - Version: 9.56.1 (active release cadence)
-- Runtimes supported: Claude Code, Codex CLI, Cursor (MCP), Gemini CLI
+- Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Gemini CLI
 
 **Measured Impact:**
 - 75% consensus gate: quantifiable disagreement detection before production

--- a/docs/COMMANDCODE.md
+++ b/docs/COMMANDCODE.md
@@ -1,0 +1,28 @@
+# Command Code CLI provider
+
+Octopus can dispatch `commandcode`, `commandcode-research`, and `commandcode-fast` through the native Command Code CLI.
+
+## Install and authenticate
+
+```bash
+npm i -g command-code@latest
+export COMMAND_CODE_API_KEY="..."
+```
+
+Interactive `cmd login` credentials are also accepted by the CLI health check. Octopus does not implement OAuth itself.
+
+## Configure a model
+
+```bash
+export OCTOPUS_COMMANDCODE_MODEL=deepseek/deepseek-v4-pro
+# or providers.json: {"providers":{"commandcode":{"default":"deepseek/deepseek-v4-pro"}}}
+```
+
+The adapter uses Command Code headless NDJSON mode, extracts the final result, disables onboarding and auto-update, and keeps Octopus as the worktree/orchestration owner. Read-only roles run in `plan` mode; implementer/developer roles receive `--yolo` only inside the Octopus-managed workspace.
+
+Optional controls:
+
+- `OCTOPUS_COMMANDCODE_BIN` — override the CLI executable.
+- `OCTOPUS_COMMANDCODE_MAX_TURNS` — default `30`.
+- `OCTOPUS_COMMANDCODE_ALLOWED_MODELS` — comma-separated model allowlist.
+- `CMD_ZDR=1` — require Command Code zero-data-retention routing.

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -51,6 +51,7 @@ get_family() {
         cursor-agent|cursor-agent-*) echo "xai" ;;
         grok|grok-*)         echo "xai" ;;   # grok-provider (xAI Grok CLI)
         openrouter|openrouter-*) echo "multi" ;;
+        commandcode|commandcode-*) echo "multi" ;;
         *)                   echo "unknown" ;;
     esac
 }
@@ -59,6 +60,13 @@ get_family() {
 # Order = preference for primary slot assignment
 AVAILABLE_CLI=()
 if octo_provider_allowed codex && command -v codex >/dev/null 2>&1; then AVAILABLE_CLI+=(codex); fi
+if octo_provider_allowed commandcode && { command -v command-code >/dev/null 2>&1 || command -v cmd >/dev/null 2>&1; }; then
+    _commandcode_bin="command-code"
+    command -v command-code >/dev/null 2>&1 || _commandcode_bin="cmd"
+    if [[ -n "${COMMAND_CODE_API_KEY:-}" ]] || "$_commandcode_bin" status --json >/dev/null 2>&1; then
+        AVAILABLE_CLI+=(commandcode)
+    fi
+fi
 if octo_provider_allowed gemini && command -v gemini >/dev/null 2>&1; then AVAILABLE_CLI+=(gemini); fi
 if octo_provider_allowed grok && declare -f grok_is_available >/dev/null 2>&1 && grok_is_available; then AVAILABLE_CLI+=(grok); fi
 if octo_provider_allowed agy && command -v agy >/dev/null 2>&1; then AVAILABLE_CLI+=(agy); fi
@@ -144,8 +152,8 @@ build_diverse_order() {
     local diverse_first=""
     local diverse_rest=""
 
-    # Preferred order for primary diversity: codex, gemini, agy, copilot, qwen, cursor-agent, opencode, ollama
-    for p in codex gemini agy copilot qwen grok cursor-agent opencode ollama; do
+    # Preferred order for primary diversity: codex, commandcode, gemini, agy, copilot, qwen, cursor-agent, opencode, ollama
+    for p in codex commandcode gemini agy copilot qwen grok cursor-agent opencode ollama; do
         is_available "$p" || continue
         local fam
         fam=$(get_family "$p")

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -70,7 +70,7 @@ if octo_provider_allowed commandcode; then
             _commandcode_bin="cmd"
         fi
     fi
-    if [[ -n "$_commandcode_bin" ]] && { [[ -n "${COMMAND_CODE_API_KEY:-}" ]] || "$_commandcode_bin" status --json >/dev/null 2>&1; }; then
+    if [[ -n "$_commandcode_bin" ]] && { [[ -x "$_commandcode_bin" ]] || command -v "$_commandcode_bin" >/dev/null 2>&1; } && { [[ -n "${COMMAND_CODE_API_KEY:-}" ]] || "$_commandcode_bin" status --json >/dev/null 2>&1; }; then
         AVAILABLE_CLI+=(commandcode)
     fi
 fi

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -60,10 +60,17 @@ get_family() {
 # Order = preference for primary slot assignment
 AVAILABLE_CLI=()
 if octo_provider_allowed codex && command -v codex >/dev/null 2>&1; then AVAILABLE_CLI+=(codex); fi
-if octo_provider_allowed commandcode && { command -v command-code >/dev/null 2>&1 || command -v cmd >/dev/null 2>&1; }; then
-    _commandcode_bin="command-code"
-    command -v command-code >/dev/null 2>&1 || _commandcode_bin="cmd"
-    if [[ -n "${COMMAND_CODE_API_KEY:-}" ]] || "$_commandcode_bin" status --json >/dev/null 2>&1; then
+if octo_provider_allowed commandcode; then
+    [[ -n "${COMMAND_CODE_API_KEY:-}" ]] || resolve_provider_env "COMMAND_CODE_API_KEY" 2>/dev/null || true
+    _commandcode_bin="${OCTOPUS_COMMANDCODE_BIN:-}"
+    if [[ -z "$_commandcode_bin" ]]; then
+        if command -v command-code >/dev/null 2>&1; then
+            _commandcode_bin="command-code"
+        elif command -v cmd >/dev/null 2>&1; then
+            _commandcode_bin="cmd"
+        fi
+    fi
+    if [[ -n "$_commandcode_bin" ]] && { [[ -n "${COMMAND_CODE_API_KEY:-}" ]] || "$_commandcode_bin" status --json >/dev/null 2>&1; }; then
         AVAILABLE_CLI+=(commandcode)
     fi
 fi

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -78,7 +78,7 @@ if [[ -z "$cc_bin" ]]; then
         cc_bin="cmd"
     fi
 fi
-if [[ -n "$cc_bin" ]]; then
+if [[ -n "$cc_bin" ]] && { [[ -x "$cc_bin" ]] || command -v "$cc_bin" >/dev/null 2>&1; }; then
     if [[ -n "${COMMAND_CODE_API_KEY:-}" ]]; then
         commandcode_state="available"
     else

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -69,11 +69,19 @@ fi
 echo "PROVIDER_CHECK_START"
 provider_status "codex" "$(command -v codex >/dev/null 2>&1 && echo available || echo missing)"
 commandcode_state="missing"
-if command -v command-code >/dev/null 2>&1 || command -v cmd >/dev/null 2>&1; then
+[[ -n "${COMMAND_CODE_API_KEY:-}" ]] || resolve_provider_env "COMMAND_CODE_API_KEY" 2>/dev/null || true
+cc_bin="${OCTOPUS_COMMANDCODE_BIN:-}"
+if [[ -z "$cc_bin" ]]; then
+    if command -v command-code >/dev/null 2>&1; then
+        cc_bin="command-code"
+    elif command -v cmd >/dev/null 2>&1; then
+        cc_bin="cmd"
+    fi
+fi
+if [[ -n "$cc_bin" ]]; then
     if [[ -n "${COMMAND_CODE_API_KEY:-}" ]]; then
         commandcode_state="available"
     else
-        cc_bin="command-code"; command -v command-code >/dev/null 2>&1 || cc_bin="cmd"
         "$cc_bin" status --json >/dev/null 2>&1 && commandcode_state="available" || commandcode_state="degraded"
     fi
 fi

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -68,6 +68,16 @@ fi
 
 echo "PROVIDER_CHECK_START"
 provider_status "codex" "$(command -v codex >/dev/null 2>&1 && echo available || echo missing)"
+commandcode_state="missing"
+if command -v command-code >/dev/null 2>&1 || command -v cmd >/dev/null 2>&1; then
+    if [[ -n "${COMMAND_CODE_API_KEY:-}" ]]; then
+        commandcode_state="available"
+    else
+        cc_bin="command-code"; command -v command-code >/dev/null 2>&1 || cc_bin="cmd"
+        "$cc_bin" status --json >/dev/null 2>&1 && commandcode_state="available" || commandcode_state="degraded"
+    fi
+fi
+provider_status "commandcode" "$commandcode_state"
 provider_status "gemini" "$(command -v gemini >/dev/null 2>&1 && echo available || echo missing)"
 provider_status "agy" "$(command -v agy >/dev/null 2>&1 && echo available || echo missing)"
 # oco-cbb: opt-in proactive probe for API-key providers (perplexity, openrouter).

--- a/scripts/helpers/commandcode-exec.sh
+++ b/scripts/helpers/commandcode-exec.sh
@@ -34,13 +34,13 @@ prompt="$(cat)"
 tmp="$(mktemp "${TMPDIR:-/tmp}/octopus-commandcode.XXXXXX")" || exit 1
 trap 'rm -f "$tmp"' EXIT INT TERM
 
-args=(-p "$prompt" --model "$model" --output-format json --max-turns "$max_turns" --skip-onboarding --no-auto-update --trust --no-session)
+args=(-p --model "$model" --output-format json --max-turns "$max_turns" --skip-onboarding --no-auto-update --trust --no-session)
 case "$permission_mode" in
   yolo) args+=(--yolo) ;;
   *) args+=(--permission-mode "$permission_mode") ;;
 esac
 
-if "$bin" "${args[@]}" >"$tmp"; then
+if printf '%s' "$prompt" | "$bin" "${args[@]}" >"$tmp"; then
   rc=0
 else
   rc=$?

--- a/scripts/helpers/commandcode-exec.sh
+++ b/scripts/helpers/commandcode-exec.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+model="${1:-${OCTOPUS_COMMANDCODE_MODEL:-deepseek/deepseek-v4-pro}}"
+permission_mode="${2:-${OCTOPUS_COMMANDCODE_PERMISSION_MODE:-plan}}"
+max_turns="${OCTOPUS_COMMANDCODE_MAX_TURNS:-30}"
+
+case "$model" in
+  ''|*[!A-Za-z0-9._/-]*) echo "commandcode: invalid model id" >&2; exit 1 ;;
+esac
+case "$max_turns" in
+  ''|*[!0-9]*) echo "commandcode: invalid max-turns" >&2; exit 1 ;;
+esac
+case "$permission_mode" in
+  plan|default|dont-ask|auto-accept|yolo) ;;
+  *) echo "commandcode: invalid permission mode" >&2; exit 1 ;;
+esac
+
+bin="${OCTOPUS_COMMANDCODE_BIN:-}"
+if [[ -z "$bin" ]]; then
+  if command -v command-code >/dev/null 2>&1; then
+    bin="command-code"
+  elif command -v cmd >/dev/null 2>&1; then
+    bin="cmd"
+  else
+    echo "commandcode: CLI not found (install: npm i -g command-code@latest)" >&2
+    exit 1
+  fi
+fi
+
+prompt="$(cat)"
+[[ -n "$prompt" ]] || { echo "commandcode: empty prompt" >&2; exit 1; }
+
+tmp="$(mktemp "${TMPDIR:-/tmp}/octopus-commandcode.XXXXXX")" || exit 1
+trap 'rm -f "$tmp"' EXIT INT TERM
+
+args=(-p "$prompt" --model "$model" --output-format json --max-turns "$max_turns" --skip-onboarding --no-auto-update --trust --no-session)
+case "$permission_mode" in
+  yolo) args+=(--yolo) ;;
+  *) args+=(--permission-mode "$permission_mode") ;;
+esac
+
+if "$bin" "${args[@]}" >"$tmp"; then
+  rc=0
+else
+  rc=$?
+fi
+
+result_line="$(awk 'BEGIN{line=""} /^\{/{line=$0} END{print line}' "$tmp")"
+if [[ -z "$result_line" ]] || ! command -v jq >/dev/null 2>&1; then
+  cat "$tmp"
+  exit "$rc"
+fi
+
+subtype="$(printf '%s\n' "$result_line" | jq -r '.subtype // empty' 2>/dev/null || true)"
+final_text="$(printf '%s\n' "$result_line" | jq -r '.finalText // empty' 2>/dev/null || true)"
+error_text="$(printf '%s\n' "$result_line" | jq -r '.error.message // .error // empty' 2>/dev/null || true)"
+
+[[ -n "$final_text" ]] && printf '%s\n' "$final_text"
+if [[ "$subtype" == "error" ]]; then
+  if [[ -n "$error_text" ]]; then
+    printf 'commandcode: %s\n' "$error_text" >&2
+  else
+    printf 'commandcode: structured error result\n' >&2
+  fi
+  [[ "$rc" -ne 0 ]] || rc=1
+fi
+exit "$rc"

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -461,6 +461,16 @@ get_agent_command() {
                 echo "${PLUGIN_DIR}/scripts/helpers/claude-sdk-exec.sh"
             fi
             ;;
+        commandcode|commandcode-research|commandcode-fast)
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
+            local commandcode_mode="plan"
+            case "$role" in
+                implementer|developer) commandcode_mode="yolo" ;;
+            esac
+            echo "${PLUGIN_DIR}/scripts/helpers/commandcode-exec.sh ${model} ${commandcode_mode}"
+            ;;
         cursor-agent)  # v9.23.0: Cursor Agent CLI — Grok 4.20 via Cursor subscription
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
                 return 1
@@ -712,6 +722,7 @@ get_agent_model() {
         openrouter*) provider="openrouter" ;;
         atlascloud*) provider="atlascloud" ;;
         openai-compatible|openai-tools|openai-compatible-agent*) provider="openai-compatible-agent" ;;
+        commandcode*) provider="commandcode" ;;
         perplexity*) provider="perplexity" ;;
         qwen*)       provider="qwen" ;;
         cursor-agent*) provider="cursor-agent" ;;
@@ -760,6 +771,7 @@ validate_model_allowed() {
         perplexity) allowlist_var="OCTOPUS_PERPLEXITY_ALLOWED_MODELS" ;;
         qwen)       allowlist_var="OCTOPUS_QWEN_ALLOWED_MODELS" ;;
         cursor-agent) allowlist_var="OCTOPUS_CURSOR_AGENT_ALLOWED_MODELS" ;;
+        commandcode) allowlist_var="OCTOPUS_COMMANDCODE_ALLOWED_MODELS" ;;
         opencode)   allowlist_var="OCTOPUS_OPENCODE_ALLOWED_MODELS" ;;
         *)          return 0 ;;  # Unknown provider — allow
     esac

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -130,7 +130,7 @@ validate_model_name_for_provider() {
 
 _octo_is_known_provider_name() {
     case "$1" in
-        codex|gemini|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|cursor-agent|vibe|agy|agy-research|antigravity)
+        codex|gemini|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|cursor-agent|commandcode|vibe|agy|agy-research|antigravity)
             return 0 ;;
         *)
             return 1 ;;
@@ -375,6 +375,7 @@ resolve_octopus_model() {
             gemini-image)    resolved_model="gemini-3-pro-image" ;;  # image, not text — must precede gemini* (codex review)
             gemini-fast|gemini-flash) resolved_model="gemini-3-flash-preview" ;;
             gemini*)         resolved_model="gemini-3.1-pro-preview" ;;
+            commandcode*)    resolved_model="deepseek/deepseek-v4-pro" ;;
             agy*|antigravity) resolved_model="default" ;;
             claude-sdk*)     resolved_model="${OCTOPUS_CLAUDE_SDK_MODEL:-claude-opus-5}" ;;  # must precede claude* glob
             claude-opus-legacy*) resolved_model="claude-opus-4.6" ;;

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -17,7 +17,7 @@
 # matchers plus two user-facing messages) and they had drifted: the reset error
 # message omitted openai-compatible and openai-tools even though the matcher
 # accepted them. Add a provider here and every site follows.
-OCTO_MODEL_CONFIG_PROVIDERS="codex gemini agy claude claude-sdk perplexity opencode openrouter atlascloud openai-compatible openai-tools openai-compatible-agent cursor-agent"
+OCTO_MODEL_CONFIG_PROVIDERS="codex gemini agy claude claude-sdk perplexity opencode openrouter atlascloud openai-compatible openai-tools openai-compatible-agent cursor-agent commandcode"
 
 octo_model_config_provider_valid() {
     case " ${OCTO_MODEL_CONFIG_PROVIDERS} " in
@@ -113,6 +113,18 @@ build_provider_env() {
             if [[ ${#_trace_env[@]} -gt 0 ]]; then
                 PROVIDER_ENV_ARRAY+=("${_trace_env[@]}")
             fi
+            ;;
+        commandcode*)
+            if [[ -z "${COMMAND_CODE_API_KEY:-}" ]]; then
+                resolve_provider_env "COMMAND_CODE_API_KEY" 2>/dev/null || true
+            fi
+            PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "TMPDIR=${TMPDIR:-/tmp}")
+            [[ -n "${COMMAND_CODE_API_KEY:-}" ]] && PROVIDER_ENV_ARRAY+=("COMMAND_CODE_API_KEY=${COMMAND_CODE_API_KEY}")
+            [[ -n "${CMD_ZDR:-}" ]] && PROVIDER_ENV_ARRAY+=("CMD_ZDR=${CMD_ZDR}")
+            [[ -n "${OCTOPUS_COMMANDCODE_BIN:-}" ]] && PROVIDER_ENV_ARRAY+=("OCTOPUS_COMMANDCODE_BIN=${OCTOPUS_COMMANDCODE_BIN}")
+            [[ -n "${OCTOPUS_COMMANDCODE_MAX_TURNS:-}" ]] && PROVIDER_ENV_ARRAY+=("OCTOPUS_COMMANDCODE_MAX_TURNS=${OCTOPUS_COMMANDCODE_MAX_TURNS}")
+            [[ ${#_trace_env[@]} -gt 0 ]] && PROVIDER_ENV_ARRAY+=("${_trace_env[@]}")
+            return 0
             ;;
         gemini*)
             if [[ -z "${GEMINI_API_KEY:-}" ]]; then

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -733,6 +733,23 @@ check_provider_health() {
                 fi
             fi
             ;;
+        commandcode)
+            if ! command -v command-code >/dev/null 2>&1 && ! command -v cmd >/dev/null 2>&1; then
+                echo "commandcode CLI not found in PATH" >&2
+                return 1
+            fi
+            if [[ -z "${COMMAND_CODE_API_KEY:-}" ]]; then
+                resolve_provider_env "COMMAND_CODE_API_KEY" 2>/dev/null || true
+            fi
+            if [[ -z "${COMMAND_CODE_API_KEY:-}" ]]; then
+                local cc_bin="command-code"
+                command -v command-code >/dev/null 2>&1 || cc_bin="cmd"
+                "$cc_bin" status --json >/dev/null 2>&1 || {
+                    echo "commandcode: no API key or authenticated CLI session" >&2
+                    return 1
+                }
+            fi
+            ;;
         gemini)
             if ! command -v gemini &>/dev/null; then
                 echo "gemini CLI not found in PATH" >&2

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -734,16 +734,22 @@ check_provider_health() {
             fi
             ;;
         commandcode)
-            if ! command -v command-code >/dev/null 2>&1 && ! command -v cmd >/dev/null 2>&1; then
-                echo "commandcode CLI not found in PATH" >&2
+            local cc_bin="${OCTOPUS_COMMANDCODE_BIN:-}"
+            if [[ -z "$cc_bin" ]]; then
+                if command -v command-code >/dev/null 2>&1; then
+                    cc_bin="command-code"
+                elif command -v cmd >/dev/null 2>&1; then
+                    cc_bin="cmd"
+                fi
+            fi
+            if [[ -z "$cc_bin" ]]; then
+                echo "commandcode CLI not found in PATH and OCTOPUS_COMMANDCODE_BIN is unset" >&2
                 return 1
             fi
             if [[ -z "${COMMAND_CODE_API_KEY:-}" ]]; then
                 resolve_provider_env "COMMAND_CODE_API_KEY" 2>/dev/null || true
             fi
             if [[ -z "${COMMAND_CODE_API_KEY:-}" ]]; then
-                local cc_bin="command-code"
-                command -v command-code >/dev/null 2>&1 || cc_bin="cmd"
                 "$cc_bin" status --json >/dev/null 2>&1 || {
                     echo "commandcode: no API key or authenticated CLI session" >&2
                     return 1

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -742,8 +742,8 @@ check_provider_health() {
                     cc_bin="cmd"
                 fi
             fi
-            if [[ -z "$cc_bin" ]]; then
-                echo "commandcode CLI not found in PATH and OCTOPUS_COMMANDCODE_BIN is unset" >&2
+            if [[ -z "$cc_bin" ]] || ! { [[ -x "$cc_bin" ]] || command -v "$cc_bin" >/dev/null 2>&1; }; then
+                echo "commandcode CLI is not executable or not found" >&2
                 return 1
             fi
             if [[ -z "${COMMAND_CODE_API_KEY:-}" ]]; then

--- a/scripts/lib/routing.sh
+++ b/scripts/lib/routing.sh
@@ -51,6 +51,8 @@ resolve_provider_to_agent() {
         copilot|copilot-research)
                                 agent="$provider" ;;
         cursor-agent|ollama)    agent="$provider" ;;
+        commandcode|commandcode-research|commandcode-fast)
+                                agent="$provider" ;;
         *)                      return 1 ;;
     esac
 
@@ -75,6 +77,7 @@ agent_display_label() {
         perplexity*) echo "Perplexity" ;;
         copilot*) echo "Copilot" ;;
         cursor-agent) echo "Cursor Agent" ;;
+        commandcode*) echo "Command Code" ;;
         ollama) echo "Ollama" ;;
         *) return 1 ;;
     esac

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -293,7 +293,8 @@ validate_agent_command() {
         return $?
     fi
     if [[ "$cmd_executable" == */vibe-exec.sh || "$cmd_executable" == */ollama-run.sh || "$cmd_executable" == */codex-run.sh \
-        || "$cmd_executable" == */scripts/helpers/agy-exec.sh || "$cmd_executable" == */scripts/helpers/copilot-exec.sh ]]; then
+        || "$cmd_executable" == */scripts/helpers/agy-exec.sh || "$cmd_executable" == */scripts/helpers/copilot-exec.sh \
+        || "$cmd_executable" == */scripts/helpers/commandcode-exec.sh ]]; then
         return 0
     fi
 

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -61,6 +61,23 @@ else
     test_pass
 fi
 
+# get_agent_command returns the commandcode shim WITH arguments (model and
+# permission mode), so the shim must be allowed via the executable-token check
+# rather than an exact-string case arm.
+test_case "validate_agent_command allows commandcode-exec shim path with args"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/commandcode-exec.sh deepseek/deepseek-v4-pro plan"; then
+    test_pass
+else
+    test_fail "expected commandcode-exec shim path to be accepted"
+fi
+
+test_case "validate_agent_command rejects embedded commandcode-exec shim path"
+if validate_agent_command "echo $PROJECT_ROOT/scripts/helpers/commandcode-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected embedded commandcode-exec shim path to be rejected"
+else
+    test_pass
+fi
+
 
 test_case "validate_agent_command allows openai-compatible helper path"
 if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --model minimax/minimax-m3 --cwd /tmp/test"; then

--- a/tests/unit/test-commandcode-harness.sh
+++ b/tests/unit/test-commandcode-harness.sh
@@ -19,6 +19,7 @@ printf '%s\n' "${MOCK_RESULT:-{\"type\":\"result\",\"subtype\":\"success\",\"ses
 exit "${MOCK_RC:-0}"
 EOF
 chmod +x "$FIXTURE_DIR/bin/command-code"
+unset OCTOPUS_COMMANDCODE_BIN MOCK_RESULT MOCK_RC
 export PATH="$FIXTURE_DIR/bin:$PATH" MOCK_ARGS MOCK_STDIN="$FIXTURE_DIR/stdin"
 
 test_case "extracts final text and passes plan-mode arguments"

--- a/tests/unit/test-commandcode-harness.sh
+++ b/tests/unit/test-commandcode-harness.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Command Code Harness"
+
+FIXTURE_DIR="$TEST_TMP_DIR/commandcode"
+MOCK_ARGS="$FIXTURE_DIR/args"
+mkdir -p "$FIXTURE_DIR/bin"
+cat > "$FIXTURE_DIR/bin/command-code" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_ARGS"
+printf '%s\n' '{"type":"event","event":{"type":"tool_running"}}'
+printf '%s\n' "${MOCK_RESULT:-{\"type\":\"result\",\"subtype\":\"success\",\"sessionId\":\"abc\",\"finalText\":\"HARNESS_OK\"}}"
+exit "${MOCK_RC:-0}"
+EOF
+chmod +x "$FIXTURE_DIR/bin/command-code"
+export PATH="$FIXTURE_DIR/bin:$PATH" MOCK_ARGS
+
+test_case "extracts final text and passes plan-mode arguments"
+out=$(printf 'inspect only' | "$PROJECT_ROOT/scripts/helpers/commandcode-exec.sh" deepseek/deepseek-v4-pro plan)
+if [[ "$out" == "HARNESS_OK" ]] && grep -Fx -- '--permission-mode' "$MOCK_ARGS" >/dev/null && grep -Fx -- 'plan' "$MOCK_ARGS" >/dev/null && grep -Fx -- '--output-format' "$MOCK_ARGS" >/dev/null && grep -Fx -- 'json' "$MOCK_ARGS" >/dev/null; then
+    test_pass
+else
+    test_fail "expected finalText and plan/json arguments"
+fi
+
+test_case "uses yolo only when explicitly selected"
+out=$(printf 'implement' | "$PROJECT_ROOT/scripts/helpers/commandcode-exec.sh" minimaxai/minimax-m3 yolo)
+if [[ "$out" == "HARNESS_OK" ]] && grep -Fx -- '--yolo' "$MOCK_ARGS" >/dev/null && grep -Fx -- 'minimaxai/minimax-m3' "$MOCK_ARGS" >/dev/null; then
+    test_pass
+else
+    test_fail "expected explicit yolo and selected model"
+fi
+
+test_case "returns non-zero for a structured error result"
+export MOCK_RESULT='{"type":"result","subtype":"error","error":{"message":"denied"}}' MOCK_RC=0
+if printf 'fail' | "$PROJECT_ROOT/scripts/helpers/commandcode-exec.sh" deepseek/deepseek-v4-pro plan >/dev/null 2>&1; then
+    test_fail "expected structured error to fail"
+else
+    test_pass
+fi
+unset MOCK_RESULT MOCK_RC
+
+test_case "preserves non-zero CLI exit status"
+export MOCK_RESULT='{"type":"result","subtype":"error","error":{"message":"failed"}}' MOCK_RC=7
+set +e
+printf 'fail' | "$PROJECT_ROOT/scripts/helpers/commandcode-exec.sh" deepseek/deepseek-v4-pro plan >/dev/null 2>&1
+rc=$?
+set -e
+unset MOCK_RESULT MOCK_RC
+if [[ "$rc" -eq 7 ]]; then test_pass; else test_fail "expected exit 7, got $rc"; fi
+
+test_case "dispatch selects yolo for implementers and plan for verifiers"
+export PLUGIN_DIR="$PROJECT_ROOT" OCTOPUS_PLATFORM=Linux HOME="$FIXTURE_DIR/home"
+mkdir -p "$HOME/.claude-octopus/config"
+source "$PROJECT_ROOT/scripts/lib/validation.sh"
+source "$PROJECT_ROOT/scripts/lib/model-cache-path.sh"
+source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+source "$PROJECT_ROOT/scripts/lib/provider-routing.sh"
+source "$PROJECT_ROOT/scripts/lib/dispatch.sh"
+export OCTOPUS_COMMANDCODE_MODEL=deepseek/deepseek-v4-pro
+impl_cmd="$(get_agent_command commandcode tangle implementer)"
+verify_cmd="$(get_agent_command commandcode verify verifier)"
+if [[ "$impl_cmd" == *'commandcode-exec.sh deepseek/deepseek-v4-pro yolo' ]] && [[ "$verify_cmd" == *'commandcode-exec.sh deepseek/deepseek-v4-pro plan' ]]; then
+    test_pass
+else
+    test_fail "unexpected role permission mapping"
+fi
+
+test_case "provider environment forwards only dedicated controls"
+export COMMAND_CODE_API_KEY=test-key CMD_ZDR=1 OCTOPUS_COMMANDCODE_BIN=/custom/cmd OCTOPUS_COMMANDCODE_MAX_TURNS=12
+build_provider_env commandcode
+joined=" ${PROVIDER_ENV_ARRAY[*]} "
+if [[ "$joined" == *' COMMAND_CODE_API_KEY=test-key '* ]] && [[ "$joined" == *' CMD_ZDR=1 '* ]] && [[ "$joined" == *' OCTOPUS_COMMANDCODE_BIN=/custom/cmd '* ]] && [[ "$joined" == *' OCTOPUS_COMMANDCODE_MAX_TURNS=12 '* ]]; then
+    test_pass
+else
+    test_fail "missing isolated Command Code environment entries"
+fi
+
+test_summary

--- a/tests/unit/test-commandcode-harness.sh
+++ b/tests/unit/test-commandcode-harness.sh
@@ -13,16 +13,17 @@ mkdir -p "$FIXTURE_DIR/bin"
 cat > "$FIXTURE_DIR/bin/command-code" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "$MOCK_ARGS"
+cat > "${MOCK_STDIN:-/dev/null}"
 printf '%s\n' '{"type":"event","event":{"type":"tool_running"}}'
 printf '%s\n' "${MOCK_RESULT:-{\"type\":\"result\",\"subtype\":\"success\",\"sessionId\":\"abc\",\"finalText\":\"HARNESS_OK\"}}"
 exit "${MOCK_RC:-0}"
 EOF
 chmod +x "$FIXTURE_DIR/bin/command-code"
-export PATH="$FIXTURE_DIR/bin:$PATH" MOCK_ARGS
+export PATH="$FIXTURE_DIR/bin:$PATH" MOCK_ARGS MOCK_STDIN="$FIXTURE_DIR/stdin"
 
 test_case "extracts final text and passes plan-mode arguments"
 out=$(printf 'inspect only' | "$PROJECT_ROOT/scripts/helpers/commandcode-exec.sh" deepseek/deepseek-v4-pro plan)
-if [[ "$out" == "HARNESS_OK" ]] && grep -Fx -- '--permission-mode' "$MOCK_ARGS" >/dev/null && grep -Fx -- 'plan' "$MOCK_ARGS" >/dev/null && grep -Fx -- '--output-format' "$MOCK_ARGS" >/dev/null && grep -Fx -- 'json' "$MOCK_ARGS" >/dev/null; then
+if [[ "$out" == "HARNESS_OK" ]] && grep -Fx -- '--permission-mode' "$MOCK_ARGS" >/dev/null && grep -Fx -- 'plan' "$MOCK_ARGS" >/dev/null && grep -Fx -- '--output-format' "$MOCK_ARGS" >/dev/null && grep -Fx -- 'json' "$MOCK_ARGS" >/dev/null && ! grep -Fx -- 'inspect only' "$MOCK_ARGS" >/dev/null && [[ "$(cat "$MOCK_STDIN")" == "inspect only" ]]; then
     test_pass
 else
     test_fail "expected finalText and plan/json arguments"

--- a/tests/unit/test-commandcode-harness.sh
+++ b/tests/unit/test-commandcode-harness.sh
@@ -73,6 +73,18 @@ else
     test_fail "unexpected role permission mapping"
 fi
 
+# The command dispatch actually returns must survive validate_agent_command, or
+# every commandcode dispatch aborts the phase before the CLI is ever invoked —
+# the same failure mode as #697 (copilot-exec.sh) and #705 (agy-exec.sh). Asserting
+# the shape of get_agent_command's output is not enough; validate it.
+test_case "dispatch commands for commandcode pass validate_agent_command"
+source "$PROJECT_ROOT/scripts/lib/utils.sh"
+if validate_agent_command "$impl_cmd" >/dev/null 2>&1 && validate_agent_command "$verify_cmd" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "commandcode dispatch command rejected by validate_agent_command"
+fi
+
 test_case "provider environment forwards only dedicated controls"
 export COMMAND_CODE_API_KEY=test-key CMD_ZDR=1 OCTOPUS_COMMANDCODE_BIN=/custom/cmd OCTOPUS_COMMANDCODE_MAX_TURNS=12
 build_provider_env commandcode


### PR DESCRIPTION
## Summary
- add a native `commandcode` provider backed by the Command Code CLI
- support API-key or existing CLI authentication without implementing OAuth
- isolate provider credentials and runtime controls
- map read-only roles to plan mode and implementation roles to the Octopus-managed worktree
- add provider detection, routing, model resolution, fleet support, docs, and tests

## Validation
- Command Code harness tests: PASS
- agent command validation: 20/20
- spawn PID capture: 8/8
- credential isolation: 30/30
- smoke suites: 16/16
- live read-only smoke: DeepSeek V4 Pro and MiniMax M3 both PASS

## Notes
The provider keeps Octopus responsible for orchestration and worktree isolation. Command Code runs headlessly with onboarding, auto-update, and persistent sessions disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Command Code CLI support as a provider, including automatic model selection, role-based execution (plan vs implementer), and provider allowlisting integration.
  * Improved provider discovery and health checking for Command Code CLI, with configurable binary/auth and runtime limits.
* **Documentation**
  * Added a Command Code CLI integration guide (installation, API key auth, model/env configuration, headless execution behavior).
* **Bug Fixes**
  * Updated Evidence “Local CI parity” unit suite count to **189** (smoke: 16, integration: 7 unchanged).
* **Tests**
  * Added unit tests for the Command Code CLI harness covering flags, parsing, error handling, and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->