### PR TITLE
fix: guard Round 1 spawn failure from aborting code review

### DIFF
--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -982,8 +982,18 @@ CRITICAL OUTPUT FORMAT: Return ONLY a valid JSON object. No markdown, no prose, 
 ${agent_prompt_base}"
         round1_prompts+=("$agent_prompt")
 
-        local round1_pid
-        round1_pid=$(spawn_agent_capture_pid "$agent_type" "$agent_prompt" "$task_id" "$role" "review")
+        # A single provider failing PID capture (e.g. a huge diff pushes prompt
+        # summarization past the wait budget) must not abort the whole round via
+        # `set -e` — that skips every remaining fleet member and leaves
+        # state.json stuck at status "running" forever (#736). Treat it the same
+        # as any other Round 1 agent that produced no result file: the existing
+        # missing-result accounting below already counts it toward
+        # round1_partial_count / _r1_failed and drives octo_proof_finalize.
+        local round1_pid=""
+        if ! round1_pid=$(spawn_agent_capture_pid "$agent_type" "$agent_prompt" "$task_id" "$role" "review"); then
+            log WARN "review_run: spawn_agent_capture_pid failed for ${agent_type}/${role}; continuing Round 1 with remaining fleet"
+            round1_pid=""
+        fi
         round1_pids+=("$round1_pid")
     done <<< "$fleet"
 

--- a/tests/unit/test-review-round1-spawn-failure.sh
+++ b/tests/unit/test-review-round1-spawn-failure.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Regression for #736: on a large diff, prompt summarization for one Round 1
+# provider can outrun spawn_agent_capture_pid's PID-wait budget. Before this
+# fix, the resulting non-zero exit propagated through orchestrate.sh's
+# `set -eo pipefail`, killing review_run() mid-dispatch: no further Round 1
+# providers were spawned, and every downstream octo_proof_finalize call
+# (including the "all providers failed" path) was skipped — leaving
+# state.json stuck at status "running" forever.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "review_run Round 1 spawn failure resilience (#736)"
+
+REVIEW_SH="$PROJECT_ROOT/scripts/lib/review.sh"
+
+# ── static guard: the exact unguarded pattern that caused #736 must be gone ──
+
+test_case "round1 spawn call is guarded against a non-zero exit"
+if grep -q 'if ! round1_pid=\$(spawn_agent_capture_pid' "$REVIEW_SH"; then
+    test_pass
+else
+    test_fail "expected an 'if ! round1_pid=\$(spawn_agent_capture_pid ...)' guard in review.sh"
+fi
+
+test_case "no bare unguarded round1_pid assignment remains"
+# The old buggy shape: a plain assignment with no if/guard around it, which
+# aborts the whole function under `set -e` on any single provider failure.
+if grep -qE '^\s*round1_pid=\$\(spawn_agent_capture_pid' "$REVIEW_SH"; then
+    test_fail "found an unguarded 'round1_pid=\$(spawn_agent_capture_pid ...)' assignment"
+else
+    test_pass
+fi
+
+# ── behavioral: extract the real Round 1 dispatch loop and prove it survives
+# a mid-fleet spawn failure under `set -e`, exactly as orchestrate.sh runs it ──
+
+test_case "a single failed provider does not abort dispatch of the rest of the fleet"
+
+LOOP_SRC=$(sed -n '/^    fleet_dispatch_begin$/,/^    fleet_dispatch_end$/p' "$REVIEW_SH")
+if [[ -z "$LOOP_SRC" ]]; then
+    test_fail "could not extract the Round 1 dispatch loop from review.sh (source drift?)"
+else
+    TEST_TMP_DIR="/tmp/octopus-tests-$$"
+    mkdir -p "$TEST_TMP_DIR"
+    trap 'rm -rf "$TEST_TMP_DIR"' EXIT
+
+    HARNESS="$TEST_TMP_DIR/harness.sh"
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'set -eo pipefail'  # mirrors orchestrate.sh exactly
+        echo 'RESULTS_DIR="'"$TEST_TMP_DIR"'"'
+        echo 'timestamp="ts1"'
+        echo 'fleet="codex:reviewer1:logic
+gemini:reviewer2:style"'
+        echo 'round1_files=(); round1_agent_types=(); round1_roles=(); round1_task_ids=(); round1_prompts=(); round1_pids=()'
+        echo 'agent_prompt_base="base prompt"'
+        echo 'log() { :; }'
+        echo 'fleet_dispatch_begin() { :; }'
+        echo 'fleet_dispatch_end() { :; }'
+        # First fleet member fails PID capture (the #736 scenario); second succeeds.
+        echo 'spawn_agent_capture_pid() {'
+        echo '    if [[ "$1" == "codex" ]]; then'
+        echo '        echo "spawn_agent produced no provider PID" >&2'
+        echo '        return 1'
+        echo '    fi'
+        echo '    echo 424242'
+        echo '}'
+        echo 'run_round1() {'
+        printf '%s\n' "$LOOP_SRC"
+        echo '}'
+        echo 'run_round1'
+        echo 'printf "count=%d\n" "${#round1_pids[@]}"'
+        echo 'printf "pid0=%s\n" "${round1_pids[0]:-}"'
+        echo 'printf "pid1=%s\n" "${round1_pids[1]:-}"'
+    } > "$HARNESS"
+
+    if HARNESS_OUT=$(bash "$HARNESS" 2>&1); then
+        count=$(printf '%s\n' "$HARNESS_OUT" | grep -o 'count=[0-9]*' | cut -d= -f2)
+        pid0=$(printf '%s\n' "$HARNESS_OUT" | grep -o 'pid0=.*' | cut -d= -f2)
+        pid1=$(printf '%s\n' "$HARNESS_OUT" | grep -o 'pid1=.*' | cut -d= -f2)
+        if [[ "$count" == "2" && -z "$pid0" && "$pid1" == "424242" ]]; then
+            test_pass
+        else
+            test_fail "expected both fleet members dispatched (count=2, pid0=empty, pid1=424242); got: $HARNESS_OUT"
+        fi
+    else
+        test_fail "harness aborted under set -e instead of continuing past the failed provider: $HARNESS_OUT"
+    fi
+fi
+
+test_summary


### PR DESCRIPTION
## Description

`review_run()`'s Round 1 dispatch loop (`scripts/lib/review.sh`) assigned `spawn_agent_capture_pid`'s output directly:

```bash
round1_pid=$(spawn_agent_capture_pid "$agent_type" "$agent_prompt" "$task_id" "$role" "review")
round1_pids+=("$round1_pid")
```

`orchestrate.sh` runs under `set -eo pipefail`. When `spawn_agent_capture_pid` returns non-zero — e.g. because prompt summarization for a huge diff outran its PID-wait budget — that propagated straight through `set -e` and killed `review_run()` mid-loop. That produced every symptom in #736:

- Only the fleet member that failed ever got a chance to spawn; every later `while IFS=: read` iteration for the rest of the fleet was skipped because the function exited immediately.
- None of the downstream accounting (`round1_partial_count`, the "all providers failed" branch, `octo_proof_finalize`) ever ran, because it all lives *after* the loop that just aborted.
- `state.json` was left at `"status": "running"` / `"finished_at": null` forever, so the next invocation adopted the dead run's state (`SUCCESS: State file already exists and is valid`).

## Fix

Guard the assignment so one provider's spawn failure is treated the same as any other Round 1 agent that produced no result file — log a warning and continue dispatching the rest of the fleet:

```bash
local round1_pid=""
if ! round1_pid=$(spawn_agent_capture_pid "$agent_type" "$agent_prompt" "$task_id" "$role" "review"); then
    log WARN "review_run: spawn_agent_capture_pid failed for ${agent_type}/${role}; continuing Round 1 with remaining fleet"
    round1_pid=""
fi
round1_pids+=("$round1_pid")
```

No result file gets written for that slot, and review.sh's existing missing-result handling (`if [[ ! -f "$f" ]]`) already counts it toward `round1_partial_count` / the all-providers-failed check, which already drives `octo_proof_finalize`. So a total-fleet failure now correctly finalizes `state.json` instead of leaving it stuck at `"running"`, and a partial failure now correctly continues with whichever providers did succeed — using code paths that already existed for the "provider crashed" case, not new heuristics.

This is scoped to the two symptoms with a clean, low-risk fix: the loop aborting and `state.json` never finalizing. It does not attempt to retune the PID-wait timeout itself (root cause #2 in the issue — summarization time vs. wait budget) or add process-group-based cleanup for orphaned provider children (root cause #3) — both are more invasive changes that need validation against a real large-diff run with live providers, which isn't available in this environment. Filed as follow-up scope, not silently dropped.

## Testing

- `bash -n scripts/lib/review.sh` and all other shell scripts — syntax OK.
- New regression suite `tests/unit/test-review-round1-spawn-failure.sh`:
  - Static check that the guarded form is present and the old unguarded assignment is gone.
  - Behavioral test: extracts the real Round 1 dispatch loop verbatim via `sed` (same technique as `test-spawn-agent-capture-pid.sh`), runs it under `set -eo pipefail` with a mock `spawn_agent_capture_pid` that fails for the first fleet member and succeeds for the second — confirms both fleet members are dispatched and the harness doesn't abort.
  - Verified this test fails on the pre-fix code (`git stash` the fix, rerun) and passes after — confirms it's a real regression test, not a tautology.
- `bash tests/unit/test-review-run.sh`, `test-review-aggregation-robustness.sh`, `test-spawn-agent-capture-pid.sh` — all pass, no regressions.
- `make test-unit` (197 suites): 195/197 pass. The 2 failures (`test-feature-disclosure.sh`, `test-hud-smart-mode.sh`) are pre-existing on unmodified `main` — confirmed by stashing this change and rerunning them — and unrelated to `review.sh`/`spawn.sh`.

## Related Issues
Closes #736


---
_Generated by [Claude Code](https://claude.ai/code/session_01JmPZS9vE1BMP3cbzmihuC3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when an agent fails to start during the first review round.
  * Remaining agents now continue launching, while failed starts are recorded and reported appropriately.

* **Tests**
  * Added regression coverage to verify failed and successful agent launches are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->