### PR TITLE
fix: label design review seats by runtime identity

### DIFF
--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -531,9 +531,24 @@ Be concise and specific. This is a planning exercise, not implementation."
     log INFO "Design review: gathering provider approaches..."
     log INFO "Design review seats: seat_1=${seat_1_label}, seat_2=${seat_2_label}, seat_3=${seat_3_label}, synthesis=${synthesis_label}, timeout=${_design_timeout_label}, synth_timeout=${_synth_timeout_label}"
 
-    seat_1_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
-    seat_2_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
-    seat_3_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony" 2>/dev/null) || true
+    seat_1_approach="$(
+        (
+            export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
+            run_agent_sync_consultative "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony"
+        ) 2>/dev/null
+    )" || true
+    seat_2_approach="$(
+        (
+            export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
+            run_agent_sync_consultative "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony"
+        ) 2>/dev/null
+    )" || true
+    seat_3_approach="$(
+        (
+            export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
+            run_agent_sync_consultative "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony"
+        ) 2>/dev/null
+    )" || true
 
     # Synthesize conflicts and resolution.
     # synthesis.start/end bracket the call so the event stream shows how long the

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -501,7 +501,7 @@ Be concise and specific. This is a planning exercise, not implementation."
 
     # Gather approaches from available providers. Keep these configurable so
     # operators can pick cheaper/faster review models without patching code.
-    local codex_approach="" gemini_approach="" sonnet_approach=""
+    local seat_1_approach="" seat_2_approach="" seat_3_approach=""
     local design_codex_agent="${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-codex-mini}"
     local design_agy_agent="${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-agy}}"
     local design_claude_agent="${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}"
@@ -522,12 +522,18 @@ Be concise and specific. This is a planning exercise, not implementation."
     local _synth_timeout_label="none"
     [[ "$design_synth_timeout" != "0" ]] && _synth_timeout_label="${design_synth_timeout}s"
 
-    log INFO "Design review: gathering provider approaches..."
-    log INFO "Design review agents: codex=${design_codex_agent}, agy=${design_agy_agent}, claude=${design_claude_agent}, synthesis=${design_synthesis_agent}, timeout=${_design_timeout_label}, synth_timeout=${_synth_timeout_label}"
+    local seat_1_label seat_2_label seat_3_label synthesis_label
+    seat_1_label="$(octo_provider_identity_label "$design_codex_agent" "implementer")"
+    seat_2_label="$(octo_provider_identity_label "$design_agy_agent" "researcher")"
+    seat_3_label="$(octo_provider_identity_label "$design_claude_agent" "code-reviewer")"
+    synthesis_label="$(octo_provider_identity_label "$design_synthesis_agent" "synthesizer")"
 
-    codex_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
-    gemini_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
-    sonnet_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony" 2>/dev/null) || true
+    log INFO "Design review: gathering provider approaches..."
+    log INFO "Design review seats: seat_1=${seat_1_label}, seat_2=${seat_2_label}, seat_3=${seat_3_label}, synthesis=${synthesis_label}, timeout=${_design_timeout_label}, synth_timeout=${_synth_timeout_label}"
+
+    seat_1_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony" 2>/dev/null) || true
+    seat_2_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony" 2>/dev/null) || true
+    seat_3_approach=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony" 2>/dev/null) || true
 
     # Synthesize conflicts and resolution.
     # synthesis.start/end bracket the call so the event stream shows how long the
@@ -543,16 +549,16 @@ Be concise and specific. This is a planning exercise, not implementation."
     local synthesis
     synthesis=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_synthesis_agent" "You are synthesizing a design review ceremony.
 
-Three providers stated their approach to this task:
+Three review seats stated their approach to this task. The headings below reflect configured runtime identity rather than historical provider slot names:
 
-CODEX APPROACH:
-${codex_approach:-[unavailable]}
+SEAT 1 - ${seat_1_label}:
+${seat_1_approach:-[unavailable]}
 
-GEMINI APPROACH:
-${gemini_approach:-[unavailable]}
+SEAT 2 - ${seat_2_label}:
+${seat_2_approach:-[unavailable]}
 
-SONNET APPROACH:
-${sonnet_approach:-[unavailable]}
+SEAT 3 - ${seat_3_label}:
+${seat_3_approach:-[unavailable]}
 
 Identify:
 1. CONFLICTS: Where do the approaches disagree?

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -215,6 +215,7 @@ octo_provider_identity_from_agent_type() {
         openai-compatible|openai-tools|openai-compatible-agent) echo "openai-compatible" ;;
         atlascloud-agent|atlascloud) echo "atlascloud" ;;
         codex*) echo "codex" ;;
+        commandcode*) echo "commandcode" ;;
         claude*) echo "anthropic" ;;
         gemini*) echo "google" ;;
         perplexity*) echo "perplexity" ;;
@@ -234,6 +235,27 @@ octo_extract_runtime_model() {
         -e 's/^OCTOPUS_RUNTIME_MODEL=([^[:space:]]+)$/\1/p' \
         | head -1 || true)
     printf '%s\n' "${value:-unknown}"
+}
+
+
+# Render a human-facing identity label for a configured executor alias.
+# Used by ceremonies and other summaries that must not expose historical slot names
+# as if they were the runtime provider.
+octo_provider_identity_label() {
+    local executor_alias="${1:-unknown}"
+    local role="${2:-unknown}"
+    local configured_provider="unknown"
+    local configured_model="unresolved"
+
+    configured_provider="$(octo_provider_identity_from_agent_type "$executor_alias" 2>/dev/null || echo unknown)"
+    if declare -f get_agent_model >/dev/null 2>&1; then
+        configured_model="$(get_agent_model "$executor_alias" "ceremony" "$role" 2>/dev/null || echo unresolved)"
+    fi
+
+    printf '%s / %s (executor: %s)' \
+        "${configured_provider:-unknown}" \
+        "${configured_model:-unresolved}" \
+        "$executor_alias"
 }
 
 octo_append_runtime_identity() {

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -73,4 +73,31 @@ else
   test_fail "one or more role events still lack stable identity/role fields"
 fi
 
+test_case "design review seat labels use resolved provider and model identity"
+get_agent_model() {
+  case "$1:$3" in
+    commandcode:implementer) echo "deepseek/deepseek-v4-pro" ;;
+    commandcode-research:researcher) echo "minimaxai/minimax-m3" ;;
+    *) echo "unresolved" ;;
+  esac
+}
+label=$(octo_provider_identity_label commandcode implementer)
+research_label=$(octo_provider_identity_label commandcode-research researcher)
+if [[ "$label" == "commandcode / deepseek/deepseek-v4-pro (executor: commandcode)" ]] && \
+   [[ "$research_label" == "commandcode / minimaxai/minimax-m3 (executor: commandcode-research)" ]]; then
+  test_pass
+else
+  test_fail "design review labels did not expose resolved runtime identity: $label | $research_label"
+fi
+
+test_case "design review synthesis prompt no longer uses historical provider headings"
+if ! grep -q '^CODEX APPROACH:' "$PROJECT_ROOT/scripts/lib/quality.sh" && \
+   ! grep -q '^GEMINI APPROACH:' "$PROJECT_ROOT/scripts/lib/quality.sh" && \
+   ! grep -q '^SONNET APPROACH:' "$PROJECT_ROOT/scripts/lib/quality.sh" && \
+   grep -q 'SEAT 1 - ${seat_1_label}:' "$PROJECT_ROOT/scripts/lib/quality.sh"; then
+  test_pass
+else
+  test_fail "historical provider headings remain in the design review synthesis prompt"
+fi
+
 test_summary


### PR DESCRIPTION
## Summary

- replace historical `CODEX` / `GEMINI` / `SONNET` design-review headings with neutral seat labels
- render each seat from the configured executor alias, provider identity, and resolved model
- add native `commandcode* -> commandcode` provider identity mapping
- log resolved seat identities for the review and synthesis agents

## Problem

The design-review ceremony could route a historical slot to a different provider (for example `commandcode-research` / MiniMax) while still labelling the output as `GEMINI APPROACH`. This made synthesis messages and diagnostics incorrectly imply that providers were used when only the slot names were historical.

The runtime identity schema introduced previously already distinguishes executor alias, configured provider/model, and runtime provider/model. The ceremony prompt was one remaining place that still presented slot names as provider identity.

## Behaviour after this change

Example headings now look like:

```text
SEAT 1 - commandcode / deepseek/deepseek-v4-pro (executor: commandcode)
SEAT 2 - commandcode / minimaxai/minimax-m3 (executor: commandcode-research)
SEAT 3 - anthropic / <resolved model> (executor: claude-sonnet)
```

The execution routing itself is unchanged.

## Tests

- `make test-unit` — 190/190 suites passed
- `tests/unit/test-runtime-provider-labels.sh` — 8/8 passed
- `tests/unit/test-ceremonies.sh` — 7/7 passed
- `tests/smoke/test-syntax.sh` — 4/4 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Design review results now display clear, configurable seat labels.
  * Review summaries identify each response using configured provider, model, and executor details.
  * CommandCode-based review seats are now recognized and labeled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->