### PR TITLE
fix: honor OCTOPUS_OLLAMA_MODEL, OCTOPUS_COPILOT_MODEL, OCTOPUS_VIBE_MODEL pins

### DIFF
--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -747,6 +747,9 @@ get_agent_model() {
         cursor-agent*) provider="cursor-agent" ;;
         grok*)       provider="grok" ;;
         opencode*)   provider="opencode" ;;
+        ollama*)     provider="ollama" ;;
+        copilot*)    provider="copilot" ;;
+        vibe*)       provider="vibe" ;;
     esac
 
     local resolved_model


### PR DESCRIPTION
## Description
`get_agent_model()` in `scripts/lib/dispatch.sh` derives its provider name from `$agent_type` via a `case` statement, then passes that provider into `resolve_octopus_model()`, which builds an env-override variable name as `OCTOPUS_<PROVIDER>_MODEL`. The case statement had no arm for `ollama*`, `copilot*`, or `vibe*`, so `provider` stayed empty (`""`) for those three agent types. That produced the unmatchable env-var name `OCTOPUS__MODEL` (double underscore), so `OCTOPUS_OLLAMA_MODEL`, `OCTOPUS_COPILOT_MODEL`, and `OCTOPUS_VIBE_MODEL` were silently ignored — dispatch always fell through to the hardcoded fallback default (`llama3.3`, `claude-sonnet-4.5`, `default`) instead. All three providers already carry an `env` capability flag in `scripts/lib/provider-registry.sh`, so the pins were expected to work.

Root cause: `scripts/lib/dispatch.sh:735-750` (case statement missing three arms) → `scripts/lib/model-resolver.sh:155` (env var name built from the empty provider).

Fix: add the three missing case arms (`ollama*`, `copilot*`, `vibe*`), matching the existing pattern for every other provider (codex, gemini, grok, opencode, etc).

Scope note: this addresses one of three symptoms filed under #800 (env pins silently dropped). It does **not** touch the other two — stale hardcoded model defaults, and missing CLI version floors for 7 providers — which are separate, broader changes better handled independently. Leaving #800 open for those.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check (`bash -n scripts/*.sh scripts/lib/*.sh scripts/helpers/*.sh`)
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync — not applicable, no registry-facing surface touched
- [ ] New skills/commands registered — not applicable
- [ ] Version bump — not applicable, no release in this PR
- [ ] Documentation updated — not applicable, these vars aren't documented anywhere in the repo yet (verified via repo-wide grep); this fix just makes the existing provider-registry `env` capability claim true for these three
- [ ] CHANGELOG.md updated — deferring to whoever cuts the next release

## Testing
Wrote a standalone harness that sources `model-resolver.sh` + `dispatch.sh` and calls `get_agent_model` directly:
- Reproduced the bug: with the old code, `OCTOPUS_OLLAMA_MODEL=llama4-test` had no effect, `get_agent_model ollama` still returned the hardcoded `llama3.3`.
- Confirmed the fix: after adding the case arms, `get_agent_model ollama|copilot|vibe` correctly returns the pinned `OCTOPUS_*_MODEL` value for all three.

Ran the full set of existing unit tests that exercise `get_agent_model` / provider resolution — all pass, no regressions:
```bash
bash tests/unit/test-env-var-effects.sh              # 9/9
bash tests/unit/test-execution-profile-dispatch.sh    # pass
bash tests/unit/test-gemini-provider.sh               # 52/52
bash tests/unit/test-grok-provider.sh                 # 7/7
bash tests/unit/test-openai-compatible-provider-config.sh  # 6/6
bash tests/unit/test-openai-compatible-agent.sh       # 19/19
bash tests/unit/test-runtime-provider-labels.sh       # 8/8
bash tests/unit/test-shipped-state-model-resolution.sh # 6/6
bash tests/unit/test-council-model-selection-fixes.sh # 10/10
bash tests/unit/test-openclaw-compat.sh               # 32/32
```
Also ran `bash -n` across all of `scripts/*.sh scripts/lib/*.sh scripts/helpers/*.sh` — clean.

Did not run `make test-integration` — the change is a 3-line case-statement addition with no behavioral change for any other provider, and no integration suite specifically exercises ollama/copilot/vibe dispatch paths that would add signal beyond the targeted unit tests above.

## Related Issues
Part of #800 (does not close — two other symptoms in that issue remain unaddressed, see scope note above)

---

_Filed by the scheduled daily bug-triage routine._


---
_Generated by [Claude Code](https://claude.ai/code/session_01EBRCN9muLZF4J7AC6azxX7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing Ollama, Copilot, and Vibe agent types and routing them to the appropriate providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->