### PR TITLE
fix: guard the five live set -e status leaks on bare kill/wait

### DIFF
--- a/scripts/lib/cursor-agent.sh
+++ b/scripts/lib/cursor-agent.sh
@@ -52,8 +52,8 @@ _cursor_agent_run_with_timeout() {
     ( /bin/sleep "$timeout_secs"; kill -TERM "$cmd_pid" 2>/dev/null; /bin/sleep 1; kill -KILL "$cmd_pid" 2>/dev/null ) &
     monitor_pid=$!
 
-    wait "$cmd_pid" 2>/dev/null
-    exit_code=$?
+    exit_code=0
+    wait "$cmd_pid" 2>/dev/null || exit_code=$?
 
     kill "$monitor_pid" 2>/dev/null || true
     wait "$monitor_pid" 2>/dev/null || true

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -194,10 +194,10 @@ run_with_timeout() {
         # 10s later so a TERM-ignoring tree cannot wedge the workflow.
         (
             sleep "$timeout_secs"
-            kill -TERM "$cmd_pid" 2>/dev/null
+            kill -TERM "$cmd_pid" 2>/dev/null || true
             pkill -TERM -P "$cmd_pid" 2>/dev/null || true
             sleep 10
-            kill -KILL "$cmd_pid" 2>/dev/null
+            kill -KILL "$cmd_pid" 2>/dev/null || true
             pkill -KILL -P "$cmd_pid" 2>/dev/null || true
         ) &
         monitor_pid=$!

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -689,8 +689,8 @@ ${_blind_spot_checklist}"
 
     # v7.19.0 P2.4: Stop progressive synthesis monitor
     if [[ -n "$synthesis_monitor_pid" ]]; then
-        kill "$synthesis_monitor_pid" 2>/dev/null
-        wait "$synthesis_monitor_pid" 2>/dev/null
+        kill "$synthesis_monitor_pid" 2>/dev/null || true
+        wait "$synthesis_monitor_pid" 2>/dev/null || true
         log "DEBUG" "Progressive synthesis monitor stopped"
     fi
 

--- a/tests/unit/test-seteleak-kill-wait-751.sh
+++ b/tests/unit/test-seteleak-kill-wait-751.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# tests/unit/test-seteleak-kill-wait-751.sh
+# Regression coverage for #751: bare `kill`/`wait`/`pkill` on an
+# already-reaped PID returns non-zero and, under `set -eo pipefail`
+# (orchestrate.sh:6), aborts the enclosing function immediately after
+# the signal/reap work already succeeded — same defect class as #738/#739.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "set -e status leaks on bare kill/wait/pkill (#751)"
+
+# Sanity check: prove the general failure mode is real, independent of any
+# specific file, before asserting the five sites are guarded against it.
+test_bare_kill_wait_aborts_under_sete() {
+    test_case "bare kill on an already-reaped PID aborts a set -e function before it completes"
+
+    local out
+    out=$(bash -c '
+        set -e
+        ( sleep 0.05 ) & m=$!
+        wait "$m"
+        kill "$m" 2>/dev/null
+        echo REACHED-END
+    ' 2>/dev/null || true)
+
+    assert_not_contains "$out" "REACHED-END" \
+        "expected the unguarded reproduction to abort before REACHED-END (proves the defect is real)" || return
+    test_pass
+}
+
+test_guarded_kill_wait_survives_sete() {
+    test_case "the || true guard pattern used in the fix prevents the abort"
+
+    local out
+    out=$(bash -c '
+        set -e
+        ( sleep 0.05 ) & m=$!
+        wait "$m" 2>/dev/null || true
+        kill "$m" 2>/dev/null || true
+        echo REACHED-END
+    ')
+
+    assert_contains "$out" "REACHED-END" \
+        "expected the guarded reproduction to reach the end under set -e" || return
+    test_pass
+}
+
+# workflows.sh:692-693 — synthesis monitor kill/wait guard (probe_discover()).
+# probe_discover() has too much external state (provider dispatch, run
+# artifacts) to exercise directly in a unit test; assert statically that the
+# specific lines carry the guard, same as the sibling assertions below.
+test_workflows_synthesis_monitor_guarded() {
+    test_case "workflows.sh: synthesis_monitor_pid kill/wait guarded with || true"
+
+    local file="$PROJECT_ROOT/scripts/lib/workflows.sh"
+    local snippet
+    snippet=$(grep -A2 'kill "\$synthesis_monitor_pid"' "$file")
+
+    assert_contains "$snippet" 'kill "$synthesis_monitor_pid" 2>/dev/null || true' \
+        "kill on synthesis_monitor_pid must be guarded" || return
+    assert_contains "$snippet" 'wait "$synthesis_monitor_pid" 2>/dev/null || true' \
+        "wait on synthesis_monitor_pid must be guarded" || return
+    test_pass
+}
+
+# heartbeat.sh:197/200 — run_with_timeout()'s TERM-then-KILL escalation.
+# This one is directly callable and lets us reproduce the exact race from
+# the issue: the wrapped command finishes before the monitor's first signal
+# fires, so kill -TERM targets an already-dead PID and must not skip the
+# pkill/KILL escalation lines that follow it in the same subshell.
+test_heartbeat_run_with_timeout_survives_early_exit_race() {
+    test_case "heartbeat.sh: run_with_timeout completes cleanup when the target exits before the monitor's first signal"
+
+    local out
+    out=$(
+        bash -c '
+            set -eo pipefail
+            source "'"$PROJECT_ROOT"'/scripts/lib/heartbeat.sh"
+            fast_ok() { return 0; }
+            # timeout_secs=1 with an instantly-returning command guarantees
+            # the monitor subshell fires kill -TERM against a PID that is
+            # already gone by the time it runs. Capture via `|| rc=$?`
+            # (not a bare call) so *this test harness* does not itself
+            # trip set -e on a non-zero return — same idiom as the fix.
+            rc=0
+            run_with_timeout 1 fast_ok || rc=$?
+            echo "RC=$rc"
+            echo REACHED-END
+        ' 2>&1
+    ) || true
+
+    assert_contains "$out" "REACHED-END" \
+        "run_with_timeout must not abort under set -e when the monitor's kill -TERM races an exited target" || return
+    assert_contains "$out" "RC=0" \
+        "run_with_timeout must still report the wrapped command's real exit code" || return
+    test_pass
+}
+
+test_heartbeat_kill_lines_guarded() {
+    test_case "heartbeat.sh: monitor's kill -TERM/-KILL lines guarded with || true"
+
+    local file="$PROJECT_ROOT/scripts/lib/heartbeat.sh"
+    local snippet
+    snippet=$(sed -n '190,205p' "$file")
+
+    assert_contains "$snippet" 'kill -TERM "$cmd_pid" 2>/dev/null || true' \
+        "kill -TERM on cmd_pid must be guarded" || return
+    assert_contains "$snippet" 'kill -KILL "$cmd_pid" 2>/dev/null || true' \
+        "kill -KILL on cmd_pid must be guarded" || return
+    test_pass
+}
+
+# cursor-agent.sh:55-56 — _cursor_agent_run_with_timeout()'s fallback path.
+# Unlike the other four sites, `wait "$cmd_pid"` here feeds `exit_code=$?`:
+# a blind `|| true` would silently zero out the real exit code, so the fix
+# uses `exit_code=0; wait ... || exit_code=$?` instead. Assert both halves:
+# no abort under set -e, and the captured code is still correct.
+test_cursor_agent_preserves_exit_code_and_survives_sete() {
+    test_case "cursor-agent.sh: fallback wait preserves the wrapped command's exit code without aborting under set -e"
+
+    local out
+    out=$(
+        bash -c '
+            set -eo pipefail
+            source "'"$PROJECT_ROOT"'/scripts/lib/cursor-agent.sh"
+            fails_with_7() { return 7; }
+            # Force the in-process fallback (skip gtimeout/timeout) by
+            # emptying PATH so neither resolves; everything the fallback
+            # itself needs is a builtin, a shell function, or an absolute
+            # path (/bin/sleep, /bin/rm), matching the code path the fix targets.
+            # Capture via `|| rc=$?` so this test harness does not itself
+            # trip set -e on the (expected, non-zero) return value.
+            rc=0
+            PATH="" _cursor_agent_run_with_timeout 0.2 fails_with_7 </dev/null || rc=$?
+            echo "RC=$rc"
+            echo REACHED-END
+        ' 2>&1
+    ) || true
+
+    assert_contains "$out" "REACHED-END" \
+        "_cursor_agent_run_with_timeout must not abort under set -e" || return
+    assert_contains "$out" "RC=7" \
+        "_cursor_agent_run_with_timeout must still return the wrapped command's real exit code (7), not silently become 0 (proves exit_code=0; wait ... || exit_code=\$? preserves the value, unlike a blind || true)" || return
+    test_pass
+}
+
+test_bare_kill_wait_aborts_under_sete
+test_guarded_kill_wait_survives_sete
+test_workflows_synthesis_monitor_guarded
+test_heartbeat_run_with_timeout_survives_early_exit_race
+test_heartbeat_kill_lines_guarded
+test_cursor_agent_preserves_exit_code_and_survives_sete
+
+test_summary

--- a/tests/unit/test-seteleak-kill-wait-751.sh
+++ b/tests/unit/test-seteleak-kill-wait-751.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # tests/unit/test-seteleak-kill-wait-751.sh
 # Regression coverage for #751: bare `kill`/`wait`/`pkill` on an
 # already-reaped PID returns non-zero and, under `set -eo pipefail`
@@ -109,8 +109,12 @@ test_heartbeat_kill_lines_guarded() {
 
     assert_contains "$snippet" 'kill -TERM "$cmd_pid" 2>/dev/null || true' \
         "kill -TERM on cmd_pid must be guarded" || return
+    assert_contains "$snippet" 'pkill -TERM -P "$cmd_pid" 2>/dev/null || true' \
+        "pkill -TERM on cmd_pid children must be guarded" || return
     assert_contains "$snippet" 'kill -KILL "$cmd_pid" 2>/dev/null || true' \
         "kill -KILL on cmd_pid must be guarded" || return
+    assert_contains "$snippet" 'pkill -KILL -P "$cmd_pid" 2>/dev/null || true' \
+        "pkill -KILL on cmd_pid children must be guarded" || return
     test_pass
 }
 


### PR DESCRIPTION
## Description
Bare `kill`/`wait` on an already-reaped PID returns non-zero and, under `set -eo pipefail` (`orchestrate.sh:6`), aborts the enclosing function immediately after the signal/reap work already succeeded. This is the same defect class as #738, one instance of which was fixed in #739. #751 enumerated five sites still carrying the bug; this PR fixes all five.

Four sites get the same `|| true` guard #739 used:
- `scripts/lib/workflows.sh:692-693` — synthesis monitor `kill`/`wait`
- `scripts/lib/heartbeat.sh:197,200` — `kill -TERM`/`kill -KILL` in `run_with_timeout()`'s escalation subshell

The fifth, `scripts/lib/cursor-agent.sh:55`, is **not** a blind `|| true` candidate: that `wait "$cmd_pid"` feeds `exit_code=$?` on the very next line, so swallowing its status would silently zero out the wrapped command's real exit code — breaking the timeout-exit-code translation the function exists to provide. Fixed with the exit-code-preserving idiom instead:
```bash
exit_code=0
wait "$cmd_pid" 2>/dev/null || exit_code=$?
```

**Scope note:** #751 also proposes a portability-lint rule to catch this class automatically in CI. Left out of this change as separate, larger scope — this PR fixes the five concrete leak sites the issue enumerated, per the smallest-fix-for-the-root-cause principle. Closing the issue anyway, consistent with how #744 handled partial-scope closure on #736.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [x] OpenClaw registry in sync: `scripts/build-openclaw.sh --check`
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` (n/a — no new skills/commands)
- [ ] Version bump (if releasing) (n/a — not a release PR)
- [ ] Documentation updated (if applicable) (n/a — internal reliability fix, no user-facing behavior change)
- [ ] CHANGELOG.md updated (n/a — left for the release PR that eventually picks this up, matching prior PRs in this cycle)

## Testing
New `tests/unit/test-seteleak-kill-wait-751.sh`:
- Reproduces the generic `set -e`/bare-`kill`-or-`wait` defect standalone, and confirms the `|| true` guard survives it.
- Statically asserts the `workflows.sh` site (not independently callable — lives inside `probe_discover()`, which needs substantial provider-dispatch mocking out of scope here) carries the guard.
- Behaviorally exercises the two directly-callable functions — `heartbeat.sh`'s `run_with_timeout()` and `cursor-agent.sh`'s `_cursor_agent_run_with_timeout()` — under the exact early-exit race from the issue (wrapped command finishes before the monitor's first signal fires, so the signal targets an already-dead PID), asserting both that the function doesn't abort and that the real exit code still comes through.
- Verified the test **fails against unfixed source** (`git stash` the three source files, rerun — the `workflows.sh` assertion fails as expected) and passes with the fix restored.

```bash
bash -n scripts/*.sh scripts/lib/*.sh                 # clean
bash tests/unit/test-seteleak-kill-wait-751.sh         # 6/6
bash tests/unit/test-cursor-agent-provider.sh          # 8/8, unaffected
bash tests/unit/test-openclaw-compat.sh                # 32/32
make test-unit                                          # 196/198 — the 2 failures
                                                          # (test-feature-disclosure.sh,
                                                          # test-hud-smart-mode.sh) reproduce
                                                          # identically on unmodified
                                                          # origin/main, confirmed pre-existing
                                                          # and unrelated (neither references
                                                          # the three edited files)
make test-integration                                    # 7/7
git diff origin/main...HEAD --summary                    # empty — no mode changes
```

## Related Issues
Closes #751


---
_Generated by [Claude Code](https://claude.ai/code/session_015PnEuP8WDmi9qFt3Y2od26)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling so command exit statuses are preserved reliably.
  * Prevented cleanup failures from interrupting timed-out process termination.
  * Made monitor shutdown more resilient when processes have already exited.

* **Tests**
  * Added regression coverage for process cleanup races, exit-status handling, and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->