### PR TITLE
fix: add ollama/copilot/vibe arms to validate_model_allowed()

### DIFF
--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -795,6 +795,9 @@ validate_model_allowed() {
         cursor-agent) allowlist_var="OCTOPUS_CURSOR_AGENT_ALLOWED_MODELS" ;;
         commandcode) allowlist_var="OCTOPUS_COMMANDCODE_ALLOWED_MODELS" ;;
         opencode)   allowlist_var="OCTOPUS_OPENCODE_ALLOWED_MODELS" ;;
+        ollama)     allowlist_var="OCTOPUS_OLLAMA_ALLOWED_MODELS" ;;
+        copilot)    allowlist_var="OCTOPUS_COPILOT_ALLOWED_MODELS" ;;
+        vibe)       allowlist_var="OCTOPUS_VIBE_ALLOWED_MODELS" ;;
         *)          return 0 ;;  # Unknown provider — allow
     esac
 


### PR DESCRIPTION
## Description
`validate_model_allowed()` in `scripts/lib/dispatch.sh:781-796` has allowlist-var case arms for codex, gemini, agy, claude-sdk, claude, openrouter, atlascloud, openai-compatible*, perplexity, qwen, cursor-agent, commandcode, and opencode, then falls through to:

```bash
*)          return 0 ;;  # Unknown provider — allow
```

`ollama`, `copilot`, and `vibe` were not covered by that case, so any `OCTOPUS_OLLAMA_ALLOWED_MODELS` / `OCTOPUS_COPILOT_ALLOWED_MODELS` / `OCTOPUS_VIBE_ALLOWED_MODELS` a user set was silently ignored — the model restriction never applied for these three providers, even though all three carry provider-registry entries and are documented/expected to support the same allowlist mechanism as every other seat.

Fix: add the three missing case arms, following the exact existing pattern:
```bash
ollama)     allowlist_var="OCTOPUS_OLLAMA_ALLOWED_MODELS" ;;
copilot)    allowlist_var="OCTOPUS_COPILOT_ALLOWED_MODELS" ;;
vibe)       allowlist_var="OCTOPUS_VIBE_ALLOWED_MODELS" ;;
```

This is item 3 of the provider-wiring checklist in `docs/PROVIDERS.md` (model allowlist var, `scripts/lib/dispatch.sh`), and is the same class of gap as #799 (unknown providers fail open) but in a different function/file (`dispatch.sh` allowlist enforcement vs. `model-resolver.sh` availability detection).

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check (`bash -n scripts/*.sh scripts/lib/*.sh scripts/helpers/*.sh`)
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync — not applicable, no registry-facing surface touched
- [ ] New skills/commands registered — not applicable
- [ ] Version bump — not applicable, no release in this PR
- [ ] Documentation updated — not applicable, this fix just makes the existing provider-registry allowlist claim true for these three providers, matching the (already-shipped) behavior for every other provider
- [ ] CHANGELOG.md updated — deferring to whoever cuts the next release

## Testing
Wrote a standalone harness that sources `dispatch.sh` and calls `validate_model_allowed` directly:
- Reproduced the bug: with the old code, `OCTOPUS_OLLAMA_ALLOWED_MODELS="llama3.3,mixtral"` had no effect on a disallowed model for `ollama`/`copilot`/`vibe` — the function always returned success (unknown-provider fallthrough).
- Confirmed the fix: after adding the case arms, a disallowed model for `ollama`, `copilot`, or `vibe` is correctly blocked (non-zero return, capability-aware fallback emitted), while an allowed model still passes, and the "no allowlist set" case still allows everything (unchanged behavior for the common case).

Ran the directly affected unit test suites — all pass, no regressions:
```bash
bash tests/unit/test-provider-allowlist.sh        # 13/13
bash tests/unit/test-ollama-provider.sh           # 10/10
bash tests/unit/test-copilot-provider.sh          # 37/37
bash tests/unit/test-vibe-provider.sh             # 5/5
bash tests/unit/test-provider-registry.sh         # 8/8
bash tests/unit/test-provider-registry-parity.sh  # 9/9
bash tests/unit/test-openclaw-compat.sh           # 32/32
```
Also ran `bash -n` across all of `scripts/*.sh scripts/lib/*.sh scripts/helpers/*.sh` — clean.

Did not run the full `make test-unit` matrix or `make test-integration` in this session — the change is a 3-line case-statement addition with the exact same shape as the already-merged sibling fix in #816, and the full suite exceeded this run's time budget; the targeted suites above cover every test file that touches `validate_model_allowed`, ollama/copilot/vibe dispatch, and provider allowlisting.

## Related Issues
Closes #817

---

_Filed by the scheduled daily bug-triage routine._


---
_Generated by [Claude Code](https://claude.ai/code/session_012pLbG4hqFYfshokDJY1AYL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring allowed models for Ollama, Copilot, and Vibe providers through environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->