### PR TITLE
feat: support literal provider-model routing objects

### DIFF
--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -250,6 +250,55 @@ resolve_octopus_model() {
         fi
 
         # 2. Role/Phase Routing
+        # Object routes are literal, explicit provider/model selections. Unlike
+        # legacy string routes (for example "codex:spark"), their model field
+        # must not be reinterpreted as a capability alias. This makes one
+        # providers.json entry sufficient for provider + exact model routing.
+        if [[ -z "$resolved_model" || "$resolved_model" == "null" ]]; then
+            local role_route_json=""
+            local phase_route_json=""
+            local role_route_type=""
+            local role_route_provider=""
+            local role_route_model=""
+            local phase_route_provider=""
+            local phase_route_model=""
+            local role_route_blocks_phase="false"
+
+            if [[ -n "$role" ]]; then
+                role_route_json=$(echo "$config_data" | jq -c --arg role "$role" '.routing.roles[$role] // empty' 2>/dev/null)
+                if [[ -n "$role_route_json" && "$role_route_json" != "null" ]]; then
+                    role_route_type=$(echo "$role_route_json" | jq -r 'type' 2>/dev/null)
+                    if [[ "$role_route_type" == "object" ]]; then
+                        role_route_provider=$(echo "$role_route_json" | jq -r '.provider // empty' 2>/dev/null)
+                        role_route_model=$(echo "$role_route_json" | jq -r '.model // empty' 2>/dev/null)
+                        if [[ -z "$role_route_provider" || "$role_route_provider" == "$canonical_provider" ]]; then
+                            role_route_blocks_phase="true"
+                            if [[ -n "$role_route_model" ]]; then
+                                resolved_model="$role_route_model"
+                                [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (literal role route): $resolved_model ← SELECTED" >&2
+                            fi
+                        fi
+                    else
+                        # Legacy string routes retain their existing alias/provider semantics.
+                        role_route_blocks_phase="true"
+                    fi
+                fi
+            fi
+
+            if [[ ( -z "$resolved_model" || "$resolved_model" == "null" ) && "$role_route_blocks_phase" != "true" && -n "$phase" ]]; then
+                phase_route_json=$(echo "$config_data" | jq -c --arg phase "$phase" '.routing.phases[$phase] // empty' 2>/dev/null)
+                if [[ -n "$phase_route_json" && "$phase_route_json" != "null" ]] && [[ "$(echo "$phase_route_json" | jq -r 'type' 2>/dev/null)" == "object" ]]; then
+                    phase_route_provider=$(echo "$phase_route_json" | jq -r '.provider // empty' 2>/dev/null)
+                    phase_route_model=$(echo "$phase_route_json" | jq -r '.model // empty' 2>/dev/null)
+                    if [[ ( -z "$phase_route_provider" || "$phase_route_provider" == "$canonical_provider" ) && -n "$phase_route_model" ]]; then
+                        resolved_model="$phase_route_model"
+                        [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (literal phase route): $resolved_model ← SELECTED" >&2
+                    fi
+                fi
+            fi
+        fi
+
+        # Legacy string role/phase routes remain supported below.
         # Role routes are more specific than phase routes. In review fleets this
         # lets `logic-reviewer` use an independent model even when the broad
         # `review` phase route points at the default coding provider/model.

--- a/tests/test-resolve-model.sh
+++ b/tests/test-resolve-model.sh
@@ -116,6 +116,72 @@ cat > "$CONFIG_FILE" << EOF
 EOF
 assert_eq "$(resolve_octopus_model "codex" "codex" "deliver")" "deliver-model" "Phase routing"
 
+# Test 5b: Literal object role routing preserves exact provider model IDs
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": {
+    "commandcode": { "default": "deepseek/deepseek-v4-pro" }
+  },
+  "routing": {
+    "roles": {
+      "researcher": {
+        "provider": "commandcode",
+        "model": "minimaxai/minimax-m3"
+      }
+    }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "commandcode" "commandcode-research" "probe" "researcher")" "minimaxai/minimax-m3" "Literal object role routing"
+
+# Test 5c: Literal object phase routing preserves exact provider model IDs
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": {
+    "commandcode": { "default": "deepseek/deepseek-v4-pro" }
+  },
+  "routing": {
+    "phases": {
+      "research": {
+        "provider": "commandcode",
+        "model": "minimaxai/minimax-m3"
+      }
+    }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "commandcode" "commandcode-research" "research" "")" "minimaxai/minimax-m3" "Literal object phase routing"
+
+# Test 5d: Cross-provider literal role route does not leak its model
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": {
+    "commandcode": { "default": "deepseek/deepseek-v4-pro" }
+  },
+  "routing": {
+    "roles": {
+      "researcher": {
+        "provider": "claude",
+        "model": "claude-sonnet-4.6"
+      }
+    },
+    "phases": {
+      "research": {
+        "provider": "commandcode",
+        "model": "minimaxai/minimax-m3"
+      }
+    }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "commandcode" "commandcode-research" "research" "researcher")" "minimaxai/minimax-m3" "Cross-provider literal role falls through to matching phase"
+
 # Test 6: Recursive reference (codex:spark)
 clear_model_cache
 cat > "$CONFIG_FILE" << EOF

--- a/tests/unit/test-resolve-model.sh
+++ b/tests/unit/test-resolve-model.sh
@@ -5,10 +5,10 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-source "$SCRIPT_DIR/helpers/test-framework.sh"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "resolve_octopus_model (v3.0 refactor)"
 
-PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ORCHESTRATE_SH="${PLUGIN_DIR}/scripts/orchestrate.sh"
 
 


### PR DESCRIPTION
## Summary

- treat object-form `routing.roles` and `routing.phases` entries as literal provider/model selections
- preserve legacy string routing and capability aliases unchanged
- prevent exact model IDs such as `minimaxai/minimax-m3` from being reinterpreted as aliases
- preserve cross-provider fallthrough semantics

## Problem

A configuration like:

```json
{
  "routing": {
    "roles": {
      "researcher": {
        "provider": "commandcode",
        "model": "minimaxai/minimax-m3"
      }
    }
  }
}
```

was flattened to `commandcode:minimaxai/minimax-m3` and then recursively resolved as though `minimaxai/minimax-m3` were a capability alias. The resolver therefore fell back to the provider default instead of invoking the exact configured model.

This forced operators to maintain extra aliases only to express a literal provider/model pair.

## Behaviour after this change

Object routes are explicit and literal:

```json
{
  "provider": "commandcode",
  "model": "minimaxai/minimax-m3"
}
```

String routes such as `codex:spark` keep their existing recursive alias semantics for backward compatibility.

Role routes remain more specific than phase routes, and an object route targeting another provider still falls through to a matching phase route.

## Tests

- `tests/test-resolve-model.sh` — 17/17 assertions passed
- `tests/unit/test-orchestrate-cwd-routing.sh` — 15/15 passed
- `tests/unit/test-model-config-role-routing.sh` — 4/4 passed
- `tests/unit/test-runtime-provider-labels.sh` — 8/8 passed
- `make test-unit` — 196/196 suites passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for explicit provider and model selections in role- and phase-based routing.
  * Role-specific selections now take precedence over phase settings.
  * Provider-specific routes apply only when the requested provider matches.
  * Existing string-based routing remains supported.

* **Bug Fixes**
  * Improved fallback behavior when a role route targets a different provider.
  * Preserved explicitly configured models and prevented unintended model leakage during fallback.
  * Role routes without a model can now suppress phase-based lookup as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->