### PR TITLE
fix: honour OCTOPUS_COMMANDCODE_PERMISSION_MODE on the dispatch path

### DIFF
--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -469,6 +469,21 @@ get_agent_command() {
             case "$role" in
                 implementer|developer) commandcode_mode="yolo" ;;
             esac
+            # OCTOPUS_COMMANDCODE_PERMISSION_MODE env override (Issue #710),
+            # matching the OCTOPUS_CODEX_SANDBOX precedent above: dispatch
+            # always passes a positional arg to commandcode-exec.sh, so its
+            # own env-var fallback is dead unless honoured here first.
+            if [[ -n "${OCTOPUS_COMMANDCODE_PERMISSION_MODE:-}" ]]; then
+                case "$OCTOPUS_COMMANDCODE_PERMISSION_MODE" in
+                    plan|default|dont-ask|auto-accept|yolo)
+                        commandcode_mode="$OCTOPUS_COMMANDCODE_PERMISSION_MODE"
+                        ;;
+                    *)
+                        log "ERROR" "Invalid OCTOPUS_COMMANDCODE_PERMISSION_MODE value: '${OCTOPUS_COMMANDCODE_PERMISSION_MODE}'. Allowed: plan, default, dont-ask, auto-accept, yolo"
+                        log "ERROR" "Falling back to role-derived default (${commandcode_mode})."
+                        ;;
+                esac
+            fi
             echo "${PLUGIN_DIR}/scripts/helpers/commandcode-exec.sh ${model} ${commandcode_mode}"
             ;;
         cursor-agent)  # v9.23.0: Cursor Agent CLI — Grok 4.20 via Cursor subscription

--- a/tests/unit/test-commandcode-harness.sh
+++ b/tests/unit/test-commandcode-harness.sh
@@ -81,13 +81,20 @@ fi
 # commandcode-exec.sh but dispatch always passed an explicit positional
 # argument, so the env var was dead on the dispatch path.
 test_case "OCTOPUS_COMMANDCODE_PERMISSION_MODE override is honoured on the dispatch path"
-export OCTOPUS_COMMANDCODE_PERMISSION_MODE=dont-ask
-override_cmd="$(get_agent_command commandcode tangle implementer)"
+override_mismatch=""
+for mode in plan default dont-ask auto-accept yolo; do
+    export OCTOPUS_COMMANDCODE_PERMISSION_MODE="$mode"
+    override_cmd="$(get_agent_command commandcode tangle implementer)"
+    if [[ "$override_cmd" != *"commandcode-exec.sh deepseek/deepseek-v4-pro ${mode}" ]]; then
+        override_mismatch="mode=${mode} got: ${override_cmd}"
+        break
+    fi
+done
 unset OCTOPUS_COMMANDCODE_PERMISSION_MODE
-if [[ "$override_cmd" == *'commandcode-exec.sh deepseek/deepseek-v4-pro dont-ask' ]]; then
+if [[ -z "$override_mismatch" ]]; then
     test_pass
 else
-    test_fail "expected env override to win over the role-derived default, got: $override_cmd"
+    test_fail "expected env override to win over the role-derived default, ${override_mismatch}"
 fi
 
 test_case "invalid OCTOPUS_COMMANDCODE_PERMISSION_MODE is rejected and falls back to the role default"
@@ -107,7 +114,9 @@ source "$PROJECT_ROOT/scripts/lib/utils.sh"
 export OCTOPUS_COMMANDCODE_PERMISSION_MODE=auto-accept
 override_valid_cmd="$(get_agent_command commandcode verify verifier)"
 unset OCTOPUS_COMMANDCODE_PERMISSION_MODE
-if validate_agent_command "$override_valid_cmd" >/dev/null 2>&1; then
+if [[ "$override_valid_cmd" != *' auto-accept' ]]; then
+    test_fail "expected auto-accept override to be forwarded, got: $override_valid_cmd"
+elif validate_agent_command "$override_valid_cmd" >/dev/null 2>&1; then
     test_pass
 else
     test_fail "override dispatch command rejected by validate_agent_command"

--- a/tests/unit/test-commandcode-harness.sh
+++ b/tests/unit/test-commandcode-harness.sh
@@ -59,6 +59,10 @@ if [[ "$rc" -eq 7 ]]; then test_pass; else test_fail "expected exit 7, got $rc";
 test_case "dispatch selects yolo for implementers and plan for verifiers"
 export PLUGIN_DIR="$PROJECT_ROOT" OCTOPUS_PLATFORM=Linux HOME="$FIXTURE_DIR/home"
 mkdir -p "$HOME/.claude-octopus/config"
+# dispatch.sh's log() lives in orchestrate.sh, which this harness never
+# sources; stub it so ERROR-path assertions can see the emitted text
+# instead of a bare "log: command not found".
+log() { local level="$1"; shift; printf '%s: %s\n' "$level" "$*" >&2; }
 source "$PROJECT_ROOT/scripts/lib/validation.sh"
 source "$PROJECT_ROOT/scripts/lib/model-cache-path.sh"
 source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
@@ -88,12 +92,14 @@ fi
 
 test_case "invalid OCTOPUS_COMMANDCODE_PERMISSION_MODE is rejected and falls back to the role default"
 export OCTOPUS_COMMANDCODE_PERMISSION_MODE=danger-full-access
-invalid_cmd="$(get_agent_command commandcode tangle implementer 2>/dev/null)"
+error_log="$FIXTURE_DIR/invalid-commandcode-permission-mode.err"
+invalid_cmd="$(get_agent_command commandcode tangle implementer 2>"$error_log")"
 unset OCTOPUS_COMMANDCODE_PERMISSION_MODE
-if [[ "$invalid_cmd" == *'commandcode-exec.sh deepseek/deepseek-v4-pro yolo' ]]; then
+if [[ "$invalid_cmd" == *'commandcode-exec.sh deepseek/deepseek-v4-pro yolo' ]] &&
+   grep -F -- 'Invalid OCTOPUS_COMMANDCODE_PERMISSION_MODE value:' "$error_log" >/dev/null; then
     test_pass
 else
-    test_fail "expected fallback to role default (yolo), got: $invalid_cmd"
+    test_fail "expected fallback to role default (yolo) with logged error, got: $invalid_cmd"
 fi
 
 test_case "override dispatch command passes validate_agent_command"

--- a/tests/unit/test-commandcode-harness.sh
+++ b/tests/unit/test-commandcode-harness.sh
@@ -96,7 +96,7 @@ error_log="$FIXTURE_DIR/invalid-commandcode-permission-mode.err"
 invalid_cmd="$(get_agent_command commandcode tangle implementer 2>"$error_log")"
 unset OCTOPUS_COMMANDCODE_PERMISSION_MODE
 if [[ "$invalid_cmd" == *'commandcode-exec.sh deepseek/deepseek-v4-pro yolo' ]] &&
-   grep -F -- 'Invalid OCTOPUS_COMMANDCODE_PERMISSION_MODE value:' "$error_log" >/dev/null; then
+   grep -F -- 'ERROR: Invalid OCTOPUS_COMMANDCODE_PERMISSION_MODE value:' "$error_log" >/dev/null; then
     test_pass
 else
     test_fail "expected fallback to role default (yolo) with logged error, got: $invalid_cmd"

--- a/tests/unit/test-commandcode-harness.sh
+++ b/tests/unit/test-commandcode-harness.sh
@@ -73,6 +73,40 @@ else
     test_fail "unexpected role permission mapping"
 fi
 
+# Issue #710: OCTOPUS_COMMANDCODE_PERMISSION_MODE was accepted by
+# commandcode-exec.sh but dispatch always passed an explicit positional
+# argument, so the env var was dead on the dispatch path.
+test_case "OCTOPUS_COMMANDCODE_PERMISSION_MODE override is honoured on the dispatch path"
+export OCTOPUS_COMMANDCODE_PERMISSION_MODE=dont-ask
+override_cmd="$(get_agent_command commandcode tangle implementer)"
+unset OCTOPUS_COMMANDCODE_PERMISSION_MODE
+if [[ "$override_cmd" == *'commandcode-exec.sh deepseek/deepseek-v4-pro dont-ask' ]]; then
+    test_pass
+else
+    test_fail "expected env override to win over the role-derived default, got: $override_cmd"
+fi
+
+test_case "invalid OCTOPUS_COMMANDCODE_PERMISSION_MODE is rejected and falls back to the role default"
+export OCTOPUS_COMMANDCODE_PERMISSION_MODE=danger-full-access
+invalid_cmd="$(get_agent_command commandcode tangle implementer 2>/dev/null)"
+unset OCTOPUS_COMMANDCODE_PERMISSION_MODE
+if [[ "$invalid_cmd" == *'commandcode-exec.sh deepseek/deepseek-v4-pro yolo' ]]; then
+    test_pass
+else
+    test_fail "expected fallback to role default (yolo), got: $invalid_cmd"
+fi
+
+test_case "override dispatch command passes validate_agent_command"
+source "$PROJECT_ROOT/scripts/lib/utils.sh"
+export OCTOPUS_COMMANDCODE_PERMISSION_MODE=auto-accept
+override_valid_cmd="$(get_agent_command commandcode verify verifier)"
+unset OCTOPUS_COMMANDCODE_PERMISSION_MODE
+if validate_agent_command "$override_valid_cmd" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "override dispatch command rejected by validate_agent_command"
+fi
+
 # The command dispatch actually returns must survive validate_agent_command, or
 # every commandcode dispatch aborts the phase before the CLI is ever invoked —
 # the same failure mode as #697 (copilot-exec.sh) and #705 (agy-exec.sh). Asserting


### PR DESCRIPTION
## Description
`get_agent_command` in `scripts/lib/dispatch.sh` derived Command Code's permission mode purely from the role (`implementer|developer` → `yolo`, everything else → `plan`) and always passed that as an explicit positional argument to `commandcode-exec.sh`. The shim itself already accepted `OCTOPUS_COMMANDCODE_PERMISSION_MODE` as a fallback (`scripts/helpers/commandcode-exec.sh:5`), but since dispatch always supplies a non-empty positional arg, the env var was dead on the real dispatch path — it only ever worked when the shim was invoked directly.

This adds the same `OCTOPUS_COMMANDCODE_PERMISSION_MODE` override to `get_agent_command`, mirroring the existing `OCTOPUS_CODEX_SANDBOX` precedent a few lines above it: read the env var, validate it against the same allowlist the shim enforces (`plan|default|dont-ask|auto-accept|yolo`), log an `ERROR` and fall back to the role-derived default on an invalid value, and forward the resolved mode positionally so the shim's own validation stays the second line of defence.

## Type of Change
- [x] Bug fix

## Root Cause
`scripts/lib/dispatch.sh:464-472` (commandcode dispatch case) hardcoded `commandcode_mode` from `$role` and never consulted `OCTOPUS_COMMANDCODE_PERMISSION_MODE`, so a user could not hold implementer dispatches at `plan`/`default` without disabling the provider entirely — unlike Codex's `OCTOPUS_CODEX_SANDBOX`.

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [x] OpenClaw registry in sync: `scripts/build-openclaw.sh --check`
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` — n/a, no new command
- [ ] Version bump — n/a, patch-worthy bug fix, not releasing here
- [ ] Documentation updated — n/a, env var was already documented as a shim fallback; behavior now matches docs
- [ ] CHANGELOG.md updated — left for release cut

## Testing
```bash
bash -n scripts/lib/dispatch.sh
bash -n tests/unit/test-commandcode-harness.sh
bash tests/unit/test-commandcode-harness.sh          # 10/10 pass (3 new cases added)
bash tests/unit/test-agent-command-validation.sh     # 26/26 pass
bash tests/unit/test-codex-sandbox-mode.sh           # 2/2 pass
bash tests/unit/test-role-mapping-v929.sh            # 14/14 pass
bash tests/unit/test-post-tool-dispatch.sh           # 3/3 pass
bash tests/unit/test-execution-profile-dispatch.sh   # pass
bash tests/unit/test-openclaw-compat.sh              # 32/32 pass
scripts/build-openclaw.sh --check                    # registry up to date
```

The full `make test-unit` suite is large and did not complete within this session's runtime budget; I ran the targeted commandcode/dispatch/role-mapping/openclaw suites directly instead, per the every-directly-affected-test guidance for a scoped change.

New test cases added to `tests/unit/test-commandcode-harness.sh`:
1. `OCTOPUS_COMMANDCODE_PERMISSION_MODE` override is honoured on the dispatch path
2. An invalid value is rejected and falls back to the role-derived default
3. The resulting override command still passes `validate_agent_command`

## Related Issues
Closes #710


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rmni8Pmkk6PVrv3YFZnrBk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring command execution permission modes through an environment setting.
  * Supports five approved permission modes and overrides the default role-based mode when valid.

* **Bug Fixes**
  * Invalid permission mode values are rejected, logged, and safely fall back to the existing role-based setting.

* **Tests**
  * Added coverage for valid overrides, invalid-value fallback behavior, error logging, and generated command validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->