### PR TITLE
release: v9.58.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.58.0"
+    "version": "9.58.1"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.58.0 - Agent topology audit, four adapted workflow skills, and the Gemini migration offered as a real choice. 32 personas, 50 commands, 63 skills. Run /octo:setup.",
-      "version": "9.58.0",
+      "description": "v9.58.1 - Guard Round 1 spawn failures from aborting code review; repair OpenRouter council seat probe/wait/model resolution. 32 personas, 50 commands, 63 skills. Run /octo:setup.",
+      "version": "9.58.1",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": "2026-06",
   "name": "octo",
   "displayName": "Claude Octopus",
-  "version": "9.58.0",
+  "version": "9.58.1",
   "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
   "author": {
     "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.58.0",
-  "description": "v9.58.0 \u2014 Agent topology audit, four adapted workflow skills, and the Gemini migration offered as a real choice. Run /octo:setup.",
+  "version": "9.58.1",
+  "description": "v9.58.1 \u2014 Guard Round 1 spawn failures from aborting code review; repair OpenRouter council seat probe/wait/model resolution. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Claude Octopus routine manifest (v9.58.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "$comment": "Claude Octopus routine manifest (v9.58.1). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
   "schemaVersion": 1,
   "routines": [
     {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.58.0",
+  "version": "9.58.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.58.0",
+  "version": "9.58.1",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.58.0"
+    "version": "9.58.1"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.58.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 50 commands, 63 skills. Run /octo:setup after install.",
-      "version": "9.58.0",
+      "description": "v9.58.1 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 50 commands, 63 skills. Run /octo:setup after install.",
+      "version": "9.58.1",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.58.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.58.0. 32 expert personas, 50 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.58.1",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.58.1. 32 expert personas, 50 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [9.58.1] - 2026-08-03
+
+### Changed
+
+- Guard Round 1 spawn failures from aborting code review; repair OpenRouter council seat probe/wait/model resolution
+
 ## [9.58.0] - 2026-08-03
 
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -78,7 +78,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 - GitHub stars: 3,889
 - GitHub forks: 365
 - Local CI parity: `make ci-local` runs the same smoke, unit, and integration suites as CI
-- Version: 9.58.0 (active release cadence)
+- Version: 9.58.1 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Gemini CLI
 
 **Measured Impact:**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 <p align="center">
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/Version-9.58.0-blue" alt="Version 9.58.0">
+  <img src="https://img.shields.io/badge/Version-9.58.1-blue" alt="Version 9.58.1">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -35,7 +35,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 ## What's New
 
 <!-- BEGIN CURRENT RELEASE -->
-> 🆕 **v9.58.0 — Agent topology audit, four adapted workflow skills, and the Gemini migration offered as a real choice.**
+> 🆕 **v9.58.1 — Guard Round 1 spawn failures from aborting code review; repair OpenRouter council seat probe/wait/model resolution.**
 >
 > **Default roster:** Claude Opus 5 leads architecture, planning, security reasoning, and final judgment; GPT-5.6 Sol is the independent implementation/review peer; Claude Sonnet 5 is the standard Claude seat; Fable 5 remains an opt-in judgment escalation. Existing model pins and provider configuration still win. See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md).
 <!-- END CURRENT RELEASE -->
@@ -55,7 +55,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 
 | Version | Best Features |
 |---------|--------------|
-| **v9.58.0** (new) | Agent topology audit, four adapted workflow skills, and the Gemini migration offered as a real choice. |
+| **v9.58.1** (new) | Guard Round 1 spawn failures from aborting code review; repair OpenRouter council seat probe/wait/model resolution. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
 | **v9** (current) | Up to 10 external provider integrations (Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.58.0",
+  "version": "9.58.1",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Release v9.58.1

Two bug-fix commits merged to `main` since the `v9.58.0` tag hadn't been released yet:

- #737 — guard Round 1 spawn failure from aborting code review (closes #736 root causes 1 & 4)
- #739 — repair OpenRouter council seat (probe, wait, model resolution)

## Changes

Version bump across all manifest surfaces (`package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.claude-plugin/plugin-manifest.json`, `.claude-plugin/routines.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.factory-plugin/plugin.json`, `.factory-plugin/marketplace.json`), `README.md`/`PRODUCT.md` release facts, and a new `CHANGELOG.md` entry.

Generated by extracting and running `scripts/release.sh`'s version-file-update logic (`octo_release_update_changelog` + `make sync`) directly, rather than running `scripts/release.sh` end-to-end — that script shells out to `gh` for PR create/checks/merge/tag (not available in this environment) and cuts a `release/v*` branch rather than a `claude/`-prefixed one.

## Verification

```bash
jq empty package.json .claude-plugin/*.json .codex-plugin/plugin.json .cursor-plugin/plugin.json .factory-plugin/*.json   # all valid
git diff origin/main...HEAD --summary   # empty — no mode changes
bash tests/unit/test-docs-sync.sh        # 141/141
make ci-local                            # sync-check + smoke + unit + integration, run separately
```

**Note:** this PR is intentionally left unmerged for a human to review and merge — I'm not merging release PRs myself. Once merged, the tag/GitHub-release steps in `RELEASING.md` §7-8 still need to run against the squash-merge commit.

## Related Issues
Ships #737, #739


---
_Generated by [Claude Code](https://claude.ai/code/session_01HMFnj97iTxLJj6rWZ8hkGT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Code reviews now handle Round 1 spawn failures without aborting.
  * Improved OpenRouter council seat probing, wait handling, and model resolution.

* **Documentation**
  * Updated release notes and product documentation to reflect these improvements.

* **Chores**
  * Released version 9.58.1 across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->