### PR TITLE
fix(embrace): YAML runtime — await sequential agents, real gate thresholds, stdout contract

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -3707,7 +3707,7 @@ ${obs_ctx}"
                 _failed_phase=$(jq -r '.current_phase // empty' "${HOME}/.claude-octopus/session.json" 2>/dev/null)
             fi
             _abort_embrace_phase "${_failed_phase:-unknown}" \
-                "YAML runtime halted: quality gate failed" "$yaml_result"
+                "YAML runtime failed" "$yaml_result"
             return 1
         fi
 

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -3698,7 +3698,11 @@ ${obs_ctx}"
         echo ""
 
         local yaml_result
-        yaml_result=$(run_yaml_workflow "embrace" "$prompt" "$task_group")
+        if ! yaml_result=$(run_yaml_workflow "embrace" "$prompt" "$task_group"); then
+            _abort_embrace_phase "${OCTOPUS_WORKFLOW_PHASE:-unknown}" \
+                "YAML runtime halted: quality gate failed" "$yaml_result"
+            return 1
+        fi
 
         # Mark workflow complete
         export OCTOPUS_WORKFLOW_PHASE="complete"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -3699,7 +3699,14 @@ ${obs_ctx}"
 
         local yaml_result
         if ! yaml_result=$(run_yaml_workflow "embrace" "$prompt" "$task_group"); then
-            _abort_embrace_phase "${OCTOPUS_WORKFLOW_PHASE:-unknown}" \
+            # run_yaml_workflow runs in a command-substitution subshell, so its
+            # phase exports cannot reach this scope. It records the failed
+            # phase in session.json before returning — read it from there.
+            local _failed_phase=""
+            if command -v jq &>/dev/null && [[ -f "${HOME}/.claude-octopus/session.json" ]]; then
+                _failed_phase=$(jq -r '.current_phase // empty' "${HOME}/.claude-octopus/session.json" 2>/dev/null)
+            fi
+            _abort_embrace_phase "${_failed_phase:-unknown}" \
                 "YAML runtime halted: quality gate failed" "$yaml_result"
             return 1
         fi

--- a/scripts/lib/yaml-workflow.sh
+++ b/scripts/lib/yaml-workflow.sh
@@ -74,24 +74,35 @@ yaml_get_phase_config() {
     local phase_name="$2"
     local field="$3"
 
+    local value=""
     if command -v yq &>/dev/null; then
-        yq eval ".phases[] | select(.name == \"$phase_name\") | .$field" "$yaml_file" 2>/dev/null
+        # Fall back to the phase quality_gate block for nested fields (threshold)
+        value=$(yq eval ".phases[] | select(.name == \"$phase_name\") | .$field // .quality_gate.$field // \"\"" "$yaml_file" 2>/dev/null)
     else
-        # awk fallback for simple fields
-        awk -v phase="$phase_name" -v field="$field" '
+        # awk fallback: match the field at any indent inside the phase block.
+        # Stops at the next top-level key so the last phase cannot bleed into
+        # the document-level quality_gates: block (that bug made ink report the
+        # consensus threshold 0.75 instead of its own 0.80).
+        value=$(awk -v phase="$phase_name" -v field="$field" '
+            in_phases && /^[a-zA-Z_]+:/ { exit }
+            /^phases:/ { in_phases=1 }
             /^  - name:/ {
                 gsub(/^  - name:[[:space:]]*/, "")
                 gsub(/["\047]/, "")
                 current_phase = $0
+                next
             }
-            current_phase == phase && $0 ~ "^    " field ":" {
-                gsub(/^[[:space:]]*[a-z_]+:[[:space:]]*/, "")
+            current_phase == phase && $0 ~ "^[[:space:]]+" field ":" {
+                gsub(/^[[:space:]]*[a-zA-Z_]+:[[:space:]]*/, "")
                 gsub(/["\047]/, "")
                 print
                 exit
             }
-        ' "$yaml_file"
+        ' "$yaml_file")
     fi
+    [[ "$value" == "null" ]] && value=""
+    [[ -n "$value" ]] && printf '%s\n' "$value"
+    [[ -n "$value" ]]
 }
 
 # Extract agents for a specific phase
@@ -144,10 +155,42 @@ yaml_get_agent_prompt() {
     local provider="$3"
 
     if command -v yq &>/dev/null; then
-        yq eval ".phases[] | select(.name == \"$phase_name\") | .agents[] | select(.provider == \"$provider\") | .prompt_template" "$yaml_file" 2>/dev/null
+        local yq_out
+        yq_out=$(yq eval ".phases[] | select(.name == \"$phase_name\") | .agents[] | select(.provider == \"$provider\") | .prompt_template // \"\"" "$yaml_file" 2>/dev/null)
+        [[ "$yq_out" == "null" ]] && yq_out=""
+        printf '%s\n' "$yq_out"
     else
-        # For awk fallback, return empty - hardcoded prompts will be used
-        echo ""
+        # awk fallback: extract the `prompt_template: |` block scalar for the
+        # matching phase+provider. Without this, every agent silently ran a
+        # bare "role: prompt" fallback whenever yq was not installed.
+        awk -v phase="$phase_name" -v provider="$provider" '
+            /^  - name:/ {
+                gsub(/^  - name:[[:space:]]*/, "")
+                gsub(/["\047]/, "")
+                current_phase = $0
+                current_provider = ""
+                in_block = 0
+                next
+            }
+            /^      - provider:/ {
+                if (in_block) exit
+                gsub(/^      - provider:[[:space:]]*/, "")
+                current_provider = $0
+                next
+            }
+            in_block {
+                if ($0 == "" || $0 ~ /^[[:space:]]{10}/) {
+                    line = $0
+                    sub(/^[[:space:]]{10}/, "", line)
+                    print line
+                    next
+                }
+                exit
+            }
+            current_phase == phase && current_provider == provider && /^        prompt_template:[[:space:]]*\|/ {
+                in_block = 1
+            }
+        ' "$yaml_file"
     fi
 }
 
@@ -191,6 +234,27 @@ _yaml_wait_for_pids() {
     return 0
 }
 
+# Wait for the .done completion markers of the given task ids. The spawn
+# wrapper writes the result file and marker AFTER the provider PID exits, so a
+# PID wait alone races the file writes. Markers hold the agent exit code.
+_yaml_wait_for_done_markers() {
+    local max_wait="$1"
+    shift || true
+    local done_dir="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents"
+    local wait_start=$SECONDS
+
+    while [[ $(( SECONDS - wait_start )) -lt $max_wait ]]; do
+        local all_done=true
+        local task_id
+        for task_id in "$@"; do
+            [[ -f "${done_dir}/${task_id}.done" ]] || { all_done=false; break; }
+        done
+        [[ "$all_done" == "true" ]] && return 0
+        sleep 1
+    done
+    return 1
+}
+
 # Execute a single workflow phase from YAML definition
 # Spawns agents as defined, respects parallel/sequential flags, evaluates quality gates
 execute_workflow_phase() {
@@ -207,13 +271,19 @@ execute_workflow_phase() {
     local alias_name
     alias_name=$(yaml_get_phase_config "$yaml_file" "$phase_name" "alias") || alias_name="$phase_name"
 
-    echo ""
-    echo -e "${MAGENTA}${_BOX_TOP}${NC}"
-    local alias_upper
-    alias_upper=$(echo "$alias_name" | tr '[:lower:]' '[:upper:]')
-    echo -e "${MAGENTA}║  ${GREEN}${alias_upper}${MAGENTA} - ${description}${MAGENTA}${NC}"
-    echo -e "${MAGENTA}${_BOX_BOT}${NC}"
-    echo ""
+    # Decorative output goes to stderr: this function is invoked inside a
+    # command substitution and stdout is reserved for the synthesis file path.
+    # Banners on stdout corrupted that path, so downstream phases never
+    # received the previous phase's output.
+    {
+        echo ""
+        echo -e "${MAGENTA}${_BOX_TOP}${NC}"
+        local alias_upper
+        alias_upper=$(echo "$alias_name" | tr '[:lower:]' '[:upper:]')
+        echo -e "${MAGENTA}║  ${GREEN}${alias_upper}${MAGENTA} - ${description}${MAGENTA}${NC}"
+        echo -e "${MAGENTA}${_BOX_BOT}${NC}"
+        echo ""
+    } >&2
 
     log "INFO" "YAML Runtime: Executing phase '$phase_name' ($description)"
 
@@ -234,6 +304,7 @@ execute_workflow_phase() {
 
     local pids=()
     local agent_idx=0
+    local spawned_tasks=()
 
     # Update session state for hooks
     local session_dir="${HOME}/.claude-octopus"
@@ -309,8 +380,15 @@ $previous_output"
                 _yaml_wait_for_pids "${TIMEOUT:-600}" "${pids[@]}"
                 pids=()
             fi
-            spawn_agent "$agent_type" "$agent_prompt" "$task_id" "$role" "$phase_name"
+            # spawn_agent backgrounds the provider internally, so capture the
+            # PID and block until it exits. Without this the phase synthesized
+            # and moved on while its sequential agent was still running, losing
+            # that agent's output from the synthesis handed to the next phase.
+            local seq_pid
+            seq_pid=$(spawn_agent_capture_pid "$agent_type" "$agent_prompt" "$task_id" "$role" "$phase_name")
+            _yaml_wait_for_pids "${TIMEOUT:-600}" "$seq_pid"
         fi
+        spawned_tasks+=("$task_id")
 
         ((agent_idx++)) || true
         sleep 0.1
@@ -347,6 +425,31 @@ $previous_output"
         fi
     fi
 
+    # Result files land shortly after the provider PIDs exit; wait for the
+    # completion markers so the collection below sees every agent's output.
+    if [[ ${#spawned_tasks[@]} -gt 0 ]]; then
+        local marker_wait="${OCTOPUS_YAML_DONE_WAIT:-30}"
+        _yaml_wait_for_done_markers "$marker_wait" "${spawned_tasks[@]}" \
+            || log "WARN" "Phase $phase_name: not all completion markers appeared within ${marker_wait}s"
+    fi
+
+    # Record completions in the bridge ledger. bridge_evaluate_gate reads
+    # completed_tasks from the ledger, but nothing ever marked tasks complete,
+    # so every gate evaluated as 0/N and "did not pass" on every phase.
+    local done_dir="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents"
+    local _task_id _agent_exit
+    if [[ ${#spawned_tasks[@]} -gt 0 ]]; then
+        for _task_id in "${spawned_tasks[@]}"; do
+            [[ -f "${done_dir}/${_task_id}.done" ]] || continue
+            _agent_exit=$(cat "${done_dir}/${_task_id}.done" 2>/dev/null)
+            if [[ "$_agent_exit" == "0" ]]; then
+                bridge_mark_task_complete "$_task_id" "completed" 2>/dev/null || true
+            else
+                bridge_mark_task_complete "$_task_id" "failed" 2>/dev/null || true
+            fi
+        done
+    fi
+
     # Collect phase output
     local phase_output=""
     local result_files
@@ -381,25 +484,37 @@ $previous_output"
         echo "$phase_output" >> "$synthesis_file"
     fi
 
-    # Evaluate quality gate
+    # Evaluate quality gate: results produced vs agents spawned
     local qg_threshold
     qg_threshold=$(yaml_get_phase_config "$yaml_file" "$phase_name" "threshold") || qg_threshold="0.5"
-    local result_count
-    result_count=$(echo "$result_files" | wc -l | tr -d ' ')
-    if [[ $result_count -ge 1 ]]; then
-        log "INFO" "Phase $phase_name quality gate: $result_count results (threshold: $qg_threshold)"
+    local result_count=0
+    [[ -n "$result_files" ]] && result_count=$(echo "$result_files" | wc -l | tr -d ' ')
+    local spawned_count=${#spawned_tasks[@]}
+
+    local gate_passed=false
+    if [[ $spawned_count -gt 0 && $result_count -gt 0 ]]; then
+        if awk -v r="$result_count" -v s="$spawned_count" -v t="$qg_threshold" \
+               'BEGIN { exit !((r / s) >= t) }'; then
+            gate_passed=true
+        fi
+    fi
+
+    if [[ "$gate_passed" == "true" ]]; then
+        log "INFO" "Phase $phase_name quality gate PASSED: $result_count/$spawned_count results (threshold: $qg_threshold)"
     else
-        log "WARN" "Phase $phase_name quality gate: no results produced"
+        log "ERROR" "Phase $phase_name quality gate FAILED: $result_count/$spawned_count results (threshold: $qg_threshold)"
     fi
 
     log "INFO" "YAML Runtime: Phase '$phase_name' complete ($result_count agent results)"
 
     # v8.7.0: Generate phase summary for bridge and refresh provider stats
     bridge_generate_phase_summary "$phase_name" "$synthesis_file"
-    bridge_evaluate_gate "$phase_name" || log "WARN" "Phase $phase_name quality gate did not pass"
+    bridge_evaluate_gate "$phase_name" 2>/dev/null \
+        || log "DEBUG" "Bridge ledger gate did not pass for $phase_name"
     refresh_provider_stats
 
     echo "$synthesis_file"
+    [[ "$gate_passed" == "true" ]]
 }
 
 # Top-level YAML workflow runner
@@ -440,11 +555,15 @@ run_yaml_workflow() {
         [[ -z "$phase_name" ]] && continue
         ((phase_num++)) || true
 
-        echo ""
-        local phase_upper
-        phase_upper=$(echo "$phase_name" | tr '[:lower:]' '[:upper:]')
-        echo -e "${CYAN}[${phase_num}/${phase_count}] Starting ${phase_upper} phase...${NC}"
-        echo ""
+        # Progress lines to stderr: run_yaml_workflow's stdout is captured by
+        # the caller and must carry only the final synthesis file path.
+        {
+            echo ""
+            local phase_upper
+            phase_upper=$(echo "$phase_name" | tr '[:lower:]' '[:upper:]')
+            echo -e "${CYAN}[${phase_num}/${phase_count}] Starting ${phase_upper} phase...${NC}"
+            echo ""
+        } >&2
 
         # Update workflow state
         export OCTOPUS_WORKFLOW_PHASE="$phase_name"
@@ -468,9 +587,20 @@ run_yaml_workflow() {
             local prev_content=""
         fi
 
-        # Execute phase
+        # Execute phase — halt the workflow when a phase's quality gate fails
+        # (fail fast; later phases would only compound on missing output)
         local phase_result
-        phase_result=$(execute_workflow_phase "$yaml_file" "$phase_name" "$prompt" "$prev_content" "$task_group")
+        if ! phase_result=$(execute_workflow_phase "$yaml_file" "$phase_name" "$prompt" "$prev_content" "$task_group"); then
+            log "ERROR" "YAML Runtime: Halting workflow '$workflow_name' — phase '$phase_name' failed its quality gate"
+            if command -v jq &>/dev/null && [[ -f "$session_dir/session.json" ]]; then
+                jq --arg phase "$phase_name" --arg status "failed" \
+                   '.current_phase = $phase | .phase_status = $status |
+                    .quality_gates = {passed: false, failed: true}' \
+                   "$session_dir/session.json" > "$session_dir/session.json.tmp" \
+                   && mv "$session_dir/session.json.tmp" "$session_dir/session.json" 2>/dev/null || true
+            fi
+            return 1
+        fi
 
         previous_output="$phase_result"
         all_outputs+=("$phase_result")

--- a/tests/unit/test-agy-research-defaults.sh
+++ b/tests/unit/test-agy-research-defaults.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Session-level octo overrides (e.g. exported via ~/.claude/settings.json env)
+# change model resolution and must not leak into these assertions.
+unset OCTOPUS_GEMINI_VIA_AGY OCTOPUS_AGY_MODEL OCTOPUS_AGENT_TIMEOUT
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 

--- a/tests/unit/test-orchestrate-cwd-routing.sh
+++ b/tests/unit/test-orchestrate-cwd-routing.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+# Session-level octo overrides (e.g. exported via ~/.claude/settings.json env)
+# change dispatch routing and must not leak into these assertions.
+unset OCTOPUS_GEMINI_VIA_AGY OCTOPUS_AGY_MODEL OCTOPUS_AGENT_TIMEOUT
+
 # tests/unit/test-orchestrate-cwd-routing.sh
 # Behavioral coverage for the orchestrate.sh dispatch fixes (bug report 260609):
 #   1. Bare provider names in routing.roles/.phases must never be returned as a

--- a/tests/unit/test-yaml-workflow-runtime.sh
+++ b/tests/unit/test-yaml-workflow-runtime.sh
@@ -47,12 +47,16 @@ command() {
 }
 
 test_case "awk fallback parses per-phase quality gate thresholds"
-declare -A expected_thresholds=([probe]="0.5" [grasp]="0.75" [tangle]="0.75" [ink]="0.80")
+# Bash 3.2 floor (macOS /bin/bash 3.2.57) has no associative arrays: the
+# subscript is evaluated arithmetically and the suite aborts with
+# `probe: unbound variable` before reaching any runtime assertion.
 threshold_failures=""
-for phase in probe grasp tangle ink; do
+for pair in "probe=0.5" "grasp=0.75" "tangle=0.75" "ink=0.80"; do
+    phase="${pair%%=*}"
+    want="${pair#*=}"
     got=$(yaml_get_phase_config "$EMBRACE_YAML" "$phase" "threshold") || got="(empty)"
-    if [[ "$got" != "${expected_thresholds[$phase]}" ]]; then
-        threshold_failures+=" $phase=$got(want ${expected_thresholds[$phase]})"
+    if [[ "$got" != "$want" ]]; then
+        threshold_failures+=" $phase=$got(want $want)"
     fi
 done
 if [[ -z "$threshold_failures" ]]; then

--- a/tests/unit/test-yaml-workflow-runtime.sh
+++ b/tests/unit/test-yaml-workflow-runtime.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Regression checks for the YAML workflow runtime (scripts/lib/yaml-workflow.sh).
+#
+# Covers the v9.52.x embrace-flow defects:
+#   1. Phase quality-gate thresholds parsed as empty (awk fallback missed the
+#      nested quality_gate.threshold key) and the last phase bled into the
+#      document-level quality_gates: block.
+#   2. prompt_template blocks silently discarded when yq is not installed.
+#   3. execute_workflow_phase/run_yaml_workflow stdout polluted by banners,
+#      corrupting the synthesis-path handoff between phases.
+#   4. Sequential (parallel: false) agents never awaited before synthesis.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+YAML_LIB="$PROJECT_ROOT/scripts/lib/yaml-workflow.sh"
+EMBRACE_YAML="$PROJECT_ROOT/config/workflows/embrace.yaml"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+set +e
+
+test_suite "yaml workflow runtime"
+
+test_case "yaml-workflow.sh has valid bash syntax"
+if bash -n "$YAML_LIB" 2>/dev/null; then
+    test_pass
+else
+    test_fail "syntax error in yaml-workflow.sh"
+fi
+
+log() { :; }
+
+# Force the awk fallback paths even when yq is installed on the host: the
+# machines this bug bit had no yq, and the fallback must stand on its own.
+_no_yq_path() {
+    local dir
+    dir=$(mktemp -d)
+    cat > "$dir/yq" <<'EOF'
+#!/usr/bin/env bash
+exit 127
+EOF
+    rm -f "$dir/yq"
+    echo "$dir"
+}
+NO_YQ_BIN=$(_no_yq_path)
+command_v_real=$(command -v yq || true)
+
+# shellcheck source=/dev/null
+source "$YAML_LIB"
+
+# Shadow `command` so `command -v yq` fails inside the sourced functions
+command() {
+    if [[ "$1" == "-v" && "$2" == "yq" ]]; then
+        return 1
+    fi
+    builtin command "$@"
+}
+
+test_case "awk fallback parses per-phase quality gate thresholds"
+declare -A expected_thresholds=([probe]="0.5" [grasp]="0.75" [tangle]="0.75" [ink]="0.80")
+threshold_failures=""
+for phase in probe grasp tangle ink; do
+    got=$(yaml_get_phase_config "$EMBRACE_YAML" "$phase" "threshold") || got="(empty)"
+    if [[ "$got" != "${expected_thresholds[$phase]}" ]]; then
+        threshold_failures+=" $phase=$got(want ${expected_thresholds[$phase]})"
+    fi
+done
+if [[ -z "$threshold_failures" ]]; then
+    test_pass
+else
+    test_fail "wrong thresholds:$threshold_failures"
+fi
+
+test_case "missing field returns non-zero so callers can default"
+if yaml_get_phase_config "$EMBRACE_YAML" "probe" "no_such_field" >/dev/null; then
+    test_fail "expected non-zero exit for missing field"
+else
+    test_pass
+fi
+
+test_case "awk fallback extracts prompt_template block scalars"
+tpl=$(yaml_get_agent_prompt "$EMBRACE_YAML" "grasp" "claude")
+if [[ "$tpl" == *"{{probe_synthesis}}"* && "$tpl" == *"consensus definition"* ]]; then
+    test_pass
+else
+    test_fail "grasp/claude template missing expected content: $(printf '%s' "$tpl" | head -c 120)"
+fi
+
+test_case "prompt_template extraction scoped to requested phase+provider"
+tpl_probe_codex=$(yaml_get_agent_prompt "$EMBRACE_YAML" "probe" "codex")
+if [[ "$tpl_probe_codex" == *"technical implementation perspective"* \
+      && "$tpl_probe_codex" != *"{{probe_synthesis}}"* ]]; then
+    test_pass
+else
+    test_fail "probe/codex template wrong or bled across blocks"
+fi
+
+# ── execute_workflow_phase behavior (stubbed spawns) ─────────────────────────
+
+TEST_TMP_DIR="/tmp/octopus-yaml-tests-$$"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
+RESULTS_DIR="$TEST_TMP_DIR/results"
+WORKSPACE_DIR="$TEST_TMP_DIR/workspace"
+PLUGIN_DIR="$PROJECT_ROOT"
+mkdir -p "$RESULTS_DIR" "$WORKSPACE_DIR/.octo/agents"
+
+CYAN="" GREEN="" MAGENTA="" NC="" _BOX_TOP="" _BOX_BOT=""
+OCTOPUS_CONVERGENCE_ENABLED=false
+TIMEOUT=30
+OCTOPUS_YAML_DONE_WAIT=3
+
+SPAWN_LOG="$TEST_TMP_DIR/spawn.log"
+: > "$SPAWN_LOG"
+
+# Stub the spawn/bridge/support surface used by execute_workflow_phase
+fleet_dispatch_begin() { :; }
+fleet_dispatch_end() { :; }
+bridge_update_current_phase() { :; }
+bridge_inject_gate_task() { :; }
+bridge_generate_phase_summary() { :; }
+bridge_evaluate_gate() { return 0; }
+bridge_mark_task_complete() { echo "bridge-complete:$1:$2" >> "$SPAWN_LOG"; }
+refresh_provider_stats() { :; }
+verify_result_integrity() { return 0; }
+deduplicate_results() { :; }
+_ucfirst() { echo "$1"; }
+
+# Each stubbed spawn writes its result + done marker after a short delay from
+# a background process, and echoes that background PID (mirroring the real
+# spawn contract). Sequential agents must be awaited for the file to exist at
+# synthesis time.
+spawn_agent_capture_pid() {
+    local agent_type="$1" task_id="$3"
+    echo "spawn:$agent_type:$task_id" >> "$SPAWN_LOG"
+    (
+        sleep 1
+        echo "output of $agent_type for $task_id" > "$RESULTS_DIR/${agent_type}-${task_id}.md"
+        echo "0" > "$WORKSPACE_DIR/.octo/agents/${task_id}.done"
+    ) &
+    echo $!
+}
+spawn_agent() { spawn_agent_capture_pid "$@" >/dev/null; }
+
+TEST_YAML="$TEST_TMP_DIR/mini.yaml"
+cat > "$TEST_YAML" <<'EOF'
+name: mini
+description: "mini workflow"
+version: "1.0.0"
+
+phases:
+  - name: alpha
+    alias: alpha
+    description: "Alpha phase"
+    emoji: "A"
+    agents:
+      - provider: claude
+        role: "Parallel worker"
+        parallel: true
+        prompt_template: |
+          Parallel: {{prompt}}
+      - provider: claude
+        role: "Sequential finisher"
+        parallel: false
+        prompt_template: |
+          Sequential: {{prompt}}
+    quality_gate:
+      threshold: 1.0
+
+quality_gates:
+  consensus:
+    threshold: 0.75
+EOF
+
+test_case "phase stdout carries only the synthesis file path"
+phase_stdout=$(execute_workflow_phase "$TEST_YAML" "alpha" "test prompt" "" "tg1" 2>/dev/null)
+phase_rc=$?
+if [[ $phase_rc -eq 0 && "$phase_stdout" == "$RESULTS_DIR/alpha-synthesis-tg1.md" && -f "$phase_stdout" ]]; then
+    test_pass
+else
+    test_fail "rc=$phase_rc stdout='$phase_stdout'"
+fi
+
+test_case "sequential agent output present in phase synthesis"
+if grep -q "Sequential finisher\|alpha-tg1-1" "$RESULTS_DIR/alpha-synthesis-tg1.md" 2>/dev/null \
+   || grep -q "for alpha-tg1-1" "$RESULTS_DIR/alpha-synthesis-tg1.md" 2>/dev/null; then
+    test_pass
+else
+    test_fail "synthesis missing sequential agent output: $(cat "$RESULTS_DIR/alpha-synthesis-tg1.md" 2>/dev/null | head -c 200)"
+fi
+
+test_case "completions recorded in bridge ledger"
+if grep -q "bridge-complete:alpha-tg1-0:completed" "$SPAWN_LOG" \
+   && grep -q "bridge-complete:alpha-tg1-1:completed" "$SPAWN_LOG"; then
+    test_pass
+else
+    test_fail "bridge_mark_task_complete not called for all tasks: $(grep bridge-complete "$SPAWN_LOG" | tr '\n' ' ')"
+fi
+
+test_case "phase fails its gate when no results are produced"
+spawn_agent_capture_pid() {
+    ( : ) &
+    echo $!
+}
+spawn_agent() { spawn_agent_capture_pid "$@" >/dev/null; }
+if execute_workflow_phase "$TEST_YAML" "alpha" "test prompt" "" "tg2" >/dev/null 2>&1; then
+    test_fail "expected non-zero exit when zero results produced"
+else
+    test_pass
+fi
+
+test_summary

--- a/tests/unit/test-yaml-workflow-runtime.sh
+++ b/tests/unit/test-yaml-workflow-runtime.sh
@@ -33,24 +33,11 @@ fi
 
 log() { :; }
 
-# Force the awk fallback paths even when yq is installed on the host: the
-# machines this bug bit had no yq, and the fallback must stand on its own.
-_no_yq_path() {
-    local dir
-    dir=$(mktemp -d)
-    cat > "$dir/yq" <<'EOF'
-#!/usr/bin/env bash
-exit 127
-EOF
-    rm -f "$dir/yq"
-    echo "$dir"
-}
-NO_YQ_BIN=$(_no_yq_path)
-command_v_real=$(command -v yq || true)
-
 # shellcheck source=/dev/null
 source "$YAML_LIB"
 
+# Force the awk fallback paths even when yq is installed on the host: the
+# machines this bug bit had no yq, and the fallback must stand on its own.
 # Shadow `command` so `command -v yq` fails inside the sourced functions
 command() {
     if [[ "$1" == "-v" && "$2" == "yq" ]]; then
@@ -100,7 +87,7 @@ fi
 
 # ── execute_workflow_phase behavior (stubbed spawns) ─────────────────────────
 
-TEST_TMP_DIR="/tmp/octopus-yaml-tests-$$"
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
 trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
 RESULTS_DIR="$TEST_TMP_DIR/results"
 WORKSPACE_DIR="$TEST_TMP_DIR/workspace"


### PR DESCRIPTION
## Summary

Live `/octo:embrace` runs surfaced five defects in the YAML workflow runtime (`scripts/lib/yaml-workflow.sh`). The workflow "completed" every time, but phases were racing their own agents and running context-blind. Diagnosed by correlating result-file mtimes against the run log.

- **Sequential (`parallel: false`) agents were never awaited.** The sequential branch called `spawn_agent` (which backgrounds the provider internally) and fell through — each phase synthesized and moved on while its final agent was still running. Evidence: tangle's synthesis was written at 19:32:11 while its claude agent finished at 19:32:53, so that output never reached the ink phase. Sequential agents now go through `spawn_agent_capture_pid` and block, and phases wait for the `.done` completion markers (written after the result file) before collecting output.

- **Cross-phase context was completely lost.** Phase banners were echoed to stdout inside command-substituted functions, so the "synthesis file path" return value was actually `banner…\npath`; the `-f` check failed and every phase received empty previous-phase context. Decorative output now goes to stderr; stdout carries only the path.

- **`prompt_template` blocks were silently discarded without `yq`.** The awk fallback returned empty and agents ran a bare `role: prompt` fallback, dropping `{{probe_synthesis}}` et al. The fallback now extracts block scalars scoped to phase+provider.

- **Quality-gate thresholds parsed as empty.** The awk fallback only matched 4-space-indented fields, missing the nested `quality_gate.threshold`; the last phase also bled into the document-level `quality_gates:` block (ink reported the consensus 0.75 instead of its own 0.80). The parser now matches any indent within the phase, stops at the next top-level key, and returns non-zero when empty so caller defaults apply.

- **`bridge_mark_task_complete` was never called anywhere**, so `completed_tasks` stayed 0 and `bridge_evaluate_gate` logged "quality gate did not pass" on every phase unconditionally — and nothing enforced it. Completions are now recorded from the `.done` markers, the gate is evaluated on results-produced / agents-spawned against the parsed threshold, and a failed gate halts the workflow (matching the fail-fast behavior of the hardcoded path) instead of warning and continuing. The embrace call site checks the runtime's exit status.

Also: `test-orchestrate-cwd-routing.sh` and `test-agy-research-defaults.sh` now unset `OCTOPUS_GEMINI_VIA_AGY` / `OCTOPUS_AGY_MODEL` / `OCTOPUS_AGENT_TIMEOUT` at suite start — session-level env (e.g. exported via `~/.claude/settings.json`) flipped gemini dispatch to the agy path and failed assertions locally; CI's clean env was unaffected.

## Test plan

- New regression suite `tests/unit/test-yaml-workflow-runtime.sh` (9 cases): parser fallbacks (per-phase thresholds incl. the ink 0.80 case, template extraction and scoping), stdout contract, sequential-agent output present in synthesis, ledger completion recording, gate failure on zero results.
- `test-embrace-fail-fast.sh`, `test-orchestrate-cwd-routing.sh`, `test-agy-research-defaults.sh` green.
- Live end-to-end verification: before the fix, gates logged empty thresholds and "did not pass" on all 4 phases while syntheses raced agents; after, all 4 phases pass with correct thresholds (probe 3/3 @0.5, grasp 1/1 @0.75, tangle 3/3 @0.75, ink 3/3 @0.80), grasp's prompt embeds the actual probe synthesis, and every synthesis is written after all of its agents finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * YAML-driven workflows now stop promptly when a phase fails instead of incorrectly reporting completion.
  * Quality gates verify that expected results are produced before allowing a phase to complete.
  * Improved phase-boundary handling, completion tracking, and workflow failure reporting.

* **Reliability**
  * Sequential workflow steps now wait for preceding agents to finish before synthesis.
  * Improved support for multiline prompts and configurations without optional tooling.

* **Tests**
  * Added regression coverage for parsing, execution, completion tracking, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->