### PR TITLE
fix: reconcile generated skill tree

### DIFF
--- a/.claude/skills/flow-deliver/SKILL.md
+++ b/.claude/skills/flow-deliver/SKILL.md
@@ -866,14 +866,16 @@ The doc-sync skill will:
 
 ## Post-Delivery: Route to Ship
 
-After delivery validation and doc-sync complete:
-1. Update `.octo/STATE.md`:
-   - status: "complete"
-   - Add history entry: "All phases complete, ready to ship"
-2. Suggest: "Project ready! Run `/octo:ship` to finalize and archive."
+After delivery validation and doc-sync complete, route according to the user's explicit
+request:
+
+- **Ship requested:** update `.octo/STATE.md` and invoke `skill-ship`.
+- **Branch wrap-up requested:** invoke `skill-finish-branch`.
+- **Review only:** deliver the synthesized findings and stop. Do not update the project
+  to a ready-to-ship state or display a shipping instruction.
 
 ```bash
-# Update state after Delivery completion
+# Run this block only when the user explicitly requested shipping.
 "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
   --status "complete" \
   --history "All phases complete, ready to ship"
@@ -892,5 +894,13 @@ echo "📦 **Project ready! Run \`/octo:ship\` to finalize and archive.**"
 ```
 
 ---
+
+## Terminal State
+
+The Deliver phase is complete ONLY when validation findings are synthesized and
+must-fix items are resolved or explicitly accepted by the user. If the user asked to
+ship or wrap the branch, then invoke `skill-ship` (or `skill-finish-branch` for tests,
+PR, and merge). For review-only requests, deliver the findings and stop; do NOT expand
+the request into shipping work without user authorization.
 
 **Ready to validate!** This skill activates automatically when users request code review, validation, or quality checks.

--- a/.claude/skills/flow-develop/SKILL.md
+++ b/.claude/skills/flow-develop/SKILL.md
@@ -828,4 +828,11 @@ modified_files=$(git diff --name-only HEAD~1 2>/dev/null || echo "See git log")
 
 ---
 
+## Terminal State
+
+The Develop phase is complete ONLY when the implementation exists, the post-develop
+checkpoint tag is created, and targeted tests pass fresh (see `skill-verification-gate`).
+Then invoke `flow-deliver` for validation. Do NOT declare the work done from here —
+completion claims belong to the Deliver phase after review.
+
 **Ready to build!** This skill activates automatically when users request implementation or building features.

--- a/.claude/skills/flow-discover/SKILL.md
+++ b/.claude/skills/flow-discover/SKILL.md
@@ -843,26 +843,43 @@ See **skill-security-framing.md** for complete documentation on:
 ## Post-Discovery: State Update
 
 After discovery completes:
-1. Update `.octo/STATE.md`:
+1. Verify the synthesis file exists and is non-empty.
+2. Present its findings to the user.
+3. Populate `.octo/PROJECT.md` with the research findings.
+4. Only then update `.octo/STATE.md`:
    - status: "complete" (for this phase)
    - Add history entry: "Discover phase completed"
-2. Populate `.octo/PROJECT.md` with research findings (vision, requirements)
 
 ```bash
-# Update state after Discovery completion
+# The phase remains incomplete unless there is a synthesis to present.
+if [[ ! -s "${SYNTHESIS_FILE:-}" ]]; then
+  echo "Discover incomplete: synthesis file is missing or empty." >&2
+  exit 1
+fi
+
+# Present findings before recording the phase as complete.
+echo "Discovery findings:"
+sed -n '1,100p' "$SYNTHESIS_FILE"
+
+# Populate PROJECT.md with research findings
+echo "📝 Updating .octo/PROJECT.md with discovery findings..."
+"${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_project \
+  --section "vision" \
+  --content "$(head -100 "$SYNTHESIS_FILE" | grep -A 10 'Key.*Findings\|Summary' || echo 'See synthesis file')"
+
+# Mark complete only after the synthesis was presented and persisted.
 "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
   --status "complete" \
   --history "Discover phase completed"
-
-# Populate PROJECT.md with research findings
-if [[ -f "$SYNTHESIS_FILE" ]]; then
-  echo "📝 Updating .octo/PROJECT.md with discovery findings..."
-  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_project \
-    --section "vision" \
-    --content "$(head -100 "$SYNTHESIS_FILE" | grep -A 10 'Key.*Findings\|Summary' || echo 'See synthesis file')"
-fi
 ```
 
 ---
+
+## Terminal State
+
+The Discover phase is complete ONLY when the synthesis file exists and its findings are
+presented to the user. Then either invoke `flow-define` (embrace workflow, or the user
+wants requirements next) or stop with research delivered. Do NOT begin scoping,
+designing, or implementation from here — that work belongs to later phases.
 
 **Ready to research!** This skill activates automatically when users request research or exploration.

--- a/.claude/skills/skill-authoring/SKILL.md
+++ b/.claude/skills/skill-authoring/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-authoring
 description: "Principles for writing skills that behave the same way every run — use when adding, editing, or reviewing a skill in this plugin"
+codex_display_name: "Skill Authoring"
 ---
 
 # Skill Authoring

--- a/.claude/skills/skill-doctor/SKILL.md
+++ b/.claude/skills/skill-doctor/SKILL.md
@@ -69,7 +69,7 @@ if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
   )"
 fi
 if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
-  echo "Claude Octopus plugin root not found. Reinstall the octo plugin, then retry /octo:doctor."
+  echo "Claude Octopus plugin root not found. Reinstall the octo plugin, then retry doctor diagnostics."
   exit 1
 fi
 mkdir -p "${HOME}/.claude-octopus"
@@ -335,9 +335,12 @@ Without a `RUNTIME.md`, orchestration prompts lack project-specific details — 
 
 ## Quick Reference
 
-| User Input | Action |
-|------------|--------|
-| `/octo:doctor` | Run all 11 categories |
-| `/octo:doctor providers` | Check provider installation only |
-| `/octo:doctor auth --verbose` | Detailed auth status |
-| `/octo:doctor --json` | Machine-readable output |
+`/octo:doctor` was removed in v9.41.0 to preserve Claude Code's native `/doctor` command.
+Invoke this skill by asking Claude naturally, or run the orchestrator directly:
+
+| What to say / run | Action |
+|-------------------|--------|
+| "run Octopus doctor diagnostics" | Run all 11 categories |
+| "check Octopus providers" | Check provider installation only |
+| `bash scripts/orchestrate.sh doctor auth --verbose` | Detailed auth status |
+| `bash scripts/orchestrate.sh doctor --json` | Machine-readable output |

--- a/.claude/skills/skill-meta-prompt/SKILL.md
+++ b/.claude/skills/skill-meta-prompt/SKILL.md
@@ -338,6 +338,15 @@ Before considering complete:
 [Context or examples from user]
 ```
 
+### Model-Specific Adjustments
+
+Tune the assembled prompt to the model that will execute it:
+
+- **Current frontier roster**: apply `skills/blocks/frontier-model-routing.md` when choosing between Opus 5, GPT-5.6, Sonnet 5, Fable 5, or cheaper seats.
+- **Claude Fable 5** (any `claude-fable-5` pin): apply `skills/blocks/fable5-prompting.md`. In short: never instruct the model to reveal or transcribe its reasoning (triggers a refusal); replace step-by-step micromanagement with a boundary plus checkable acceptance criteria; drop "CRITICAL"/"MUST" emphasis unless strict compliance is required; add grounded-progress and act-when-ready language for long runs.
+- **Codex / GPT-5.6**: apply `docs/GPT-5.6-PROMPTING.md`; give it a concrete outcome, scoped repository constraints, checkable acceptance criteria, non-goals, and the required verification.
+- **Older Claude models**: the fuller template below applies as written.
+
 ---
 
 ## Phase 6: Output & Iteration

--- a/.claude/skills/skill-parallel-agents/SKILL.md
+++ b/.claude/skills/skill-parallel-agents/SKILL.md
@@ -619,13 +619,13 @@ The `tangle` phase enforces quality gates:
 
 | Agent | Model | Best For |
 |-------|-------|----------|
-| `codex` | gpt-5.3-codex | Complex code, deep refactoring (premium default) |
-| `codex-standard` | gpt-5.2-codex | Standard tier implementation |
-| `codex-mini` | gpt-5.4-mini | Quick fixes, simple tasks |
-| `gemini` | gemini-3-pro-preview | Deep analysis, 1M context |
+| `codex` | gpt-5.6-sol | Frontier implementation and independent review |
+| `codex-standard` | gpt-5.6-terra | Balanced implementation and review |
+| `codex-mini` | gpt-5.6-luna | Quick fixes, simple tasks |
+| `gemini` | gemini-3.1-pro-preview | Deep analysis, 1M context |
 | `gemini-fast` | gemini-3-flash-preview | Speed-critical tasks |
 | `gemini-image` | gemini-3-pro-image-preview | Image generation |
-| `codex-review` | gpt-5.2-codex | Code review mode |
+| `codex-review` | gpt-5.6-sol | Code review mode |
 | `openrouter` | Various | Universal fallback (400+ models) |
 
 ## Provider-Aware Routing (v4.8)

--- a/.claude/skills/skill-security-audit/SKILL.md
+++ b/.claude/skills/skill-security-audit/SKILL.md
@@ -56,6 +56,10 @@ ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh auto "security audit the p
 
 No user action needed — mode detection happens automatically from the git diff context.
 
+## Model Selection Caveat: Fable 5
+
+Never dispatch security-audit passes to Claude Fable 5, even when the session has `OCTOPUS_OPUS_MODEL=claude-fable-5` pinned. Fable 5's safety classifiers target offensive cybersecurity content and can refuse adversarial red-team phrasing in authorized audits. Route these passes to `claude-opus-5` and keep prompts defensively framed (find and report vulnerabilities; do not request working exploits). On refusal, allow exactly one retry on Opus 5, including when the initial attempt already targeted Opus 5; then surface the refusal without further dispatches. Details: `skills/blocks/fable5-prompting.md`.
+
 ## Capabilities
 
 ### Core (both modes)

--- a/.claude/skills/skill-ui-ux-design/SKILL.md
+++ b/.claude/skills/skill-ui-ux-design/SKILL.md
@@ -83,10 +83,25 @@ AskUserQuestion({
         {label: "Page layouts", description: "Wireframe-level layout specifications"},
         {label: "Style guide", description: "Visual style direction with rationale"}
       ]
+    },
+    {
+      question: "How adventurous should the design be?",
+      header: "Dials",
+      multiSelect: false,
+      options: [
+        {label: "Conservative (v3 m2 d4)", description: "Familiar patterns, minimal motion — enterprise, gov, finance"},
+        {label: "Balanced (v5 m4 d5)", description: "Contemporary but safe — most SaaS and product work"},
+        {label: "Expressive (v7 m6 d5)", description: "Distinctive direction, noticeable motion — marketing, launch pages"},
+        {label: "Maximal (v9 m8 d6)", description: "Take real aesthetic risks — portfolios, creative brands"}
+      ]
     }
   ]
 })
 ```
+
+The dial answer maps to `--variance/--motion/--density` values (v/m/d above) passed to
+every `search.py` call and stated in the design direction. Infer instead of asking only
+when the user's brief already names a vibe ("brutalist", "playful", "corporate").
 
 ### STEP 2: Display Banner
 
@@ -132,7 +147,7 @@ else
 fi
 ```
 
-**If MISSING_SEARCH_PY**: Tell user to run `cd "${HOME}/.claude-octopus/plugin" && git submodule update --init vendors/ui-ux-pro-max-skill`
+**If MISSING_SEARCH_PY**: The vendored design intelligence files are missing — tell the user to reinstall or update the plugin (the `vendors/ui-ux-pro-max-skill/` directory ships with it as plain files).
 **If MISSING_PYTHON**: Tell user python3 is required for design intelligence.
 
 ### STEP 4: Phase 1 — Discover (Design Research)
@@ -159,6 +174,10 @@ python3 "$SEARCH_PY" "<key user flow>" --domain ux
 
 # 6. Stack-specific search (if user specified a stack)
 python3 "$SEARCH_PY" "<user's requirements>" --stack <stack>
+
+# 7. Full design-system draft with the dials from Step 1 (v2.11.0+)
+python3 "$SEARCH_PY" "<user's product description>" --design-system \
+  --variance <v> --motion <m> --density <d>
 ```
 
 **If user provided a Figma URL**, also pull design context:
@@ -183,13 +202,18 @@ Stack: [from Step 1]
 Search context: [key findings from Step 4 BM25 searches]
 
 Produce:
-1. A style name (2-3 words, e.g., "Warm Minimalism", "Bold Industrial", "Soft Gradient")
+1. A style name (2-3 words, e.g., "Warm Minimalism", "Bold Industrial", "Cobalt Editorial")
 2. Primary color palette (3-5 colors with hex values)
 3. Font pairing (heading + body)
 4. Layout philosophy (e.g., "generous whitespace with card-based content")
 5. One paragraph describing the overall feel
 
 Be distinctive — take a clear position rather than playing it safe.
+
+Hard constraints (see skills/blocks/design-taste.md): do NOT produce any of the three
+AI-slop looks (cream+serif+terracotta, near-black+acid accent, purple-violet gradients),
+and do not default to Inter, Roboto, Space Grotesk, Fraunces, or Instrument Serif
+without a brief-tied reason.
 ```
 
 **Dispatch to different providers for maximum diversity:**
@@ -209,14 +233,14 @@ Fonts: Inter + Source Serif 4
 Feel: Clean, approachable, content-first with warm accent touches
 
 ━━━ Variant B: "Bold Industrial" (🟡 Gemini) ━━━
-Colors: #0A0A0A, #FFFFFF, #FF6B35, #004E89, #1A936F
-Fonts: Space Grotesk + IBM Plex Sans
+Colors: #101418, #FFFFFF, #FF6B35, #004E89, #1A936F
+Fonts: Archivo + IBM Plex Sans
 Feel: High-contrast, technical authority, strong hierarchy
 
-━━━ Variant C: "Soft Gradient" (🔵 Claude) ━━━
-Colors: #667EEA, #764BA2, #F093FB, #F5F7FA, #1A202C
-Fonts: Satoshi + General Sans
-Feel: Modern, approachable, subtle depth through gradients
+━━━ Variant C: "Cobalt Editorial" (🔵 Claude) ━━━
+Colors: #1D4ED8, #F7F6F2, #14181F, #C8CFDB, #E8B04B
+Fonts: Newsreader + General Sans
+Feel: Confident print-inspired hierarchy with one saturated anchor color
 ```
 
 **Then ask the user to choose:**
@@ -249,6 +273,7 @@ Synthesize search results (and chosen variant if shotgun mode) into a design dir
 3. **Typography** — heading + body font pairing with Google Fonts import
 4. **Layout approach** — grid system, spacing scale, responsive strategy
 5. **Design principles** — 3-5 guiding principles derived from UX search results
+6. **Taste compliance** — one line confirming the direction passes `skills/blocks/design-taste.md` (not one of the three banned looks; no unjustified banned-default fonts; boldness spent in one place)
 
 **Output: Write the design direction as a structured section you can reference in the next step.**
 
@@ -267,6 +292,7 @@ Critique dimensions:
 2. PRACTICALITY — Does this typography actually render well on the stated tech stack? Are the fonts available and performant (file size, loading)? Does the spacing scale work with the layout system?
 3. FIT — Does the visual style actually match the product type and audience? Would a user of [product type] feel comfortable with this aesthetic?
 4. GAPS — What did the research miss? Are there common UX patterns for this product type that aren't addressed? Are there competitive norms being ignored?
+5. SLOP — Run the checklist in skills/blocks/design-taste.md. Is this one of the three AI-slop looks (cream+serif+terracotta, near-black+acid, purple gradients)? Banned default fonts without a stated reason? Would another model given the same brief land on the same palette and fonts? Two or more checklist misses fail the direction.
 
 For each issue found, state: what's wrong, why it matters, and what to do instead.
 ```
@@ -352,10 +378,19 @@ mcp__shadcn__search_items_in_registries({ query: "<component name>" })
 
 ### STEP 7: Phase 4 — Deliver (Validation)
 
-1. **Accessibility audit** — validate all colors against WCAG AA (4.5:1 for text, 3:1 for large text)
-2. **Completeness check** — verify all requested deliverables are present
-3. **Implementation readiness** — confirm specs are detailed enough for frontend-developer
-4. **Figma push-back** (if connected) — offer to push design tokens to Figma
+1. **Accessibility audit — run the checker, do not eyeball.** Every text/background pair in the token set goes through the contrast validator:
+
+```bash
+python3 "${HOME}/.claude-octopus/plugin/scripts/helpers/contrast-check.py" \
+  '<text-hex>:<bg-hex>' '<heading-hex>:<bg-hex>:large' '<muted-hex>:<bg-hex>' ...
+```
+
+Exit 1 means at least one pair fails WCAG AA — fix the palette and re-run before delivering. Include the checker output in the final document as evidence.
+
+2. **Slop check** — run the pre-ship checklist in `skills/blocks/design-taste.md`; two or more misses means revise before delivering
+3. **Completeness check** — verify all requested deliverables are present
+4. **Implementation readiness** — confirm specs are detailed enough for frontend-developer
+5. **Figma push-back** (if connected) — offer to push design tokens to Figma
 
 ### STEP 7b: AI Surface Audit (when the interface calls a model)
 
@@ -412,7 +447,7 @@ no thresholds — no confidence cutoffs, no latency budgets — and inventing th
 here would attribute numbers to a source that does not publish them. State
 direction, cite the source, and let the product supply its own values.
 
-### STEP 8: Present Results
+### STEP 8: Present Results and Persist
 
 Format the final design system as a structured document with:
 - Executive summary (style direction + rationale)
@@ -421,6 +456,22 @@ Format the final design system as a structured document with:
 - Page layouts
 - Implementation notes for the development team
 - Sources (which search results informed each decision)
+
+**Persist the design system so it survives the session** (contract: `skill-design-lineage`):
+
+```bash
+SLUG=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo "no-branch")
+DATETIME=$(date -u +"%Y%m%d-%H%M%S")
+DESIGNS_DIR="${HOME}/.claude-octopus/designs/${SLUG}"
+mkdir -p "$DESIGNS_DIR"
+# Write the full design system document (with YAML frontmatter per skill-design-lineage)
+# to: ${DESIGNS_DIR}/${USER}-${BRANCH}-design-${DATETIME}.md
+```
+
+Later sessions (and `flow-develop` / `frontend-developer` handoffs) MUST check
+`~/.claude-octopus/designs/<slug>/` for the newest design document before inventing new
+tokens; a revision supersedes rather than edits (set the `supersedes:` frontmatter field).
 
 **Offer next steps:**
 - "Want me to implement these specs?" → hand off to frontend-developer persona

--- a/.claude/skills/skill-verification-gate/SKILL.md
+++ b/.claude/skills/skill-verification-gate/SKILL.md
@@ -2,6 +2,7 @@
 name: skill-verification-gate
 effort: low
 description: "Use when about to declare work complete, fixed, passing, or done"
+codex_alias_description: "Use when a nontrivial change needs end-to-end verification before committing or shipping"
 trigger: |
   AUTOMATICALLY ACTIVATE when:
   - About to claim work is complete, fixed, or passing
@@ -34,6 +35,17 @@ Before claiming any success or expressing satisfaction:
 5. **ONLY THEN** — State the claim WITH evidence
 
 Skip any step = the claim is unverified.
+
+## Rationalization Table
+
+| Excuse | Reality |
+|--------|---------|
+| "I ran the tests earlier this session" | Earlier is not fresh. Code changed since. Run again. |
+| "The edit was trivial, it can't break anything" | Trivial edits break builds daily. The gate has no size exemption. |
+| "The subagent reported success" | Agent reports are claims, not evidence. Verify independently. |
+| "CI will catch it anyway" | CI is the safety net, not the verification. Verify before push. |
+| "I'm confident this works" | Confidence is not evidence. Run the command. |
+| "Running the full suite is slow" | Then run the targeted suite — but run something, fresh. |
 
 ## What Counts as Evidence
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Verify Codex skills are up to date
+        run: ./scripts/build-codex-skills.sh --check
+
       - name: Check for GNU-only sed patterns
         run: |
           echo "Checking for non-portable sed usage..."

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,166 +1,166 @@
 # AI Agent Handoff
 
-Last updated: 2026-08-05
-Status: v9.59.0 released and tagged; `main` green; one open PR (#762, an
-external contributor's draft) and six open issues, all blocked or awaiting a
-maintainer decision
-Branch: `main`
-Release: https://github.com/nyldn/claude-octopus/releases/tag/v9.59.0
-Release squash: `a5d38ee325a823ba2cd4f9ef71f256cae4dec712` (pushed to
-`upstream/main`)
-Tag target: `v9.59.0` is annotated, resolves to that exact squash commit, and
-is pushed; the main-branch Test Suite passed on that commit before tagging
+Last updated: 2026-08-09
+Status: v9.61.0 is released. The model-routing fixes for #797 and #798, the
+generator safety repair, and the flow-define pilot are merged. PR #812 carries
+the final #804 skill-tree reconciliation. Issues #799-#801 and streamlining
+Parts 4b/4c/4d remain unstarted.
+Branch: `fix/skill-tree-drift`
+Release: https://github.com/nyldn/claude-octopus/releases/tag/v9.61.0
 
 ## Start Here
 
-This file is the portable resume point for Claude Code, Codex, and other LLM
-harnesses. It is a context packet, not the task tracker.
+This file is the portable resume point for Claude Code, Codex, Copilot,
+OpenCode, and other harnesses. It is a context packet, not the task tracker.
 
 Read in order:
 
 1. `AGENTS.md` and `RTK.md`
 2. `git status --short --branch`
-3. the latest commits on the current branch
-4. the relevant `bd` issue before editing; if Beads is blocked, read
-   `Tracking Blocker` below and do not migrate the database
-5. `docs/MODEL-ROUTING-STRATEGY.md`
-6. `docs/GPT-5.6-PROMPTING.md`
+3. the latest commits and live PR state
+4. the relevant `bd` issue; if Beads is still blocked, read `Tracking Blocker`
+   below and do not migrate the database
+5. `docs/MODEL-ROUTING-STRATEGY.md` for model-routing work
+6. `docs/GPT-5.6-PROMPTING.md` for GPT-5.6 prompt changes
+
+Harness-local files such as `.octo-continue.md` may be stale. The existing
+untracked copy predates this work and remains user-owned; do not overwrite it.
 
 ## Delivered Goal
 
-Opus 5 is the default complex-work owner in Claude Octopus while keeping
-Fable 5 as a capability escalation, Codex/GPT-5.6 as an independent peer,
-cheaper model tiers, user overrides, and legacy compatibility.
+Opus 5 remains the default complex-work owner while Fable 5 stays an explicit
+capability escalation, GPT-5.6 Sol remains the independent Codex peer, cheaper
+tiers remain available, and explicit user pins and role/phase routes continue
+to override defaults.
 
-## Decisions
+## Durable Decisions
 
 - Opus 5 is the default premium Claude owner, not the only workflow model.
-- Fable 5 is an explicit escalation and does not add an independent provider
-  organization beside Opus.
+- Fable 5 is an explicit escalation and does not create a second Claude
+  provider organization.
 - GPT-5.6 Sol is the default Codex peer; Terra and Luna are standard and budget
-  tiers.
-- Sonnet 5 is the standard Claude seat.
-- Explicit user pins and role/phase routes remain higher priority than defaults.
-- Claude model allowlists remain a compliance boundary: direct normal and fast
-  Opus dispatch validate the final rerouted model and any fallback before
-  command serialization.
-- Tangle implementation isolation defaults on for orchestrated and direct
-  library calls; explicit `OCTOPUS_TANGLE_RUN_WORKTREE=false` is the opt-out.
-- Tangle uses one run ID across its branch, delegated tasks, markers, and
-  validation artifacts, and resolves caller-relative ignored context before
-  changing worktrees.
-- Verification-only results fail closed unless all declared evidence members
-  are strings and the baseline, reproduction, and implementation flags are
-  internally consistent.
-- Multi-model fan-out remains mandatory only for commands whose explicit
-  contract is council, debate, parallel, or multi-provider research.
-- Tests and runtime evidence remain mandatory; redundant prompt-only
+  tiers. Sonnet 5 is the standard Claude seat.
+- Claude allowlists are a compliance boundary. Normal, fast, rerouted, and
+  fallback dispatches validate the final model before command serialization.
+- Tangle implementation isolation defaults on. One run ID spans its branch,
+  delegated tasks, markers, and validation artifacts.
+- Verification-only results fail closed unless evidence types and baseline,
+  reproduction, and implementation flags are internally consistent.
+- Multi-model fan-out is mandatory only where the command contract explicitly
+  requires council, debate, parallel, or multi-provider research.
+- Runtime evidence and tests remain mandatory; duplicated prompt-only
   self-verification is removed.
-- Release summaries, model defaults, component counts, runtime compatibility,
-  and provider counts in the public README surfaces are generated from
-  repository sources rather than maintained as duplicated prose.
-- `make sync` repairs README drift and `make sync-check` rejects it. Release
-  preparation updates the changelog first, then runs the same synchronization.
-- Public test-suite counts are derived from the same `test-*.sh` discovery used
-  by the smoke, unit, and integration runners.
-- Review findings are fixed on the release branch before merge; review comments
-  marked addressed are still checked against the actual head rather than
-  accepted as evidence.
-- `.octo-continue.md` predates this work and is preserved as user-owned state.
+- Public release/model/component/provider facts and test counts are generated
+  from repository sources. `make sync` repairs drift and `make sync-check`
+  rejects it.
+- Review findings are verified against the current head before being marked
+  resolved.
 
 ## Tracking Blocker
 
 Beads is readable but not writable. The remote-backed database is on schema
-v49 with four pending migrations to v53. Repository rules prohibit migrating
-without the single designated migrator. No migration was run, so this work
-could not be claimed or recorded as a new Beads issue.
+v49 with four pending migrations to v53. Repository rules reserve migration for
+the designated migrator. No migration was run, so this work could not be
+claimed or recorded in `bd`; use this handoff for the blocked tracking record.
 
-## Current Evidence
+## Delivered in This Cycle
 
-- Release v9.59.0 is the resume baseline: ten reliability fixes plus literal
-  provider-model routing (#734) and three test systems (#749, #752). Tagged on
-  the squash commit per `RELEASING.md` step 7, with main verified green first
-  per step 9.
-- The release notes were rewritten before publication because they described
-  three fixes while `main` had gained fifteen more. Every cited PR was verified
-  by content, not by label: the batch PRs show CLOSED rather than MERGED
-  because #764 squashed them, so a label check reads as though they never
-  landed.
-- #762 (provider-registry consolidation) is verified, CI-green and Bash 3.2
-  clean, but is still the author's **draft**. It was deliberately excluded from
-  v9.59.0 and the registry claim was removed from the notes rather than
-  shipping a description of a change users would not have. It should lead the
-  next release.
-- Main went red on the v9.59.0 commit and the tag was held. Root cause was a
-  single macOS timing flake, not the release: `integration-heavy` declares
-  `needs: [unit-required]`, so a failed unit gate skips it and the `integration`
-  gate then fails on `heavy_tests=true` with result `skipped`. One flake, two
-  red checks. Both halves fixed in #771.
-- The flake was never reproduced locally across eleven runs including three
-  under CPU load. What established nondeterminism was a re-run of the identical
-  commit going green with no code change.
-- #769 fixed a live dispatch break: `grok-exec.sh` and `claude-sdk-exec.sh`
-  existed but were absent from `validate_agent_command`'s allowlist, so every
-  grok and claude-sdk dispatch aborted before the CLI ran. Third occurrence of
-  this pattern after #697 and #705. The fix requires exactly three tokens
-  (`env`, `VAR=`, shim), and four injection shapes were confirmed rejected.
-- #774 lowered both SessionEnd timeouts to Codex's 3s cap. This reversed an
-  earlier judgement made without measurement: `session-end.sh` runs 142 ms
-  nominal and 360 ms against a 2.7 MB session file with 6000 errors, 3000
-  phases and 300 memory dirs; `workflow-verification.sh` runs 20 ms. Codex
-  clamps to 3s regardless, so the declared 15s only ever produced a startup
-  warning. `main` now declares zero async hooks and zero over-cap timeouts.
-- #775 registered `/octo:whats-new`, which had shipped unregistered since
-  2026-07-30 (51 command files, 50 registered). Found by
-  `tests/test-command-registration.sh`, one of the 34 files no CI gate runs.
-  That is the concrete payoff #752 predicted.
-- All 34 unreachable files are triaged: 27 pass and are misplaced (including
-  `test-credential-isolation.sh`, which is clean); 1 found the bug above; 1
-  (`test-enforcement-pattern.sh`) is stale, demanding an attribution footer
-  that **0 of 57** skills carry; 2 are version-named and need reading; 1
-  baseline entry points at a deleted file.
-- Relocating those 27 is **not** a `git mv`. `tests/` root resolves
-  `PROJECT_ROOT` as `$SCRIPT_DIR/..` while `tests/unit/` uses
-  `$SCRIPT_DIR/../..`. Demonstrated: a moved test dies on
-  `tests/unit/helpers/test-framework.sh: No such file or directory`. A path
-  error that resolves rather than errors yields a green test asserting nothing,
-  so each move needs verifying by content.
-- Three consecutive releases filed identical E2E reports. #717 and #735 are
-  closed: their `B2c /octo:model-config` failure no longer reproduces, with no
-  root cause identified — treat a recurrence as nondeterministic. The surviving
-  `gemini:degraded` is correct behaviour, not a defect:
-  `check-providers.sh:30-32` names "gemini exhausted" as a case that should
-  report degraded. The stale assertion lives in an external harness. Tracked
-  in #772.
-- Merged this session with `main` green on every commit: #771 (`ec52a786`),
-  #769 (`49e036c0`), #774 (`1b078482`), #775 (`a595a264`), #773 (`be1534b2`).
-- `make ci-local` on the #762 branch passed 16 smoke, 201 unit, 7 integration.
-  `test-hud-smart-mode.sh` fails in one long-lived local checkout and passes in
-  a fresh worktree and in CI; treat it as environmental.
-- Auto-merge is disabled at the repository level and merge queues are
-  org-only, so under `strict: true` every merge invalidates every other PR.
-  Five sequential rebases were needed today. Enabling auto-merge is a one-line
-  repository setting and was left for the maintainer.
-- `make sync-check` passes with no script mode changes; no stashes; working
-  tree clean on `main`.
+- **#805 merged (`f0586e73`)** — added vendor-correct no-config model fallbacks
+  for grok, OpenRouter, Vibe, and AtlasCloud, with behavioural regression tests.
+  Fixes #797.
+- **#806 closed** — duplicate of #805 and intentionally not merged.
+- **#807 merged (`b449bebb`)** — migrates stale GPT-5.x pins, not only pre-GPT-5
+  model IDs. Fixes #798.
+- **#808 merged (`6df8d231`)** — prevents the Codex generator from deleting the
+  hand-maintained `skill-council` and starter-pack directories.
+- **#809 merged (`c9cfd8b2`)** — removes a GNU grep SIGPIPE failure from the
+  agent-fields test under `set -o pipefail`.
+- **#810 merged (`4ad6ddde`)** — flow-define streamlining pilot. Its final
+  review pass made provider gating operational, clarified the terminal
+  transition, scoped enforcement detection to real contract sections, and
+  added caller-level generation regressions.
+- **#812** — final #804 reconciliation, based on `4ad6ddde`. The code commit is
+  `31cc5d03` plus this handoff update.
 
-## Merge Queue
+## PR #812 / Issue #804
 
-- Merged this session: #771, #769, #774, #775, #773. Earlier in the same cycle:
-  #765, #767, and the nine-PR integration batch #764 (#740, #742, #743, #744,
-  #747, #757, #758, #759, #761), plus #763, #734, #760, #754, #739, #737, and
-  release PR #748 (v9.59.0).
-- Open: **#762 only**, an external contributor's draft. Do not convert someone
-  else's draft to ready; the author has been asked and told it missed v9.59.0.
-- Open issues, none of them available work without a decision or an unblock:
-  #768 and the structural half of #750 are blocked on #762; #772 needs a change
-  in an external E2E harness; #724 is a phase-handoff contract change needing
-  design; #701 is a product-scope call (recommendation given: fold into
-  `octopus-ui-ux-design` rather than add a 58th skill); #741 has a scoped plan
-  and a ratchet preventing growth.
+The canonical `.claude/skills/` tree and generated `skills/` tree had real
+content drift mixed with expected generator transformations. The reconciliation
+does the following:
+
+- Back-ports generated-only operational guidance into canonical sources for
+  flow-deliver, flow-develop, flow-discover, security audit, UI/UX design,
+  doctor, meta-prompt, parallel agents, and verification gate.
+- Keeps expected name transformations such as `skill-ui-ux-design` to
+  `octopus-ui-ux-design`; those are not drift.
+- Treats `skill-intent-contract` as source-ahead and regenerates it.
+- Removes the duplicate generated Iron Law from the `skill-verify` alias while
+  retaining its rationalization table.
+- Adds explicit Codex display-name and alias-description overrides rather than
+  hand-editing generated frontmatter.
+- Wires `build-codex-skills.sh` into `make sync`, `make sync-check`, and the
+  portability CI job so future drift fails deterministically.
+
+Verification on the final rebased code commit:
+
+- `./scripts/build-codex-skills.sh --check`: 58 generated, 0 skipped, 0 errors;
+  `skills/` up to date.
+- `make ci-local`: 16 smoke, 245 unit, and 7 integration suites passed.
+- No executable-bit changes.
+
+The plugin-lifecycle integration test can overwrite canonical flow files in a
+long-lived checkout from the currently installed marketplace copy. The test
+run was therefore followed by recreating the isolated worktree from the
+verified commit; do not mistake those test side effects for intended changes.
+
+## Model Audit Still Open
+
+- **#799 — provider availability/auth parity.** `check-providers.sh` still uses
+  binary presence alone for several providers, while preflight has stronger
+  auth checks. `is_agent_available_v2` also has an optimistic default arm.
+- **#800 — stale pins and dead environment overrides.** Copilot and Ollama have
+  stale defaults, and some provider IDs do not map to their documented
+  `OCTOPUS_*_MODEL` variables.
+- **#801 — catalog and price-table consolidation.** Model membership, tiering,
+  and pricing still disagree across `models.sh`, `octo-model-config.sh`,
+  `cost.sh`, and `usage-report.sh`.
+
+Each issue contains a concrete reproduction. Do not combine them into one
+large provider refactor; preserve the behavioural-test-first pattern used by
+#805 and #807.
 
 ## Next Action
 
-Merge #762 when its author clears the draft flag, then fix all three #768 items
-in one pass. Two decisions belong to the maintainer: enabling repository
-auto-merge, and the Beads migration below.
+1. If PR #812 is open, inspect the live head, resolve only valid review
+   findings, keep the branch rebased on `main`, and let auto-merge complete
+   after all checks pass. If it is merged, verify #804 closed and start from the
+   resulting `main` commit.
+2. Re-check the release PR/state before starting new work; release activity may
+   advance `main` while #812 is under review.
+3. Pick up #799, #800, and #801 as separate test-first fixes.
+4. Remaining streamlining work is still unstarted:
+   - **4c:** remove obsolete drift detection, its unreachable duplicate, and
+     the deprecated wizard only after confirming all call sites.
+   - **4b:** cull unused/below-floor `SUPPORTS_*` flags together with the
+     `sync-readme.py` parser change required when the set becomes empty.
+   - **4d:** remove `tangle_reformat_decomposition` only after verifying whether
+     current agy/Codex decomposition still needs weak-format repair.
+
+Do not remove `lib/fable5.sh`, the Markdown-fence stripping in `review.sh`, or
+the provider-outage fallback ladder in `review.sh`; each handles a current
+runtime case rather than obsolete model weakness.
+
+## Standing Constraints
+
+- Bash floor is `/bin/bash` 3.2.57: no associative arrays or namerefs.
+- Provider wiring uses the 7-point checklist in `docs/PROVIDERS.md`; provider
+  case globs are order-sensitive (`claude-sdk*` before `claude*`).
+- Regenerate owned artifacts through their scripts. Never hand-edit
+  `.claude-plugin/marketplace.json`, `openclaw/src/tools/index.ts`, or generated
+  `skills/` output.
+- Run `make sync` after skill/provider/metadata changes and `make ci-local`
+  before pushing code.
+- Re-check script modes after local tests. The branch diff must contain no
+  unintended mode changes.
+- At session end, update this handoff, commit, pull/rebase, push, and verify the
+  branch is up to date with its remote.

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,14 @@ sync:
 	@./scripts/sync-readme.py
 	@./scripts/sync-marketplace.sh
 	@./scripts/build-openclaw.sh
+	@./scripts/build-codex-skills.sh
 
 # Verify derived artifacts are current (what CI enforces)
 sync-check:
 	@./scripts/sync-readme.py --check
 	@./scripts/sync-marketplace.sh --check
 	@./scripts/build-openclaw.sh --check
+	@./scripts/build-codex-skills.sh --check
 
 # CI parity: everything the required checks run, locally.
 # Local green here predicts remote green; targeted suites alone do not.

--- a/scripts/build-codex-skills.sh
+++ b/scripts/build-codex-skills.sh
@@ -327,6 +327,11 @@ write_skill() {
     local skill_dir="$2"
     local codex_name="$3"
     local codex_desc="$4"
+    local codex_display_name="${5:-}"
+
+    if [[ -z "$codex_display_name" ]]; then
+        codex_display_name="$(display_name "$codex_name")"
+    fi
 
     mkdir -p "$skill_dir"
 
@@ -342,7 +347,7 @@ write_skill() {
     mkdir -p "$skill_dir/agents"
     {
         echo "interface:"
-        printf '  display_name: %s\n' "$(yaml_quote "$(display_name "$codex_name")")"
+        printf '  display_name: %s\n' "$(yaml_quote "$codex_display_name")"
         printf '  short_description: %s\n' "$(yaml_quote "$codex_desc")"
     } > "$skill_dir/agents/openai.yaml"
 }
@@ -444,7 +449,10 @@ main() {
         local codex_desc
         codex_desc=$(truncate "$description" 1024)
 
-        write_skill "$file" "$target_dir/$codex_name" "$codex_name" "$codex_desc"
+        local codex_display_name
+        codex_display_name=$(extract_field "$file" "codex_display_name")
+
+        write_skill "$file" "$target_dir/$codex_name" "$codex_name" "$codex_desc" "$codex_display_name"
 
         ((count++)) || true
         $VERBOSE && echo "  OK: $basename → skills/$codex_name/SKILL.md"
@@ -452,7 +460,15 @@ main() {
         local alias_name
         alias_name="$(compat_alias_for "$codex_name")"
         if [[ -n "$alias_name" ]]; then
-            write_skill "$file" "$target_dir/$alias_name" "$alias_name" "$codex_desc"
+            local alias_desc
+            alias_desc=$(extract_field "$file" "codex_alias_description")
+            [[ -n "$alias_desc" ]] || alias_desc="$codex_desc"
+            alias_desc=$(truncate "$alias_desc" 1024)
+
+            local alias_display_name
+            alias_display_name=$(extract_field "$file" "codex_alias_display_name")
+
+            write_skill "$file" "$target_dir/$alias_name" "$alias_name" "$alias_desc" "$alias_display_name"
             ((count++)) || true
             $VERBOSE && echo "  OK: $basename → skills/$alias_name/SKILL.md (compat alias)"
         fi

--- a/skills/skill-intent-contract/SKILL.md
+++ b/skills/skill-intent-contract/SKILL.md
@@ -64,11 +64,19 @@ What this should NOT be:
 ## Clarifying Context
 [Any answers from the 3-question pattern]
 
+## Task Allocation
+**Risk**: [low | intermediate | high]
+**Initiative**: [human | AI] — who starts and proposes
+**Control**: [human | AI] — who oversees execution as it runs
+**Decision rights**: [human | AI] — who has final say on the outcome
+**Resolved AUTONOMY_MODE**: [supervised | semi-autonomous | loop-until-approved | autonomous]
+
 ## Validation Checklist
 - [ ] Meets "good enough" criteria
 - [ ] Respects all boundaries
 - [ ] Works for all stakeholders
 - [ ] Builds on existing assets appropriately
+- [ ] Allocation still fits what the task turned out to be
 ```
 
 
@@ -85,6 +93,70 @@ Create an intent contract when:
 - Quick, single-action commands
 - Simple file reads or searches
 - Conversational questions
+
+### Step 0: Allocate the work before scoping it
+
+Run this before capturing intent. The question is not how to run the task across
+agents but whether it should be delegated at all, and if so, which parts of the
+authority go where. Framework: Afroogh, Varshney & D'Cruz (2025), *A Task-Driven
+Human-AI Collaboration* ([arXiv:2505.18422](https://arxiv.org/abs/2505.18422)).
+
+**Classify risk.** Complexity is already scored elsewhere — defer to
+`estimate_complexity` and `classify_cynefin` in `scripts/lib/routing.sh` rather
+than re-deriving it. Risk is a separate axis that nothing in the codebase
+measures, so judge it here on three questions:
+
+- **Irreversibility** — can the effect be undone, and at what cost?
+- **Consequence** — is anything material at stake: safety, money, data, users?
+- **Accountability** — is a specific person expected to answer for the outcome?
+
+| Risk | Reading |
+|------|---------|
+| **Low** | Reversible, no material consequence, no named accountability. |
+| **Intermediate** | Reversible only at real cost, or consequence is unclear. |
+| **High** | Irreversible, materially consequential, or someone must answer for it. |
+
+**Allocate the three dimensions separately.** They are independent, and treating
+them as one axis is the mistake this step exists to prevent. People readily hand
+AI the *initiative* on unfamiliar work while keeping control and decision rights
+— an allocation a single autonomy slider cannot express.
+
+- **Initiative** — who starts, proposes, drafts.
+- **Control** — who oversees execution while it runs.
+- **Decision rights** — who has final say on the result.
+
+Low risk with low complexity supports AI autonomy across all three. Low risk with
+high complexity is collaborative: shared initiative, human decision rights. High
+risk with low complexity is human oversight, with AI holding no direct authority.
+High risk with high complexity is adversarial: the human leads and AI is pointed
+at the decision to attack it, as a deliberate counterweight to the human's own
+bias.
+
+**The rule that inverts.** For **intermediate-risk** work where uncertainty is
+highest, the cited evidence says avoid AI entirely — "neither as a gatekeeper nor
+as a second opinion". This contradicts the smooth intuition that middling risk
+implies middling involvement, and it also sits in tension with the same paper's
+broader claim that complete human autonomy is rarely justified. That tension is
+real and unresolved; surface it to the user and let them decide rather than
+quietly picking a side.
+
+**Resolve to a setting.** The workflow engine reads one variable,
+`AUTONOMY_MODE`, with four values:
+
+| Allocation | `AUTONOMY_MODE` |
+|---|---|
+| Human holds control and decision rights, approving each phase | `supervised` |
+| AI runs; human is pulled in on failures and quality gates | `semi-autonomous` |
+| AI runs and iterates; human holds final decision rights | `loop-until-approved` |
+| AI holds all three | `autonomous` |
+
+Record the three dimensions *and* the resolved mode. The mapping is lossy: one
+axis cannot represent three independent allocations, so a contract that stores
+only the mode loses the reason it was chosen. That record is what a later
+reviewer needs when the allocation turns out to have been wrong.
+
+If the classification lands on intermediate risk, stop and raise it before
+proceeding rather than defaulting to a mode.
 
 ### Step 1: Capture Intent
 

--- a/skills/skill-meta-prompt/SKILL.md
+++ b/skills/skill-meta-prompt/SKILL.md
@@ -319,7 +319,6 @@ Before considering complete:
 [Context or examples from user]
 ```
 
-
 ### Model-Specific Adjustments
 
 Tune the assembled prompt to the model that will execute it:
@@ -328,6 +327,7 @@ Tune the assembled prompt to the model that will execute it:
 - **Claude Fable 5** (any `claude-fable-5` pin): apply `skills/blocks/fable5-prompting.md`. In short: never instruct the model to reveal or transcribe its reasoning (triggers a refusal); replace step-by-step micromanagement with a boundary plus checkable acceptance criteria; drop "CRITICAL"/"MUST" emphasis unless strict compliance is required; add grounded-progress and act-when-ready language for long runs.
 - **Codex / GPT-5.6**: apply `docs/GPT-5.6-PROMPTING.md`; give it a concrete outcome, scoped repository constraints, checkable acceptance criteria, non-goals, and the required verification.
 - **Older Claude models**: the fuller template below applies as written.
+
 
 ## Phase 6: Output & Iteration
 

--- a/skills/skill-verify/SKILL.md
+++ b/skills/skill-verify/SKILL.md
@@ -17,10 +17,6 @@ description: "Use when a nontrivial change needs end-to-end verification before 
 NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE
 </HARD-GATE>
 
-```
-NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE
-```
-
 If you haven't run the verification command in this turn, you cannot claim it passes.
 
 ## The Gate
@@ -34,6 +30,17 @@ Before claiming any success or expressing satisfaction:
 5. **ONLY THEN** — State the claim WITH evidence
 
 Skip any step = the claim is unverified.
+
+## Rationalization Table
+
+| Excuse | Reality |
+|--------|---------|
+| "I ran the tests earlier this session" | Earlier is not fresh. Code changed since. Run again. |
+| "The edit was trivial, it can't break anything" | Trivial edits break builds daily. The gate has no size exemption. |
+| "The subagent reported success" | Agent reports are claims, not evidence. Verify independently. |
+| "CI will catch it anyway" | CI is the safety net, not the verification. Verify before push. |
+| "I'm confident this works" | Confidence is not evidence. Run the command. |
+| "Running the full suite is slow" | Then run the targeted suite — but run something, fresh. |
 
 ## What Counts as Evidence
 


### PR DESCRIPTION
Closes #804

## Summary
- back-port generated-only skill guidance into canonical .claude/skills sources
- teach the Codex generator about display-name and alias-description overrides
- regenerate the supported Codex outputs while preserving hand-maintained directories
- make generated-skill drift part of make sync, make sync-check, and portability CI

## Verification
- ./scripts/build-codex-skills.sh --check
- make ci-local: 16 smoke, 245 unit, 7 integration suites passed
- no executable-bit changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Improvements**
  - Added clearer completion requirements for discovery, development, delivery, and verification phases.
  - Improved routing for shipping, branch wrap-up, review-only requests, and intermediate-risk tasks.
  - Design workflows now preserve revisions, reuse the latest direction, and validate accessibility and visual quality.

- **Documentation**
  - Updated guidance for model selection, security reviews, agent assignments, and natural-language commands.
  - Added stronger evidence-based verification guidance and task-authority tracking.

- **Maintenance**
  - Added checks to ensure generated skill artifacts stay synchronized and current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->