### PR TITLE
fix: is_agent_available_v2 fails closed for unrecognized agents

### DIFF
--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -524,10 +524,10 @@ _octo_assignment_has_nonempty_value() {
 
     value="$(sed -n "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*//p" "$file" 2>/dev/null | tail -n 1)"
     value="$(printf '%s\n' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    value="$(printf '%s\n' "$value" | sed 's/[[:space:]][[:space:]]*#.*$//; s/[[:space:]]*$//')"
     case "$value" in
         \"*\") value="${value#\"}"; value="${value%\"}" ;;
         \'*\') value="${value#\'}"; value="${value%\'}" ;;
-        *) value="$(printf '%s\n' "$value" | sed 's/[[:space:]][[:space:]]*#.*$//')" ;;
     esac
     value="$(printf '%s\n' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
     [[ -n "$value" ]]

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -579,8 +579,37 @@ is_agent_available_v2() {
                 grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null
             }
             ;;
+        grok|grok-*)
+            declare -f grok_is_available >/dev/null 2>&1 && grok_is_available
+            ;;
+        commandcode|commandcode-*)
+            local cc_bin="${OCTOPUS_COMMANDCODE_BIN:-}"
+            [[ -z "$cc_bin" ]] && command -v command-code &>/dev/null && cc_bin="command-code"
+            [[ -z "$cc_bin" ]] && command -v cmd &>/dev/null && cc_bin="cmd"
+            [[ -n "$cc_bin" ]] && { [[ -x "$cc_bin" ]] || command -v "$cc_bin" &>/dev/null; } && \
+                { [[ -n "${COMMAND_CODE_API_KEY:-}" ]] || "$cc_bin" status --json &>/dev/null; }
+            ;;
+        atlascloud|atlascloud-*)
+            if [[ -z "${ATLASCLOUD_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
+                resolve_provider_env "ATLASCLOUD_API_KEY" 2>/dev/null || true
+            fi
+            [[ -n "${ATLASCLOUD_API_KEY:-}" ]] && \
+                { [[ -n "${ATLASCLOUD_MODEL:-}" ]] || [[ -n "${OCTOPUS_ATLASCLOUD_MODEL:-}" ]] || [[ -n "${OPENAI_COMPAT_MODEL:-}" ]]; }
+            ;;
+        vibe|vibe-*)
+            if [[ -z "${MISTRAL_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
+                resolve_provider_env "MISTRAL_API_KEY" 2>/dev/null || true
+            fi
+            command -v vibe &>/dev/null && {
+                [[ -n "${MISTRAL_API_KEY:-}" ]] || \
+                { [[ -f "${HOME}/.vibe/.env" ]] && grep -Eq '^[[:space:]]*MISTRAL_API_KEY=' "${HOME}/.vibe/.env" 2>/dev/null; } || \
+                { [[ -f "${HOME}/.vibe/config.toml" ]] && grep -Eq '^[[:space:]]*api_key[[:space:]]*=' "${HOME}/.vibe/config.toml" 2>/dev/null; }
+            }
+            ;;
         *)
-            return 0  # Unknown agents assumed available
+            return 1  # Unknown agents fail closed (#799: was `return 0`, which
+                      # could seat a provider with no availability contract and
+                      # defer the failure until mid-workflow)
             ;;
     esac
 }

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -518,19 +518,51 @@ validate_model_name() {
 
 
 # ── v2 agent helpers (moved from orchestrate.sh v9.22.1) ──
+_octo_value_has_nonwhitespace() {
+    local value
+    value="$(printf '%s\n' "${1:-}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [[ -n "$value" ]]
+}
+
+_octo_strip_unquoted_comment() {
+    local input="$1" output="" quote="" char
+    local index=0 escaped=0 length=${#1}
+    while (( index < length )); do
+        char="${input:index:1}"
+        if (( escaped )); then
+            output="${output}${char}"
+            escaped=0
+        elif [[ "$quote" == '"' && "$char" == "\\" ]]; then
+            output="${output}${char}"
+            escaped=1
+        elif [[ -z "$quote" && "$char" == "#" ]]; then
+            break
+        else
+            output="${output}${char}"
+            if [[ -z "$quote" && ( "$char" == '"' || "$char" == "'" ) ]]; then
+                quote="$char"
+            elif [[ -n "$quote" && "$char" == "$quote" ]]; then
+                quote=""
+            fi
+        fi
+        index=$((index + 1))
+    done
+    printf '%s\n' "$output"
+}
+
 _octo_assignment_has_nonempty_value() {
     local file="$1" key="$2" value
     [[ -f "$file" ]] || return 1
 
     value="$(sed -n "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*//p" "$file" 2>/dev/null | tail -n 1)"
     value="$(printf '%s\n' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
-    value="$(printf '%s\n' "$value" | sed 's/[[:space:]][[:space:]]*#.*$//; s/[[:space:]]*$//')"
+    value="$(_octo_strip_unquoted_comment "$value")"
+    value="$(printf '%s\n' "$value" | sed 's/[[:space:]]*$//')"
     case "$value" in
         \"*\") value="${value#\"}"; value="${value%\"}" ;;
         \'*\') value="${value#\'}"; value="${value%\'}" ;;
     esac
-    value="$(printf '%s\n' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
-    [[ -n "$value" ]]
+    _octo_value_has_nonwhitespace "$value"
 }
 
 is_agent_available_v2() {
@@ -616,7 +648,7 @@ is_agent_available_v2() {
                 resolve_provider_env "MISTRAL_API_KEY" 2>/dev/null || true
             fi
             command -v vibe &>/dev/null && {
-                [[ -n "${MISTRAL_API_KEY:-}" ]] || \
+                _octo_value_has_nonwhitespace "${MISTRAL_API_KEY:-}" || \
                 _octo_assignment_has_nonempty_value "${HOME}/.vibe/.env" "MISTRAL_API_KEY" || \
                 _octo_assignment_has_nonempty_value "${HOME}/.vibe/config.toml" "api_key"
             }

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -518,6 +518,21 @@ validate_model_name() {
 
 
 # ── v2 agent helpers (moved from orchestrate.sh v9.22.1) ──
+_octo_assignment_has_nonempty_value() {
+    local file="$1" key="$2" value
+    [[ -f "$file" ]] || return 1
+
+    value="$(sed -n "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*//p" "$file" 2>/dev/null | tail -n 1)"
+    value="$(printf '%s\n' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    case "$value" in
+        \"*\") value="${value#\"}"; value="${value%\"}" ;;
+        \'*\') value="${value#\'}"; value="${value%\'}" ;;
+        *) value="$(printf '%s\n' "$value" | sed 's/[[:space:]][[:space:]]*#.*$//')" ;;
+    esac
+    value="$(printf '%s\n' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [[ -n "$value" ]]
+}
+
 is_agent_available_v2() {
     local agent="$1"
 
@@ -602,8 +617,8 @@ is_agent_available_v2() {
             fi
             command -v vibe &>/dev/null && {
                 [[ -n "${MISTRAL_API_KEY:-}" ]] || \
-                { [[ -f "${HOME}/.vibe/.env" ]] && grep -Eq '^[[:space:]]*MISTRAL_API_KEY=' "${HOME}/.vibe/.env" 2>/dev/null; } || \
-                { [[ -f "${HOME}/.vibe/config.toml" ]] && grep -Eq '^[[:space:]]*api_key[[:space:]]*=' "${HOME}/.vibe/config.toml" 2>/dev/null; }
+                _octo_assignment_has_nonempty_value "${HOME}/.vibe/.env" "MISTRAL_API_KEY" || \
+                _octo_assignment_has_nonempty_value "${HOME}/.vibe/config.toml" "api_key"
             }
             ;;
         *)

--- a/tests/unit/test-agent-predicates.sh
+++ b/tests/unit/test-agent-predicates.sh
@@ -88,36 +88,48 @@ fi
 unset -f grok_is_available
 
 test_case "is_agent_available_v2 recognizes authenticated Vibe and rejects missing auth (#799)"
-vibe() { :; }
-if MISTRAL_API_KEY="test-key" is_agent_available_v2 "vibe-research"; then
-    octo_saved_home="$HOME"
-    HOME="$(mktemp -d /tmp/octopus-vibe-predicate.XXXXXX)"
-    if ! is_agent_available_v2 "vibe"; then
-        rm -rf "$HOME"
-        HOME="$octo_saved_home"
-        unset -f vibe
-        test_pass
-    else
-        rm -rf "$HOME"
-        HOME="$octo_saved_home"
-        unset -f vibe
-        test_fail "Vibe reported available without any supported authentication"
-    fi
+if (
+    vibe() { :; }
+    resolve_provider_env() { return 1; }
+    HOME="$TEST_TMP_DIR/vibe-predicate-home"
+    mkdir -p "$HOME/.vibe"
+    unset MISTRAL_API_KEY
+    octo_fixture_value="fixture-value"
+
+    MISTRAL_API_KEY="$octo_fixture_value" is_agent_available_v2 "vibe-research" || exit 1
+    is_agent_available_v2 "vibe" && exit 1
+
+    printf 'MISTRAL_API_KEY=\n' > "$HOME/.vibe/.env"
+    is_agent_available_v2 "vibe" && exit 1
+    printf 'MISTRAL_API_KEY=""\n' > "$HOME/.vibe/.env"
+    is_agent_available_v2 "vibe" && exit 1
+    rm -f "$HOME/.vibe/.env"
+
+    printf 'api_key =\n' > "$HOME/.vibe/config.toml"
+    is_agent_available_v2 "vibe" && exit 1
+    printf 'api_key = ""\n' > "$HOME/.vibe/config.toml"
+    is_agent_available_v2 "vibe" && exit 1
+    printf 'api_key = "%s"\n' "$octo_fixture_value" > "$HOME/.vibe/config.toml"
+    is_agent_available_v2 "vibe"
+); then
+    test_pass
 else
-    unset -f vibe
-    test_fail "Authenticated Vibe provider was rejected"
+    test_fail "Vibe availability accepted blank auth or rejected a valid credential"
 fi
 
 test_case "is_agent_available_v2 Atlas Cloud requires both API key and model (#799)"
-unset ATLASCLOUD_MODEL OCTOPUS_ATLASCLOUD_MODEL OPENAI_COMPAT_MODEL
-if ! ATLASCLOUD_API_KEY="test-key" is_agent_available_v2 "atlascloud"; then
-    if ATLASCLOUD_API_KEY="test-key" OCTOPUS_ATLASCLOUD_MODEL="vendor/model" is_agent_available_v2 "atlascloud"; then
-        test_pass
-    else
-        test_fail "Atlas Cloud was rejected despite API key and model"
-    fi
+if (
+    resolve_provider_env() { return 1; }
+    unset ATLASCLOUD_API_KEY ATLASCLOUD_MODEL OCTOPUS_ATLASCLOUD_MODEL OPENAI_COMPAT_MODEL
+    octo_fixture_value="fixture-value"
+    export ATLASCLOUD_API_KEY="$octo_fixture_value"
+    is_agent_available_v2 "atlascloud" && exit 1
+    export OCTOPUS_ATLASCLOUD_MODEL="vendor/model"
+    is_agent_available_v2 "atlascloud"
+); then
+    test_pass
 else
-    test_fail "Atlas Cloud was accepted without a dispatchable model"
+    test_fail "Atlas Cloud did not require both API key and model"
 fi
 
 test_summary

--- a/tests/unit/test-agent-predicates.sh
+++ b/tests/unit/test-agent-predicates.sh
@@ -87,55 +87,82 @@ else
 fi
 unset -f grok_is_available
 
-test_case "is_agent_available_v2 recognizes authenticated Vibe and rejects missing auth (#799)"
-if (
+VIBE_PREDICATE_HOME="$TEST_TMP_DIR/vibe-predicate-home"
+mkdir -p "$VIBE_PREDICATE_HOME/.vibe"
+
+vibe_fixture_available() (
     vibe() { :; }
     resolve_provider_env() { return 1; }
-    HOME="$TEST_TMP_DIR/vibe-predicate-home"
-    mkdir -p "$HOME/.vibe"
-    unset MISTRAL_API_KEY
-    octo_fixture_value="fixture-value"
+    HOME="$VIBE_PREDICATE_HOME"
+    if [[ "${1:-unset}" == "unset" ]]; then
+        unset MISTRAL_API_KEY
+    else
+        export "MISTRAL_API_KEY=${1}"
+    fi
+    is_agent_available_v2 "${2:-vibe}"
+)
 
-    export "MISTRAL_API_KEY=${octo_fixture_value}"
-    is_agent_available_v2 "vibe-research" || exit 1
-    unset MISTRAL_API_KEY
-    is_agent_available_v2 "vibe" && exit 1
-
-    printf 'MISTRAL_API_KEY=\n' > "$HOME/.vibe/.env"
-    is_agent_available_v2 "vibe" && exit 1
-    printf 'MISTRAL_API_KEY=""\n' > "$HOME/.vibe/.env"
-    is_agent_available_v2 "vibe" && exit 1
-    printf 'MISTRAL_API_KEY="" # intentionally blank\n' > "$HOME/.vibe/.env"
-    is_agent_available_v2 "vibe" && exit 1
-    rm -f "$HOME/.vibe/.env"
-
-    printf 'api_key =\n' > "$HOME/.vibe/config.toml"
-    is_agent_available_v2 "vibe" && exit 1
-    printf 'api_key = ""\n' > "$HOME/.vibe/config.toml"
-    is_agent_available_v2 "vibe" && exit 1
-    printf 'api_key = "" # intentionally blank\n' > "$HOME/.vibe/config.toml"
-    is_agent_available_v2 "vibe" && exit 1
-    printf 'api_key = "%s"\n' "$octo_fixture_value" > "$HOME/.vibe/config.toml"
-    is_agent_available_v2 "vibe"
-); then
+test_case "is_agent_available_v2 accepts authenticated Vibe (#799)"
+if vibe_fixture_available "fixture-value" "vibe-research"; then
     test_pass
 else
-    test_fail "Vibe availability accepted blank auth or rejected a valid credential"
+    test_fail "authenticated Vibe was rejected"
 fi
 
-test_case "is_agent_available_v2 Atlas Cloud requires both API key and model (#799)"
-if (
+test_case "is_agent_available_v2 rejects missing and whitespace-only Vibe environment auth (#799)"
+rm -f "$VIBE_PREDICATE_HOME/.vibe/.env" "$VIBE_PREDICATE_HOME/.vibe/config.toml"
+if ! vibe_fixture_available && ! vibe_fixture_available "   "; then
+    test_pass
+else
+    test_fail "Vibe accepted missing or whitespace-only environment auth"
+fi
+
+test_case "is_agent_available_v2 rejects blank Vibe .env assignments (#799)"
+printf 'MISTRAL_API_KEY=\nMISTRAL_API_KEY=""\nMISTRAL_API_KEY="" # intentionally blank\n' > "$VIBE_PREDICATE_HOME/.vibe/.env"
+if ! vibe_fixture_available; then
+    test_pass
+else
+    test_fail "Vibe accepted a blank .env credential"
+fi
+rm -f "$VIBE_PREDICATE_HOME/.vibe/.env"
+
+test_case "is_agent_available_v2 rejects blank Vibe TOML assignments and comments (#799)"
+printf 'api_key = ""# intentionally blank\n' > "$VIBE_PREDICATE_HOME/.vibe/config.toml"
+if ! vibe_fixture_available; then
+    test_pass
+else
+    test_fail "Vibe accepted a quoted-empty TOML credential with an inline comment"
+fi
+
+test_case "is_agent_available_v2 preserves hash characters inside valid quoted Vibe auth (#799)"
+printf 'api_key = "fixture#value" # valid comment\n' > "$VIBE_PREDICATE_HOME/.vibe/config.toml"
+if vibe_fixture_available; then
+    test_pass
+else
+    test_fail "Vibe rejected a nonempty quoted credential containing a hash"
+fi
+
+atlascloud_fixture_available() (
     resolve_provider_env() { return 1; }
     unset ATLASCLOUD_API_KEY ATLASCLOUD_MODEL OCTOPUS_ATLASCLOUD_MODEL OPENAI_COMPAT_MODEL
     octo_fixture_value="fixture-value"
-    export ATLASCLOUD_API_KEY="$octo_fixture_value"
-    is_agent_available_v2 "atlascloud" && exit 1
-    export OCTOPUS_ATLASCLOUD_MODEL="vendor/model"
+    export "ATLASCLOUD_API_KEY=${octo_fixture_value}"
+    [[ "${1:-missing}" == "configured" ]] && export OCTOPUS_ATLASCLOUD_MODEL="vendor/model"
     is_agent_available_v2 "atlascloud"
-); then
+)
+
+test_case "is_agent_available_v2 rejects Atlas Cloud without a model (#799)"
+if ! atlascloud_fixture_available; then
     test_pass
 else
-    test_fail "Atlas Cloud did not require both API key and model"
+    test_fail "Atlas Cloud was accepted without a dispatchable model"
+fi
+
+test_case "is_agent_available_v2 accepts Atlas Cloud with API key and model (#799)"
+if atlascloud_fixture_available "configured"; then
+    test_pass
+else
+    test_fail "Atlas Cloud was rejected despite API key and model"
 fi
 
 test_summary

--- a/tests/unit/test-agent-predicates.sh
+++ b/tests/unit/test-agent-predicates.sh
@@ -66,4 +66,58 @@ else
     test_fail "claude-opus-fast bypassed Claude provider availability"
 fi
 
+test_case "is_agent_available_v2 fails closed for a truly unknown agent name (#799)"
+if ! is_agent_available_v2 "some-future-provider-nobody-registered"; then
+    test_pass
+else
+    test_fail "Unknown agent type was reported available (fail-open regression)"
+fi
+
+test_case "is_agent_available_v2 grok arm defers to grok_is_available (#799)"
+grok_is_available() { return 0; }
+if is_agent_available_v2 "grok"; then
+    grok_is_available() { return 1; }
+    if ! is_agent_available_v2 "grok"; then
+        test_pass
+    else
+        test_fail "grok reported available despite grok_is_available returning false"
+    fi
+else
+    test_fail "grok reported unavailable despite grok_is_available returning true"
+fi
+unset -f grok_is_available
+
+test_case "is_agent_available_v2 recognizes authenticated Vibe and rejects missing auth (#799)"
+vibe() { :; }
+if MISTRAL_API_KEY="test-key" is_agent_available_v2 "vibe-research"; then
+    octo_saved_home="$HOME"
+    HOME="$(mktemp -d /tmp/octopus-vibe-predicate.XXXXXX)"
+    if ! is_agent_available_v2 "vibe"; then
+        rm -rf "$HOME"
+        HOME="$octo_saved_home"
+        unset -f vibe
+        test_pass
+    else
+        rm -rf "$HOME"
+        HOME="$octo_saved_home"
+        unset -f vibe
+        test_fail "Vibe reported available without any supported authentication"
+    fi
+else
+    unset -f vibe
+    test_fail "Authenticated Vibe provider was rejected"
+fi
+
+test_case "is_agent_available_v2 Atlas Cloud requires both API key and model (#799)"
+unset ATLASCLOUD_MODEL OCTOPUS_ATLASCLOUD_MODEL OPENAI_COMPAT_MODEL
+if ! ATLASCLOUD_API_KEY="test-key" is_agent_available_v2 "atlascloud"; then
+    if ATLASCLOUD_API_KEY="test-key" OCTOPUS_ATLASCLOUD_MODEL="vendor/model" is_agent_available_v2 "atlascloud"; then
+        test_pass
+    else
+        test_fail "Atlas Cloud was rejected despite API key and model"
+    fi
+else
+    test_fail "Atlas Cloud was accepted without a dispatchable model"
+fi
+
 test_summary

--- a/tests/unit/test-agent-predicates.sh
+++ b/tests/unit/test-agent-predicates.sh
@@ -96,18 +96,24 @@ if (
     unset MISTRAL_API_KEY
     octo_fixture_value="fixture-value"
 
-    MISTRAL_API_KEY="$octo_fixture_value" is_agent_available_v2 "vibe-research" || exit 1
+    export "MISTRAL_API_KEY=${octo_fixture_value}"
+    is_agent_available_v2 "vibe-research" || exit 1
+    unset MISTRAL_API_KEY
     is_agent_available_v2 "vibe" && exit 1
 
     printf 'MISTRAL_API_KEY=\n' > "$HOME/.vibe/.env"
     is_agent_available_v2 "vibe" && exit 1
     printf 'MISTRAL_API_KEY=""\n' > "$HOME/.vibe/.env"
     is_agent_available_v2 "vibe" && exit 1
+    printf 'MISTRAL_API_KEY="" # intentionally blank\n' > "$HOME/.vibe/.env"
+    is_agent_available_v2 "vibe" && exit 1
     rm -f "$HOME/.vibe/.env"
 
     printf 'api_key =\n' > "$HOME/.vibe/config.toml"
     is_agent_available_v2 "vibe" && exit 1
     printf 'api_key = ""\n' > "$HOME/.vibe/config.toml"
+    is_agent_available_v2 "vibe" && exit 1
+    printf 'api_key = "" # intentionally blank\n' > "$HOME/.vibe/config.toml"
     is_agent_available_v2 "vibe" && exit 1
     printf 'api_key = "%s"\n' "$octo_fixture_value" > "$HOME/.vibe/config.toml"
     is_agent_available_v2 "vibe"


### PR DESCRIPTION
## Problem

`is_agent_available_v2()` treated every unrecognized agent as available. Several registered providers also lacked explicit arms, so simply changing the default to fail closed would have disabled supported Vibe routing and left Atlas Cloud less strict than its actual dispatch contract.

## Fix

- Fail closed for genuinely unknown agents.
- Add explicit availability contracts for Grok, Command Code, Atlas Cloud, and Vibe.
- Require both an Atlas Cloud API key and a configured model.
- Require Vibe CLI plus nonblank env, `.env`, or config auth.
- Parse file assignments with quote-aware comment handling: blank/quoted-empty values are rejected, while `#` inside a quoted credential is preserved.
- Isolate provider-auth tests from inherited environment/profile state and use framework-native assertions.

## Verification

- Red baselines covered supported-provider lockout, missing Atlas model, blank/whitespace credentials, and no-space TOML comments.
- `test-agent-predicates.sh`: 13/13
- `test-vibe-provider.sh`: 5/5
- `test-v8.1.0-feature-detection.sh`: 20/20
- `test-openai-compatible-agent.sh`: 19/19
- Bash syntax and `git diff --check`: clean
- No executable-bit changes

Addresses the fail-open predicate portion of #799. The broader provider detection/auth-parity work in #799 remains open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of supported AI agent availability, including Grok, Command Code, AtlasCloud, and Mistral Vibe.
  - Added provider-specific checks for required credentials, environment settings, configuration files, and model selections.
  - Improved handling of quoted values, whitespace, escapes, and comments in configuration.
  - Unknown agents are now correctly treated as unavailable instead of being assumed available.

- **Tests**
  - Added coverage for authentication requirements, API keys, model settings, configuration sources, and provider availability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->