### PR TITLE
chore: gitignore project-local auto-memory directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,12 @@ logs/
 results/
 .parallel-agents/
 
+# Auto-memory preferences written by hooks/session-end.sh / read by
+# hooks/session-start-memory.sh when CLAUDE_PROJECT_DIR resolves to this repo
+# (e.g. developing on the plugin itself). Per-machine session state, not a
+# shared artifact.
+/memory/
+
 # Temporary files
 tmp/
 temp/


### PR DESCRIPTION
## Description
`hooks/session-end.sh` writes `octopus-preferences.md` / `octopus-learnings.md` to `${CLAUDE_PROJECT_DIR}/memory/` when `CLAUDE_PROJECT_DIR` resolves to this repo (e.g. a Claude Code session working directly on the plugin itself, as opposed to a consumer project that installed it). `hooks/session-start-memory.sh` reads the same path back in on the next session.

That `memory/` directory wasn't gitignored, so it showed up as untracked local state (`git status` dirty) on every session that develops on this repo directly — the same class of leak `.claude-octopus/` already guards against a few lines above, with the identical "just in case someone runs from the repo directory" rationale.

Per this repo's own `CLAUDE.md` File Creation Policy, session/working-state files must never be committed — they belong in the scratchpad, not the plugin dir. This directory is generated auto-memory state, not a checked-in file, so gitignoring it (rather than tracking it) is the correct fix.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (describe): Repo hygiene — `.gitignore` only, no source changes

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [ ] Tests pass: `bash tests/unit/test-openclaw-compat.sh` — n/a, no OpenClaw-facing surface touched
- [ ] OpenClaw registry in sync — n/a
- [ ] New skills/commands registered — n/a
- [ ] Version bump — n/a
- [ ] Documentation updated — n/a
- [ ] CHANGELOG.md updated — n/a, non-functional repo hygiene

## Testing
```bash
git status --short   # `?? memory/` before this change, clean after
```

## Related Issues
None filed — found while investigating a stop-hook nag about untracked files during unrelated triage work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPuDffYpvaJrNKcAm6GyRY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an ignore rule for local, machine-specific session state files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->