### PR TITLE
fix: guard seat kill/wait status leaks under set -e

### DIFF
--- a/scripts/lib/cursor-agent.sh
+++ b/scripts/lib/cursor-agent.sh
@@ -49,11 +49,20 @@ _cursor_agent_run_with_timeout() {
 
     "$@" >"$output_file" 2>&1 <&0 &
     cmd_pid=$!
-    ( /bin/sleep "$timeout_secs"; kill -TERM "$cmd_pid" 2>/dev/null; /bin/sleep 1; kill -KILL "$cmd_pid" 2>/dev/null ) &
+    # Bare `kill`/`wait` here return non-zero once the target has already exited;
+    # under the parent's `set -e` (inherited into this subshell) that would abort
+    # the monitor mid-sequence, skipping the SIGKILL fallback. Same class as #751.
+    ( /bin/sleep "$timeout_secs"; kill -TERM "$cmd_pid" 2>/dev/null || true; /bin/sleep 1; kill -KILL "$cmd_pid" 2>/dev/null || true ) &
     monitor_pid=$!
 
-    wait "$cmd_pid" 2>/dev/null
-    exit_code=$?
+    # Preserve the real exit code (needed for the 137/143 signal check below) —
+    # a bare `wait` would abort this function under `set -e` before exit_code=$?
+    # ever ran whenever "$@" exited non-zero. Same class as #739/#751.
+    if wait "$cmd_pid" 2>/dev/null; then
+        exit_code=0
+    else
+        exit_code=$?
+    fi
 
     kill "$monitor_pid" 2>/dev/null || true
     wait "$monitor_pid" 2>/dev/null || true

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -194,10 +194,13 @@ run_with_timeout() {
         # 10s later so a TERM-ignoring tree cannot wedge the workflow.
         (
             sleep "$timeout_secs"
-            kill -TERM "$cmd_pid" 2>/dev/null
+            # Bare `kill` on an already-exited cmd_pid returns non-zero — under
+            # `set -e` (inherited into this subshell) that would abort before the
+            # pkill/sleep/SIGKILL steps below ever ran. Same class as #739/#751.
+            kill -TERM "$cmd_pid" 2>/dev/null || true
             pkill -TERM -P "$cmd_pid" 2>/dev/null || true
             sleep 10
-            kill -KILL "$cmd_pid" 2>/dev/null
+            kill -KILL "$cmd_pid" 2>/dev/null || true
             pkill -KILL -P "$cmd_pid" 2>/dev/null || true
         ) &
         monitor_pid=$!

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -689,8 +689,11 @@ ${_blind_spot_checklist}"
 
     # v7.19.0 P2.4: Stop progressive synthesis monitor
     if [[ -n "$synthesis_monitor_pid" ]]; then
-        kill "$synthesis_monitor_pid" 2>/dev/null
-        wait "$synthesis_monitor_pid" 2>/dev/null
+        # `kill`/`wait` on a monitor that already exited on its own return non-zero —
+        # under `set -e` that would abort this function (skipping display_progress_summary
+        # below) after synthesis already succeeded. Same class as #739/#751.
+        kill "$synthesis_monitor_pid" 2>/dev/null || true
+        wait "$synthesis_monitor_pid" 2>/dev/null || true
         log "DEBUG" "Progressive synthesis monitor stopped"
     fi
 

--- a/tests/unit/test-seat-kill-status-leaks.sh
+++ b/tests/unit/test-seat-kill-status-leaks.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# tests/unit/test-seat-kill-status-leaks.sh
+# Regression coverage for #751: bare `kill`/`wait`/`pkill` statements on a
+# monitor/child PID that has already exited return non-zero and, under the
+# orchestrator's `set -eo pipefail`, abort the enclosing function *after* the
+# real work already succeeded. #739 fixed one instance of this in perplexity.sh;
+# this covers the five remaining sites (workflows.sh, cursor-agent.sh x2,
+# heartbeat.sh x2) named in #751.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Seat kill/wait status leaks (#751)"
+
+# Behavioral proof of the underlying failure mode: a bare `kill`/`wait` on an
+# already-reaped PID aborts a `set -e` shell before later statements run.
+test_bare_kill_wait_aborts_under_set_e() {
+    test_case "bare kill/wait on a reaped PID aborts under set -e (unguarded control)"
+
+    local out
+    out=$(bash -c '
+        set -e
+        ( sleep 0.05 ) & m=$!
+        wait "$m" 2>/dev/null
+        kill "$m" 2>/dev/null
+        echo REACHED-END
+    ' 2>/dev/null) || true
+
+    if [[ "$out" != *"REACHED-END"* ]]; then
+        test_pass
+    else
+        test_fail "expected the unguarded kill to abort the shell before REACHED-END; got: $out"
+    fi
+}
+
+test_guarded_kill_wait_survives_under_set_e() {
+    test_case "|| true guarded kill/wait survives under set -e"
+
+    local out
+    out=$(bash -c '
+        set -e
+        ( sleep 0.05 ) & m=$!
+        wait "$m" 2>/dev/null || true
+        kill "$m" 2>/dev/null || true
+        echo REACHED-END
+    ' 2>/dev/null) || true
+
+    if [[ "$out" == *"REACHED-END"* ]]; then
+        test_pass
+    else
+        test_fail "expected REACHED-END after guarded kill/wait; got: $out"
+    fi
+}
+
+# Static checks: each of the five sites named in #751 now guards its
+# kill/wait so a bare, unguarded regression can't creep back in.
+test_workflows_monitor_stop_guarded() {
+    test_case "workflows.sh: synthesis monitor kill/wait guarded"
+
+    local block
+    block=$(sed -n '/Stop progressive synthesis monitor/,/^    fi$/p' "$PROJECT_ROOT/scripts/lib/workflows.sh")
+
+    if grep -q 'kill "\$synthesis_monitor_pid" 2>/dev/null || true' <<< "$block" && \
+       grep -q 'wait "\$synthesis_monitor_pid" 2>/dev/null || true' <<< "$block"; then
+        test_pass
+    else
+        test_fail "synthesis_monitor_pid kill/wait is not guarded with || true"
+    fi
+}
+
+test_cursor_agent_monitor_and_wait_guarded() {
+    test_case "cursor-agent.sh: fallback monitor kill/wait guarded, exit code preserved"
+
+    local fn
+    fn=$(sed -n '/_cursor_agent_run_with_timeout()/,/^}/p' "$PROJECT_ROOT/scripts/lib/cursor-agent.sh")
+
+    if grep -q 'kill -TERM "\$cmd_pid" 2>/dev/null || true' <<< "$fn" && \
+       grep -q 'kill -KILL "\$cmd_pid" 2>/dev/null || true' <<< "$fn" && \
+       grep -Fq 'if wait "$cmd_pid" 2>/dev/null; then' <<< "$fn"; then
+        test_pass
+    else
+        test_fail "cursor-agent fallback timeout monitor/wait is not guarded"
+    fi
+}
+
+test_heartbeat_monitor_guarded() {
+    test_case "heartbeat.sh: run_with_timeout SIGTERM/SIGKILL kill guarded"
+
+    local fn
+    fn=$(sed -n '/run_with_timeout()/,/^}/p' "$PROJECT_ROOT/scripts/lib/heartbeat.sh")
+
+    if grep -q 'kill -TERM "\$cmd_pid" 2>/dev/null || true' <<< "$fn" && \
+       grep -q 'kill -KILL "\$cmd_pid" 2>/dev/null || true' <<< "$fn"; then
+        test_pass
+    else
+        test_fail "heartbeat.sh run_with_timeout SIGTERM/SIGKILL kill is not guarded"
+    fi
+}
+
+test_cursor_agent_exit_code_preserved() {
+    test_case "cursor-agent.sh: real exit code of \"\$@\" still reaches the 137/143 check"
+
+    local fn
+    fn=$(sed -n '/_cursor_agent_run_with_timeout()/,/^}/p' "$PROJECT_ROOT/scripts/lib/cursor-agent.sh")
+
+    # A prior version of the fix used a bare `|| true` here, which would have
+    # silently forced exit_code=0 regardless of what "$@" actually returned.
+    if grep -Fq 'if wait "$cmd_pid" 2>/dev/null; then' <<< "$fn" && \
+       grep -Fq 'exit_code=$?' <<< "$fn"; then
+        test_pass
+    else
+        test_fail "exit_code capture for \"\$@\" appears to have been lost or short-circuited"
+    fi
+}
+
+test_bare_kill_wait_aborts_under_set_e
+test_guarded_kill_wait_survives_under_set_e
+test_workflows_monitor_stop_guarded
+test_cursor_agent_monitor_and_wait_guarded
+test_heartbeat_monitor_guarded
+test_cursor_agent_exit_code_preserved
+
+test_summary


### PR DESCRIPTION
## Description

`orchestrate.sh` runs under `set -eo pipefail`. `kill`/`wait`/`pkill` on a monitor or child PID that has *already exited on its own* returns non-zero — under `set -e` that aborts the enclosing function immediately, after the real work already succeeded. #739 fixed one instance of this in `perplexity.sh`/`heartbeat.sh`; #751 found four more still live plus proposed a lint rule (left out of scope here — see below) to catch the class going forward.

Fixed the five sites named in the issue, plus one additional instance of the identical pattern found in the same function while implementing the fix:

- `scripts/lib/workflows.sh:692-693` — `probe_discover`'s progressive-synthesis monitor `kill`/`wait`. An abort here would skip `display_progress_summary` right after synthesis succeeded.
- `scripts/lib/cursor-agent.sh` (`_cursor_agent_run_with_timeout`, fallback path used when neither `gtimeout` nor `timeout` is available):
  - The one-line monitor subshell `kill -TERM ...; sleep 1; kill -KILL ...` — an already-exited command would abort the subshell before its SIGKILL fallback ever ran. **This wasn't in the issue's list of five** — it's the identical bug, in the same function, discovered while fixing the adjacent `wait "$cmd_pid"` site below.
  - `wait "$cmd_pid" 2>/dev/null; exit_code=$?` — this one needed care: a bare `|| true` would have silently forced `exit_code=0` regardless of what the wrapped command actually returned, breaking the downstream 137/143 signal-timeout check. Used the `if wait ...; then exit_code=0; else exit_code=$?; fi` pattern that already exists in `heartbeat.sh` for this exact situation, instead of inventing a second idiom.
- `scripts/lib/heartbeat.sh:197,200` — `run_with_timeout`'s SIGTERM/SIGKILL monitor subshell. An abort at the SIGTERM `kill` would skip the child-reaping `pkill`, the 10s grace sleep, and the SIGKILL step entirely.

**Deliberately left out of scope:** the portability-lint rule the issue also proposes (flagging bare `kill`/`wait`/`pkill` in `scripts/lib/**` and `scripts/helpers/**`). That's a CI/tooling addition distinct from the bug fix itself and carries more risk to get right in one pass; filing as a natural follow-up rather than expanding this PR.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (32/32)
- [x] OpenClaw registry in sync: `scripts/build-openclaw.sh --check` (n/a — no skills/commands touched)
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` (n/a — none added)
- [ ] Version bump (n/a — not a release PR)
- [ ] Documentation updated (n/a — internal dispatch/cleanup fix, no user-facing behavior change)
- [ ] CHANGELOG.md updated (n/a — left for the release PR that eventually picks this up, matching #737/#744/#747's precedent)

## Testing

```bash
bash -n scripts/lib/workflows.sh scripts/lib/cursor-agent.sh scripts/lib/heartbeat.sh scripts/orchestrate.sh   # clean
bash tests/unit/test-cursor-agent-provider.sh     # 8/8
bash tests/unit/test-heartbeat-timeout.sh         # 12/12
bash tests/unit/test-stdin-timeout-guards.sh      # 12/12
bash tests/unit/test-openclaw-compat.sh           # 32/32
```

Added `tests/unit/test-seat-kill-status-leaks.sh` (6 cases):
- A behavioral pair proving the underlying failure mode in isolation (unguarded `kill`/`wait` on a reaped PID aborts a `set -e` shell; the `|| true`-guarded form survives).
- Four static checks, one per fixed site, that the guarded/if-else form is present.

Verified these aren't tautological by stashing the fix and re-running: the 4 static checks fail cleanly against the pre-fix code (`synthesis_monitor_pid kill/wait is not guarded`, etc.) and pass after — confirmed real regression coverage, not just asserting current state.

`make test-unit` (198 suites, one more than baseline for the new test file): 195 pass, 3 pre-existing failures (`test-feature-disclosure.sh`, `test-github-work-queue-hook.sh`, `test-hud-smart-mode.sh`) — confirmed present identically on unmodified `origin/main` and unrelated to `workflows.sh`/`cursor-agent.sh`/`heartbeat.sh`.

No mode changes: `git diff origin/main...HEAD --summary` is empty.

## Related Issues
Closes #751

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ua91hPgxT7DjgRJedKVmza)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timeout and process cleanup reliability when monitored commands have already exited.
  - Ensured fallback termination steps continue without interrupting workflows.
  - Preserved the original command’s exit status for accurate results.
  - Prevented progressive workflow monitoring from stopping before displaying its progress summary.

- **Tests**
  - Added regression coverage for process termination, exit-status handling, and workflow continuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->