### PR TITLE
fix: reap orphaned provider children on spawn PID-capture timeout

### DIFF
--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -1178,7 +1178,19 @@ spawn_agent_capture_pid() {
         if [[ -s "$pid_file" ]]; then
             tail -20 "$pid_file" >&2 || true
         fi
-        kill "$wrapper_pid" 2>/dev/null || true
+        # #736: the wait budget can expire while $wrapper_pid is still blocked
+        # inside the provider pipeline (e.g. summarization outran the PID-wait
+        # window). A bare `kill "$wrapper_pid"` only signals that one process —
+        # any already-forked pipeline children (timeout/codex/gemini) become
+        # orphans that keep running and spending tokens. Reap the whole tree
+        # with the same helper review.sh uses for stalled providers, falling
+        # back to the old single-PID kill if review.sh wasn't sourced (e.g.
+        # a test harness that loads only this file).
+        if declare -F review_terminate_process_tree >/dev/null 2>&1; then
+            review_terminate_process_tree "$wrapper_pid" 5
+        else
+            kill "$wrapper_pid" 2>/dev/null || true
+        fi
         wait "$wrapper_pid" 2>/dev/null || true
         rm -f "$pid_file"
         return 1

--- a/tests/unit/test-spawn-agent-capture-pid.sh
+++ b/tests/unit/test-spawn-agent-capture-pid.sh
@@ -147,6 +147,7 @@ fi
 test_case "descendant of a failed spawn is reaped, not left orphaned (#736)"
 eval "$(sed -n '/^review_process_tree_depth_first() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
 eval "$(sed -n '/^review_terminate_process_tree() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
+eval "$(sed -n '/^review_process_is_running() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
 : > "$TEST_TMP_DIR/leaked_child_pid"
 spawn_agent() {
     # Simulate a wrapper that has already forked a long-running child (the
@@ -154,7 +155,11 @@ spawn_agent() {
     # without ever printing a provider PID.
     ( sleep 30 & echo $! > "$TEST_TMP_DIR/leaked_child_pid"; wait )
 }
-export "OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS=3"
+# 3s of headroom (not the 0.3s a tight 3-attempt budget would give) so a
+# loaded CI runner has time to schedule the fixture's fork before the
+# wait budget expires — a slow scheduler shouldn't read as "cleanup
+# didn't run" when the real gap is "the descendant was never forked yet".
+export "OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS=30"
 pid=$(spawn_agent_capture_pid codex prompt orphan-task implementer tangle 2>/dev/null) || true
 for _ in $(seq 1 50); do
     [[ -s "$TEST_TMP_DIR/leaked_child_pid" ]] && break
@@ -163,10 +168,22 @@ done
 leaked_pid=$(cat "$TEST_TMP_DIR/leaked_child_pid" 2>/dev/null || true)
 if [[ -z "$leaked_pid" ]]; then
     test_fail "descendant PID was never recorded — fixture did not exercise the timeout path"
-elif kill -0 "$leaked_pid" 2>/dev/null; then
-    test_fail "descendant PID $leaked_pid survived spawn_agent_capture_pid's timeout cleanup"
 else
-    test_pass
+    # kill -0 alone would false-positive on an unreaped zombie (the PID slot
+    # stays allocated until something waits on it). review_process_is_running
+    # also checks `ps` state for 'Z' so a killed-but-not-yet-reaped descendant
+    # doesn't read as "still alive".
+    still_running=false
+    for _ in $(seq 1 20); do
+        review_process_is_running "$leaked_pid" || { still_running=false; break; }
+        still_running=true
+        sleep 0.1
+    done
+    if [[ "$still_running" == "true" ]]; then
+        test_fail "descendant PID $leaked_pid survived spawn_agent_capture_pid's timeout cleanup"
+    else
+        test_pass
+    fi
 fi
 
 test_summary

--- a/tests/unit/test-spawn-agent-capture-pid.sh
+++ b/tests/unit/test-spawn-agent-capture-pid.sh
@@ -139,4 +139,34 @@ else
     test_fail "expected capture_pid's omitted task_id to match the shared helper's shape, got: $captured_id"
 fi
 
+# Regression for #736 (root cause 3): when the PID-wait budget expires,
+# $wrapper_pid may already have forked a real descendant (e.g. mid-pipeline
+# provider call). A bare `kill "$wrapper_pid"` only signals that one process,
+# orphaning the descendant. Load review.sh's tree-kill helper the same way
+# spawn.sh's fixed code path resolves it, and prove the descendant is reaped.
+test_case "descendant of a failed spawn is reaped, not left orphaned (#736)"
+eval "$(sed -n '/^review_process_tree_depth_first() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
+eval "$(sed -n '/^review_terminate_process_tree() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
+: > "$TEST_TMP_DIR/leaked_child_pid"
+spawn_agent() {
+    # Simulate a wrapper that has already forked a long-running child (the
+    # provider pipeline) before the PID-wait budget runs out, then blocks
+    # without ever printing a provider PID.
+    ( sleep 30 & echo $! > "$TEST_TMP_DIR/leaked_child_pid"; wait )
+}
+export "OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS=3"
+pid=$(spawn_agent_capture_pid codex prompt orphan-task implementer tangle 2>/dev/null) || true
+for _ in $(seq 1 50); do
+    [[ -s "$TEST_TMP_DIR/leaked_child_pid" ]] && break
+    sleep 0.1
+done
+leaked_pid=$(cat "$TEST_TMP_DIR/leaked_child_pid" 2>/dev/null || true)
+if [[ -z "$leaked_pid" ]]; then
+    test_fail "descendant PID was never recorded — fixture did not exercise the timeout path"
+elif kill -0 "$leaked_pid" 2>/dev/null; then
+    test_fail "descendant PID $leaked_pid survived spawn_agent_capture_pid's timeout cleanup"
+else
+    test_pass
+fi
+
 test_summary


### PR DESCRIPTION
## Description

`spawn_agent_capture_pid()` (`scripts/lib/spawn.sh:1143`) waits up to `OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS` (default ~120s) for the backgrounded `spawn_agent` wrapper to print a provider PID. When that budget expires — e.g. because prompt summarization for a large diff outran the wait window — the timeout branch (`scripts/lib/spawn.sh:1176-1190`) only did `kill "$wrapper_pid"`. That signals the wrapper shell itself, but not any descendants it had already forked (the `timeout ... codex exec ...` / `gemini` pipeline mid-flight), leaving those provider processes orphaned and still consuming tokens after the run had already given up on them.

This is root cause (3) from #736, which the maintainer explicitly called out as the most urgent of the two still-open items after #737 fixed root causes (1) and (4):

> **(3) The process leak.** Nine `orchestrate.sh code-review` processes with byte-identical argv from one invocation, and `pkill` on the parents orphaning the `codex exec` children. This is the part I'd treat as most urgent after the abort — an orphaned provider keeps spending tokens after you believe you have killed the run.

## Type of Change
- [x] Bug fix

## Fix

`scripts/lib/review.sh` already has a tested recursive process-tree killer (`review_terminate_process_tree`, used by `review_run_agent_sync_progress` to reap stalled providers). `orchestrate.sh` sources `review.sh` before `spawn.sh`, so that helper is available by the time `spawn_agent_capture_pid` needs it. The fix reuses it instead of inventing a second implementation: on PID-capture timeout, walk and terminate the whole descendant tree of `$wrapper_pid`, falling back to the old single-PID `kill` only when `review.sh` wasn't sourced (e.g. a test harness that loads `spawn.sh` standalone).

```bash
if declare -F review_terminate_process_tree >/dev/null 2>&1; then
    review_terminate_process_tree "$wrapper_pid" 5
else
    kill "$wrapper_pid" 2>/dev/null || true
fi
```

Root cause (2) (the PID-wait budget itself being sized off provider startup rather than summarization time) is intentionally left out of scope, per the maintainer's own note that it needs validation against a real large-diff run with live providers.

## Testing

Added a regression test (`tests/unit/test-spawn-agent-capture-pid.sh`) that has a fixture fork a real child process before blocking past the PID-wait budget, then asserts the child is dead after `spawn_agent_capture_pid` gives up. Verified the test fails without the fix (orphaned PID survives) and passes with it.

```bash
bash -n scripts/lib/spawn.sh scripts/lib/review.sh scripts/orchestrate.sh
bash tests/unit/test-spawn-agent-capture-pid.sh       # 9/9, including the new case
bash tests/unit/test-review-round1-spawn-failure.sh   # 3/3, unaffected
bash tests/unit/test-openclaw-compat.sh               # 32/32
make test-unit                                        # 195/197 — the 2 failures
                                                        # (test-feature-disclosure.sh,
                                                        # test-hud-smart-mode.sh) reproduce
                                                        # identically on unmodified origin/main,
                                                        # confirmed pre-existing and unrelated
```

No mode changes (`git diff origin/main...HEAD --summary` empty).

## Related Issues
Closes #736 (remaining scope: root cause (2), the PID-wait budget vs. summarization timing, tracked separately)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HMFnj97iTxLJj6rWZ8hkGT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for background processes by terminating the full process tree, preventing child processes from remaining active after a timeout.
  * Preserved fallback behavior when full process-tree termination is unavailable.

* **Tests**
  * Added regression coverage confirming that timed-out child processes are properly terminated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->