### PR TITLE
fix: resolve symlinked-checkout mismatch in test-feature-disclosure.sh

### DIFF
--- a/tests/unit/test-feature-disclosure.sh
+++ b/tests/unit/test-feature-disclosure.sh
@@ -3,8 +3,11 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# features.sh resolves paths with `cd -P && pwd` (physical, symlinks resolved).
+# Matching that here, not `cd && pwd` (logical), avoids a false mismatch on a
+# symlinked checkout (e.g. macOS /tmp -> /private/tmp).
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd)"
 
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Feature disclosure"


### PR DESCRIPTION
## Description
`tests/unit/test-feature-disclosure.sh` fails two cases when the repo is checked out under a symlinked path (e.g. macOS `/tmp` → `/private/tmp`).

**Root cause.** `scripts/lib/features.sh:89,98` resolves the manifest path with `cd -P "$candidate" && pwd` — a physical path with symlinks resolved. The test computed its own `PROJECT_ROOT` at `tests/unit/test-feature-disclosure.sh:6-7` with plain `cd ... && pwd` — a logical path. On a non-symlinked checkout the two happen to agree; on a symlinked one they diverge, and the two assertions that compare against `$MANIFEST` (derived from `PROJECT_ROOT`) fail even though the library's own resolution is correct.

**Fix.** Resolve `SCRIPT_DIR`/`PROJECT_ROOT` in the test with `cd -P` too, so it matches what `features.sh` computes. No production code changed — this is a test-only fix.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Shell scripts pass `bash -n` syntax check (`bash -n scripts/*.sh scripts/lib/*.sh` — clean)
- [x] Tests pass: `bash tests/unit/test-feature-disclosure.sh` (44/46 — see Testing)
- [x] No file mode changes (`git diff --summary origin/main...HEAD` empty)
- [ ] N/A — no skills/commands/manifests touched

## Testing
- `bash -n` over all shell scripts: clean.
- `bash tests/unit/test-feature-disclosure.sh`: 44/46 pass. The 2 remaining failures (`first-run welcome emits a valid SessionStart object`, `first-run directs the assistant to run setup`) are pre-existing on `main` — reproduced identically with this branch's changes stashed, so unrelated to this fix.
- Reproduced the actual symlink scenario: symlinked a directory to the working tree and ran the suite through the symlink. Before the fix, `manifest resolves when sourced from an unrelated cwd` and `stale CLAUDE_PLUGIN_ROOT falls back to the repo manifest` fail exactly as described in #712. After the fix, both pass.
- `make test-unit` (full suite): 3 pre-existing suite-level failures unrelated to this diff (`GitHub work queue hook`, `HUD smart mode...`, plus the 2 `Feature disclosure` first-run cases above) — confirmed identical with this change stashed, so this is sandbox/environment state (no network/GitHub CLI access, missing HUD-dependent binaries), not a regression from this PR.

## Related Issues
Closes #712

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKpWt1PeVmZ9c8Te7HGnQA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test path handling for symlinked checkouts, ensuring feature disclosure tests locate project files reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->