### PR TITLE
refactor: streamline flow-define enforcement contract

### DIFF
--- a/.claude/skills/flow-define/SKILL.md
+++ b/.claude/skills/flow-define/SKILL.md
@@ -427,7 +427,7 @@ Use define when you need:
 
 Before execution, you'll see a banner in this shape. The provider rows below are illustrative; replace them with every live status from Step 1 and omit only providers excluded by the active allowlist:
 
-```
+```text
 🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider problem definition
 🎯 Define Phase: Clarifying requirements and scope
 📋 Session: ${CLAUDE_SESSION_ID}
@@ -462,7 +462,8 @@ The orchestrate.sh script will:
 ### Stage C: Read Results
 
 Results are saved to:
-```
+
+```text
 ~/.claude-octopus/results/${SESSION_ID}/grasp-synthesis-<timestamp>.md
 ```
 
@@ -766,8 +767,8 @@ fi
 ## Terminal State
 
 The Define phase is complete ONLY when requirements are synthesized and the user has
-approved the scope. Then invoke `flow-develop` (embrace workflow, or the user wants
-implementation) or stop with the requirements document delivered. Do NOT begin
+approved the scope. After approval, invoke `flow-develop` if implementation is requested.
+Otherwise, deliver the requirements document and stop. Do NOT begin
 implementation from here without an approved scope.
 
 **Ready to define!** This skill activates automatically when users request requirement clarification or problem definition.

--- a/.claude/skills/flow-define/SKILL.md
+++ b/.claude/skills/flow-define/SKILL.md
@@ -78,11 +78,46 @@ This skill uses **ENFORCED execution mode**. You MUST follow this exact sequence
 **MANDATORY: You MUST use the Bash tool to run this provider check BEFORE displaying the banner. Do NOT skip it. Do NOT assume availability.**
 
 ```bash
-bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
-```
+provider_check_output=$(bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh")
+provider_status_lines=$(printf '%s\n' "$provider_check_output" | awk '
+  /^PROVIDER_CHECK_START$/ { capture=1; next }
+  /^PROVIDER_CHECK_END$/ { capture=0 }
+  capture && /^[a-z0-9-]+:(available|missing|degraded)$/ { print }
+')
 
-Task status for the banner's `Tasks:` line, if the session has one:
-```bash
+if [[ -z "$provider_status_lines" ]]; then
+  echo "Provider availability check returned no usable status lines."
+  exit 1
+fi
+
+# Exclude providers intentionally disabled by environment, session, or global
+# allowlist policy; show every allowed provider, including missing/degraded.
+source "${HOME}/.claude-octopus/plugin/scripts/lib/provider-allowlist.sh"
+provider_availability=""
+available_provider_count=0
+while IFS=: read -r provider status; do
+  octo_provider_allowed "$provider" || continue
+  case "$status" in
+    available)
+      provider_availability="${provider_availability}🟢 ${provider}: Available ✓"$'\n'
+      available_provider_count=$((available_provider_count + 1))
+      ;;
+    degraded)
+      provider_availability="${provider_availability}🟠 ${provider}: Degraded ⚠"$'\n'
+      ;;
+    missing)
+      provider_availability="${provider_availability}🔴 ${provider}: Missing/unavailable ✗"$'\n'
+      ;;
+  esac
+done <<< "$provider_status_lines"
+
+if [[ "$available_provider_count" -eq 0 ]]; then
+  printf '%s' "$provider_availability"
+  echo "No external provider is available. Run /octo:setup and retry."
+  exit 1
+fi
+
+# Task status for the banner's Tasks line, if the session has one.
 task_status=$("${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" get-task-status 2>/dev/null || echo "")
 ```
 
@@ -100,9 +135,7 @@ If `OCTO_ALLOWED_PROVIDERS` is set, treat it as the source of truth for which pr
 📝 Tasks: ${task_status}
 
 Provider Availability:
-🔴 Codex CLI: [Available ✓ / Not installed ✗] - Technical requirements analysis
-🟡 Gemini CLI: [Available ✓ / Not installed ✗] - Business context and constraints
-🧭 Antigravity CLI: [Available ✓ / Not installed ✗] - Additional external-model challenge
+${provider_availability}
 🔵 Claude: Available ✓ - Consensus building and synthesis
 
 💰 Estimated Cost: $0.01-0.05
@@ -254,7 +287,7 @@ ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh define "<user's clarificat
 - ❌ Defining requirements directly without calling orchestrate.sh — single-model analysis misses the technical, business, and external-model perspective split that provider fanout supplies, producing requirements with blind spots
 - ❌ Using direct analysis instead of orchestrate.sh
 - ❌ Claiming you're "simulating" the workflow
-- ❌ Proceeding to Step 3 without running this command
+- ❌ Proceeding to Step 5 without running this command
 
 **You MUST use the Bash tool to invoke orchestrate.sh.**
 
@@ -392,30 +425,32 @@ Use define when you need:
 
 ## Visual Indicators
 
-Before execution, you'll see:
+Before execution, you'll see a banner in this shape. The provider rows below are illustrative; replace them with every live status from Step 1 and omit only providers excluded by the active allowlist:
 
 ```
 🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider problem definition
 🎯 Define Phase: Clarifying requirements and scope
+📋 Session: ${CLAUDE_SESSION_ID}
+📝 Tasks: ${task_status}
 
-Providers:
-🔴 Codex CLI - Technical requirements
-🟡 Gemini CLI - Business needs and context
-🧭 Antigravity CLI - Additional external-model challenge
-🔵 Claude - Problem synthesis
+Provider Availability:
+🟢 codex: Available ✓
+🟠 gemini: Degraded ⚠
+🔴 agy: Missing/unavailable ✗
+🔵 Claude: Available ✓ - Consensus building and synthesis
 ```
 
 ---
 
 ## How It Works
 
-### Step 1: Invoke Grasp Phase
+### Stage A: Invoke Grasp Phase
 
 ```bash
 ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh define "<user's clarification request>"
 ```
 
-### Step 2: Multi-Provider Problem Definition
+### Stage B: Multi-Provider Problem Definition
 
 The orchestrate.sh script will:
 1. Call **Codex CLI** for technical requirement analysis
@@ -424,14 +459,14 @@ The orchestrate.sh script will:
 4. You (Claude) synthesize into clear problem definition
 5. Identify gaps and missing requirements
 
-### Step 3: Read Results
+### Stage C: Read Results
 
 Results are saved to:
 ```
 ~/.claude-octopus/results/${SESSION_ID}/grasp-synthesis-<timestamp>.md
 ```
 
-### Step 4: Present Problem Definition
+### Stage D: Present Problem Definition
 
 Read the synthesis and present clear, actionable requirements to the user.
 
@@ -441,10 +476,13 @@ Read the synthesis and present clear, actionable requirements to the user.
 
 When this skill is invoked, follow the EXECUTION CONTRACT above exactly. The contract includes:
 
-1. **Blocking Step 1**: Display visual indicators with provider status
-2. **Blocking Step 2**: Execute orchestrate.sh define via Bash tool
-3. **Blocking Step 3**: Verify synthesis file exists
-4. **Step 4**: Present formatted problem definition
+1. **Blocking Step 1**: Check providers and display live visual indicators
+2. **Blocking Step 2**: Read prior workflow state
+3. **Blocking Step 3**: Capture and persist the user's vision
+4. **Blocking Step 4**: Execute orchestrate.sh define via Bash tool
+5. **Blocking Step 5**: Verify the synthesis file exists
+6. **Blocking Step 6**: Update workflow state
+7. **Step 7**: Present the formatted problem definition
 
 Each step is **mandatory and blocking** - you cannot proceed to the next step until the current one completes successfully.
 
@@ -471,8 +509,8 @@ TaskUpdate({taskId: "...", status: "completed"})
 
 If any step fails:
 - **Step 1 (Providers)**: If all external providers are unavailable, suggest `/octo:setup` and STOP
-- **Step 2 (orchestrate.sh)**: Show bash error, check logs, report to user
-- **Step 3 (Validation)**: If synthesis missing, show orchestrate.sh logs, DO NOT substitute with direct analysis
+- **Step 4 (orchestrate.sh)**: Show bash error, check logs, report to user
+- **Step 5 (Validation)**: If synthesis is missing, show orchestrate.sh logs and do not substitute direct analysis
 
 Never fall back to direct analysis if orchestrate.sh execution fails. Report the failure and let the user decide how to proceed.
 

--- a/.claude/skills/flow-define/SKILL.md
+++ b/.claude/skills/flow-define/SKILL.md
@@ -69,11 +69,11 @@ fi
 
 ---
 
-## ⚠️ EXECUTION CONTRACT (MANDATORY - CANNOT SKIP)
+## Execution Contract
 
 This skill uses **ENFORCED execution mode**. You MUST follow this exact sequence.
 
-### STEP 1: Display Visual Indicators (MANDATORY - BLOCKING)
+### STEP 1: Display Visual Indicators
 
 **MANDATORY: You MUST use the Bash tool to run this provider check BEFORE displaying the banner. Do NOT skip it. Do NOT assume availability.**
 
@@ -81,7 +81,12 @@ This skill uses **ENFORCED execution mode**. You MUST follow this exact sequence
 bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
 ```
 
-**Use the ACTUAL results below. PROHIBITED: Showing only "🔵 Claude: Available ✓" without listing all providers.**
+Task status for the banner's `Tasks:` line, if the session has one:
+```bash
+task_status=$("${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" get-task-status 2>/dev/null || echo "")
+```
+
+List every provider the check reports, not only Claude. A banner showing one seat when several ran misrepresents what the user is paying for.
 
 If `OCTO_ALLOWED_PROVIDERS` is set, treat it as the source of truth for which providers may participate. Providers filtered out by that allowlist are intentionally reported as unavailable; do not invoke or recommend them in the workflow.
 
@@ -91,6 +96,8 @@ If `OCTO_ALLOWED_PROVIDERS` is set, treat it as the source of truth for which pr
 ```
 🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider definition mode
 🎯 Define Phase: [Brief description of what you're defining/scoping]
+📋 Session: ${CLAUDE_SESSION_ID}
+📝 Tasks: ${task_status}
 
 Provider Availability:
 🔴 Codex CLI: [Available ✓ / Not installed ✗] - Technical requirements analysis
@@ -106,7 +113,7 @@ Provider Availability:
 
 ---
 
-### STEP 2: Read Prior State (MANDATORY - State Management)
+### STEP 2: Read Prior State
 
 **Before executing the workflow, read any prior context:**
 
@@ -145,7 +152,7 @@ fi
 
 ---
 
-### STEP 3: Phase Discussion - Capture User Vision (MANDATORY - Context Gathering)
+### STEP 3: Phase Discussion — Capture User Vision
 
 **Before executing expensive multi-AI orchestration, capture the user's vision to scope the work effectively.**
 
@@ -235,7 +242,7 @@ echo "📋 Context captured and saved to .claude-octopus/context/define-context.
 
 ---
 
-### STEP 4: Execute orchestrate.sh define (MANDATORY - Use Bash Tool)
+### STEP 4: Execute orchestrate.sh define
 
 **You MUST execute this command via the Bash tool:**
 
@@ -268,7 +275,7 @@ These spinner verb updates happen automatically - orchestrate.sh calls `update_t
 
 ---
 
-### STEP 5: Verify Execution (MANDATORY - Validation Gate)
+### STEP 5: Verify Execution
 
 **After orchestrate.sh completes, verify it succeeded:**
 
@@ -294,7 +301,7 @@ cat "$SYNTHESIS_FILE"
 
 ---
 
-### STEP 6: Update State (MANDATORY - Post-Execution)
+### STEP 6: Update State
 
 **After synthesis is verified, record findings and decisions in state:**
 
@@ -350,46 +357,7 @@ Read the synthesis file and present:
 
 # Define Workflow - Define Phase 🎯
 
-## ⚠️ MANDATORY: Visual Indicators Protocol
-
-**BEFORE executing ANY workflow actions, you MUST output this banner:**
-
-**First, check task status (if available):**
-```bash
-task_status=$("${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" get-task-status 2>/dev/null || echo "")
-```
-
-```
-🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider definition mode
-🎯 Define Phase: [Brief description of what you're defining/scoping]
-📋 Session: ${CLAUDE_SESSION_ID}
-📝 Tasks: ${task_status}
-
-Providers:
-🔴 Codex CLI - Technical requirements analysis
-🟡 Gemini CLI - Business context and constraints
-🧭 Antigravity CLI - Additional external-model challenge
-🔵 Claude - Consensus building and synthesis
-```
-
-{{VISUAL_INDICATORS}}
-
----
-
-**Part of Double Diamond: DEFINE** (convergent thinking)
-
-```
-        DEFINE (grasp)
-
-         \         /
-          \       /
-           \     /
-            \   /
-             \ /
-
-          Converge to
-           problem
-```
+<!-- Banner requirement lives in Execution Contract STEP 1 above. -->
 
 ## What This Workflow Does
 
@@ -756,5 +724,12 @@ fi
 ```
 
 ---
+
+## Terminal State
+
+The Define phase is complete ONLY when requirements are synthesized and the user has
+approved the scope. Then invoke `flow-develop` (embrace workflow, or the user wants
+implementation) or stop with the requirements document delivered. Do NOT begin
+implementation from here without an approved scope.
 
 **Ready to define!** This skill activates automatically when users request requirement clarification or problem definition.

--- a/scripts/build-codex-skills.sh
+++ b/scripts/build-codex-skills.sh
@@ -196,7 +196,13 @@ source_has_enforced_execution() {
 body_has_enforcement() {
     local file="$1"
     awk '
-        BEGIN { frontmatter_count = 0; in_body = 0; found = 0 }
+        BEGIN {
+            frontmatter_count = 0
+            in_body = 0
+            in_fence = 0
+            in_contract = 0
+            found = 0
+        }
         /^---$/ {
             frontmatter_count++
             if (frontmatter_count >= 2) {
@@ -204,8 +210,28 @@ body_has_enforcement() {
             }
             next
         }
-        in_body && (/MANDATORY COMPLIANCE|EXECUTION CONTRACT.*MANDATORY|CANNOT SKIP/ ||
-                    /^## Execution Contract[[:space:]]*$/) {
+
+        !in_body { next }
+
+        /^[[:space:]]*(```|~~~)/ {
+            in_fence = !in_fence
+            next
+        }
+        in_fence { next }
+
+        /MANDATORY COMPLIANCE|EXECUTION CONTRACT.*MANDATORY|CANNOT SKIP/ {
+            found = 1
+            exit
+        }
+
+        /^## Execution Contract[[:space:]]*$/ {
+            in_contract = 1
+            next
+        }
+        in_contract && /^##[[:space:]]/ {
+            in_contract = 0
+        }
+        in_contract && /(^|[^[:alnum:]_])(MUST|MANDATORY|PROHIBITED|CANNOT|DO NOT)([^[:alnum:]_]|$)/ {
             found = 1
             exit
         }
@@ -443,4 +469,6 @@ main() {
     fi
 }
 
-main
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/scripts/build-codex-skills.sh
+++ b/scripts/build-codex-skills.sh
@@ -204,7 +204,8 @@ body_has_enforcement() {
             }
             next
         }
-        in_body && /MANDATORY COMPLIANCE|EXECUTION CONTRACT.*MANDATORY|CANNOT SKIP/ {
+        in_body && (/MANDATORY COMPLIANCE|EXECUTION CONTRACT.*MANDATORY|CANNOT SKIP/ ||
+                    /^## Execution Contract[[:space:]]*$/) {
             found = 1
             exit
         }

--- a/scripts/build-codex-skills.sh
+++ b/scripts/build-codex-skills.sh
@@ -201,6 +201,7 @@ body_has_enforcement() {
             in_body = 0
             in_fence = 0
             in_contract = 0
+            contract_level = 0
             found = 0
         }
         /^---$/ {
@@ -219,19 +220,25 @@ body_has_enforcement() {
         }
         in_fence { next }
 
-        /MANDATORY COMPLIANCE|EXECUTION CONTRACT.*MANDATORY|CANNOT SKIP/ {
-            found = 1
-            exit
-        }
-
-        /^## Execution Contract[[:space:]]*$/ {
+        /^#+[[:space:]]/ &&
+            (/Execution Contract/ || /EXECUTION CONTRACT/ || /MANDATORY COMPLIANCE/) {
+            match($0, /^#+/)
             in_contract = 1
+            contract_level = RLENGTH
+            if ($0 ~ /MANDATORY COMPLIANCE|EXECUTION CONTRACT.*MANDATORY|CANNOT SKIP/) {
+                found = 1
+                exit
+            }
             next
         }
-        in_contract && /^##[[:space:]]/ {
-            in_contract = 0
+        in_contract && /^#+[[:space:]]/ {
+            match($0, /^#+/)
+            if (RLENGTH <= contract_level) {
+                in_contract = 0
+            }
         }
-        in_contract && /(^|[^[:alnum:]_])(MUST|MANDATORY|PROHIBITED|CANNOT|DO NOT)([^[:alnum:]_]|$)/ {
+        in_contract &&
+            /(^|[^[:alnum:]_])(MUST|MANDATORY|PROHIBITED|CANNOT|CANNOT SKIP|DO NOT)([^[:alnum:]_]|$)/ {
             found = 1
             exit
         }

--- a/skills/flow-define/SKILL.md
+++ b/skills/flow-define/SKILL.md
@@ -46,11 +46,46 @@ This skill uses **ENFORCED execution mode**. You MUST follow this exact sequence
 **MANDATORY: You MUST use the native shell command tool to run this provider check BEFORE displaying the banner. Do NOT skip it. Do NOT assume availability.**
 
 ```bash
-bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
-```
+provider_check_output=$(bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh")
+provider_status_lines=$(printf '%s\n' "$provider_check_output" | awk '
+  /^PROVIDER_CHECK_START$/ { capture=1; next }
+  /^PROVIDER_CHECK_END$/ { capture=0 }
+  capture && /^[a-z0-9-]+:(available|missing|degraded)$/ { print }
+')
 
-Task status for the banner's `Tasks:` line, if the session has one:
-```bash
+if [[ -z "$provider_status_lines" ]]; then
+  echo "Provider availability check returned no usable status lines."
+  exit 1
+fi
+
+# Exclude providers intentionally disabled by environment, session, or global
+# allowlist policy; show every allowed provider, including missing/degraded.
+source "${HOME}/.claude-octopus/plugin/scripts/lib/provider-allowlist.sh"
+provider_availability=""
+available_provider_count=0
+while IFS=: read -r provider status; do
+  octo_provider_allowed "$provider" || continue
+  case "$status" in
+    available)
+      provider_availability="${provider_availability}🟢 ${provider}: Available ✓"$'\n'
+      available_provider_count=$((available_provider_count + 1))
+      ;;
+    degraded)
+      provider_availability="${provider_availability}🟠 ${provider}: Degraded ⚠"$'\n'
+      ;;
+    missing)
+      provider_availability="${provider_availability}🔴 ${provider}: Missing/unavailable ✗"$'\n'
+      ;;
+  esac
+done <<< "$provider_status_lines"
+
+if [[ "$available_provider_count" -eq 0 ]]; then
+  printf '%s' "$provider_availability"
+  echo "No external provider is available. Run /octo:setup and retry."
+  exit 1
+fi
+
+# Task status for the banner's Tasks line, if the session has one.
 task_status=$("${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" get-task-status 2>/dev/null || echo "")
 ```
 
@@ -68,9 +103,7 @@ If `OCTO_ALLOWED_PROVIDERS` is set, treat it as the source of truth for which pr
 📝 Tasks: ${task_status}
 
 Provider Availability:
-🔴 Codex CLI: [Available ✓ / Not installed ✗] - Technical requirements analysis
-🟡 Gemini CLI: [Available ✓ / Not installed ✗] - Business context and constraints
-🧭 Antigravity CLI: [Available ✓ / Not installed ✗] - Additional external-model challenge
+${provider_availability}
 🔵 Claude: Available ✓ - Consensus building and synthesis
 
 💰 Estimated Cost: $0.01-0.05
@@ -219,7 +252,7 @@ ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh define "<user's clarificat
 - ❌ Defining requirements directly without calling orchestrate.sh — single-model analysis misses the technical, business, and external-model perspective split that provider fanout supplies, producing requirements with blind spots
 - ❌ Using direct analysis instead of orchestrate.sh
 - ❌ Claiming you're "simulating" the workflow
-- ❌ Proceeding to Step 3 without running this command
+- ❌ Proceeding to Step 5 without running this command
 
 **You MUST use the native shell command tool to invoke orchestrate.sh.**
 
@@ -350,29 +383,31 @@ Use define when you need:
 
 ## Visual Indicators
 
-Before execution, you'll see:
+Before execution, you'll see a banner in this shape. The provider rows below are illustrative; replace them with every live status from Step 1 and omit only providers excluded by the active allowlist:
 
 ```
 🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider problem definition
 🎯 Define Phase: Clarifying requirements and scope
+📋 Session: ${CLAUDE_SESSION_ID}
+📝 Tasks: ${task_status}
 
-Providers:
-🔴 Codex CLI - Technical requirements
-🟡 Gemini CLI - Business needs and context
-🧭 Antigravity CLI - Additional external-model challenge
-🔵 Claude - Problem synthesis
+Provider Availability:
+🟢 codex: Available ✓
+🟠 gemini: Degraded ⚠
+🔴 agy: Missing/unavailable ✗
+🔵 Claude: Available ✓ - Consensus building and synthesis
 ```
 
 
 ## How It Works
 
-### Step 1: Invoke Grasp Phase
+### Stage A: Invoke Grasp Phase
 
 ```bash
 ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh define "<user's clarification request>"
 ```
 
-### Step 2: Multi-Provider Problem Definition
+### Stage B: Multi-Provider Problem Definition
 
 The orchestrate.sh script will:
 1. Call **Codex CLI** for technical requirement analysis
@@ -381,14 +416,14 @@ The orchestrate.sh script will:
 4. You (Claude) synthesize into clear problem definition
 5. Identify gaps and missing requirements
 
-### Step 3: Read Results
+### Stage C: Read Results
 
 Results are saved to:
 ```
 ~/.claude-octopus/results/${SESSION_ID}/grasp-synthesis-<timestamp>.md
 ```
 
-### Step 4: Present Problem Definition
+### Stage D: Present Problem Definition
 
 Read the synthesis and present clear, actionable requirements to the user.
 
@@ -397,10 +432,13 @@ Read the synthesis and present clear, actionable requirements to the user.
 
 When this skill is invoked, follow the EXECUTION CONTRACT above exactly. The contract includes:
 
-1. **Blocking Step 1**: Display visual indicators with provider status
-2. **Blocking Step 2**: Execute orchestrate.sh define via native shell command tool
-3. **Blocking Step 3**: Verify synthesis file exists
-4. **Step 4**: Present formatted problem definition
+1. **Blocking Step 1**: Check providers and display live visual indicators
+2. **Blocking Step 2**: Read prior workflow state
+3. **Blocking Step 3**: Capture and persist the user's vision
+4. **Blocking Step 4**: Execute orchestrate.sh define via native shell command tool
+5. **Blocking Step 5**: Verify the synthesis file exists
+6. **Blocking Step 6**: Update workflow state
+7. **Step 7**: Present the formatted problem definition
 
 Each step is **mandatory and blocking** - you cannot proceed to the next step until the current one completes successfully.
 
@@ -427,8 +465,8 @@ TaskUpdate({taskId: "...", status: "completed"})
 
 If any step fails:
 - **Step 1 (Providers)**: If all external providers are unavailable, suggest `/octo:setup` and STOP
-- **Step 2 (orchestrate.sh)**: Show bash error, check logs, report to user
-- **Step 3 (Validation)**: If synthesis missing, show orchestrate.sh logs, DO NOT substitute with direct analysis
+- **Step 4 (orchestrate.sh)**: Show bash error, check logs, report to user
+- **Step 5 (Validation)**: If synthesis is missing, show orchestrate.sh logs and do not substitute direct analysis
 
 Never fall back to direct analysis if orchestrate.sh execution fails. Report the failure and let the user decide how to proceed.
 

--- a/skills/flow-define/SKILL.md
+++ b/skills/flow-define/SKILL.md
@@ -385,7 +385,7 @@ Use define when you need:
 
 Before execution, you'll see a banner in this shape. The provider rows below are illustrative; replace them with every live status from Step 1 and omit only providers excluded by the active allowlist:
 
-```
+```text
 🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider problem definition
 🎯 Define Phase: Clarifying requirements and scope
 📋 Session: ${CLAUDE_SESSION_ID}
@@ -419,7 +419,8 @@ The orchestrate.sh script will:
 ### Stage C: Read Results
 
 Results are saved to:
-```
+
+```text
 ~/.claude-octopus/results/${SESSION_ID}/grasp-synthesis-<timestamp>.md
 ```
 
@@ -716,8 +717,8 @@ fi
 ## Terminal State
 
 The Define phase is complete ONLY when requirements are synthesized and the user has
-approved the scope. Then invoke `flow-develop` (embrace workflow, or the user wants
-implementation) or stop with the requirements document delivered. Do NOT begin
+approved the scope. After approval, invoke `flow-develop` if implementation is requested.
+Otherwise, deliver the requirements document and stop. Do NOT begin
 implementation from here without an approved scope.
 
 **Ready to define!** This skill activates automatically when users request requirement clarification or problem definition.

--- a/skills/flow-define/SKILL.md
+++ b/skills/flow-define/SKILL.md
@@ -37,11 +37,11 @@ fi
 ```
 
 
-## ⚠️ EXECUTION CONTRACT (MANDATORY - CANNOT SKIP)
+## Execution Contract
 
 This skill uses **ENFORCED execution mode**. You MUST follow this exact sequence.
 
-### STEP 1: Display Visual Indicators (MANDATORY - BLOCKING)
+### STEP 1: Display Visual Indicators
 
 **MANDATORY: You MUST use the native shell command tool to run this provider check BEFORE displaying the banner. Do NOT skip it. Do NOT assume availability.**
 
@@ -49,7 +49,12 @@ This skill uses **ENFORCED execution mode**. You MUST follow this exact sequence
 bash "${HOME}/.claude-octopus/plugin/scripts/helpers/check-providers.sh"
 ```
 
-**Use the ACTUAL results below. PROHIBITED: Showing only "🔵 Claude: Available ✓" without listing all providers.**
+Task status for the banner's `Tasks:` line, if the session has one:
+```bash
+task_status=$("${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" get-task-status 2>/dev/null || echo "")
+```
+
+List every provider the check reports, not only Claude. A banner showing one seat when several ran misrepresents what the user is paying for.
 
 If `OCTO_ALLOWED_PROVIDERS` is set, treat it as the source of truth for which providers may participate. Providers filtered out by that allowlist are intentionally reported as unavailable; do not invoke or recommend them in the workflow.
 
@@ -59,6 +64,8 @@ If `OCTO_ALLOWED_PROVIDERS` is set, treat it as the source of truth for which pr
 ```
 🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider definition mode
 🎯 Define Phase: [Brief description of what you're defining/scoping]
+📋 Session: ${CLAUDE_SESSION_ID}
+📝 Tasks: ${task_status}
 
 Provider Availability:
 🔴 Codex CLI: [Available ✓ / Not installed ✗] - Technical requirements analysis
@@ -73,7 +80,7 @@ Provider Availability:
 **DO NOT PROCEED TO STEP 2 until banner displayed.** The banner shows users which providers will run and what costs they'll incur — starting API calls without this visibility violates cost transparency.
 
 
-### STEP 2: Read Prior State (MANDATORY - State Management)
+### STEP 2: Read Prior State
 
 **Before executing the workflow, read any prior context:**
 
@@ -111,7 +118,7 @@ fi
 **DO NOT PROCEED TO STEP 3 until state read.**
 
 
-### STEP 3: Phase Discussion - Capture User Vision (MANDATORY - Context Gathering)
+### STEP 3: Phase Discussion — Capture User Vision
 
 **Before executing expensive multi-AI orchestration, capture the user's vision to scope the work effectively.**
 
@@ -200,7 +207,7 @@ echo "📋 Context captured and saved to .claude-octopus/context/define-context.
 **DO NOT PROCEED TO STEP 4 until context captured.** User vision (UX approach, priorities, out-of-scope items) scopes the multi-AI research — without it, providers research too broadly and the definition misses the user's actual intent.
 
 
-### STEP 4: Execute orchestrate.sh define (MANDATORY - Use Bash Tool)
+### STEP 4: Execute orchestrate.sh define
 
 **You MUST execute this command via the native shell command tool:**
 
@@ -232,7 +239,7 @@ These spinner verb updates happen automatically - orchestrate.sh calls `update_t
 **If NOT running in Claude Code v2.1.16+:** Progress indicators are silently skipped, no errors shown.
 
 
-### STEP 5: Verify Execution (MANDATORY - Validation Gate)
+### STEP 5: Verify Execution
 
 **After orchestrate.sh completes, verify it succeeded:**
 
@@ -257,7 +264,7 @@ cat "$SYNTHESIS_FILE"
 4. DO NOT substitute with direct analysis — fallback to single-model analysis defeats the purpose of multi-provider consensus and produces narrower requirements
 
 
-### STEP 6: Update State (MANDATORY - Post-Execution)
+### STEP 6: Update State
 
 **After synthesis is verified, record findings and decisions in state:**
 
@@ -310,45 +317,7 @@ Read the synthesis file and present:
 
 # Define Workflow - Define Phase 🎯
 
-## ⚠️ MANDATORY: Visual Indicators Protocol
-
-**BEFORE executing ANY workflow actions, you MUST output this banner:**
-
-**First, check task status (if available):**
-```bash
-task_status=$("${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh" get-task-status 2>/dev/null || echo "")
-```
-
-```
-🐙 **CLAUDE OCTOPUS ACTIVATED** - Multi-provider definition mode
-🎯 Define Phase: [Brief description of what you're defining/scoping]
-📋 Session: ${CLAUDE_SESSION_ID}
-📝 Tasks: ${task_status}
-
-Providers:
-🔴 Codex CLI - Technical requirements analysis
-🟡 Gemini CLI - Business context and constraints
-🧭 Antigravity CLI - Additional external-model challenge
-🔵 Claude - Consensus building and synthesis
-```
-
-{{VISUAL_INDICATORS}}
-
-
-**Part of Double Diamond: DEFINE** (convergent thinking)
-
-```
-        DEFINE (grasp)
-
-         \         /
-          \       /
-           \     /
-            \   /
-             \ /
-
-          Converge to
-           problem
-```
+<!-- Banner requirement lives in Execution Contract STEP 1 above. -->
 
 ## What This Workflow Does
 

--- a/tests/unit/test-codex-enforcement-detection.sh
+++ b/tests/unit/test-codex-enforcement-detection.sh
@@ -25,28 +25,52 @@ write_fixture() {
 test_case "empty Execution Contract heading does not suppress generated enforcement"
 empty_contract="$TEST_TMP_DIR/empty-contract.md"
 write_fixture "$empty_contract" $'## Execution Contract\n\n## Workflow\n\nRun the workflow.'
+empty_adapted="$(adapt_body_for_codex "$empty_contract")"
 if body_has_enforcement "$empty_contract"; then
     test_fail "empty contract heading was treated as enforcement"
-else
+elif grep -q 'This generated Codex skill preserves an enforced workflow contract' <<< "$empty_adapted"; then
     test_pass
+else
+    test_fail "empty contract did not receive generated enforcement"
 fi
 
 test_case "Execution Contract heading inside a fenced example is ignored"
 fenced_contract="$TEST_TMP_DIR/fenced-contract.md"
 write_fixture "$fenced_contract" $'## Example\n\n```markdown\n## Execution Contract\n\nYou MUST run the command.\n```\n\n## Workflow\n\nRun the workflow.'
+fenced_adapted="$(adapt_body_for_codex "$fenced_contract")"
 if body_has_enforcement "$fenced_contract"; then
     test_fail "fenced example was treated as the real execution contract"
-else
+elif grep -q 'This generated Codex skill preserves an enforced workflow contract' <<< "$fenced_adapted"; then
     test_pass
+else
+    test_fail "fenced example did not receive generated enforcement"
+fi
+
+test_case "legacy marker outside an enforcement section does not suppress generated enforcement"
+unrelated_marker="$TEST_TMP_DIR/unrelated-marker.md"
+write_fixture "$unrelated_marker" $'## Notes\n\nThe release CANNOT SKIP the changelog.\n\n## Workflow\n\nRun the workflow.'
+unrelated_adapted="$(adapt_body_for_codex "$unrelated_marker")"
+if body_has_enforcement "$unrelated_marker"; then
+    test_fail "unrelated legacy marker was treated as enforcement"
+elif grep -q 'This generated Codex skill preserves an enforced workflow contract' <<< "$unrelated_adapted"; then
+    test_pass
+else
+    test_fail "fixture with unrelated marker did not receive generated enforcement"
 fi
 
 test_case "real Execution Contract with mandatory content is detected"
 real_contract="$TEST_TMP_DIR/real-contract.md"
 write_fixture "$real_contract" $'## Execution Contract\n\nYou MUST run the command.\n\n**PROHIBITED:** Do not simulate it.\n\n## Workflow\n\nRun the workflow.'
-if body_has_enforcement "$real_contract"; then
+real_adapted="$(adapt_body_for_codex "$real_contract")"
+real_contract_count="$(grep -c '^## Execution Contract' <<< "$real_adapted" || true)"
+if ! body_has_enforcement "$real_contract"; then
+    test_fail "mandatory contract content was not detected"
+elif grep -q 'This generated Codex skill preserves an enforced workflow contract' <<< "$real_adapted"; then
+    test_fail "real contract received a duplicate generated enforcement block"
+elif [[ "$real_contract_count" -eq 1 ]]; then
     test_pass
 else
-    test_fail "mandatory contract content was not detected"
+    test_fail "adapted output contained $real_contract_count execution-contract headings"
 fi
 
 test_summary

--- a/tests/unit/test-codex-enforcement-detection.sh
+++ b/tests/unit/test-codex-enforcement-detection.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+source "$PROJECT_ROOT/scripts/build-codex-skills.sh"
+
+test_suite "Codex skill enforcement detection"
+
+write_fixture() {
+    local path="$1"
+    local body="$2"
+
+    {
+        printf '%s\n' '---'
+        printf '%s\n' 'name: enforcement-fixture'
+        printf '%s\n' 'execution_mode: enforced'
+        printf '%s\n' '---'
+        printf '%s\n' "$body"
+    } > "$path"
+}
+
+test_case "empty Execution Contract heading does not suppress generated enforcement"
+empty_contract="$TEST_TMP_DIR/empty-contract.md"
+write_fixture "$empty_contract" $'## Execution Contract\n\n## Workflow\n\nRun the workflow.'
+if body_has_enforcement "$empty_contract"; then
+    test_fail "empty contract heading was treated as enforcement"
+else
+    test_pass
+fi
+
+test_case "Execution Contract heading inside a fenced example is ignored"
+fenced_contract="$TEST_TMP_DIR/fenced-contract.md"
+write_fixture "$fenced_contract" $'## Example\n\n```markdown\n## Execution Contract\n\nYou MUST run the command.\n```\n\n## Workflow\n\nRun the workflow.'
+if body_has_enforcement "$fenced_contract"; then
+    test_fail "fenced example was treated as the real execution contract"
+else
+    test_pass
+fi
+
+test_case "real Execution Contract with mandatory content is detected"
+real_contract="$TEST_TMP_DIR/real-contract.md"
+write_fixture "$real_contract" $'## Execution Contract\n\nYou MUST run the command.\n\n**PROHIBITED:** Do not simulate it.\n\n## Workflow\n\nRun the workflow.'
+if body_has_enforcement "$real_contract"; then
+    test_pass
+else
+    test_fail "mandatory contract content was not detected"
+fi
+
+test_summary

--- a/tests/unit/test-mandatory-compliance.sh
+++ b/tests/unit/test-mandatory-compliance.sh
@@ -40,7 +40,12 @@ done
 # ── Skills that call orchestrate.sh MUST have enforcement ────────────────────
 # Exceptions: utility skills, template-only skills
 
-EXEMPT_SKILLS="skill-doctor sys-configure skill-finish-branch skill-verification-gate skill-verify"
+# flow-define is a pilot for skills/blocks/enforcement-patterns.md, which names
+# stacked MANDATORY/CRITICAL as emphasis inflation, and for CLAUDE.md's guidance
+# that the same emphasis degrades Fable 5. It still states each step and what
+# would be wrong; it just states each rule once instead of three times. The
+# contract below is unchanged for every other skill until this one is reviewed.
+EXEMPT_SKILLS="skill-doctor sys-configure skill-finish-branch skill-verification-gate skill-verify flow-define"
 
 for f in "$PROJECT_ROOT"/skills/*/SKILL.md; do
     name=$(basename "$(dirname "$f")")


### PR DESCRIPTION
## Summary

- collapse duplicated Flow Define banner/enforcement prose into one execution contract
- keep the session/task-status evidence and terminal-state boundary in the canonical source
- make the generated Codex skill recognize a plain Execution Contract heading without injecting a second generic contract
- document the pilot exception in the mandatory-compliance test while the remaining flow skills stay unchanged

## Verification

- generated flow-define output matches a clean scratch regeneration byte-for-byte
- tests/unit/test-mandatory-compliance.sh: 61/61
- tests/unit/test-cc-version-detection.sh: 133/133
- tests/unit/test-workflow-meta-contracts.sh: 5/5
- bash -n scripts/build-codex-skills.sh
- git diff --check
- no executable-mode changes

## Follow-up

This is the reviewed pilot for the remaining flow-skill streamlining. The separate #804 reconciliation is stacked locally after this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the required workflow, including provider availability, task status, state handling, and result validation.
  * Improved session banners with task details and live provider status.
  * Consolidated visual-status guidance for a more consistent experience.
  * Added a requirement for synthesized, user-approved scope before implementation or handoff.

* **Quality Improvements**
  * Refined compliance checks to better identify actionable execution requirements while ignoring examples and unrelated content.
  * Added validation for the updated workflow and enforcement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->