### PR TITLE
release: v9.61.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.61.1"
+    "version": "9.61.2"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.61.1 - Provider routing, workflow contracts, and generated-skill reliability fixes. 32 personas, 51 commands, 63 skills. Run /octo:setup.",
-      "version": "9.61.1",
+      "description": "v9.61.2 - Honor OCTOPUS_OLLAMA_MODEL, OCTOPUS_COPILOT_MODEL, and OCTOPUS_VIBE_MODEL pins. 32 personas, 51 commands, 63 skills. Run /octo:setup.",
+      "version": "9.61.2",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": "2026-06",
   "name": "octo",
   "displayName": "Claude Octopus",
-  "version": "9.61.1",
+  "version": "9.61.2",
   "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
   "author": {
     "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.61.1",
-  "description": "v9.61.1 \u2014 Provider routing, workflow contracts, and generated-skill reliability fixes. Run /octo:setup.",
+  "version": "9.61.2",
+  "description": "v9.61.2 \u2014 Honor OCTOPUS_OLLAMA_MODEL, OCTOPUS_COPILOT_MODEL, and OCTOPUS_VIBE_MODEL pins. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Claude Octopus routine manifest (v9.61.1). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "$comment": "Claude Octopus routine manifest (v9.61.2). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
   "schemaVersion": 1,
   "routines": [
     {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.61.1",
+  "version": "9.61.2",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.61.1",
+  "version": "9.61.2",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.61.1"
+    "version": "9.61.2"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.61.1 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 51 commands, 63 skills. Run /octo:setup after install.",
-      "version": "9.61.1",
+      "description": "v9.61.2 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 51 commands, 63 skills. Run /octo:setup after install.",
+      "version": "9.61.2",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.61.1",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.61.1. 32 expert personas, 51 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.61.2",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.61.2. 32 expert personas, 51 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [9.61.2] - 2026-08-09
+
+### Changed
+
+- Honor OCTOPUS_OLLAMA_MODEL, OCTOPUS_COPILOT_MODEL, and OCTOPUS_VIBE_MODEL pins
+
 ## [9.61.1] - 2026-08-09
 
 ### Changed

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -78,7 +78,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 - GitHub stars: 3,889
 - GitHub forks: 365
 - Local CI parity: `make ci-local` runs the same smoke, unit, and integration suites as CI
-- Version: 9.61.1 (active release cadence)
+- Version: 9.61.2 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Gemini CLI
 
 **Measured Impact:**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 <p align="center">
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/Version-9.61.1-blue" alt="Version 9.61.1">
+  <img src="https://img.shields.io/badge/Version-9.61.2-blue" alt="Version 9.61.2">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -35,7 +35,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 ## What's New
 
 <!-- BEGIN CURRENT RELEASE -->
-> 🆕 **v9.61.1 — Provider routing, workflow contracts, and generated-skill reliability fixes.**
+> 🆕 **v9.61.2 — Honor OCTOPUS_OLLAMA_MODEL, OCTOPUS_COPILOT_MODEL, and OCTOPUS_VIBE_MODEL pins.**
 >
 > **Default roster:** Claude Opus 5 leads architecture, planning, security reasoning, and final judgment; GPT-5.6 Sol is the independent implementation/review peer; Claude Sonnet 5 is the standard Claude seat; Fable 5 remains an opt-in judgment escalation. Existing model pins and provider configuration still win. See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md).
 <!-- END CURRENT RELEASE -->
@@ -55,7 +55,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 
 | Version | Best Features |
 |---------|--------------|
-| **v9.61.1** (new) | Provider routing, workflow contracts, and generated-skill reliability fixes. |
+| **v9.61.2** (new) | Honor OCTOPUS_OLLAMA_MODEL, OCTOPUS_COPILOT_MODEL, and OCTOPUS_VIBE_MODEL pins. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
 | **v9** | Up to 10 external provider integrations (Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.61.1",
+  "version": "9.61.2",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Description
Patch release for #816 (merged): `get_agent_model()` now maps `ollama*`/`copilot*`/`vibe*` agent types to their providers, so `OCTOPUS_OLLAMA_MODEL`, `OCTOPUS_COPILOT_MODEL`, and `OCTOPUS_VIBE_MODEL` are honored instead of silently ignored.

Version bumped per `RELEASING.md` step 2 (every location in the table), derived artifacts regenerated via `make sync` per step 3 (README/PRODUCT.md release facts, marketplace.json counts, openclaw registry), and `Unreleased` folded into a new `## [9.61.2]` CHANGELOG entry.

Not using `scripts/release.sh` for this PR: it shells out to the `gh` CLI (unavailable in this environment — GitHub access here goes through the GitHub MCP server instead) and its default branch name (`release/vX.Y.Z`) doesn't match this session's `claude/`-prefixed branch policy. I replicated its version-bump logic (the same Python blocks, byte-for-byte) by hand instead, then ran `make sync` exactly as the script does.

## Type of Change
- [x] Other (describe): release / version bump

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (32/32)
- [x] OpenClaw registry in sync (`./scripts/build-openclaw.sh --check` via `make sync-check`)
- [x] New skills/commands registered — n/a, no new components in this release
- [x] Version bump: package.json + plugin/marketplace manifests + public adapter manifests + README.md + CHANGELOG.md — all per the RELEASING.md table
- [x] Documentation updated — README/PRODUCT.md regenerated via `make sync`
- [x] CHANGELOG.md updated

## Testing
```bash
jq empty package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json \
  .claude-plugin/plugin-manifest.json .claude-plugin/routines.json \
  .codex-plugin/plugin.json .cursor-plugin/plugin.json \
  .factory-plugin/plugin.json .factory-plugin/marketplace.json   # all valid
bash -n scripts/*.sh scripts/lib/*.sh scripts/helpers/*.sh         # clean
make sync-check                                                    # README/marketplace/openclaw sync: pass*
bash tests/unit/test-docs-sync.sh                                  # 141/141
bash tests/unit/test-readme-release-sync.sh                        # 8/8
bash tests/unit/test-openclaw-compat.sh                            # 32/32
make test-smoke                                                    # 16/16 suites
make test-unit                                                     # 243-245/245 suites (see note)
```

\* `make sync-check`'s `build-codex-skills.sh --check` step reports drift in 5 `skills/*/agents/openai.yaml` files (truncation-boundary text differences). Confirmed this reproduces identically on a **pristine `origin/main` clone** in this sandbox — it's a pre-existing, environment-specific generator quirk (unrelated to this release), not something this PR introduces. Did not include those 5 files in this commit.

**Note on `make test-unit`:** 2-3 suites (`test-execution-profile-dispatch.sh`, `test-feature-disclosure.sh`, `test-hud-smart-mode.sh`) failed intermittently across runs in this local sandbox. Root-caused to a real ambient `/root/.claude-octopus/config/providers.json` with test-incompatible content, picked up by tests that don't sandbox `$HOME` — confirmed by reproducing the identical failures on a **pristine `origin/main` clone** in the same sandbox, with no version-bump changes applied at all. Pre-existing local-environment contamination, not a regression from this release. Deferring to this PR's actual CI run (clean container) as the authoritative signal.

Did not run `make test-integration` locally (5-10 min, and — per the above — this sandbox's `/root/.claude-octopus` state is known-contaminated for provider/HUD-adjacent suites) — relying on this PR's CI run for that signal instead.

## Related Issues
Releases #816.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EBRCN9muLZF4J7AC6azxX7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for honoring pinned models configured for Ollama, Copilot, and Vibe providers.

* **Documentation**
  * Updated release documentation and changelog with model-pin support details.
  * Updated displayed product and plugin version to 9.61.2.

* **Release**
  * Published version 9.61.2 across supported package and plugin metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->