### PR TITLE
fix: fail loud when a global flag after the subcommand is read as the prompt

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -77,7 +77,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 **Traction (as of 2026-07-27):**
 - GitHub stars: 3,889
 - GitHub forks: 365
-- Local CI parity: 16 smoke, 189 unit, and 7 integration suites
+- Local CI parity: 16 smoke, 190 unit, and 7 integration suites
 - Version: 9.56.1 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Gemini CLI
 

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -2285,6 +2285,19 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     done
     set -- "${_late_args[@]}"
 
+    # v9.57.0: A global flag that isn't recognized by the late-args loop above
+    # (e.g. --timeout after the subcommand) lands here unconsumed and would
+    # otherwise be silently read as the prompt (#698) — the run "succeeds"
+    # having answered a question nobody asked. Fail loud instead.
+    case "$COMMAND" in
+        discover|research|probe|define|grasp|verify|verification-only|develop|tangle|deliver|ink|embrace|squeeze|red-team)
+            if [[ "${1:-}" == -* && "${1:-}" != "-h" && "${1:-}" != "--help" ]]; then
+                log ERROR "'$1' looks like a flag but was read as the prompt. Global flags must precede the subcommand: $(basename "$0") $1 ... $COMMAND \"...\""
+                exit 1
+            fi
+            ;;
+    esac
+
 # Check for first-run on commands that need setup (skip for help/setup/preflight)
 if [[ "$COMMAND" != "help" && "$COMMAND" != "setup" && "$COMMAND" != "preflight" && "$COMMAND" != "-h" && "$COMMAND" != "--help" ]]; then
     check_first_run || true  # Show hint but don't block

--- a/tests/unit/test-cli-flag-after-subcommand.sh
+++ b/tests/unit/test-cli-flag-after-subcommand.sh
@@ -43,28 +43,53 @@ else
     test_fail "expected successful dry-run with the real prompt; got exit=$rc, output: $out"
 fi
 
-test_case "probe --parallel after subcommand fails loud"
-out="$(run_orchestrate probe --parallel 3 "topic" --dry-run)" && rc=0 || rc=$?
-if [[ "$rc" -ne 0 && "$out" == *"looks like a flag but was read as the prompt"* ]]; then
+# Table-driven coverage: every command that consumes a free-text prompt and
+# shares the vulnerable late-args loop should get the same guard. grapple and
+# probe-single are deliberately excluded — they run their own local flag
+# parsers instead of falling through to the shared late-args loop.
+GUARDED_COMMANDS=(
+    "discover:--parallel 3"
+    "research:--parallel 3"
+    "probe:--parallel 3"
+    "grasp:--timeout 540"
+    "verify:--branch foo"
+    "verification-only:--branch foo"
+    "develop:--branch foo"
+    "tangle:--branch foo"
+    "deliver:--branch foo"
+    "ink:--branch foo"
+    "embrace:--branch foo"
+    "squeeze:--branch foo"
+    "red-team:--branch foo"
+)
+
+for entry in "${GUARDED_COMMANDS[@]}"; do
+    cmd="${entry%%:*}"
+    flag="${entry#*:}"
+    test_case "$cmd $flag after subcommand fails loud"
+    # shellcheck disable=SC2086 # deliberate split of the "flag value" pair
+    out="$(run_orchestrate "$cmd" $flag "some prompt" --dry-run)" && rc=0 || rc=$?
+    if [[ "$rc" -ne 0 && "$out" == *"looks like a flag but was read as the prompt"* ]]; then
+        test_pass
+    else
+        test_fail "expected a loud error; got exit=$rc, output: $out"
+    fi
+done
+
+test_case "define -h prints usage and is not mistaken for the flag-guard error"
+out="$(run_orchestrate define -h)" && rc=0 || rc=$?
+if [[ "$rc" -eq 0 && "$out" == *"Usage:"* && "$out" != *"looks like a flag but was read as the prompt"* ]]; then
     test_pass
 else
-    test_fail "expected a loud error; got exit=$rc, output: $out"
+    test_fail "expected usage output; got exit=$rc, output: $out"
 fi
 
-test_case "develop --branch after subcommand fails loud"
-out="$(run_orchestrate develop --branch foo "build the thing" --dry-run)" && rc=0 || rc=$?
-if [[ "$rc" -ne 0 && "$out" == *"looks like a flag but was read as the prompt"* ]]; then
-    test_pass
-else
-    test_fail "expected a loud error; got exit=$rc, output: $out"
-fi
-
-test_case "define --help after subcommand is not mistaken for the flag-guard error"
+test_case "define --help prints usage and is not mistaken for the flag-guard error"
 out="$(run_orchestrate define --help)" && rc=0 || rc=$?
-if [[ "$rc" -eq 0 && "$out" != *"looks like a flag but was read as the prompt"* ]]; then
+if [[ "$rc" -eq 0 && "$out" == *"Usage:"* && "$out" != *"looks like a flag but was read as the prompt"* ]]; then
     test_pass
 else
-    test_fail "expected normal help output; got exit=$rc, output: $out"
+    test_fail "expected usage output; got exit=$rc, output: $out"
 fi
 
 test_summary

--- a/tests/unit/test-cli-flag-after-subcommand.sh
+++ b/tests/unit/test-cli-flag-after-subcommand.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+# tests/unit/test-cli-flag-after-subcommand.sh
+# Regression coverage for issue #698: a global flag placed AFTER the
+# subcommand (e.g. `orchestrate.sh define --timeout 540 "prompt"`) that
+# isn't recognized by the late-args loop used to be silently read as the
+# prompt itself, discarding the real prompt with no error. orchestrate.sh
+# must now fail loud instead of running on the flag name as its task.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "CLI: global flags after the subcommand (issue #698)"
+
+run_orchestrate() {
+    (cd "$PROJECT_ROOT" && bash scripts/orchestrate.sh "$@" 2>&1)
+}
+
+test_case "define --timeout after subcommand fails loud instead of eating the prompt"
+out="$(run_orchestrate define --timeout 540 "REAL PROMPT HERE" --dry-run)" && rc=0 || rc=$?
+if [[ "$rc" -ne 0 && "$out" == *"looks like a flag but was read as the prompt"* ]]; then
+    test_pass
+else
+    test_fail "expected a loud error; got exit=$rc, output: $out"
+fi
+
+test_case "define --timeout after subcommand never reaches grasp_define with the flag as prompt"
+out="$(run_orchestrate define --timeout 540 "REAL PROMPT HERE" --dry-run)" || true
+if [[ "$out" != *"Would grasp: --timeout"* ]]; then
+    test_pass
+else
+    test_fail "flag name was silently treated as the prompt: $out"
+fi
+
+test_case "--timeout before the subcommand still works (unaffected)"
+out="$(run_orchestrate --timeout 540 define "REAL PROMPT HERE" --dry-run)" && rc=0 || rc=$?
+if [[ "$rc" -eq 0 && "$out" == *"Would grasp: REAL PROMPT HERE"* ]]; then
+    test_pass
+else
+    test_fail "expected successful dry-run with the real prompt; got exit=$rc, output: $out"
+fi
+
+test_case "probe --parallel after subcommand fails loud"
+out="$(run_orchestrate probe --parallel 3 "topic" --dry-run)" && rc=0 || rc=$?
+if [[ "$rc" -ne 0 && "$out" == *"looks like a flag but was read as the prompt"* ]]; then
+    test_pass
+else
+    test_fail "expected a loud error; got exit=$rc, output: $out"
+fi
+
+test_case "develop --branch after subcommand fails loud"
+out="$(run_orchestrate develop --branch foo "build the thing" --dry-run)" && rc=0 || rc=$?
+if [[ "$rc" -ne 0 && "$out" == *"looks like a flag but was read as the prompt"* ]]; then
+    test_pass
+else
+    test_fail "expected a loud error; got exit=$rc, output: $out"
+fi
+
+test_case "define --help after subcommand is not mistaken for the flag-guard error"
+out="$(run_orchestrate define --help)" && rc=0 || rc=$?
+if [[ "$rc" -eq 0 && "$out" != *"looks like a flag but was read as the prompt"* ]]; then
+    test_pass
+else
+    test_fail "expected normal help output; got exit=$rc, output: $out"
+fi
+
+test_summary


### PR DESCRIPTION
## Root cause

`orchestrate.sh`'s late-args loop (`scripts/orchestrate.sh:2251-2286`) lets a subset of global flags appear after the subcommand — `-n`/`--dry-run`, `--debug`, `-v`, `-Q`, `-P`, `--tier`, `--provider`, `--cost-first`, `--quality-first`, `--openrouter-nitro`, `--openrouter-floor`. Any other global flag (`--timeout`, `--parallel`, `--branch`, etc.) isn't recognized there, falls through the catch-all `*)` arm, and lands in the prompt's positional slot.

Commands that consume the prompt as `"$1"` (`define`, `develop`, `deliver`) then silently treat the flag name itself as the whole prompt — the real prompt and anything after the flag's value is dropped. Commands using `"$*"` (`discover`/`probe`, `verify`, `embrace`, `squeeze`) embed the stray flag/value into the prompt text instead. Either way there's no error — the run "succeeds" having answered a question nobody asked (closes #698).

## Fix

Added a guard immediately after the late-args loop, scoped to the commands that take a free-text prompt (`discover|research|probe`, `define|grasp`, `verify|verification-only`, `develop|tangle`, `deliver|ink`, `embrace`, `squeeze|red-team`). If the resolved first argument still looks like a flag (starts with `-`, excluding `-h`/`--help`), it errors out naming the flag and pointing at the fix, instead of silently running on it. This is fix option (1) from the issue — "converts a silent failure into a loud one" — the cheapest option and the one the issue calls out as sufficient on its own.

`grapple` and `probe-single` were left untouched — they already have their own local flag parsers for the case they need, and blanket-rejecting a leading `-` there would break legitimate use (e.g. `probe-single --output-dir`).

## Test plan

- New `tests/unit/test-cli-flag-after-subcommand.sh`: reproduces the exact issue repro (`define --timeout 540 "REAL PROMPT HERE" --dry-run` now fails loud instead of running `Would grasp: --timeout`), confirms flags-before-subcommand still work, checks `probe`/`develop` with other unrecognized flags, and confirms `--help` isn't mistaken for the guard.
- `make test-unit`: 185/189 suites pass; the 4 failures (`test-feature-disclosure`, `test-github-work-queue-hook`, `test-hud-smart-mode`, `test-readme-release-sync`) reproduce identically on unmodified `origin/main` — pre-existing, unrelated to this change.
- `make test-integration`: 7/7 suites pass.
- `bash -n` across all shell scripts: clean.
- Manually verified `probe-single --output-dir` (own scoped parser) and `grapple` are unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X3GGNpJgxsW1cwoPchFQfD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow commands now reject unsupported flag-like arguments instead of treating them as prompts.
  * Help requests using `-h` or `--help` continue to work as expected.

* **Tests**
  * Added coverage for misplaced flags across multiple workflow commands and valid flag placement.

* **Documentation**
  * Updated the documented local CI suite count to reflect the latest coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->