### PR TITLE
test: avoid grep SIGPIPE under pipefail

### DIFF
--- a/tests/unit/test-v8.2.0-agent-fields.sh
+++ b/tests/unit/test-v8.2.0-agent-fields.sh
@@ -64,49 +64,49 @@ echo -e "${BLUE}Test Group 1: Config.yaml Field Declarations${NC}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # 1.1: permissionMode exists for probe agent (ai-engineer)
-if grep -A 10 '  ai-engineer:' "$CONFIG_YAML" | grep -q 'permissionMode: plan'; then
+if grep -A 10 '  ai-engineer:' "$CONFIG_YAML" | grep 'permissionMode: plan' >/dev/null; then
     assert_pass "1.1 ai-engineer has permissionMode: plan (probe agent)"
 else
     assert_fail "1.1 ai-engineer has permissionMode: plan (probe agent)"
 fi
 
 # 1.2: permissionMode exists for tangle agent (tdd-orchestrator)
-if grep -A 10 '  tdd-orchestrator:' "$CONFIG_YAML" | grep -q 'permissionMode: acceptEdits'; then
+if grep -A 10 '  tdd-orchestrator:' "$CONFIG_YAML" | grep 'permissionMode: acceptEdits' >/dev/null; then
     assert_pass "1.2 tdd-orchestrator has permissionMode: acceptEdits (tangle agent)"
 else
     assert_fail "1.2 tdd-orchestrator has permissionMode: acceptEdits (tangle agent)"
 fi
 
 # 1.3: permissionMode exists for ink agent (code-reviewer)
-if grep -A 15 '  code-reviewer:' "$CONFIG_YAML" | grep -q 'permissionMode: default'; then
+if grep -A 15 '  code-reviewer:' "$CONFIG_YAML" | grep 'permissionMode: default' >/dev/null; then
     assert_pass "1.3 code-reviewer has permissionMode: default (ink agent)"
 else
     assert_fail "1.3 code-reviewer has permissionMode: default (ink agent)"
 fi
 
 # 1.4: memory: project exists for code-reviewer
-if grep -A 10 '  code-reviewer:' "$CONFIG_YAML" | grep -q 'memory: project'; then
+if grep -A 10 '  code-reviewer:' "$CONFIG_YAML" | grep 'memory: project' >/dev/null; then
     assert_pass "1.4 code-reviewer has memory: project"
 else
     assert_fail "1.4 code-reviewer has memory: project"
 fi
 
 # 1.5: memory: project exists for security-auditor
-if grep -A 10 '  security-auditor:' "$CONFIG_YAML" | grep -q 'memory: project'; then
+if grep -A 10 '  security-auditor:' "$CONFIG_YAML" | grep 'memory: project' >/dev/null; then
     assert_pass "1.5 security-auditor has memory: project"
 else
     assert_fail "1.5 security-auditor has memory: project"
 fi
 
 # 1.6: skills field exists for code-reviewer -> skill-code-review
-if grep -A 10 '  code-reviewer:' "$CONFIG_YAML" | grep -q 'skills:.*skill-code-review'; then
+if grep -A 10 '  code-reviewer:' "$CONFIG_YAML" | grep 'skills:.*skill-code-review' >/dev/null; then
     assert_pass "1.6 code-reviewer has skills: [skill-code-review]"
 else
     assert_fail "1.6 code-reviewer has skills: [skill-code-review]"
 fi
 
 # 1.7: skills field exists for tdd-orchestrator -> skill-tdd
-if grep -A 10 '  tdd-orchestrator:' "$CONFIG_YAML" | grep -q 'skills:.*skill-tdd'; then
+if grep -A 10 '  tdd-orchestrator:' "$CONFIG_YAML" | grep 'skills:.*skill-tdd' >/dev/null; then
     assert_pass "1.7 tdd-orchestrator has skills: [skill-tdd]"
 else
     assert_fail "1.7 tdd-orchestrator has skills: [skill-tdd]"
@@ -166,21 +166,21 @@ else
 fi
 
 # 2.6: Functions use get_agent_config internally
-if grep -A 5 'get_agent_memory()' "$ALL_SRC" | grep -q 'get_agent_config'; then
+if grep -A 5 'get_agent_memory()' "$ALL_SRC" | grep 'get_agent_config' >/dev/null; then
     assert_pass "2.6 get_agent_memory uses get_agent_config internally"
 else
     assert_fail "2.6 get_agent_memory uses get_agent_config internally"
 fi
 
 # 2.7: load_agent_skill_content strips YAML frontmatter (awk pattern)
-if grep -A 25 'load_agent_skill_content()' "$ALL_SRC" | grep -q 'in_fm.*past_fm'; then
+if grep -A 25 'load_agent_skill_content()' "$ALL_SRC" | grep 'in_fm.*past_fm' >/dev/null; then
     assert_pass "2.7 load_agent_skill_content strips YAML frontmatter (awk pattern)"
 else
     assert_fail "2.7 load_agent_skill_content strips YAML frontmatter (awk pattern)"
 fi
 
 # 2.8: build_skill_context iterates skills list
-if grep -A 15 'build_skill_context()' "$ALL_SRC" | grep -q 'for skill in'; then
+if grep -A 15 'build_skill_context()' "$ALL_SRC" | grep 'for skill in' >/dev/null; then
     assert_pass "2.8 build_skill_context iterates skills list"
 else
     assert_fail "2.8 build_skill_context iterates skills list"
@@ -195,21 +195,21 @@ echo -e "${BLUE}Test Group 3: spawn_agent Skills Injection${NC}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # 3.1: spawn_agent references build_skill_context
-if grep -A 130 '^spawn_agent()' "$ALL_SRC" | grep -q 'build_skill_context'; then
+if grep -A 130 '^spawn_agent()' "$ALL_SRC" | grep 'build_skill_context' >/dev/null; then
     assert_pass "3.1 spawn_agent references build_skill_context"
 else
     assert_fail "3.1 spawn_agent references build_skill_context"
 fi
 
 # 3.2: spawn_agent references select_curated_agent for skill lookup
-if grep -A 150 '^spawn_agent()' "$ALL_SRC" | grep -q 'select_curated_agent.*prompt.*phase'; then
+if grep -A 150 '^spawn_agent()' "$ALL_SRC" | grep 'select_curated_agent.*prompt.*phase' >/dev/null; then
     assert_pass "3.2 spawn_agent references select_curated_agent for skill lookup"
 else
     assert_fail "3.2 spawn_agent references select_curated_agent for skill lookup"
 fi
 
 # 3.3: Skills injection gated behind SUPPORTS_AGENT_TYPE_ROUTING
-if grep -A 150 '^spawn_agent()' "$ALL_SRC" | grep -q 'SUPPORTS_AGENT_TYPE_ROUTING.*true'; then
+if grep -A 150 '^spawn_agent()' "$ALL_SRC" | grep 'SUPPORTS_AGENT_TYPE_ROUTING.*true' >/dev/null; then
     assert_pass "3.3 Skills injection gated behind SUPPORTS_AGENT_TYPE_ROUTING"
 else
     assert_fail "3.3 Skills injection gated behind SUPPORTS_AGENT_TYPE_ROUTING"
@@ -230,7 +230,7 @@ else
 fi
 
 # 3.6: Skill content appended after persona+prompt (v8.16 cache optimization)
-if grep -A 140 '^spawn_agent()' "$ALL_SRC" | grep -q 'Agent Skill Context'; then
+if grep -A 140 '^spawn_agent()' "$ALL_SRC" | grep 'Agent Skill Context' >/dev/null; then
     assert_pass "3.6 Skill content appended after persona+prompt (cache-optimized)"
 else
     assert_fail "3.6 Skill content appended after persona+prompt (cache-optimized)"


### PR DESCRIPTION
## Summary

- replace downstream grep -q calls in piped assertions so GNU grep consumes the full upstream context
- prevent false failures under set -o pipefail when the producer receives SIGPIPE
- preserve all existing assertion semantics

## Verification

- make ci-local (all required checks passed)
- tests/unit/test-v8.2.0-agent-fields.sh: 30/30 locally
- Ubuntu 24.04 container: full test passed 20 consecutive iterations after deterministic pre-fix reproduction
- bash -n tests/unit/test-v8.2.0-agent-fields.sh
- git diff --check
- no executable-mode changes

## Context

This fixes the intermittent Broken pipe failure observed in the Symlinked Path job after #808 merged. The rerun passed, but the original pipeline remains vulnerable to GNU grep exiting with SIGPIPE under pipefail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test portability by replacing nonportable quiet grep usage with broadly supported output redirection.
  * Preserved existing test coverage and observable assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->