### PR TITLE
ci: enforce the Bash 3.2 floor, and fix a live violation it found

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,28 @@ jobs:
           fi
           echo "OK: No non-portable sed patterns found."
 
+      # CLAUDE.md sets a Bash 3.2 floor because macOS ships /bin/bash 3.2.57,
+      # which has no associative arrays or namerefs. Nothing caught this before:
+      # the macOS runner resolves `#!/usr/bin/env bash` to Homebrew bash 5 on
+      # PATH, so a `declare -A` passes CI and then dies on a maintainer's stock
+      # shell with `line N: <key>: unbound variable`. tests/ is included because
+      # that is where the violation landed (#782).
+      - name: Check for Bash 4+ constructs below the 3.2 floor
+        run: |
+          FAIL=0
+          if grep -rnE '^[[:space:]]*(declare|local|typeset)[[:space:]]+-[A-Za-z]*A' \
+              scripts/ hooks/ tests/ 2>/dev/null; then
+            echo "::error::associative arrays require Bash 4; the floor is 3.2 (macOS /bin/bash)"
+            FAIL=1
+          fi
+          if grep -rnE '^[[:space:]]*(declare|local)[[:space:]]+-n[[:space:]]' \
+              scripts/ hooks/ tests/ 2>/dev/null; then
+            echo "::error::namerefs require Bash 4.3; the floor is 3.2 (macOS /bin/bash)"
+            FAIL=1
+          fi
+          if [ "$FAIL" -eq 1 ]; then exit 1; fi
+          echo "No Bash 4+ constructs found."
+
       - name: Install ShellCheck
         run: |
           sudo apt-get install -y shellcheck

--- a/scripts/async-tmux-features.sh
+++ b/scripts/async-tmux-features.sh
@@ -208,19 +208,26 @@ wait_async_agents() {
 
     log INFO "Waiting for ${#pids[@]} async agents to complete"
 
-    local -A completed_pids=()
+    # Bash 3.2 floor (macOS /bin/bash 3.2.57) has no associative arrays, so
+    # completion is tracked as a space-delimited set of PIDs rather than
+    # `local -A`. That construct aborted this function outright with
+    # `local: -A: invalid option`, which mattered because orchestrate.sh
+    # sources this file unconditionally.
+    local completed_set=" "
+    local completed_count=0
     local start_time=$(date +%s)
 
-    while [[ ${#completed_pids[@]} -lt ${#pids[@]} ]]; do
+    while [[ "$completed_count" -lt "${#pids[@]}" ]]; do
         for pid in "${pids[@]}"; do
             # Skip already completed PIDs
-            [[ -n "${completed_pids[$pid]:-}" ]] && continue
+            [[ "$completed_set" == *" ${pid} "* ]] && continue
 
             # Check if process is still running
             if ! kill -0 "$pid" 2>/dev/null; then
                 # Reap zombie process and capture exit code
                 wait "$pid" 2>/dev/null
-                completed_pids[$pid]=$?
+                completed_set="${completed_set}${pid} "
+                completed_count=$((completed_count + 1))
             fi
         done
 
@@ -230,7 +237,7 @@ wait_async_agents() {
         local secs=$((elapsed % 60))
 
         # Show progress with elapsed time
-        echo -ne "\r${CYAN}Progress: ${#completed_pids[@]}/${#pids[@]} agents complete (${mins}m ${secs}s elapsed)${NC}     "
+        echo -ne "\r${CYAN}Progress: ${completed_count}/${#pids[@]} agents complete (${mins}m ${secs}s elapsed)${NC}     "
 
         sleep 0.5
     done


### PR DESCRIPTION
CLAUDE.md declares a Bash 3.2 floor because macOS ships /bin/bash
3.2.57, but nothing enforced it. Portability Lint greps only for
GNU-only sed patterns and runs ShellCheck, over scripts/ and hooks/;
it never checked for Bash 4 constructs and never scanned tests/.

CI cannot catch these either: GitHub's macOS runner resolves
'#!/usr/bin/env bash' to Homebrew bash 5 on PATH, so a 'declare -A'
passes Unit Tests (macos-latest) and then dies on a maintainer's stock
shell.

Adding the check immediately found a live bug in production code.
scripts/async-tmux-features.sh:211 used 'local -A completed_pids',
and orchestrate.sh:580 sources that file unconditionally, so on stock
macOS bash wait_async_agents() aborted at once:

    /bin/bash: line 211: local: -A: invalid option

Rewritten to track completion as a space-delimited PID set with an
explicit counter. Verified on GNU bash 3.2.57: two staggered sleeps
progress 0/2 -> 2/2 and the function exits 0.

The check also covers namerefs (Bash 4.3) and scans tests/, which is
where the violation in #782 landed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older Bash versions when running asynchronous tasks.
  * Preserved process completion tracking, reaping, and progress reporting.

* **Tests**
  * Added automated checks to detect unsupported Bash 4+ features in scripts, hooks, and tests.
  * Builds now provide clear error annotations when incompatible declarations are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->