### PR TITLE
fix: anchor agy-exec.sh shim check to executable token, not command suffix

### DIFF
--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -292,7 +292,7 @@ validate_agent_command() {
         _validate_openai_compatible_agent_command "$cmd"
         return $?
     fi
-    if [[ "$cmd_executable" == */vibe-exec.sh || "$cmd_executable" == */ollama-run.sh || "$cmd_executable" == */codex-run.sh ]]; then
+    if [[ "$cmd_executable" == */vibe-exec.sh || "$cmd_executable" == */ollama-run.sh || "$cmd_executable" == */codex-run.sh || "$cmd_executable" == */scripts/helpers/agy-exec.sh ]]; then
         return 0
     fi
 
@@ -303,8 +303,6 @@ validate_agent_command() {
         "gemini "*|"gemini")
             return 0 ;;
         "agy "*|"agy")
-            return 0 ;;
-        *"/scripts/helpers/agy-exec.sh")
             return 0 ;;
         "claude "*|"claude")
             return 0 ;;


### PR DESCRIPTION
## Description
`validate_agent_command()` in `scripts/lib/utils.sh` had a `case "$cmd" in *"/scripts/helpers/agy-exec.sh") return 0 ;;` arm. Bash `case`/glob patterns aren't path-anchored, so `*` matches across `/` too — the pattern accepts anything *ending* in that suffix, not just the shim invoked as the command itself:

```bash
$ bash -c '
case "some-command /scripts/helpers/agy-exec.sh" in
    *"/scripts/helpers/agy-exec.sh") echo "MATCH (should not match)" ;;
    *) echo "NOMATCH" ;;
esac
'
MATCH (should not match)
```

Same class of bug CodeRabbit caught on #702's fresh `copilot-exec.sh` copy-paste of this pattern; that instance was fixed by moving the check into the existing `cmd_executable`-anchored block (already used for `vibe-exec.sh`, `ollama-run.sh`, `codex-run.sh`). This PR applies the identical fix to the pre-existing `agy-exec.sh` arm, which was left untouched in #702 as out of scope for a Copilot-specific fix.

Low practical severity today — `$cmd` in current callers is built internally by `dispatch.sh`, not untrusted external input — but `validate_agent_command` is a security allowlist and this defeats its intended anchoring guarantee. Closing as defense in depth, per the issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync — n/a, no OpenClaw-facing surface touched
- [ ] New skills/commands registered — n/a
- [ ] Version bump — n/a, patch-level bug fix only
- [ ] Documentation updated — n/a
- [ ] CHANGELOG.md updated — deferring to release process

## Testing
```bash
source scripts/lib/utils.sh
validate_agent_command ".../scripts/helpers/agy-exec.sh"                  # PASS (legitimate shim)
validate_agent_command "some-command /scripts/helpers/agy-exec.sh"        # FAIL (was PASS before this change)
validate_agent_command ".../scripts/helpers/agy-exec.sh --model foo"      # PASS (shim with args, matches vibe/ollama/codex pattern)

bash tests/unit/test-agent-command-validation.sh   # 20/20 pass — direct coverage of validate_agent_command
make test-unit         # 185/188 pass; the 3 failures (test-feature-disclosure.sh, test-github-work-queue-hook.sh,
                        # test-hud-smart-mode.sh) are pre-existing and reproduce identically on unmodified
                        # origin/main — confirmed unrelated to this change
make test-integration   # 7/7 pass
git diff origin/main...HEAD --summary | grep "mode change"   # empty — no exec-bit changes
```

## Related Issues
Closes #705

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPuDffYpvaJrNKcAm6GyRY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command validation to correctly recognize the supported execution helper.
  * Preserved existing validation behavior for other approved commands and utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->