### PR TITLE
fix: read phase-output checkpoints by key instead of splicing the name into jq

### DIFF
--- a/scripts/lib/session.sh
+++ b/scripts/lib/session.sh
@@ -506,7 +506,13 @@ get_resume_phase() {
 get_phase_output() {
     local phase="$1"
     if [[ -f "$SESSION_FILE" ]] && command -v jq &> /dev/null; then
-        jq -r ".phases.$phase.output // \"\"" "$SESSION_FILE"
+        # Bind the phase as data, not as filter text. The previous form,
+        # `jq -r ".phases.$phase.output"`, parsed a hyphenated name as
+        # subtraction — `debate-probe` failed with `probe/0 is not defined` — so
+        # every checkpoint written by workflows.sh's `save_session_checkpoint
+        # "debate-${gate_slug}"` was unreadable. Splicing a phase name into a jq
+        # program is also an injection vector; the writer already used --arg.
+        jq -r --arg phase "$phase" '.phases[$phase].output // ""' "$SESSION_FILE"
     fi
 }
 

--- a/tests/unit/test-phase-output-registry.sh
+++ b/tests/unit/test-phase-output-registry.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Phase-output registry round-trip (issue #724).
+#
+# save_session_checkpoint() records .phases[<name>] = {status, output, timestamp}
+# and get_phase_output() reads the output path back. That registry is the
+# structured phase handoff #724 asked for — it already existed — but the reader
+# was broken for any phase name jq cannot parse as a bare field path.
+#
+# workflows.sh:3300 writes `save_session_checkpoint "debate-${gate_slug}"`. The
+# reader's filter was `jq -r ".phases.$phase.output"`, which parses
+# `debate-probe` as subtraction and fails with `probe/0 is not defined`. Every
+# debate-gate checkpoint was therefore write-only, and splicing a phase name into
+# a jq program is an injection vector besides.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Phase output registry round-trip (#724)"
+
+SESSION_LIB="$PROJECT_ROOT/scripts/lib/session.sh"
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# Extract only the reader. Sourcing session.sh wholesale executes top-level code
+# (check_resume_session carries a `read -p`), which hangs a test run.
+READER="$FIXTURE/reader.sh"
+sed -n '/^get_phase_output()/,/^}/p' "$SESSION_LIB" > "$READER"
+
+# A session file in exactly the shape save_session_checkpoint writes, including
+# the hyphenated debate-gate key from workflows.sh:3300.
+cat > "$FIXTURE/session.json" <<'JSON'
+{
+  "workflow": "embrace",
+  "status": "in_progress",
+  "phases": {
+    "probe":        { "status": "completed", "output": "/tmp/probe-1.md" },
+    "debate-probe": { "status": "completed", "output": "/tmp/gate-probe.md" },
+    "probe\"] | keys": { "status": "completed", "output": "/tmp/inj.md" }
+  }
+}
+JSON
+
+# Always returns 0: the framework sources `set -euo pipefail`, so a probing call
+# that legitimately fails (which is the point of the hyphenated case) would
+# otherwise abort the whole suite before it could be reported.
+read_phase() {
+    { bash -c '
+        SESSION_FILE="$1"
+        source "$2"
+        get_phase_output "$3" 2>/dev/null
+    ' _ "$FIXTURE/session.json" "$READER" "$1" 2>/dev/null || true; } | tail -1
+}
+
+test_case "a plain phase name reads back"
+got="$(read_phase probe)"
+if [[ "$got" == "/tmp/probe-1.md" ]]; then test_pass; else test_fail "expected /tmp/probe-1.md, got '$got'"; fi
+
+# The bug. workflows.sh writes this shape for every debate gate.
+test_case "a hyphenated phase name reads back"
+got="$(read_phase debate-probe)"
+if [[ "$got" == "/tmp/gate-probe.md" ]]; then
+    test_pass
+else
+    test_fail "expected /tmp/gate-probe.md, got '$got' — jq parses 'debate-probe' as subtraction unless bound via --arg"
+fi
+
+test_case "an unrecorded phase yields empty, not an error string"
+got="$(read_phase never-ran)"
+if [[ -z "$got" ]]; then test_pass; else test_fail "expected empty, got '$got'"; fi
+
+# Phase names come from workflow code and gate slugs, so this input is reachable.
+test_case "a phase name containing jq syntax is looked up, not evaluated"
+got="$(read_phase 'probe"] | keys')"
+if [[ "$got" == "/tmp/inj.md" ]]; then
+    test_pass
+else
+    test_fail "expected /tmp/inj.md via key lookup, got '$got'"
+fi
+
+# Static guards, so a later refactor cannot quietly reintroduce the splice.
+test_case "get_phase_output binds the phase with --arg"
+fn="$(cat "$READER")"
+if grep -q -- '--arg' <<< "$fn"; then test_pass; else test_fail "reader must bind the phase with --arg"; fi
+
+test_case "get_phase_output does not interpolate the phase into the jq program"
+# Strip comments first: the fix documents the old broken form, and that prose
+# would otherwise trip this guard.
+code="$(grep -v '^[[:space:]]*#' <<< "$fn")"
+if grep -q 'phases\.\$' <<< "$code"; then
+    test_fail "reader still splices the phase name into the filter"
+else
+    test_pass
+fi
+
+test_case "save_session_checkpoint writes with --arg phase (unchanged)"
+writer="$(sed -n '/^save_session_checkpoint()/,/^}/p' "$SESSION_LIB")"
+if grep -q -- '--arg phase' <<< "$writer"; then test_pass; else test_fail "writer should bind phase with --arg"; fi
+
+test_summary


### PR DESCRIPTION
Groundwork for #724, plus a real bug found on the way in.

## The bug

`get_phase_output` used `jq -r ".phases.$phase.output"`. jq parses a hyphenated name as subtraction, so:

```
$ jq -r '.phases.debate-probe.output' session.json
jq: error: probe/0 is not defined
```

`workflows.sh:3300` writes exactly that shape — `save_session_checkpoint "debate-${gate_slug}"` — so every debate-gate checkpoint was write-only. Fixed by binding with `--arg`, which the *writer* already did.

**Impact, stated honestly: latent, not a live break.** The three real callers (`workflows.sh:3605/3645/3711`) pass `probe`, `grasp`, `tangle` — plain names that worked. Nothing currently reads a `debate-*` checkpoint, so the effect so far was unreadable data rather than a failing feature. It would have bitten the first consumer of a debate gate on resume, and the splice was an injection vector for any phase name arriving from workflow code or a gate slug.

## What the investigation found, which differs from #724

I filed #724 and three of its claims were wrong. Recording that rather than quietly building on it:

- It cites `scripts/lib/state.sh`. **That file does not exist.** Session state is `scripts/lib/session.sh`.
- It says phase handoffs pass free-text synthesis. **Embrace does not** — it hands off *file paths*, preferring this checkpoint registry and falling back to an `ls -t` glob. The structured-slot mechanism #724 asks for already exists there, keyed by phase, storing `{status, output, timestamp}`.
- The genuine free-text interpolation is in `research.sh` and `sentinel.sh`, which splice a prior step's content into the next prompt inside their own multi-step flows. That is the remaining work and it is **narrower than filed**.

So #724 should be rescoped to those two libraries rather than a new subsystem. Building a parallel slot mechanism when a keyed registry already exists is exactly what `skill-agent-topology` would flag.

## Tests

7 cases: plain, hyphenated, unrecorded, and jq-syntax phase names, plus static guards that the reader binds via `--arg` and never splices. Mutation-checked — restoring the original filter fails 3.

One harness note worth recording, since it cost me several iterations: `tests/helpers/test-framework.sh:6` sets `set -euo pipefail` and is *sourced*, so `-e` is active in every test regardless of what the test sets before sourcing. A deliberately-failing probe therefore aborts the suite mid-run unless the helper returns 0 explicitly. That is a footgun for anyone writing a test that asserts a failure path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of phase names containing hyphens or special characters.
  * Prevented malformed phase names from being interpreted as query syntax when retrieving saved session data.

* **Tests**
  * Added regression coverage for standard, hyphenated, missing, and special-character phase names.
  * Added verification that phase data can be safely saved and retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->