### PR TITLE
test: hold every documented OCTOPUS_* variable accountable (closes #749)

### DIFF
--- a/tests/unit/fixtures/env-var-effects.tsv
+++ b/tests/unit/fixtures/env-var-effects.tsv
@@ -1,0 +1,57 @@
+# Env-var effect manifest (#749)
+#
+# Every OCTOPUS_* variable documented in CLAUDE.md, docs/*.md or
+# config/features.json must appear here. tests/unit/test-env-var-effects.sh
+# fails on any documented variable missing an entry — that inverted default is
+# the point: four variables shipped inert in one cycle (#715, #720, #710, and
+# OCTOPUS_COMMANDCODE_PERMISSION_MODE) and no test noticed.
+#
+# Format: <VAR><TAB><kind><TAB><detail>
+#   covered-by  <test file>  a suite that exercises this variable's effect
+#   skip        <reason>     real variable, assertion impractical — reason required
+#   placeholder <note>       not a variable; a template fragment in docs
+#
+# Prefer moving entries from skip to covered-by over time. A skip is a recorded
+# decision, not an excuse.
+
+OCTOPUS_AGENT_	placeholder	doc template fragment, not a real variable
+OCTOPUS_AGENT_LIFECYCLE_HOOK	covered-by	test-agent-lifecycle-events.sh
+OCTOPUS_AGENT_LIFECYCLE_HOOK_LOG	covered-by	test-agent-lifecycle-events.sh
+OCTOPUS_AGY_MODEL	covered-by	test-agy-provider.sh
+OCTOPUS_AUTO_TITLE	skip	sets the Claude Code session title; observable only in the host UI
+OCTOPUS_CLAUDE_SDK_MODEL	covered-by	test-claude-sdk-provider.sh
+OCTOPUS_CODEX_MODEL	covered-by	test-role-mapping-v929.sh
+OCTOPUS_COMMANDCODE_ALLOWED_MODELS	skip	allowlist for a provider with no CLI on CI runners
+OCTOPUS_COMMANDCODE_BIN	covered-by	test-commandcode-harness.sh
+OCTOPUS_COMMANDCODE_MAX_TURNS	covered-by	test-commandcode-harness.sh
+OCTOPUS_COMMANDCODE_MODEL	covered-by	test-commandcode-harness.sh
+OCTOPUS_COMPACT_BANNERS	skip	changes banner prose only; asserting it would pin cosmetic output
+OCTOPUS_EFFORT_OVERRIDE	covered-by	test-execution-mechanism.sh
+OCTOPUS_FABLE5_FALLBACK_MODEL	covered-by	test-fable5-mode.sh
+OCTOPUS_FABLE5_MODE	covered-by	test-fable5-mode.sh
+OCTOPUS_FABLE5_NO_RETRY	covered-by	test-fable5-mode.sh
+OCTOPUS_FABLE5_ROUTING	covered-by	test-fable5-escalation.sh
+OCTOPUS_GEMINI_VIA_AGY	covered-by	test-agy-provider.sh
+OCTOPUS_IDE_	placeholder	doc template fragment, not a real variable
+OCTOPUS_JOB_ID	skip	opaque correlation id passed through to logs; no behavioural delta
+OCTOPUS_LEGACY_ROLES	covered-by	test-agy-research-defaults.sh
+OCTOPUS_MAX_COST_USD	skip	aborts a run mid-dispatch; needs a live provider to reach the check
+OCTOPUS_MYPROV_ALLOWED_MODELS	placeholder	doc template fragment, not a real variable
+OCTOPUS_OLLAMA_ALLOW_PULL	covered-by	test-codex-pull-guard.sh
+OCTOPUS_OLLAMA_MAX_PULL_GB	covered-by	test-codex-pull-guard.sh
+OCTOPUS_OPUS5_AUTO_XHIGH	covered-by	test-opus-48-routing.sh
+OCTOPUS_OPUS_MODE	covered-by	test-execution-mechanism.sh
+OCTOPUS_OPUS_MODEL	covered-by	test-fable5-escalation.sh
+OCTOPUS_OVERSIZE_STRATEGY	covered-by	test-dispatch-oversize.sh
+OCTOPUS_PREFLIGHT_PROBE	covered-by	test-provider-health-probe.sh
+OCTOPUS_QUALITY_THRESHOLD	skip	gates a quality score produced by a live provider dispatch
+OCTOPUS_RELEASE_RUNTIME_SMOKE	covered-by	test-cc-v2126-131-sync.sh
+OCTOPUS_RELEASE_SMOKE_MAX_BUDGET_USD	skip	release-smoke harness only; not reachable from unit scope
+OCTOPUS_RELEASE_SMOKE_PORT	skip	release-smoke harness only; not reachable from unit scope
+OCTOPUS_REQUIRE_ALL	covered-by	test-agent-summary.sh
+OCTOPUS_RESEARCH_BREADTH	skip	changes how many provider seats a research run fans out to
+OCTOPUS_REVIEWER_FLIP	covered-by	test-fable5-escalation.sh
+OCTOPUS_RUN_ID	covered-by	test-agent-summary.sh
+OCTOPUS_SENTINEL_ENABLED	covered-by	test-sentinel.sh
+OCTOPUS_TRACE_MODELS	skip	emits trace lines to stderr; covered indirectly by model-resolver suites
+OCTOPUS_X_MODEL	placeholder	doc template fragment, not a real variable

--- a/tests/unit/test-env-var-effects.sh
+++ b/tests/unit/test-env-var-effects.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Every documented OCTOPUS_* variable must be accounted for (#749).
+#
+# Four variables shipped inert in a single release cycle and no test noticed:
+#
+#   #715  OCTOPUS_GEMINI_VIA_AGY                three dispatch sites read the raw
+#                                               env var, so a recorded answer never
+#                                               reached them
+#   #720  OCTOPUS_REVIEWER_FLIP                 octo_features_choice only forwards
+#                                               values matching a declared choice,
+#                                               so =1 was dropped — while a comment
+#                                               promised it worked
+#   #710  OCTOPUS_COMMANDCODE_PERMISSION_MODE   the shim accepted it, but dispatch
+#                                               always passed a positional argument
+#                                               that overrode it
+#   —     invocation: human_only                custom key stripped at build time;
+#                                               enforcement was a hardcoded list
+#
+# Three of those four share one root cause. Every one had passing tests around it.
+# The failure was never "nobody tested this function" — it was that the
+# documentation and the enforcement live in different files with nothing linking
+# them. This suite is the link: it derives its work list FROM the documentation.
+#
+# It deliberately does not try to assert all 41 variables. It asserts that none is
+# unaccounted for, which is the property that rots silently.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Documented env-var accountability (#749)"
+
+MANIFEST="$SCRIPT_DIR/fixtures/env-var-effects.tsv"
+
+# Same harvest the manifest was generated from. Kept here rather than in a helper
+# so the sources being treated as "documentation" are visible at the assertion.
+documented_vars() {
+    grep -rhoE 'OCTOPUS_[A-Z0-9_]+' \
+        "$PROJECT_ROOT/CLAUDE.md" \
+        "$PROJECT_ROOT"/docs/*.md \
+        "$PROJECT_ROOT/config/features.json" 2>/dev/null | sort -u
+}
+
+manifest_vars() { grep -vE '^\s*(#|$)' "$MANIFEST" 2>/dev/null | cut -f1 | sort -u; }
+manifest_kind() { grep -m1 -E "^$1	" "$MANIFEST" 2>/dev/null | cut -f2; }
+manifest_detail() { grep -m1 -E "^$1	" "$MANIFEST" 2>/dev/null | cut -f3; }
+
+test_case "the manifest exists and parses"
+if [[ -f "$MANIFEST" ]] && [[ -n "$(manifest_vars)" ]]; then
+    test_pass
+else
+    test_fail "missing or empty $MANIFEST"
+fi
+
+test_case "documentation actually yields variables (guards a vacuous pass)"
+n="$(documented_vars | grep -c . || true)"
+if [[ "${n:-0}" -ge 20 ]]; then
+    test_pass
+else
+    test_fail "harvested only ${n} variables — the sources or the pattern changed, so every assertion below would be vacuous"
+fi
+
+# The assertion that matters. A variable added to the docs without a manifest
+# entry fails here, which is what makes this self-maintaining.
+test_case "every documented variable has a manifest entry"
+missing="$(comm -23 <(documented_vars) <(manifest_vars) || true)"
+count="$(printf '%s' "$missing" | grep -c . || true)"
+if [[ "${count:-0}" -eq 0 ]]; then
+    test_pass
+else
+    test_fail "${count} documented variable(s) unaccounted for: $(printf '%s' "$missing" | tr '\n' ' ')— add a covered-by, skip or placeholder entry to $(basename "$MANIFEST")"
+fi
+
+# The other direction: a manifest entry for a variable no longer documented is
+# stale, and a stale entry hides the fact that coverage is no longer needed.
+test_case "the manifest names no variable that is no longer documented"
+stale="$(comm -13 <(documented_vars) <(manifest_vars) || true)"
+count="$(printf '%s' "$stale" | grep -c . || true)"
+if [[ "${count:-0}" -eq 0 ]]; then
+    test_pass
+else
+    test_fail "${count} stale entr(ies): $(printf '%s' "$stale" | tr '\n' ' ')— remove them from $(basename "$MANIFEST")"
+fi
+
+test_case "every kind is one of covered-by, skip or placeholder"
+bad=""
+while IFS= read -r v; do
+    [[ -n "$v" ]] || continue
+    case "$(manifest_kind "$v")" in
+        covered-by|skip|placeholder) ;;
+        *) bad="$bad $v" ;;
+    esac
+done < <(manifest_vars)
+if [[ -z "$bad" ]]; then test_pass; else test_fail "unknown kind for:$bad"; fi
+
+# A covered-by pointing at a file that does not exist, or that never mentions the
+# variable, is coverage on paper only — exactly the state the four bugs above were
+# in before they were found.
+test_case "every covered-by target exists and mentions its variable"
+bad=""
+while IFS= read -r v; do
+    [[ -n "$v" ]] || continue
+    [[ "$(manifest_kind "$v")" == "covered-by" ]] || continue
+    f="$SCRIPT_DIR/$(manifest_detail "$v")"
+    if [[ ! -f "$f" ]]; then bad="$bad ${v}(no-file)"; continue; fi
+    grep -q -- "$v" "$f" || bad="$bad ${v}(not-mentioned)"
+done < <(manifest_vars)
+if [[ -z "$bad" ]]; then test_pass; else test_fail "broken covered-by entries:$bad"; fi
+
+# Skips must justify themselves. An unexplained skip is indistinguishable from an
+# oversight six months later.
+test_case "every skip carries a reason"
+bad=""
+while IFS= read -r v; do
+    [[ -n "$v" ]] || continue
+    [[ "$(manifest_kind "$v")" == "skip" ]] || continue
+    d="$(manifest_detail "$v")"
+    if [[ -z "$d" || "$d" == TODO* ]]; then bad="$bad $v"; fi
+done < <(manifest_vars)
+if [[ -z "$bad" ]]; then test_pass; else test_fail "skip without a reason (or still TODO):$bad"; fi
+
+# Ratchet: coverage may improve, never regress.
+test_case "covered-by count has not fallen below its recorded floor"
+FLOOR=27
+now="$(grep -c $'\tcovered-by\t' "$MANIFEST" || true)"
+if [[ "${now:-0}" -ge "$FLOOR" ]]; then
+    test_pass
+else
+    test_fail "covered-by fell from ${FLOOR} to ${now} — a variable lost its assertion; raise the floor only when it increases"
+fi
+
+# A placeholder is a claim that the harvester matched documentation prose rather
+# than a variable. Verify: a real variable is read somewhere in the codebase.
+test_case "no placeholder is actually read by the code"
+bad=""
+while IFS= read -r v; do
+    [[ -n "$v" ]] || continue
+    [[ "$(manifest_kind "$v")" == "placeholder" ]] || continue
+    if grep -rq -- "\${${v}[:-]" "$PROJECT_ROOT/scripts" "$PROJECT_ROOT/hooks" 2>/dev/null; then
+        bad="$bad $v"
+    fi
+done < <(manifest_vars)
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "marked placeholder but read as a variable:$bad — reclassify as covered-by or skip"
+fi
+
+test_summary


### PR DESCRIPTION
Closes #749.

## The problem this addresses

Four variables shipped inert in one release cycle:

| Issue | Variable | Why it did nothing |
|---|---|---|
| #715 | `OCTOPUS_GEMINI_VIA_AGY` | Three dispatch sites read the raw env var, so a recorded answer never reached them |
| #720 | `OCTOPUS_REVIEWER_FLIP` | `octo_features_choice` only forwards values matching a declared choice, so `=1` was dropped — while a comment promised it worked |
| #710 | `OCTOPUS_COMMANDCODE_PERMISSION_MODE` | The shim accepted it; dispatch always passed a positional argument that overrode it |
| #726 | `invocation: human_only` | Custom key stripped at build time; enforcement was a hardcoded list that disagreed with it |

Three share one root cause. **Every one had passing tests around it.**

The failure was never "nobody tested this function". It was that documentation and enforcement live in different files with nothing linking them, so a variable could be documented, read by a shim, and overridden three layers up with every existing test green. This suite is the link: it derives its work list **from the documentation**.

## What it does and does not do

It does **not** attempt to assert all 41 variables — that is a much larger job and most of the remainder need live providers. It asserts that **none is unaccounted for**, which is the property that rots silently. A variable added to `CLAUDE.md`, `docs/*.md` or `config/features.json` without a manifest entry fails here. That inverted default is the whole design.

Manifest breakdown:

- **27 `covered-by`** — points at a suite that exercises the variable
- **10 `skip`** — real variable, assertion impractical, each with a *required* reason. An unexplained skip is indistinguishable from an oversight six months later.
- **4 `placeholder`** — not variables. The harvest regex matches doc template fragments like `OCTOPUS_AGENT_<NAME>` and `OCTOPUS_MYPROV_ALLOWED_MODELS`; without this category the suite would be permanently red on documentation prose.

## Guards, because a manifest rots in more than one way

- a `covered-by` target must exist **and mention its variable** — coverage on paper fails, which is the exact state the four bugs above were in
- a `placeholder` must not actually be read as a variable in `scripts/` or `hooks/`
- stale entries for no-longer-documented variables are reported
- the `covered-by` count has a floor, so coverage can improve but not regress
- the harvest must yield ≥20 variables, or every assertion below it would be vacuous

## Verification

Mutation-checked both directions:

```
new knob added to CLAUDE.md, no manifest entry  -> fails, names OCTOPUS_BRAND_NEW_KNOB
covered-by repointed at a file that never
  mentions its variable                          -> fails, flags (not-mentioned)
```

## Honest limitation

`covered-by` asserts a suite *mentions* the variable, not that it asserts the variable's effect. That is weaker than #749 proposed. Strengthening it means writing real behavioural assertions for the remaining 27, which is worth doing incrementally — moving entries from `skip` to `covered-by`, and then tightening what `covered-by` requires. The floor ratchet is there to make that direction one-way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation to ensure documented configuration variables are accurately represented in the project manifest.
  * Checks now identify missing or outdated entries, invalid classifications, incomplete references, and missing skip explanations.
  * Added reporting that summarizes validation results for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->