### PR TITLE
fix: stop churning derived test-suite counts in PRODUCT.md

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -77,7 +77,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 **Traction (as of 2026-07-27):**
 - GitHub stars: 3,889
 - GitHub forks: 365
-- Local CI parity: 16 smoke, 194 unit, and 7 integration suites
+- Local CI parity: smoke, unit, and integration suites covering install, commands, and provider wiring
 - Version: 9.57.0 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Gemini CLI
 

--- a/scripts/sync-readme.py
+++ b/scripts/sync-readme.py
@@ -144,12 +144,6 @@ def derive_facts(root: Path) -> dict[str, object]:
     command_count = len(plugin.get("commands", []))
     skill_count = len(plugin.get("skills", []))
     persona_count = len(list((root / "agents/personas").glob("*.md")))
-    test_suite_counts = {
-        category: len(list((root / "tests" / category).glob("test-*.sh")))
-        for category in ("smoke", "unit", "integration")
-    }
-    if not all(test_suite_counts.values()):
-        raise ValueError("unable to derive local CI suite counts")
 
     orchestrate = (root / "scripts/orchestrate.sh").read_text()
     providers = (root / "scripts/lib/providers.sh").read_text()
@@ -191,9 +185,6 @@ def derive_facts(root: Path) -> dict[str, object]:
         "command_count": command_count,
         "skill_count": skill_count,
         "persona_count": persona_count,
-        "smoke_suite_count": test_suite_counts["smoke"],
-        "unit_suite_count": test_suite_counts["unit"],
-        "integration_suite_count": test_suite_counts["integration"],
         "minimum_version": minimum_version,
         "capability_count": len(capability_flags),
         "capability_ceiling": capability_ceiling,
@@ -397,9 +388,6 @@ def sync_product(text: str, facts: dict[str, object]) -> str:
     ceiling = str(facts["capability_ceiling"])
     release_date = str(facts["release_date"])
     provider_count = int(facts["provider_count"])
-    smoke_suite_count = int(facts["smoke_suite_count"])
-    unit_suite_count = int(facts["unit_suite_count"])
-    integration_suite_count = int(facts["integration_suite_count"])
 
     text = re.sub(r"^last_reviewed: [0-9-]+$", f"last_reviewed: {release_date}", text, flags=re.MULTILINE)
     text = re.sub(
@@ -420,15 +408,6 @@ def sync_product(text: str, facts: dict[str, object]) -> str:
     text = re.sub(
         r"^- Version: [0-9]+\.[0-9]+\.[0-9]+ \(active release cadence\)$",
         f"- Version: {version} (active release cadence)",
-        text,
-        flags=re.MULTILINE,
-    )
-    text = re.sub(
-        r"^- Local CI parity: \d+ smoke, \d+ unit, and \d+ integration suites$",
-        (
-            f"- Local CI parity: {smoke_suite_count} smoke, "
-            f"{unit_suite_count} unit, and {integration_suite_count} integration suites"
-        ),
         text,
         flags=re.MULTILINE,
     )

--- a/tests/unit/test-readme-release-sync.sh
+++ b/tests/unit/test-readme-release-sync.sh
@@ -12,9 +12,6 @@ test_suite "README Release Sync"
 SYNC_SCRIPT="$PROJECT_ROOT/scripts/sync-readme.py"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-readme-sync-test.XXXXXX")"
 CURRENT_VERSION="$(jq -r '.version' "$PROJECT_ROOT/.claude-plugin/plugin.json")"
-SMOKE_SUITE_COUNT="$(find "$PROJECT_ROOT/tests/smoke" -maxdepth 1 -name 'test-*.sh' | wc -l | tr -d ' ')"
-UNIT_SUITE_COUNT="$(find "$PROJECT_ROOT/tests/unit" -maxdepth 1 -name 'test-*.sh' | wc -l | tr -d ' ')"
-INTEGRATION_SUITE_COUNT="$(find "$PROJECT_ROOT/tests/integration" -maxdepth 1 -name 'test-*.sh' | wc -l | tr -d ' ')"
 
 cleanup() {
     rm -rf "$TMP_DIR"
@@ -112,11 +109,6 @@ product_text = product_text.replace(
     "up to 10 external AI integrations",
     "up to 9 AI CLIs",
 )
-product_text = re.sub(
-    r"Local CI parity: \d+ smoke, \d+ unit, and \d+ integration suites",
-    "Local CI parity: 1 smoke, 1 unit, and 1 integration suites",
-    product_text,
-)
 product.write_text(product_text)
 PY
 
@@ -139,7 +131,6 @@ if "$SYNC_SCRIPT" --root "$fixture" >/tmp/octo-readme-sync-update.out 2>&1 &&
    grep -qE '[0-9]+ Claude Code capability flags through.*v[0-9]+\.[0-9]+\.[0-9]+' "$fixture/README.md" &&
    grep -q 'OpenCode CLI, and xAI API key (Grok)' "$fixture/.claude-plugin/README.md" &&
    grep -q 'up to 10 external AI integrations' "$fixture/PRODUCT.md" &&
-   grep -q "Local CI parity: ${SMOKE_SUITE_COUNT} smoke, ${UNIT_SUITE_COUNT} unit, and ${INTEGRATION_SUITE_COUNT} integration suites" "$fixture/PRODUCT.md" &&
    ! grep -qE 'Version-0\.0\.0-blue|stale release copy|v2\.1\.157' "$fixture/README.md"; then
     test_pass
 else


### PR DESCRIPTION
## Root cause

`scripts/sync-readme.py:147` globbed `tests/{smoke,unit,integration}/test-*.sh` and wrote the exact counts into a tracked line in `PRODUCT.md`:

```
- Local CI parity: 16 smoke, 194 unit, and 7 integration suites
```

`tests/unit/test-readme-release-sync.sh` then asserted the file matched. Since adding a single test file is a required edit to that one shared line, any two PRs that each added a test file collided on it — every time — and the conflict wasn't hand-resolvable: taking either side leaves a wrong number, and the only correct resolution is discarding both and re-running `make sync`, which isn't obvious from the conflict markers.

This isn't hypothetical: while rebasing this branch onto `main` (which had just picked up #726, itself adding a test file), I hit exactly this conflict on `PRODUCT.md` live.

## Fix

Per the issue author's own recommendation (option 1 of three offered — "stop storing the derived counts"):

- `scripts/sync-readme.py`: removed the `test_suite_counts` glob/derivation in `derive_facts()`, the `smoke_suite_count`/`unit_suite_count`/`integration_suite_count` facts, and the regex substitution that wrote them into `PRODUCT.md` in `sync_product()`.
- `PRODUCT.md`: replaced the numeric line with a stable phrase that carries the same information without needing regeneration: `Local CI parity: smoke, unit, and integration suites covering install, commands, and provider wiring`.
- `tests/unit/test-readme-release-sync.sh`: dropped the now-unused `SMOKE_SUITE_COUNT`/`UNIT_SUITE_COUNT`/`INTEGRATION_SUITE_COUNT` fixture vars, the stale-count mutation in the fixture-building script, and the assertion that checked the regenerated count string.

Scope was verified to be exactly these three files (`grep -rn "Local CI parity\|smoke_suite_count\|test_suite_counts"`), so nothing else depends on this fact.

## Verification

- Confirmed the fix actually closes the reported mechanism: added a scratch test file, ran `sync-readme.py --check` (passes) and `git diff --stat PRODUCT.md` (empty) — adding a test file no longer touches `PRODUCT.md`.
- `python3 -c "import ast; ast.parse(...)"` on `sync-readme.py` and `bash -n` on the shell test — both clean.
- `bash tests/unit/test-readme-release-sync.sh`: 8/8 passed.
- `make test-unit`: 191/194 suites passed. The 3 failures (`test-feature-disclosure.sh`, `test-github-work-queue-hook.sh`, `test-hud-smart-mode.sh`) are pre-existing — verified identical on unmodified `main` via `git stash` before re-running them.
- No file-mode changes (`git diff origin/main...HEAD --summary` is empty).

Closes #729.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L34WZnWDW3oaABjX3Md8zF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product documentation to describe local CI coverage by test-suite category instead of exact test counts.
  * Simplified README synchronization so release, provider, capability, and model information remains updated without suite-count details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->