### PR TITLE
ci: answer merge_group events so a merge queue can be enabled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main ]
+  # Required before a merge queue can be enabled on main. The queue dispatches
+  # merge_group events against a temporary branch holding the projected result
+  # of merging the queued PRs; if no workflow answers that event, the required
+  # checks never report and every queue entry hangs until it times out. Adding
+  # the trigger is inert until a queue exists, so it lands first, on its own.
+  merge_group:
   schedule:
     # Nightly builds at 2 AM UTC
     - cron: '0 2 * * *'


### PR DESCRIPTION
**Prerequisite. This must land before the queue is turned on — enabling it first would break all merging.**

A merge queue dispatches `merge_group` events against a temporary branch holding the projected result of merging the queued PRs. If no workflow answers that event, the three required checks (Smoke Tests, Unit Tests, Integration Tests) never report and **every queue entry hangs until it times out**. No workflow in this repo listens for `merge_group` today — I checked before touching any settings.

The trigger is inert until a queue exists, so this is safe to land on its own.

## Verified, not assumed

Every job is gated on `classify-changes.outputs.heavy_tests`, so I traced what that does for the new event:

```
if   event_name == 'pull_request'   -> diff base..head
elif github.event.before is set     -> diff before..sha
else                                 -> heavy_tests=true
```

A `merge_group` event matches neither of the first two, so it takes the fallback and runs the **full** suite. That is the safe direction, and the right one for a queue entry — it is the last check before code reaches main.

## Why a queue

Branch protection has `strict: true`, so every PR must be up to date with main at merge time. With 11 PRs open, each merge invalidates the other ten and costs each of them a full ~7-minute CI cycle to rebase. I have rebased some of these three times today without converging, and two new PRs arrived mid-drain.

A queue tests the *projected merge result* instead, which is what that requirement is actually trying to achieve — it just does it once per batch rather than N times per merge.

## Sequencing after this

1. merge this
2. add a `merge_queue` rule for `main` via a ruleset
3. drop `strict` from branch protection — the queue subsumes it, and leaving both on makes the queue pointless
4. queue the remaining PRs

Steps 2 and 3 are settings changes I'll make only once this is merged and I've confirmed the workflow answers a real `merge_group` event. Both are reversible: delete the ruleset, re-enable `strict`.