### PR TITLE
fix: make release validation recursive and monotonic

### DIFF
--- a/scripts/lib/release-validation.sh
+++ b/scripts/lib/release-validation.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Helpers for release manifest validation.
+
+octo_release_skill_files() {
+    local root="$1"
+    local skills_root="${root%/}/skills"
+
+    [[ -d "$skills_root" ]] || return 0
+
+    find "$skills_root" -mindepth 2 -type f -name 'SKILL.md' -print 2>/dev/null |
+        while IFS= read -r skill_path; do
+            skill_path="${skill_path#"$skills_root"/}"
+            printf '%s\n' "${skill_path%/SKILL.md}"
+        done |
+        sort
+}

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+# shellcheck source=scripts/lib/release-validation.sh
+source "$SCRIPT_DIR/lib/release-validation.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -367,7 +369,7 @@ echo ""
 echo "🎯 Checking skill registration..."
 
 if command -v jq >/dev/null 2>&1 && jq -e '.skills[]? | select(startswith("./skills/"))' "$ROOT_DIR/.claude-plugin/plugin.json" >/dev/null 2>&1; then
-    SKILL_FILES=$(find "$ROOT_DIR/skills" -mindepth 2 -maxdepth 2 -name "SKILL.md" -type f 2>/dev/null | sed "s|^$ROOT_DIR/skills/||;s|/SKILL.md$||" | sort)
+    SKILL_FILES=$(octo_release_skill_files "$ROOT_DIR")
     REGISTERED_SKILLS=$(jq -r '.skills[]? | select(startswith("./skills/")) | sub("^\\./skills/"; "") | sub("/$"; "")' "$ROOT_DIR/.claude-plugin/plugin.json" | sort)
 else
     SKILL_FILES=$({

--- a/tests/unit/test-provider-auth-validity.sh
+++ b/tests/unit/test-provider-auth-validity.sh
@@ -256,14 +256,13 @@ sleep 600
 EOF
     chmod +x "$stubborn"
 
-    local start end dur ec
-    start="$(date +%s)"
+    local start dur ec
+    start=$SECONDS
     set +e
     run_with_timeout 2 "$stubborn" >/dev/null 2>&1
     ec=$?
     set -e
-    end="$(date +%s)"
-    dur=$(( end - start ))
+    dur=$(( SECONDS - start ))
 
     if [[ "$ec" -ne 0 && "$dur" -lt 20 ]]; then
         test_pass

--- a/tests/unit/test-release-validation.sh
+++ b/tests/unit/test-release-validation.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Regression coverage for release validation helpers.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VALIDATION_LIB="$PROJECT_ROOT/scripts/lib/release-validation.sh"
+VALIDATE_RELEASE="$PROJECT_ROOT/scripts/validate-release.sh"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+source "$VALIDATION_LIB"
+
+test_suite "release validation helpers"
+
+test_nested_skill_discovery() {
+    test_case "skill discovery preserves ordinary and nested registration paths"
+
+    local fixture
+    fixture="$(mktemp -d "${TMPDIR:-/tmp}/octo-release-validation.XXXXXX")"
+    mkdir -p \
+        "$fixture/skills/plain-skill" \
+        "$fixture/skills/starter-pack/nested-skill" \
+        "$fixture/skills/starter-pack/not-a-skill"
+    touch \
+        "$fixture/skills/plain-skill/SKILL.md" \
+        "$fixture/skills/starter-pack/nested-skill/SKILL.md" \
+        "$fixture/skills/starter-pack/not-a-skill/README.md"
+
+    local actual expected
+    actual="$(octo_release_skill_files "$fixture")"
+    expected=$'plain-skill\nstarter-pack/nested-skill'
+    rm -rf "$fixture"
+
+    if [[ "$actual" == "$expected" ]]; then
+        test_pass
+    else
+        test_fail "unexpected skill paths: ${actual}"
+    fi
+}
+
+test_validator_uses_recursive_skill_discovery() {
+    test_case "validate-release delegates skill discovery to the tested helper"
+
+    if grep -Fq 'octo_release_skill_files "$ROOT_DIR"' "$VALIDATE_RELEASE"; then
+        test_pass
+    else
+        test_fail "validate-release does not use octo_release_skill_files"
+    fi
+}
+
+test_nested_skill_discovery
+test_validator_uses_recursive_skill_discovery
+
+test_summary


### PR DESCRIPTION
## Summary

- recursively discover `SKILL.md` registration paths, including supported nested bundles such as `skills/octopus-starter-pack/<skill>`
- move skill discovery into a directly tested release-validation helper
- make the SIGKILL timeout regression use Bash `SECONDS`, avoiding false failures when the host wall clock changes

Closes #829.
Closes #832.

## Verification

- `bash tests/unit/test-release-validation.sh` — 2/2
- `bash tests/unit/test-provider-auth-validity.sh` — 18/18, three consecutive runs
- `make sync-check`
- `OCTOPUS_NON_INTERACTIVE=1 make ci-local` — 247/247 unit suites, 16/16 smoke suites, 7/7 integration suites; all CI-only verifications green
- no mode changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation to reliably discover nested skill files.
  * Safely handles releases without a skills directory.
  * Improved timeout measurement for provider authentication validation.

* **Tests**
  * Added regression coverage for nested skill discovery, invalid directories, and validation behavior.
  * Confirmed timeout checks complete within the expected limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->