### PR TITLE
fix: guard set -e status leaks on bare kill/wait in monitor cleanup

### DIFF
--- a/scripts/lib/cursor-agent.sh
+++ b/scripts/lib/cursor-agent.sh
@@ -52,8 +52,15 @@ _cursor_agent_run_with_timeout() {
     ( /bin/sleep "$timeout_secs"; kill -TERM "$cmd_pid" 2>/dev/null; /bin/sleep 1; kill -KILL "$cmd_pid" 2>/dev/null ) &
     monitor_pid=$!
 
-    wait "$cmd_pid" 2>/dev/null
-    exit_code=$?
+    # `wait` returns the command's own exit status, so a non-zero exit under
+    # `set -eo pipefail` would abort this function before exit_code=$? runs.
+    # The if/else keeps the wait inside a tested context so set -e doesn't
+    # fire, while still capturing the real exit code. (#751)
+    if wait "$cmd_pid" 2>/dev/null; then
+        exit_code=0
+    else
+        exit_code=$?
+    fi
 
     kill "$monitor_pid" 2>/dev/null || true
     wait "$monitor_pid" 2>/dev/null || true

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -192,12 +192,15 @@ run_with_timeout() {
 
         # oco-dar: SIGTERM at the cap, then SIGKILL the process AND its children
         # 10s later so a TERM-ignoring tree cannot wedge the workflow.
+        # This subshell inherits `set -eo pipefail`; a bare kill on a cmd_pid
+        # that already exited on its own returns non-zero and would abort the
+        # subshell before the SIGKILL escalation runs. (#751)
         (
             sleep "$timeout_secs"
-            kill -TERM "$cmd_pid" 2>/dev/null
+            kill -TERM "$cmd_pid" 2>/dev/null || true
             pkill -TERM -P "$cmd_pid" 2>/dev/null || true
             sleep 10
-            kill -KILL "$cmd_pid" 2>/dev/null
+            kill -KILL "$cmd_pid" 2>/dev/null || true
             pkill -KILL -P "$cmd_pid" 2>/dev/null || true
         ) &
         monitor_pid=$!

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -688,9 +688,13 @@ ${_blind_spot_checklist}"
     log DEBUG "Synthesis marker removed (synthesis completed successfully)"
 
     # v7.19.0 P2.4: Stop progressive synthesis monitor
+    # `kill`/`wait` on a monitor that already exited on its own return non-zero —
+    # under `set -eo pipefail` that would abort this function (and skip
+    # display_progress_summary below) right after synthesis succeeded. Same
+    # class as the subshell kill fixed in #336/#739. (#751)
     if [[ -n "$synthesis_monitor_pid" ]]; then
-        kill "$synthesis_monitor_pid" 2>/dev/null
-        wait "$synthesis_monitor_pid" 2>/dev/null
+        kill "$synthesis_monitor_pid" 2>/dev/null || true
+        wait "$synthesis_monitor_pid" 2>/dev/null || true
         log "DEBUG" "Progressive synthesis monitor stopped"
     fi
 


### PR DESCRIPTION
## Description
`#739` fixed one instance of a bare `kill`/`wait` aborting its enclosing function under `set -eo pipefail` when the target process had already exited on its own. Four more sites shared the same defect, all flagged with exact locations in #751. This PR fixes all five.

- `scripts/lib/workflows.sh:692-693` — synthesis monitor `kill`/`wait` runs right after synthesis succeeded; an abort here would skip `display_progress_summary`.
- `scripts/lib/heartbeat.sh:197,200` — the TERM/KILL escalation inside `run_with_timeout`'s background monitor subshell; that subshell inherits `set -eo pipefail`, so a `kill -TERM` on an already-exited `cmd_pid` would abort the subshell before the SIGKILL escalation runs.
- `scripts/lib/cursor-agent.sh:55` — needed a different fix than the other three. The existing `wait "$cmd_pid" 2>/dev/null; exit_code=$?` loses the exit code entirely under `set -e` whenever the command exits non-zero — `wait` returns that same non-zero status and the function aborts *before* `exit_code=$?` ever runs (verified empirically below). A bare `|| true` there would stop the abort but zero out `exit_code` on every failure. Instead this uses the `if wait ...; then exit_code=0; else exit_code=$?; fi` pattern already established in `heartbeat.sh`'s primary wait, which keeps `wait` inside a tested context (so `set -e` doesn't fire) while still capturing the real exit code.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [x] OpenClaw registry in sync: n/a (no skills/commands changed)
- [x] New skills/commands registered in `.claude-plugin/plugin.json`: n/a
- [ ] Version bump (if releasing): n/a, not a release
- [ ] Documentation updated (if applicable): n/a, internal shell-guard fix
- [ ] CHANGELOG.md updated: left for the release PR that picks this up

## Testing
- `bash -n` on all three changed files, plus a full repo-wide `bash -n` sweep — clean.
- Reproduced the underlying `set -e` abort directly (matching the issue's own repro):
  ```
  bash -c 'set -e; ( sleep 0.05 ) & m=$!; wait "$m" 2>/dev/null; kill "$m" 2>/dev/null; echo REACHED-END'
  # exits 1, REACHED-END never printed
  bash -c 'set -e; ( sleep 0.05 ) & m=$!; wait "$m" 2>/dev/null; kill "$m" 2>/dev/null || true; echo REACHED-END'
  # exits 0, REACHED-END printed
  ```
- Verified the `cursor-agent.sh` exit-code case specifically: with the old pattern, `set -e` aborts before `exit_code=$?` runs whenever the wrapped command exits non-zero (the echo after it never executes, and the script's own exit code is silently that of the failed command instead of being captured into a local var). With the new `if/else` pattern, the real exit code (7 in the test) is captured correctly and the function continues to its cleanup/return path.
- Targeted unit suites exercising the changed code paths, all passing:
  - `tests/unit/test-cursor-agent-provider.sh` (8/8)
  - `tests/unit/test-perplexity-issue-307.sh` (6/6, includes `run_with_timeout preserves stdin into background shell function`, which directly exercises the touched `heartbeat.sh` path)
  - `tests/test-v7.19.0-performance-fixes.sh` (35/35, covers the progressive synthesis monitor in `workflows.sh`)
  - `tests/unit/test-openclaw-compat.sh` (32/32)
- Ran the broader `make test-unit` suite (it exceeds the 570s harness timeout and gets `Terminated` partway through, same as on a clean `main` checkout — not something this PR changes). Through ~7500 lines of output, the only failures were `test-feature-disclosure.sh`, `test-github-work-queue-hook.sh`, and `test-hud-smart-mode.sh`. Verified these are pre-existing and unrelated: reran all three against a clean `origin/main` worktree with none of this PR's changes, and got the identical failures (SessionStart hook / GitHub work-queue hook / HUD statusline environment-dependent tests, unrelated to signal handling).
- `make test-integration` was not run — this change touches only signal-handling around already-completed background jobs, has no integration surface, and the direct-path tests above cover the actual behavior change.

## Related Issues
Closes #751 (the accompanying portability-lint rule proposed in that issue is left as a follow-up — this PR fixes the five call sites the issue identified as still live, matching the scope of the original #739 precedent)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3Ee2zcTjWfZgd2VBcqUUG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling so commands that finish early no longer interrupt cleanup or escalation.
  * Prevented workflow failures when stopping already-exited monitoring processes.
  * Ensured progress summaries continue to display reliably after command completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->