### PR TITLE
fix: exclude smoke-test-failed providers from probe dispatch

### DIFF
--- a/scripts/lib/embrace.sh
+++ b/scripts/lib/embrace.sh
@@ -22,6 +22,16 @@ _gds_provider_allowed() {
     ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "$1"
 }
 
+# Providers that just failed the current run's smoke test are marked
+# quota/auth-dead for the rest of the session (quota-watcher.sh); every other
+# dispatch path (is_agent_available_v2, build-fleet.sh, check-providers.sh)
+# already excludes on that marker. get_dispatch_strategy() did not, so a
+# provider that had just failed smoke testing was still selected into the
+# fleet a moment later. (#840)
+_gds_not_quota_dead() {
+    ! declare -f octo_quota_is_dead >/dev/null 2>&1 || ! octo_quota_is_dead "$1"
+}
+
 get_dispatch_strategy() {
     local prompt="$1"
     local workflow="${2:-auto}"
@@ -30,18 +40,18 @@ get_dispatch_strategy() {
     case "$strategy" in
         full)
             local all_p="claude-sonnet"
-            _gds_provider_allowed codex && command -v codex >/dev/null 2>&1 && all_p="codex,${all_p}"
-            _gds_provider_allowed gemini && command -v gemini >/dev/null 2>&1 && all_p="gemini,${all_p}"
+            _gds_provider_allowed codex && _gds_not_quota_dead codex && command -v codex >/dev/null 2>&1 && all_p="codex,${all_p}"
+            _gds_provider_allowed gemini && _gds_not_quota_dead gemini && command -v gemini >/dev/null 2>&1 && all_p="gemini,${all_p}"
             # Antigravity (agy) is the Google seat since the Gemini CLI sunset (#524)
-            _gds_provider_allowed agy && command -v agy >/dev/null 2>&1 && all_p="agy,${all_p}"
+            _gds_provider_allowed agy && _gds_not_quota_dead agy && command -v agy >/dev/null 2>&1 && all_p="agy,${all_p}"
             local _full_count; _full_count=$(awk -F, '{print NF}' <<< "$all_p")
             echo "${_full_count}:${all_p}:high"
             return 0 ;;
         minimal)
             # agy (Google seat) preferred over the sunset Gemini CLI (#524)
-            if _gds_provider_allowed agy && command -v agy >/dev/null 2>&1; then echo "2:agy,claude-sonnet:high"
-            elif _gds_provider_allowed gemini && command -v gemini >/dev/null 2>&1; then echo "2:gemini,claude-sonnet:high"
-            elif _gds_provider_allowed codex && command -v codex >/dev/null 2>&1; then echo "2:codex,claude-sonnet:high"
+            if _gds_provider_allowed agy && _gds_not_quota_dead agy && command -v agy >/dev/null 2>&1; then echo "2:agy,claude-sonnet:high"
+            elif _gds_provider_allowed gemini && _gds_not_quota_dead gemini && command -v gemini >/dev/null 2>&1; then echo "2:gemini,claude-sonnet:high"
+            elif _gds_provider_allowed codex && _gds_not_quota_dead codex && command -v codex >/dev/null 2>&1; then echo "2:codex,claude-sonnet:high"
             else echo "1:claude-sonnet:high"; fi
             return 0 ;;
     esac
@@ -69,19 +79,19 @@ get_dispatch_strategy() {
     # fan-out never seated it before, so Antigravity-only setups fell back to
     # Claude-only dispatch (Gemini CLI sunset 2026-06-18, #524).
     local has_codex=false has_gemini=false has_copilot=false has_qwen=false has_ollama=false has_cursor_agent=false has_agy=false
-    _gds_provider_allowed codex  && command -v codex  >/dev/null 2>&1 && has_codex=true
-    _gds_provider_allowed gemini && command -v gemini >/dev/null 2>&1 && has_gemini=true
-    _gds_provider_allowed agy    && command -v agy    >/dev/null 2>&1 && has_agy=true
-    _gds_provider_allowed copilot && command -v copilot >/dev/null 2>&1 && has_copilot=true
-    if _gds_provider_allowed qwen; then
+    _gds_provider_allowed codex  && _gds_not_quota_dead codex  && command -v codex  >/dev/null 2>&1 && has_codex=true
+    _gds_provider_allowed gemini && _gds_not_quota_dead gemini && command -v gemini >/dev/null 2>&1 && has_gemini=true
+    _gds_provider_allowed agy    && _gds_not_quota_dead agy    && command -v agy    >/dev/null 2>&1 && has_agy=true
+    _gds_provider_allowed copilot && _gds_not_quota_dead copilot && command -v copilot >/dev/null 2>&1 && has_copilot=true
+    if _gds_provider_allowed qwen && _gds_not_quota_dead qwen; then
         if declare -f qwen_is_usable >/dev/null 2>&1; then
             qwen_is_usable && has_qwen=true
         elif command -v qwen >/dev/null 2>&1; then
             has_qwen=true
         fi
     fi
-    _gds_provider_allowed ollama && command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags &>/dev/null && has_ollama=true
-    if _gds_provider_allowed cursor-agent; then
+    _gds_provider_allowed ollama && _gds_not_quota_dead ollama && command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags &>/dev/null && has_ollama=true
+    if _gds_provider_allowed cursor-agent && _gds_not_quota_dead cursor-agent; then
         if declare -f cursor_agent_is_available >/dev/null 2>&1; then
             cursor_agent_is_available && has_cursor_agent=true
         elif declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then

--- a/scripts/lib/quota-watcher.sh
+++ b/scripts/lib/quota-watcher.sh
@@ -58,6 +58,31 @@ octo_quota_mark_dead() {
     return 0
 }
 
+# octo_quota_clear_dead <provider>
+# A successful health probe is stronger evidence than a cached failure. Remove
+# both the compatibility marker and any per-provider expiry metadata so a
+# recovered provider becomes selectable immediately after its smoke test.
+octo_quota_clear_dead() {
+    local provider="$1"
+    [[ -n "$provider" ]] || return 0
+
+    local f meta tmp
+    f="$(octo_quota_dead_file)"
+    if [[ -f "$f" ]]; then
+        tmp="$(mktemp "${f}.XXXXXX")" 2>/dev/null || return 0
+        grep -vxF "$provider" "$f" > "$tmp" 2>/dev/null || true
+        mv "$tmp" "$f" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    fi
+
+    meta="$(octo_quota_dead_meta_file)"
+    if [[ -f "$meta" ]]; then
+        tmp="$(mktemp "${meta}.XXXXXX")" 2>/dev/null || return 0
+        grep -v "^${provider}	" "$meta" > "$tmp" 2>/dev/null || true
+        mv "$tmp" "$meta" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    fi
+    return 0
+}
+
 # _octo_quota_meta_expired <provider> — 0 when a recorded per-provider window has
 # elapsed, 1 when it is still in force, 2 when no metadata exists (caller falls
 # back to the file-mtime default).

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -1163,7 +1163,12 @@ _smoke_test_provider() {
 _smoke_tally_result() {
     local provider="$1" result="$2"
     case "${result%%:*}" in
-        PASS) ((++pass_count)) ;;
+        PASS)
+            ((++pass_count))
+            if declare -f octo_quota_clear_dead >/dev/null 2>&1; then
+                octo_quota_clear_dead "$provider"
+            fi
+            ;;
         SKIP) ((++skip_count)) ;;
         *)
             ((++fail_count))

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -1155,6 +1155,23 @@ _smoke_test_provider() {
     rm -f "$stderr_file" 2>/dev/null
 }
 
+# Tally one provider's smoke-test result and, on failure, mark it quota/auth-dead
+# for the rest of this session so get_dispatch_strategy() (embrace.sh) and the
+# other octo_quota_is_dead() consumers stop selecting it. Without this, a smoke
+# test failure was only ever logged — the provider stayed selectable and got
+# dispatched into the same failure a moment later. (#840)
+_smoke_tally_result() {
+    local provider="$1" result="$2"
+    case "${result%%:*}" in
+        PASS) ((++pass_count)) ;;
+        SKIP) ((++skip_count)) ;;
+        *)
+            ((++fail_count))
+            declare -f octo_quota_mark_dead >/dev/null 2>&1 && octo_quota_mark_dead "$provider"
+            ;;
+    esac
+}
+
 # Orchestrate parallel smoke tests for all available providers
 provider_smoke_test() {
     local force_check="${1:-false}"
@@ -1244,13 +1261,10 @@ provider_smoke_test() {
 
     local pass_count=0 fail_count=0 skip_count=0
 
-    for result in "$codex_result" "$gemini_result" "$cursor_agent_result" "$agy_result"; do
-        case "${result%%:*}" in
-            PASS) ((++pass_count)) ;;
-            SKIP) ((++skip_count)) ;;
-            *) ((++fail_count)) ;;
-        esac
-    done
+    _smoke_tally_result "codex" "$codex_result"
+    _smoke_tally_result "gemini" "$gemini_result"
+    _smoke_tally_result "cursor-agent" "$cursor_agent_result"
+    _smoke_tally_result "agy" "$agy_result"
 
     # Display results
     if [[ $fail_count -gt 0 ]]; then

--- a/tests/unit/test-smoke-test-dispatch-exclusion.sh
+++ b/tests/unit/test-smoke-test-dispatch-exclusion.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Regression coverage for #840: a provider that fails the current run's
+# smoke test must not be selected into probe/discover dispatch a moment later.
+#
+# Two things had to be true for that to hold, and each half is its own bug:
+#   1. provider_smoke_test() (lib/smoke.sh) must record *which* provider
+#      failed somewhere a later dispatch decision can see.
+#   2. get_dispatch_strategy() (lib/embrace.sh) must actually consult that
+#      record, not just `command -v <provider>`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "smoke test failures exclude providers from dispatch"
+
+log() { :; }
+
+TEST_TMP_DIR="/tmp/octopus-smoke-dispatch-tests-$$"
+WORKSPACE_DIR="$TEST_TMP_DIR/workspace"
+HOME="$TEST_TMP_DIR/home"
+FAKE_BIN_DIR="$TEST_TMP_DIR/bin"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
+mkdir -p "$WORKSPACE_DIR" "$HOME" "$FAKE_BIN_DIR"
+
+# ─── Part 1: provider_smoke_test's per-result tally marks failures dead ───
+
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/quota-watcher.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/smoke.sh"
+
+pass_count=0
+fail_count=0
+skip_count=0
+
+_smoke_tally_result "codex" "PASS"
+_smoke_tally_result "gemini" "UNKNOWN:gemini-3.1-pro-preview"
+_smoke_tally_result "agy" "SKIP"
+
+test_case "_smoke_tally_result marks a failed provider quota-dead"
+if octo_quota_is_dead "gemini"; then
+    test_pass
+else
+    test_fail "gemini failed its smoke test but was not marked quota-dead"
+fi
+
+test_case "_smoke_tally_result does not mark a passing provider quota-dead"
+if ! octo_quota_is_dead "codex"; then
+    test_pass
+else
+    test_fail "codex passed its smoke test but was marked quota-dead anyway"
+fi
+
+test_case "_smoke_tally_result does not mark a skipped provider quota-dead"
+if ! octo_quota_is_dead "agy"; then
+    test_pass
+else
+    test_fail "agy was skipped (not tested) but was marked quota-dead anyway"
+fi
+
+test_case "_smoke_tally_result tallies pass/fail/skip correctly"
+if [[ "$pass_count" -eq 1 && "$fail_count" -eq 1 && "$skip_count" -eq 1 ]]; then
+    test_pass
+else
+    test_fail "expected 1 pass / 1 fail / 1 skip, got ${pass_count}/${fail_count}/${skip_count}"
+fi
+
+# ─── Part 2: get_dispatch_strategy honors the quota-dead marker ───
+
+cat > "$FAKE_BIN_DIR/codex" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$FAKE_BIN_DIR/gemini" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BIN_DIR/codex" "$FAKE_BIN_DIR/gemini"
+export PATH="$FAKE_BIN_DIR:$PATH"
+
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/embrace.sh"
+
+# gemini "just failed" this run's smoke test; codex passed.
+octo_quota_mark_dead "gemini"
+
+OCTOPUS_DISPATCH_STRATEGY="smart"
+result="$(get_dispatch_strategy "research this topic" "research")"
+
+test_case "get_dispatch_strategy excludes a provider marked quota-dead by smoke test"
+if [[ "$result" != *"gemini"* ]]; then
+    test_pass
+else
+    test_fail "gemini was marked quota-dead but still appeared in dispatch: $result"
+fi
+
+test_case "get_dispatch_strategy still selects a provider that is not quota-dead"
+if [[ "$result" == *"codex"* ]]; then
+    test_pass
+else
+    test_fail "codex is healthy and on PATH but was excluded from dispatch: $result"
+fi
+
+full_result="$(OCTOPUS_DISPATCH_STRATEGY=full get_dispatch_strategy "unused" "unused")"
+
+test_case "get_dispatch_strategy (full) also excludes a quota-dead provider"
+if [[ "$full_result" != *"gemini"* && "$full_result" == *"codex"* ]]; then
+    test_pass
+else
+    test_fail "full strategy did not exclude quota-dead gemini while keeping codex: $full_result"
+fi
+
+test_summary

--- a/tests/unit/test-smoke-test-dispatch-exclusion.sh
+++ b/tests/unit/test-smoke-test-dispatch-exclusion.sh
@@ -38,6 +38,8 @@ pass_count=0
 fail_count=0
 skip_count=0
 
+# Simulate a provider that failed an earlier smoke test but has now recovered.
+octo_quota_mark_dead "codex" 0
 _smoke_tally_result "codex" "PASS"
 _smoke_tally_result "gemini" "UNKNOWN:gemini-3.1-pro-preview"
 _smoke_tally_result "agy" "SKIP"
@@ -49,11 +51,18 @@ else
     test_fail "gemini failed its smoke test but was not marked quota-dead"
 fi
 
-test_case "_smoke_tally_result does not mark a passing provider quota-dead"
+test_case "_smoke_tally_result clears a passing provider's stale dead marker"
 if ! octo_quota_is_dead "codex"; then
     test_pass
 else
-    test_fail "codex passed its smoke test but was marked quota-dead anyway"
+    test_fail "codex passed its smoke test but its stale dead marker remained"
+fi
+
+test_case "successful smoke also clears stale per-provider expiry metadata"
+if ! grep -q "^codex	" "$(octo_quota_dead_meta_file)" 2>/dev/null; then
+    test_pass
+else
+    test_fail "codex passed its smoke test but stale permanent metadata remained"
 fi
 
 test_case "_smoke_tally_result does not mark a skipped provider quota-dead"

--- a/tests/unit/test-smoke-test-dispatch-exclusion.sh
+++ b/tests/unit/test-smoke-test-dispatch-exclusion.sh
@@ -87,7 +87,11 @@ cat > "$FAKE_BIN_DIR/gemini" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-chmod +x "$FAKE_BIN_DIR/codex" "$FAKE_BIN_DIR/gemini"
+cat > "$FAKE_BIN_DIR/agy" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BIN_DIR/codex" "$FAKE_BIN_DIR/gemini" "$FAKE_BIN_DIR/agy"
 export PATH="$FAKE_BIN_DIR:$PATH"
 
 # shellcheck source=/dev/null

--- a/tests/unit/test-smoke-test-dispatch-exclusion.sh
+++ b/tests/unit/test-smoke-test-dispatch-exclusion.sh
@@ -20,11 +20,9 @@ test_suite "smoke test failures exclude providers from dispatch"
 
 log() { :; }
 
-TEST_TMP_DIR="/tmp/octopus-smoke-dispatch-tests-$$"
 WORKSPACE_DIR="$TEST_TMP_DIR/workspace"
 HOME="$TEST_TMP_DIR/home"
 FAKE_BIN_DIR="$TEST_TMP_DIR/bin"
-trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
 mkdir -p "$WORKSPACE_DIR" "$HOME" "$FAKE_BIN_DIR"
 
 # ─── Part 1: provider_smoke_test's per-result tally marks failures dead ───
@@ -122,6 +120,16 @@ if [[ "$full_result" != *"gemini"* && "$full_result" == *"codex"* ]]; then
     test_pass
 else
     test_fail "full strategy did not exclude quota-dead gemini while keeping codex: $full_result"
+fi
+
+octo_quota_mark_dead "agy"
+minimal_result="$(OCTOPUS_DISPATCH_STRATEGY=minimal get_dispatch_strategy "unused" "unused")"
+
+test_case "get_dispatch_strategy (minimal) falls through dead Google seats to codex"
+if [[ "$minimal_result" == *"codex"* && "$minimal_result" != *"gemini"* && "$minimal_result" != *"agy"* ]]; then
+    test_pass
+else
+    test_fail "minimal strategy did not fall through dead gemini/agy seats to codex: $minimal_result"
 fi
 
 test_summary


### PR DESCRIPTION
## Problem

A provider could fail the current workflow smoke test and still be selected and spawned moments later because failures were tallied anonymously and `get_dispatch_strategy()` only checked executable presence.

Review also found a recovery edge: reusing the persistent health marker without clearing it on a later PASS would suppress a provider for up to an hour after credentials or model configuration were fixed.

## Fix

- Record each failed smoke provider through the existing health-marker mechanism.
- Exclude marked providers across full, minimal, and smart dispatch strategies.
- Clear both the compatibility marker and per-provider expiry metadata when a later smoke test passes, so recovery is immediate.
- Keep SKIP neutral and use the framework-owned test cleanup lifecycle.

## Verification

- Red baseline: the new recovery case failed and cascaded into provider exclusion before PASS clearing was implemented.
- `test-smoke-test-dispatch-exclusion.sh`: 9/9 across smart/full/minimal
- `test-quota-watcher.sh`: 2/2
- `test-embrace-fail-fast.sh`: 6/6
- `test-gemini-provider.sh`: 52/52
- Bash syntax and `git diff --check`: clean
- No executable-bit changes

Closes #840.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dispatch now excludes providers unavailable due to quota or authentication failures.
  * Healthy providers remain eligible, and previously failed providers are restored after passing health checks.
  * Safeguards apply consistently across automatic, minimal, and full dispatch modes.

* **Tests**
  * Added coverage for provider exclusion, recovery, skipped-provider handling, and accurate health-check results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->