### PR TITLE
test(hooks): assert lifecycle watchdog cleanup

### DIFF
--- a/tests/unit/test-agent-lifecycle-events.sh
+++ b/tests/unit/test-agent-lifecycle-events.sh
@@ -111,8 +111,12 @@ HOOK
 chmod +x "$TMP_DIR/slow-hook.sh"
 
 test_case "built-in lifecycle timeout uses a sleep watchdog, not a wall clock"
-fallback_impl=$(sed -n '/# Built-in timeout fallback:/,/wait "\$_hook_pid"/p' "$PROJECT_ROOT/scripts/lib/spawn.sh")
-if grep -q '_hook_watchdog_pid' <<<"$fallback_impl" && ! grep -q '\$SECONDS' <<<"$fallback_impl"; then
+# shellcheck disable=SC2016 # Intentionally match literal shell source.
+fallback_impl=$(sed -n '/# Built-in timeout fallback:/,/wait "\$_hook_watchdog_pid"/p' "$PROJECT_ROOT/scripts/lib/spawn.sh")
+if grep -Fq "sleep \"\$hook_timeout\" &" <<<"$fallback_impl" &&
+   grep -Fq "kill \"\$_hook_watchdog_pid\"" <<<"$fallback_impl" &&
+   grep -Fq "wait \"\$_hook_watchdog_pid\"" <<<"$fallback_impl" &&
+   ! grep -Fq "\$SECONDS" <<<"$fallback_impl"; then
   test_pass
 else
   test_fail "fallback must use a reaped sleep watchdog without a SECONDS deadline"


### PR DESCRIPTION
## Problem

PR #833 merged the lifecycle watchdog runtime fix, but its initial static contract could still pass if watchdog cleanup was deleted because the extracted range stopped at the hook wait.

## Fix

The contract now extracts through watchdog reaping and explicitly requires watchdog creation, kill, wait, and absence of `$SECONDS`.

## Verification

- Mutation red: deleting the production watchdog kill/wait makes the targeted case fail
- Restored production code: `test-agent-lifecycle-events.sh` 10/10
- Bash syntax, ShellCheck, and `git diff --check`: clean
- No executable-bit changes

Closes #844.