### PR TITLE
fix: repair OpenRouter council seat (probe, wait, model resolution)

### DIFF
--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2392,6 +2392,16 @@ council_detect_providers() {
                         status="missing"
                     fi
                     ;;
+                openrouter)
+                    # API-key provider, not a CLI binary — no `openrouter` executable
+                    # ships with the plugin. Dispatch goes through the shell function
+                    # openrouter_execute, so probe the key instead of `command -v` (#738).
+                    if [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
+                        status="available"
+                    else
+                        status="missing"
+                    fi
+                    ;;
                 *)
                     cmd="$(council_provider_command "$provider")"
                     if command -v "$cmd" >/dev/null 2>&1; then

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -209,8 +209,11 @@ run_with_timeout() {
         fi
 
         # Stop the monitor and sweep any stragglers parented to the command.
+        # `wait` on a just-SIGTERMed monitor returns 143 — under `set -e` that would
+        # kill this function (and the seat's already-captured output with it) after
+        # the provider call succeeded. Same class as the subshell kill fixed in #336. (#738)
         kill "$monitor_pid" 2>/dev/null
-        wait "$monitor_pid" 2>/dev/null
+        wait "$monitor_pid" 2>/dev/null || true
         pkill -KILL -P "$cmd_pid" 2>/dev/null || true
     fi
 

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -209,10 +209,11 @@ run_with_timeout() {
         fi
 
         # Stop the monitor and sweep any stragglers parented to the command.
-        # `wait` on a just-SIGTERMed monitor returns 143 — under `set -e` that would
-        # kill this function (and the seat's already-captured output with it) after
-        # the provider call succeeded. Same class as the subshell kill fixed in #336. (#738)
-        kill "$monitor_pid" 2>/dev/null
+        # `kill`/`wait` on a monitor that already exited on its own (race with its
+        # sleep) return non-zero — under `set -e` that would kill this function (and
+        # the seat's already-captured output with it) after the provider call
+        # succeeded. Same class as the subshell kill fixed in #336. (#738)
+        kill "$monitor_pid" 2>/dev/null || true
         wait "$monitor_pid" 2>/dev/null || true
         pkill -KILL -P "$cmd_pid" 2>/dev/null || true
     fi

--- a/scripts/lib/perplexity.sh
+++ b/scripts/lib/perplexity.sh
@@ -157,8 +157,14 @@ openrouter_execute() {
     local complexity="${3:-2}"
     local output_file="${4:-}"
 
-    local model
-    model=$(get_openrouter_model "$task_type" "$complexity")
+    # Prefer the configured model (OCTOPUS_OPENROUTER_MODEL / providers.json) over
+    # the hardcoded task-type table, so the roster's advertised model actually runs
+    # instead of silently duplicating the Anthropic chair's lab (#738).
+    local model="${OCTOPUS_OPENROUTER_MODEL:-}"
+    if [[ -z "$model" ]] && declare -f resolve_octopus_model >/dev/null 2>&1; then
+        model="$(resolve_octopus_model openrouter openrouter "" "" 2>/dev/null || true)"
+    fi
+    [[ -z "$model" ]] && model=$(get_openrouter_model "$task_type" "$complexity")
 
     openrouter_execute_model "$model" "$prompt" "$task_type" "$complexity" "$output_file"
 }


### PR DESCRIPTION
## Description

`council` with a valid `OPENROUTER_API_KEY` never produced an OpenRouter seat. Three independent bugs in the council → OpenRouter path, all reported and pre-verified by the issue author:

1. **`council_detect_providers()`** (`scripts/lib/council.sh:2387-2404`) checked `command -v openrouter`, but the plugin ships no `openrouter` binary — dispatch goes through the shell function `openrouter_execute`. The seat was always reported `missing` regardless of the key. Fixed by adding an `openrouter)` case that probes `OPENROUTER_API_KEY` instead, mirroring the existing `openai-compatible` pattern.
2. **`run_with_timeout()`**'s in-process fallback (`scripts/lib/heartbeat.sh:212-214`, used for shell-function providers like `openrouter_execute`) ran `wait "$monitor_pid"` unguarded right after SIGTERMing that monitor. Under `set -eo pipefail` (`orchestrate.sh` line 6) the monitor's 143 exit code terminated the function — and the seat's already-captured output with it — *after* the provider call had succeeded. Same class of bug as the subshell kill fixed in #336. Fixed with `|| true`.
3. **`openrouter_execute()`** (`scripts/lib/perplexity.sh:149-164`) always resolved its model from the hardcoded task-type table via `get_openrouter_model`, ignoring `OCTOPUS_OPENROUTER_MODEL` / `providers.json`. The council roster advertised the configured model while the seat silently ran a different one. Fixed to prefer the env override, then `resolve_octopus_model`, falling back to the task-type table only if both are empty.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: directly affected suites (see Testing below)
- [ ] OpenClaw registry in sync — N/A, no tool/command surface changed
- [ ] New skills/commands registered — N/A
- [ ] Version bump — N/A, this is a fix PR; version bump happens in the release PR
- [ ] Documentation updated — N/A
- [ ] CHANGELOG.md updated — left for the release PR, per repo convention (see recent `fix:` commits on `main`, e.g. #722, #726, #721)

## Testing

```bash
bash -n scripts/lib/council.sh scripts/lib/heartbeat.sh scripts/lib/perplexity.sh
bash -n scripts/*.sh scripts/lib/*.sh

bash tests/unit/test-council-command.sh          # 67 passed
bash tests/unit/test-heartbeat-timeout.sh        # 12 passed
bash tests/unit/test-council-model-selection-fixes.sh  # 10 passed
bash tests/unit/test-qwen-council-provider.sh    # 6 passed
bash tests/unit/test-perplexity-issue-307.sh     # 6 passed
bash tests/unit/test-provider-health-probe.sh    # 12 passed
```

Also manually re-verified fix 1 by sourcing `council.sh` and calling `council_detect_providers` with `COUNCIL_PROVIDERS=openrouter`, toggling `OPENROUTER_API_KEY` — reports `available`/`missing` correctly.

`make test-unit` (full suite) was also run locally.

## Related Issues
Closes #738


---
_Generated by [Claude Code](https://claude.ai/code/session_01At8qoUSS8omaktiiou7wSA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenRouter availability detection when configured with an API key.
  - Fixed timeout handling to prevent interrupted monitoring from prematurely terminating operations.
  - Improved model selection by honoring explicit configuration and resolved model preferences before applying fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->