### PR TITLE
fix: allowlist copilot-exec.sh shim path in validate_agent_command

### DIFF
--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -306,6 +306,8 @@ validate_agent_command() {
             return 0 ;;
         *"/scripts/helpers/agy-exec.sh")
             return 0 ;;
+        *"/scripts/helpers/copilot-exec.sh")
+            return 0 ;;
         "claude "*|"claude")
             return 0 ;;
         "openrouter_execute"*) # openrouter_execute and openrouter_execute_model

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -292,7 +292,8 @@ validate_agent_command() {
         _validate_openai_compatible_agent_command "$cmd"
         return $?
     fi
-    if [[ "$cmd_executable" == */vibe-exec.sh || "$cmd_executable" == */ollama-run.sh || "$cmd_executable" == */codex-run.sh || "$cmd_executable" == */scripts/helpers/copilot-exec.sh ]]; then
+    if [[ "$cmd_executable" == */vibe-exec.sh || "$cmd_executable" == */ollama-run.sh || "$cmd_executable" == */codex-run.sh \
+        || "$cmd_executable" == */scripts/helpers/agy-exec.sh || "$cmd_executable" == */scripts/helpers/copilot-exec.sh ]]; then
         return 0
     fi
 
@@ -303,8 +304,6 @@ validate_agent_command() {
         "gemini "*|"gemini")
             return 0 ;;
         "agy "*|"agy")
-            return 0 ;;
-        *"/scripts/helpers/agy-exec.sh")
             return 0 ;;
         "claude "*|"claude")
             return 0 ;;

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -292,7 +292,7 @@ validate_agent_command() {
         _validate_openai_compatible_agent_command "$cmd"
         return $?
     fi
-    if [[ "$cmd_executable" == */vibe-exec.sh || "$cmd_executable" == */ollama-run.sh || "$cmd_executable" == */codex-run.sh ]]; then
+    if [[ "$cmd_executable" == */vibe-exec.sh || "$cmd_executable" == */ollama-run.sh || "$cmd_executable" == */codex-run.sh || "$cmd_executable" == */scripts/helpers/copilot-exec.sh ]]; then
         return 0
     fi
 
@@ -305,8 +305,6 @@ validate_agent_command() {
         "agy "*|"agy")
             return 0 ;;
         *"/scripts/helpers/agy-exec.sh")
-            return 0 ;;
-        *"/scripts/helpers/copilot-exec.sh")
             return 0 ;;
         "claude "*|"claude")
             return 0 ;;

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -33,6 +33,34 @@ else
     test_pass
 fi
 
+test_case "validate_agent_command allows agy-exec shim path"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/agy-exec.sh"; then
+    test_pass
+else
+    test_fail "expected agy-exec shim path to be accepted"
+fi
+
+test_case "validate_agent_command rejects embedded agy-exec shim path"
+if validate_agent_command "echo $PROJECT_ROOT/scripts/helpers/agy-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected embedded agy-exec shim path to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command allows copilot-exec shim path"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/copilot-exec.sh"; then
+    test_pass
+else
+    test_fail "expected copilot-exec shim path to be accepted"
+fi
+
+test_case "validate_agent_command rejects embedded copilot-exec shim path"
+if validate_agent_command "echo $PROJECT_ROOT/scripts/helpers/copilot-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected embedded copilot-exec shim path to be rejected"
+else
+    test_pass
+fi
+
 
 test_case "validate_agent_command allows openai-compatible helper path"
 if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --model minimax/minimax-m3 --cwd /tmp/test"; then


### PR DESCRIPTION
## Description
`dispatch.sh:406-411` returns the `copilot-exec.sh` shim path as the Copilot agent command (since v9.9.0), but `validate_agent_command()` in `scripts/lib/utils.sh:283` never had a case arm for that shim path — only for the bare `copilot` command. Since `spawn_agent`/`validate_agent_command` treats a validation failure as fatal (`scripts/lib/spawn.sh:463`, `scripts/lib/workflows.sh:113`), every Copilot dispatch was rejected, and because the failure is fatal to the whole phase, it aborted sibling in-flight agents (codex/gemini/agy) too.

This is the same class of bug fixed for `agy-exec.sh` in #206 — a new shim was added later without updating the allowlist. This PR adds the missing `copilot-exec.sh` allowlist entry.

**Update:** CodeRabbit's review caught that the initial fix used a `case "$cmd"` suffix-glob pattern (mirroring the pre-existing `agy-exec.sh` arm) that isn't path-anchored — it would also accept a command whose *args* end in that path (e.g. `some-command /scripts/helpers/copilot-exec.sh`), not just the shim invoked as the executable. Fixed by validating against the extracted `cmd_executable` token instead, matching how `vibe-exec.sh`/`ollama-run.sh`/`codex-run.sh` already do it. The pre-existing `agy-exec.sh` arm had the identical bypass (filed as #705) and has now been fixed the same way in this PR, with regression tests added for both shims.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync: n/a — no new components added
- [ ] New skills/commands registered in `.claude-plugin/plugin.json`: n/a
- [ ] Version bump: n/a — no release cut with this PR
- [ ] Documentation updated: n/a
- [ ] CHANGELOG.md updated: n/a — leaving for release PR to reference this fix

## Testing
```bash
# Direct reproduction from the issue
source scripts/lib/utils.sh
validate_agent_command ".../scripts/helpers/copilot-exec.sh" && echo PASS || echo FAIL
# => PASS (was FAIL before this change)

# Bypass check (CodeRabbit finding, now fixed)
validate_agent_command "some-command /scripts/helpers/copilot-exec.sh" && echo BYPASSED || echo REJECTED
# => REJECTED

make test-unit         # 185/188 passed; the 3 failures (test-feature-disclosure,
                        # test-github-work-queue-hook, test-hud-smart-mode) are
                        # pre-existing and reproduce identically on unmodified origin/main
make test-integration   # 7/7 suites passed
bash tests/unit/test-agent-command-validation.sh  # 24/24 passed (new regression tests)
```

## Related Issues
Closes #697
Closes #705