### PR TITLE
fix: codex-review seat now threads OCTOPUS_CODEX_SANDBOX

### DIFF
--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -250,7 +250,11 @@ get_agent_command() {
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
                 return 1
             fi
-            echo "codex exec review --model ${model} --skip-git-repo-check"
+            # `codex exec review` has no --sandbox/--profile flag (unlike plain
+            # `codex exec`), so it silently inherits sandbox_mode from the
+            # user's ~/.codex/config.toml — OCTOPUS_CODEX_SANDBOX would not
+            # constrain it otherwise. -c overrides the config value directly.
+            echo "codex exec review --model ${model} --skip-git-repo-check -c sandbox_mode=${codex_sandbox}"
             ;;
         claude)
             local reasoning_level reasoning_policy reasoning_fragment

--- a/tests/unit/test-codex-sandbox-mode.sh
+++ b/tests/unit/test-codex-sandbox-mode.sh
@@ -42,7 +42,7 @@ fi
 test_case "codex-review threads OCTOPUS_CODEX_SANDBOX via -c sandbox_mode"
 export OCTOPUS_CODEX_SANDBOX=read-only
 cmd="$(get_agent_command codex-review tangle reviewer)"
-if [[ "$cmd" == *"-c sandbox_mode=read-only"* ]]; then
+if [[ " $cmd " == *" -c sandbox_mode=read-only "* ]]; then
     test_pass
 else
     test_fail "expected -c sandbox_mode=read-only, got: $cmd"
@@ -51,7 +51,7 @@ fi
 test_case "codex-review defaults to workspace-write when unset"
 unset OCTOPUS_CODEX_SANDBOX
 cmd="$(get_agent_command codex-review tangle reviewer)"
-if [[ "$cmd" == *"-c sandbox_mode=workspace-write"* ]]; then
+if [[ " $cmd " == *" -c sandbox_mode=workspace-write "* ]]; then
     test_pass
 else
     test_fail "expected -c sandbox_mode=workspace-write default, got: $cmd"

--- a/tests/unit/test-codex-sandbox-mode.sh
+++ b/tests/unit/test-codex-sandbox-mode.sh
@@ -35,4 +35,35 @@ else
     test_fail "expected workspace-write fallback, got: $cmd"
 fi
 
+# Issue #746: `codex exec review` has no --sandbox flag, so the seat used to
+# silently inherit sandbox_mode from ~/.codex/config.toml regardless of
+# OCTOPUS_CODEX_SANDBOX. It must thread the resolved sandbox through -c
+# sandbox_mode=... instead.
+test_case "codex-review threads OCTOPUS_CODEX_SANDBOX via -c sandbox_mode"
+export OCTOPUS_CODEX_SANDBOX=read-only
+cmd="$(get_agent_command codex-review tangle reviewer)"
+if [[ "$cmd" == *"-c sandbox_mode=read-only"* ]]; then
+    test_pass
+else
+    test_fail "expected -c sandbox_mode=read-only, got: $cmd"
+fi
+
+test_case "codex-review defaults to workspace-write when unset"
+unset OCTOPUS_CODEX_SANDBOX
+cmd="$(get_agent_command codex-review tangle reviewer)"
+if [[ "$cmd" == *"-c sandbox_mode=workspace-write"* ]]; then
+    test_pass
+else
+    test_fail "expected -c sandbox_mode=workspace-write default, got: $cmd"
+fi
+
+test_case "codex-review never passes bare --sandbox (unsupported by codex exec review)"
+export OCTOPUS_CODEX_SANDBOX=danger-full-access
+cmd="$(get_agent_command codex-review tangle reviewer)"
+if [[ "$cmd" != *" --sandbox "* ]]; then
+    test_pass
+else
+    test_fail "codex-review must not pass --sandbox, got: $cmd"
+fi
+
 test_summary

--- a/tests/unit/test-codex-sandbox-mode.sh
+++ b/tests/unit/test-codex-sandbox-mode.sh
@@ -60,7 +60,7 @@ fi
 test_case "codex-review never passes bare --sandbox (unsupported by codex exec review)"
 export OCTOPUS_CODEX_SANDBOX=danger-full-access
 cmd="$(get_agent_command codex-review tangle reviewer)"
-if [[ "$cmd" != *" --sandbox "* ]]; then
+if [[ " $cmd " != *" --sandbox "* ]]; then
     test_pass
 else
     test_fail "codex-review must not pass --sandbox, got: $cmd"


### PR DESCRIPTION
## Description
`codex exec review` (the `codex-review` dispatch arm) accepts neither `-s/--sandbox` nor `-p/--profile`, unlike plain `codex exec`. Because of that, it silently inherited `sandbox_mode` from the user's `~/.codex/config.toml` instead of respecting `OCTOPUS_CODEX_SANDBOX`. A user running `sandbox_mode = "danger-full-access"` got an unsandboxed review agent, and `OCTOPUS_CODEX_SANDBOX=read-only` did not constrain it, even though the env var exists precisely to govern this (#9, extended in #710).

The already-resolved `codex_sandbox` local variable in `get_agent_command()` (`scripts/lib/dispatch.sh`) was in scope for the `codex-review` case but never used there. This threads it through as a `-c sandbox_mode=...` config override — the mechanism `codex exec review` does support — instead of the unsupported `--sandbox` flag.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [x] OpenClaw registry in sync: `scripts/build-openclaw.sh --check`
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` (n/a — no new skills/commands)
- [ ] Version bump (if releasing) (n/a — not a release PR)
- [ ] Documentation updated (if applicable) (n/a — internal dispatch fix, no user-facing docs describe this flag's per-seat behavior)
- [ ] CHANGELOG.md updated (n/a — left for the release PR that eventually picks this up)

## Testing
- `bash -n scripts/lib/dispatch.sh` and `bash -n scripts/*.sh scripts/lib/*.sh` — all clean.
- `bash tests/unit/test-codex-sandbox-mode.sh` — extended with 3 new cases covering the `codex-review` arm (threads `OCTOPUS_CODEX_SANDBOX`, defaults to `workspace-write`, never emits a bare `--sandbox` flag). All 5 cases in the file pass.
- `make test-unit` (197 suites) — 194 pass, 3 pre-existing failures (`test-feature-disclosure.sh`, `test-github-work-queue-hook.sh`, `test-hud-smart-mode.sh`) confirmed present on unmodified `origin/main` via `git stash`, unrelated to this change (none reference `dispatch.sh` or `codex-review`).
- `make test-integration` (7 suites) — all pass.

The issue's suggested regression approach (a real filesystem canary write to prove enforcement, not just string-matching) needs a live `codex` binary and isn't reproducible in this sandbox; the added tests instead assert the emitted command string, matching the existing pattern in this test file for the `codex` (non-review) arm.

## Related Issues
Closes #746


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ5yxPM8gqY5GWyapgd8Wr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Codex review dispatches now consistently use the configured sandbox mode instead of inheriting conflicting settings.
  * Added a default `workspace-write` sandbox mode when no explicit value is provided.
  * Prevented unsupported sandbox arguments from being passed during review dispatches.
  * Review runs are now more predictable across different local configurations.

* **Tests**
  * Added coverage for sandbox configuration propagation, default behavior, and unsupported argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->