### PR TITLE
fix(hooks): make lifecycle timeout and regression clocks deterministic

### DIFF
--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -89,11 +89,11 @@ _octopus_agent_lifecycle_event() {
         elif command -v timeout >/dev/null 2>&1; then
             timeout "$hook_timeout" "$hook" "$event"
         else
-            # Built-in timeout fallback: run hook in background, wait with a
-            # SECONDS-based deadline, and kill if still running. Uses only
-            # Bash builtins plus the already-required sleep command, so
-            # systems without the Octopus run_with_timeout helper or GNU
-            # timeout do not execute hooks unbounded. See issue #511.
+            # Built-in timeout fallback: run the hook and an independent sleep
+            # watchdog in parallel, then kill the hook group if the watchdog
+            # finishes first. This avoids wall-clock deadlines (`SECONDS` can
+            # jump with the host clock) and uses only Bash builtins plus the
+            # already-required sleep command. See issues #511 and #837.
             #
             # `set -m` puts the backgrounded hook in its own process group
             # (Bash's job-control assigns pgid = pid of the group leader),
@@ -103,8 +103,9 @@ _octopus_agent_lifecycle_event() {
             "$hook" "$event" &
             local _hook_pid=$!
             set +m
-            local _hook_deadline=$((SECONDS + hook_timeout))
-            while kill -0 "$_hook_pid" 2>/dev/null && [[ "$SECONDS" -lt "$_hook_deadline" ]]; do
+            sleep "$hook_timeout" &
+            local _hook_watchdog_pid=$!
+            while kill -0 "$_hook_pid" 2>/dev/null && kill -0 "$_hook_watchdog_pid" 2>/dev/null; do
                 sleep 1
             done
             if kill -0 "$_hook_pid" 2>/dev/null; then
@@ -115,6 +116,8 @@ _octopus_agent_lifecycle_event() {
                 kill -KILL "$_hook_pid" 2>/dev/null || true
             fi
             wait "$_hook_pid" 2>/dev/null || true
+            kill "$_hook_watchdog_pid" 2>/dev/null || true
+            wait "$_hook_watchdog_pid" 2>/dev/null || true
         fi
     ) >>"$hook_log" 2>&1 || true
 }

--- a/tests/unit/test-agent-lifecycle-events.sh
+++ b/tests/unit/test-agent-lifecycle-events.sh
@@ -17,6 +17,11 @@ source "$PROJECT_ROOT/scripts/lib/events.sh"
 # shellcheck source=/dev/null
 source "$PROJECT_ROOT/scripts/lib/spawn.sh"
 
+MONOTONIC_PYTHON=$(command -v python3)
+monotonic_millis() {
+  "$MONOTONIC_PYTHON" -c 'import time; print(time.monotonic_ns() // 1000000)'
+}
+
 test_suite "agent lifecycle events"
 
 TEST_TMP_DIR="/tmp/octopus-tests-$$"
@@ -105,21 +110,29 @@ sleep 60
 HOOK
 chmod +x "$TMP_DIR/slow-hook.sh"
 
+test_case "built-in lifecycle timeout uses a sleep watchdog, not a wall clock"
+fallback_impl=$(sed -n '/# Built-in timeout fallback:/,/wait "\$_hook_pid"/p' "$PROJECT_ROOT/scripts/lib/spawn.sh")
+if grep -q '_hook_watchdog_pid' <<<"$fallback_impl" && ! grep -q '\$SECONDS' <<<"$fallback_impl"; then
+  test_pass
+else
+  test_fail "fallback must use a reaped sleep watchdog without a SECONDS deadline"
+fi
+
 test_case "lifecycle hook timeout prevents observer hangs"
 export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/slow-hook.sh"
 hook_timeout_secs=1
 export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT="$hook_timeout_secs"
-start=$SECONDS
+start_ms=$(monotonic_millis)
 _octopus_agent_lifecycle_event "spawned" "codex" "task-slow-hook" "developer" "tangle" "555" "$RESULTS_DIR/codex-slow-hook.md" "" "running"
-elapsed=$((SECONDS - start))
+elapsed_ms=$(( $(monotonic_millis) - start_ms ))
 # oco-588: measure against the configured timeout plus a generous grace
 # margin instead of a fixed small bound — loaded runners have exhibited
 # scheduler pauses above 10s. The hook sleeps 60s so a broken timeout still
 # cannot finish naturally inside this 30s bound.
-if [[ "$elapsed" -lt $((hook_timeout_secs + 29)) ]]; then
+if [[ "$elapsed_ms" -lt $(( (hook_timeout_secs + 29) * 1000 )) ]]; then
   test_pass
 else
-  test_fail "hook timeout did not return promptly"
+  test_fail "hook timeout did not return promptly (${elapsed_ms}ms)"
 fi
 unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 
@@ -155,7 +168,7 @@ export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/slow-fallback-hook.sh"
 hook_timeout_secs=1
 export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT="$hook_timeout_secs"
 saved_path="$PATH"
-start=$SECONDS
+start_ms=$(monotonic_millis)
 PATH="$no_timeout_bin"
 # declare -f run_with_timeout is checked before the PATH-based `timeout`
 # lookup, so PATH alone doesn't guarantee this test hits the built-in
@@ -164,14 +177,14 @@ PATH="$no_timeout_bin"
 unset -f run_with_timeout 2>/dev/null || true
 _octopus_agent_lifecycle_event "spawned" "codex" "task-fallback-timeout" "developer" "tangle" "556" "$RESULTS_DIR/codex-fallback-timeout.md" "" "running"
 PATH="$saved_path"
-elapsed=$((SECONDS - start))
+elapsed_ms=$(( $(monotonic_millis) - start_ms ))
 # oco-588: same generous grace margin as the primary timeout test above —
-# the built-in fallback polls in whole-second SECONDS increments, which
-# adds its own rounding jitter on top of scheduler jitter.
-if [[ "$elapsed" -lt $((hook_timeout_secs + 29)) ]]; then
+# the built-in fallback watchdog sleeps in whole seconds, which adds its own
+# rounding jitter on top of scheduler jitter.
+if [[ "$elapsed_ms" -lt $(( (hook_timeout_secs + 29) * 1000 )) ]]; then
   test_pass
 else
-  test_fail "built-in timeout fallback did not return promptly"
+  test_fail "built-in timeout fallback did not return promptly (${elapsed_ms}ms)"
 fi
 unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 
@@ -204,9 +217,9 @@ unset -f run_with_timeout 2>/dev/null || true
 # sleep-60 children exit naturally — bound elapsed time so that regression
 # can't hide behind an eventual, too-slow pass. Same generous grace margin
 # as the sibling built-in-fallback test above.
-hook_started=$SECONDS
+hook_started_ms=$(monotonic_millis)
 _octopus_agent_lifecycle_event "spawned" "codex" "task-orphan-check" "developer" "tangle" "558" "$RESULTS_DIR/codex-orphan-check.md" "" "running"
-hook_elapsed=$((SECONDS - hook_started))
+hook_elapsed_ms=$(( $(monotonic_millis) - hook_started_ms ))
 PATH="$saved_path"
 orphan_survivor=0
 child_count=0
@@ -223,10 +236,10 @@ for pidfile in "$TMP_DIR/orphan-check"/child*.pid; do
     orphan_survivor=1
   fi
 done
-if [[ "$hook_elapsed" -lt $((hook_timeout_secs + 29)) && "$child_count" -eq 2 && "$orphan_survivor" -eq 0 ]]; then
+if [[ "$hook_elapsed_ms" -lt $(( (hook_timeout_secs + 29) * 1000 )) && "$child_count" -eq 2 && "$orphan_survivor" -eq 0 ]]; then
   test_pass
 else
-  test_fail "fallback did not finish within the bound (${hook_elapsed}s), didn't record both children ($child_count/2), or a grandchild survived teardown"
+  test_fail "fallback did not finish within the bound (${hook_elapsed_ms}ms), didn't record both children ($child_count/2), or a grandchild survived teardown"
 fi
 unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 

--- a/tests/unit/test-provider-auth-validity.sh
+++ b/tests/unit/test-provider-auth-validity.sh
@@ -256,18 +256,19 @@ sleep 600
 EOF
     chmod +x "$stubborn"
 
-    local start dur ec
-    start=$SECONDS
+    local start_ms end_ms dur_ms ec
+    start_ms=$(python3 -c 'import time; print(time.monotonic_ns() // 1000000)')
     set +e
     run_with_timeout 2 "$stubborn" >/dev/null 2>&1
     ec=$?
     set -e
-    dur=$((SECONDS - start))
+    end_ms=$(python3 -c 'import time; print(time.monotonic_ns() // 1000000)')
+    dur_ms=$((end_ms - start_ms))
 
-    if [[ "$ec" -ne 0 && "$dur" -lt 20 ]]; then
+    if [[ "$ec" -ne 0 && "$dur_ms" -lt 20000 ]]; then
         test_pass
     else
-        test_fail "stubborn process not killed promptly (exit=$ec, dur=${dur}s; expected non-zero exit, <20s)"
+        test_fail "stubborn process not killed promptly (exit=$ec, dur=${dur_ms}ms; expected non-zero exit, <20000ms)"
     fi
 }
 

--- a/tests/unit/test-provider-auth-validity.sh
+++ b/tests/unit/test-provider-auth-validity.sh
@@ -249,26 +249,32 @@ test_fleet_includes_openai_compat_qwen() {
 test_timeout_kills_term_ignorer() {
     test_case "run_with_timeout: SIGTERM-ignoring process is SIGKILLed"
     local stubborn="$FIXTURE/stubborn.sh"
+    local started="$FIXTURE/stubborn.started"
     cat > "$stubborn" <<'EOF'
 #!/bin/bash
+printf '%s\n' "$$" > "$1"
 trap '' TERM        # ignore SIGTERM — only SIGKILL can stop us
 sleep 600
 EOF
     chmod +x "$stubborn"
 
-    local start_ms end_ms dur_ms ec
+    local start_ms end_ms dur_ms ec started_pid="" still_alive=false
     start_ms=$(python3 -c 'import time; print(time.monotonic_ns() // 1000000)')
     set +e
-    run_with_timeout 2 "$stubborn" >/dev/null 2>&1
+    run_with_timeout 2 "$stubborn" "$started" >/dev/null 2>&1
     ec=$?
     set -e
     end_ms=$(python3 -c 'import time; print(time.monotonic_ns() // 1000000)')
     dur_ms=$((end_ms - start_ms))
+    [[ -s "$started" ]] && started_pid=$(cat "$started")
+    if [[ -n "$started_pid" ]] && kill -0 "$started_pid" 2>/dev/null; then
+        still_alive=true
+    fi
 
-    if [[ "$ec" -ne 0 && "$dur_ms" -lt 20000 ]]; then
+    if [[ "$ec" -eq 137 && -n "$started_pid" && "$still_alive" == "false" && "$dur_ms" -lt 20000 ]]; then
         test_pass
     else
-        test_fail "stubborn process not killed promptly (exit=$ec, dur=${dur_ms}ms; expected non-zero exit, <20000ms)"
+        test_fail "stubborn process did not prove SIGKILL escalation (exit=$ec, pid=${started_pid:-missing}, alive=$still_alive, dur=${dur_ms}ms; expected exit=137, started+dead pid, <20000ms)"
     fi
 }
 

--- a/tests/unit/test-provider-auth-validity.sh
+++ b/tests/unit/test-provider-auth-validity.sh
@@ -256,14 +256,13 @@ sleep 600
 EOF
     chmod +x "$stubborn"
 
-    local start end dur ec
-    start="$(date +%s)"
+    local start dur ec
+    start=$SECONDS
     set +e
     run_with_timeout 2 "$stubborn" >/dev/null 2>&1
     ec=$?
     set -e
-    end="$(date +%s)"
-    dur=$(( end - start ))
+    dur=$((SECONDS - start))
 
     if [[ "$ec" -ne 0 && "$dur" -lt 20 ]]; then
         test_pass


### PR DESCRIPTION
## Problem

Two related clock/evidence defects made hook timeout tests flaky and left the minimal-environment lifecycle fallback dependent on wall time:

- `test_timeout_kills_term_ignorer` used `date +%s`, so a host clock jump could report hundreds of seconds after a correct kill. Its old assertion also accepted any nonzero exit.
- Three lifecycle promptness tests and the production no-`timeout` fallback used Bash `SECONDS`, which is also wall-clock-backed.

## Fix

- Provider regression timestamps use Python `time.monotonic_ns()`. The fixture records its PID, and the test requires exit 137, a started-and-dead process, and the `<20s` bound.
- The production lifecycle fallback uses a reaped `sleep` watchdog instead of a `SECONDS` deadline, retaining process-group TERM/KILL cleanup without `pkill`.
- All three lifecycle elapsed-time assertions use the same true monotonic helper.
- A contract regression rejects any return to a `$SECONDS` lifecycle deadline.

## Verification

- Red baseline: watchdog contract failed against the prior production fallback.
- `bash tests/unit/test-agent-lifecycle-events.sh`: 10/10
- `bash tests/unit/test-provider-auth-validity.sh`: 18/18
- Bash syntax, ShellCheck, and `git diff --check`: clean
- Complete remote Linux/macOS/symlink matrix is rerunning on final head `21f6158c`.

Closes #832.
Closes #837.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle-hook timeout handling with a more reliable watchdog mechanism.
  * Timed-out processes are now terminated and cleaned up more consistently, including processes that ignore termination requests.

* **Tests**
  * Expanded timeout regression coverage with reliable elapsed-time measurements and child-process tracking.
  * Verifies correct failure reporting and completion within the expected 20-second limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->