### PR TITLE
fix: register /octo:whats-new, which shipped unregistered (refs #741)

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -21,7 +21,7 @@ You get:    A structured comparison with three independent viewpoints,
             scored for agreement. Disagreements are flagged, not hidden.
 ```
 
-This works for research, escalated code review, debugging, TDD, escalated security audits, UI design, PRDs, and full build-to-ship workflows — 50 commands, 63 skills, 32 specialized personas.
+This works for research, escalated code review, debugging, TDD, escalated security audits, UI design, PRDs, and full build-to-ship workflows — 51 commands, 63 skills, 32 specialized personas.
 
 Multi-provider runs show an agent summary before synthesis, so failed, timed out, or oversize-rejected Codex, Gemini, Antigravity, OpenRouter, and other perspectives are visible instead of being hidden behind a polished final answer.
 
@@ -68,7 +68,7 @@ Octopus orchestrates — it doesn't replace domain knowledge. If three models co
 ## Learn More
 
 - [**Full README**](../README.md) — feature deep-dive, provider grid, architecture, star history
-- [**Command Reference**](../docs/COMMAND-REFERENCE.md) — all 50 commands with triggers
+- [**Command Reference**](../docs/COMMAND-REFERENCE.md) — all 51 commands with triggers
 - [**Persona Guide**](../docs/AGENTS.md) — 32 specialized agents
 - [**Changelog**](../CHANGELOG.md) — release history
 - [**Issues**](https://github.com/nyldn/claude-octopus/issues) — bugs and feature requests

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.59.0 - Ten reliability fixes: orphaned provider children are reaped, council seats cancel without a race or pgrep, the OpenRouter seat works again, and debate-gate checkpoints are readable. Adds literal provider-model routing. 32 personas, 50 commands, 63 skills. Run /octo:setup.",
+      "description": "v9.59.0 - Ten reliability fixes: orphaned provider children are reaped, council seats cancel without a race or pgrep, the OpenRouter seat works again, and debate-gate checkpoints are readable. Adds literal provider-model routing. 32 personas, 51 commands, 63 skills. Run /octo:setup.",
       "version": "9.59.0",
       "author": {
         "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -138,6 +138,7 @@
     "./commands/retro.md",
     "./commands/history.md",
     "./commands/discipline.md",
-    "./commands/usage.md"
+    "./commands/usage.md",
+    "./commands/whats-new.md"
   ]
 }

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -39,7 +39,7 @@ Claude Octopus is a **multi-runtime orchestration plugin** with three architectu
 | **Workflow engine** (`skills/`) | Structures every task into Discover → Define → Develop → Deliver with quality gates | Stops ad-hoc "just ask Claude" from shipping low-confidence output |
 | **Consensus layer** | 75% gate: flags disagreements across providers before code is finalized | The actual blind-spot catcher — surfaces the 1-in-5 case where Claude was wrong |
 
-50 slash commands, 63 skills, 32 specialized personas activate the right layer for the right job.
+51 slash commands, 63 skills, 32 specialized personas activate the right layer for the right job.
 
 ## Core Value Propositions
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 
 🔄 **Four-phase methodology, not just tools.** Every task moves through Discover → Define → Develop → Deliver, with quality gates between phases. Other orchestrators give you infrastructure. Octopus gives you the workflows.
 
-🐙 **32 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **50 commands** (slash commands you type), **63 skills** (reusable workflow modules). Say "audit my API" and the right expert activates. Don't know the command? The smart router figures it out.
+🐙 **32 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **51 commands** (slash commands you type), **63 skills** (reusable workflow modules). Say "audit my API" and the right expert activates. Don't know the command? The smart router figures it out.
 
 🐙 **Works with just Claude. Adds up to ten external provider integrations.** Zero external providers are needed to start. Add them one at a time — each activates automatically when detected.
 


### PR DESCRIPTION
commands/whats-new.md has existed since 2026-07-30 with valid
frontmatter but was never added to plugin.json: 51 command files on
disk, 50 registered, exactly one gap and no orphans in the other
direction.

Found by tests/test-command-registration.sh, which is one of the 34
files #752 showed CI has never run. That is the concrete payoff the
reachability work predicted — a user-facing command silently absent
from the plugin manifest, caught by a test that existed and asserted
nothing because no gate invoked it.

make sync propagates the count to 51 across marketplace.json,
README.md, .claude-plugin/README.md and PRODUCT.md.

Appended rather than inserted alphabetically: the existing list is
append-ordered, and sorting it churned 38 lines for a one-entry
change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “What’s New” command to the plugin.

* **Documentation**
  * Updated plugin documentation and listings to reflect the expanded total of 51 available commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->