### PR TITLE
fix: use monotonic clock in lifecycle hook timeout tests

### DIFF
--- a/tests/unit/test-agent-lifecycle-events.sh
+++ b/tests/unit/test-agent-lifecycle-events.sh
@@ -19,6 +19,14 @@ source "$PROJECT_ROOT/scripts/lib/spawn.sh"
 
 test_suite "agent lifecycle events"
 
+# Bash SECONDS is wall-clock-backed, not monotonic — a host/NTP/VM clock
+# jump can produce a negative or wildly inflated delta and false-fail (or
+# false-pass) a timeout regression. Use a monotonic source instead.
+# Resolved once, up front: later test cases below deliberately restrict
+# PATH to a directory without python3 to simulate a host missing `timeout`.
+_PYTHON3_BIN="$(command -v python3)"
+_now_ms() { "$_PYTHON3_BIN" -c 'import time; print(time.monotonic_ns() // 1000000)'; }
+
 TEST_TMP_DIR="/tmp/octopus-tests-$$"
 mkdir -p "$TEST_TMP_DIR"
 trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
@@ -109,17 +117,17 @@ test_case "lifecycle hook timeout prevents observer hangs"
 export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/slow-hook.sh"
 hook_timeout_secs=1
 export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT="$hook_timeout_secs"
-start=$SECONDS
+start_ms=$(_now_ms)
 _octopus_agent_lifecycle_event "spawned" "codex" "task-slow-hook" "developer" "tangle" "555" "$RESULTS_DIR/codex-slow-hook.md" "" "running"
-elapsed=$((SECONDS - start))
+elapsed_ms=$(( $(_now_ms) - start_ms ))
 # oco-588: measure against the configured timeout plus a generous grace
 # margin instead of a fixed small bound — loaded runners have exhibited
 # scheduler pauses above 10s. The hook sleeps 60s so a broken timeout still
 # cannot finish naturally inside this 30s bound.
-if [[ "$elapsed" -lt $((hook_timeout_secs + 29)) ]]; then
+if [[ "$elapsed_ms" -lt $(( (hook_timeout_secs + 29) * 1000 )) ]]; then
   test_pass
 else
-  test_fail "hook timeout did not return promptly"
+  test_fail "hook timeout did not return promptly (${elapsed_ms}ms)"
 fi
 unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 
@@ -155,7 +163,7 @@ export OCTOPUS_AGENT_LIFECYCLE_HOOK="$TMP_DIR/slow-fallback-hook.sh"
 hook_timeout_secs=1
 export OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT="$hook_timeout_secs"
 saved_path="$PATH"
-start=$SECONDS
+start_ms=$(_now_ms)
 PATH="$no_timeout_bin"
 # declare -f run_with_timeout is checked before the PATH-based `timeout`
 # lookup, so PATH alone doesn't guarantee this test hits the built-in
@@ -164,14 +172,14 @@ PATH="$no_timeout_bin"
 unset -f run_with_timeout 2>/dev/null || true
 _octopus_agent_lifecycle_event "spawned" "codex" "task-fallback-timeout" "developer" "tangle" "556" "$RESULTS_DIR/codex-fallback-timeout.md" "" "running"
 PATH="$saved_path"
-elapsed=$((SECONDS - start))
+elapsed_ms=$(( $(_now_ms) - start_ms ))
 # oco-588: same generous grace margin as the primary timeout test above —
 # the built-in fallback polls in whole-second SECONDS increments, which
 # adds its own rounding jitter on top of scheduler jitter.
-if [[ "$elapsed" -lt $((hook_timeout_secs + 29)) ]]; then
+if [[ "$elapsed_ms" -lt $(( (hook_timeout_secs + 29) * 1000 )) ]]; then
   test_pass
 else
-  test_fail "built-in timeout fallback did not return promptly"
+  test_fail "built-in timeout fallback did not return promptly (${elapsed_ms}ms)"
 fi
 unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 
@@ -204,9 +212,9 @@ unset -f run_with_timeout 2>/dev/null || true
 # sleep-60 children exit naturally — bound elapsed time so that regression
 # can't hide behind an eventual, too-slow pass. Same generous grace margin
 # as the sibling built-in-fallback test above.
-hook_started=$SECONDS
+hook_started_ms=$(_now_ms)
 _octopus_agent_lifecycle_event "spawned" "codex" "task-orphan-check" "developer" "tangle" "558" "$RESULTS_DIR/codex-orphan-check.md" "" "running"
-hook_elapsed=$((SECONDS - hook_started))
+hook_elapsed_ms=$(( $(_now_ms) - hook_started_ms ))
 PATH="$saved_path"
 orphan_survivor=0
 child_count=0
@@ -223,10 +231,10 @@ for pidfile in "$TMP_DIR/orphan-check"/child*.pid; do
     orphan_survivor=1
   fi
 done
-if [[ "$hook_elapsed" -lt $((hook_timeout_secs + 29)) && "$child_count" -eq 2 && "$orphan_survivor" -eq 0 ]]; then
+if [[ "$hook_elapsed_ms" -lt $(( (hook_timeout_secs + 29) * 1000 )) && "$child_count" -eq 2 && "$orphan_survivor" -eq 0 ]]; then
   test_pass
 else
-  test_fail "fallback did not finish within the bound (${hook_elapsed}s), didn't record both children ($child_count/2), or a grandchild survived teardown"
+  test_fail "fallback did not finish within the bound (${hook_elapsed_ms}ms), didn't record both children ($child_count/2), or a grandchild survived teardown"
 fi
 unset OCTOPUS_AGENT_LIFECYCLE_HOOK_TIMEOUT
 


### PR DESCRIPTION
## Problem

`tests/unit/test-agent-lifecycle-events.sh` measured elapsed time with Bash `SECONDS` in three timeout-bound assertions (`tests/unit/test-agent-lifecycle-events.sh:117-124`, `:163-179`, `:212-232`). `SECONDS` follows the wall clock, not a monotonic source, so a host/NTP/VM clock jump can false-fail a healthy timeout or hide an overrun — the same flake class PR #833 already removed from `tests/unit/test-provider-auth-validity.sh`.

## Fix

- Added a `_now_ms()` helper using `python3 -c 'import time; print(time.monotonic_ns() // 1000000)'`, matching the pattern already established in #833.
- Replaced all three `SECONDS`-based measurements with `_now_ms()`, converting the existing generous bounds (`hook_timeout_secs + 29` seconds) to milliseconds explicitly.
- Resolved `python3`'s path once up front (`_PYTHON3_BIN="$(command -v python3)"`) rather than calling `python3` bare: the "built-in timeout fallback" test case deliberately restricts `PATH` to a directory containing only `sleep`/`bash`/`date`/`dirname` to simulate a host without `timeout`, and that restricted `PATH` does not include `python3`. Calling `python3` bare inside that block fails with `command not found` — caught by actually running the suite, not just syntax-checking it.
- Left the Bash 3.2 production floor untouched — this only touches a test file, and Python in tests is already an accepted dependency (established by #833).

## Verification

```
bash -n tests/unit/test-agent-lifecycle-events.sh
bash tests/unit/test-agent-lifecycle-events.sh   # 9/9 passing
bash tests/unit/test-provider-auth-validity.sh   # 18/18 passing (sibling monotonic-clock suite, unaffected)
bash -n scripts/*.sh scripts/lib/*.sh tests/unit/*.sh   # all clean
git diff --summary | grep "mode change"   # empty, no mode changes
```

`shellcheck` was not available in this environment to verify locally; relying on CI for that check.

Did not run the full `make ci-local` / `make test-unit` / `make test-integration` matrix — this is a single test-file change with no production code touched, so the directly affected suite plus its sibling monotonic-clock suite is the meaningful surface; relying on CI (Smoke Tests, Unit Tests, Integration Tests) for the rest.

Closes #837.

---

_Filed by the scheduled daily bug-triage routine._


---
_Generated by [Claude Code](https://claude.ai/code/session_013DvNwnZKEn7sApKczCbtFh)_