### PR TITLE
fix(codex): trim defaultPrompt to 3 entries for Codex host compat

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -44,8 +44,7 @@
     "defaultPrompt": [
       "Research OAuth patterns across providers",
       "Build a feature using multi-AI implementation",
-      "Review this code with adversarial multi-provider analysis",
-      "Run a structured debate between AI providers"
+      "Review this code with adversarial multi-provider analysis"
     ],
     "brandColor": "#6366F1"
   }

--- a/scripts/test-codex-compat.sh
+++ b/scripts/test-codex-compat.sh
@@ -120,6 +120,10 @@ test_output "Codex manifest points at portable root skills tree" \
 test_cmd "Codex manifest does not reference Claude-only paths" \
     "cd '$PLUGIN_ROOT' && ! grep -q '\\.claude' .codex-plugin/plugin.json"
 
+test_output "Codex manifest defaultPrompt has 3 or fewer entries" \
+    "jq '.interface.defaultPrompt | length' '$PLUGIN_ROOT/.codex-plugin/plugin.json'" \
+    "^[0-3]$"
+
 test_cmd "skills/ directory exists" \
     "test -d '$PLUGIN_ROOT/skills'"
 

--- a/scripts/test-codex-compat.sh
+++ b/scripts/test-codex-compat.sh
@@ -120,9 +120,8 @@ test_output "Codex manifest points at portable root skills tree" \
 test_cmd "Codex manifest does not reference Claude-only paths" \
     "cd '$PLUGIN_ROOT' && ! grep -q '\\.claude' .codex-plugin/plugin.json"
 
-test_output "Codex manifest defaultPrompt has 3 or fewer entries" \
-    "jq '.interface.defaultPrompt | length' '$PLUGIN_ROOT/.codex-plugin/plugin.json'" \
-    "^[0-3]$"
+test_cmd "Codex manifest defaultPrompt is an array with 3 or fewer entries" \
+    "jq -e '(.interface.defaultPrompt | type) == \"array\" and (.interface.defaultPrompt | length) <= 3' '$PLUGIN_ROOT/.codex-plugin/plugin.json' >/dev/null"
 
 test_cmd "skills/ directory exists" \
     "test -d '$PLUGIN_ROOT/skills'"


### PR DESCRIPTION
## Description
`.codex-plugin/plugin.json` declared four `interface.defaultPrompt` entries, but Codex plugin discovery supports at most three. Every discovery pass logged `ignoring interface.defaultPrompt: maximum of 3 prompts is supported` and dropped the field entirely on the Codex host.

Root cause: `.codex-plugin/plugin.json:44-49` — a plain array-length mismatch against Codex's documented limit, first observed while v9.61.1 was active and still present in the current v9.61.2 manifest.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Fix
- Dropped the "Run a structured debate between AI providers" entry, keeping the three prompts that map to the plugin's core Double Diamond phases (research / build / review).
- Added a regression check to `scripts/test-codex-compat.sh` asserting `interface.defaultPrompt` has 3 or fewer entries, per the issue's suggested acceptance test.

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync: `scripts/build-openclaw.sh --check` (not applicable — no skills/commands/registry touched)
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` (not applicable)
- [ ] Version bump (not applicable — patch-level manifest fix, not a release)
- [ ] Documentation updated (not applicable)
- [ ] CHANGELOG.md updated (left for the release step, per this repo's daily-triage convention)

## Testing
```bash
bash -n scripts/*.sh scripts/lib/*.sh   # all pass
jq empty .codex-plugin/plugin.json      # valid JSON
bash scripts/test-codex-compat.sh       # 114 passed, 4 failed — same 4 pre-existing
                                         # failures reproduced independently on
                                         # unmodified origin/main (skill-metadata
                                         # drift unrelated to this change)
bash tests/unit/test-openclaw-compat.sh # 32/32 passed
```

`make test-unit` / `make test-integration` were not run to completion: the full suite exceeded this environment's background-task time budget, and the change is a two-line, single-file manifest fix isolated to Codex host compatibility, fully covered by `test-codex-compat.sh` (which already validates this manifest) plus the new regression case above.

## Related Issues
Closes #849


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELtJoKxxsqv6RR9axjsgf9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Simplified the plugin’s available default prompts by removing the structured debate option.
  * Added a compatibility check to ensure the default prompt list contains no more than three entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->