### PR TITLE
fix: preserve valid explicit new write scopes

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -979,10 +979,46 @@ ${resolved:-<none resolved>}
 EOF
 }
 
+tangle_scope_is_safe_relative_path() {
+    local scope="$1"
+    local normalized="${scope#./}"
+    normalized="${normalized%/}"
+
+    [[ -n "$normalized" ]] || return 1
+    case "$normalized" in
+        /*|.|..|.git|.git/*|*\\*|*'*'*|*'?'*|*'['*|*']'*) return 1 ;;
+    esac
+    case "/$normalized/" in
+        */../*|*/./*) return 1 ;;
+    esac
+    return 0
+}
+
+tangle_scope_has_existing_repo_ancestor() {
+    local repo_root="$1"
+    local normalized="$2"
+    local probe="$normalized"
+
+    while [[ "$probe" == */* ]]; do
+        probe="${probe%/*}"
+        [[ -n "$probe" ]] || break
+        if [[ -d "$repo_root/$probe" || -f "$repo_root/$probe" ]]; then
+            return 0
+        fi
+        if git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1; then
+            if [[ -n "$(git -C "$repo_root" ls-files "$probe/" 2>/dev/null || true)" ]]; then
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
 tangle_scope_is_known_or_explicit_new_file() {
     local scope="$1"
-    local normalized="${scope%/}"
-    [[ -z "$normalized" ]] && return 1
+    local normalized="${scope#./}"
+    normalized="${normalized%/}"
+    tangle_scope_is_safe_relative_path "$scope" || return 1
 
     local repo_root
     if ! repo_root=$(tangle_resolve_repo_root 2>/dev/null); then
@@ -992,32 +1028,22 @@ tangle_scope_is_known_or_explicit_new_file() {
             repo_root=$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || pwd)
         fi
     fi
+
     if git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1; then
         if git -C "$repo_root" ls-files --error-unmatch "$normalized" >/dev/null 2>&1; then
             return 0
         fi
-        local child_matches
-        child_matches=$(git -C "$repo_root" ls-files "$normalized/" 2>/dev/null || true)
-        if [[ -n "$child_matches" ]]; then
+        if [[ -n "$(git -C "$repo_root" ls-files "$normalized/" 2>/dev/null || true)" ]]; then
             return 0
         fi
     fi
 
     [[ -e "$repo_root/$normalized" ]] && return 0
 
-    if [[ "$scope" != */ && "${normalized##*/}" == *.* ]]; then
-        local parent="${normalized%/*}"
-        [[ "$parent" == "$normalized" ]] && return 0
-        [[ -d "$repo_root/$parent" ]] && return 0
-        if git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1; then
-            local parent_matches
-            parent_matches=$(git -C "$repo_root" ls-files "$parent/" 2>/dev/null || true)
-            if [[ -n "$parent_matches" ]]; then
-                return 0
-            fi
-        fi
-    fi
-    return 1
+    # Explicit new files or directories are valid when anchored below an
+    # existing repository path. Preserve the declared scope instead of
+    # replacing it with heuristic context-file inference.
+    tangle_scope_has_existing_repo_ancestor "$repo_root" "$normalized"
 }
 
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -984,9 +984,22 @@ tangle_scope_is_safe_relative_path() {
     local normalized="${scope#./}"
     normalized="${normalized%/}"
 
-    [[ -n "$normalized" ]] || return 1
+    # Reject scopes that are empty once trimmed, not merely empty: a
+    # whitespace-only scope is non-empty here but names nothing.
+    [[ -n "${normalized//[[:space:]]/}" ]] || return 1
     case "$normalized" in
-        /*|.|..|.git|.git/*|*\\*|*'*'*|*'?'*|*'['*|*']'*) return 1 ;;
+        /*|.|..|*\\*|*'*'*|*'?'*|*'['*|*']'*) return 1 ;;
+    esac
+    # Compare the .git check case-insensitively. macOS APFS/HFS+ is
+    # case-insensitive by default and is this project's primary platform, so a
+    # literal `.git` match let `.GIT/hooks/pre-commit` through — which resolves
+    # to the real hook and is arbitrary code execution on the next commit.
+    # Verified in a scratch repo: `mkdir -p .GIT/hooks && echo x > .GIT/hooks/p`
+    # creates `.git/hooks/p`.
+    local lower
+    lower=$(printf '%s' "$normalized" | tr '[:upper:]' '[:lower:]')
+    case "$lower" in
+        .git|.git/*) return 1 ;;
     esac
     case "/$normalized/" in
         */../*|*/./*) return 1 ;;

--- a/tests/unit/test-tangle-explicit-new-scopes.sh
+++ b/tests/unit/test-tangle-explicit-new-scopes.sh
@@ -43,6 +43,26 @@ if tangle_scope_is_known_or_explicit_new_file "/tmp/outside.js"; then test_fail 
 test_case "rejects glob scope"
 if tangle_scope_is_known_or_explicit_new_file "apps/server/src/**"; then test_fail "glob accepted"; else test_pass; fi
 
+# macOS APFS/HFS+ is case-insensitive by default and is this project's primary
+# platform, so a literal `.git` match let these through — and `.GIT/hooks/*`
+# resolves to the real hook directory, making it arbitrary code execution on the
+# next commit. A guard whose suite never tries a case variant passes while the
+# hole is open, which is what happened here.
+test_case "rejects .git"
+if tangle_scope_is_known_or_explicit_new_file ".git/config"; then test_fail ".git accepted"; else test_pass; fi
+
+for variant in ".GIT/config" ".Git/hooks/pre-commit" ".gIt/HOOKS/pre-commit"; do
+    test_case "rejects case variant $variant"
+    if tangle_scope_is_known_or_explicit_new_file "$variant"; then
+        test_fail "$variant accepted — resolves into .git on a case-insensitive filesystem"
+    else
+        test_pass
+    fi
+done
+
+test_case "rejects a whitespace-only scope"
+if tangle_scope_is_known_or_explicit_new_file "  "; then test_fail "whitespace-only scope accepted"; else test_pass; fi
+
 test_case "explicit new scope does not fall back to README heuristic"
 subtasks='1. [CODING] Docs — Files: README.md — Task: Update documentation and acceptance notes.
 2. [CODING] Development scope — Files: apps/server/src/development-scope/ — Task: Implement a new development-only server module and tests.'

--- a/tests/unit/test-tangle-explicit-new-scopes.sh
+++ b/tests/unit/test-tangle-explicit-new-scopes.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT_REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+source "$PROJECT_ROOT_REPO/scripts/lib/workflows.sh"
+
+test_suite "tangle explicit new scope preservation"
+
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+mkdir -p "$fixture/apps/server/src" "$fixture/apps/web/src"
+printf 'root\n' > "$fixture/README.md"
+printf '{}\n' > "$fixture/package.json"
+printf 'server\n' > "$fixture/apps/server/src/index.js"
+printf 'web\n' > "$fixture/apps/web/src/main.jsx"
+git -C "$fixture" init -q
+git -C "$fixture" config user.email test@example.com
+git -C "$fixture" config user.name Test
+git -C "$fixture" add .
+git -C "$fixture" commit -qm init
+export PROJECT_ROOT="$fixture"
+
+test_case "preserves existing tracked file"
+if tangle_scope_is_known_or_explicit_new_file "README.md"; then test_pass; else test_fail "tracked file rejected"; fi
+
+test_case "preserves invented development directory under existing ancestor"
+if tangle_scope_is_known_or_explicit_new_file "apps/server/src/development-scope/"; then test_pass; else test_fail "new anchored directory rejected"; fi
+
+test_case "preserves invented new file under existing ancestor"
+if tangle_scope_is_known_or_explicit_new_file "apps/server/src/development-scope/handler.js"; then test_pass; else test_fail "new anchored file rejected"; fi
+
+test_case "rejects unanchored top-level invented tree"
+if tangle_scope_is_known_or_explicit_new_file "totally-invented-tree/deep/file.js"; then test_fail "unanchored tree accepted"; else test_pass; fi
+
+test_case "rejects traversal"
+if tangle_scope_is_known_or_explicit_new_file "apps/server/../../outside.js"; then test_fail "traversal accepted"; else test_pass; fi
+
+test_case "rejects absolute path"
+if tangle_scope_is_known_or_explicit_new_file "/tmp/outside.js"; then test_fail "absolute path accepted"; else test_pass; fi
+
+test_case "rejects glob scope"
+if tangle_scope_is_known_or_explicit_new_file "apps/server/src/**"; then test_fail "glob accepted"; else test_pass; fi
+
+test_case "explicit new scope does not fall back to README heuristic"
+subtasks='1. [CODING] Docs — Files: README.md — Task: Update documentation and acceptance notes.
+2. [CODING] Development scope — Files: apps/server/src/development-scope/ — Task: Implement a new development-only server module and tests.'
+if tangle_validate_parallel_write_scopes "$subtasks"; then
+    test_pass
+else
+    test_fail "valid new scope falsely overlapped README.md"
+fi
+
+test_case "new parent and child scopes still overlap"
+subtasks='1. [CODING] Parent — Files: apps/server/src/development-scope/ — Task: Implement parent module.
+2. [CODING] Child — Files: apps/server/src/development-scope/child.js — Task: Implement child module.'
+if reason=$(tangle_validate_parallel_write_scopes "$subtasks"); then
+    test_fail "parent/child overlap was accepted"
+elif [[ "$reason" == *"overlaps"* ]]; then
+    test_pass
+else
+    test_fail "unexpected overlap reason: $reason"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

- preserve explicit new file and directory scopes when they are safely anchored under an existing repository path
- avoid replacing valid declared scopes with heuristic context-file inference
- reject unsafe absolute, traversal, glob, `.git`, and unanchored invented paths
- retain parent/child overlap detection for newly declared scopes

## Problem

Tangle decomposition can legitimately assign work to files or directories that do not exist yet, for example:

```text
Files: apps/server/src/development-scope/
```

When the declared path was new, the scope resolver could discard it and infer an unrelated existing file from the task prose, such as `README.md`. That created false overlap failures even though the planner had produced disjoint explicit scopes.

Observed failure mode:

```text
apps/server/src/domain/
→ heuristic context inference
→ README.md
→ false overlap with the documentation task
```

## Behaviour after this change

An explicit new scope is preserved when it:

- is repository-relative
- has no traversal, globbing, backslash, or absolute prefix
- does not target `.git`
- is anchored below an existing tracked or on-disk repository path

Examples:

```text
apps/server/src/development-scope/            accepted
apps/server/src/development-scope/handler.js accepted
totally-invented-tree/deep/file.js            rejected
apps/server/../../outside.js                  rejected
/tmp/outside.js                               rejected
apps/server/src/**                            rejected
```

New parent/child scopes are still treated as overlapping.

## Validation

Focused regression suites:

- `tests/unit/test-tangle-explicit-new-scopes.sh` — 9/9 passed
- `tests/unit/test-tangle-write-scope-safety.sh` — 12/12 passed

The focused tests include an invented development scope under an existing repository tree and verify that it is not rewritten to `README.md`.

Full unit suite:

- `make test-unit` — 197/197 suites passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for relative write paths, including normalization and stricter safety checks.
  * Added support for explicitly creating new files and directories beneath existing repository paths.
  * Rejected unsafe paths, including absolute paths, traversal attempts, unsupported globs, backslashes, and `.git` paths.
  * Improved detection of overlapping and unrelated scopes during parallel operations.

* **Tests**
  * Added coverage for tracked paths, valid repository-anchored paths, invalid paths, and scope overlap scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->