### PR TITLE
fix: one owner for provider lockout; restore the dropped fallback arm

### DIFF
--- a/scripts/lib/provider-lockout.sh
+++ b/scripts/lib/provider-lockout.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# lib/provider-lockout.sh — single owner of the provider lockout + history protocol
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# These seven functions were previously defined TWICE, in lib/quality.sh and
+# lib/provider-routing.sh, identical except for the fallback provider. Because
+# orchestrate.sh sources quality.sh (:194) before provider-routing.sh (:205),
+# the routing copy silently won and a locked codex fell back to `gemini` —
+# whose free tier is sunset and returns IneligibleTierError, so the recovery
+# path routed into a known-dead seat.
+#
+# Extracting to one file rather than deleting one copy keeps standalone
+# consumers working: several tests source provider-routing.sh alone and call
+# append_provider_history / read_provider_history / build_provider_context.
+#
+# Fallback policy: codex -> agy -> claude-sonnet. agy is the current Google
+# seat; gemini is not a valid recovery target while its tier is sunset.
+#
+# Functions: lock_provider, is_provider_locked, get_alternate_provider,
+#            reset_provider_lockouts, append_provider_history,
+#            read_provider_history, build_provider_context
+
+lock_provider() {
+    local provider="$1"
+    # v9.5: bash builtin word check (zero subshells)
+    if [[ " $LOCKED_PROVIDERS " != *" $provider "* ]]; then
+        LOCKED_PROVIDERS="${LOCKED_PROVIDERS:+$LOCKED_PROVIDERS }$provider"
+        log WARN "Provider locked out: $provider (will not self-revise)"
+    fi
+}
+
+is_provider_locked() {
+    local provider="$1"
+    [[ " $LOCKED_PROVIDERS " == *" $provider "* ]]
+}
+
+get_alternate_provider() {
+    local locked_provider="$1"
+    case "$locked_provider" in
+        codex|codex-fast|codex-mini)
+            if ! is_provider_locked "agy"; then
+                echo "agy"
+            elif ! is_provider_locked "claude-sonnet"; then
+                echo "claude-sonnet"
+            else
+                echo "$locked_provider"  # All locked, use original
+            fi
+            ;;
+        gemini|gemini-fast)
+            # Present in the provider-routing.sh copy but not the quality.sh one.
+            # Neither file had complete coverage: without this arm a locked
+            # gemini falls through to *) and is offered itself as its own
+            # alternate, so the lockout never routes anywhere.
+            if ! is_provider_locked "codex"; then
+                echo "codex"
+            elif ! is_provider_locked "claude-sonnet"; then
+                echo "claude-sonnet"
+            else
+                echo "$locked_provider"
+            fi
+            ;;
+        agy|agy-research|antigravity)
+            if ! is_provider_locked "codex"; then
+                echo "codex"
+            elif ! is_provider_locked "claude-sonnet"; then
+                echo "claude-sonnet"
+            else
+                echo "$locked_provider"
+            fi
+            ;;
+        claude-sonnet|claude*)
+            if ! is_provider_locked "codex"; then
+                echo "codex"
+            elif ! is_provider_locked "agy"; then
+                echo "agy"
+            else
+                echo "$locked_provider"
+            fi
+            ;;
+        *)
+            echo "$locked_provider"
+            ;;
+    esac
+}
+
+reset_provider_lockouts() {
+    if [[ -n "$LOCKED_PROVIDERS" ]]; then
+        log INFO "Resetting provider lockouts (were: $LOCKED_PROVIDERS)"
+    fi
+    LOCKED_PROVIDERS=""
+}
+
+# v8.18.0 Feature: Per-Provider History Files
+# Each provider accumulates project-specific knowledge in .octo/providers/{name}-history.md
+
+append_provider_history() {
+    case "${OCTOPUS_PROVIDER_HISTORY:-on}" in
+        off|false|0|no) return 0 ;;
+    esac
+
+    local provider="$1"
+    local phase="$2"
+    local task_brief="$3"
+    local learned="$4"
+
+    local history_dir="${WORKSPACE_DIR}/.octo/providers"
+    local history_file="$history_dir/${provider}-history.md"
+    mkdir -p "$history_dir"
+
+    local timestamp
+    timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    # Append structured entry
+    cat >> "$history_file" << HISTEOF
+### ${phase} | ${timestamp}
+**Task:** ${task_brief:0:100}
+**Learned:** ${learned:0:200}
+---
+HISTEOF
+
+    # Cap at 50 entries: count entries and trim oldest if exceeded
+    local entry_count
+    entry_count=$(grep -c "^### " "$history_file" 2>/dev/null) || entry_count=0
+    if [[ "$entry_count" -gt 50 ]]; then
+        local excess=$((entry_count - 50))
+        # Remove oldest entries (from top of file)
+        local trim_line
+        trim_line=$(grep -n "^### " "$history_file" | sed -n "$((excess + 1))p" | cut -d: -f1)
+        if [[ -n "$trim_line" && "$trim_line" -gt 1 ]]; then
+            tail -n "+$trim_line" "$history_file" > "$history_file.tmp" && mv "$history_file.tmp" "$history_file"
+        fi
+    fi
+
+    log DEBUG "Appended provider history for $provider (phase: $phase)"
+}
+
+read_provider_history() {
+    case "${OCTOPUS_PROVIDER_HISTORY:-on}" in
+        off|false|0|no) return 0 ;;
+    esac
+
+    local provider="$1"
+    local history_file="${WORKSPACE_DIR}/.octo/providers/${provider}-history.md"
+
+    if [[ -f "$history_file" ]]; then
+        cat "$history_file"
+    fi
+}
+
+build_provider_context() {
+    local agent_type="$1"
+    local base_provider="${agent_type%%-*}"  # codex-fast -> codex
+    local history
+    history=$(read_provider_history "$base_provider")
+
+    if [[ -z "$history" ]]; then
+        return
+    fi
+
+    # Truncate to max 2000 chars for prompt injection
+    if [[ ${#history} -gt 2000 ]]; then
+        history="${history:0:2000}..."
+    fi
+
+    echo "## Provider History (${base_provider})
+Recent learnings from this project:
+${history}"
+}

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -604,139 +604,16 @@ reset_provider_model() {
     rm -f "$persistent_cache"
 }
 
-lock_provider() {
-    local provider="$1"
-    # v9.5: bash builtin word check (zero subshells)
-    if [[ " $LOCKED_PROVIDERS " != *" $provider "* ]]; then
-        LOCKED_PROVIDERS="${LOCKED_PROVIDERS:+$LOCKED_PROVIDERS }$provider"
-        log WARN "Provider locked out: $provider (will not self-revise)"
-    fi
-}
+# Provider lockout + history protocol has a single owner: lib/provider-lockout.sh.
+# It was previously defined here AND in the sibling file, differing only in the
+# fallback provider, so source order silently decided routing behaviour.
+if ! declare -f get_alternate_provider >/dev/null 2>&1; then
+    _lockout_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # shellcheck source=/dev/null
+    source "${_lockout_dir}/provider-lockout.sh" 2>/dev/null || true
+fi
 
-is_provider_locked() {
-    local provider="$1"
-    [[ " $LOCKED_PROVIDERS " == *" $provider "* ]]
-}
 
-get_alternate_provider() {
-    local locked_provider="$1"
-    case "$locked_provider" in
-        codex|codex-fast|codex-mini)
-            if ! is_provider_locked "gemini"; then
-                echo "gemini"
-            elif ! is_provider_locked "claude-sonnet"; then
-                echo "claude-sonnet"
-            else
-                echo "$locked_provider"  # All locked, use original
-            fi
-            ;;
-        gemini|gemini-fast)
-            if ! is_provider_locked "codex"; then
-                echo "codex"
-            elif ! is_provider_locked "claude-sonnet"; then
-                echo "claude-sonnet"
-            else
-                echo "$locked_provider"
-            fi
-            ;;
-        claude-sonnet|claude*)
-            if ! is_provider_locked "codex"; then
-                echo "codex"
-            elif ! is_provider_locked "gemini"; then
-                echo "gemini"
-            else
-                echo "$locked_provider"
-            fi
-            ;;
-        *)
-            echo "$locked_provider"
-            ;;
-    esac
-}
-
-reset_provider_lockouts() {
-    if [[ -n "$LOCKED_PROVIDERS" ]]; then
-        log INFO "Resetting provider lockouts (were: $LOCKED_PROVIDERS)"
-    fi
-    LOCKED_PROVIDERS=""
-}
-
-# v8.18.0 Feature: Per-Provider History Files
-# Each provider accumulates project-specific knowledge in .octo/providers/{name}-history.md
-
-append_provider_history() {
-    case "${OCTOPUS_PROVIDER_HISTORY:-on}" in
-        off|false|0|no) return 0 ;;
-    esac
-
-    local provider="$1"
-    local phase="$2"
-    local task_brief="$3"
-    local learned="$4"
-
-    local history_dir="${WORKSPACE_DIR}/.octo/providers"
-    local history_file="$history_dir/${provider}-history.md"
-    mkdir -p "$history_dir"
-
-    local timestamp
-    timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-    # Append structured entry
-    cat >> "$history_file" << HISTEOF
-### ${phase} | ${timestamp}
-**Task:** ${task_brief:0:100}
-**Learned:** ${learned:0:200}
----
-HISTEOF
-
-    # Cap at 50 entries: count entries and trim oldest if exceeded
-    local entry_count
-    entry_count=$(grep -c "^### " "$history_file" 2>/dev/null) || entry_count=0
-    if [[ "$entry_count" -gt 50 ]]; then
-        local excess=$((entry_count - 50))
-        # Remove oldest entries (from top of file)
-        local trim_line
-        trim_line=$(grep -n "^### " "$history_file" | sed -n "$((excess + 1))p" | cut -d: -f1)
-        if [[ -n "$trim_line" && "$trim_line" -gt 1 ]]; then
-            tail -n "+$trim_line" "$history_file" > "$history_file.tmp" && mv "$history_file.tmp" "$history_file"
-        fi
-    fi
-
-    log DEBUG "Appended provider history for $provider (phase: $phase)"
-}
-
-read_provider_history() {
-    case "${OCTOPUS_PROVIDER_HISTORY:-on}" in
-        off|false|0|no) return 0 ;;
-    esac
-
-    local provider="$1"
-    local history_file="${WORKSPACE_DIR}/.octo/providers/${provider}-history.md"
-
-    if [[ -f "$history_file" ]]; then
-        cat "$history_file"
-    fi
-}
-
-build_provider_context() {
-    local agent_type="$1"
-    local base_provider="${agent_type%%-*}"  # codex-fast -> codex
-    local history
-    history=$(read_provider_history "$base_provider")
-
-    if [[ -z "$history" ]]; then
-        return
-    fi
-
-    # Truncate to max 2000 chars for prompt injection
-    if [[ ${#history} -gt 2000 ]]; then
-        history="${history:0:2000}..."
-    fi
-
-    echo "## Provider History (${base_provider})
-Recent learnings from this project:
-${history}"
-}
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -266,139 +266,16 @@ OCTOPUS_FACTORY_SATISFACTION_TARGET="${OCTOPUS_FACTORY_SATISFACTION_TARGET:-}"
 # lock it out from self-revision and route retries to an alternate provider.
 LOCKED_PROVIDERS=""
 
-lock_provider() {
-    local provider="$1"
-    # v9.5: bash builtin word check (zero subshells)
-    if [[ " $LOCKED_PROVIDERS " != *" $provider "* ]]; then
-        LOCKED_PROVIDERS="${LOCKED_PROVIDERS:+$LOCKED_PROVIDERS }$provider"
-        log WARN "Provider locked out: $provider (will not self-revise)"
-    fi
-}
+# Provider lockout + history protocol has a single owner: lib/provider-lockout.sh.
+# It was previously defined here AND in the sibling file, differing only in the
+# fallback provider, so source order silently decided routing behaviour.
+if ! declare -f get_alternate_provider >/dev/null 2>&1; then
+    _lockout_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # shellcheck source=/dev/null
+    source "${_lockout_dir}/provider-lockout.sh" 2>/dev/null || true
+fi
 
-is_provider_locked() {
-    local provider="$1"
-    [[ " $LOCKED_PROVIDERS " == *" $provider "* ]]
-}
 
-get_alternate_provider() {
-    local locked_provider="$1"
-    case "$locked_provider" in
-        codex|codex-fast|codex-mini)
-            if ! is_provider_locked "agy"; then
-                echo "agy"
-            elif ! is_provider_locked "claude-sonnet"; then
-                echo "claude-sonnet"
-            else
-                echo "$locked_provider"  # All locked, use original
-            fi
-            ;;
-        agy|agy-research|antigravity)
-            if ! is_provider_locked "codex"; then
-                echo "codex"
-            elif ! is_provider_locked "claude-sonnet"; then
-                echo "claude-sonnet"
-            else
-                echo "$locked_provider"
-            fi
-            ;;
-        claude-sonnet|claude*)
-            if ! is_provider_locked "codex"; then
-                echo "codex"
-            elif ! is_provider_locked "agy"; then
-                echo "agy"
-            else
-                echo "$locked_provider"
-            fi
-            ;;
-        *)
-            echo "$locked_provider"
-            ;;
-    esac
-}
-
-reset_provider_lockouts() {
-    if [[ -n "$LOCKED_PROVIDERS" ]]; then
-        log INFO "Resetting provider lockouts (were: $LOCKED_PROVIDERS)"
-    fi
-    LOCKED_PROVIDERS=""
-}
-
-# v8.18.0 Feature: Per-Provider History Files
-# Each provider accumulates project-specific knowledge in .octo/providers/{name}-history.md
-
-append_provider_history() {
-    case "${OCTOPUS_PROVIDER_HISTORY:-on}" in
-        off|false|0|no) return 0 ;;
-    esac
-
-    local provider="$1"
-    local phase="$2"
-    local task_brief="$3"
-    local learned="$4"
-
-    local history_dir="${WORKSPACE_DIR}/.octo/providers"
-    local history_file="$history_dir/${provider}-history.md"
-    mkdir -p "$history_dir"
-
-    local timestamp
-    timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-    # Append structured entry
-    cat >> "$history_file" << HISTEOF
-### ${phase} | ${timestamp}
-**Task:** ${task_brief:0:100}
-**Learned:** ${learned:0:200}
----
-HISTEOF
-
-    # Cap at 50 entries: count entries and trim oldest if exceeded
-    local entry_count
-    entry_count=$(grep -c "^### " "$history_file" 2>/dev/null) || entry_count=0
-    if [[ "$entry_count" -gt 50 ]]; then
-        local excess=$((entry_count - 50))
-        # Remove oldest entries (from top of file)
-        local trim_line
-        trim_line=$(grep -n "^### " "$history_file" | sed -n "$((excess + 1))p" | cut -d: -f1)
-        if [[ -n "$trim_line" && "$trim_line" -gt 1 ]]; then
-            tail -n "+$trim_line" "$history_file" > "$history_file.tmp" && mv "$history_file.tmp" "$history_file"
-        fi
-    fi
-
-    log DEBUG "Appended provider history for $provider (phase: $phase)"
-}
-
-read_provider_history() {
-    case "${OCTOPUS_PROVIDER_HISTORY:-on}" in
-        off|false|0|no) return 0 ;;
-    esac
-
-    local provider="$1"
-    local history_file="${WORKSPACE_DIR}/.octo/providers/${provider}-history.md"
-
-    if [[ -f "$history_file" ]]; then
-        cat "$history_file"
-    fi
-}
-
-build_provider_context() {
-    local agent_type="$1"
-    local base_provider="${agent_type%%-*}"  # codex-fast -> codex
-    local history
-    history=$(read_provider_history "$base_provider")
-
-    if [[ -z "$history" ]]; then
-        return
-    fi
-
-    # Truncate to max 2000 chars for prompt injection
-    if [[ ${#history} -gt 2000 ]]; then
-        history="${history:0:2000}..."
-    fi
-
-    echo "## Provider History (${base_provider})
-Recent learnings from this project:
-${history}"
-}
 
 # v8.18.0 Feature: Structured Decision Format
 # Append-only .octo/decisions.md with structured, git-mergeable entries

--- a/tests/unit/test-lockout-integration.sh
+++ b/tests/unit/test-lockout-integration.sh
@@ -19,54 +19,13 @@ LOCKED_PROVIDERS=""
 # Minimal log stub for lock_provider's log call
 log() { :; }
 
-lock_provider() {
-    local provider="$1"
-    if ! echo "$LOCKED_PROVIDERS" | grep -qw "$provider"; then
-        LOCKED_PROVIDERS="${LOCKED_PROVIDERS:+$LOCKED_PROVIDERS }$provider"
-        log WARN "Provider locked out: $provider (will not self-revise)"
-    fi
-}
+# Source the real implementation instead of copying it. These suites
+# previously defined their own get_alternate_provider returning "gemini"
+# and asserted against that copy, so they passed while production policy
+# said otherwise — a test that cannot fail for the right reason.
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/provider-lockout.sh"
 
-is_provider_locked() {
-    local provider="$1"
-    echo "$LOCKED_PROVIDERS" | grep -qw "$provider"
-}
-
-get_alternate_provider() {
-    local locked_provider="$1"
-    case "$locked_provider" in
-        codex|codex-fast|codex-mini)
-            if ! is_provider_locked "gemini"; then
-                echo "gemini"
-            elif ! is_provider_locked "claude-sonnet"; then
-                echo "claude-sonnet"
-            else
-                echo "$locked_provider"
-            fi
-            ;;
-        gemini|gemini-fast)
-            if ! is_provider_locked "codex"; then
-                echo "codex"
-            elif ! is_provider_locked "claude-sonnet"; then
-                echo "claude-sonnet"
-            else
-                echo "$locked_provider"
-            fi
-            ;;
-        claude-sonnet|claude*)
-            if ! is_provider_locked "codex"; then
-                echo "codex"
-            elif ! is_provider_locked "gemini"; then
-                echo "gemini"
-            else
-                echo "$locked_provider"
-            fi
-            ;;
-        *)
-            echo "$locked_provider"
-            ;;
-    esac
-}
 
 test_suite "Lockout Protocol Integration (v8.18.0)"
 
@@ -99,7 +58,7 @@ test_locked_provider_gets_alternate() {
     local alt
     alt=$(get_alternate_provider "codex")
 
-    if [[ "$alt" == "gemini" ]]; then
+    if [[ "$alt" == "agy" ]]; then
         test_pass
     else
         test_fail "codex should alternate to gemini, got: $alt"

--- a/tests/unit/test-lockout-protocol.sh
+++ b/tests/unit/test-lockout-protocol.sh
@@ -20,53 +20,13 @@ setup_lockout_env() {
 }
 
 # Define the functions inline for unit testing (avoids sourcing entire orchestrate.sh)
-lock_provider() {
-    local provider="$1"
-    if ! echo "$LOCKED_PROVIDERS" | grep -qw "$provider"; then
-        LOCKED_PROVIDERS="${LOCKED_PROVIDERS:+$LOCKED_PROVIDERS }$provider"
-    fi
-}
+# Source the real implementation instead of copying it. These suites
+# previously defined their own get_alternate_provider returning "gemini"
+# and asserted against that copy, so they passed while production policy
+# said otherwise — a test that cannot fail for the right reason.
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/provider-lockout.sh"
 
-is_provider_locked() {
-    local provider="$1"
-    echo "$LOCKED_PROVIDERS" | grep -qw "$provider"
-}
-
-get_alternate_provider() {
-    local locked_provider="$1"
-    case "$locked_provider" in
-        codex|codex-fast|codex-mini)
-            if ! is_provider_locked "gemini"; then
-                echo "gemini"
-            elif ! is_provider_locked "claude-sonnet"; then
-                echo "claude-sonnet"
-            else
-                echo "$locked_provider"
-            fi
-            ;;
-        gemini|gemini-fast)
-            if ! is_provider_locked "codex"; then
-                echo "codex"
-            elif ! is_provider_locked "claude-sonnet"; then
-                echo "claude-sonnet"
-            else
-                echo "$locked_provider"
-            fi
-            ;;
-        claude-sonnet|claude*)
-            if ! is_provider_locked "codex"; then
-                echo "codex"
-            elif ! is_provider_locked "gemini"; then
-                echo "gemini"
-            else
-                echo "$locked_provider"
-            fi
-            ;;
-        *)
-            echo "$locked_provider"
-            ;;
-    esac
-}
 
 reset_provider_lockouts() {
     LOCKED_PROVIDERS=""
@@ -92,12 +52,12 @@ test_lock_multiple_providers() {
     setup_lockout_env
 
     lock_provider "codex"
-    lock_provider "gemini"
+    lock_provider "agy"
 
-    if echo "$LOCKED_PROVIDERS" | grep -qw "codex" && echo "$LOCKED_PROVIDERS" | grep -qw "gemini"; then
+    if echo "$LOCKED_PROVIDERS" | grep -qw "codex" && echo "$LOCKED_PROVIDERS" | grep -qw "agy"; then
         test_pass
     else
-        test_fail "Expected both codex and gemini locked, got '$LOCKED_PROVIDERS'"
+        test_fail "Expected both codex and agy locked, got '$LOCKED_PROVIDERS'"
     fi
 }
 
@@ -132,16 +92,16 @@ test_is_provider_locked() {
 }
 
 test_alternate_codex_to_gemini() {
-    test_case "get_alternate_provider routes codex to gemini"
+    test_case "get_alternate_provider routes codex to agy"
     setup_lockout_env
 
     local alt
     alt=$(get_alternate_provider "codex")
 
-    if [[ "$alt" == "gemini" ]]; then
+    if [[ "$alt" == "agy" ]]; then
         test_pass
     else
-        test_fail "Expected 'gemini', got '$alt'"
+        test_fail "Expected 'agy', got '$alt'"
     fi
 }
 
@@ -163,7 +123,9 @@ test_alternate_cascade() {
     test_case "get_alternate_provider cascades when first alternate locked"
     setup_lockout_env
 
-    lock_provider "gemini"
+    # codex's first alternate is agy (gemini is a sunset seat), so the
+    # cascade fixture must lock agy to exercise the second hop.
+    lock_provider "agy"
     local alt
     alt=$(get_alternate_provider "codex")
 
@@ -178,7 +140,7 @@ test_alternate_all_locked() {
     test_case "get_alternate_provider returns original when all locked"
     setup_lockout_env
 
-    lock_provider "gemini"
+    lock_provider "agy"
     lock_provider "claude-sonnet"
     local alt
     alt=$(get_alternate_provider "codex")
@@ -195,7 +157,7 @@ test_reset_lockouts() {
     setup_lockout_env
 
     lock_provider "codex"
-    lock_provider "gemini"
+    lock_provider "agy"
     reset_provider_lockouts
 
     if [[ -z "$LOCKED_PROVIDERS" ]]; then
@@ -213,10 +175,10 @@ test_codex_variants() {
     alt_fast=$(get_alternate_provider "codex-fast")
     alt_mini=$(get_alternate_provider "codex-mini")
 
-    if [[ "$alt_fast" == "gemini" && "$alt_mini" == "gemini" ]]; then
+    if [[ "$alt_fast" == "agy" && "$alt_mini" == "agy" ]]; then
         test_pass
     else
-        test_fail "Expected gemini for both, got fast='$alt_fast' mini='$alt_mini'"
+        test_fail "Expected agy for both, got fast='$alt_fast' mini='$alt_mini'"
     fi
 }
 

--- a/tests/unit/test-provider-fallback-single-owner.sh
+++ b/tests/unit/test-provider-fallback-single-owner.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Provider lockout helpers must have exactly one definition.
+#
+# lock_provider, is_provider_locked, get_alternate_provider,
+# reset_provider_lockouts, append_provider_history, read_provider_history and
+# build_provider_context were defined twice — in lib/quality.sh and again in
+# lib/provider-routing.sh — identical except for the fallback provider.
+#
+# orchestrate.sh sources quality.sh at :194 and provider-routing.sh at :205, so
+# the second definition silently won. The effective fallback for a locked codex
+# was therefore `gemini`, whose free tier is sunset and returns
+# IneligibleTierError — the recovery path routed to a known-dead seat. The
+# surviving quality.sh chain falls back to `agy`, the current Google seat, then
+# to Claude for a genuinely separate failure domain.
+#
+# Nothing about that was visible in either file. It was decided by source order.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Provider fallback has a single owner"
+
+LOCKOUT_FNS="lock_provider is_provider_locked get_alternate_provider reset_provider_lockouts append_provider_history read_provider_history build_provider_context"
+
+# The assertion that matters: one definition each, repo-wide. Two definitions
+# mean behaviour depends on source order, which is not reviewable.
+test_case "each lockout helper is defined exactly once across scripts/"
+dupes=""
+for fn in $LOCKOUT_FNS; do
+    n="$(grep -rlE "^${fn}\(\)" "$PROJECT_ROOT/scripts" 2>/dev/null | grep -c . || true)"
+    [[ "${n:-0}" -le 1 ]] || dupes="$dupes ${fn}(${n})"
+done
+if [[ -z "$dupes" ]]; then
+    test_pass
+else
+    test_fail "defined in more than one file:${dupes} — source order would decide which wins"
+fi
+
+test_case "the surviving definitions live in provider-lockout.sh"
+missing=""
+for fn in $LOCKOUT_FNS; do
+    grep -qE "^${fn}\(\)" "$PROJECT_ROOT/scripts/lib/provider-lockout.sh" || missing="$missing $fn"
+done
+if [[ -z "$missing" ]]; then
+    test_pass
+else
+    test_fail "not found in provider-lockout.sh:${missing}"
+fi
+
+# Behavioural check, not just structural: sourcing both files in the real order
+# must still yield the intended fallback.
+resolve_fallback() {
+    bash -c '
+        source "$1/scripts/lib/quality.sh" 2>/dev/null
+        source "$1/scripts/lib/provider-routing.sh" 2>/dev/null
+        LOCKED_PROVIDERS=" $2 "
+        get_alternate_provider "$2" 2>/dev/null
+    ' _ "$PROJECT_ROOT" "$1" 2>/dev/null | tail -1
+}
+
+test_case "a locked codex falls back to agy, not the sunset gemini seat"
+got="$(resolve_fallback codex)"
+if [[ "$got" == "agy" ]]; then
+    test_pass
+else
+    test_fail "expected agy, got '${got}' — gemini's free tier is sunset (IneligibleTierError), so falling back to it routes into a known-dead seat"
+fi
+
+test_case "the fallback survives sourcing provider-routing.sh second"
+# Explicitly mirrors orchestrate.sh's order (quality.sh :194, routing :205).
+got="$(resolve_fallback codex)"
+got2="$(bash -c '
+    source "$1/scripts/lib/provider-routing.sh" 2>/dev/null
+    source "$1/scripts/lib/quality.sh" 2>/dev/null
+    LOCKED_PROVIDERS=" codex "
+    get_alternate_provider codex 2>/dev/null
+' _ "$PROJECT_ROOT" 2>/dev/null | tail -1)"
+if [[ "$got" == "$got2" ]]; then
+    test_pass
+else
+    test_fail "fallback depends on source order: forward='${got}' reversed='${got2}' — that is the bug this suite exists to prevent"
+fi
+
+# Guards a vacuous pass: if the helper stops resolving at all, the assertions
+# above would compare two empty strings and agree.
+test_case "get_alternate_provider actually resolves something"
+if [[ -n "$(resolve_fallback codex)" ]]; then
+    test_pass
+else
+    test_fail "resolved empty — the helper is not loading, so the comparisons above prove nothing"
+fi
+
+test_case "both consumers source the single owner rather than redefining it"
+bad=""
+for consumer in quality.sh provider-routing.sh; do
+    grep -q 'provider-lockout.sh' "$PROJECT_ROOT/scripts/lib/$consumer" || bad="$bad $consumer"
+done
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "these do not source the single owner:${bad} — sourcing one of them standalone would leave the helpers undefined"
+fi
+
+# Neither original copy had complete coverage: quality.sh keyed on agy, the
+# provider-routing.sh copy keyed on gemini. Keeping only one silently dropped
+# an arm, so a locked provider was offered itself as its own alternate.
+test_case "every routable provider has an alternate that is not itself"
+selfref=""
+for p in codex gemini gemini-fast agy claude-sonnet; do
+    got="$(resolve_fallback "$p")"
+    [[ -n "$got" && "$got" != "$p" ]] || selfref="$selfref ${p}(${got:-empty})"
+done
+if [[ -z "$selfref" ]]; then
+    test_pass
+else
+    test_fail "these resolve to themselves, so lockout never routes anywhere:${selfref}"
+fi
+
+test_summary


### PR DESCRIPTION
The seven lockout/history helpers were defined in both quality.sh and
provider-routing.sh. orchestrate.sh sources quality.sh (:194) before
provider-routing.sh (:205), so the routing copy silently won and a
locked codex fell back to gemini — whose free tier is sunset and
returns IneligibleTierError. The recovery path routed to a dead seat,
and nothing in either file made that visible: source order decided it.

Extracted to lib/provider-lockout.sh, sourced by both with a guard.
Deleting one copy instead was my first attempt and was wrong: several
tests source provider-routing.sh alone and call these functions, so
that left test-provider-history-toggle.sh with three undefined
symbols. Codex review caught it; my own check had grepped for the
string 'quality.sh' anywhere in a file rather than an actual source
line, so a comment counted as sourcing it.

Extracting then exposed a second problem neither copy revealed alone:
they had DIFFERENT case arms, not just different fallbacks. quality.sh
keyed on agy, the routing copy on gemini. Keeping either alone dropped
an arm, leaving that provider with no alternate but itself. The merged
version carries both:

    codex  -> agy        agy           -> codex
    gemini -> codex      claude-sonnet -> codex

Two lockout suites defined their own copy of get_alternate_provider
returning gemini and asserted against that copy — passing while
contradicting production. They now source the real implementation, and
their fixtures lock agy so the cascade is actually exercised.

New test asserts single definition, identical resolution under either
source order, and that no provider resolves to itself.

Local CI: 16 smoke, 242 unit, 7 integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recovery when a service provider is unavailable by selecting more appropriate alternate providers.
  * Added provider-specific history that can be included in future task context, with configurable retention and size limits.
  * Added support for resetting provider lockouts and disabling history collection.

* **Bug Fixes**
  * Prevented Gemini from being selected as a fallback for Codex-family providers.
  * Improved handling for Gemini, Agy, Claude, and unknown provider scenarios.
  * Standardized provider fallback behavior across supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->