### PR TITLE
feat: AI surface audit in the design skill, phase context slots (closes #701, #724)

### DIFF
--- a/.claude/skills/skill-ui-ux-design/SKILL.md
+++ b/.claude/skills/skill-ui-ux-design/SKILL.md
@@ -357,6 +357,61 @@ mcp__shadcn__search_items_in_registries({ query: "<component name>" })
 3. **Implementation readiness** — confirm specs are detailed enough for frontend-developer
 4. **Figma push-back** (if connected) — offer to push design tokens to Figma
 
+### STEP 7b: AI Surface Audit (when the interface calls a model)
+
+Run this whenever the thing being designed sends input to a model and shows the
+result, and especially when it then **acts** on that result. Style guides and
+component specs do not answer what an AI feature must show and let the user
+control; this step does. Skip it entirely for interfaces with no model in the
+loop.
+
+Ask each question and record an explicit answer. "Not applicable" is a valid
+answer; silence is not.
+
+**1. Uncertainty.** Does the surface distinguish a confident answer from a
+guess? If it cannot, say so plainly rather than implying uniform reliability.
+Do not invent a numeric threshold — pick a representation the underlying system
+can actually justify.
+
+**2. Provenance.** Can the user see what the answer was derived from? Retrieval
+and search features need citations; a summariser needs the source it summarised.
+An answer with no traceable origin is unreviewable.
+
+**3. Interruption.** If output streams or the task is long-running, is there a
+cancel affordance, and does cancelling actually stop the work rather than just
+hiding it? A stop button that abandons a still-running job is worse than none,
+because it misreports the system's state.
+
+**4. The review gate.** Where does a human check the output, and is that
+placement load-bearing? A gate after an irreversible action is decoration.
+`skill-intent-contract` already elicits initiative, control, and decision rights
+separately — reuse those answers here rather than re-deriving them, and if they
+disagree with the placement, the contract wins.
+
+**5. Failure and degradation.** What does the surface show when the model is
+slow, unavailable, rate-limited, or returns something unusable? Each needs a
+distinct state. Collapsing them into one generic error teaches users to ignore
+it.
+
+**6. Consent and data use.** Does the user know what is sent, where, and whether
+it is retained? Required wherever input may contain someone else's data.
+
+**7. Rollback.** If the feature takes a real-world action — files, sends, pays,
+deletes — what undoes it, and is that path visible before the action, not only
+after it fails?
+
+**Output contract.** Answer all seven in the delivered document, each with the
+decision and its rationale. Where a question is unanswerable because the
+underlying system cannot support it, record that as a finding rather than
+leaving the row blank: an unanswerable question about rollback is a design
+constraint, not an omission.
+
+**Attribution.** The framing follows the AI Interaction Atlas by Brandon Harwood
+(ai-interaction.com). Depend on it, do not copy it: the Atlas deliberately ships
+no thresholds — no confidence cutoffs, no latency budgets — and inventing them
+here would attribute numbers to a source that does not publish them. State
+direction, cite the source, and let the product supply its own values.
+
 ### STEP 8: Present Results
 
 Format the final design system as a structured document with:

--- a/scripts/lib/research.sh
+++ b/scripts/lib/research.sh
@@ -44,10 +44,23 @@ Format as a structured research synthesis." "${TIMEOUT:-300}" "ux-researcher" "e
         synthesis=$(run_agent_sync "claude-sonnet" "You are a UX researcher. Synthesize user research for: $prompt. Provide: key insights, pain points, unmet needs, behavioral themes." "${TIMEOUT:-300}" "ux-researcher" "empathize") || true
     }
 
+    # Record phase 1's finding as a named slot before handing off (#724). The
+    # prompt below still interpolates the prose, so behaviour is unchanged if
+    # the slot cannot be written — but the finding is now addressable by key
+    # instead of existing only inside the next prompt string.
+    declare -f save_phase_slot >/dev/null 2>&1 && \
+        save_phase_slot "empathize" "synthesis" "$synthesis" 2>/dev/null || true
+
     echo -e "${CYAN}🦑 Phase 2/4: Creating personas and journey maps...${NC}"
     local personas
+    local _handoff_synthesis="$synthesis"
+    if declare -f get_phase_slot >/dev/null 2>&1; then
+        local _slot
+        _slot="$(get_phase_slot "empathize" "synthesis" 2>/dev/null || true)"
+        [[ -n "$_slot" ]] && _handoff_synthesis="$_slot"
+    fi
     personas=$(run_agent_sync "gemini" "Based on this research synthesis:
-$synthesis
+$_handoff_synthesis
 
 Create:
 1. 2-3 distinct user personas with goals, frustrations, and behaviors

--- a/scripts/lib/session.sh
+++ b/scripts/lib/session.sh
@@ -516,6 +516,66 @@ get_phase_output() {
     fi
 }
 
+# --- Phase context slots (#724) -------------------------------------------
+#
+# Phases used to hand off by interpolating a prior phase's prose into the next
+# prompt: research.sh built phase 2 from "Based on this research synthesis:
+# $synthesis". Whatever the receiving agent needed and the sending agent held
+# but did not write into that string was gone at the boundary, with nothing
+# recording that it was lost.
+#
+# These slots give a phase somewhere to deposit a named finding that a later
+# phase reads by key. They sit alongside the existing .phases registry rather
+# than replacing it: that registry records status/output/timestamp per phase,
+# and slots record the phase's *content* under .phases[<phase>].slots.
+#
+# Deliberate choices:
+#   - Slots are additive within a phase and overwritten per key, so re-running a
+#     phase replaces its own findings without disturbing another phase's.
+#   - A slot that is never filled reads as empty rather than erroring. A missing
+#     handoff should degrade to the current free-text behaviour, not abort a
+#     workflow mid-run.
+#   - Both key and phase are bound with --arg. A phase name like `debate-probe`
+#     parses as subtraction if spliced into a jq filter (see get_phase_output),
+#     and slot keys come from workflow code, so the same rule applies.
+
+save_phase_slot() {
+    local phase="$1"
+    local key="$2"
+    local value="$3"
+
+    [[ -n "$phase" && -n "$key" ]] || return 0
+    if [[ ! -f "$SESSION_FILE" ]] || ! command -v jq &> /dev/null; then
+        return 0
+    fi
+
+    jq --arg phase "$phase" --arg key "$key" --arg value "$value" \
+       '.phases[$phase] //= {} | .phases[$phase].slots //= {} | .phases[$phase].slots[$key] = $value' \
+       "$SESSION_FILE" > "${SESSION_FILE}.tmp" && mv "${SESSION_FILE}.tmp" "$SESSION_FILE"
+}
+
+get_phase_slot() {
+    local phase="$1"
+    local key="$2"
+
+    [[ -n "$phase" && -n "$key" ]] || return 0
+    if [[ -f "$SESSION_FILE" ]] && command -v jq &> /dev/null; then
+        jq -r --arg phase "$phase" --arg key "$key" \
+           '.phases[$phase].slots[$key] // ""' "$SESSION_FILE"
+    fi
+}
+
+# Names the slots a phase actually filled, so a caller can tell "not recorded"
+# from "recorded empty" without guessing at key names.
+list_phase_slots() {
+    local phase="$1"
+    [[ -n "$phase" ]] || return 0
+    if [[ -f "$SESSION_FILE" ]] && command -v jq &> /dev/null; then
+        jq -r --arg phase "$phase" \
+           '(.phases[$phase].slots // {}) | keys[]?' "$SESSION_FILE"
+    fi
+}
+
 # Mark session as complete
 complete_session() {
     if [[ -f "$SESSION_FILE" ]] && command -v jq &> /dev/null; then

--- a/skills/octopus-ui-ux-design/SKILL.md
+++ b/skills/octopus-ui-ux-design/SKILL.md
@@ -367,6 +367,61 @@ Exit 1 means at least one pair fails WCAG AA — fix the palette and re-run befo
 4. **Implementation readiness** — confirm specs are detailed enough for frontend-developer
 5. **Figma push-back** (if connected) — offer to push design tokens to Figma
 
+### STEP 7b: AI Surface Audit (when the interface calls a model)
+
+Run this whenever the thing being designed sends input to a model and shows the
+result, and especially when it then **acts** on that result. Style guides and
+component specs do not answer what an AI feature must show and let the user
+control; this step does. Skip it entirely for interfaces with no model in the
+loop.
+
+Ask each question and record an explicit answer. "Not applicable" is a valid
+answer; silence is not.
+
+**1. Uncertainty.** Does the surface distinguish a confident answer from a
+guess? If it cannot, say so plainly rather than implying uniform reliability.
+Do not invent a numeric threshold — pick a representation the underlying system
+can actually justify.
+
+**2. Provenance.** Can the user see what the answer was derived from? Retrieval
+and search features need citations; a summariser needs the source it summarised.
+An answer with no traceable origin is unreviewable.
+
+**3. Interruption.** If output streams or the task is long-running, is there a
+cancel affordance, and does cancelling actually stop the work rather than just
+hiding it? A stop button that abandons a still-running job is worse than none,
+because it misreports the system's state.
+
+**4. The review gate.** Where does a human check the output, and is that
+placement load-bearing? A gate after an irreversible action is decoration.
+`skill-intent-contract` already elicits initiative, control, and decision rights
+separately — reuse those answers here rather than re-deriving them, and if they
+disagree with the placement, the contract wins.
+
+**5. Failure and degradation.** What does the surface show when the model is
+slow, unavailable, rate-limited, or returns something unusable? Each needs a
+distinct state. Collapsing them into one generic error teaches users to ignore
+it.
+
+**6. Consent and data use.** Does the user know what is sent, where, and whether
+it is retained? Required wherever input may contain someone else's data.
+
+**7. Rollback.** If the feature takes a real-world action — files, sends, pays,
+deletes — what undoes it, and is that path visible before the action, not only
+after it fails?
+
+**Output contract.** Answer all seven in the delivered document, each with the
+decision and its rationale. Where a question is unanswerable because the
+underlying system cannot support it, record that as a finding rather than
+leaving the row blank: an unanswerable question about rollback is a design
+constraint, not an omission.
+
+**Attribution.** The framing follows the AI Interaction Atlas by Brandon Harwood
+(ai-interaction.com). Depend on it, do not copy it: the Atlas deliberately ships
+no thresholds — no confidence cutoffs, no latency budgets — and inventing them
+here would attribute numbers to a source that does not publish them. State
+direction, cite the source, and let the product supply its own values.
+
 ### STEP 8: Present Results and Persist
 
 Format the final design system as a structured document with:

--- a/tests/unit/test-phase-context-slots.sh
+++ b/tests/unit/test-phase-context-slots.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Phases can hand off named findings, not just interpolated prose (#724).
+#
+# research.sh built phase 2's prompt as "Based on this research synthesis:
+# $synthesis". Anything the sending phase knew but did not write into that
+# string was gone at the boundary, and nothing recorded that it was lost.
+#
+# The .phases registry already existed (status/output/timestamp per phase); what
+# was missing was a place for a phase to deposit *content* a later phase reads
+# by key. save_phase_slot/get_phase_slot add that alongside the registry rather
+# than replacing it.
+#
+# The hyphenated-phase and injection cases below are not hypothetical: the same
+# registry's reader spliced the phase name into a jq filter, so `debate-probe`
+# parsed as subtraction and every debate-gate checkpoint was write-only (#743).
+# Slots take a phase AND a key, so both are bound with --arg here.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Phase context slots (#724)"
+
+SESSION_LIB="$PROJECT_ROOT/scripts/lib/session.sh"
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# Extract only the slot functions. Sourcing session.sh wholesale runs top-level
+# code (check_resume_session carries a `read -p`), which hangs a test run.
+SLOTS="$FIXTURE/slots.sh"
+for fn in save_phase_slot get_phase_slot list_phase_slots; do
+    sed -n "/^${fn}()/,/^}/p" "$SESSION_LIB" >> "$SLOTS"
+done
+
+printf '{"workflow":"research","phases":{}}\n' > "$FIXTURE/session.json"
+
+# Always returns 0: the framework sources `set -euo pipefail`, so a probing call
+# that legitimately fails would abort the suite before it could be reported.
+slot() {
+    { bash -c '
+        SESSION_FILE="$1"
+        source "$2"
+        case "$3" in
+            set)  save_phase_slot "$4" "$5" "$6" ;;
+            get)  get_phase_slot "$4" "$5" ;;
+            list) list_phase_slots "$4" | tr "\n" " " ;;
+        esac
+    ' _ "$FIXTURE/session.json" "$SLOTS" "$@" 2>/dev/null || true; }
+}
+
+test_case "the slot helpers were extracted"
+if [[ -s "$SLOTS" ]] && grep -q 'save_phase_slot' "$SLOTS" && grep -q 'get_phase_slot' "$SLOTS"; then
+    test_pass
+else
+    test_fail "could not extract the slot functions from session.sh — nothing below is meaningful"
+fi
+
+test_case "a slot round-trips"
+slot set empathize synthesis "pain points and unmet needs" >/dev/null
+got="$(slot get empathize synthesis)"
+if [[ "$got" == "pain points and unmet needs" ]]; then test_pass; else test_fail "got '$got'"; fi
+
+test_case "a hyphenated phase name round-trips"
+slot set debate-probe verdict "codex dissented" >/dev/null
+got="$(slot get debate-probe verdict)"
+if [[ "$got" == "codex dissented" ]]; then
+    test_pass
+else
+    test_fail "got '$got' — a hyphenated phase parses as subtraction unless bound with --arg (#743)"
+fi
+
+test_case "an unfilled slot reads empty rather than failing"
+got="$(slot get empathize never-written)"
+if [[ -z "$got" ]]; then
+    test_pass
+else
+    test_fail "expected empty, got '$got' — a missing handoff must degrade, not abort a run"
+fi
+
+test_case "an unknown phase reads empty"
+got="$(slot get no-such-phase synthesis)"
+if [[ -z "$got" ]]; then test_pass; else test_fail "got '$got'"; fi
+
+test_case "slots are additive within a phase"
+slot set empathize themes "three behavioural clusters" >/dev/null
+a="$(slot get empathize synthesis)"
+b="$(slot get empathize themes)"
+if [[ "$a" == "pain points and unmet needs" && "$b" == "three behavioural clusters" ]]; then
+    test_pass
+else
+    test_fail "writing a second key disturbed the first: synthesis='$a' themes='$b'"
+fi
+
+test_case "re-running a phase overwrites its own key, not another phase's"
+slot set empathize synthesis "revised synthesis" >/dev/null
+a="$(slot get empathize synthesis)"
+b="$(slot get debate-probe verdict)"
+if [[ "$a" == "revised synthesis" && "$b" == "codex dissented" ]]; then
+    test_pass
+else
+    test_fail "overwrite leaked across phases: empathize='$a' debate-probe='$b'"
+fi
+
+# Distinguishes "not recorded" from "recorded empty" without guessing key names.
+test_case "list_phase_slots names what a phase filled"
+got="$(slot list empathize)"
+if grep -q 'synthesis' <<< "$got" && grep -q 'themes' <<< "$got"; then
+    test_pass
+else
+    test_fail "expected synthesis and themes, got '$got'"
+fi
+
+# Slot keys and phase names come from workflow code, so this input is reachable.
+test_case "a key containing jq syntax is looked up, not evaluated"
+slot set empathize 'x"] | keys' "injected" >/dev/null
+got="$(slot get empathize 'x"] | keys')"
+if [[ "$got" == "injected" ]]; then
+    test_pass
+else
+    test_fail "expected 'injected' via key lookup, got '$got'"
+fi
+
+# Static guards, so a later refactor cannot reintroduce the splice.
+test_case "both slot helpers bind phase and key with --arg"
+body="$(cat "$SLOTS")"
+if [[ "$(grep -c -- '--arg key' <<< "$body")" -ge 2 ]] && [[ "$(grep -c -- '--arg phase' <<< "$body")" -ge 2 ]]; then
+    test_pass
+else
+    test_fail "slot helpers must bind both phase and key as data"
+fi
+
+# The consumer. A slot API nothing uses proves nothing about the handoff.
+test_case "research.sh writes and reads the empathize synthesis slot"
+r="$PROJECT_ROOT/scripts/lib/research.sh"
+if grep -q 'save_phase_slot "empathize" "synthesis"' "$r" && grep -q 'get_phase_slot "empathize" "synthesis"' "$r"; then
+    test_pass
+else
+    test_fail "research.sh must both record and consume the slot, or the contract is unexercised"
+fi
+
+# The handoff must still work where jq is missing or the session file is absent,
+# because that is the state most CI and first-run environments are in.
+test_case "research.sh falls back to the interpolated prose when no slot exists"
+if grep -q '_handoff_synthesis="$synthesis"' "$r"; then
+    test_pass
+else
+    test_fail "research.sh must default to the prior free-text value so a missing slot degrades instead of emptying the prompt"
+fi
+
+test_summary


### PR DESCRIPTION
#701 — AI surface audit, folded into skill-ui-ux-design rather than
added as a 58th skill. The gap was real: 'human-in-the-loop' appeared
in zero skill files, and nothing covered what an AI feature must show
and let a user control. Seven questions with recorded answers —
uncertainty, provenance, interruption, review-gate placement, failure
states, consent, rollback — reusing skill-intent-contract's agency
triad instead of re-deriving it.

Attribution follows the AI Interaction Atlas and deliberately ships no
thresholds. The Atlas publishes none, and inventing confidence cutoffs
would attribute numbers to a source that does not have them.

Known limitation, stated rather than glossed: skill-ui-ux-design is on
the human-only list, so this content never auto-triggers. A user has to
ask for the skill. Widening that list is a bigger decision than this
change.

#724 — phase context slots. save_phase_slot/get_phase_slot/
list_phase_slots sit alongside the existing .phases registry: that
registry records status/output/timestamp, these record content a later
phase reads by key. research.sh is wired as a real consumer, writing
the empathize synthesis and reading it back, so the contract is
exercised rather than merely available.

Deliberate: slots are additive per phase and overwritten per key; an
unfilled slot reads empty so a missing handoff degrades to the current
free-text behaviour rather than aborting a run; research.sh keeps the
interpolated prose as its fallback.

Both phase and key bind with --arg. Verified the alternative directly:
the spliced form fails on a hyphenated phase with 'probe/0 is not
defined' — the exact #743 bug — while the bound form returns the value.

Note the issue cited scripts/lib/state.sh, which does not exist; the
phase registry lives in session.sh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI Surface Audit for model-powered interfaces, covering uncertainty, data use, human review, failure handling, interruption, and rollback.
  * Added guidance for documenting decisions, rationale, and unsupported capabilities as design constraints.

* **Improvements**
  * Research workflows now preserve and reuse synthesis context between phases, improving continuity and reliability.
  * Added safer handling for missing or unavailable research context, with automatic fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->