### PR TITLE
fix: make skill-template test hermetic, stop mutating the checkout

### DIFF
--- a/scripts/gen-skill-docs.sh
+++ b/scripts/gen-skill-docs.sh
@@ -5,11 +5,15 @@
 # Templates use {{PLACEHOLDER}} syntax. Shared blocks from skills/blocks/
 # are resolved first, then metadata placeholders (COMMAND_COUNT, etc.).
 # --dry-run exits non-zero if any generated file differs from committed file.
+#
+# GEN_SKILL_DOCS_ROOT overrides the plugin root the generator reads from and
+# writes into — used by tests to run the generator against a throwaway
+# fixture instead of the tracked checkout.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+PLUGIN_ROOT="${GEN_SKILL_DOCS_ROOT:-$(dirname "$SCRIPT_DIR")}"
 SKILLS_DIR="$PLUGIN_ROOT/.claude/skills"
 BLOCKS_DIR="$PLUGIN_ROOT/skills/blocks"
 DRY_RUN=false

--- a/tests/unit/test-skill-templates.sh
+++ b/tests/unit/test-skill-templates.sh
@@ -109,8 +109,10 @@ done
 # checkout. Copy the inputs gen-skill-docs.sh reads/writes into a throwaway
 # root and point it there via GEN_SKILL_DOCS_ROOT. ────────────────────────────
 
-FIXTURE_ROOT=$(mktemp -d)
-trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+# Nest under TEST_TMP_DIR (already created by test_suite() and cleaned up by
+# the framework's own EXIT trap) instead of a standalone mktemp+trap, which
+# would clobber that trap.
+FIXTURE_ROOT="$TEST_TMP_DIR/gen-skill-docs-fixture"
 
 mkdir -p "$FIXTURE_ROOT/.claude/skills" "$FIXTURE_ROOT/skills/blocks" \
     "$FIXTURE_ROOT/commands" "$FIXTURE_ROOT/agents/personas" "$FIXTURE_ROOT/hooks"
@@ -121,7 +123,7 @@ cp -R "$PROJECT_ROOT/agents/personas/." "$FIXTURE_ROOT/agents/personas/" 2>/dev/
 [[ -d "$PROJECT_ROOT/hooks" ]] && cp -R "$PROJECT_ROOT/hooks/." "$FIXTURE_ROOT/hooks/" 2>/dev/null || true
 cp "$PROJECT_ROOT/package.json" "$FIXTURE_ROOT/package.json"
 
-run_gen() { GEN_SKILL_DOCS_ROOT="$FIXTURE_ROOT" "$GEN_SCRIPT" "$@"; }
+run_gen() { env "GEN_SKILL_DOCS_ROOT=${FIXTURE_ROOT}" "$GEN_SCRIPT" "$@"; }
 
 tracked_flow_hashes() {
     for f in flow-discover.md flow-define.md flow-develop.md flow-deliver.md; do
@@ -198,10 +200,10 @@ if [[ -x "$GEN_SCRIPT" && -d "$BLOCKS_DIR" ]]; then
     stale_exit=0
     stale_output=$(run_gen --dry-run 2>&1) || stale_exit=$?
 
-    if [[ $stale_exit -ne 0 ]]; then
+    if [[ $stale_exit -ne 0 ]] && echo "$stale_output" | grep -q 'STALE: flow-discover'; then
         pass "--dry-run exits non-zero when files are stale"
     else
-        fail "--dry-run exits non-zero when files are stale" "exit code was 0"
+        fail "--dry-run exits non-zero when files are stale" "exit code was $stale_exit, output: $stale_output"
     fi
 else
     pass "template generation skipped (blocks removed, skills directly authored)"

--- a/tests/unit/test-skill-templates.sh
+++ b/tests/unit/test-skill-templates.sh
@@ -105,16 +105,41 @@ for tmpl_name in flow-develop.tmpl flow-deliver.tmpl; do
     fi
 done
 
+# ── Hermetic fixture: generator mutation checks must never touch the tracked
+# checkout. Copy the inputs gen-skill-docs.sh reads/writes into a throwaway
+# root and point it there via GEN_SKILL_DOCS_ROOT. ────────────────────────────
+
+FIXTURE_ROOT=$(mktemp -d)
+trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+
+mkdir -p "$FIXTURE_ROOT/.claude/skills" "$FIXTURE_ROOT/skills/blocks" \
+    "$FIXTURE_ROOT/commands" "$FIXTURE_ROOT/agents/personas" "$FIXTURE_ROOT/hooks"
+cp -R "$SKILLS_DIR/." "$FIXTURE_ROOT/.claude/skills/"
+[[ -d "$BLOCKS_DIR" ]] && cp -R "$BLOCKS_DIR/." "$FIXTURE_ROOT/skills/blocks/"
+cp -R "$PROJECT_ROOT/commands/." "$FIXTURE_ROOT/commands/" 2>/dev/null || true
+cp -R "$PROJECT_ROOT/agents/personas/." "$FIXTURE_ROOT/agents/personas/" 2>/dev/null || true
+[[ -d "$PROJECT_ROOT/hooks" ]] && cp -R "$PROJECT_ROOT/hooks/." "$FIXTURE_ROOT/hooks/" 2>/dev/null || true
+cp "$PROJECT_ROOT/package.json" "$FIXTURE_ROOT/package.json"
+
+run_gen() { GEN_SKILL_DOCS_ROOT="$FIXTURE_ROOT" "$GEN_SCRIPT" "$@"; }
+
+tracked_flow_hashes() {
+    for f in flow-discover.md flow-define.md flow-develop.md flow-deliver.md; do
+        local p; p="$(resolve_claude_skill_path "$f" 2>/dev/null)" || continue
+        [[ -f "$p" ]] && sha256sum "$p"
+    done
+}
+TRACKED_HASHES_BEFORE="$(tracked_flow_hashes)"
+
 # ── --dry-run mode works (files are fresh after generation) ──────────────────
 
-dry_run_output=$("$GEN_SCRIPT" --dry-run 2>&1) || true
-dry_run_exit=$?
+dry_run_output=$(run_gen --dry-run 2>&1) || true
 
-# First regenerate to ensure freshness
-"$GEN_SCRIPT" > /dev/null 2>&1
+# First regenerate the fixture to ensure freshness
+run_gen > /dev/null 2>&1
 
 # Now dry-run should pass
-dry_run_output=$("$GEN_SCRIPT" --dry-run 2>&1)
+dry_run_output=$(run_gen --dry-run 2>&1)
 dry_run_exit=$?
 
 if [[ $dry_run_exit -eq 0 ]]; then
@@ -165,21 +190,31 @@ done
 # ── Template system dry-run (only if gen-skill-docs.sh and blocks exist) ─────
 
 if [[ -x "$GEN_SCRIPT" && -d "$BLOCKS_DIR" ]]; then
-    # Intentionally make a file stale
-    echo "# stale marker" >> "$(resolve_claude_skill_path "flow-discover")"
+    # Intentionally make the fixture copy stale — never the tracked file
+    stale_target="$FIXTURE_ROOT/.claude/skills/flow-discover/SKILL.md"
+    [[ -f "$stale_target" ]] || stale_target="$FIXTURE_ROOT/.claude/skills/flow-discover.md"
+    echo "# stale marker" >> "$stale_target"
 
     stale_exit=0
-    stale_output=$("$GEN_SCRIPT" --dry-run 2>&1) || stale_exit=$?
+    stale_output=$(run_gen --dry-run 2>&1) || stale_exit=$?
 
     if [[ $stale_exit -ne 0 ]]; then
         pass "--dry-run exits non-zero when files are stale"
     else
         fail "--dry-run exits non-zero when files are stale" "exit code was 0"
     fi
-
-    # Restore fresh state
-    "$GEN_SCRIPT" > /dev/null 2>&1
 else
     pass "template generation skipped (blocks removed, skills directly authored)"
 fi
+
+# ── Regression: none of the fixture-based generator runs above may have
+# touched the real tracked flow-*.md files ───────────────────────────────────
+
+TRACKED_HASHES_AFTER="$(tracked_flow_hashes)"
+if [[ "$TRACKED_HASHES_BEFORE" == "$TRACKED_HASHES_AFTER" ]]; then
+    pass "generator fixture runs do not mutate tracked skill files"
+else
+    fail "generator fixture runs do not mutate tracked skill files" "tracked flow-*.md changed on disk"
+fi
+
 test_summary


### PR DESCRIPTION
## Description

`tests/unit/test-skill-templates.sh` ran `scripts/gen-skill-docs.sh` directly against the tracked `.claude/skills/*/SKILL.md` files to exercise `--dry-run` staleness detection, then "restored" them by regenerating from templates. Since those files have been directly authored (not template-derived) since v9.10.2, the regenerate step silently overwrote hand-authored content with template output, leaving the checkout dirty after an otherwise-green `make ci-local`:

```
 M .claude/skills/flow-define/SKILL.md
 M .claude/skills/flow-deliver/SKILL.md
 M .claude/skills/flow-develop/SKILL.md
 M .claude/skills/flow-discover/SKILL.md
```

I reproduced this on `main` (3d3f972f) before making any change: the test suite passes 42/42, but `git status --short` shows the four files above modified afterward.

## Root cause

`scripts/gen-skill-docs.sh:12` hardcodes its plugin root from its own script location, so any invocation — including from a test — always reads and writes the real checkout. The test has no way to point the generator at a throwaway copy.

## Fix

- `scripts/gen-skill-docs.sh:12`: `PLUGIN_ROOT` now honors an optional `GEN_SKILL_DOCS_ROOT` override, defaulting to the existing behavior when unset (no change to normal usage — CI and manual `scripts/gen-skill-docs.sh` calls are unaffected).
- `tests/unit/test-skill-templates.sh`: the mutating checks (fresh-file dry-run, stale-file dry-run) now copy the skill/template/block/command inputs into a `mktemp -d` fixture and run the generator against that fixture via `GEN_SKILL_DOCS_ROOT`, instead of against `PROJECT_ROOT`.
- Added a regression assertion that hashes the real tracked `flow-*.md` skill files before and after the fixture runs and fails if they changed — so a future reintroduction of this bug fails loudly instead of silently.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check (`bash -n scripts/*.sh scripts/lib/*.sh scripts/helpers/*.sh` — clean)
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (32/32)
- [ ] OpenClaw registry in sync — not applicable, no OpenClaw-facing surface touched
- [ ] New skills/commands registered — not applicable
- [ ] Version bump — not applicable, no release in this PR
- [ ] Documentation updated — not applicable, no user-facing behavior changed (generator default behavior is unchanged when the new env var is unset)
- [ ] CHANGELOG.md updated — deferring to whoever cuts the next release

## Testing

```bash
bash tests/unit/test-skill-templates.sh   # 43/43 (was 42/42 on main, +1 new regression check)
bash tests/unit/test-openclaw-compat.sh   # 32/32
bash -n scripts/*.sh scripts/lib/*.sh scripts/helpers/*.sh   # clean
```

Confirmed on `main` before this change that the test passes but leaves the checkout dirty (see repro above), and confirmed after this change that the checkout stays clean across full and stale/dry-run cycles (checked `git status --short` before/after).

Did not run the full `make test-unit` / `make test-integration` matrix in this session — it exceeded the run's time budget (same constraint noted in the immediately preceding PR #819 today). This change only touches one test file and one script's root-resolution, and `tests/unit/test-skill-templates.sh` is the only file anywhere in the repo that references `gen-skill-docs.sh` (`grep -rl gen-skill-docs tests/ scripts/ Makefile` confirms), so the targeted run above covers everything this change can affect.

## Related Issues
Closes #822

---

_Filed by the scheduled daily bug-triage routine._


---
_Generated by [Claude Code](https://claude.ai/code/session_01M57sX5uxAfnTkpYdbZD9J7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating skill documentation from an alternate project root while retaining the existing default behavior.
  - This enables documentation generation in isolated or custom project setups.

- **Tests**
  - Improved generator tests to use isolated temporary fixtures.
  - Added validation that generation does not modify tracked project files.
  - Expanded coverage for stale-file handling and fixture cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->