### PR TITLE
fix: stop the macOS timing-flake and misleading integration-red on unit failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -371,13 +371,16 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
-    needs: [classify-changes, integration-heavy]
+    needs: [classify-changes, unit-required, integration-heavy]
     if: always()
     steps:
       - name: Verify integration tests passed
         run: |
           if [[ "${{ needs.classify-changes.outputs.heavy_tests }}" == "false" ]]; then
             echo "Fast path: skipping integration tests for release/docs-only changes."
+          elif [[ "${{ needs.unit-required.result }}" != "success" ]]; then
+            echo "Integration Tests did not run: blocked by Unit Tests (${{ needs.unit-required.result }}), not an integration failure."
+            exit 1
           elif [[ "${{ needs.integration-heavy.result }}" != "success" ]]; then
             echo "Integration result: ${{ needs.integration-heavy.result }}"
             exit 1

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -169,20 +169,27 @@ sleep 1 &
 dead_provider_pid=$!
 review_wait_for_result_status "$dead_result" "$dead_provider_pid" dead-provider "$TEST_TMP_DIR" 02 01 &
 waiter_pid=$!
-waiter_finished=false
-for _ in 1 2 3 4; do
-    if ! review_process_is_running "$waiter_pid"; then
-        waiter_finished=true
-        break
-    fi
-    sleep 1
-done
+# Block on the waiter's own exit (SIGCHLD-driven) instead of racing a fixed
+# poll budget against scheduler jitter — the old 4x1s poll had only ~1-2s of
+# margin over the waiter's own ~2s internal cycle and went red intermittently
+# on loaded macOS runners. A generous watchdog still bounds the test so a
+# real regression (waiter never detects the dead process) fails instead of
+# hanging.
+(
+    sleep 15
+    kill -KILL "$waiter_pid" 2>/dev/null
+) &
+watchdog_pid=$!
+if wait "$waiter_pid" 2>/dev/null; then
+    waiter_finished=true
+else
+    waiter_finished=false
+fi
+kill "$watchdog_pid" 2>/dev/null || true
+wait "$watchdog_pid" 2>/dev/null || true
 if [[ "$waiter_finished" == "true" ]]; then
-    wait "$waiter_pid" 2>/dev/null || true
     test_pass
 else
-    kill -KILL "$waiter_pid" 2>/dev/null || true
-    wait "$waiter_pid" 2>/dev/null || true
     test_fail "waiter remained alive after provider exited"
 fi
 


### PR DESCRIPTION
## Description

Fixes both problems reported in #770.

**1. macOS timing flake in `test-review-aggregation-robustness.sh`.** The "retry wait stops when provider exits without terminal status" case raced a fixed 4×1s poll budget against `review_wait_for_result_status`'s own ~2s internal detection cycle (`scripts/lib/review.sh:391-429`), leaving only ~1-2s of margin against scheduler jitter — enough to flake on a loaded macOS runner. Replaced the poll with a blocking `wait` on the waiter's own exit (SIGCHLD-driven, no scheduling race), bounded by a generous 15s watchdog so a genuine regression (waiter never detects the dead process) still fails the test instead of hanging forever. Verified the fail path independently by pointing the same wait/watchdog pattern at a process that never exits — it correctly reported failure after the watchdog fired.

**2. Misleading double-red in `.github/workflows/test.yml`.** The `integration` gate (`.github/workflows/test.yml:371-384`) only checked `needs.integration-heavy.result`. `integration-heavy` requires `unit-required` to succeed, so a failed `unit-required` causes GitHub to skip `integration-heavy` outright. `integration` then read that skip as its own failure and reported "Integration Tests failed" — a single flaky/failing unit test produced two red required checks, with the second misattributing a skip as an integration bug. The gate now checks `unit-required.result` first and reports explicitly that it was blocked by Unit Tests before falling through to the original integration-result check. Still fails closed either way; only the diagnosis is now correct.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (32/32)
- [x] OpenClaw registry in sync — untouched by this change
- [x] New skills/commands registered — n/a, no new skills/commands
- [x] Version bump — n/a, not a release PR
- [x] Documentation updated — n/a
- [x] CHANGELOG.md updated — n/a, internal CI/test fix, no user-facing behavior change

## Testing

```bash
bash -n tests/unit/test-review-aggregation-robustness.sh   # syntax check
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"  # YAML validity

bash tests/unit/test-review-aggregation-robustness.sh      # 19/19 pass
make test-smoke                                             # 16/16 suites pass
make test-unit                                               # 203/205 pass
```

`make test-unit`'s 2 failures (`test-feature-disclosure.sh`, `test-hud-smart-mode.sh`) are pre-existing on unmodified `origin/main` — confirmed by stashing this change and re-running both directly against the release commit. Neither touches `review.sh` or the workflow file.

Also confirmed no unintended file-mode drift from local test runs (`git diff --summary` shows only the two content changes, no `mode change` lines) before committing, per this repo's Portability Lint rule.

## Related Issues
Closes #770

---
_Generated by [Claude Code](https://claude.ai/code/session_013mV3LDTpvjhBKk7A9JAXzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved automated verification reliability by ensuring integration checks run only after required prerequisite checks succeed.
  - Added clearer failure reporting to distinguish blocked integration checks from integration test failures.
  - Added timeout protection for retry-wait verification, preventing stalled checks from running indefinitely.

- **Chores**
  - Updated continuous integration workflows to provide more predictable and actionable validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->