### PR TITLE
fix: restore Codex marketplace update compatibility

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "octo",
+  "name": "claude-octopus",
   "version": "9.61.1",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Existing Codex marketplace installs can update again.** The Codex adapter
+  preserves its original `claude-octopus` marketplace identity instead of
+  borrowing Claude Code's separate `octo` selector. Shared-marketplace release
+  sync now validates both host manifests, preventing stale Codex bundles from
+  being stranded behind an identifier mismatch. (#818)
+
 ## [9.61.1] - 2026-08-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ editing cache files or symlinks directly:
 codex plugin marketplace upgrade nyldn-plugins
 codex plugin add claude-octopus@nyldn-plugins
 ```
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -95,10 +95,19 @@ Claude Code **v2.1.14+** is the minimum supported runtime. Newer Claude Code rel
 <summary>Install for Codex CLI</summary>
 
 ```bash
-git clone --depth 1 https://github.com/nyldn/claude-octopus.git ~/.codex/claude-octopus && mkdir -p ~/.agents/skills && ln -sf ~/.codex/claude-octopus/skills ~/.agents/skills/claude-octopus
+codex plugin marketplace add https://github.com/nyldn/plugins.git
+codex plugin add claude-octopus@nyldn-plugins
 ```
 
 Restart Codex. Skills appear automatically — invoke with `$skill-doctor`, `$skill-debug`, etc.
+
+Codex owns the versioned cache. To refresh an existing installation without
+editing cache files or symlinks directly:
+
+```bash
+codex plugin marketplace upgrade nyldn-plugins
+codex plugin add claude-octopus@nyldn-plugins
+```
 </details>
 
 <details>

--- a/scripts/sync-shared-marketplace.sh
+++ b/scripts/sync-shared-marketplace.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# sync-shared-marketplace.sh - Sync the octo entry into nyldn/plugins.
+# sync-shared-marketplace.sh - Sync and validate Octopus entries in nyldn/plugins.
 #
 # The shared marketplace contains multiple plugins. Never copy this repo's
-# whole marketplace.json over it; only replace plugins[].name == "octo".
+# whole marketplace.json over it; only replace the Claude marketplace's
+# plugins[].name == "octo" entry. The Codex marketplace intentionally uses the
+# stable public selector "claude-octopus" so existing installs can update.
 
 set -euo pipefail
 
@@ -79,6 +81,19 @@ if [[ ! -f "$LOCAL_MARKETPLACE" ]]; then
     exit 1
 fi
 
+LOCAL_CODEX_MANIFEST="$ROOT_DIR/.codex-plugin/plugin.json"
+if [[ ! -f "$LOCAL_CODEX_MANIFEST" ]]; then
+    echo "ERROR: missing local Codex plugin manifest: $LOCAL_CODEX_MANIFEST" >&2
+    exit 1
+fi
+
+EXPECTED_CODEX_PLUGIN_NAME="claude-octopus"
+CODEX_PLUGIN_NAME="$(jq -r '.name // empty' "$LOCAL_CODEX_MANIFEST")"
+if [[ "$CODEX_PLUGIN_NAME" != "$EXPECTED_CODEX_PLUGIN_NAME" ]]; then
+    echo "ERROR: Codex plugin name must remain '$EXPECTED_CODEX_PLUGIN_NAME' for installed marketplace upgrades (found '$CODEX_PLUGIN_NAME')" >&2
+    exit 1
+fi
+
 LOCAL_ENTRY="$(mktemp "${TMPDIR:-/tmp}/octo-marketplace-entry.XXXXXX")"
 cleanup_entry() {
     rm -f "$LOCAL_ENTRY"
@@ -137,6 +152,29 @@ if [[ ! -f "$SHARED_MARKETPLACE" ]]; then
     echo "ERROR: shared marketplace checkout is missing .claude-plugin/marketplace.json" >&2
     exit 1
 fi
+
+SHARED_CODEX_MARKETPLACE="$WORKDIR/.agents/plugins/marketplace.json"
+if [[ ! -f "$SHARED_CODEX_MARKETPLACE" ]]; then
+    echo "ERROR: shared marketplace checkout is missing .agents/plugins/marketplace.json" >&2
+    exit 1
+fi
+
+if ! jq -e --arg name "$CODEX_PLUGIN_NAME" \
+    '.plugins | map(select(.name == $name)) | length == 1' \
+    "$SHARED_CODEX_MARKETPLACE" >/dev/null; then
+    echo "ERROR: shared Codex marketplace must have exactly one '$CODEX_PLUGIN_NAME' plugin entry" >&2
+    exit 1
+fi
+
+SHARED_CODEX_SOURCE="$(jq -r --arg name "$CODEX_PLUGIN_NAME" \
+    '.plugins[] | select(.name == $name) | .source.url // empty' \
+    "$SHARED_CODEX_MARKETPLACE")"
+if [[ "$SHARED_CODEX_SOURCE" != "https://github.com/nyldn/claude-octopus.git" ]]; then
+    echo "ERROR: shared Codex marketplace '$CODEX_PLUGIN_NAME' source is invalid: ${SHARED_CODEX_SOURCE:-missing}" >&2
+    exit 1
+fi
+
+echo "OK: shared Codex marketplace selector is compatible ($CODEX_PLUGIN_NAME)"
 
 if ! jq -e '.plugins | map(select(.name == "octo")) | length == 1' "$SHARED_MARKETPLACE" >/dev/null; then
     echo "ERROR: shared marketplace must have exactly one octo plugin entry" >&2

--- a/scripts/sync-shared-marketplace.sh
+++ b/scripts/sync-shared-marketplace.sh
@@ -11,6 +11,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
+log() {
+    local level="$1"
+    shift
+    printf '[%s] %s\n' "$level" "$*" >&2
+}
+
 MARKETPLACE_REPO="${OCTOPUS_SHARED_MARKETPLACE_REPO:-https://github.com/nyldn/plugins.git}"
 MARKETPLACE_BRANCH="${OCTOPUS_SHARED_MARKETPLACE_BRANCH:-main}"
 WORKDIR=""
@@ -83,14 +89,14 @@ fi
 
 LOCAL_CODEX_MANIFEST="$ROOT_DIR/.codex-plugin/plugin.json"
 if [[ ! -f "$LOCAL_CODEX_MANIFEST" ]]; then
-    echo "ERROR: missing local Codex plugin manifest: $LOCAL_CODEX_MANIFEST" >&2
+    log ERROR "missing local Codex plugin manifest: $LOCAL_CODEX_MANIFEST"
     exit 1
 fi
 
 EXPECTED_CODEX_PLUGIN_NAME="claude-octopus"
 CODEX_PLUGIN_NAME="$(jq -r '.name // empty' "$LOCAL_CODEX_MANIFEST")"
 if [[ "$CODEX_PLUGIN_NAME" != "$EXPECTED_CODEX_PLUGIN_NAME" ]]; then
-    echo "ERROR: Codex plugin name must remain '$EXPECTED_CODEX_PLUGIN_NAME' for installed marketplace upgrades (found '$CODEX_PLUGIN_NAME')" >&2
+    log ERROR "Codex plugin name must remain '$EXPECTED_CODEX_PLUGIN_NAME' for installed marketplace upgrades (found '$CODEX_PLUGIN_NAME')"
     exit 1
 fi
 
@@ -155,14 +161,14 @@ fi
 
 SHARED_CODEX_MARKETPLACE="$WORKDIR/.agents/plugins/marketplace.json"
 if [[ ! -f "$SHARED_CODEX_MARKETPLACE" ]]; then
-    echo "ERROR: shared marketplace checkout is missing .agents/plugins/marketplace.json" >&2
+    log ERROR "shared marketplace checkout is missing .agents/plugins/marketplace.json"
     exit 1
 fi
 
 if ! jq -e --arg name "$CODEX_PLUGIN_NAME" \
     '.plugins | map(select(.name == $name)) | length == 1' \
     "$SHARED_CODEX_MARKETPLACE" >/dev/null; then
-    echo "ERROR: shared Codex marketplace must have exactly one '$CODEX_PLUGIN_NAME' plugin entry" >&2
+    log ERROR "shared Codex marketplace must have exactly one '$CODEX_PLUGIN_NAME' plugin entry"
     exit 1
 fi
 
@@ -170,11 +176,11 @@ SHARED_CODEX_SOURCE="$(jq -r --arg name "$CODEX_PLUGIN_NAME" \
     '.plugins[] | select(.name == $name) | .source.url // empty' \
     "$SHARED_CODEX_MARKETPLACE")"
 if [[ "$SHARED_CODEX_SOURCE" != "https://github.com/nyldn/claude-octopus.git" ]]; then
-    echo "ERROR: shared Codex marketplace '$CODEX_PLUGIN_NAME' source is invalid: ${SHARED_CODEX_SOURCE:-missing}" >&2
+    log ERROR "shared Codex marketplace '$CODEX_PLUGIN_NAME' source is invalid: ${SHARED_CODEX_SOURCE:-missing}"
     exit 1
 fi
 
-echo "OK: shared Codex marketplace selector is compatible ($CODEX_PLUGIN_NAME)"
+log INFO "OK: shared Codex marketplace selector is compatible ($CODEX_PLUGIN_NAME)"
 
 if ! jq -e '.plugins | map(select(.name == "octo")) | length == 1' "$SHARED_MARKETPLACE" >/dev/null; then
     echo "ERROR: shared marketplace must have exactly one octo plugin entry" >&2

--- a/scripts/test-codex-compat.sh
+++ b/scripts/test-codex-compat.sh
@@ -105,9 +105,9 @@ echo "--- 2. Manifest + Output Structure (skills/) ---"
 test_cmd "Codex manifest is valid JSON" \
     "jq empty '$PLUGIN_ROOT/.codex-plugin/plugin.json'"
 
-test_output "Codex manifest name matches marketplace selector" \
-    "printf '%s:%s\n' \"\$(jq -r '.name' '$PLUGIN_ROOT/.codex-plugin/plugin.json')\" \"\$(jq -r '.plugins[] | select(.name == \"octo\") | .name' '$PLUGIN_ROOT/.claude-plugin/marketplace.json')\"" \
-    "^octo:octo$"
+test_output "Codex manifest preserves the installed marketplace selector" \
+    "jq -r '.name' '$PLUGIN_ROOT/.codex-plugin/plugin.json'" \
+    "^claude-octopus$"
 
 test_output "Release validation reports a missing Codex manifest clearly" \
     "tmpdir=\$(mktemp -d); mkdir -p \"\$tmpdir/scripts\" \"\$tmpdir/.claude-plugin\"; cp '$SCRIPT_DIR/validate-release.sh' \"\$tmpdir/scripts/validate-release.sh\"; printf '%s\n' '{\"name\":\"octo\"}' > \"\$tmpdir/.claude-plugin/plugin.json\"; bash \"\$tmpdir/scripts/validate-release.sh\" 2>&1 || true; rm -rf \"\$tmpdir\"" \

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -12,6 +12,12 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+log() {
+    local level="$1"
+    shift
+    printf '[%s] %s\n' "$level" "$*" >&2
+}
+
 errors=0
 warnings=0
 
@@ -27,7 +33,7 @@ echo "🔒 Checking plugin names..."
 PLUGIN_NAME=$(grep '"name"' "$ROOT_DIR/.claude-plugin/plugin.json" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
 CODEX_PLUGIN_JSON="$ROOT_DIR/.codex-plugin/plugin.json"
 if [[ ! -f "$CODEX_PLUGIN_JSON" ]]; then
-    echo -e "  ${RED}CRITICAL ERROR: Codex plugin manifest not found at $CODEX_PLUGIN_JSON${NC}"
+    log ERROR "CRITICAL: Codex plugin manifest not found at $CODEX_PLUGIN_JSON"
     exit 1
 fi
 CODEX_PLUGIN_NAME=$(grep '"name"' "$CODEX_PLUGIN_JSON" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
@@ -51,11 +57,11 @@ else
 fi
 
 if [[ "$CODEX_PLUGIN_NAME" != "$EXPECTED_CODEX_PLUGIN_NAME" ]]; then
-    echo -e "  ${RED}CRITICAL ERROR: Codex plugin name '$CODEX_PLUGIN_NAME' - MUST remain '$EXPECTED_CODEX_PLUGIN_NAME'${NC}"
-    echo -e "  ${RED}Existing Codex installs and the Codex marketplace use '$EXPECTED_CODEX_PLUGIN_NAME'${NC}"
+    log ERROR "CRITICAL: Codex plugin name '$CODEX_PLUGIN_NAME' - MUST remain '$EXPECTED_CODEX_PLUGIN_NAME'"
+    log ERROR "Existing Codex installs and the Codex marketplace use '$EXPECTED_CODEX_PLUGIN_NAME'"
     ((errors++)) || true
 else
-    echo -e "  ${GREEN}✓ Codex plugin name: $CODEX_PLUGIN_NAME (stable Codex marketplace selector)${NC}"
+    log INFO "Codex plugin name: $CODEX_PLUGIN_NAME (stable Codex marketplace selector)"
 fi
 
 echo ""

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -31,6 +31,7 @@ if [[ ! -f "$CODEX_PLUGIN_JSON" ]]; then
     exit 1
 fi
 CODEX_PLUGIN_NAME=$(grep '"name"' "$CODEX_PLUGIN_JSON" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
+EXPECTED_CODEX_PLUGIN_NAME="claude-octopus"
 MARKETPLACE_PLUGIN_NAME=$(sed -n '/"plugins"/,/]/p' "$ROOT_DIR/.claude-plugin/marketplace.json" | grep '"name"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
 
 if [[ "$PLUGIN_NAME" != "octo" ]]; then
@@ -49,12 +50,12 @@ else
     echo -e "  ${GREEN}✓ marketplace.json plugin name: octo (matches plugin.json for /plugin UI)${NC}"
 fi
 
-if [[ "$CODEX_PLUGIN_NAME" != "$MARKETPLACE_PLUGIN_NAME" ]]; then
-    echo -e "  ${RED}CRITICAL ERROR: Codex plugin name '$CODEX_PLUGIN_NAME' does not match marketplace name '$MARKETPLACE_PLUGIN_NAME'${NC}"
-    echo -e "  ${RED}Codex rejects installation when these names differ${NC}"
+if [[ "$CODEX_PLUGIN_NAME" != "$EXPECTED_CODEX_PLUGIN_NAME" ]]; then
+    echo -e "  ${RED}CRITICAL ERROR: Codex plugin name '$CODEX_PLUGIN_NAME' - MUST remain '$EXPECTED_CODEX_PLUGIN_NAME'${NC}"
+    echo -e "  ${RED}Existing Codex installs and the Codex marketplace use '$EXPECTED_CODEX_PLUGIN_NAME'${NC}"
     ((errors++)) || true
 else
-    echo -e "  ${GREEN}✓ Codex plugin name: $CODEX_PLUGIN_NAME (matches marketplace selector)${NC}"
+    echo -e "  ${GREEN}✓ Codex plugin name: $CODEX_PLUGIN_NAME (stable Codex marketplace selector)${NC}"
 fi
 
 echo ""

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -299,6 +299,8 @@ test_shared_marketplace_sync_updates_only_octo() {
     local sync_output="$TMP_DIR/octo-shared-marketplace-sync.out"
     local check_output="$TMP_DIR/octo-shared-marketplace-check2.out"
     local drift_output="$TMP_DIR/octo-shared-marketplace-codex-drift.out"
+    local duplicate_output="$TMP_DIR/octo-shared-marketplace-codex-duplicate.out"
+    local source_output="$TMP_DIR/octo-shared-marketplace-codex-source.out"
     create_shared_marketplace_remote "$remote" "$seed"
 
     test_case "--check fails when shared octo entry is stale"
@@ -344,6 +346,32 @@ test_shared_marketplace_sync_updates_only_octo() {
         test_pass
     else
         test_fail "expected Codex selector mismatch diagnostic; output: $(cat "$drift_output" 2>/dev/null)"
+    fi
+
+    test_case "--check rejects duplicate Codex marketplace selectors"
+    git -C "$work" show HEAD:.agents/plugins/marketplace.json > "$work/.agents/plugins/marketplace.json"
+    jq '.plugins += [.plugins[] | select(.name == "claude-octopus")]' \
+        "$work/.agents/plugins/marketplace.json" > "$work/.agents/plugins/marketplace.json.tmp"
+    mv "$work/.agents/plugins/marketplace.json.tmp" "$work/.agents/plugins/marketplace.json"
+    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" --check >"$duplicate_output" 2>&1; then
+        test_fail "expected duplicate Codex selectors to fail compatibility validation"
+    elif grep -q "shared Codex marketplace must have exactly one 'claude-octopus' plugin entry" "$duplicate_output"; then
+        test_pass
+    else
+        test_fail "expected duplicate Codex selector diagnostic; output: $(cat "$duplicate_output" 2>/dev/null)"
+    fi
+
+    test_case "--check rejects an invalid Codex marketplace source URL"
+    git -C "$work" show HEAD:.agents/plugins/marketplace.json > "$work/.agents/plugins/marketplace.json"
+    jq '(.plugins[] | select(.name == "claude-octopus").source.url) = "https://example.com/not-octopus.git"' \
+        "$work/.agents/plugins/marketplace.json" > "$work/.agents/plugins/marketplace.json.tmp"
+    mv "$work/.agents/plugins/marketplace.json.tmp" "$work/.agents/plugins/marketplace.json"
+    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" --check >"$source_output" 2>&1; then
+        test_fail "expected invalid Codex source URL to fail compatibility validation"
+    elif grep -q "shared Codex marketplace 'claude-octopus' source is invalid: https://example.com/not-octopus.git" "$source_output"; then
+        test_pass
+    else
+        test_fail "expected invalid Codex source diagnostic; output: $(cat "$source_output" 2>/dev/null)"
     fi
 }
 

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -243,7 +243,7 @@ MD
 
     # shellcheck disable=SC1090
     source "$CHANGELOG_LIB"
-    octo_release_update_changelog "$changelog" "9.42.0" "2026-06-02" "Release summary" >/tmp/octo-release-changelog.out
+    octo_release_update_changelog "$changelog" "9.42.0" "2026-06-02" "Release summary" >"$TMP_DIR/octo-release-changelog.out"
 
     unreleased_block="$(awk '/^## \[Unreleased\]/{flag=1; next} /^## \[9\.42\.0\]/{flag=0} flag {print}' "$changelog")"
     version_block="$(awk '/^## \[9\.42\.0\]/{flag=1; next} /^## \[9\.41\.2\]/{flag=0} flag {print}' "$changelog")"
@@ -295,17 +295,21 @@ test_shared_marketplace_sync_updates_only_octo() {
     local remote="$TMP_DIR/plugins.git"
     local seed="$TMP_DIR/seed"
     local work="$TMP_DIR/work"
+    local stale_output="$TMP_DIR/octo-shared-marketplace-check.out"
+    local sync_output="$TMP_DIR/octo-shared-marketplace-sync.out"
+    local check_output="$TMP_DIR/octo-shared-marketplace-check2.out"
+    local drift_output="$TMP_DIR/octo-shared-marketplace-codex-drift.out"
     create_shared_marketplace_remote "$remote" "$seed"
 
     test_case "--check fails when shared octo entry is stale"
-    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" --check >/tmp/octo-shared-marketplace-check.out 2>&1; then
+    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" --check >"$stale_output" 2>&1; then
         test_fail "expected stale shared marketplace check to fail"
     else
         test_pass
     fi
 
     test_case "sync updates octo entry and pushes it to the shared marketplace"
-    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" >/tmp/octo-shared-marketplace-sync.out 2>&1; then
+    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" >"$sync_output" 2>&1; then
         local expected_version expected_desc got_version got_desc img_version metadata_version
         expected_version="$(local_octo_version)"
         expected_desc="$(local_octo_description)"
@@ -319,27 +323,27 @@ test_shared_marketplace_sync_updates_only_octo() {
             test_fail "expected octo=$expected_version and img=0.1.18/metadata=1.0.0, got octo=$got_version img=$img_version metadata=$metadata_version"
         fi
     else
-        test_fail "sync command failed; output: $(cat /tmp/octo-shared-marketplace-sync.out 2>/dev/null)"
+        test_fail "sync command failed; output: $(cat "$sync_output" 2>/dev/null)"
     fi
 
     test_case "--check passes after sync"
-    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" --check >/tmp/octo-shared-marketplace-check2.out 2>&1 &&
-       grep -q 'shared Codex marketplace selector is compatible (claude-octopus)' /tmp/octo-shared-marketplace-check2.out; then
+    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" --check >"$check_output" 2>&1 &&
+       grep -q 'shared Codex marketplace selector is compatible (claude-octopus)' "$check_output"; then
         test_pass
     else
-        test_fail "expected synced Claude entry and stable Codex selector to pass; output: $(cat /tmp/octo-shared-marketplace-check2.out 2>/dev/null)"
+        test_fail "expected synced Claude entry and stable Codex selector to pass; output: $(cat "$check_output" 2>/dev/null)"
     fi
 
     test_case "--check rejects a renamed Codex marketplace selector"
     jq '(.plugins[] | select(.name == "claude-octopus")).name = "octo"' \
         "$work/.agents/plugins/marketplace.json" > "$work/.agents/plugins/marketplace.json.tmp"
     mv "$work/.agents/plugins/marketplace.json.tmp" "$work/.agents/plugins/marketplace.json"
-    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" --check >/tmp/octo-shared-marketplace-codex-drift.out 2>&1; then
+    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" --check >"$drift_output" 2>&1; then
         test_fail "expected renamed Codex selector to fail compatibility validation"
-    elif grep -q "shared Codex marketplace must have exactly one 'claude-octopus' plugin entry" /tmp/octo-shared-marketplace-codex-drift.out; then
+    elif grep -q "shared Codex marketplace must have exactly one 'claude-octopus' plugin entry" "$drift_output"; then
         test_pass
     else
-        test_fail "expected Codex selector mismatch diagnostic; output: $(cat /tmp/octo-shared-marketplace-codex-drift.out 2>/dev/null)"
+        test_fail "expected Codex selector mismatch diagnostic; output: $(cat "$drift_output" 2>/dev/null)"
     fi
 }
 

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -43,7 +43,7 @@ create_shared_marketplace_remote() {
     git -C "$seed" config user.name "Octopus Test"
     git -C "$seed" config user.email "octopus-test@example.com"
 
-    mkdir -p "$seed/.claude-plugin"
+    mkdir -p "$seed/.claude-plugin" "$seed/.agents/plugins"
     cat > "$seed/.claude-plugin/marketplace.json" <<'JSON'
 {
   "name": "nyldn-plugins",
@@ -100,7 +100,27 @@ create_shared_marketplace_remote() {
 }
 JSON
 
-    git -C "$seed" add .claude-plugin/marketplace.json
+    cat > "$seed/.agents/plugins/marketplace.json" <<'JSON'
+{
+  "name": "nyldn-plugins",
+  "plugins": [
+    {
+      "name": "claude-octopus",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/nyldn/claude-octopus.git"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Orchestration"
+    }
+  ]
+}
+JSON
+
+    git -C "$seed" add .claude-plugin/marketplace.json .agents/plugins/marketplace.json
     git -C "$seed" commit -q -m "seed shared marketplace"
     git -C "$seed" remote add origin "$remote"
     git -C "$seed" push -q origin main
@@ -303,10 +323,23 @@ test_shared_marketplace_sync_updates_only_octo() {
     fi
 
     test_case "--check passes after sync"
-    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" --check >/tmp/octo-shared-marketplace-check2.out 2>&1; then
+    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" --check >/tmp/octo-shared-marketplace-check2.out 2>&1 &&
+       grep -q 'shared Codex marketplace selector is compatible (claude-octopus)' /tmp/octo-shared-marketplace-check2.out; then
         test_pass
     else
-        test_fail "expected synced shared marketplace check to pass; output: $(cat /tmp/octo-shared-marketplace-check2.out 2>/dev/null)"
+        test_fail "expected synced Claude entry and stable Codex selector to pass; output: $(cat /tmp/octo-shared-marketplace-check2.out 2>/dev/null)"
+    fi
+
+    test_case "--check rejects a renamed Codex marketplace selector"
+    jq '(.plugins[] | select(.name == "claude-octopus")).name = "octo"' \
+        "$work/.agents/plugins/marketplace.json" > "$work/.agents/plugins/marketplace.json.tmp"
+    mv "$work/.agents/plugins/marketplace.json.tmp" "$work/.agents/plugins/marketplace.json"
+    if "$SYNC_SCRIPT" --repo "$remote" --workdir "$work" --check >/tmp/octo-shared-marketplace-codex-drift.out 2>&1; then
+        test_fail "expected renamed Codex selector to fail compatibility validation"
+    elif grep -q "shared Codex marketplace must have exactly one 'claude-octopus' plugin entry" /tmp/octo-shared-marketplace-codex-drift.out; then
+        test_pass
+    else
+        test_fail "expected Codex selector mismatch diagnostic; output: $(cat /tmp/octo-shared-marketplace-codex-drift.out 2>/dev/null)"
     fi
 }
 

--- a/tests/unit/test-skill-doctor-stable-link.sh
+++ b/tests/unit/test-skill-doctor-stable-link.sh
@@ -26,6 +26,7 @@ extract_first_bash_block() {
 assert_resolver_preserves_stable_link() {
     local label="$1"
     local skill_file="$2"
+    local host="$3"
     local work="$TEST_TMP_DIR/${label// /-}"
     local fake_home="$work/home"
     local plugin_root="$work/cache/9.61.2"
@@ -49,11 +50,20 @@ assert_resolver_preserves_stable_link() {
         return
     fi
 
-    env \
-        HOME="$fake_home" \
-        CLAUDE_PLUGIN_ROOT="$stable_link" \
-        DOCTOR_CALL_LOG="$call_log" \
-        bash "$resolver"
+    if [[ "$host" == "claude" ]]; then
+        env \
+            "HOME=$fake_home" \
+            "CLAUDE_PLUGIN_ROOT=$stable_link" \
+            "DOCTOR_CALL_LOG=$call_log" \
+            bash "$resolver"
+    else
+        # Codex does not provide CLAUDE_PLUGIN_ROOT. Exercise the packaged
+        # resolver's stable-link discovery instead of its Claude host shortcut.
+        env -u CLAUDE_PLUGIN_ROOT \
+            "HOME=$fake_home" \
+            "DOCTOR_CALL_LOG=$call_log" \
+            bash "$resolver"
+    fi
 
     if [[ ! -L "$stable_link" ]]; then
         test_fail "$label resolver replaced the stable symlink"
@@ -80,10 +90,12 @@ test_codex_package_is_generated_from_guarded_source() {
 
 assert_resolver_preserves_stable_link \
     "Claude skill" \
-    "$PROJECT_ROOT/.claude/skills/skill-doctor/SKILL.md"
+    "$PROJECT_ROOT/.claude/skills/skill-doctor/SKILL.md" \
+    "claude"
 assert_resolver_preserves_stable_link \
     "Codex skill" \
-    "$PROJECT_ROOT/skills/skill-doctor/SKILL.md"
+    "$PROJECT_ROOT/skills/skill-doctor/SKILL.md" \
+    "codex"
 test_codex_package_is_generated_from_guarded_source
 
 test_summary

--- a/tests/unit/test-skill-doctor-stable-link.sh
+++ b/tests/unit/test-skill-doctor-stable-link.sh
@@ -51,7 +51,7 @@ assert_resolver_preserves_stable_link() {
     fi
 
     if [[ "$host" == "claude" ]]; then
-        env \
+        env -u OCTO_PLUGIN_ROOT \
             "HOME=$fake_home" \
             "CLAUDE_PLUGIN_ROOT=$stable_link" \
             "DOCTOR_CALL_LOG=$call_log" \
@@ -61,6 +61,7 @@ assert_resolver_preserves_stable_link() {
         # resolver's stable-link discovery instead of its Claude host shortcut.
         env -u CLAUDE_PLUGIN_ROOT \
             "HOME=$fake_home" \
+            "OCTO_PLUGIN_ROOT=$stable_link" \
             "DOCTOR_CALL_LOG=$call_log" \
             bash "$resolver"
     fi

--- a/tests/unit/test-skill-doctor-stable-link.sh
+++ b/tests/unit/test-skill-doctor-stable-link.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Regression coverage for the skill-doctor stable-link resolver shipped to
+# Claude Code and Codex. See #481 and #818.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck disable=SC1090
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Skill Doctor Stable-Link Resolver (#818)"
+
+extract_first_bash_block() {
+    local skill_file="$1"
+    local output_file="$2"
+
+    awk '
+        /^```bash$/ && !found { found = 1; capture = 1; next }
+        capture && /^```$/ { exit }
+        capture { print }
+    ' "$skill_file" > "$output_file"
+}
+
+assert_resolver_preserves_stable_link() {
+    local label="$1"
+    local skill_file="$2"
+    local work="$TEST_TMP_DIR/${label// /-}"
+    local fake_home="$work/home"
+    local plugin_root="$work/cache/9.61.2"
+    local stable_link="$fake_home/.claude-octopus/plugin"
+    local resolver="$work/resolver.sh"
+    local call_log="$work/doctor-call.log"
+
+    test_case "$label preserves an existing stable symlink without creating a loop"
+
+    mkdir -p "$plugin_root/scripts" "$fake_home/.claude-octopus"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'printf "%s\\n" "$*" > "$DOCTOR_CALL_LOG"' \
+        > "$plugin_root/scripts/orchestrate.sh"
+    chmod +x "$plugin_root/scripts/orchestrate.sh"
+    ln -s "$plugin_root" "$stable_link"
+
+    extract_first_bash_block "$skill_file" "$resolver"
+    if ! grep -q 'pwd -P' "$resolver"; then
+        test_fail "$label package is missing the physical-path guard"
+        return
+    fi
+
+    env \
+        HOME="$fake_home" \
+        CLAUDE_PLUGIN_ROOT="$stable_link" \
+        DOCTOR_CALL_LOG="$call_log" \
+        bash "$resolver"
+
+    if [[ ! -L "$stable_link" ]]; then
+        test_fail "$label resolver replaced the stable symlink"
+    elif [[ "$(readlink "$stable_link")" != "$plugin_root" ]]; then
+        test_fail "$label resolver rewrote the stable link to $(readlink "$stable_link")"
+    elif [[ "$(cat "$call_log" 2>/dev/null || true)" != "doctor" ]]; then
+        test_fail "$label resolver did not invoke doctor through the stable link"
+    elif ! test -x "$stable_link/scripts/orchestrate.sh"; then
+        test_fail "$label stable link no longer resolves to the plugin"
+    else
+        test_pass
+    fi
+}
+
+test_codex_package_is_generated_from_guarded_source() {
+    test_case "Codex skill package is synchronized with the guarded Claude source"
+
+    if "$PROJECT_ROOT/scripts/build-codex-skills.sh" --check >/dev/null; then
+        test_pass
+    else
+        test_fail "skills/ is stale; regenerate it before publishing the Codex package"
+    fi
+}
+
+assert_resolver_preserves_stable_link \
+    "Claude skill" \
+    "$PROJECT_ROOT/.claude/skills/skill-doctor/SKILL.md"
+assert_resolver_preserves_stable_link \
+    "Codex skill" \
+    "$PROJECT_ROOT/skills/skill-doctor/SKILL.md"
+test_codex_package_is_generated_from_guarded_source
+
+test_summary

--- a/tests/validate-plugin-name.sh
+++ b/tests/validate-plugin-name.sh
@@ -51,6 +51,7 @@ fi
 
 CODEX_PLUGIN_NAME=$(grep '"name"' "$CODEX_PLUGIN_JSON" | head -1 | sed 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
 
+test_case "Codex plugin name preserves marketplace selector"
 if [[ "$CODEX_PLUGIN_NAME" != "$EXPECTED_CODEX_NAME" ]]; then
     echo -e "${RED}❌ CRITICAL ERROR: Codex plugin name is incorrect!${NC}"
     echo ""
@@ -60,7 +61,9 @@ if [[ "$CODEX_PLUGIN_NAME" != "$EXPECTED_CODEX_NAME" ]]; then
     echo "The Codex manifest name MUST preserve the installed marketplace selector."
     echo "Otherwise, 'codex plugin add claude-octopus@nyldn-plugins' rejects the plugin."
     echo ""
-    exit 1
+    test_fail "Codex plugin name must be '$EXPECTED_CODEX_NAME', found '$CODEX_PLUGIN_NAME'"
+else
+    test_pass
 fi
 
 # Also validate that package.json has correct name
@@ -75,6 +78,6 @@ if [[ -f "$PACKAGE_JSON" ]]; then
 fi
 
 echo -e "${GREEN}✅ Plugin name is correct: \"$PLUGIN_NAME\"${NC}"
-echo -e "${GREEN}✅ Codex plugin name is correct: \"$CODEX_PLUGIN_NAME\"${NC}"
+[[ "$CODEX_PLUGIN_NAME" == "$EXPECTED_CODEX_NAME" ]] && echo -e "${GREEN}✅ Codex plugin name is correct: \"$CODEX_PLUGIN_NAME\"${NC}"
 echo "   Commands will work as: /octo:discover, /octo:debate, etc."
 test_summary

--- a/tests/validate-plugin-name.sh
+++ b/tests/validate-plugin-name.sh
@@ -27,6 +27,7 @@ PLUGIN_NAME=$(grep '"name"' "$PLUGIN_JSON" | head -1 | sed 's/.*"name"[[:space:]
 
 # Expected plugin name
 EXPECTED_NAME="octo"
+EXPECTED_CODEX_NAME="claude-octopus"
 
 # Validate
 if [[ "$PLUGIN_NAME" != "$EXPECTED_NAME" ]]; then
@@ -50,14 +51,14 @@ fi
 
 CODEX_PLUGIN_NAME=$(grep '"name"' "$CODEX_PLUGIN_JSON" | head -1 | sed 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
 
-if [[ "$CODEX_PLUGIN_NAME" != "$EXPECTED_NAME" ]]; then
+if [[ "$CODEX_PLUGIN_NAME" != "$EXPECTED_CODEX_NAME" ]]; then
     echo -e "${RED}❌ CRITICAL ERROR: Codex plugin name is incorrect!${NC}"
     echo ""
     echo -e "  Current:  ${YELLOW}\"$CODEX_PLUGIN_NAME\"${NC}"
-    echo -e "  Expected: ${GREEN}\"$EXPECTED_NAME\"${NC}"
+    echo -e "  Expected: ${GREEN}\"$EXPECTED_CODEX_NAME\"${NC}"
     echo ""
-    echo "The Codex manifest name MUST match the marketplace selector."
-    echo "Otherwise, 'codex plugin add octo@nyldn-plugins' rejects the plugin."
+    echo "The Codex manifest name MUST preserve the installed marketplace selector."
+    echo "Otherwise, 'codex plugin add claude-octopus@nyldn-plugins' rejects the plugin."
     echo ""
     exit 1
 fi


### PR DESCRIPTION
## Summary

- restore the stable Codex plugin identity `claude-octopus`
- validate that identity against the actual Codex marketplace manifest during release sync
- document host-managed Codex install and refresh commands
- keep the separate Claude Code marketplace selector `octo` unchanged

## Root cause

The Codex marketplace entry is named `claude-octopus`, but `.codex-plugin/plugin.json` was renamed to `octo` in #570 after it was compared with the Claude Code marketplace manifest instead of the Codex `.agents/plugins/marketplace.json` manifest. Codex rejects the mismatch before installation:

```text
codex plugin add claude-octopus@nyldn-plugins --json
Error: plugin.json name `octo` does not match marketplace plugin name `claude-octopus`
```

That makes marketplace refreshes unable to replace old cached packages and strands users on versions such as 9.44.0, including the stale doctor implementation behind #818.

## Verification

- TDD regression: shared marketplace test failed before the production change and now passes 14/14
- `make sync-check`
- `tests/validate-plugin-name.sh`
- shell syntax and `git diff --check`
- isolated `make ci-local`: all smoke, unit, and 7/7 integration suites passed

Fixes #818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the Codex plugin marketplace identity to `claude-octopus`, separate from the Claude Code `octo` selector.
  * Improved release validation for missing, duplicate, or mismatched marketplace entries.
  * Ensured marketplace synchronization preserves the correct Codex plugin selector and source.
  * Fixed Skill Doctor stable-link handling so links remain intact and resolve to the expected plugin.

* **Documentation**
  * Updated Codex installation instructions with marketplace-based setup, upgrade, and re-add commands.
  * Documented the marketplace identity correction in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->