### PR TITLE
test: regression coverage for the #738 OpenRouter council seat fixes

### DIFF
--- a/tests/unit/test-issue-738-openrouter-council-seat.sh
+++ b/tests/unit/test-issue-738-openrouter-council-seat.sh
@@ -23,7 +23,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Issue #738: OpenRouter council seat (probe, wait, model resolution)"
 
-TEST_TMP_DIR="/tmp/octopus-tests-738-$$"
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
 trap 'rm -rf "$TEST_TMP_DIR"' EXIT
 mkdir -p "$TEST_TMP_DIR"
 
@@ -144,7 +144,7 @@ run_openrouter_execute() {
             *resolver*) resolve_octopus_model() { echo "resolver-model"; } ;;
         esac
         case "$1" in
-            *env*) export OCTOPUS_OPENROUTER_MODEL="env-pinned-model" ;;
+            *env*) export "OCTOPUS_OPENROUTER_MODEL=env-pinned-model" ;;
         esac
         # get_openrouter_model lives in providers.sh (not sourced here); stub it
         # to isolate this test to openrouter_execute'"'"'s own fallback ordering.

--- a/tests/unit/test-issue-738-openrouter-council-seat.sh
+++ b/tests/unit/test-issue-738-openrouter-council-seat.sh
@@ -35,6 +35,11 @@ mkdir -p "$TEST_TMP_DIR"
 # ═══════════════════════════════════════════════════════════════════════════
 
 test_case "kill/wait on an already-reaped monitor does not abort under set -e"
+# Illustrative repro of the underlying bash behavior (the maintainer's own
+# reproduction from the #739 review, lifted verbatim) — it carries its own
+# || true guards, so it passes on both sides of the fix and is not itself a
+# heartbeat.sh regression detector. The next test (source-anchored) is: it is
+# verified to fail against the pre-#739 heartbeat.sh and pass against the fix.
 out=$(bash -c '
     set -eo pipefail
     ( sleep 0.05 ) &
@@ -85,17 +90,21 @@ load_council_lib() {
     source "$lib"
 }
 
-# Confirms the test proves what it claims: no `openrouter` binary is
-# reachable from this shell's PATH while these assertions run.
-if command -v openrouter >/dev/null 2>&1; then
-    test_fail "an 'openrouter' binary is on PATH — this test cannot prove key-only detection"
-fi
+# Restrict PATH to a directory holding only what these two assertions need
+# (jq; bash builtins need no PATH entry at all), so a real `openrouter`
+# executable on the host/CI machine's PATH can never make this test prove
+# less than it claims.
+JQ_BIN="$(command -v jq)"
+NO_OPENROUTER_BIN_DIR="$TEST_TMP_DIR/no-openrouter-bin"
+mkdir -p "$NO_OPENROUTER_BIN_DIR"
+ln -sf "$JQ_BIN" "$NO_OPENROUTER_BIN_DIR/jq"
 
 test_case "council_detect_providers reports openrouter available on OPENROUTER_API_KEY alone (no binary on PATH)"
 load_council_lib || true
 (
+    export PATH="$NO_OPENROUTER_BIN_DIR"
     unset OCTOPUS_COUNCIL_PROVIDER_FIXTURE
-    export OPENROUTER_API_KEY="test-key-not-real"
+    export "OPENROUTER_API_KEY=test-key-not-real"
     COUNCIL_PROVIDERS="openrouter"
     council_detect_providers
     status="$(jq -r '.openrouter // "missing"' <<< "$COUNCIL_PROVIDER_STATUS_JSON")"
@@ -104,6 +113,7 @@ load_council_lib || true
 
 test_case "council_detect_providers reports openrouter missing when OPENROUTER_API_KEY is unset"
 (
+    export PATH="$NO_OPENROUTER_BIN_DIR"
     unset OCTOPUS_COUNCIL_PROVIDER_FIXTURE
     unset OPENROUTER_API_KEY 2>/dev/null || true
     COUNCIL_PROVIDERS="openrouter"
@@ -125,6 +135,10 @@ run_openrouter_execute() {
     bash -c '
         log() { :; }
         source "'"$PROJECT_ROOT"'/scripts/lib/perplexity.sh" 2>/dev/null
+        # Each scenario must validate its own precedence branch, not whatever
+        # this process happened to inherit from the ambient environment.
+        unset OCTOPUS_OPENROUTER_MODEL
+        unset -f resolve_octopus_model 2>/dev/null || true
         openrouter_execute_model() { printf "%s\n" "$1" > "'"$MODEL_ARGS_FILE"'"; echo "ok"; }
         case "$1" in
             *resolver*) resolve_octopus_model() { echo "resolver-model"; } ;;

--- a/tests/unit/test-issue-738-openrouter-council-seat.sh
+++ b/tests/unit/test-issue-738-openrouter-council-seat.sh
@@ -102,7 +102,7 @@ ln -sf "$JQ_BIN" "$NO_OPENROUTER_BIN_DIR/jq"
 test_case "council_detect_providers reports openrouter available on OPENROUTER_API_KEY alone (no binary on PATH)"
 load_council_lib || true
 (
-    export PATH="$NO_OPENROUTER_BIN_DIR"
+    export "PATH=${NO_OPENROUTER_BIN_DIR}"
     unset OCTOPUS_COUNCIL_PROVIDER_FIXTURE
     export "OPENROUTER_API_KEY=test-key-not-real"
     COUNCIL_PROVIDERS="openrouter"
@@ -113,7 +113,7 @@ load_council_lib || true
 
 test_case "council_detect_providers reports openrouter missing when OPENROUTER_API_KEY is unset"
 (
-    export PATH="$NO_OPENROUTER_BIN_DIR"
+    export "PATH=${NO_OPENROUTER_BIN_DIR}"
     unset OCTOPUS_COUNCIL_PROVIDER_FIXTURE
     unset OPENROUTER_API_KEY 2>/dev/null || true
     COUNCIL_PROVIDERS="openrouter"

--- a/tests/unit/test-issue-738-openrouter-council-seat.sh
+++ b/tests/unit/test-issue-738-openrouter-council-seat.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# tests/unit/test-issue-738-openrouter-council-seat.sh
+# Regression tests for issue #738 / PR #739, requested as a follow-up during
+# review of #739 (three bugs, all in the council -> OpenRouter seat path):
+#   1. run_with_timeout()'s in-process fallback (scripts/lib/heartbeat.sh)
+#      ran kill/wait on the timeout monitor unguarded. Under set -eo pipefail
+#      (orchestrate.sh), a monitor that returns non-zero from kill or wait —
+#      because it had already exited on its own — aborted the function after
+#      the wrapped command had already succeeded, losing its captured output.
+#   2. council_detect_providers() (scripts/lib/council.sh) probed `command -v
+#      openrouter`, but OpenRouter is an API-key provider with no CLI binary —
+#      dispatch goes through the shell function openrouter_execute. The seat
+#      was always reported "missing" regardless of OPENROUTER_API_KEY.
+#   3. openrouter_execute() (scripts/lib/perplexity.sh) always resolved its
+#      model from the hardcoded task-type table, ignoring
+#      OCTOPUS_OPENROUTER_MODEL / providers.json, so the seat silently ran a
+#      different model than the one the council roster advertised.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Issue #738: OpenRouter council seat (probe, wait, model resolution)"
+
+TEST_TMP_DIR="/tmp/octopus-tests-738-$$"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT
+mkdir -p "$TEST_TMP_DIR"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Bug 1: kill/wait on an already-gone monitor process must not abort a
+# set -e script. This is the maintainer's own reproduction from the #739
+# review (verified to fail on the pre-fix code: unguarded `wait` alone
+# aborts, and separately an unguarded `kill` alone aborts).
+# ═══════════════════════════════════════════════════════════════════════════
+
+test_case "kill/wait on an already-reaped monitor does not abort under set -e"
+out=$(bash -c '
+    set -eo pipefail
+    ( sleep 0.05 ) &
+    m=$!
+    wait "$m" 2>/dev/null || true   # reaps the monitor, simulating it having already exited
+    kill "$m" 2>/dev/null || true   # now-guarded: kill on an already-reaped pid
+    wait "$m" 2>/dev/null || true   # now-guarded: wait on an already-reaped pid
+    echo "REACHED-END"
+')
+if [[ "$out" == "REACHED-END" ]]; then
+    test_pass
+else
+    test_fail "expected REACHED-END, got: '$out' (set -e aborted before reaching the end)"
+fi
+
+test_case "heartbeat.sh guards both the monitor kill and the monitor wait with || true"
+HB="$PROJECT_ROOT/scripts/lib/heartbeat.sh"
+if grep -qE 'kill "\$monitor_pid" 2>/dev/null \|\| true' "$HB" && \
+   grep -qE 'wait "\$monitor_pid" 2>/dev/null \|\| true' "$HB"; then
+    test_pass
+else
+    test_fail "monitor cleanup in heartbeat.sh is missing the || true guard on kill and/or wait (#738 regression)"
+fi
+
+test_case "run_with_timeout's in-process fallback still returns the captured output of a fast function command"
+out=$(bash -c '
+    source "'"$PROJECT_ROOT"'/scripts/lib/heartbeat.sh" 2>/dev/null || exit 2
+    quick_ok() { echo "seat-output"; return 0; }
+    export -f quick_ok
+    _cmd_is_function=true
+    run_with_timeout 5 quick_ok
+' 2>/dev/null)
+if [[ "$out" == "seat-output" ]]; then
+    test_pass
+else
+    test_fail "expected seat-output, got: '$out'"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Bug 2: council_detect_providers() must probe OPENROUTER_API_KEY, not
+# `command -v openrouter` (no such binary ships with the plugin).
+# ═══════════════════════════════════════════════════════════════════════════
+
+load_council_lib() {
+    local lib="$PROJECT_ROOT/scripts/lib/council.sh"
+    [[ -f "$lib" ]] || { test_fail "Missing $lib"; return 1; }
+    # shellcheck disable=SC1090
+    source "$lib"
+}
+
+# Confirms the test proves what it claims: no `openrouter` binary is
+# reachable from this shell's PATH while these assertions run.
+if command -v openrouter >/dev/null 2>&1; then
+    test_fail "an 'openrouter' binary is on PATH — this test cannot prove key-only detection"
+fi
+
+test_case "council_detect_providers reports openrouter available on OPENROUTER_API_KEY alone (no binary on PATH)"
+load_council_lib || true
+(
+    unset OCTOPUS_COUNCIL_PROVIDER_FIXTURE
+    export OPENROUTER_API_KEY="test-key-not-real"
+    COUNCIL_PROVIDERS="openrouter"
+    council_detect_providers
+    status="$(jq -r '.openrouter // "missing"' <<< "$COUNCIL_PROVIDER_STATUS_JSON")"
+    [[ "$status" == "available" ]]
+) && test_pass || test_fail "expected openrouter:available with OPENROUTER_API_KEY set and no binary on PATH"
+
+test_case "council_detect_providers reports openrouter missing when OPENROUTER_API_KEY is unset"
+(
+    unset OCTOPUS_COUNCIL_PROVIDER_FIXTURE
+    unset OPENROUTER_API_KEY 2>/dev/null || true
+    COUNCIL_PROVIDERS="openrouter"
+    council_detect_providers
+    status="$(jq -r '.openrouter // "missing"' <<< "$COUNCIL_PROVIDER_STATUS_JSON")"
+    [[ "$status" == "missing" ]]
+) && test_pass || test_fail "expected openrouter:missing with no OPENROUTER_API_KEY"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Bug 3: openrouter_execute() must prefer the configured model
+# (OCTOPUS_OPENROUTER_MODEL, then resolve_octopus_model) over the hardcoded
+# task-type table, so the roster's advertised model is what actually runs.
+# ═══════════════════════════════════════════════════════════════════════════
+
+MODEL_ARGS_FILE="$TEST_TMP_DIR/openrouter-model-args.txt"
+
+run_openrouter_execute() {
+    local scenario="$1"
+    bash -c '
+        log() { :; }
+        source "'"$PROJECT_ROOT"'/scripts/lib/perplexity.sh" 2>/dev/null
+        openrouter_execute_model() { printf "%s\n" "$1" > "'"$MODEL_ARGS_FILE"'"; echo "ok"; }
+        case "$1" in
+            *resolver*) resolve_octopus_model() { echo "resolver-model"; } ;;
+        esac
+        case "$1" in
+            *env*) export OCTOPUS_OPENROUTER_MODEL="env-pinned-model" ;;
+        esac
+        # get_openrouter_model lives in providers.sh (not sourced here); stub it
+        # to isolate this test to openrouter_execute'"'"'s own fallback ordering.
+        get_openrouter_model() { echo "table-fallback-model"; }
+        openrouter_execute "test prompt" "general" 2 "" >/dev/null
+    ' _ "$scenario"
+}
+
+test_case "openrouter_execute honours OCTOPUS_OPENROUTER_MODEL over resolve_octopus_model and the task-type table"
+rm -f "$MODEL_ARGS_FILE"
+run_openrouter_execute "env-and-resolver"
+out="$(cat "$MODEL_ARGS_FILE" 2>/dev/null || true)"
+if [[ "$out" == "env-pinned-model" ]]; then
+    test_pass
+else
+    test_fail "expected env-pinned-model, got '$out'"
+fi
+
+test_case "openrouter_execute falls back to resolve_octopus_model when OCTOPUS_OPENROUTER_MODEL is unset"
+rm -f "$MODEL_ARGS_FILE"
+run_openrouter_execute "resolver"
+out="$(cat "$MODEL_ARGS_FILE" 2>/dev/null || true)"
+if [[ "$out" == "resolver-model" ]]; then
+    test_pass
+else
+    test_fail "expected resolver-model, got '$out'"
+fi
+
+test_case "openrouter_execute falls back to the task-type table when neither env nor resolver is available"
+rm -f "$MODEL_ARGS_FILE"
+run_openrouter_execute "plain"
+out="$(cat "$MODEL_ARGS_FILE" 2>/dev/null || true)"
+if [[ "$out" == "table-fallback-model" ]]; then
+    test_pass
+else
+    test_fail "expected table-fallback-model, got '$out'"
+fi
+
+test_summary


### PR DESCRIPTION
## Description

Follow-up requested by @nyldn in [review of #739](https://github.com/nyldn/claude-octopus/pull/739#issuecomment-generated):

> **Gap: no tests.** `run_with_timeout` has 11 existing unit suites and `openrouter_execute` has 1, but none covers these three behaviours — so nothing stops any of them regressing. [...] I'd like a follow-up adding:
> 1. `kill`/`wait` on an already-reaped monitor does not abort `run_with_timeout` and the captured output survives;
> 2. `council_detect_providers` reports `openrouter` available on `OPENROUTER_API_KEY` alone, with no binary on PATH;
> 3. `openrouter_execute` honours `OCTOPUS_OPENROUTER_MODEL` over the task-type table.

This PR adds `tests/unit/test-issue-738-openrouter-council-seat.sh` with 8 tests covering all three, plus the fallback ordering (`OCTOPUS_OPENROUTER_MODEL` → `resolve_octopus_model` → task-type table) and the negative case (`OPENROUTER_API_KEY` unset → `missing`).

Each test was verified against both sides of the fix landed in #739:
- Temporarily swapped in the pre-#739 versions of `council.sh`, `heartbeat.sh`, `perplexity.sh` → 4 of the 8 tests fail (the ones covering the actual bugs), 4 pass (guard-behavior/negative-path tests that were already correct pre-fix).
- Restored the merged fix → all 8 pass.

This confirms the tests are not vacuous.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (describe): test-only, no production code changed

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: new suite + all directly related existing suites (see Testing below)
- [ ] OpenClaw registry in sync — N/A, no tool/command surface changed
- [ ] New skills/commands registered — N/A
- [ ] Version bump — N/A, test-only change
- [ ] Documentation updated — N/A
- [ ] CHANGELOG.md updated — left for the release PR, per repo convention

## Testing

```bash
bash -n tests/unit/test-issue-738-openrouter-council-seat.sh

bash tests/unit/test-issue-738-openrouter-council-seat.sh   # 8 passed (new)
bash tests/unit/test-council-command.sh                     # 67 passed
bash tests/unit/test-heartbeat-timeout.sh                   # 12 passed
bash tests/unit/test-perplexity-issue-307.sh                # 6 passed
bash tests/unit/test-provider-health-probe.sh                # 12 passed
bash tests/unit/test-council-model-selection-fixes.sh        # 10 passed
```

## Related Issues
Follow-up to #738 / #739


---
_Generated by [Claude Code](https://claude.ai/code/session_01At8qoUSS8omaktiiou7wSA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for heartbeat monitor cleanup and timeout handling, including preservation of fallback output.
  * Added tests for OpenRouter provider detection, API-key validation, and model selection precedence.
  * Verified behavior when provider credentials are missing and when models are selected through environment settings, resolvers, or task-type fallbacks.
  * Expanded coverage for configuration edge cases and provider selection reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->