### PR TITLE
docs: use the /octo: prefix for Octopus commands in user-facing examples

### DIFF
--- a/.claude/skills/skill-debate/SKILL.md
+++ b/.claude/skills/skill-debate/SKILL.md
@@ -100,30 +100,30 @@ Users can invoke the debate skill in natural language. You parse the intent and 
 
 ### Basic Invocation
 ```
-/debate <question or task>
+/octo:debate <question or task>
 ```
 
 ### With Flags
 ```
-/debate -r 3 -d thorough <question>
-/debate --rounds 2 --debate-style adversarial <question>
-/debate --path debates/009-new-topic <question>
+/octo:debate -r 3 -d thorough <question>
+/octo:debate --rounds 2 --debate-style adversarial <question>
+/octo:debate --path debates/009-new-topic <question>
 ```
 
 ### With File References
 Users can mention files naturally - you resolve them to full paths:
 ```
-/debate Is our CLAUDE.md accurate?
+/octo:debate Is our CLAUDE.md accurate?
 -> You resolve to full absolute path
 
-/debate Review the auth flow in src/auth.ts
+/octo:debate Review the auth flow in src/auth.ts
 -> You find src/auth.ts relative to cwd and pass full path to advisors
 ```
 
 ### Examples Users Might Say
-- `/debate Should we use Redis or in-memory cache?`
-- `/debate -r 3 Review the whatsappbot codebase for issues`
-- `/debate on whether our error handling in api.ts is sufficient`
+- `/octo:debate Should we use Redis or in-memory cache?`
+- `/octo:debate -r 3 Review the whatsappbot codebase for issues`
+- `/octo:debate on whether our error handling in api.ts is sufficient`
 - `Run a debate about the database schema design`
 - `I want gemini and codex to review this PR`
 
@@ -268,7 +268,7 @@ Export debates to professional formats via the document-delivery skill:
 
 ## Implementation Steps
 
-When the user invokes `/debate`:
+When the user invokes `/octo:debate`:
 
 ### Step 1: Check Provider Availability & Display Banner
 
@@ -605,7 +605,7 @@ IMPORTANT: The deliverable is a PROPOSAL. Never auto-apply changes without user 
 
 ### Example 1: Quick Debate
 ```
-User: /debate Should we use Redis or in-memory cache?
+User: /octo:debate Should we use Redis or in-memory cache?
 
 Claude:
 1. Creates debate folder at ~/.claude-octopus/debates/${SESSION_ID}/042-redis-vs-memcached/
@@ -621,7 +621,7 @@ Claude:
 
 ### Example 2: Thorough Adversarial Debate
 ```
-User: /debate -r 3 -d adversarial Review our authentication implementation in src/auth.ts
+User: /octo:debate -r 3 -d adversarial Review our authentication implementation in src/auth.ts
 
 Claude:
 1. Reads src/auth.ts to understand context
@@ -668,7 +668,7 @@ After debate completes:
 ### Knowledge Mode
 Debates can be used in knowledge mode workflows:
 ```
-Knowledge mode "deliberate" phase → Run /debate to get multiple perspectives
+Knowledge mode "deliberate" phase → Run /octo:debate to get multiple perspectives
 → Use synthesis for final decision
 ```
 
@@ -713,4 +713,4 @@ After debate completes, export results via document-delivery skill:
 
 ---
 
-**Ready to debate!** Users can invoke with `/debate <question>` or natural language.
+**Ready to debate!** Users can invoke with `/octo:debate <question>` or natural language.

--- a/.claude/skills/skill-parallel-agents/SKILL.md
+++ b/.claude/skills/skill-parallel-agents/SKILL.md
@@ -132,7 +132,7 @@ Claude Octopus uses **visual indicators** so you always know which AI is respond
 
 **External CLIs execute when:**
 - Using `/parallel-agents` command explicitly
-- Using `/debate` command (AI Debate Hub)
+- Using `/octo:debate` command (AI Debate Hub)
 - Running orchestrate.sh workflows (probe, grasp, tangle, ink, embrace, grapple, squeeze)
 - Knowledge mode deliberation (when Knowledge Mode is ON)
 - Natural language that triggers this skill (research, build, review tasks)

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -106,7 +106,7 @@ This file enables product-aware council reviews:
 
 - **`/pre-mortem`** — Automatically includes `product` perspectives (user-value, adoption-barriers, competitive-position) alongside plan-review judges when this file exists.
 - **`/vibe`** — Automatically includes `developer-experience` perspectives (api-clarity, error-experience, discoverability) alongside code-review judges when this file exists.
-- **`/council --preset=product`** — Run product review on demand.
-- **`/council --preset=developer-experience`** — Run DX review on demand.
+- **`/octo:council --preset=product`** — Run product review on demand.
+- **`/octo:council --preset=developer-experience`** — Run DX review on demand.
 
 Explicit `--preset` overrides from the user skip auto-include (user intent takes precedence).

--- a/skills/skill-debate/SKILL.md
+++ b/skills/skill-debate/SKILL.md
@@ -80,30 +80,30 @@ Users can invoke the debate skill in natural language. You parse the intent and 
 
 ### Basic Invocation
 ```
-/debate <question or task>
+/octo:debate <question or task>
 ```
 
 ### With Flags
 ```
-/debate -r 3 -d thorough <question>
-/debate --rounds 2 --debate-style adversarial <question>
-/debate --path debates/009-new-topic <question>
+/octo:debate -r 3 -d thorough <question>
+/octo:debate --rounds 2 --debate-style adversarial <question>
+/octo:debate --path debates/009-new-topic <question>
 ```
 
 ### With File References
 Users can mention files naturally - you resolve them to full paths:
 ```
-/debate Is our CLAUDE.md accurate?
+/octo:debate Is our CLAUDE.md accurate?
 -> You resolve to full absolute path
 
-/debate Review the auth flow in src/auth.ts
+/octo:debate Review the auth flow in src/auth.ts
 -> You find src/auth.ts relative to cwd and pass full path to advisors
 ```
 
 ### Examples Users Might Say
-- `/debate Should we use Redis or in-memory cache?`
-- `/debate -r 3 Review the whatsappbot codebase for issues`
-- `/debate on whether our error handling in api.ts is sufficient`
+- `/octo:debate Should we use Redis or in-memory cache?`
+- `/octo:debate -r 3 Review the whatsappbot codebase for issues`
+- `/octo:debate on whether our error handling in api.ts is sufficient`
 - `Run a debate about the database schema design`
 - `I want gemini and codex to review this PR`
 
@@ -244,7 +244,7 @@ Export debates to professional formats via the document-delivery skill:
 
 ## Implementation Steps
 
-When the user invokes `/debate`:
+When the user invokes `/octo:debate`:
 
 ### Step 1: Check Provider Availability & Display Banner
 
@@ -580,7 +580,7 @@ IMPORTANT: The deliverable is a PROPOSAL. Never auto-apply changes without user 
 
 ### Example 1: Quick Debate
 ```
-User: /debate Should we use Redis or in-memory cache?
+User: /octo:debate Should we use Redis or in-memory cache?
 
 Claude:
 1. Creates debate folder at ~/.claude-octopus/debates/${SESSION_ID}/042-redis-vs-memcached/
@@ -596,7 +596,7 @@ Claude:
 
 ### Example 2: Thorough Adversarial Debate
 ```
-User: /debate -r 3 -d adversarial Review our authentication implementation in src/auth.ts
+User: /octo:debate -r 3 -d adversarial Review our authentication implementation in src/auth.ts
 
 Claude:
 1. Reads src/auth.ts to understand context
@@ -641,7 +641,7 @@ After debate completes:
 ### Knowledge Mode
 Debates can be used in knowledge mode workflows:
 ```
-Knowledge mode "deliberate" phase → Run /debate to get multiple perspectives
+Knowledge mode "deliberate" phase → Run /octo:debate to get multiple perspectives
 → Use synthesis for final decision
 ```
 
@@ -684,4 +684,4 @@ After debate completes, export results via document-delivery skill:
 - **Enhancements**: Claude-Octopus integration (session-aware storage, quality gates, cost tracking, document export, provider debate with Sonnet)
 
 
-**Ready to debate!** Users can invoke with `/debate <question>` or natural language.
+**Ready to debate!** Users can invoke with `/octo:debate <question>` or natural language.

--- a/skills/skill-parallel-agents/SKILL.md
+++ b/skills/skill-parallel-agents/SKILL.md
@@ -109,7 +109,7 @@ Claude Octopus uses **visual indicators** so you always know which AI is respond
 
 **External CLIs execute when:**
 - Using `/parallel-agents` command explicitly
-- Using `/debate` command (AI Debate Hub)
+- Using `/octo:debate` command (AI Debate Hub)
 - Running orchestrate.sh workflows (probe, grasp, tangle, ink, embrace, grapple, squeeze)
 - Knowledge mode deliberation (when Knowledge Mode is ON)
 - Natural language that triggers this skill (research, build, review tasks)


### PR DESCRIPTION
Audit of every bare `/command` reference in markdown, prompted by a request to check the prefix is used consistently.

## The bug

`skill-debate/SKILL.md` documents its own invocation as bare `/debate` in 14 places — the usage synopsis, every worked example, the "When the user invokes" line, and the closing "Users can invoke with `/debate <question>`".

That command does not resolve. Commands declare a bare name in frontmatter (`command: debate`) and the plugin namespace supplies the prefix, so the real invocation is `/octo:debate`. Anyone following the debate skill's own documentation typed something that does not exist.

Same issue in `skill-parallel-agents` ("Using `/debate` command (AI Debate Hub)") and `PRODUCT.md` (`/council --preset=product`, `/council --preset=developer-experience`).

## Deliberately not changed

Most bare references in the repo are **correct** and prefixing them would be a regression. `/init`, `/review`, `/security-review`, `/usage`, `/debug` and `/plugin browse` are Claude Code's own commands, cited throughout precisely to contrast them with their `/octo:` counterparts under the repo's "Claude-native first, Octopus for escalation" policy:

> Use Claude-native `/init`, `/review`, and `/security-review` when Claude is enough. — `README.md:5`

> | Claude-native `/review` | Single-turn, current diff | Claude only | Ordinary review, one perspective suffices | — `commands/review.md:18`

Prefixing those inverts the meaning of the sentences they appear in. `skill-debug:313` even says "Run `/debug`: **This native command** generates a debug bundle".

I audited all 53 bare references across `README.md`, `PRODUCT.md`, `commands/`, `skills/`, `.claude/skills/` and `docs/`. The ones fixed here are the only incorrect ones.

## Scope note

The generated `skills/` copies are updated alongside their `.claude/skills/` sources, because `build-codex-skills.sh` is not run by `make sync` and both are tracked.

## Verification

- `make sync-check` clean — confirms the PRODUCT.md lines edited are hand-written prose, not a generated region
- `tests/smoke/test-debate-skill.sh` 10/10
- `test-workflow-meta-contracts` 5/5, `test-docs-sync` 136/136, `test-openclaw-compat` 32/32
- No double-prefixing introduced: the only `/octo:octo` hits in the repo are historical CHANGELOG entries about the former smart-router command name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated debate command references to use the `/octo:debate` namespace.
  * Updated council command examples to use the `/octo:council` namespace for product and developer-experience presets.
  * Revised usage instructions, examples, integrations, and completion guidance to reflect the updated commands.
  * Natural-language invocation of debate functionality remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->