### PR TITLE
fix: guard remaining bare kill/wait sites against set -e aborts

### DIFF
--- a/scripts/lib/cursor-agent.sh
+++ b/scripts/lib/cursor-agent.sh
@@ -52,8 +52,16 @@ _cursor_agent_run_with_timeout() {
     ( /bin/sleep "$timeout_secs"; kill -TERM "$cmd_pid" 2>/dev/null; /bin/sleep 1; kill -KILL "$cmd_pid" 2>/dev/null ) &
     monitor_pid=$!
 
-    wait "$cmd_pid" 2>/dev/null
-    exit_code=$?
+    # wait's own return reflects $cmd_pid's exit status, so a nonzero exit from
+    # the wrapped command would abort this function under set -e before
+    # exit_code is even captured. Branch on it instead of using `|| true`,
+    # which would discard the real exit code. Same idiom as heartbeat.sh's
+    # in-process fallback. (#751)
+    if wait "$cmd_pid" 2>/dev/null; then
+        exit_code=0
+    else
+        exit_code=$?
+    fi
 
     kill "$monitor_pid" 2>/dev/null || true
     wait "$monitor_pid" 2>/dev/null || true

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -192,12 +192,16 @@ run_with_timeout() {
 
         # oco-dar: SIGTERM at the cap, then SIGKILL the process AND its children
         # 10s later so a TERM-ignoring tree cannot wedge the workflow.
+        # kill on a $cmd_pid that already exited (race with the wait below)
+        # returns non-zero; under set -e (inherited into this subshell) that
+        # would abort it and skip the pkill sweep and the SIGKILL escalation.
+        # Same class as the monitor kill/wait guarded below. (#751)
         (
             sleep "$timeout_secs"
-            kill -TERM "$cmd_pid" 2>/dev/null
+            kill -TERM "$cmd_pid" 2>/dev/null || true
             pkill -TERM -P "$cmd_pid" 2>/dev/null || true
             sleep 10
-            kill -KILL "$cmd_pid" 2>/dev/null
+            kill -KILL "$cmd_pid" 2>/dev/null || true
             pkill -KILL -P "$cmd_pid" 2>/dev/null || true
         ) &
         monitor_pid=$!

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -689,8 +689,12 @@ ${_blind_spot_checklist}"
 
     # v7.19.0 P2.4: Stop progressive synthesis monitor
     if [[ -n "$synthesis_monitor_pid" ]]; then
-        kill "$synthesis_monitor_pid" 2>/dev/null
-        wait "$synthesis_monitor_pid" 2>/dev/null
+        # kill/wait on a monitor that already exited on its own return non-zero;
+        # under set -e that would abort this function (and skip
+        # display_progress_summary) right after synthesis succeeded. Same class
+        # as the subshell kill fixed in #336/#739. (#751)
+        kill "$synthesis_monitor_pid" 2>/dev/null || true
+        wait "$synthesis_monitor_pid" 2>/dev/null || true
         log "DEBUG" "Progressive synthesis monitor stopped"
     fi
 


### PR DESCRIPTION
## Description

#739 fixed one instance of a recurring bug class: under `set -eo pipefail` (`orchestrate.sh:6`, inherited by every sourced lib), `kill`/`wait` on a PID that has already exited returns non-zero, which aborts the enclosing function immediately — even though the real work already succeeded.

#751 found five more live sites in this shape. This PR fixes those five.

- `scripts/lib/workflows.sh:692-693` — the progressive-synthesis monitor's `kill`/`wait` could abort right after the "Synthesis succeeded" log line, skipping `display_progress_summary`.
- `scripts/lib/heartbeat.sh:197,200` — the timeout-escalation subshell's `kill -TERM`/`kill -KILL` on `$cmd_pid` could abort mid-sweep if the command already exited, skipping the `pkill` cleanup and, for the TERM case, the later SIGKILL escalation.
- `scripts/lib/cursor-agent.sh:55` — a different shape, worth calling out: `wait "$cmd_pid"`'s own return value is consumed via `$?` on the next line to build `exit_code`. A blind `|| true` here would have silently zeroed out every non-zero exit code from the wrapped command — a worse bug than the one being fixed. Used the `if/else` idiom already established at `heartbeat.sh:205-209` instead, which avoids the `set -e` abort without discarding the real exit code.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check (ran across all of `scripts/*.sh scripts/lib/*.sh`)
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (32/32)
- [x] OpenClaw registry in sync: `scripts/build-openclaw.sh --check` (covered by the compat test above)
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` — n/a, no new skills/commands
- [ ] Version bump — n/a, not a release PR
- [ ] Documentation updated — n/a
- [ ] CHANGELOG.md updated — left for the release PR that picks this up

## Testing

- `bash -n` across all shell scripts and lib files: clean.
- Reproduced the exact bug in isolation (`set -e`; wait a job to reap it; bare `kill` on the reaped PID aborts the script) and confirmed `|| true` fixes it.
- Confirmed the `cursor-agent.sh` `if/else` idiom still returns the wrapped command's real exit code, by stubbing a command that returns 7 and asserting the wrapper returns 7 (not swallowed to 0).
- `tests/unit/test-cursor-agent-provider.sh` — 8/8 pass.
- `tests/unit/test-heartbeat-timeout.sh` — 12/12 pass.
- `tests/unit/test-openclaw-compat.sh` — 32/32 pass.
- Full `make test-unit` (`tests/run-all.sh unit`) was still running in the background past this session's foreground command budget with no failures observed through the Council/benchmark suites; will comment here if it turns up anything relevant once it finishes.
- `make test-integration` not run — this change only touches cleanup-path error handling around already-exited PIDs in three lib files with no behavioral change to the happy path, so the unit coverage above is the directly affected surface.

## Related Issues

Part of #751 — fixes the "five sites still live" list. The issue's other ask, a CI-enforced portability-lint rule to catch this bug class automatically, is **not** included here: a robust version needs a suppression-comment escape hatch (as the issue notes) and careful false-positive validation against the existing codebase, which is more design work than fits a single automated daily-triage pass. Left open for a follow-up; commented on the issue with this scope split.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L1J3QUmsEjbGHetV4915QF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling to preserve the wrapped command’s exit status.
  * Prevented premature workflow termination when monitored processes exit during cleanup.
  * Ensured progress summaries are displayed even when child-process termination or waiting encounters expected failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->