### PR TITLE
test: derive the memory_scope expectation from git, not a logical path

### DIFF
--- a/tests/unit/test-memory-contract.sh
+++ b/tests/unit/test-memory-contract.sh
@@ -143,7 +143,17 @@ test_backends_detects_agentmemory_env() {
 test_scope_uses_repo_basename() {
     test_case "memory_scope falls back to git repo basename"
     local out expected
-    expected=$(basename "$PROJECT_ROOT")
+    # Derive the expectation from the same source memory_scope uses — git's
+    # toplevel — not from PROJECT_ROOT. PROJECT_ROOT is resolved logically
+    # (`cd && pwd`, line 7) while `git rev-parse --show-toplevel` resolves
+    # symlinks, so the two diverge behind a symlinked checkout and this case
+    # failed with `expected 'octo-linked', got: claude-octopus`. The code is
+    # right: a scope keyed on the link name would fragment one repo's memory
+    # across every path used to reach it. Same class as #712.
+    local scope_root
+    scope_root=$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null || true)
+    [[ -n "$scope_root" ]] || scope_root=$(cd -P "$PROJECT_ROOT" && pwd)
+    expected=$(basename "$scope_root")
     # shellcheck disable=SC1090
     out=$(cd "$PROJECT_ROOT" && bash -c "source '$MEM'; memory_scope")
     [[ "$out" == "$expected" ]] \


### PR DESCRIPTION
Found by the symlinked-path CI job in #758, on its **first run**. Prerequisite for that PR going green.

## What broke

`test-memory-contract.sh` asserted `basename "$PROJECT_ROOT"` against `memory_scope`'s output. `PROJECT_ROOT` is resolved logically (`cd && pwd`, line 7); `memory_scope` uses `git rev-parse --show-toplevel`, which resolves symlinks. They agree under a normal checkout and diverge behind one:

```
memory_scope falls back to git repo basename:
  expected 'octo-linked', got: claude-octopus
```

## The code is right; the test was wrong

A scope keyed on the *link* name would fragment one repository's memory across every path used to reach it — the opposite of what a scope is for. `git rev-parse --show-toplevel` gives a stable identity, which is correct. Same class as #712.

The expectation now derives from the same source the code uses, with a physical-path fallback for the non-repo case.

## Verification

```
real path:  15 passed, 0 failed
symlinked:  15 passed, 0 failed
```

Mutation-checked so the assertion has not been weakened into a tautology: making `memory_scope` return a wrong scope still fails the case.

## One note for the next person

The obvious one-liner is wrong:

```bash
expected=$(basename "$(git ... --show-toplevel 2>/dev/null || cd -P "$PROJECT_ROOT" && pwd)")
```

That parses as `(git || cd) && pwd`, so `pwd` runs even when git succeeded and overrides its output. I shipped it briefly and the symlink run caught that too — which is a second small vote for the job in #758.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability when the project is accessed through a logical path or symlink.
  * Tests now determine the expected repository scope from the actual Git project location, with a fallback for non-Git environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->