### PR TITLE
ci: run the unit suite through a symlinked path (#752)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,6 +245,57 @@ jobs:
           path: /tmp/test_*.log
           retention-days: 7
 
+  # Catches tests that conflate logical and physical paths. This failure mode is
+  # invisible to every other job by construction: runners check out under a real
+  # path, so a test deriving PROJECT_ROOT with `cd && pwd` while the code under
+  # test resolves with `cd -P && pwd` agrees there and diverges anywhere behind a
+  # symlink. #712 hit exactly that — test-feature-disclosure.sh failed only in a
+  # /tmp release worktree on macOS, which is the workflow RELEASING.md §0
+  # recommends, so it bit at release time and CI could never have warned.
+  #
+  # Ubuntu only: the divergence is a property of symlinked paths, not of macOS,
+  # and the ubuntu unit run is the faster of the two. Runs in parallel with the
+  # existing matrix, so it adds no wall-clock.
+  symlinked-path:
+    name: Symlinked Path
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [classify-changes, smoke, portability-lint]
+    if: needs.classify-changes.outputs.heavy_tests == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Make scripts executable
+        run: |
+          chmod +x scripts/orchestrate.sh
+          find tests -name "*.sh" -type f -exec chmod +x {} \;
+
+      - name: Run unit tests through a symlinked path
+        run: |
+          set -euo pipefail
+          link="$(mktemp -d)/octo-linked"
+          ln -s "$GITHUB_WORKSPACE" "$link"
+          echo "Real path:    $GITHUB_WORKSPACE"
+          echo "Via symlink:  $link"
+          # Verify the link really is a distinct logical path, or this job would
+          # silently duplicate the ordinary unit run and prove nothing.
+          if [[ "$(cd "$link" && pwd)" == "$(cd "$link" && pwd -P)" ]]; then
+            echo "::error::logical and physical paths match — the symlink is not exercising anything"
+            exit 1
+          fi
+          cd "$link"
+          make test-unit
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: symlinked-path-logs
+          path: /tmp/test_*.log
+          retention-days: 7
+
   smoke-required:
     name: Smoke Tests
     runs-on: ubuntu-latest

--- a/tests/unit/test-windows-doctor-compat.sh
+++ b/tests/unit/test-windows-doctor-compat.sh
@@ -3,8 +3,14 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Resolve physically. session-manager.sh:43 writes the shim with
+# `cd "$plugin_root_raw" && pwd -P` deliberately — its header comment says the
+# recorded path must be "the real install path", and the assertion below is
+# named "shim points at real plugin root". A logically-derived PROJECT_ROOT
+# agrees under a normal checkout and diverges behind a symlink, so the case
+# failed in the symlinked-path job while the code was correct.
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd)"
 source "$PROJECT_ROOT/tests/helpers/test-framework.sh"
 
 test_suite "Windows doctor compatibility"
@@ -86,14 +92,25 @@ if assert_contains "$output" "hook check skipped on Windows Git Bash" "Windows R
     test_pass
 fi
 
+# Pass a SYMLINKED plugin root, not the real one. session-manager.sh:43 resolves
+# with `pwd -P` deliberately so the shim records the real install path — a shim
+# pointing at a symlink breaks once that link is replaced on upgrade. Handing it
+# the physical path (as this case used to) meant `pwd` and `pwd -P` returned the
+# same value and the assertion proved nothing; it passed with the resolution
+# removed entirely. Verified: reverting `pwd -P` to `pwd` now fails this case.
 test_case "session manager writes stable script shims when symlink root is unavailable"
 shim_home="$TEST_TMP_DIR/shim-home"
 mkdir -p "$shim_home/.claude-octopus/plugin"
-HOME="$shim_home" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$PROJECT_ROOT/scripts/session-manager.sh" export >/dev/null
+linked_root="$TEST_TMP_DIR/linked-plugin-root"
+ln -sfn "$PROJECT_ROOT" "$linked_root"
+HOME="$shim_home" CLAUDE_PLUGIN_ROOT="$linked_root" bash "$PROJECT_ROOT/scripts/session-manager.sh" export >/dev/null
 shim="$shim_home/.claude-octopus/plugin/scripts/orchestrate.sh"
 if assert_file_exists "$shim" "orchestrate shim exists" &&
-   assert_file_contains "$shim" "$PROJECT_ROOT/scripts/orchestrate.sh" "shim points at real plugin root"; then
+   assert_file_contains "$shim" "$PROJECT_ROOT/scripts/orchestrate.sh" "shim points at real plugin root" &&
+   ! grep -q "$linked_root" "$shim"; then
     test_pass
+else
+    test_fail "shim should record the resolved plugin root, not the symlink it was reached through"
 fi
 
 test_summary


### PR DESCRIPTION
Second half of #752. Pairs with #757 (test reachability); independent of it.

## Why a dedicated job

This failure mode is **invisible to every other job by construction.** Runners check out under a real path, so a test deriving `PROJECT_ROOT` with `cd && pwd` while the code under test resolves with `cd -P && pwd` agrees there — and diverges only behind a symlink.

#712 was exactly that: `test-feature-disclosure.sh` failed *solely* in a `/tmp` release worktree on macOS, which is the workflow `RELEASING.md` §0 recommends. So it bit at release time, and no amount of ordinary CI could have warned.

## Verified, not assumed

I reverted #713's `cd -P` fix and ran the same suite both ways:

```
through the symlink : 44 passed, 2 failed
via the real path   : 46 passed, 0 failed
```

The job catches the class; the existing matrix cannot. That asymmetry is the entire argument for adding a job rather than a test.

## Design notes

**The step aborts if logical and physical paths match.** Without that guard, a future runner change could make the symlink a no-op and the job would silently duplicate the ordinary unit run while still reporting green. A check that cannot fail is worse than no check.

**Ubuntu only.** The divergence is a property of symlinked paths, not of macOS, and ubuntu unit is the faster of the two (~6m vs ~8m). Gated on `heavy_tests` like the existing matrix and running in parallel with it, so it adds no wall-clock — only a runner slot.

**No untrusted input.** The `run:` block uses `$GITHUB_WORKSPACE` and `mktemp` only, with no `github.event.*` interpolation anywhere in the job.

## Scope

Five bugs this cycle came from tests reading ambient host state rather than the code under test — a `$HOME` quota marker (#690), reviewer-flip reading the real `PATH`, CLI prereq probes needing stubs, the BSD/GNU `grep -E "\t"` divergence, and #712. This closes the path subset mechanically. The others need per-case hermeticity work and are not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Ubuntu-based test coverage for projects accessed through symlinked paths.
  * Added failure log uploads to support diagnosing test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->