### PR TITLE
fix(codex): cap default prompts at host limit

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -46,8 +46,7 @@
     "defaultPrompt": [
       "Research OAuth patterns across providers",
       "Build a feature using multi-AI implementation",
-      "Review this code with adversarial multi-provider analysis",
-      "Run a structured debate between AI providers"
+      "Review this code with adversarial multi-provider analysis"
     ],
     "brandColor": "#6366F1"
   }

--- a/tests/unit/test-codex-manifest.sh
+++ b/tests/unit/test-codex-manifest.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Codex plugin manifest"
+
+test_case "Codex default prompts stay within the host limit of three"
+if [[ "$(jq '.interface.defaultPrompt | length' "$PROJECT_ROOT/.codex-plugin/plugin.json")" -le 3 ]]; then
+    test_pass
+else
+    test_fail "Codex supports at most three interface.defaultPrompt entries"
+fi
+
+test_summary

--- a/tests/unit/test-codex-manifest.sh
+++ b/tests/unit/test-codex-manifest.sh
@@ -8,7 +8,8 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Codex plugin manifest"
 
 test_case "Codex default prompts stay within the host limit of three"
-if [[ "$(jq '.interface.defaultPrompt | length' "$PROJECT_ROOT/.codex-plugin/plugin.json")" -le 3 ]]; then
+if jq -e '.interface.defaultPrompt | (type == "array" and length <= 3)' \
+    "$PROJECT_ROOT/.codex-plugin/plugin.json" >/dev/null; then
     test_pass
 else
     test_fail "Codex supports at most three interface.defaultPrompt entries"


### PR DESCRIPTION
## Summary

- reduce the Codex manifest default prompt list from four entries to the supported maximum of three
- add a unit regression that fails if the host limit is exceeded again

## Verification

- tests/unit/test-codex-manifest.sh: 1/1
- make sync-check
- jq manifest validation
- git diff --check

Closes #849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed the structured AI provider debate prompt from the plugin’s default prompt options.
  * Limited the available default prompt options to a maximum of three.
  * Added validation to help ensure the plugin’s prompt configuration remains within the supported limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->