### PR TITLE
fix: migrate stale gpt-5.x model pins, not just pre-gpt-5 ones

### DIFF
--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -445,8 +445,9 @@ EOF
                 replacement="gemini-3-pro-image" ;;  # shutdown 2026-06-25 (codex review)
             gpt-4o*|gpt-4-turbo*|gpt-4-*|o1-*|chatgpt-*)
                 replacement="gpt-5.6-sol" ;;
-            gpt-5.5*|gpt-5.4*|gpt-5.3-codex*|gpt-5.2-codex*|gpt-5.1-codex-max)
-                replacement="gpt-5.6-sol" ;;  # gpt-5.x line predates the GPT-5.6 refresh (#798); gpt-5.6-* itself doesn't match these globs
+            gpt-5.5|gpt-5.5-pro|gpt-5.4|gpt-5.4-pro|gpt-5.3-codex|gpt-5.2-codex|gpt-5.1-codex-max)
+                replacement="gpt-5.6-sol" ;;  # gpt-5.x line predates GPT-5.6 (#798). Exact names, not wildcards —
+                                               # gpt-5.4-mini/gpt-5.3-codex-spark are distinct current tiers, not stale
         esac
 
         if [[ -n "$replacement" ]]; then

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -445,6 +445,8 @@ EOF
                 replacement="gemini-3-pro-image" ;;  # shutdown 2026-06-25 (codex review)
             gpt-4o*|gpt-4-turbo*|gpt-4-*|o1-*|chatgpt-*)
                 replacement="gpt-5.6-sol" ;;
+            gpt-5.5*|gpt-5.4*|gpt-5.3-codex*|gpt-5.2-codex*|gpt-5.1-codex-max)
+                replacement="gpt-5.6-sol" ;;  # gpt-5.x line predates the GPT-5.6 refresh (#798); gpt-5.6-* itself doesn't match these globs
         esac
 
         if [[ -n "$replacement" ]]; then

--- a/tests/unit/test-migrate-stale-gpt5-line.sh
+++ b/tests/unit/test-migrate-stale-gpt5-line.sh
@@ -89,8 +89,41 @@ assert_stale_model_migrates() {
     [[ "$val" == "gpt-5.6-sol" ]] && test_pass || test_fail "expected gpt-5.6-sol, got: $val"
 }
 
-for stale_model in gpt-5.5 gpt-5.4-pro gpt-5.3-codex gpt-5.2-codex gpt-5.1-codex-max; do
+for stale_model in gpt-5.5 gpt-5.5-pro gpt-5.4-pro gpt-5.3-codex gpt-5.2-codex gpt-5.1-codex-max; do
     assert_stale_model_migrates "$stale_model"
+done
+
+# Regression for a review finding on this fix (#807): the first pass used
+# gpt-5.4*/gpt-5.3-codex* wildcards, which also matched gpt-5.4-mini (budget
+# tier) and gpt-5.3-codex-spark (spark tier) — still-current, differently
+# tiered models a user may have deliberately pinned, not stale defaults. The
+# fix narrowed the case arm to exact names; these must NOT migrate.
+assert_current_tier_variant_is_untouched() {
+    local current_model="$1"
+    local fixture_home="$TEST_TMP_DIR/home-untouched-$current_model"
+    local fixture_file="$fixture_home/.claude-octopus/config/providers.json"
+
+    mkdir -p "$(dirname "$fixture_file")"
+    jq -n --arg model "$current_model" '{
+      version: "3.0",
+      providers: {codex: {default: $model}},
+      phases: {}, roles: {}, tiers: {}, overrides: {}
+    }' > "$fixture_file"
+
+    (
+        log() { :; }
+        HOME="$fixture_home"
+        source "$PROJECT_ROOT/scripts/lib/provider-routing.sh" >/dev/null 2>&1
+        migrate_provider_config
+    )
+
+    test_case "current tier variant ($current_model) is NOT migrated"
+    val="$(jq -r '.providers.codex.default' "$fixture_file")"
+    [[ "$val" == "$current_model" ]] && test_pass || test_fail "expected $current_model (unchanged), got: $val"
+}
+
+for current_model in gpt-5.4-mini gpt-5.3-codex-spark; do
+    assert_current_tier_variant_is_untouched "$current_model"
 done
 
 test_case "already-current gemini default is left untouched"

--- a/tests/unit/test-migrate-stale-gpt5-line.sh
+++ b/tests/unit/test-migrate-stale-gpt5-line.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# tests/unit/test-migrate-stale-gpt5-line.sh
+# Regression coverage for #798: migrate_provider_config's stale-model rewrite
+# map (scripts/lib/provider-routing.sh) had cases for gpt-4o/o1/chatgpt-era
+# names but nothing for the gpt-5.x line, so an install pinned to an older
+# gpt-5.x point release (gpt-5.4, gpt-5.1-codex-max, ...) was never
+# recognised as stale and silently stayed on it forever, even though
+# CLAUDE.md and model-resolver.sh both document GPT-5.6 Sol as current.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "migrate_provider_config gpt-5.x staleness (#798)"
+
+TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT
+rm -rf "$TEST_TMP_DIR"
+mkdir -p "$TEST_TMP_DIR/home/.claude-octopus/config"
+CONFIG_FILE="$TEST_TMP_DIR/home/.claude-octopus/config/providers.json"
+
+# Reproduces the issue's "Evidence from a live machine" providers.json:
+# every codex slot pinned to gpt-5.4 (a real config from before the GPT-5.6
+# refresh, 972d9597, 2026-07-27). version:3.0 skips the unrelated structural
+# v3.0 migration block so only the stale-model rewrite loop is exercised.
+cat > "$CONFIG_FILE" <<'JSON'
+{
+  "version": "3.0",
+  "providers": {
+    "codex": {
+      "default": "gpt-5.4",
+      "fallback": "gpt-5.4",
+      "spark": "gpt-5.4",
+      "mini": "gpt-5.4",
+      "reasoning": "o1-preview",
+      "large_context": "gpt-5.4"
+    },
+    "gemini": { "default": "gemini-3.1-pro-preview" }
+  },
+  "phases": {}, "roles": {}, "tiers": {}, "overrides": {}
+}
+JSON
+
+run_migration_in_subshell() {
+    # migrate_provider_config memoizes via _PROVIDER_CONFIG_MIGRATED and is
+    # meant to run once per process — a fresh subshell per invocation avoids
+    # that guard masking a second call.
+    (
+        log() { :; }
+        HOME="$TEST_TMP_DIR/home"
+        source "$PROJECT_ROOT/scripts/lib/provider-routing.sh" >/dev/null 2>&1
+        migrate_provider_config
+    )
+}
+
+run_migration_in_subshell
+
+test_case "stale codex.default (gpt-5.4) migrates to the current default"
+val="$(jq -r '.providers.codex.default' "$CONFIG_FILE")"
+[[ "$val" == "gpt-5.6-sol" ]] && test_pass || test_fail "expected gpt-5.6-sol, got: $val"
+
+test_case "stale codex.fallback (gpt-5.4) migrates to the current default"
+val="$(jq -r '.providers.codex.fallback' "$CONFIG_FILE")"
+[[ "$val" == "gpt-5.6-sol" ]] && test_pass || test_fail "expected gpt-5.6-sol, got: $val"
+
+test_case "already-current gemini default is left untouched"
+val="$(jq -r '.providers.gemini.default' "$CONFIG_FILE")"
+[[ "$val" == "gemini-3.1-pro-preview" ]] && test_pass || test_fail "expected gemini-3.1-pro-preview (unchanged), got: $val"
+
+# Known, deliberately out-of-scope gap this fix does NOT close: stale_paths
+# only lists .providers.codex.{default,fallback} and the gemini equivalents,
+# so codex.spark/mini/reasoning/large_context are never inspected at all —
+# stale or not, they pass through untouched. That's issue #798's second,
+# separate limitation ("no other provider's pins are ever migrated"), left
+# for a follow-up. Documented here so a future stale_paths widening updates
+# this assertion instead of silently leaving it stale itself.
+test_case "codex.spark is NOT migrated (stale_paths doesn't cover it — known gap, not this fix's scope)"
+val="$(jq -r '.providers.codex.spark' "$CONFIG_FILE")"
+[[ "$val" == "gpt-5.4" ]] && test_pass || test_fail "expected gpt-5.4 (still untouched — if this now migrates, stale_paths grew; update this test), got: $val"
+
+# A second config, already on the current GPT-5.6 line, must not be rewritten
+# (proves the new glob doesn't also swallow gpt-5.6-* values).
+CONFIG_FILE2="$TEST_TMP_DIR/home2/.claude-octopus/config/providers.json"
+mkdir -p "$(dirname "$CONFIG_FILE2")"
+cat > "$CONFIG_FILE2" <<'JSON'
+{
+  "version": "3.0",
+  "providers": { "codex": { "default": "gpt-5.6-sol", "fallback": "gpt-5.6-terra" } },
+  "phases": {}, "roles": {}, "tiers": {}, "overrides": {}
+}
+JSON
+(
+    log() { :; }
+    HOME="$TEST_TMP_DIR/home2"
+    source "$PROJECT_ROOT/scripts/lib/provider-routing.sh" >/dev/null 2>&1
+    migrate_provider_config
+)
+
+test_case "already-current codex.default (gpt-5.6-sol) is left untouched"
+val="$(jq -r '.providers.codex.default' "$CONFIG_FILE2")"
+[[ "$val" == "gpt-5.6-sol" ]] && test_pass || test_fail "expected gpt-5.6-sol (unchanged), got: $val"
+
+test_case "already-current codex.fallback (gpt-5.6-terra) is left untouched"
+val="$(jq -r '.providers.codex.fallback' "$CONFIG_FILE2")"
+[[ "$val" == "gpt-5.6-terra" ]] && test_pass || test_fail "expected gpt-5.6-terra (unchanged), got: $val"
+
+test_summary

--- a/tests/unit/test-migrate-stale-gpt5-line.sh
+++ b/tests/unit/test-migrate-stale-gpt5-line.sh
@@ -65,6 +65,34 @@ test_case "stale codex.fallback (gpt-5.4) migrates to the current default"
 val="$(jq -r '.providers.codex.fallback' "$CONFIG_FILE")"
 [[ "$val" == "gpt-5.6-sol" ]] && test_pass || test_fail "expected gpt-5.6-sol, got: $val"
 
+assert_stale_model_migrates() {
+    local stale_model="$1"
+    local fixture_home="$TEST_TMP_DIR/home-$stale_model"
+    local fixture_file="$fixture_home/.claude-octopus/config/providers.json"
+
+    mkdir -p "$(dirname "$fixture_file")"
+    jq -n --arg model "$stale_model" '{
+      version: "3.0",
+      providers: {codex: {default: $model}},
+      phases: {}, roles: {}, tiers: {}, overrides: {}
+    }' > "$fixture_file"
+
+    (
+        log() { :; }
+        HOME="$fixture_home"
+        source "$PROJECT_ROOT/scripts/lib/provider-routing.sh" >/dev/null 2>&1
+        migrate_provider_config
+    )
+
+    test_case "stale codex.default ($stale_model) migrates to the current default"
+    val="$(jq -r '.providers.codex.default' "$fixture_file")"
+    [[ "$val" == "gpt-5.6-sol" ]] && test_pass || test_fail "expected gpt-5.6-sol, got: $val"
+}
+
+for stale_model in gpt-5.5 gpt-5.4-pro gpt-5.3-codex gpt-5.2-codex gpt-5.1-codex-max; do
+    assert_stale_model_migrates "$stale_model"
+done
+
 test_case "already-current gemini default is left untouched"
 val="$(jq -r '.providers.gemini.default' "$CONFIG_FILE")"
 [[ "$val" == "gemini-3.1-pro-preview" ]] && test_pass || test_fail "expected gemini-3.1-pro-preview (unchanged), got: $val"


### PR DESCRIPTION
## Description
`migrate_provider_config`'s stale-model rewrite map (`scripts/lib/provider-routing.sh:437-447`) only recognized `gpt-4o`/`gpt-4-turbo`/`o1-*`/`chatgpt-*` as stale for codex — there was no case for the gpt-5.x line itself. An install pinned to `gpt-5.4` (or any other pre-GPT-5.6 point release: `gpt-5.5`, `gpt-5.4-pro`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-max`) was never recognized as stale and stayed on it permanently, silently — even though `CLAUDE.md` and `model-resolver.sh`'s `codex_default_model()` both document `gpt-5.6-sol` as current since the GPT-5.6 refresh (`972d9597`, 2026-07-27). Unlike a wrong *default* (which only affects new installs), a missed *migration* affects every existing install forever.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Fix
Added a case arm matching the `gpt-5.5`/`5.4`/`5.3-codex`/`5.2-codex`/`5.1-codex-max` prefixes, rewriting them to `gpt-5.6-sol` via the same `jq --arg` path already used for the existing entries. The new globs don't overlap `gpt-5.6-*` itself, so already-current configs are left untouched (covered by a test case).

### Scope note
The issue also flags a second, separate limitation: `stale_paths` only inspects `.providers.codex.{default,fallback}` and the gemini equivalents, so `codex.spark`/`mini`/`reasoning`/`large_context` and every non-codex/gemini provider's pins are never migrated at all. That's a materially larger change (it needs a staleness definition per provider/slot) and is left as follow-up rather than guessed at here. This fix is scoped to the issue's primary, clearly-evidenced symptom — the live-machine repro showing `gpt-5.4` surviving migration on every codex slot the function *does* check. The gap is documented explicitly with a regression test asserting `codex.spark` is **not** touched by this change, so a future widening of `stale_paths` updates that assertion instead of silently leaving it stale itself.

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n scripts/*.sh scripts/lib/*.sh scripts/helpers/*.sh`
- [x] New/changed file permissions unchanged (`git diff origin/main...HEAD --summary` has no mode changes; new test file created at the standard `755`)
- [ ] OpenClaw registry in sync (not applicable — no OpenClaw-facing surface touched)
- [ ] New skills/commands registered in `plugin.json` (not applicable)
- [ ] Version bump (left for a release PR per repo convention)
- [ ] CHANGELOG.md updated (left for a release PR, per repo convention of batching fix entries)

## Testing
Added `tests/unit/test-migrate-stale-gpt5-line.sh`, reproducing the issue's exact live-machine `providers.json` (every codex slot pinned to `gpt-5.4`) against a real `migrate_provider_config()` run. Verified the test fails on unmodified `main` (2/6 cases fail: `codex.default`/`codex.fallback` stay at `gpt-5.4`) and passes with this fix (6/6).

```
bash tests/unit/test-migrate-stale-gpt5-line.sh   # 6/6 pass (was 4/6 on main)
```

Also ran the 18 other unit tests that source `provider-routing.sh` or call `migrate_provider_config` — all pass, no regressions:
```
test-agent-command-validation, test-agy-provider, test-agy-research-defaults,
test-claude-sdk-provider, test-codex-pull-guard, test-codex-sandbox-mode,
test-commandcode-harness, test-credential-isolation, test-dispatch-round-trip,
test-gemini-via-agy-consent, test-grok-provider, test-openai-compatible-agent,
test-provider-history-toggle, test-provider-registry-contracts,
test-provider-registry-parity, test-provider-registry, test-quota-fast-fail,
test-role-mapping-v929
```

Did not run the full `make test-unit`/`make test-integration` suite in this sandbox (a full run exceeded the available command timeout here); the targeted set above covers every suite that touches the changed function, consistent with "if the change is tiny and integration is irrelevant, run only the directly affected tests."

## Related Issues
Closes #798

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSqUF4TbRc24GztjZueTqm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated migration handling for outdated GPT-5.x and Codex model names.
  * Preserved current Gemini, GPT-5.6, and supported tier-specific model configurations.
  * Improved handling of unsupported model paths without changing valid provider settings.

* **Tests**
  * Added regression coverage for stale model defaults, fallback behavior, preserved configurations, and unsupported model paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->