### PR TITLE
fix: stop Codex from silently skipping the telemetry-webhook hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -113,7 +113,6 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/telemetry-webhook.sh",
-            "async": true,
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Description

`hooks/hooks.json` declared the `telemetry-webhook.sh` PostToolUse hook with `"async": true`. Codex CLI doesn't support async hooks, and per #766 it doesn't downgrade them to synchronous — it **skips them entirely**, printing `warning: skipping async hook ... async hooks are not supported yet`. That means the webhook hook silently never fires for Codex users who opt in via `OCTOPUS_WEBHOOK_URL`, beyond the cosmetic warning noise.

Fix: drop `async: true`. The hook keeps its existing 10s timeout and `if: env.OCTOPUS_WEBHOOK_URL` gate (opt-in only), so on hosts that do support async it now just blocks briefly instead of running in the background — no behavior change when the webhook isn't configured.

**This is a partial fix for #766.** The other two warnings in that issue (`session-end.sh` and `workflow-verification.sh` SessionEnd hooks clamped to Codex's 3s cap) are intentionally not touched here: `hooks/hooks.json` is shared across every host, and shrinking the declared timeout from 15s/10s to 3s to silence the Codex warning would also cut Claude Code's actual budget for `session-end.sh`, which does several `jq` calls, file writes, and shells out to `write-handoff.sh` and `session-manager.sh cleanup`. There's no per-host hook manifest mechanism in this repo today, so fixing that properly is a design decision (per-host manifest vs. trimming `session-end.sh` to fit 3s), not a one-line change — left a comment on #766 explaining this and asking for direction rather than guessing.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [x] `hooks/hooks.json` is valid JSON (verified with `python3 -m json.tool`)
- [ ] OpenClaw registry in sync — not applicable, no tool/skill/command change
- [ ] New skills/commands registered — not applicable
- [ ] Version bump — not applicable, no release cut in this change
- [ ] Documentation updated — not applicable
- [ ] CHANGELOG.md updated — deferred to whoever finishes the SessionEnd half of #766, so the entry covers the full fix in one line

## Testing

The change is a single-line JSON edit (removing `"async": true"` from one hook entry), so I ran the directly affected surface rather than the full suite:

```bash
python3 -c "import json; json.load(open('hooks/hooks.json'))"   # valid JSON
bash -n scripts/*.sh scripts/lib/*.sh hooks/*.sh                 # syntax check, all pass
bash tests/unit/test-auto-router-hooks.sh                        # 13/13 pass
bash tests/unit/test-docs-sync.sh                                 # 141/141 pass
bash tests/unit/test-github-work-queue-hook.sh                    # 4/4 pass
bash tests/unit/test-hook-err-traps.sh                             # 8/8 pass
bash tests/unit/test-shell-safe-hooks-v2183.sh                    # 8/8 pass
bash tests/unit/test-openclaw-compat.sh                           # 32/32 pass
```

No test in the repo currently pins the `async`/timeout values in `hooks/hooks.json` (confirmed by grep), so nothing was pinning the old behavior and nothing regresses it. #766 itself suggests adding regression coverage for this — that's still open.

## Related Issues
Refs #766 (partial — see PR description and issue comment for what's still open)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SDXrwHfZYqsnR9gd2MZE8k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated telemetry webhook execution settings for more consistent hook behavior.
  * Webhook conditions, command, and timeout remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->