### PR TITLE
test: remove duplicate test targets and consolidate syntax checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-smoke test-unit test-integration test-e2e test-live test-coverage test-all test-plugin-name validate-plugin-assembly clean-tests help sync sync-check ci-local
+.PHONY: test test-smoke test-unit test-integration test-live test-root test-coverage test-all test-plugin-name validate-plugin-assembly clean-tests help sync sync-check ci-local
 
 # Default: smoke + unit (fast feedback)
 test: test-smoke test-unit
@@ -30,7 +30,7 @@ validate-plugin-assembly:
 	@./scripts/validate-plugin-assembly.py --root .
 
 # Run all tests
-test-all: test-smoke test-unit test-integration test-e2e
+test-all: test-smoke test-unit test-integration
 
 # Smoke tests (pre-commit, <30s)
 test-smoke: test-plugin-name
@@ -47,26 +47,16 @@ test-integration:
 	@echo "Running integration tests..."
 	@./tests/run-all.sh integration
 
-# E2E tests (15-30min)
-test-e2e:
-	@echo "Running E2E tests..."
-	@./tests/run-all.sh e2e
-
 # Live tests - real Claude Code sessions (2-5min per test, uses API)
 test-live:
 	@echo "Running live tests (real Claude Code sessions)..."
 	@echo "WARNING: This makes real API calls"
 	@./tests/run-all.sh live
 
-# Performance tests
-test-performance:
-	@echo "Running performance tests..."
-	@./tests/run-all.sh performance
-
-# Regression tests
-test-regression:
-	@echo "Running regression tests..."
-	@./tests/run-all.sh regression
+# tests/ root category (see #741 — not run by any CI gate)
+test-root:
+	@echo "Running tests/ root suites..."
+	@./tests/run-all.sh root
 
 # Coverage report
 test-coverage:
@@ -96,10 +86,11 @@ help:
 	@echo "  make test-smoke        - Run smoke tests (<30s)"
 	@echo "  make test-unit         - Run unit tests (1-2min)"
 	@echo "  make test-integration  - Run integration tests (5-10min)"
-	@echo "  make test-e2e          - Run E2E tests (15-30min)"
-	@echo "  make test-live         - Run live tests (real Claude sessions)"
-	@echo "  make test-performance  - Run performance tests"
-	@echo "  make test-regression   - Run regression tests"
+	@echo "  make          - Run E2E tests (15-30min)"
+	@echo "  make test-live         - Run live tests (real Claude sessions, real API cost)"
+	@echo "  make test-root         - Run tests/ root suites (not in CI, see #741)"
+	@echo "  make  - Run performance tests"
+	@echo "  make   - Run regression tests"
 	@echo "  make test-coverage     - Generate coverage report"
 	@echo "  make validate-plugin-assembly - Validate plugin assembly structure"
 	@echo "  make test-verbose      - Run all tests with verbose output"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test:smoke": "make test-smoke",
     "test:unit": "make test-unit",
     "test:integration": "make test-integration",
-    "test:e2e": "make test-e2e",
     "test:all": "make test-all",
     "test:coverage": "make test-coverage",
     "test:verbose": "make test-verbose",

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -120,9 +120,11 @@ for arg in "$@"; do
         --integration) CATEGORIES+=("integration") ;;
         --root)        CATEGORIES+=("root") ;;
         --live)        CATEGORIES+=("live") ;;
-        --regression)  CATEGORIES+=("root") ;;  # backward compat
-        --e2e)         CATEGORIES+=("integration") ;;  # backward compat
-        --performance) CATEGORIES+=("live") ;;  # backward compat
+        # Removed compat aliases: --e2e ran "integration" and --performance ran
+        # "live", so each category was reachable under two names. --e2e made
+        # `make test-all` run the integration suites twice, and --performance
+        # dispatched real provider sessions without the warning `test-live`
+        # prints. --regression ran "root", which is now reachable as --root.
         --all)         CATEGORIES=("smoke" "unit" "integration" "root") ;;
         --everything)  CATEGORIES=("smoke" "unit" "integration" "root" "live") ;;
         --fail-fast)   FAIL_FAST=true ;;

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,28 +1,37 @@
 #!/usr/bin/env bash
 # Compatibility wrapper for Makefile targets.
-# Historical Makefile targets call: ./tests/run-all.sh <category>
+# Historical Makefile targets call: ./tests/run-all.sh <category> [extra flags]
 #
 # Supported categories:
-#   unit | integration | e2e | live | performance | regression | all | smoke
-
+#   smoke | unit | integration | root | live | all
+#
+# Removed aliases, each of which ran an existing category under a second name:
+#   e2e         -> ran `integration`, so `make test-all` executed the
+#                  integration suites twice and the help text advertised a
+#                  "15-30min" E2E run that was really the ~1min integration run.
+#   performance -> ran `live`, which dispatches real `claude -p` sessions, but
+#                  without the "real API calls" warning that `test-live` prints.
+#   regression  -> ran `root`, now reachable under that honest name.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 category="${1:-all}"
+shift || true
 
+# Extra arguments are forwarded. They previously were not, so `--list` was
+# silently discarded and a request to *list* a category ran it instead — which
+# for `live` meant billing real provider calls to answer a question about which
+# files exist.
 case "$category" in
-  smoke)       exec "$SCRIPT_DIR/run-all-tests.sh" --smoke ;;
-  unit)        exec "$SCRIPT_DIR/run-all-tests.sh" --unit ;;
-  integration) exec "$SCRIPT_DIR/run-all-tests.sh" --integration ;;
-  e2e)         exec "$SCRIPT_DIR/run-all-tests.sh" --e2e ;;
-  live)        exec "$SCRIPT_DIR/run-all-tests.sh" --live ;;
-  performance) exec "$SCRIPT_DIR/run-all-tests.sh" --performance ;;
-  regression)  exec "$SCRIPT_DIR/run-all-tests.sh" --regression ;;
-  all)         exec "$SCRIPT_DIR/run-all-tests.sh" --all ;;
+  smoke)       exec "$SCRIPT_DIR/run-all-tests.sh" --smoke "$@" ;;
+  unit)        exec "$SCRIPT_DIR/run-all-tests.sh" --unit "$@" ;;
+  integration) exec "$SCRIPT_DIR/run-all-tests.sh" --integration "$@" ;;
+  root)        exec "$SCRIPT_DIR/run-all-tests.sh" --root "$@" ;;
+  live)        exec "$SCRIPT_DIR/run-all-tests.sh" --live "$@" ;;
+  all)         exec "$SCRIPT_DIR/run-all-tests.sh" --all "$@" ;;
   *)
-    echo "Usage: $(basename "$0") {smoke|unit|integration|e2e|live|performance|regression|all}" >&2
+    echo "Usage: $(basename "$0") {smoke|unit|integration|root|live|all} [flags]" >&2
     exit 2
     ;;
 esac
-

--- a/tests/smoke/test-syntax.sh
+++ b/tests/smoke/test-syntax.sh
@@ -86,10 +86,47 @@ test_executable_permissions() {
     fi
 }
 
+# One authoritative syntax sweep over the shipped scripts.
+#
+# Previously only orchestrate.sh and tests/helpers/*.sh were checked here, so
+# scripts/lib/*.sh and scripts/helpers/*.sh had no syntax gate in CI at all.
+# Seven unit suites had each grown their own `workflows.sh has valid bash
+# syntax` case to compensate, and the only comprehensive sweeps lived in the
+# tests/ root files that no CI gate runs (#741). That is the worst of both:
+# the same file checked seven times, and 95 others not checked at all.
+test_shipped_scripts_syntax() {
+    test_case "All shipped scripts have valid bash syntax"
+
+    local failed=0 checked=0 script
+    for script in "$PROJECT_ROOT"/scripts/lib/*.sh "$PROJECT_ROOT"/scripts/helpers/*.sh; do
+        [[ -f "$script" ]] || continue
+        checked=$((checked + 1))
+        if ! bash -n "$script" 2>/dev/null; then
+            echo "  Syntax error in: ${script#"$PROJECT_ROOT"/}"
+            failed=1
+        fi
+    done
+
+    # Guards a vacuous pass: if the globs stop matching, every file would be
+    # skipped and this would report success having checked nothing.
+    if [[ "$checked" -lt 50 ]]; then
+        test_fail "only ${checked} scripts matched — the glob is wrong, so this assertion proves nothing"
+        return 1
+    fi
+
+    if [[ $failed -eq 0 ]]; then
+        test_pass
+    else
+        test_fail "One or more shipped scripts have syntax errors"
+        return 1
+    fi
+}
+
 # Run tests
 test_orchestrate_syntax
 test_main_skill_syntax
 test_helper_scripts_syntax
+test_shipped_scripts_syntax
 test_executable_permissions
 
 test_summary

--- a/tests/unit/test-develop-md-file-resolution.sh
+++ b/tests/unit/test-develop-md-file-resolution.sh
@@ -37,13 +37,6 @@ assert_lacks() {
     fi
 }
 
-test_case "workflows.sh has valid bash syntax"
-if bash -n "$WORKFLOWS" 2>/dev/null; then
-    test_pass
-else
-    test_fail "syntax error in workflows.sh"
-fi
-
 assert_lacks 'grep -oE .*\.\.md.*head -1|grep -oE .*\\.md.*head -1' \
     "plan reference scan avoids grep|head pipeline"
 

--- a/tests/unit/test-embrace-fail-fast.sh
+++ b/tests/unit/test-embrace-fail-fast.sh
@@ -17,13 +17,6 @@ set +e
 
 test_suite "embrace phase fail-fast"
 
-test_case "workflows.sh has valid bash syntax"
-if bash -n "$WORKFLOWS" 2>/dev/null; then
-    test_pass
-else
-    test_fail "syntax error in workflows.sh"
-fi
-
 # shellcheck source=/dev/null
 source "$WORKFLOWS"
 

--- a/tests/unit/test-ink-compact-delivery.sh
+++ b/tests/unit/test-ink-compact-delivery.sh
@@ -12,13 +12,6 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 
 test_suite "ink compact delivery"
 
-test_case "workflows.sh has valid bash syntax"
-if bash -n "$WORKFLOWS" 2>/dev/null; then
-    test_pass
-else
-    test_fail "syntax error in workflows.sh"
-fi
-
 # shellcheck source=/dev/null
 source "$WORKFLOWS"
 

--- a/tests/unit/test-suite-reachability.sh
+++ b/tests/unit/test-suite-reachability.sh
@@ -117,8 +117,11 @@ fi
 
 # Guards the derivation itself: if someone points the Makefile at a category the
 # runner does not implement, reachability would silently compute as empty.
-# Follows compat aliases: run-all-tests.sh:124 maps `--e2e` to the integration
-# category, so `e2e` is implemented even though no `e2e)` arm exists.
+# A category counts as implemented if the runner has either a bare `<cat>)` arm
+# or a `--<cat>) CATEGORIES` flag arm; the flag form is what the real categories
+# use. This previously also absorbed the compat aliases (`--e2e` resolving to
+# integration, `--performance` to live), which have since been removed because
+# each made a category reachable under a second name.
 test_case "every category the Makefile invokes resolves to a real runner category"
 bad=""
 while IFS= read -r cat; do

--- a/tests/unit/test-tangle-direct-fallback.sh
+++ b/tests/unit/test-tangle-direct-fallback.sh
@@ -15,13 +15,6 @@ test_suite "tangle direct fallback"
 # These tests exercise tangle dispatch/validation behavior, not contextual review.
 export OCTOPUS_TANGLE_CODE_REVIEW=false
 
-test_case "workflows.sh has valid bash syntax"
-if bash -n "$WORKFLOWS" 2>/dev/null; then
-    test_pass
-else
-    test_fail "syntax error in workflows.sh"
-fi
-
 # shellcheck source=/dev/null
 source "$WORKFLOWS"
 

--- a/tests/unit/test-tangle-dispatch-stdin-isolation.sh
+++ b/tests/unit/test-tangle-dispatch-stdin-isolation.sh
@@ -16,13 +16,6 @@ test_suite "tangle dispatch stdin isolation"
 # These tests exercise tangle dispatch/validation behavior, not contextual review.
 export OCTOPUS_TANGLE_CODE_REVIEW=false
 
-test_case "workflows.sh has valid bash syntax"
-if bash -n "$WORKFLOWS" 2>/dev/null; then
-    test_pass
-else
-    test_fail "syntax error in workflows.sh"
-fi
-
 # shellcheck source=/dev/null
 source "$WORKFLOWS"
 

--- a/tests/unit/test-tangle-subtask-context.sh
+++ b/tests/unit/test-tangle-subtask-context.sh
@@ -15,13 +15,6 @@ test_suite "tangle subtask context preservation"
 # These tests exercise tangle dispatch/validation behavior, not contextual review.
 export OCTOPUS_TANGLE_CODE_REVIEW=false
 
-test_case "workflows.sh has valid bash syntax"
-if bash -n "$WORKFLOWS" 2>/dev/null; then
-    test_pass
-else
-    test_fail "syntax error in workflows.sh"
-fi
-
 # shellcheck source=/dev/null
 source "$WORKFLOWS"
 

--- a/tests/unit/test-tangle-write-scope-safety.sh
+++ b/tests/unit/test-tangle-write-scope-safety.sh
@@ -15,13 +15,6 @@ test_suite "tangle write-scope safety"
 # These tests exercise tangle dispatch/validation behavior, not contextual review.
 export OCTOPUS_TANGLE_CODE_REVIEW=false
 
-test_case "workflows.sh has valid bash syntax"
-if bash -n "$WORKFLOWS" 2>/dev/null; then
-    test_pass
-else
-    test_fail "syntax error in workflows.sh"
-fi
-
 # shellcheck source=/dev/null
 source "$WORKFLOWS"
 


### PR DESCRIPTION
Three Makefile targets ran categories that already had a target:

  test-e2e        -> integration. Made `make test-all` run the
                     integration suites twice, and help advertised a
                     '15-30min E2E run' that was the ~1min integration run.
  test-performance -> live. Same category as test-live but without the
                     'WARNING: This makes real API calls' banner, so it
                     billed provider sessions silently.
  test-regression  -> root. Not redundant (sole accessor) but misnamed;
                     renamed test-root to match the real category.

Also fixes a live bug: run-all.sh never forwarded "$@", so --list was
silently dropped and asking to *list* a category ran it instead. For
the live category that means real `claude -p` dispatches. I hit this
while auditing and billed several calls to answer a question about
which files exist. --list now returns in 0s instead of executing.

Syntax checks were both duplicated and missing. Seven unit suites each
asserted 'workflows.sh has valid bash syntax' while smoke checked only
orchestrate.sh and tests/helpers — scripts/lib (77 files) and
scripts/helpers (19) had no CI syntax gate at all, their only
comprehensive sweeps living in the tests/ root files no gate runs
(#741). Replaced with one sweep in smoke over all 96, with a
vacuous-pass guard; removed the 7 duplicates. Mutation-checked: a
deliberate syntax error is caught and the offending file named.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Testing**
  - Added a root-level test command for broader repository validation.
  - Simplified the full test run to smoke, unit, and integration coverage.
  - Removed end-to-end, performance, and regression aliases from supported test commands.
  - Added syntax validation for shipped scripts with safeguards against incomplete coverage.
  - Updated test discovery checks for current category formats.
  - Consolidated workflow syntax validation within relevant test execution while preserving behavior coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->