### PR TITLE
fix: allowlist copilot-exec.sh shim path in validate_agent_command

### DIFF
--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -306,6 +306,8 @@ validate_agent_command() {
             return 0 ;;
         *"/scripts/helpers/agy-exec.sh")
             return 0 ;;
+        *"/scripts/helpers/copilot-exec.sh")
+            return 0 ;;
         "claude "*|"claude")
             return 0 ;;
         "openrouter_execute"*) # openrouter_execute and openrouter_execute_model


### PR DESCRIPTION
## Description
`validate_agent_command` in `scripts/lib/utils.sh` allowlisted the bare `copilot` command and the `agy-exec.sh` helper shim path, but not the `copilot-exec.sh` helper shim path. Since `scripts/lib/dispatch.sh:411` returns the `copilot-exec.sh` shim path (introduced in v9.9.0) rather than the bare `copilot` binary, every Copilot dispatch fails validation. Because `spawn_agent` treats a validation failure as fatal, this aborts the whole phase and kills sibling in-flight agents rather than degrading gracefully — a regression of #206 Bug 2 in a new form.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [x] OpenClaw registry in sync: `scripts/build-openclaw.sh --check` (unaffected — no skills/commands changed)
- [x] New skills/commands registered in `.claude-plugin/plugin.json` (n/a — no new skills/commands)
- [ ] Version bump (if releasing): package.json + plugin/marketplace manifests + public adapter manifests + README.md + CHANGELOG.md
- [ ] Documentation updated (if applicable) — n/a
- [ ] CHANGELOG.md updated (for features/fixes) — left to release process

## Testing
Fix: add one `case` arm mirroring the existing `agy-exec.sh` entry:

```diff
         *"/scripts/helpers/agy-exec.sh")
             return 0 ;;
+        *"/scripts/helpers/copilot-exec.sh")
+            return 0 ;;
         "claude "*|"claude")
```

Verified the exact reproduction from the issue now passes:
```bash
$ source scripts/lib/utils.sh
$ validate_agent_command ".../scripts/helpers/copilot-exec.sh" && echo PASS || echo FAIL
PASS
```

Ran:
```bash
bash -n scripts/*.sh scripts/lib/*.sh   # clean
bash tests/unit/test-agent-command-validation.sh   # 20/20 pass — direct coverage of validate_agent_command
make test-unit    # 185/188 pass; the 3 failures (test-feature-disclosure.sh, test-github-work-queue-hook.sh,
                   # test-hud-smart-mode.sh) are pre-existing and reproduce identically on a clean origin/main
                   # checkout with no changes applied — unrelated to this fix
make test-integration   # 7/7 suites pass
bash tests/unit/test-openclaw-compat.sh   # 32/32 pass
```

## Related Issues
Closes #697

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPuDffYpvaJrNKcAm6GyRY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command validation to support an additional approved helper executable path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->