### PR TITLE
fix: stop the skill generator deleting hand-maintained directories

### DIFF
--- a/scripts/build-codex-skills.sh
+++ b/scripts/build-codex-skills.sh
@@ -313,20 +313,43 @@ write_skill() {
     } > "$skill_dir/agents/openai.yaml"
 }
 
+# Directories under skills/ that are hand-maintained rather than generated.
+# Everything else is wiped and rebuilt from .claude/skills/, so anything listed
+# here MUST be excluded or a plain regeneration silently deletes it.
+#
+#   blocks               shared prose fragments, no per-skill source
+#   octopus-starter-pack a bundle of four sub-skills with no .claude/skills
+#                        counterpart, registered in plugin.json
+#   skill-council        has never had a source (no delete recorded in git
+#                        history); generating without this exclusion removes it
+PRESERVED_SKILL_DIRS=(blocks octopus-starter-pack skill-council)
+
+_preserve_find_args() {
+    local d
+    for d in "${PRESERVED_SKILL_DIRS[@]}"; do
+        printf '%s\n' "!" "-name" "$d"
+    done
+}
+
 prepare_target_dir() {
     local target_dir="$1"
 
     if [[ "$target_dir" == "$OUTPUT_DIR" ]]; then
         mkdir -p "$target_dir"
-        find "$target_dir" -mindepth 1 -maxdepth 1 -type d ! -name blocks -exec rm -rf {} +
+        local -a keep=()
+        while IFS= read -r a; do keep+=("$a"); done < <(_preserve_find_args)
+        find "$target_dir" -mindepth 1 -maxdepth 1 -type d "${keep[@]}" -exec rm -rf {} +
         find "$target_dir" -mindepth 1 -maxdepth 1 -type f -delete
     else
         rm -rf "$target_dir"
         mkdir -p "$target_dir"
-        if [[ -d "$OUTPUT_DIR/blocks" ]]; then
-            mkdir -p "$target_dir/blocks"
-            cp -R "$OUTPUT_DIR/blocks/." "$target_dir/blocks/"
-        fi
+        local d
+        for d in "${PRESERVED_SKILL_DIRS[@]}"; do
+            if [[ -d "$OUTPUT_DIR/$d" ]]; then
+                mkdir -p "$target_dir/$d"
+                cp -R "$OUTPUT_DIR/$d/." "$target_dir/$d/"
+            fi
+        done
     fi
 
     write_codex_adapter_block "$target_dir"


### PR DESCRIPTION
prepare_target_dir wiped everything under skills/ except blocks/, so a
plain regeneration silently deleted octopus-starter-pack (four
sub-skills, registered in plugin.json) and skill-council. Verified in a
scratch copy: before this change the generator removed both and added
nothing; after it, all three hand-maintained trees survive.

This is the same hazard that stripped 395 lines from 21 committed skill
files earlier in this cycle via the sibling openclaw generator. The
exclusion is now a named list with a comment explaining why each entry
is there, rather than a bare '! -name blocks'.

Does NOT make build-codex-skills.sh --check pass. That still fails, and
should: twelve skills carry content that exists only in the generated
tree (## Terminal State in all four flow skills, a Fable 5 model
caveat in octopus-security-audit, STEP 8 in octopus-ui-ux-design, a
Rationalization Table in skill-verification-gate). Regenerating would
destroy it. That back-port is filed separately; forcing the gate green
first would delete the very content the gate is meant to protect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved selected skill directories during output regeneration.
  * Prevented existing content in these directories from being removed during rebuilds.
  * Ensured preserved content is carried into temporary build output before regeneration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->