### PR TITLE
fix: honour legacy truthy/falsy OCTOPUS_REVIEWER_FLIP values

### DIFF
--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -64,19 +64,22 @@ _BARE_OPT="${_BARE_OPT:-}"
 # vendor diversity instead of creating it.
 _octo_reviewer_flip_active() {
     command -v codex >/dev/null 2>&1 || return 1
+    # Legacy truthy/falsy values are normalized here, before consulting the
+    # features ledger: octo_features_choice only passes an env value through
+    # when it matches one of the feature's declared choices (claude|codex), so
+    # "1"/"on"/"true"/"yes" would otherwise be silently dropped and fall back
+    # to the ledger/default instead of meaning what they used to.
+    case "${OCTOPUS_REVIEWER_FLIP:-}" in
+        claude|1|on|true|yes) return 0 ;;
+        codex|0|off|false|no) return 1 ;;
+    esac
     local choice
     if declare -f octo_features_choice >/dev/null 2>&1; then
         choice="$(octo_features_choice "codex-reviewer-flip")"
     else
-        choice="${OCTOPUS_REVIEWER_FLIP:-codex}"
+        choice="codex"
     fi
-    # "claude" is the only value that moves review off the implementing vendor.
-    # Legacy truthy values are accepted so an existing OCTOPUS_REVIEWER_FLIP=1 in
-    # someone's profile keeps meaning what it used to.
-    case "$choice" in
-        claude|1|on|true|yes) return 0 ;;
-    esac
-    return 1
+    [[ "$choice" == "claude" ]]
 }
 
 get_role_mapping() {

--- a/tests/unit/test-fable5-escalation.sh
+++ b/tests/unit/test-fable5-escalation.sh
@@ -301,6 +301,30 @@ else
     test_fail "flip must not move implementation, got '$got'"
 fi
 
+# Regression for issue #720: octo_features_choice only passes an env value
+# through when it matches a declared choice (claude|codex), so legacy truthy
+# aliases must be normalized against the raw env var, not routed through it,
+# or they get silently dropped and the flip never fires on code-reviewer.
+for legacy in 1 on true yes; do
+    test_case "reviewer flip honours legacy truthy OCTOPUS_REVIEWER_FLIP=$legacy on code-reviewer"
+    got=$(PATH="$flip_bin:$PATH" OCTOPUS_REVIEWER_FLIP="$legacy" bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
+    if [[ "$got" == claude-opus:* ]]; then
+        test_pass
+    else
+        test_fail "legacy value '$legacy' should flip review to the Claude opus seat, got '$got'"
+    fi
+done
+
+for legacy in 0 off false no; do
+    test_case "reviewer flip honours legacy falsy OCTOPUS_REVIEWER_FLIP=$legacy on code-reviewer"
+    got=$(PATH="$flip_bin:$PATH" OCTOPUS_REVIEWER_FLIP="$legacy" bash -c "source '$FEATURES_LIB' 2>/dev/null; source '$AGENT_UTILS' 2>/dev/null; get_role_mapping code-reviewer")
+    if [[ "$got" == codex-review:* ]]; then
+        test_pass
+    else
+        test_fail "legacy value '$legacy' should leave review on Codex, got '$got'"
+    fi
+done
+
 # Without Codex the implementer already falls back off Codex, so flipping review
 # away from it would remove vendor diversity rather than create it.
 test_case "reviewer flip stays inert when the Codex CLI is absent"


### PR DESCRIPTION
## Root cause

`_octo_reviewer_flip_active` in `scripts/lib/agent-utils.sh:65-80` claims legacy truthy values (`1`/`on`/`true`/`yes`) are honoured for `OCTOPUS_REVIEWER_FLIP`, but they weren't, on the normal dispatch path (with `codex` on `PATH` and `features.sh` sourced, as `orchestrate.sh` does).

`octo_features_choice` (`scripts/lib/features.sh:220-235`) only passes an env value through when it matches one of the feature's *declared* choices. `codex-reviewer-flip` declares `claude`/`codex`, so `1`/`on`/`true`/`yes` aren't valid choices — they get silently dropped, and resolution falls through to the ledger/default (`codex`), leaving the flip inert.

## Fix

Normalize `OCTOPUS_REVIEWER_FLIP` against the legacy vocabulary *before* consulting `octo_features_choice`, rather than routing it through the ledger's choice validation — mirroring the approach the linked issue notes was used for `octo_gemini_via_agy_active` in #715.

## Test coverage gap

The existing test (`tests/unit/test-fable5-escalation.sh`) only exercised `OCTOPUS_REVIEWER_FLIP=1` against the `implementer` role, which is unaffected by the flip either way — so it passed vacuously while the actual `code-reviewer` case was broken. Added 8 regression cases exercising all four truthy and four falsy legacy aliases against `code-reviewer` specifically.

## Test results

```
tests/unit/test-fable5-escalation.sh: 34/34 passed (was 26/26 before this change; +8 new cases)
```

Full `make test-unit` run: 187/190 suites passed. The 3 pre-existing failures (`test-feature-disclosure.sh`, `test-github-work-queue-hook.sh`, `test-hud-smart-mode.sh`) reproduce identically on the unmodified branch and are unrelated to `agent-utils.sh` or the reviewer-flip feature — verified by stashing this change and re-running them.

Closes #720.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PCuB7u4yVV8AeT79vEUJbd)_