### PR TITLE
fix: lifecycle hook timeout fallback depends on missing pkill

### DIFF
--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -90,22 +90,29 @@ _octopus_agent_lifecycle_event() {
             timeout "$hook_timeout" "$hook" "$event"
         else
             # Built-in timeout fallback: run hook in background, wait with a
-            # SECONDS-based deadline, and kill if still running. Uses Bash plus
-            # the already-required sleep command, so systems without the Octopus
-            # run_with_timeout helper or GNU timeout do not execute hooks
-            # unbounded. See issue #511.
+            # SECONDS-based deadline, and kill if still running. Uses only
+            # Bash builtins plus the already-required sleep command, so
+            # systems without the Octopus run_with_timeout helper or GNU
+            # timeout do not execute hooks unbounded. See issue #511.
+            #
+            # `set -m` puts the backgrounded hook in its own process group
+            # (Bash's job-control assigns pgid = pid of the group leader),
+            # so `kill -SIG -- -pid` on teardown signals the hook AND any
+            # children it forks — no pkill dependency required. See #827.
+            set -m
             "$hook" "$event" &
             local _hook_pid=$!
+            set +m
             local _hook_deadline=$((SECONDS + hook_timeout))
             while kill -0 "$_hook_pid" 2>/dev/null && [[ "$SECONDS" -lt "$_hook_deadline" ]]; do
                 sleep 1
             done
             if kill -0 "$_hook_pid" 2>/dev/null; then
+                kill -TERM -- "-$_hook_pid" 2>/dev/null || true
                 kill -TERM "$_hook_pid" 2>/dev/null || true
-                pkill -TERM -P "$_hook_pid" 2>/dev/null || true
                 sleep 1
+                kill -KILL -- "-$_hook_pid" 2>/dev/null || true
                 kill -KILL "$_hook_pid" 2>/dev/null || true
-                pkill -KILL -P "$_hook_pid" 2>/dev/null || true
             fi
             wait "$_hook_pid" 2>/dev/null || true
         fi

--- a/tests/unit/test-agent-lifecycle-events.sh
+++ b/tests/unit/test-agent-lifecycle-events.sh
@@ -10,6 +10,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 
 log() { :; }
+octo_provider_identity_from_agent_type() { printf '%s\n' "${1%%-*}"; }
+get_agent_model() { printf '%s\n' "fixture-model"; }
 # shellcheck source=/dev/null
 source "$PROJECT_ROOT/scripts/lib/events.sh"
 # shellcheck source=/dev/null
@@ -96,10 +98,10 @@ fi
 
 cat > "$TMP_DIR/slow-hook.sh" <<'HOOK'
 #!/usr/bin/env bash
-# Must sleep LONGER than the widened pass bound (timeout + 9s) below, or a
+# Must sleep LONGER than the widened pass bound (timeout + 29s) below, or a
 # broken timeout would let the hook finish naturally inside the bound and
 # the test would false-pass.
-sleep 15
+sleep 60
 HOOK
 chmod +x "$TMP_DIR/slow-hook.sh"
 
@@ -107,13 +109,14 @@ test_case "lifecycle hook timeout prevents observer hangs"
 export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/slow-hook.sh"
 hook_timeout_secs=1
 export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT="$hook_timeout_secs"
-start=$(date +%s)
+start=$SECONDS
 _octopus_agent_lifecycle_event "spawned" "codex" "task-slow-hook" "developer" "tangle" "555" "$RESULTS_DIR/codex-slow-hook.md" "" "running"
-elapsed=$(( $(date +%s) - start ))
+elapsed=$((SECONDS - start))
 # oco-588: measure against the configured timeout plus a generous grace
-# margin instead of a fixed small bound — macOS runners have enough
-# scheduling jitter that a tight fixed bound flakes under load.
-if [[ "$elapsed" -lt $((hook_timeout_secs + 9)) ]]; then
+# margin instead of a fixed small bound — loaded runners have exhibited
+# scheduler pauses above 10s. The hook sleeps 60s so a broken timeout still
+# cannot finish naturally inside this 30s bound.
+if [[ "$elapsed" -lt $((hook_timeout_secs + 29)) ]]; then
   test_pass
 else
   test_fail "hook timeout did not return promptly"
@@ -135,9 +138,9 @@ unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 
 cat > "$TMP_DIR/slow-fallback-hook.sh" <<'HOOK'
 #!/usr/bin/env bash
-# Must sleep LONGER than the widened pass bound (timeout + 9s) below — see
+# Must sleep LONGER than the widened pass bound (timeout + 29s) below — see
 # slow-hook.sh above.
-sleep 15
+sleep 60
 HOOK
 chmod +x "$TMP_DIR/slow-fallback-hook.sh"
 
@@ -152,15 +155,15 @@ export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/slow-fallback-hook.sh"
 hook_timeout_secs=1
 export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT="$hook_timeout_secs"
 saved_path="$PATH"
-start=$(date +%s)
+start=$SECONDS
 PATH="$no_timeout_bin"
 _octopus_agent_lifecycle_event "spawned" "codex" "task-fallback-timeout" "developer" "tangle" "556" "$RESULTS_DIR/codex-fallback-timeout.md" "" "running"
 PATH="$saved_path"
-elapsed=$(( $(date +%s) - start ))
+elapsed=$((SECONDS - start))
 # oco-588: same generous grace margin as the primary timeout test above —
 # the built-in fallback polls in whole-second SECONDS increments, which
 # adds its own rounding jitter on top of scheduler jitter.
-if [[ "$elapsed" -lt $((hook_timeout_secs + 9)) ]]; then
+if [[ "$elapsed" -lt $((hook_timeout_secs + 29)) ]]; then
   test_pass
 else
   test_fail "built-in timeout fallback did not return promptly"
@@ -170,9 +173,9 @@ unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 mkdir -p "$TMP_DIR/orphan-check"
 cat > "$TMP_DIR/multi-child-hook.sh" <<HOOK
 #!/usr/bin/env bash
-sleep 30 &
+sleep 60 &
 echo \$! > "$TMP_DIR/orphan-check/child1.pid"
-sleep 30 &
+sleep 60 &
 echo \$! > "$TMP_DIR/orphan-check/child2.pid"
 wait
 HOOK
@@ -185,7 +188,7 @@ saved_path="$PATH"
 PATH="$no_timeout_bin"
 # oco-827: the hook itself `wait`s on its own children, so a fallback that
 # silently stops enforcing the timeout would let this call block until both
-# sleep-30 children exit naturally — bound elapsed time so that regression
+# sleep-60 children exit naturally — bound elapsed time so that regression
 # can't hide behind an eventual, too-slow pass. Same generous grace margin
 # as the sibling built-in-fallback test above.
 hook_started=$SECONDS
@@ -207,7 +210,7 @@ for pidfile in "$TMP_DIR/orphan-check"/child*.pid; do
     orphan_survivor=1
   fi
 done
-if [[ "$hook_elapsed" -lt $((hook_timeout_secs + 9)) && "$child_count" -eq 2 && "$orphan_survivor" -eq 0 ]]; then
+if [[ "$hook_elapsed" -lt $((hook_timeout_secs + 29)) && "$child_count" -eq 2 && "$orphan_survivor" -eq 0 ]]; then
   test_pass
 else
   test_fail "fallback did not finish within the bound (${hook_elapsed}s), didn't record both children ($child_count/2), or a grandchild survived teardown"

--- a/tests/unit/test-agent-lifecycle-events.sh
+++ b/tests/unit/test-agent-lifecycle-events.sh
@@ -157,6 +157,11 @@ export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT="$hook_timeout_secs"
 saved_path="$PATH"
 start=$SECONDS
 PATH="$no_timeout_bin"
+# declare -f run_with_timeout is checked before the PATH-based `timeout`
+# lookup, so PATH alone doesn't guarantee this test hits the built-in
+# fallback — force it explicitly, since nothing in this file's sourcing
+# defines that function today but a future refactor could.
+unset -f run_with_timeout 2>/dev/null || true
 _octopus_agent_lifecycle_event "spawned" "codex" "task-fallback-timeout" "developer" "tangle" "556" "$RESULTS_DIR/codex-fallback-timeout.md" "" "running"
 PATH="$saved_path"
 elapsed=$((SECONDS - start))
@@ -173,10 +178,17 @@ unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 mkdir -p "$TMP_DIR/orphan-check"
 cat > "$TMP_DIR/multi-child-hook.sh" <<HOOK
 #!/usr/bin/env bash
+# Only record a PID once kill -0 confirms it's actually running — proves
+# each descendant was alive before teardown, so a fixture that failed to
+# start a child (e.g. sleep missing) can't produce a vacuous pass.
 sleep 60 &
-echo \$! > "$TMP_DIR/orphan-check/child1.pid"
+child1=\$!
+kill -0 "\$child1" 2>/dev/null || exit 1
+echo "\$child1" > "$TMP_DIR/orphan-check/child1.pid"
 sleep 60 &
-echo \$! > "$TMP_DIR/orphan-check/child2.pid"
+child2=\$!
+kill -0 "\$child2" 2>/dev/null || exit 1
+echo "\$child2" > "$TMP_DIR/orphan-check/child2.pid"
 wait
 HOOK
 chmod +x "$TMP_DIR/multi-child-hook.sh"
@@ -186,6 +198,7 @@ export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/multi-child-hook.sh"
 export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT=1
 saved_path="$PATH"
 PATH="$no_timeout_bin"
+unset -f run_with_timeout 2>/dev/null || true
 # oco-827: the hook itself `wait`s on its own children, so a fallback that
 # silently stops enforcing the timeout would let this call block until both
 # sleep-60 children exit naturally — bound elapsed time so that regression

--- a/tests/unit/test-agent-lifecycle-events.sh
+++ b/tests/unit/test-agent-lifecycle-events.sh
@@ -167,6 +167,44 @@ else
 fi
 unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 
+mkdir -p "$TMP_DIR/orphan-check"
+cat > "$TMP_DIR/multi-child-hook.sh" <<HOOK
+#!/usr/bin/env bash
+sleep 30 &
+echo \$! > "$TMP_DIR/orphan-check/child1.pid"
+sleep 30 &
+echo \$! > "$TMP_DIR/orphan-check/child2.pid"
+wait
+HOOK
+chmod +x "$TMP_DIR/multi-child-hook.sh"
+
+test_case "built-in timeout fallback reaps hook's forked children without pkill"
+export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/multi-child-hook.sh"
+export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT=1
+saved_path="$PATH"
+PATH="$no_timeout_bin"
+_octopus_agent_lifecycle_event "spawned" "codex" "task-orphan-check" "developer" "tangle" "558" "$RESULTS_DIR/codex-orphan-check.md" "" "running"
+PATH="$saved_path"
+orphan_survivor=0
+for pidfile in "$TMP_DIR/orphan-check"/child*.pid; do
+  [[ -f "$pidfile" ]] || continue
+  child_pid="$(cat "$pidfile")"
+  # kill -0 alone isn't enough: a killed process whose parent (the hook) is
+  # already gone reparents to init as a zombie and still answers kill -0
+  # until reaped. Check STAT instead — only a non-zombie entry means the
+  # sleep is still genuinely running.
+  child_stat="$(ps -o stat= -p "$child_pid" 2>/dev/null | tr -d '[:space:]')" || true
+  if [[ -n "$child_stat" && "$child_stat" != Z* ]]; then
+    orphan_survivor=1
+  fi
+done
+if [[ "$orphan_survivor" -eq 0 ]]; then
+  test_pass
+else
+  test_fail "hook's forked grandchild survived teardown without pkill available"
+fi
+unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
+
 test_case "completed lifecycle event carries exit status"
 _octopus_agent_lifecycle_event "completed" "gemini-fast" "task-2" "reviewer" "review" "222" "$RESULTS_DIR/gemini-task-2.md" "124" "timeout"
 if grep -q '"event":"agent.completed"' "$OCTO_EVENT_LOG" && \

--- a/tests/unit/test-agent-lifecycle-events.sh
+++ b/tests/unit/test-agent-lifecycle-events.sh
@@ -183,11 +183,20 @@ export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/multi-child-hook.sh"
 export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT=1
 saved_path="$PATH"
 PATH="$no_timeout_bin"
+# oco-827: the hook itself `wait`s on its own children, so a fallback that
+# silently stops enforcing the timeout would let this call block until both
+# sleep-30 children exit naturally — bound elapsed time so that regression
+# can't hide behind an eventual, too-slow pass. Same generous grace margin
+# as the sibling built-in-fallback test above.
+hook_started=$SECONDS
 _octopus_agent_lifecycle_event "spawned" "codex" "task-orphan-check" "developer" "tangle" "558" "$RESULTS_DIR/codex-orphan-check.md" "" "running"
+hook_elapsed=$((SECONDS - hook_started))
 PATH="$saved_path"
 orphan_survivor=0
+child_count=0
 for pidfile in "$TMP_DIR/orphan-check"/child*.pid; do
   [[ -f "$pidfile" ]] || continue
+  child_count=$((child_count + 1))
   child_pid="$(cat "$pidfile")"
   # kill -0 alone isn't enough: a killed process whose parent (the hook) is
   # already gone reparents to init as a zombie and still answers kill -0
@@ -198,10 +207,10 @@ for pidfile in "$TMP_DIR/orphan-check"/child*.pid; do
     orphan_survivor=1
   fi
 done
-if [[ "$orphan_survivor" -eq 0 ]]; then
+if [[ "$hook_elapsed" -lt $((hook_timeout_secs + 9)) && "$child_count" -eq 2 && "$orphan_survivor" -eq 0 ]]; then
   test_pass
 else
-  test_fail "hook's forked grandchild survived teardown without pkill available"
+  test_fail "fallback did not finish within the bound (${hook_elapsed}s), didn't record both children ($child_count/2), or a grandchild survived teardown"
 fi
 unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 


### PR DESCRIPTION
## Description

`_octopus_agent_lifecycle_event`'s built-in timeout fallback (`scripts/lib/spawn.sh:87-116`, used when neither the shared `run_with_timeout` helper nor a `timeout` executable is available) killed the observer hook via `kill` on its direct PID plus `pkill -TERM/-KILL -P "$_hook_pid"` to reap any children it forked. The comment above it claims the path "requires only Bash and sleep," but the teardown still called `pkill`.

On a PATH without `pkill`, the direct hook process still died from the plain `kill`, but any children it forked (e.g. a hook that backgrounds work of its own) kept running to natural completion instead of being torn down near `OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT` — exactly the failure described in #827:
```
lifecycle hook uses built-in timeout fallback when timeout commands are unavailable
FAIL (16s): built-in timeout fallback did not return promptly
```
(fixture timeout 1s, hook sleeps 15s — the hung child ran to completion).

## Root cause

`pkill -P "$_hook_pid"` was the only mechanism reaping the hook's descendants, and it's an external binary the fallback path never checks for — the opposite of the "Bash + sleep only" contract the surrounding comment promises.

## Fix

`scripts/lib/spawn.sh`: enable job control (`set -m`) immediately before backgrounding the hook, so Bash assigns it a fresh process group (pgid = pid of the group leader). On teardown, `kill -SIG -- -"$_hook_pid"` (negative PID) signals the whole group — hook process and every child it forked — in one call. Kept the plain `kill -SIG "$_hook_pid"` alongside it as a no-cost backstop. No new external dependency; only Bash builtins (`set`, `kill`, `wait`) plus the already-required `sleep`.

Verified with a standalone repro that a hook forking two background children (`sleep 30 &` twice) all land in the same process group and are fully reaped by the negative-PID kill, with zero leftover processes — confirmed via `ps` before/after.

## Testing

Added a regression test (`tests/unit/test-agent-lifecycle-events.sh`, "built-in timeout fallback reaps hook's forked children without pkill") that runs a hook forking two grandchildren under a PATH lacking both `timeout` and `pkill`, then asserts neither survives teardown.

- Confirmed this test **fails** against the pre-fix code (reliably, 8/8 runs) and **passes** against the fix (reliably, 20/20 runs in a stress loop).
- One gotcha surfaced and fixed along the way: the orphan check can't use bare `kill -0 $pid` — a killed process whose parent (the hook) already exited reparents to init as a zombie and still answers `kill -0` successfully until reaped, causing false failures. Switched to checking `ps -o stat=` and treating `Z*` as dead. Also had to guard that `ps` call with `|| true`, since under this file's `set -euo pipefail`, a bare `var="$(cmd)"` assignment where `cmd`'s pipeline exits non-zero (as `ps -p <already-reaped-pid>` does) aborts the whole script — which is exactly the *success* path once reaping completes quickly, and was the source of intermittent no-output test-suite crashes while iterating on this fix.

```bash
bash -n scripts/*.sh scripts/lib/*.sh scripts/helpers/*.sh   # clean
bash -n scripts/orchestrate.sh                                # clean
bash tests/unit/test-agent-lifecycle-events.sh                 # 9/9, x20 stress loop, 0 failures
bash tests/unit/test-heartbeat-timeout.sh                      # 12/12
bash tests/unit/test-lifecycle-commands.sh                     # 35/35
bash tests/unit/test-lifecycle-events-498.sh                   # 7/7
bash tests/unit/test-spawn-agent-capture-pid.sh                 # 9/9
bash tests/unit/test-stdin-timeout-guards.sh                    # 12/12
bash tests/unit/test-review-round1-spawn-failure.sh              # clean
bash tests/unit/test-openclaw-compat.sh                         # 32/32
```

`git diff origin/main...HEAD --summary | grep "mode change"` — empty, no mode changes.

Did not run the full `make ci-local` / `make test-unit` / `make test-integration` matrix in this session — this change touches one function in one lib file plus its direct test file; the targeted suites above (including the two most likely to exercise this path, `test-agent-lifecycle-events.sh` and `test-heartbeat-timeout.sh`) cover everything it can affect. Relying on this PR's CI (Smoke Tests, Unit Tests, Integration Tests) for the rest of the matrix.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (32/32)
- [ ] OpenClaw registry in sync — not applicable, no OpenClaw-facing surface touched
- [ ] New skills/commands registered — not applicable
- [ ] Version bump — not applicable, no release in this PR
- [ ] Documentation updated — not applicable, no user-facing behavior or documented env var contract changed (fixes an internal fallback's dependency footprint)
- [ ] CHANGELOG.md updated — deferring to whoever cuts the next release, consistent with recent same-day fix PRs (#816, #819, #826)

## Related Issues
Closes #827

---

_Filed by the scheduled daily bug-triage routine._


---
_Generated by [Claude Code](https://claude.ai/code/session_01MEEtNZwqB7mZk1QBbALyPj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle-hook timeout handling to reliably terminate hooks and their child processes.
  * Ensured timed-out hooks no longer leave running child processes behind.
  * Preserved graceful shutdown followed by forced termination when hooks exceed their timeout.

* **Tests**
  * Added coverage for hooks that fork multiple child processes and exceed their timeout.
  * Verified all associated processes are cleaned up after timeout handling completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->