### PR TITLE
fix: stop 4 providers silently inheriting OpenAI's frontier default

### DIFF
--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -435,6 +435,7 @@ resolve_octopus_model() {
             openrouter-glm*)  resolved_model="z-ai/glm-5" ;;
             openrouter-kimi*) resolved_model="moonshotai/kimi-k2.5" ;;
             openrouter-deepseek*) resolved_model="deepseek/deepseek-r1-0528" ;;
+            openrouter)      resolved_model="anthropic/claude-sonnet-4" ;; # bare openrouter needs a namespaced id (provider/model); matches get_openrouter_model's own general-task default (#797)
             openai-compatible|openai-tools|openai-compatible-agent*) resolved_model="${OPENAI_COMPAT_MODEL:-gpt-5.4}" ;;
             ollama*)         resolved_model="llama3.3" ;;
             copilot*)        resolved_model="claude-sonnet-4.5" ;; # Copilot default; actual model selected by copilot CLI
@@ -443,6 +444,9 @@ resolve_octopus_model() {
             opencode-research*) resolved_model="opencode/glm-5.1" ;;
             opencode-fast*)  resolved_model="opencode/deepseek-v4-flash-free" ;;
             opencode*)       resolved_model="opencode/deepseek-v4-flash-free" ;;
+            grok*)           resolved_model="default" ;; # xAI's own CLI default; dispatch.sh only adds --model when this is not "default" (#797)
+            vibe*)           resolved_model="default" ;; # model lives in ~/.vibe/config.toml; dispatch never passes --model for vibe (#797)
+            atlascloud*)     resolved_model="" ;; # no cross-vendor default exists — force explicit ATLASCLOUD_MODEL/OCTOPUS_ATLASCLOUD_MODEL/config (fails validation below), same as providers.sh's own availability check (#797)
             *)              resolved_model="$(codex_default_model)" ;; # Safest universal fallback
         esac
         [[ -n "$_trace" ]] && echo "[model-trace] Tier 7 (hardcoded fallback): $resolved_model ← SELECTED" >&2


### PR DESCRIPTION
## Description
`resolve_octopus_model`'s Priority-7 hardcoded fallback (`scripts/lib/model-resolver.sh:420-447`) only has explicit case arms for a subset of providers; anything without an arm falls through to `codex_default_model()` (`gpt-5.6-sol`). In the shipped no-config state (fresh install, no `providers.json`), four providers hit that catch-all instead of a vendor-appropriate default: `grok`, bare `openrouter`, `atlascloud`, and `vibe`.

The worst case is `grok`: `dispatch.sh` sees a resolved model that isn't `"default"` and emits `env OCTOPUS_GROK_MODEL=gpt-5.6-sol .../grok-exec.sh`, which appends `--model gpt-5.6-sol` — an OpenAI model ID handed to the xAI CLI. Bare `openrouter` is similar; OpenRouter requires namespaced IDs (`vendor/model`), so an unnamespaced `gpt-5.6-sol` isn't valid there either. This produces no error, just silently wrong output from the wrong model — unlike the related #696/#697/#705/#769 class of bugs, which all failed loudly.

## Type of Change
- [x] Bug fix

## Fix
Added explicit Priority-7 arms in `scripts/lib/model-resolver.sh`:
- `grok*` / `vibe*` → resolve to `"default"`, the sentinel `dispatch.sh` and `grok-exec.sh` already treat as "let the CLI use its own default" (grok's model lives in its own CLI config; vibe's lives in `~/.vibe/config.toml` and dispatch never even passes `--model` for it).
- bare `openrouter` → resolves to the namespaced `anthropic/claude-sonnet-4`, matching `get_openrouter_model`'s own general-task default in `providers.sh`, instead of an invalid unnamespaced OpenAI ID.
- `atlascloud*` → resolves to empty, which fails `validate_model_name` and returns a loud `log ERROR` + non-zero exit. Atlas Cloud has no sane cross-vendor default and already requires an explicit `ATLASCLOUD_MODEL`/`OCTOPUS_ATLASCLOUD_MODEL` per `providers.sh`'s own availability check (`providers.sh:838-841`) — this makes the resolver consistent with that instead of inventing a wrong value.

Scope kept intentionally minimal — the issue's suggested "derive the guard from `provider-registry.sh`'s organization field" is a larger refactor and out of scope for this fix.

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] New skills/commands registered in `.claude-plugin/plugin.json` (n/a — no new commands)
- [ ] Version bump (n/a — patch-worthy fix, left for release process)
- [ ] Documentation updated (n/a)
- [ ] CHANGELOG.md updated (left for release process)

## Testing
Reproduced the issue's exact repro (`HOME` pointed at an empty dir, sourced `provider-registry`/`utils`/`model-resolver`/`provider-routing`/`dispatch`, called `get_agent_model <provider> probe researcher`) before and after the fix:

| provider | before | after |
|---|---|---|
| `grok` | `gpt-5.6-sol` | `default` |
| `openrouter` (bare) | `gpt-5.6-sol` | `anthropic/claude-sonnet-4` |
| `atlascloud` | `gpt-5.6-sol` | *(fails validation, non-zero exit — no silent value)* |
| `vibe` | `gpt-5.6-sol` | `default` |

Ran the directly affected unit suites:
```bash
bash tests/unit/test-grok-provider.sh                          # 7/7 pass
bash tests/unit/test-issue-738-openrouter-council-seat.sh       # 8/8 pass
bash tests/unit/test-vibe-provider.sh                           # 5/5 pass
bash tests/unit/test-agy-provider.sh                            # 44/44 pass
bash tests/unit/test-agy-research-defaults.sh                   # 6/6 pass
bash tests/unit/test-codex-sandbox-mode.sh                      # 5/5 pass
bash tests/unit/test-fable5-mode.sh                             # 27/27 pass
bash tests/unit/test-openai-compatible-agent.sh                 # 19/19 pass
bash tests/unit/test-opencode-model-defaults.sh                 # 12/12 pass
bash tests/unit/test-orchestrate-cwd-routing.sh                 # 15/15 pass
bash tests/unit/test-resolve-model.sh                           # 17/17 pass
bash tests/unit/test-role-mapping-v929.sh                       # 14/14 pass
bash tests/unit/test-dispatch-round-trip.sh                     # 6/6 pass
bash tests/unit/test-consultative-agent-dispatch.sh             # 6/6 pass
```
`tests/unit/test-execution-profile-dispatch.sh` fails both on this branch and on unmodified `main` (confirmed via `git stash`) — pre-existing, unrelated to this change.

The full `make test-unit` run exceeds this environment's command timeout; ran the targeted subset above instead (all suites touching `resolve_octopus_model`/dispatch/provider model selection).

No atlascloud-specific unit test exists yet — the issue notes this is exactly why CI didn't catch this class of bug for atlascloud/openrouter/vibe/grok's no-config state. Left out of scope for this minimal fix; worth a follow-up issue.

## Related Issues
Closes #797


---
_Generated by [Claude Code](https://claude.ai/code/session_015uCw9gW2hZFxtN7MdvSvjc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model selection fallbacks for OpenRouter, Grok, and Vibe.
  * Removed the implicit model fallback for AtlasCloud to prevent unintended model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->