### PR TITLE
release: v9.61.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.61.1"
+    "version": "9.61.2"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.61.1 - Provider routing, workflow contracts, and generated-skill reliability fixes. 32 personas, 51 commands, 63 skills. Run /octo:setup.",
-      "version": "9.61.1",
+      "description": "v9.61.2 - Ollama, Copilot, and Vibe now honor model pins and allowlists. 32 personas, 51 commands, 63 skills. Run /octo:setup.",
+      "version": "9.61.2",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": "2026-06",
   "name": "octo",
   "displayName": "Claude Octopus",
-  "version": "9.61.1",
+  "version": "9.61.2",
   "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
   "author": {
     "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.61.1",
-  "description": "v9.61.1 \u2014 Provider routing, workflow contracts, and generated-skill reliability fixes. Run /octo:setup.",
+  "version": "9.61.2",
+  "description": "v9.61.2 \u2014 Ollama, Copilot, and Vibe now honor model pins and allowlists. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Claude Octopus routine manifest (v9.61.1). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "$comment": "Claude Octopus routine manifest (v9.61.2). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
   "schemaVersion": 1,
   "routines": [
     {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "octo",
-  "version": "9.61.1",
+  "version": "9.61.2",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Gemini, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.61.1",
+  "version": "9.61.2",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.61.1"
+    "version": "9.61.2"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.61.1 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 51 commands, 63 skills. Run /octo:setup after install.",
-      "version": "9.61.1",
+      "description": "v9.61.2 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 51 commands, 63 skills. Run /octo:setup after install.",
+      "version": "9.61.2",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.61.1",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.61.1. 32 expert personas, 51 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.61.2",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.61.2. 32 expert personas, 51 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,9 +251,10 @@ jobs:
   unit:
     name: Unit Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    # The macOS matrix currently completes the full suite in just over 10 minutes.
-    # Leave enough headroom for teardown and artifact upload on slower runners.
-    timeout-minutes: 15
+    # The macOS matrix crossed the old 15-minute ceiling as the suite grew to
+    # 248 files (run 31411222295). Keep enough headroom for slower runners,
+    # teardown, and artifact upload instead of canceling an otherwise-green run.
+    timeout-minutes: 25
     needs: [classify-changes, smoke, portability-lint]
     if: needs.classify-changes.outputs.heavy_tests == 'true'
     strategy:

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -121,6 +121,10 @@ claimed or recorded in `bd`; use this handoff for the blocked tracking record.
   while a later PASS clears marker and expiry state immediately. The final
   minimal-strategy regression includes a real fake agy executable and is
   mutation-proven. Issue #840 closed.
+- **#846 filed and fixed in the release candidate** — the 248-suite macOS unit
+  job exhausted the old 15-minute GitHub Actions ceiling while its individual
+  tests were still passing. The unit matrix now has a 25-minute budget, guarded
+  by a workflow-contract regression.
 - **#836** — the update guide explains that Claude Code owns plugin updates,
   third-party marketplace auto-update is off by default, and users can enable
   it under `/plugin` -> Marketplaces -> `nyldn-plugins`; Codex retains its host

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,12 +1,14 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-10
-Status: v9.61.2 is the active release, with permanent hook-timeout cleanup,
-careful-mode false-positive fixes, Codex marketplace update recovery, and
-provider availability/health hardening. The Gemini macOS keychain modal remains
-tracked as future issue #838; cancellation cleanup remains #841.
+Status: v9.61.2 is the release candidate in PR #823, with permanent
+hook-timeout cleanup, careful-mode false-positive fixes, Codex marketplace
+update recovery, and provider availability/health hardening. Publication is
+pending the exact-main CI, tag, GitHub Release, and marketplace verification.
+The Gemini macOS keychain modal remains future issue #838; cancellation cleanup
+remains #841.
 Branch: `main`
-Release: [v9.61.2](https://github.com/nyldn/claude-octopus/releases/tag/v9.61.2)
+Candidate: [PR #823](https://github.com/nyldn/claude-octopus/pull/823)
 
 ## Start Here
 
@@ -65,7 +67,7 @@ v49 with four pending migrations to v53. Repository rules reserve migration for
 the designated migrator. No migration was run, so this work could not be
 claimed or recorded in `bd`; use this handoff for the blocked tracking record.
 
-## Release v9.61.2
+## Release Candidate v9.61.2
 
 - Release vehicle: [PR #823](https://github.com/nyldn/claude-octopus/pull/823)
   on `release/v9.61.2`, refreshed through main commit `52db2f8e` (PR #843).
@@ -83,7 +85,7 @@ claimed or recorded in `bd`; use this handoff for the blocked tracking record.
   the GitHub Release, sync `nyldn/plugins`, and verify real Claude and Codex
   upgrades from the installed v9.61.1 baseline.
 
-## Delivered in v9.61.2 Cycle
+## Included in v9.61.2 Candidate
 
 - **#816 / #819 merged (`53629216`, `3d3f972f`)** — Ollama, Copilot, and
   Vibe model pins and allowlists now reach dispatch instead of falling through
@@ -141,7 +143,7 @@ Verification completed before the release candidate:
 - PR #833 final local `make ci-local`: 16 smoke, 247 unit, and 7 integration
   suites passed; Linux, macOS, symlink, and integration checks also passed
   remotely.
-- Lifecycle focused suites: 10/10 and provider auth timeout 18/18.
+- Lifecycle-focused suites: 10/10 and provider auth timeout 18/18.
 - Careful-hook safety suite: 26/26 plus direct real-hook probes for quiet and
   destructive cases.
 - Provider predicates: 13/13; Vibe 5/5; feature detection 20/20;

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,11 +1,12 @@
 # AI Agent Handoff
 
-Last updated: 2026-08-09
-Status: v9.61.1 is published with the completed model-routing,
-generator-safety, flow-define, and #804 skill-tree work. Issues #799-#801 and
-streamlining Parts 4b/4c/4d remain unstarted.
+Last updated: 2026-08-10
+Status: v9.61.2 is the active release, with permanent hook-timeout cleanup,
+careful-mode false-positive fixes, Codex marketplace update recovery, and
+provider availability/health hardening. The Gemini macOS keychain modal remains
+tracked as future issue #838; cancellation cleanup remains #841.
 Branch: `main`
-Release: [v9.61.1](https://github.com/nyldn/claude-octopus/releases/tag/v9.61.1)
+Release: [v9.61.2](https://github.com/nyldn/claude-octopus/releases/tag/v9.61.2)
 
 ## Start Here
 
@@ -64,7 +65,89 @@ v49 with four pending migrations to v53. Repository rules reserve migration for
 the designated migrator. No migration was run, so this work could not be
 claimed or recorded in `bd`; use this handoff for the blocked tracking record.
 
-## Delivered in This Cycle
+## Release v9.61.2
+
+- Release vehicle: [PR #823](https://github.com/nyldn/claude-octopus/pull/823)
+  on `release/v9.61.2`, refreshed through main commit `52db2f8e` (PR #843).
+- Exact combined-candidate `OCTOPUS_NON_INTERACTIVE=1 make ci-local` result:
+  16 smoke suites, 248 unit suites, and 7 integration suites passed.
+- `make sync`, `make sync-check`, `./scripts/validate-release.sh 9.61.2`,
+  `bash tests/unit/test-handoff.sh`, `git diff --check`, and the executable-mode
+  check passed. Release validation reported only the two expected pre-release
+  warnings: the tag and GitHub Release do not exist until PR #823 is merged.
+- PR #843's current-head remote matrix passed on Ubuntu, macOS, the symlinked
+  install path, and integration tests; CodeRabbit approved it with zero
+  unresolved threads.
+- Publication must follow `RELEASING.md`: squash-merge PR #823, wait for the
+  exact main commit's Test Suite, tag that squash commit as `v9.61.2`, create
+  the GitHub Release, sync `nyldn/plugins`, and verify real Claude and Codex
+  upgrades from the installed v9.61.1 baseline.
+
+## Delivered in v9.61.2 Cycle
+
+- **#816 / #819 merged (`53629216`, `3d3f972f`)** — Ollama, Copilot, and
+  Vibe model pins and allowlists now reach dispatch instead of falling through
+  to defaults or the unknown-provider allow arm. Issues #817 and #819 closed.
+- **#820 merged (`104400d6`)** — restored the stable
+  `claude-octopus@nyldn-plugins` Codex marketplace identity, added shared
+  marketplace validation, and verified the real Claude/Codex symlink resolver.
+  Issues #818 and #820 closed.
+- **#824 merged (`3c4830aa`)** — skill-template tests now generate in an
+  isolated copy instead of mutating the checkout. Issues #822 and #824 closed.
+- **#826 merged (`5233de11`)** — council approval gates deny when automation
+  lacks a controlling TTY even if inherited terminal signals are present.
+  Issues #825 and #826 closed.
+- **#828 merged (`8d879c24`)** — lifecycle timeout cleanup owns and reaps the
+  hook process group without a `pkill` dependency. Issues #827 and #828 closed.
+- **#830 merged (`e3e2f87c`)** — the release validator recognizes nested
+  `SKILL.md` directories. Issues #829 and #830 closed.
+- **#833 merged (`cf4ec6fd`)** — provider timeout evidence and every lifecycle
+  duration assertion use true monotonic time; the production no-`timeout`
+  fallback uses a reaped `sleep` watchdog instead of wall-clock-backed Bash
+  `SECONDS`. Issues #832 and #837 closed.
+- **#845 merged (`6cca4d3b`)** — the watchdog contract now requires creation,
+  kill, and wait cleanup. Mutation testing proved deleting cleanup fails the
+  case. Issue #844 closed.
+- **#831 merged (`91f765be`)** — careful-mode SQL, `rm`, and whole-tree Git
+  guards are scoped to executable context and token boundaries. Source-search,
+  quoted-documentation, incomplete-SQL, dotfile, and subpath false positives
+  stay quiet while actual destructive commands still fire. Issue #835 closed.
+- **#842 merged (`e1be285b`)** — unknown agents fail closed without disabling
+  supported Grok, Command Code, Atlas Cloud, or Vibe seats. Vibe credential
+  parsing rejects blank/whitespace auth and handles TOML comments without
+  dropping `#` inside quoted values. This addresses one bounded part of #799;
+  #799 intentionally remains open.
+- **#843 merged (`52db2f8e`)** — smoke-failed providers are removed from smart/full/minimal fleets,
+  while a later PASS clears marker and expiry state immediately. The final
+  minimal-strategy regression includes a real fake agy executable and is
+  mutation-proven. Issue #840 closed.
+- **#836** — the update guide explains that Claude Code owns plugin updates,
+  third-party marketplace auto-update is off by default, and users can enable
+  it under `/plugin` -> Marketplaces -> `nyldn-plugins`; Codex retains its host
+  marketplace upgrade flow. The plugin does not rewrite its own loaded cache or
+  enablement state.
+- **#838 filed for the reported Gemini popup** — unattended workflow dispatch
+  can still trigger macOS Keychain access for `gemini-cli-workspace-oauth` via
+  the Node-based Gemini CLI. The issue records the screenshot text, suspected
+  detection/config paths, and non-prompting acceptance criteria. It is a future
+  task, not part of v9.61.2.
+
+Verification completed before the release candidate:
+
+- PR #833 final local `make ci-local`: 16 smoke, 247 unit, and 7 integration
+  suites passed; Linux, macOS, symlink, and integration checks also passed
+  remotely.
+- Lifecycle focused suites: 10/10 and provider auth timeout 18/18.
+- Careful-hook safety suite: 26/26 plus direct real-hook probes for quiet and
+  destructive cases.
+- Provider predicates: 13/13; Vibe 5/5; feature detection 20/20;
+  OpenAI-compatible agent 19/19.
+- Smoke dispatch exclusion: 9/9; quota watcher 2/2; embrace fail-fast 6/6;
+  Gemini provider 52/52.
+- Bash syntax, relevant ShellCheck gates, diff checks, and executable-mode
+  checks were clean. Test-created stale worktree records were pruned.
+
+## Delivered in v9.61.1 Cycle
 
 - **#805 merged (`f0586e73`)** — added vendor-correct no-config model fallbacks
   for grok, OpenRouter, Vibe, and AtlasCloud, with behavioural regression tests.
@@ -180,10 +263,12 @@ were removed with that worktree and did not contaminate the task branch.
 
 - **#799 — provider availability/auth parity.** `check-providers.sh` still uses
   binary presence alone for several providers, while preflight has stronger
-  auth checks. `is_agent_available_v2` also has an optimistic default arm.
+  auth checks. PR #842 fixed `is_agent_available_v2`'s optimistic default and
+  added missing explicit contracts; do not close #799 until the remaining
+  active detection surfaces agree.
 - **#800 — stale pins and dead environment overrides.** Copilot and Ollama have
-  stale defaults, and some provider IDs do not map to their documented
-  `OCTOPUS_*_MODEL` variables.
+  stale defaults/version floors. The missing Ollama/Copilot/Vibe model and
+  allowlist wiring was fixed in #816/#819, but the broader issue remains.
 - **#801 — catalog and price-table consolidation.** Model membership, tiering,
   and pricing still disagree across `models.sh`, `octo-model-config.sh`,
   `cost.sh`, and `usage-report.sh`.
@@ -194,8 +279,17 @@ provider refactor; preserve the behavioural-test-first pattern used by `#805` an
 
 ## Next Action
 
-1. Pick up #799, #800, and #801 as separate test-first fixes.
-2. Remaining streamlining work is still unstarted:
+1. **#838:** reproduce the current Gemini CLI macOS Keychain behavior and make
+   unattended dispatch fail closed before any prompt-capable OAuth invocation.
+   Correct the current false "keychain bypass active" assurance and preserve
+   explicit interactive use.
+2. **#841:** add workflow cancellation cleanup for provider trees, PID and
+   heartbeat registries, incomplete result stubs, terminal events, and
+   project-local state pollution.
+3. Continue #799, #800, and #801 as separate test-first fixes; do not reopen
+   the bounded portions already delivered in v9.61.2.
+4. Revisit #815 alongside #838 for Gemini environment-level E2E coverage.
+5. Remaining streamlining work is still unstarted:
    - **4c:** remove obsolete drift detection, its unreachable duplicate, and
      the deprecated wizard only after confirming all call sites.
    - **4b:** cull unused/below-floor `SUPPORTS_*` flags together with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 - Release validation now recognizes nested `SKILL.md` directories instead of
   falsely reporting registered skills as missing during a release. (closes
   #829, #830)
+- The CI unit matrix now has a 25-minute budget and a regression floor after
+  the 248-suite macOS job exhausted the old 15-minute ceiling while tests were
+  still passing. (closes #846)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,26 @@
   sync now validates both host manifests, preventing stale Codex bundles from
   being stranded behind an identifier mismatch. (#818)
 - **Ollama, Copilot, and Vibe now honor model pins and allowlists.** `get_agent_model()` had no case arm for these three providers, so `OCTOPUS_OLLAMA_MODEL` / `OCTOPUS_COPILOT_MODEL` / `OCTOPUS_VIBE_MODEL` were silently ignored and dispatch always fell through to the hardcoded default. (#816) `validate_model_allowed()` had the same gap one function over — `OCTOPUS_OLLAMA_ALLOWED_MODELS` / `OCTOPUS_COPILOT_ALLOWED_MODELS` / `OCTOPUS_VIBE_ALLOWED_MODELS` fell through to the unknown-provider "allow" default, so the model restriction never applied. (closes #817, #819)
-- **Lifecycle observer timeouts now reap the hook's entire process group without `pkill`.** The built-in fallback works on minimal and macOS-style environments where GNU `timeout` and `pkill` are unavailable, so a timed-out observer cannot leave background descendants running. The regression forces that fallback, proves both descendants started, uses monotonic timing, and runs through the symlinked install path. (closes #827, #828)
+- **Provider availability now fails closed without disabling supported seats.**
+  Unknown agent IDs no longer default to available; Grok, Command Code, Atlas
+  Cloud, and Vibe have explicit contracts. Atlas Cloud requires a key and
+  model, while Vibe requires CLI plus nonblank auth with quote-aware config
+  parsing. This addresses the optimistic-predicate portion of #799; the broader
+  provider detection/auth-parity work remains open. (#842)
+- **Smoke-failed providers are excluded from the current workflow fleet.**
+  Full, minimal, and smart dispatch honor the shared provider-health marker;
+  a later passing smoke test clears both marker and expiry metadata immediately
+  so repaired credentials or model configuration recover without a stale
+  one-hour lockout. (closes #840, #843)
+- **Lifecycle observer timeouts now reap the hook's entire process group without `pkill` or wall-clock deadlines.** The built-in fallback uses an independent, reaped `sleep` watchdog on minimal and macOS-style environments where GNU `timeout` and `pkill` are unavailable, so timed-out observers cannot leave descendants running and host clock jumps cannot fabricate timeout failures. Regressions require the timeout exit, dead process evidence, watchdog creation/kill/wait cleanup, true monotonic test timing, and the symlinked install path. (closes #827, #828, #832, #837, #844)
 - **Council approval gates no longer prompt in non-interactive sessions.** PTY-backed automation can carry inherited terminal signals even when no user can answer; the shared session-interactivity detector now prevents those false prompts while preserving real interactive approval gates. (closes #825, #826)
 
 ### Internal
 
 - Skill-template tests generate into an isolated temporary copy instead of rewriting the live checkout, permanently removing a test-side source of hook and working-tree noise. (closes #822, #824)
+- Release validation now recognizes nested `SKILL.md` directories instead of
+  falsely reporting registered skills as missing during a release. (closes
+  #829, #830)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [9.61.2] - 2026-08-09
+
+### Changed
+
+- Ollama, Copilot, and Vibe now honor model pins and allowlists
+
 ## [9.61.1] - 2026-08-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 - Skill-template tests generate into an isolated temporary copy instead of rewriting the live checkout, permanently removing a test-side source of hook and working-tree noise. (closes #822, #824)
 
+### Documentation
+
+- The update guide now surfaces Claude Code's host-managed auto-update opt-in for the third-party `nyldn-plugins` marketplace, retains the manual recovery commands, and explains how to reload the updated plugin. The plugin never rewrites its own loaded cache or user enablement state. (closes #836)
+
 ## [9.61.1] - 2026-08-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ## [9.61.2] - 2026-08-09
 
-### Changed
+### Fixed
 
-- Ollama, Copilot, and Vibe now honor model pins and allowlists
+- **Ollama, Copilot, and Vibe now honor model pins and allowlists.** `get_agent_model()` had no case arm for these three providers, so `OCTOPUS_OLLAMA_MODEL` / `OCTOPUS_COPILOT_MODEL` / `OCTOPUS_VIBE_MODEL` were silently ignored and dispatch always fell through to the hardcoded default. (#816) `validate_model_allowed()` had the same gap one function over — `OCTOPUS_OLLAMA_ALLOWED_MODELS` / `OCTOPUS_COPILOT_ALLOWED_MODELS` / `OCTOPUS_VIBE_ALLOWED_MODELS` fell through to the unknown-provider "allow" default, so the model restriction never applied. (closes #817, #819)
 
 ## [9.61.1] - 2026-08-09
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -78,7 +78,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 - GitHub stars: 3,889
 - GitHub forks: 365
 - Local CI parity: `make ci-local` runs the same smoke, unit, and integration suites as CI
-- Version: 9.61.1 (active release cadence)
+- Version: 9.61.2 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Gemini CLI
 
 **Measured Impact:**

--- a/README.md
+++ b/README.md
@@ -197,8 +197,14 @@ droid plugin install octo@nyldn-plugins
 <details>
 <summary>Update / Troubleshooting</summary>
 
+[Claude Code leaves auto-update off by default for third-party marketplaces](https://code.claude.com/docs/en/discover-plugins#configure-auto-updates).
+To opt in to host-managed startup updates, run `/plugin`, open
+**Marketplaces**, select **nyldn-plugins**, and choose **Enable auto-update**.
+When Claude reports that Octopus was updated, run `/reload-plugins` (or restart
+Claude Code) before using the new version.
+
 ```bash
-# Update
+# Manual update
 claude plugin marketplace update nyldn-plugins
 claude plugin update octo@nyldn-plugins
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 <p align="center">
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/Version-9.61.1-blue" alt="Version 9.61.1">
+  <img src="https://img.shields.io/badge/Version-9.61.2-blue" alt="Version 9.61.2">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -35,7 +35,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 ## What's New
 
 <!-- BEGIN CURRENT RELEASE -->
-> 🆕 **v9.61.1 — Provider routing, workflow contracts, and generated-skill reliability fixes.**
+> 🆕 **v9.61.2 — Ollama, Copilot, and Vibe now honor model pins and allowlists.**
 >
 > **Default roster:** Claude Opus 5 leads architecture, planning, security reasoning, and final judgment; GPT-5.6 Sol is the independent implementation/review peer; Claude Sonnet 5 is the standard Claude seat; Fable 5 remains an opt-in judgment escalation. Existing model pins and provider configuration still win. See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md).
 <!-- END CURRENT RELEASE -->
@@ -55,7 +55,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 
 | Version | Best Features |
 |---------|--------------|
-| **v9.61.1** (new) | Provider routing, workflow contracts, and generated-skill reliability fixes. |
+| **v9.61.2** (new) | Ollama, Copilot, and Vibe now honor model pins and allowlists. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
 | **v9** | Up to 10 external provider integrations (Codex, Gemini, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.61.1",
+  "version": "9.61.2",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/tests/unit/test-suite-reachability.sh
+++ b/tests/unit/test-suite-reachability.sh
@@ -196,7 +196,7 @@ test_case "the unit matrix timeout has headroom for slow macOS runners"
 unit_timeout_minutes="$(awk '
     /^  unit:/ { in_unit = 1; next }
     in_unit && /^  [[:alnum:]_-]+:/ { exit }
-    in_unit && /timeout-minutes:/ { print $2; exit }
+    in_unit && /^    timeout-minutes:[[:space:]]/ { print $2; exit }
 ' "$WORKFLOW")"
 if [[ "$unit_timeout_minutes" =~ ^[0-9]+$ ]] && [[ "$unit_timeout_minutes" -ge 20 ]]; then
     test_pass

--- a/tests/unit/test-suite-reachability.sh
+++ b/tests/unit/test-suite-reachability.sh
@@ -192,6 +192,18 @@ else
     test_fail "found only ${n_targets} 'make test-*' invocations in the workflow — the grep or the workflow changed, so the assertion above would be vacuous"
 fi
 
+test_case "the unit matrix timeout has headroom for slow macOS runners"
+unit_timeout_minutes="$(awk '
+    /^  unit:/ { in_unit = 1; next }
+    in_unit && /^  [[:alnum:]_-]+:/ { exit }
+    in_unit && /timeout-minutes:/ { print $2; exit }
+' "$WORKFLOW")"
+if [[ "$unit_timeout_minutes" =~ ^[0-9]+$ ]] && [[ "$unit_timeout_minutes" -ge 20 ]]; then
+    test_pass
+else
+    test_fail "unit timeout is ${unit_timeout_minutes:-missing} minutes; the 248-suite macOS job exceeded 15 minutes in run 31411222295 — keep at least 20 minutes of budget"
+fi
+
 test_case "at least one test is actually discovered (guards a silent empty set)"
 n="$(reachable_files | grep -c . || true)"
 if [[ "${n:-0}" -gt 50 ]]; then


### PR DESCRIPTION
## Release v9.61.2

This release rolls the hook reliability, stale-install update recovery, model routing, provider health, and release-validation fixes into one tested artifact.

### Hook reliability

- Careful-mode guards now recognize executable context and token boundaries, eliminating the recurring `rg`/`grep`/documentation, dotfile, subpath, and word-substring false positives while retaining destructive-command protection (#831, fixes #835).
- Lifecycle hook timeouts no longer depend on wall-clock `SECONDS`, GNU `timeout`, or `pkill`; the built-in watchdog owns and reaps the entire process group, with static and mutation-proven cleanup contracts (#828, #833, #845; closes #827, #832, #837, #844).
- Non-interactive council approval gates no longer prompt merely because automation inherited terminal signals (#826; closes #825).
- Skill-template tests generate in an isolated copy, removing a test-side source of hook and working-tree noise (#824; closes #822).

### Stale plugin updates

- Restores the stable `claude-octopus@nyldn-plugins` Codex marketplace identity and validates both Claude and Codex selectors during shared-marketplace sync (#820; closes #818).
- Documents the Claude host-managed auto-update opt-in for third-party marketplaces, manual update/reload recovery, and the Codex marketplace upgrade flow. Octopus does not rewrite its live cache or enablement state.

### Provider and release hardening

- Ollama, Copilot, and Vibe now honor model pins and allowlists (#816, #819; closes #817).
- Unknown agent IDs fail closed while supported Grok, Command Code, Atlas Cloud, and Vibe seats retain explicit auth contracts (#842; bounded part of #799).
- Smoke-failed providers are excluded from smart/full/minimal fleets, and successful recovery clears the lockout immediately (#843; closes #840).
- Release validation recognizes nested skill directories (#830; closes #829).

### Verification

- Exact combined candidate: `OCTOPUS_NON_INTERACTIVE=1 make ci-local` — 16 smoke suites, 248 unit suites, and 7 integration suites passed.
- `make sync`, `make sync-check`, `./scripts/validate-release.sh 9.61.2`, `bash tests/unit/test-handoff.sh`, `git diff --check`, and executable-mode validation passed.
- Underlying current-head PR matrices passed on Ubuntu, macOS, the symlinked install path, and integration tests with CodeRabbit approval and zero unresolved threads.

After squash merge, the tag will be created on the exact main merge commit, followed by the GitHub Release, shared marketplace sync, and real Claude/Codex upgrade verification from v9.61.1.

Closes #836.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model pin and allowlist handling across supported providers.
  * Added safer provider availability checks and recovery after smoke-test failures.
  * Improved lifecycle cleanup and non-interactive approval handling.

* **Documentation**
  * Updated release information, feature descriptions, and upgrade instructions.
  * Added guidance for marketplace auto-updates and plugin reloading.

* **Tests**
  * Expanded validation for skills and provider workflows.
  * Added coverage to ensure unit-test workflows have sufficient execution time.

* **Release**
  * Published version 9.61.2 with synchronized version information across supported integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #846.
