### PR TITLE
fix: forward WORKSPACE_DIR into isolated provider envs so quota dead-marks are visible

### DIFF
--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -50,7 +50,39 @@ fi
 # Populates PROVIDER_ENV_ARRAY with argv tokens that limit environment
 # variables to essentials only. This stays safe when PATH contains spaces.
 # ═══════════════════════════════════════════════════════════════════════════════
+# `env -i` wipes WORKSPACE_DIR, and two shims that run under it mark a provider
+# quota/auth-dead: gemini-exec.sh on `IneligibleTierError` and agy-exec.sh on
+# `Individual quota reached`. `octo_quota_dead_file` derives its path from
+# WORKSPACE_DIR with a `$HOME/.claude-octopus` fallback, so under `env -i` the
+# shim writes the marker to the fallback while orchestrate.sh and
+# check-providers.sh read it under `$CLAUDE_PLUGIN_DATA` (set by Claude Code
+# v2.1.78+). The mark lands where nobody reads it: the provider keeps
+# advertising `available`, is reseated every session, and the user is prompted
+# for the gemini keychain entry every single run.
+#
+# Applied as a wrapper rather than per-arm because several arms `return 0` from
+# inside the case and would skip a tail hook, and because a per-call-site fix is
+# exactly what let the quota downgrade cover four of thirteen providers before
+# it moved into `provider_status`.
+_octo_provider_env_forward_workspace_dir() {
+    [[ ${#PROVIDER_ENV_ARRAY[@]} -gt 0 ]] || return 0
+    [[ "${PROVIDER_ENV_ARRAY[0]}" == "env" ]] || return 0
+    local _entry
+    for _entry in "${PROVIDER_ENV_ARRAY[@]}"; do
+        [[ "$_entry" == WORKSPACE_DIR=* ]] && return 0
+    done
+    PROVIDER_ENV_ARRAY+=("WORKSPACE_DIR=${WORKSPACE_DIR:-$HOME/.claude-octopus}")
+    return 0
+}
+
 build_provider_env() {
+    _octo_build_provider_env_impl "$@"
+    local _rc=$?
+    _octo_provider_env_forward_workspace_dir
+    return "$_rc"
+}
+
+_octo_build_provider_env_impl() {
     local provider="$1"
     PROVIDER_ENV_ARRAY=()
 

--- a/tests/unit/test-quota-fast-fail.sh
+++ b/tests/unit/test-quota-fast-fail.sh
@@ -146,8 +146,57 @@ test_check_providers_applies_dead_marker_to_every_provider() {
     fi
 }
 
+# A dead-mark written by a shim running under `env -i` must be visible to the
+# reader. gemini-exec.sh and agy-exec.sh both mark dead from inside the isolated
+# environment; if WORKSPACE_DIR is not forwarded they write to the
+# $HOME/.claude-octopus fallback while check-providers.sh reads
+# $CLAUDE_PLUGIN_DATA, so the provider keeps advertising `available` and is
+# reseated (and re-prompts for the gemini keychain entry) every session.
+test_provider_env_forwards_workspace_dir() {
+    test_case "build_provider_env forwards WORKSPACE_DIR into every isolated env"
+    local out missing=""
+    for p in gemini agy codex; do
+        out="$(WORKSPACE_DIR=/tmp/octo-wsdir-probe bash -c '
+            cd "$1" || exit 1
+            source scripts/lib/validation.sh 2>/dev/null
+            source scripts/lib/provider-routing.sh
+            build_provider_env "$2"
+            printf "%s\n" "${PROVIDER_ENV_ARRAY[@]}"
+        ' _ "$PROJECT_ROOT" "$p" 2>/dev/null)"
+        printf '%s\n' "$out" | grep -q '^WORKSPACE_DIR=/tmp/octo-wsdir-probe$' || missing="$missing $p"
+    done
+    if [[ -z "$missing" ]]; then
+        test_pass
+    else
+        test_fail "WORKSPACE_DIR not forwarded for:$missing"
+    fi
+}
+
+test_dead_mark_survives_isolated_env() {
+    test_case "a dead-mark written under the isolated env is visible to the reader"
+    local th pd res
+    th="$(mktemp -d)"; pd="$(mktemp -d)"
+    res="$(HOME="$th" WORKSPACE_DIR="$pd" bash -c '
+        cd "$1" || exit 1
+        source scripts/lib/validation.sh 2>/dev/null
+        source scripts/lib/provider-routing.sh
+        build_provider_env gemini
+        "${PROVIDER_ENV_ARRAY[@]}" bash -c "cd \"$1\"; source scripts/lib/quota-watcher.sh; octo_quota_mark_dead gemini 0" _ "$1"
+        source scripts/lib/quota-watcher.sh
+        octo_quota_is_dead gemini && echo DEAD || echo ALIVE
+    ' _ "$PROJECT_ROOT" 2>/dev/null)"
+    rm -rf "$th" "$pd"
+    if [[ "$res" == "DEAD" ]]; then
+        test_pass
+    else
+        test_fail "mark written under env -i was invisible to the reader (got '$res')"
+    fi
+}
+
 test_quota_dead_cache_roundtrip
 test_quota_dead_cache_dedup
+test_provider_env_forwards_workspace_dir
+test_dead_mark_survives_isolated_env
 test_pattern_matches_terminal_errors
 test_watcher_marks_dead_on_match
 test_is_agent_available_skips_dead


### PR DESCRIPTION
Closes the gap behind the recurring `gemini-cli-workspace-oauth` keychain prompt that a user is still hitting after #690 and #692.

## What is wrong

`gemini-exec.sh` marks gemini quota/auth-dead on `IneligibleTierError`; `agy-exec.sh` does the same on `Individual quota reached`. Both run under the `env -i` isolation built by `build_provider_env`, and none of the five `env -i` arms forwarded `WORKSPACE_DIR`.

`octo_quota_dead_file` derives its path from `WORKSPACE_DIR` with a `$HOME/.claude-octopus` fallback. So under `env -i` the shim writes the marker to the fallback while `orchestrate.sh` and `check-providers.sh` read it under `$CLAUDE_PLUGIN_DATA` — which Claude Code v2.1.78+ sets and which `orchestrate.sh:215` prefers over the `$HOME` default. Writer and reader point at different files; the mark is invisible.

Reproduced before fixing:

```
WRITER path: /…/tmp.QT5FFEwMoL/.claude-octopus/state/.provider-quota-dead
READER path: /…/tmp.eBk6FenI88/state/.provider-quota-dead
READER sees gemini ALIVE  <-- marker invisible
```

## Why the user still sees it

#690 and #692 made the seat report honestly **only in the default-workspace case**. With `CLAUDE_PLUGIN_DATA` set, gemini keeps advertising `available` after every failure and is reseated on every run — which matches the reported banner showing `🟡 Gemini CLI: Available ✓`. Each reseat spawns the gemini CLI again, and node re-reads the keychain, so the prompt recurs every session.

Worth stating plainly: the keychain dialog appears *before* `IneligibleTierError` is returned. A purely reactive dead-mark can suppress later prompts in a session but can never suppress the first one in any session that reseats the provider. Making the mark persist correctly is necessary but not sufficient — see the follow-up note below.

## Fix

A wrapper around the case statement rather than a per-arm edit. Several arms `return 0` from inside the case and would skip a tail hook, and a per-call-site fix is exactly what let the quota downgrade cover four of thirteen providers before it moved into `provider_status`.

Verified end to end after the fix: writer and reader resolve the same path, and the reader sees `DEAD`.

## Tests

Two regression cases in `test-quota-fast-fail.sh`: `WORKSPACE_DIR` is forwarded for gemini, agy and codex; and a mark written from inside the isolated env is visible to the reader. Both fail when the wrapper call is removed:

```
• build_provider_env forwards WORKSPACE_DIR into every isolated env: WORKSPACE_DIR not forwarded for: gemini agy codex
• a dead-mark written under the isolated env is visible to the reader: got 'ALIVE'
```

## Pattern

Fourth instance of a path frozen or derived against the wrong `WORKSPACE_DIR`: `quality.sh`, `cost.sh`, `USAGE_FILE` (#694), and now this. A sweep for the class is worth scheduling separately.

## Follow-up, not in this PR

`gemini-via-agy` is declared `decision: none` with default `0` in `config/features.json`, so the actual migration path off the sunset Gemini Code Assist OAuth is never offered to anyone. Given the free tier is gone and the direct path can only fail, that default and that classification both look wrong — it is a real policy question, which is what `decision: required` is for. Filing separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolated provider environments so workspace paths remain available.
  * Ensured quota-related markers are correctly detected across provider environments.

* **Tests**
  * Added coverage for workspace path forwarding and quota-dead marker visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->