### PR TITLE
fix: grok and claude-sdk dispatch rejected by validate_agent_command

### DIFF
--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -294,7 +294,8 @@ validate_agent_command() {
     fi
     if [[ "$cmd_executable" == */vibe-exec.sh || "$cmd_executable" == */ollama-run.sh || "$cmd_executable" == */codex-run.sh \
         || "$cmd_executable" == */scripts/helpers/agy-exec.sh || "$cmd_executable" == */scripts/helpers/copilot-exec.sh \
-        || "$cmd_executable" == */scripts/helpers/commandcode-exec.sh ]]; then
+        || "$cmd_executable" == */scripts/helpers/commandcode-exec.sh || "$cmd_executable" == */scripts/helpers/grok-exec.sh \
+        || "$cmd_executable" == */scripts/helpers/claude-sdk-exec.sh ]]; then
         return 0
     fi
 
@@ -323,6 +324,10 @@ validate_agent_command() {
         "agent "*|"agent")        # Cursor Agent CLI (v9.23.0)
             return 0 ;;
         "env NODE_NO_WARNINGS="*) # only allow env with NODE_NO_WARNINGS prefix
+            return 0 ;;
+        "env OCTOPUS_GROK_MODEL="*)      # grok-exec.sh model prefix (v9.10.0)
+            return 0 ;;
+        "env OCTOPUS_CLAUDE_SDK_MODEL="*) # claude-sdk-exec.sh model prefix (v9.50.0)
             return 0 ;;
         *)
             _utils_log ERROR "Invalid agent command: $cmd"

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -207,6 +207,22 @@ _octopus_is_safe_openai_compatible_value() {
     return 0
 }
 
+# Grok/claude-sdk dispatch commands take the shape
+# `env OCTOPUS_<PROVIDER>_MODEL=<model> <shim path>` with nothing else — bind
+# the env assignment to the shim being the *next* token (not merely appearing
+# later in the string), so `env OCTOPUS_GROK_MODEL=x echo pwned <shim>` is
+# rejected instead of matching on a fixed prefix/suffix pair.
+_validate_env_prefixed_shim_command() {
+    local cmd="$1" env_prefix="$2" shim_suffix="$3"
+    local -a parts
+    read -r -a parts <<< "$cmd"
+    [[ "${#parts[@]}" -eq 3 ]] || return 1
+    [[ "${parts[0]}" == "env" ]] || return 1
+    [[ "${parts[1]}" == "${env_prefix}="* ]] || return 1
+    [[ "${parts[2]}" == *"$shim_suffix" ]] || return 1
+    return 0
+}
+
 _validate_openai_compatible_agent_command() {
     local cmd="$1"
     local -a parts
@@ -298,6 +314,14 @@ validate_agent_command() {
         || "$cmd_executable" == */scripts/helpers/claude-sdk-exec.sh ]]; then
         return 0
     fi
+    if [[ "$cmd_executable" == "env" ]]; then
+        if _validate_env_prefixed_shim_command "$cmd" "OCTOPUS_GROK_MODEL" "/scripts/helpers/grok-exec.sh"; then
+            return 0
+        fi
+        if _validate_env_prefixed_shim_command "$cmd" "OCTOPUS_CLAUDE_SDK_MODEL" "/scripts/helpers/claude-sdk-exec.sh"; then
+            return 0
+        fi
+    fi
 
     # Whitelist of allowed command prefixes (v7.19.0: tightened to exact patterns)
     case "$cmd" in
@@ -324,10 +348,6 @@ validate_agent_command() {
         "agent "*|"agent")        # Cursor Agent CLI (v9.23.0)
             return 0 ;;
         "env NODE_NO_WARNINGS="*) # only allow env with NODE_NO_WARNINGS prefix
-            return 0 ;;
-        "env OCTOPUS_GROK_MODEL="*"/scripts/helpers/grok-exec.sh") # grok-exec.sh model prefix (v9.10.0); bind the prefix to its shim so an arbitrary executable can't ride along after it
-            return 0 ;;
-        "env OCTOPUS_CLAUDE_SDK_MODEL="*"/scripts/helpers/claude-sdk-exec.sh") # claude-sdk-exec.sh model prefix (v9.50.0); same binding
             return 0 ;;
         *)
             _utils_log ERROR "Invalid agent command: $cmd"

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -325,9 +325,9 @@ validate_agent_command() {
             return 0 ;;
         "env NODE_NO_WARNINGS="*) # only allow env with NODE_NO_WARNINGS prefix
             return 0 ;;
-        "env OCTOPUS_GROK_MODEL="*)      # grok-exec.sh model prefix (v9.10.0)
+        "env OCTOPUS_GROK_MODEL="*"/scripts/helpers/grok-exec.sh") # grok-exec.sh model prefix (v9.10.0); bind the prefix to its shim so an arbitrary executable can't ride along after it
             return 0 ;;
-        "env OCTOPUS_CLAUDE_SDK_MODEL="*) # claude-sdk-exec.sh model prefix (v9.50.0)
+        "env OCTOPUS_CLAUDE_SDK_MODEL="*"/scripts/helpers/claude-sdk-exec.sh") # claude-sdk-exec.sh model prefix (v9.50.0); same binding
             return 0 ;;
         *)
             _utils_log ERROR "Invalid agent command: $cmd"

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -218,6 +218,16 @@ else
     test_pass
 fi
 
+# CodeRabbit (#769): the OCTOPUS_GROK_MODEL/OCTOPUS_CLAUDE_SDK_MODEL env-prefix
+# arms must bind to their matching shim, or any executable can ride along
+# after the prefix — e.g. `env OCTOPUS_GROK_MODEL=x echo pwned` would pass.
+test_case "validate_agent_command rejects env-prefixed grok command with wrong executable"
+if validate_agent_command "env OCTOPUS_GROK_MODEL=x echo pwned" >/dev/null 2>&1; then
+    test_fail "expected env-prefixed command without the grok-exec shim to be rejected"
+else
+    test_pass
+fi
+
 test_case "validate_agent_command allows claude-sdk-exec shim path"
 if validate_agent_command "$PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh"; then
     test_pass
@@ -235,6 +245,13 @@ fi
 test_case "validate_agent_command rejects embedded claude-sdk-exec shim path"
 if validate_agent_command "echo $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh" >/dev/null 2>&1; then
     test_fail "expected embedded claude-sdk-exec shim path to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects env-prefixed claude-sdk command with wrong executable"
+if validate_agent_command "env OCTOPUS_CLAUDE_SDK_MODEL=x echo pwned" >/dev/null 2>&1; then
+    test_fail "expected env-prefixed command without the claude-sdk-exec shim to be rejected"
 else
     test_pass
 fi

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -228,6 +228,16 @@ else
     test_pass
 fi
 
+# CodeRabbit (#769, round 2): binding on prefix+suffix alone still let a wrong
+# executable ride along as long as the shim path trailed it somewhere in the
+# string — the shim must be the *next token*, not merely present later.
+test_case "validate_agent_command rejects grok command with wrong executable trailed by the shim path"
+if validate_agent_command "env OCTOPUS_GROK_MODEL=x echo pwned $PROJECT_ROOT/scripts/helpers/grok-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected wrong-executable-then-shim-path to be rejected"
+else
+    test_pass
+fi
+
 test_case "validate_agent_command allows claude-sdk-exec shim path"
 if validate_agent_command "$PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh"; then
     test_pass
@@ -252,6 +262,13 @@ fi
 test_case "validate_agent_command rejects env-prefixed claude-sdk command with wrong executable"
 if validate_agent_command "env OCTOPUS_CLAUDE_SDK_MODEL=x echo pwned" >/dev/null 2>&1; then
     test_fail "expected env-prefixed command without the claude-sdk-exec shim to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects claude-sdk command with wrong executable trailed by the shim path"
+if validate_agent_command "env OCTOPUS_CLAUDE_SDK_MODEL=x echo pwned $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected wrong-executable-then-shim-path to be rejected"
 else
     test_pass
 fi

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -191,6 +191,80 @@ else
     test_pass
 fi
 
+# get_agent_command emits these two shapes for grok (v9.10.0) and claude-sdk
+# (v9.50.0) — a bare shim path when no model override is set, or an
+# `env OCTOPUS_*_MODEL=<model> <shim>` prefix when one is. Neither shape was in
+# validate_agent_command's allowlist, so every grok/claude-sdk dispatch aborted
+# with "Invalid agent command" before the CLI ever ran — the same failure mode
+# as #697 (copilot-exec.sh) and #705 (agy-exec.sh), predicted by #750.
+test_case "validate_agent_command allows grok-exec shim path"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/grok-exec.sh"; then
+    test_pass
+else
+    test_fail "expected bare grok-exec shim path to be accepted"
+fi
+
+test_case "validate_agent_command allows grok-exec shim path with model env prefix"
+if validate_agent_command "env OCTOPUS_GROK_MODEL=grok-4-fast $PROJECT_ROOT/scripts/helpers/grok-exec.sh"; then
+    test_pass
+else
+    test_fail "expected env-prefixed grok-exec shim path to be accepted"
+fi
+
+test_case "validate_agent_command rejects embedded grok-exec shim path"
+if validate_agent_command "echo $PROJECT_ROOT/scripts/helpers/grok-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected embedded grok-exec shim path to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command allows claude-sdk-exec shim path"
+if validate_agent_command "$PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh"; then
+    test_pass
+else
+    test_fail "expected bare claude-sdk-exec shim path to be accepted"
+fi
+
+test_case "validate_agent_command allows claude-sdk-exec shim path with model env prefix"
+if validate_agent_command "env OCTOPUS_CLAUDE_SDK_MODEL=claude-opus-5 $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh"; then
+    test_pass
+else
+    test_fail "expected env-prefixed claude-sdk-exec shim path to be accepted"
+fi
+
+test_case "validate_agent_command rejects embedded claude-sdk-exec shim path"
+if validate_agent_command "echo $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected embedded claude-sdk-exec shim path to be rejected"
+else
+    test_pass
+fi
+
+# End-to-end: exercise the real get_agent_command output, not just hand-written
+# literals, so a future change to the grok/claude-sdk command shape is caught
+# here instead of shipping silently broken (the actual #750 failure mode).
+test_case "get_agent_command dispatch commands for grok and claude-sdk pass validate_agent_command"
+(
+    FIXTURE_HOME="$TEST_TMP_DIR/agent-command-validation-home"
+    mkdir -p "$FIXTURE_HOME/.claude-octopus/config"
+    export PLUGIN_DIR="$PROJECT_ROOT" OCTOPUS_PLATFORM=Linux HOME="$FIXTURE_HOME"
+    export OCTOPUS_GROK_MODEL=grok-4-fast OCTOPUS_CLAUDE_SDK_MODEL=claude-opus-5
+    log() { :; }
+    source "$PROJECT_ROOT/scripts/lib/validation.sh"
+    source "$PROJECT_ROOT/scripts/lib/model-cache-path.sh"
+    source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+    source "$PROJECT_ROOT/scripts/lib/provider-routing.sh"
+    source "$PROJECT_ROOT/scripts/lib/dispatch.sh"
+    grok_cmd="$(get_agent_command grok tangle implementer)" || exit 1
+    sdk_cmd="$(get_agent_command claude-sdk tangle implementer)" || exit 1
+    validate_agent_command "$grok_cmd" >/dev/null 2>&1 || exit 1
+    validate_agent_command "$sdk_cmd" >/dev/null 2>&1 || exit 1
+)
+if [[ $? -eq 0 ]]; then
+    test_pass
+else
+    test_fail "get_agent_command output for grok/claude-sdk rejected by validate_agent_command"
+fi
+
 test_case "validate_agent_command rejects unsafe command"
 if validate_agent_command "rm -rf /" >/dev/null 2>&1; then
     test_fail "expected unsafe command to be rejected"


### PR DESCRIPTION
## Description

While triaging #750 (the gap where `validate_agent_command` is asserted shim-by-shim instead of looped over the provider list), I reproduced a live instance of exactly the failure pattern it predicts: `get_agent_command` emits a bare shim path or an `env OCTOPUS_*_MODEL=<model> <shim>` prefix for the **grok** (v9.10.0) and **claude-sdk** (v9.50.0) providers, but neither shape was ever added to `validate_agent_command`'s allowlist in `scripts/lib/utils.sh:283`.

Root cause: `validate_agent_command`'s shim-path allowlist (`scripts/lib/utils.sh:295-299`) lists `vibe-exec.sh`, `ollama-run.sh`, `codex-run.sh`, `agy-exec.sh`, `copilot-exec.sh`, `commandcode-exec.sh` — but never `grok-exec.sh` or `claude-sdk-exec.sh`. The env-prefixed case (`dispatch.sh:452` / `dispatch.sh:463`) also has no matching arm in the `case "$cmd"` whitelist (only `env NODE_NO_WARNINGS=`* is allowed, for qwen).

Impact: **every grok and claude-sdk dispatch is currently rejected** with `"Invalid agent command"` at the two call sites that gate on this function (`scripts/lib/spawn.sh:463`, `scripts/lib/workflows.sh:113`) — the CLI never runs. Confirmed by direct reproduction before the fix:

```
REJECTED: /fake/plugin/dir/scripts/helpers/grok-exec.sh
REJECTED: env OCTOPUS_GROK_MODEL=grok-4-fast /fake/plugin/dir/scripts/helpers/grok-exec.sh
REJECTED: /fake/plugin/dir/scripts/helpers/claude-sdk-exec.sh
REJECTED: env OCTOPUS_CLAUDE_SDK_MODEL=claude-opus-5 /fake/plugin/dir/scripts/helpers/claude-sdk-exec.sh
```

This is the same failure mode as #697 (`copilot-exec.sh`) and #705 (`agy-exec.sh`) — both cited in #750 as prior incidents of this exact gap.

## Fix

- Add `grok-exec.sh` and `claude-sdk-exec.sh` to the executable-token shim allowlist (`scripts/lib/utils.sh`).
- Add `"env OCTOPUS_GROK_MODEL="*` and `"env OCTOPUS_CLAUDE_SDK_MODEL="*` case arms, mirroring the existing qwen `NODE_NO_WARNINGS` precedent.
- Command-embedding rejection is preserved — `echo <shim path>` (injection attempt) is still rejected; only the executable-token position is trusted.

## Scope note

This fixes the concrete instance I found and reproduced, plus adds regression coverage for it. It does **not** implement the fully generalized "loop over `OCTO_MODEL_CONFIG_PROVIDERS`" test #750 proposes — that list and `get_agent_command`'s accepted `agent_type` values aren't 1:1 (e.g. `atlascloud` vs. `atlascloud-agent`), so building that loop correctly is a larger, separate piece of work. Leaving #750 open for that; happy to pick it up in a follow-up if wanted.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [x] OpenClaw registry in sync: `scripts/build-openclaw.sh --check`
- [x] New skills/commands registered in `.claude-plugin/plugin.json` (n/a — no new skills/commands)
- [x] Version bump (if releasing) (n/a — not a release PR)
- [ ] Documentation updated (if applicable) (n/a — internal dispatch fix only)
- [ ] CHANGELOG.md updated (leaving to release process)

## Testing

```bash
bash -n scripts/*.sh scripts/lib/*.sh   # all pass
bash tests/unit/test-agent-command-validation.sh   # 33/33 pass (7 new)
make test-unit    # 203/205 pass — 2 pre-existing failures confirmed present
                   # and unrelated on unmodified origin/main:
                   # test-feature-disclosure.sh, test-hud-smart-mode.sh
make test-integration   # 7/7 pass
bash tests/unit/test-openclaw-compat.sh   # 32/32 pass
./scripts/build-openclaw.sh --check       # registry up to date
```

New tests in `tests/unit/test-agent-command-validation.sh`:
- Literal-string acceptance for both shim shapes (bare path + env-prefixed)
- Injection-rejection for both (`echo <shim>` still rejected)
- An end-to-end test that sources the real `dispatch.sh`, calls `get_agent_command grok ...` / `get_agent_command claude-sdk ...`, and feeds the actual output through `validate_agent_command` — so a future change to either command's shape is caught here instead of shipping silently broken.

## Related Issues
Refs #750 (does not close — see scope note above)


---
_Generated by [Claude Code](https://claude.ai/code/session_019bwmgNSm6QAocoEtSMgJxc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Grok and Claude SDK execution commands.
  * Added support for configuring their models through environment-prefixed commands.

* **Bug Fixes**
  * Improved command validation to accept approved execution helpers while rejecting embedded, mismatched, invalid, or trailing commands.

* **Tests**
  * Added coverage for direct and environment-prefixed commands, including end-to-end validation of supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->