### PR TITLE
fix: allowlist copilot-exec.sh shim in validate_agent_command

### DIFF
--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -306,6 +306,8 @@ validate_agent_command() {
             return 0 ;;
         *"/scripts/helpers/agy-exec.sh")
             return 0 ;;
+        *"/scripts/helpers/copilot-exec.sh")
+            return 0 ;;
         "claude "*|"claude")
             return 0 ;;
         "openrouter_execute"*) # openrouter_execute and openrouter_execute_model


### PR DESCRIPTION
## Description
`validate_agent_command` in `scripts/lib/utils.sh` allowlisted the bare `copilot` command and the `agy-exec.sh` helper shim path, but never the `copilot-exec.sh` helper shim path. Since `dispatch.sh:406-411` (`get_agent_command`) returns the shim path for the `copilot`/`copilot-research` agent types, every Copilot dispatch fails validation in `spawn_agent`, which treats the failure as fatal — aborting the whole phase and killing sibling agents that are already mid-flight.

This is the same class of bug as #206 Bug 2 (which allowlisted the bare `copilot` command), reintroduced when the `copilot-exec.sh` shim was added in v9.9.0 without a matching allowlist entry.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-agent-command-validation.sh` (20/20)
- [ ] OpenClaw registry in sync — not applicable, no OpenClaw-facing surface touched
- [ ] New skills/commands registered — not applicable
- [ ] Version bump — not applicable, patch-level bug fix only
- [ ] Documentation updated — not applicable
- [ ] CHANGELOG.md updated — deferring to release process

## Testing
```bash
bash -n scripts/lib/utils.sh              # syntax OK
source scripts/lib/utils.sh
validate_agent_command ".../scripts/helpers/copilot-exec.sh"  # now PASS
validate_agent_command "rm -rf /"                              # still FAIL (whitelist still safe)

bash tests/unit/test-agent-command-validation.sh   # 20/20 passed

make test-unit   # 186/188 suites passed
```
The 2 failing suites (`test-feature-disclosure.sh`, `test-hud-smart-mode.sh`) fail identically on unmodified `origin/main` — confirmed pre-existing and unrelated to this change by stashing the fix and re-running both against a clean checkout.

## Related Issues
Closes #697

---
_Generated by [Claude Code](https://claude.ai/code/session_0113oFRSia4q16PQVayk6YvZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command validation to recognize an additional supported execution helper path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->