### PR TITLE
release: v9.57.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.57.0 - Command Code provider, selective Fable 5 escalation, and progressive feature disclosure. 32 personas, 50 commands, 63 skills. Run /octo:setup.",
-      "version": "9.57.0",
+      "description": "v9.57.1 - Command Code provider, selective Fable 5 escalation, and progressive feature disclosure. 32 personas, 50 commands, 63 skills. Run /octo:setup.",
+      "version": "9.57.1",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.57.0",
-  "description": "v9.57.0 \u2014 Command Code provider, selective Fable 5 escalation, and progressive feature disclosure. Run /octo:setup.",
+  "version": "9.57.1",
+  "description": "v9.57.1 \u2014 Command Code provider, selective Fable 5 escalation, and progressive feature disclosure. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.57.0",
+  "version": "9.57.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.57.0",
+  "version": "9.57.1",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.57.0"
+    "version": "9.57.1"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.57.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 50 commands, 58 skills. Run /octo:setup after install.",
-      "version": "9.57.0",
+      "description": "v9.57.1 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 50 commands, 58 skills. Run /octo:setup after install.",
+      "version": "9.57.1",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.57.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.57.0. 32 expert personas, 50 commands, 58 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.57.1",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.57.1. 32 expert personas, 50 commands, 58 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+## [9.57.1] - 2026-08-02
+
+### Fixed
+
+- **Legacy `OCTOPUS_REVIEWER_FLIP` truthy/falsy values (`1`/`on`/`true`/`yes`/`0`/`off`/`false`/`no`) were silently dropped on the normal dispatch path.** `_octo_reviewer_flip_active()` deferred to `octo_features_choice()`, which only passes an env value through when it matches a declared choice (`claude`/`codex`) — so any legacy value fell back to the `codex` default instead of honoring the documented aliases. The legacy values are now normalized locally before the feature-choice ledger is consulted. (#720)
+- **`gemini-via-agy`, the migration path off the sunset Gemini Code Assist free-tier OAuth, shipped silently disabled and was never offered**, leaving affected users stuck on a dispatch path that can only fail. The feature is now `decision: required`, prompting once so users can route gemini seats through Antigravity or opt out explicitly. (#715)
+- **`OCTOPUS_COMMANDCODE_PERMISSION_MODE` had no effect on the dispatch path**, unlike the equivalent Codex sandbox override — the role-derived default always won regardless of the env var. (#710)
+- Design review seats were labeled by role instead of runtime identity.
+- Tests resolved `PROJECT_ROOT` without `cd -P`, diverging from how `features.sh` resolves it on symlinked checkouts. (#712)
+- `WORKSPACE_DIR` was not forwarded into isolated provider environments, hiding dead-marks from providers that needed to see them.
+- The human-only skill list no longer matched what skills actually declare.
+
+### Added
+
+- **Agent topology audit skill, and agency allocation in the intent contract** — classify a task for organisation-form and human/AI agency tradeoffs before a workflow is chosen. (#699, #700)
+- Four workflow skills adapted from mattpocock/skills.
+
+### Documentation
+
+- User-facing command examples now consistently use the `/octo:` prefix.
+- Cross-harness handoff doc updated to the v9.57.0 baseline.
+
 ## [9.57.0] - 2026-08-02
 
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -78,7 +78,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 - GitHub stars: 3,889
 - GitHub forks: 365
 - Local CI parity: 16 smoke, 196 unit, and 7 integration suites
-- Version: 9.57.0 (active release cadence)
+- Version: 9.57.1 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Gemini CLI
 
 **Measured Impact:**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 <p align="center">
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/Version-9.57.0-blue" alt="Version 9.57.0">
+  <img src="https://img.shields.io/badge/Version-9.57.1-blue" alt="Version 9.57.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -35,7 +35,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 ## What's New
 
 <!-- BEGIN CURRENT RELEASE -->
-> 🆕 **v9.57.0 — Command Code provider, selective Fable 5 escalation, and progressive feature disclosure.**
+> 🆕 **v9.57.1 — Command Code provider, selective Fable 5 escalation, and progressive feature disclosure.**
 >
 > **Default roster:** Claude Opus 5 leads architecture, planning, security reasoning, and final judgment; GPT-5.6 Sol is the independent implementation/review peer; Claude Sonnet 5 is the standard Claude seat; Fable 5 remains an opt-in judgment escalation. Existing model pins and provider configuration still win. See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md).
 <!-- END CURRENT RELEASE -->
@@ -55,7 +55,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 
 | Version | Best Features |
 |---------|--------------|
-| **v9.57.0** (new) | Command Code provider, selective Fable 5 escalation, and progressive feature disclosure. |
+| **v9.57.1** (new) | Command Code provider, selective Fable 5 escalation, and progressive feature disclosure. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
 | **v9** (current) | Up to 10 external provider integrations (Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.57.0",
+  "version": "9.57.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Description
Patch release covering everything merged to `main` since v9.57.0, most notably #722 (the bug fix from this run's daily triage) plus several other merged fixes/features.

**Version bump:** `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (regenerated via `./scripts/sync-marketplace.sh`, never hand-edited), `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.factory-plugin/plugin.json`, `.factory-plugin/marketplace.json`, `README.md` (regenerated via `./scripts/sync-readme.py`), `PRODUCT.md` (same), `CHANGELOG.md`.

Note: several of the commits since v9.57.0 are `feat:` commits (#699/#700/#723 agent topology audit skill, #728 four workflow skills), which would normally call for a minor bump under semver. This release only advances the patch version per this routine's scope (`patch only — bumping minor or major requires a human`); a human should confirm whether a minor version is more appropriate before/after this merges.

## Type of Change
- [x] Other: release

## Checklist
- [x] `jq empty` on all seven manifest/marketplace JSON files — all valid
- [x] `python3 scripts/sync-readme.py --check` — synchronized (v9.57.1, 182 capabilities through v2.1.219)
- [x] `bash tests/unit/test-docs-sync.sh` — 141/141 pass
- [x] `make test-unit` — 194/196 suites pass; the 2 failures (`test-feature-disclosure.sh`, `test-hud-smart-mode.sh`) are pre-existing sandbox/environment-specific failures unrelated to this release (confirmed against unmodified `main` earlier in this session)
- [x] `make test-integration` — 7/7 suites pass
- [x] No file mode changes (`git diff --summary | grep "mode change"` empty)
- [x] CHANGELOG.md updated with a full `[9.57.1]` entry covering all 11 commits merged since v9.57.0

## Testing
```bash
jq empty package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json \
  .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/plugin.json \
  .factory-plugin/marketplace.json
python3 scripts/sync-readme.py --check
bash tests/unit/test-docs-sync.sh
make test-unit
make test-integration
```

## Related Issues
Includes #722 (closes #720)

Per the release workflow: **not merging this myself.** Leaving it for a human, or CI-gated auto-merge if branch policy allows it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TckwmjFnp2EbgFtRC6ZMpj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent-topology and agency-allocation capabilities.
  * Added four adapted workflow skills.
* **Bug Fixes**
  * Improved legacy reviewer-flip handling, Gemini migration availability, command permission overrides, runtime identity labels, symlink-aware test paths, workspace propagation, and human-only skill list accuracy.
* **Documentation**
  * Updated guidance for command prefixes and cross-harness handoff.
* **Chores**
  * Released version 9.57.1 across supported integrations and updated product documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->