### PR TITLE
fix: offer the Gemini migration as a real choice and honour the answer (closes #715)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -77,7 +77,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 **Traction (as of 2026-07-27):**
 - GitHub stars: 3,889
 - GitHub forks: 365
-- Local CI parity: 16 smoke, 190 unit, and 7 integration suites
+- Local CI parity: 16 smoke, 191 unit, and 7 integration suites
 - Version: 9.57.0 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Gemini CLI
 

--- a/config/features.json
+++ b/config/features.json
@@ -72,13 +72,25 @@
     {
       "id": "gemini-via-agy",
       "added_in": "9.52.0",
-      "backfill": false,
-      "decision": "none",
+      "backfill": true,
+      "decision": "required",
       "title": "Route Gemini seats through Antigravity",
-      "description": "Serves gemini* seats via the Antigravity CLI. Gemini Code Assist free-tier OAuth is sunset, so the direct path returns IneligibleTierError. Set OCTOPUS_GEMINI_VIA_AGY=1 to enable.",
+      "question": "Google sunset the Gemini Code Assist free tier. How should Gemini seats run?",
       "key": "OCTOPUS_GEMINI_VIA_AGY",
       "default": "0",
-      "prereq": "agy-cli"
+      "prereq": "gemini-cli",
+      "choices": [
+        {
+          "value": "1",
+          "label": "Through Antigravity",
+          "description": "Serves gemini seats via the Antigravity CLI, which is the supported path now. Needs the agy CLI installed; backend cost follows OCTOPUS_AGY_MODEL rather than being free."
+        },
+        {
+          "value": "0",
+          "label": "Keep the direct path",
+          "description": "Current behaviour. Correct only if you hold a paid Gemini Code Assist tier; on the free tier every dispatch returns IneligibleTierError after prompting for the gemini-cli keychain entry."
+        }
+      ]
     }
   ]
 }

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -287,7 +287,7 @@ ${provider_ctx}"
         gemini*)
             _provider_for_health="gemini"
             # gemini seats served via agy health-check agy instead.
-            [[ "${OCTOPUS_GEMINI_VIA_AGY:-0}" =~ ^(1|on|true|yes)$ ]] && _provider_for_health="agy"
+            octo_gemini_via_agy_active && _provider_for_health="agy"
             ;;
         agy*|antigravity) _provider_for_health="agy" ;;
         claude*)     _provider_for_health="claude" ;;
@@ -369,7 +369,7 @@ ${provider_ctx}"
 
     # gemini* seats served via agy (OCTOPUS_GEMINI_VIA_AGY) take the agy path.
     if [[ "$agent_type" == agy* || "$agent_type" == "antigravity" ]] || \
-       { [[ "$agent_type" == gemini* ]] && [[ "${OCTOPUS_GEMINI_VIA_AGY:-0}" =~ ^(1|on|true|yes)$ ]]; }; then
+       { [[ "$agent_type" == gemini* ]] && octo_gemini_via_agy_active; }; then
         set +e
         printf '%s' "$enhanced_prompt" | run_with_timeout "$timeout_secs" "${cmd_array[@]}" 2>"$temp_err" >"$temp_out"
         exit_code=$?

--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -51,6 +51,32 @@ _BARE_OPT="${_BARE_OPT:-}"
 # Fallback:  consumers (see lib/agents.sh get_fallback_agent) silently downshift when the
 #            preferred CLI is unavailable (e.g. no Anthropic auth → architect → current Codex).
 
+# octo_gemini_via_agy_active — true when gemini* seats should be served through
+# the Antigravity CLI instead of gemini-cli.
+#
+# Reads the progressive-disclosure ledger first, with OCTOPUS_GEMINI_VIA_AGY as a
+# session override, mirroring _octo_reviewer_flip_active. The three dispatch
+# sites used to read the raw env var directly, which meant a user who answered
+# the disclosure question changed nothing: the answer was recorded and then
+# ignored. Routing every site through one accessor keeps the recorded choice and
+# the env override in agreement.
+# The env var is normalised here, before the ledger is consulted, rather than
+# being handed to octo_features_choice. That function only passes an env value
+# through when it is a declared choice for the feature, and this feature's
+# choices are the literal "1" and "0" — so `OCTOPUS_GEMINI_VIA_AGY=true` (which
+# the previous raw `^(1|on|true|yes)$` reads accepted) would be dropped and the
+# user silently returned to the failing direct path, and `=false` would lose to
+# a recorded "1". Normalising locally keeps the documented aliases working in
+# both directions without changing choice semantics for every other feature.
+octo_gemini_via_agy_active() {
+    case "${OCTOPUS_GEMINI_VIA_AGY:-}" in
+        1|on|true|yes)  return 0 ;;
+        0|off|false|no) return 1 ;;
+    esac
+    declare -f octo_features_choice >/dev/null 2>&1 || return 1
+    [[ "$(octo_features_choice "gemini-via-agy")" == "1" ]]
+}
+
 # _octo_reviewer_flip_active — true when code review should move off the Codex
 # seat because Codex is the implementer.
 #

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -204,7 +204,7 @@ get_agent_command() {
             # are unaffected. Model pins follow OCTOPUS_AGY_MODEL (labels from
             # `agy models`), not gemini model ids. Gemini reasoning policy does
             # not apply — the agy seat has its own model/reasoning controls.
-            if [[ "${OCTOPUS_GEMINI_VIA_AGY:-0}" =~ ^(1|on|true|yes)$ ]]; then
+            if octo_gemini_via_agy_active; then
                 echo "${PLUGIN_DIR}/scripts/helpers/agy-exec.sh"
                 return 0
             fi

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -747,7 +747,7 @@ ${heuristic_ctx}"
             # Previously only gemini used stdin; codex/claude passed prompt as CLI arg which fails on large diffs.
             # gemini* seats served via agy (OCTOPUS_GEMINI_VIA_AGY) take the agy path.
             if [[ "$agent_type" == agy* || "$agent_type" == "antigravity" ]] || \
-               { [[ "$agent_type" == gemini* ]] && [[ "${OCTOPUS_GEMINI_VIA_AGY:-0}" =~ ^(1|on|true|yes)$ ]]; }; then
+               { [[ "$agent_type" == gemini* ]] && octo_gemini_via_agy_active; }; then
                 printf '%s' "$enhanced_prompt" | OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="spawn-agent-heartbeat" run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"
                 exit_code=${PIPESTATUS[1]:-0}
             elif printf '%s' "$enhanced_prompt" | OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="spawn-agent-heartbeat" run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then

--- a/tests/unit/test-feature-disclosure.sh
+++ b/tests/unit/test-feature-disclosure.sh
@@ -211,13 +211,57 @@ else
     test_fail "offered [$ids], expected backfill set [$expected]"
 fi
 
+# Tested against a synthetic manifest rather than a real feature id. Pinning this
+# to a shipped feature made the test rot the moment that feature's backfill or
+# decision classification changed, and it then failed for a reason unrelated to
+# the watermark gate it exists to protect.
 test_case "a pre-watermark feature is never offered"
 reset_ledger '{"last_seen_version":"9.55.0"}'
-ids=$(bash -c "source '$FEATURES_LIB'; octo_features_seed_watermark; octo_features_offerable_ids")
-if ! grep -qx "gemini-via-agy" <<< "$ids"; then
+watermark_fixture="$TEST_TMP_DIR/watermark-manifest.json"
+cat > "$watermark_fixture" <<'FIXTURE'
+{
+  "schema": "features_v1",
+  "features": [
+    {
+      "id": "below-watermark-probe",
+      "added_in": "9.52.0",
+      "backfill": false,
+      "decision": "required",
+      "title": "Below the watermark",
+      "question": "Should this ever be asked?",
+      "key": "OCTOPUS_BELOW_WATERMARK_PROBE",
+      "default": "0",
+      "prereq": "none",
+      "choices": [
+        { "value": "1", "label": "Yes", "description": "enabled" },
+        { "value": "0", "label": "No", "description": "disabled" }
+      ]
+    },
+    {
+      "id": "above-watermark-probe",
+      "added_in": "9.56.0",
+      "backfill": false,
+      "decision": "required",
+      "title": "Above the watermark",
+      "question": "Should this be asked?",
+      "key": "OCTOPUS_ABOVE_WATERMARK_PROBE",
+      "default": "0",
+      "prereq": "none",
+      "choices": [
+        { "value": "1", "label": "Yes", "description": "enabled" },
+        { "value": "0", "label": "No", "description": "disabled" }
+      ]
+    }
+  ]
+}
+FIXTURE
+ids=$(OCTOPUS_FEATURES_MANIFEST="$watermark_fixture" bash -c "source '$FEATURES_LIB'; octo_features_seed_watermark; octo_features_offerable_ids")
+# The above-watermark twin proves the gate discriminates rather than suppressing
+# everything, which a bare "not offered" assertion would not catch.
+if ! grep -qx "below-watermark-probe" <<< "$ids" && grep -qx "above-watermark-probe" <<< "$ids"; then
     test_pass
 else
-    test_fail "gemini-via-agy (added 9.52.0) is below the 9.55.0 watermark and must not be offered"
+    test_fail "watermark gate wrong: a non-backfill feature added at 9.52.0 must not be offered at watermark 9.55.0, and one added at 9.56.0 must be; got [$ids]"
 fi
 
 test_case "a recorded choice is sticky across repeated sessions"
@@ -265,13 +309,25 @@ else
     test_fail "expected the manifest default 'off', got '$out'"
 fi
 
+# Derived from the manifest rather than naming ids, so reclassifying a feature
+# cannot silently narrow what this covers.
 test_case "silent features are never raised however new they are"
 reset_ledger '{"last_seen_version":"9.0.0"}'
 out=$(bash -c "source '$FEATURES_LIB'; octo_features_seed_watermark; octo_features_offerable_ids")
-if ! grep -qx "preflight-probe" <<< "$out" && ! grep -qx "gemini-via-agy" <<< "$out"; then
-    test_pass
+silent_ids=$(jq -r '.features[] | select(.decision == "none") | .id' "$MANIFEST")
+if [[ -z "$silent_ids" ]]; then
+    test_fail "manifest has no decision=none feature, so this invariant is untested — add one or delete this case"
 else
-    test_fail "decision=none features must never be prompted: $out"
+    leaked=""
+    while IFS= read -r sid; do
+        [[ -n "$sid" ]] || continue
+        grep -qx "$sid" <<< "$out" && leaked="$leaked $sid"
+    done <<< "$silent_ids"
+    if [[ -z "$leaked" ]]; then
+        test_pass
+    else
+        test_fail "decision=none features must never be prompted, but these were:$leaked"
+    fi
 fi
 
 test_case "only decision=required features are ever offered"

--- a/tests/unit/test-gemini-via-agy-consent.sh
+++ b/tests/unit/test-gemini-via-agy-consent.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# tests/unit/test-gemini-via-agy-consent.sh
+#
+# gemini-via-agy is the migration path off Google's sunset Gemini Code Assist
+# free tier (issue #715). It is now a `decision: required` progressive-disclosure
+# feature, so the recorded answer — not just the env var — has to reach dispatch.
+#
+# The pre-existing coverage in test-agy-provider.sh greps the three source files
+# for the literal string OCTOPUS_GEMINI_VIA_AGY. That passes even when the
+# routing is broken, and it passed unchanged while the sites were switched from
+# reading the env var to reading the ledger. These cases execute the path.
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "gemini-via-agy consent routing (issue #715)"
+
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# Resolve the gemini dispatch command under a given ledger/env state. Sources in
+# orchestrate.sh's order so the accessor in agent-utils.sh is present exactly as
+# it is at runtime.
+resolve_gemini_cmd() {
+    env -i \
+        PATH="$PATH" \
+        HOME="$FIXTURE/home" \
+        OCTOPUS_STATE_DIR="$FIXTURE/state" \
+        PLUGIN_DIR="$PROJECT_ROOT" \
+        ${1:+OCTOPUS_GEMINI_VIA_AGY="$1"} \
+        bash -c '
+            cd "$0" || exit 1
+            log() { :; }
+            source scripts/lib/validation.sh          2>/dev/null
+            source scripts/lib/model-cache-path.sh    2>/dev/null
+            source scripts/lib/model-resolver.sh      2>/dev/null
+            source scripts/lib/provider-routing.sh    2>/dev/null
+            source scripts/lib/features.sh            2>/dev/null
+            source scripts/lib/dispatch.sh            2>/dev/null
+            source scripts/lib/agent-utils.sh         2>/dev/null
+            get_agent_command gemini probe researcher 2>/dev/null
+        ' "$PROJECT_ROOT"
+}
+
+record_choice() {
+    env -i PATH="$PATH" HOME="$FIXTURE/home" OCTOPUS_STATE_DIR="$FIXTURE/state" \
+        bash -c '
+            cd "$0" || exit 1
+            source scripts/lib/features.sh 2>/dev/null
+            octo_features_record gemini-via-agy "$1" 9.57.1 >/dev/null 2>&1
+        ' "$PROJECT_ROOT" "$1"
+}
+
+reset_ledger() { rm -rf "$FIXTURE/state" "$FIXTURE/home"; mkdir -p "$FIXTURE/state" "$FIXTURE/home"; }
+
+# ── default (no answer recorded, no override) ────────────────────────────────
+reset_ledger
+test_case "with no recorded answer the direct gemini path is kept"
+out="$(resolve_gemini_cmd "")"
+if [[ -n "$out" && "$out" != *"agy-exec.sh"* ]]; then
+    test_pass
+else
+    test_fail "default should resolve a non-empty gemini command; got: $out"
+fi
+
+# ── recorded answer drives routing, with no env var set ──────────────────────
+reset_ledger
+record_choice 1
+test_case "a recorded 'through Antigravity' answer reroutes gemini to agy-exec"
+out="$(resolve_gemini_cmd "")"
+if [[ "$out" == *"agy-exec.sh"* ]]; then
+    test_pass
+else
+    test_fail "recorded choice was ignored — the answer must reach dispatch; got: $out"
+fi
+
+reset_ledger
+record_choice 0
+test_case "a recorded 'keep the direct path' answer leaves gemini on gemini-cli"
+out="$(resolve_gemini_cmd "")"
+if [[ -n "$out" && "$out" != *"agy-exec.sh"* ]]; then
+    test_pass
+else
+    test_fail "recorded 0 should keep a non-empty direct gemini command; got: $out"
+fi
+
+# ── env override still wins in both directions ───────────────────────────────
+reset_ledger
+record_choice 0
+test_case "OCTOPUS_GEMINI_VIA_AGY=1 overrides a recorded 0"
+out="$(resolve_gemini_cmd 1)"
+if [[ "$out" == *"agy-exec.sh"* ]]; then
+    test_pass
+else
+    test_fail "session override should win over the ledger; got: $out"
+fi
+
+reset_ledger
+record_choice 1
+test_case "OCTOPUS_GEMINI_VIA_AGY=0 overrides a recorded 1"
+out="$(resolve_gemini_cmd 0)"
+if [[ -n "$out" && "$out" != *"agy-exec.sh"* ]]; then
+    test_pass
+else
+    test_fail "session override should win over the ledger; got: $out"
+fi
+
+# ── the feature is actually raised to an existing user ───────────────────────
+test_case "gemini-via-agy is offered to a user upgrading from an older version"
+offered="$(env -i PATH="$PATH" HOME="$FIXTURE/home2" OCTOPUS_STATE_DIR="$FIXTURE/state2" \
+    bash -c '
+        cd "$0" || exit 1
+        mkdir -p "$1/bin"
+        printf "#!/bin/sh\nexit 0\n" > "$1/bin/gemini"; chmod +x "$1/bin/gemini"
+        PATH="$1/bin:$PATH"
+        source scripts/lib/features.sh 2>/dev/null
+        octo_features_seed_watermark "9.56.1" >/dev/null 2>&1
+        octo_features_is_offerable gemini-via-agy && echo yes || echo no
+    ' "$PROJECT_ROOT" "$FIXTURE")"
+if [[ "$offered" == "yes" ]]; then
+    test_pass
+else
+    test_fail "feature must be raised to existing users, else the migration is never surfaced"
+fi
+
+# ── documented env aliases keep working in both directions ───────────────────
+# octo_features_choice only passes an env value through when it is a declared
+# choice, and this feature's choices are the literal "1"/"0". Routing the sites
+# at the ledger without normalising the env first silently dropped `=true`,
+# returning already-migrated users to the failing direct path.
+reset_ledger
+for alias_on in true on yes; do
+    test_case "OCTOPUS_GEMINI_VIA_AGY=$alias_on still routes through agy"
+    out="$(resolve_gemini_cmd "$alias_on")"
+    if [[ "$out" == *"agy-exec.sh"* ]]; then
+        test_pass
+    else
+        test_fail "documented truthy alias '$alias_on' was dropped; got: $out"
+    fi
+done
+
+reset_ledger
+record_choice 1
+for alias_off in false off no; do
+    test_case "OCTOPUS_GEMINI_VIA_AGY=$alias_off overrides a recorded 1"
+    out="$(resolve_gemini_cmd "$alias_off")"
+    if [[ -n "$out" && "$out" != *"agy-exec.sh"* ]]; then
+        test_pass
+    else
+        test_fail "documented falsy alias '$alias_off' lost to the ledger; got: $out"
+    fi
+done
+
+# ── the question actually reaches the picker ─────────────────────────────────
+# octo_features_is_offerable never consults prereq; prereq is enforced in
+# octo_features_prompt_manifest and octo_features_actionable_count, which are
+# what decide whether a user is asked. Reverting prereq to agy-cli, or typoing
+# it into an unknown check (which fails closed), would silently drop the
+# question for every gemini-only user — the original shipping bug — while an
+# is_offerable-only assertion stayed green.
+test_case "the question is emitted for a gemini-only user with no agy installed"
+manifest_out="$(env -i PATH="/usr/bin:/bin" HOME="$FIXTURE/home3" OCTOPUS_STATE_DIR="$FIXTURE/state3" \
+    bash -c '
+        cd "$0" || exit 1
+        mkdir -p "$1/bin3"
+        printf "#!/bin/sh\nexit 0\n" > "$1/bin3/gemini"; chmod +x "$1/bin3/gemini"
+        export PATH="$1/bin3:/usr/bin:/bin"
+        command -v agy >/dev/null 2>&1 && { echo "PRECONDITION-FAILED: agy on PATH"; exit 0; }
+        source scripts/lib/features.sh 2>/dev/null
+        octo_features_seed_watermark "9.56.1" >/dev/null 2>&1
+        octo_features_prompt_manifest 2>/dev/null
+    ' "$PROJECT_ROOT" "$FIXTURE")"
+if [[ "$manifest_out" == *"PRECONDITION-FAILED"* ]]; then
+    test_fail "test precondition broken: agy is on PATH, so this cannot prove the gemini-only case"
+elif printf '%s' "$manifest_out" | grep -q "^Q.*gemini-via-agy"; then
+    test_pass
+else
+    test_fail "no question row for a gemini-only user — the migration would never be surfaced"
+fi
+
+test_case "answering the question stops it being asked again"
+answered="$(env -i PATH="$PATH" HOME="$FIXTURE/home4" OCTOPUS_STATE_DIR="$FIXTURE/state4" \
+    bash -c '
+        cd "$0" || exit 1
+        source scripts/lib/features.sh 2>/dev/null
+        octo_features_seed_watermark "9.56.1" >/dev/null 2>&1
+        octo_features_record gemini-via-agy 0 9.57.1 >/dev/null 2>&1
+        octo_features_is_offerable gemini-via-agy && echo yes || echo no
+    ' "$PROJECT_ROOT")"
+if [[ "$answered" == "no" ]]; then
+    test_pass
+else
+    test_fail "a recorded answer must be sticky, including the 'keep current behaviour' answer"
+fi
+
+# ── the accessor is the single read point ────────────────────────────────────
+# Matches ${OCTOPUS_GEMINI_VIA_AGY... in any brace form, so a reintroduced read
+# written as ${OCTOPUS_GEMINI_VIA_AGY} is caught too. The bare name would be too
+# broad: comments in spawn.sh and agent-sync.sh still mention the variable.
+test_case "no dispatch site reads OCTOPUS_GEMINI_VIA_AGY directly"
+stray="$(grep -rln '\${OCTOPUS_GEMINI_VIA_AGY' \
+    "$PROJECT_ROOT/scripts/lib/dispatch.sh" \
+    "$PROJECT_ROOT/scripts/lib/spawn.sh" \
+    "$PROJECT_ROOT/scripts/lib/agent-sync.sh" 2>/dev/null || true)"
+if [[ -z "$stray" ]]; then
+    test_pass
+else
+    test_fail "these still bypass octo_gemini_via_agy_active: $stray"
+fi
+
+test_summary


### PR DESCRIPTION
Closes #715. This is the half of the recurring `gemini-cli-workspace-oauth` keychain prompt that #714 could not fix — #714 made the dead-mark stick, but the keychain dialog fires *before* `IneligibleTierError` returns, so a reactive mark can never suppress the first prompt of a session that seats gemini. The fix is to stop seating it.

## The problem

The migration path (route gemini seats through the Antigravity CLI) was already wired through `dispatch.sh`, `spawn.sh` and `agent-sync.sh`. It shipped as `decision: none` with default `0` — the progressive-disclosure framework was explicitly told never to raise it. So the plugin knew the direct path was sunset, had a working replacement, and left users on the failing one behind an env var nobody is told about.

## Changes

**`config/features.json`** — `gemini-via-agy` becomes `decision: required` with a question and two choices.

- `backfill: true` rather than bumping `added_in`. Backfill entries are offered once regardless of the watermark, so existing users get asked without the manifest claiming a false introduction version. Verified this cannot re-offer after any answer, including `0`: the sticky branch blocks it and there is no `reoffer_at`.
- `prereq` moves `agy-cli` → `gemini-cli`. Gating on agy hid the question from exactly the population stuck on the broken path. The cost is that someone can pick "through Antigravity" without agy installed; that fails loudly at dispatch rather than silently, which beats un-honouring a recorded answer.
- `default` stays `0`. Defaulting to `1` would silently move spend to another vendor and break agy-less headless runs. Anyone who never answers keeps Google's failure, not a new one.

**The consent actually reaching dispatch.** The three sites read `${OCTOPUS_GEMINI_VIA_AGY:-0}` directly, so a recorded answer would have been recorded and then ignored — the question asked, and nothing changed. They now route through a single accessor, `octo_gemini_via_agy_active`.

**Env normalisation lives in the accessor, not in `octo_features_choice`.** That function only forwards an env value when it is a *declared choice*, and this feature's choices are the literal `1` and `0`. The naive ledger-first form measurably regressed already-migrated users:

```
before fix:  =1 ACTIVE   =true inactive  =on inactive  =yes inactive
after fix:   =1 ACTIVE   =true ACTIVE    =on ACTIVE    =yes ACTIVE
             ledger=1 + =false/off/no  ->  override honoured (was ignored)
```

Normalising locally keeps the documented aliases working in both directions without changing choice semantics for every other feature.

## Tests

`tests/unit/test-gemini-via-agy-consent.sh` (15 cases) executes the real resolution path, sourcing in `orchestrate.sh`'s order: recorded answers reach dispatch, env overrides win both ways, documented aliases work, the question is emitted for a gemini-only user with **no agy on PATH** (asserted, with a precondition guard), and answering makes it sticky.

The pre-existing coverage in `test-agy-provider.sh` greps the three sources for the literal string `OCTOPUS_GEMINI_VIA_AGY`. It stayed green (43/43) while I had the wiring deliberately broken, so it is not relied on here.

Mutation-checked:
- remove the env normalisation → **6 of 15 fail**
- revert `prereq` to `agy-cli` → the prompt-manifest case fails (`no question row for a gemini-only user`)

## Review

Reviewed by Claude Fable 5, which caught the env-alias regression before merge; I reproduced it independently before applying the fix. It also flagged the same defect pre-existing in `_octo_reviewer_flip_active` — confirmed, and filed as **#720** rather than folded in here, since that feature has a different choice vocabulary and this change should stay revertible on its own.

## Not fixed here

Detecting the sunset condition at preflight, so the seat never reaches the keychain even once for a user who declines the migration. That needs a probe that does not itself trigger the OAuth read. Worth its own issue if the prompt persists for anyone who answers "keep the direct path".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a guided policy choice for routing Gemini through Antigravity or using a direct connection.
  - Existing users receive the choice through progressive disclosure.
  - Saved preferences now consistently control routing across health checks and dispatch.

- **Bug Fixes**
  - Improved handling of routing preferences, including common on/off value formats.
  - Gemini-only users now see the appropriate policy prompt.
  - Routing safely defaults to a direct connection when no valid preference is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->