### PR TITLE
fix(workflows): clean interrupted probe state

### DIFF
--- a/.claude/skills/flow-discover/SKILL.md
+++ b/.claude/skills/flow-discover/SKILL.md
@@ -56,28 +56,23 @@ trigger: |
 - Before synthesis, run `${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh agent-summary` and use only providers reported as `ok`, `degraded`, or `timeout` with usable output.
 - For `standard` and `deep` research, require at least 2 usable provider outputs unless fewer providers are installed; failed/rejected providers are reported as gaps, not cited as evidence.
 
-## Pre-Discovery: Project Initialization
+## Pre-Discovery: Optional Project Persistence
 
-Before starting discovery:
-1. Check if `.octo/` directory exists
-2. If NOT exists: Call `./scripts/octo-state.sh init_project` to create it
-3. Update `.octo/STATE.md`:
-   - current_phase: 1
-   - phase_position: "Discovery"
-   - status: "in_progress"
+Workflow state is stored in the host workspace by default. Only create the
+project-local `.octo/` lifecycle artifacts when the user explicitly opts in by
+setting `OCTOPUS_PROJECT_PERSISTENCE=true`.
 
 ```bash
-# Check and initialize .octo/ state
-if [[ ! -d ".octo" ]]; then
-  echo "📁 Initializing .octo/ project state..."
-  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project
+if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
+  if [[ ! -d ".octo" ]]; then
+    echo "📁 Initializing opt-in .octo/ project state..."
+    "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project
+  fi
+  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+    --phase 1 \
+    --position "Discovery" \
+    --status "in_progress"
 fi
-
-# Update state for Discovery phase
-"${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-  --phase 1 \
-  --position "Discovery" \
-  --status "in_progress"
 ```
 
 ---
@@ -95,7 +90,7 @@ Check if native plan mode is active:
 if [[ -n "${PLAN_MODE_ACTIVE}" ]] || claude-code plan status 2>/dev/null | grep -q "active"; then
     echo "⚠️  Native plan mode detected"
     echo ""
-    echo "   Claude Octopus uses file-based state (.claude-octopus/)"
+    echo "   Resolve Claude Octopus workflow state with: octopus state-path"
     echo "   State will persist across plan mode context clears"
     echo "   Multi-AI orchestration will continue normally"
     echo ""
@@ -845,8 +840,8 @@ See **skill-security-framing.md** for complete documentation on:
 After discovery completes:
 1. Verify the synthesis file exists and is non-empty.
 2. Present its findings to the user.
-3. Populate `.octo/PROJECT.md` with the research findings.
-4. Only then update `.octo/STATE.md`:
+3. If project-local persistence was explicitly enabled, populate
+   `.octo/PROJECT.md`, then update `.octo/STATE.md`:
    - status: "complete" (for this phase)
    - Add history entry: "Discover phase completed"
 
@@ -861,27 +856,28 @@ fi
 echo "Discovery findings:"
 cat "$SYNTHESIS_FILE"
 
-# Populate PROJECT.md with the complete research synthesis and fail closed.
-echo "📝 Updating .octo/PROJECT.md with discovery findings..."
-if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_project \
-    --section "vision" \
-    --content-file "$SYNTHESIS_FILE"; then
-  echo "Discover incomplete: could not persist findings to .octo/PROJECT.md." >&2
-  exit 1
+# Project-local lifecycle documents are a separate, explicit opt-in.
+if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
+  echo "📝 Updating opt-in .octo/PROJECT.md with discovery findings..."
+  if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_project \
+      --section "vision" \
+      --content-file "$SYNTHESIS_FILE"; then
+    echo "Discover incomplete: could not persist findings to .octo/PROJECT.md." >&2
+    exit 1
+  fi
+  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+    --status "complete" \
+    --history "Discover phase completed"
 fi
-
-# Mark complete only after the synthesis was presented and persisted.
-"${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-  --status "complete" \
-  --history "Discover phase completed"
 ```
 
 ---
 
 ## Terminal State
 
-The Discover phase is complete ONLY when the synthesis file exists, its complete findings
-are presented to the user, and those findings are persisted in `.octo/PROJECT.md`. Then
+The Discover phase is complete ONLY when the synthesis file exists and its complete findings
+are presented to the user. When `OCTOPUS_PROJECT_PERSISTENCE=true`, the findings must also
+be persisted in `.octo/PROJECT.md`. Then
 either invoke `flow-define` (embrace workflow, or the user wants requirements next) or
 stop with research delivered. Do NOT begin scoping, designing, or implementation from
 here — that work belongs to later phases.

--- a/.claude/skills/flow-discover/SKILL.md
+++ b/.claude/skills/flow-discover/SKILL.md
@@ -106,7 +106,7 @@ fi
 
 **How it works:**
 - Native plan mode may clear Claude's memory via `ExitPlanMode`
-- claude-octopus state persists in `.claude-octopus/state.json`
+- Claude Octopus workflow state persists in the host workspace, namespaced by project; resolve its exact path with `state-manager.sh state_path`
 - Each workflow phase reads prior state at startup
 - Context is automatically restored from files
 

--- a/.claude/skills/flow-discover/SKILL.md
+++ b/.claude/skills/flow-discover/SKILL.md
@@ -66,12 +66,18 @@ setting `OCTOPUS_PROJECT_PERSISTENCE=true`.
 if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
   if [[ ! -d ".octo" ]]; then
     echo "📁 Initializing opt-in .octo/ project state..."
-    "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project
+    if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project; then
+      echo "Discover incomplete: could not initialize opt-in project state." >&2
+      exit 1
+    fi
   fi
-  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-    --phase 1 \
-    --position "Discovery" \
-    --status "in_progress"
+  if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+      --phase 1 \
+      --position "Discovery" \
+      --status "in_progress"; then
+    echo "Discover incomplete: could not persist in-progress state." >&2
+    exit 1
+  fi
 fi
 ```
 
@@ -865,9 +871,12 @@ if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
     echo "Discover incomplete: could not persist findings to .octo/PROJECT.md." >&2
     exit 1
   fi
-  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-    --status "complete" \
-    --history "Discover phase completed"
+  if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+      --status "complete" \
+      --history "Discover phase completed"; then
+    echo "Discover incomplete: could not persist completion state." >&2
+    exit 1
+  fi
 fi
 ```
 

--- a/.claude/skills/flow-discover/flow-discover.tmpl
+++ b/.claude/skills/flow-discover/flow-discover.tmpl
@@ -106,7 +106,7 @@ fi
 
 **How it works:**
 - Native plan mode may clear Claude's memory via `ExitPlanMode`
-- claude-octopus state persists in `.claude-octopus/state.json`
+- Claude Octopus workflow state persists in the host workspace, namespaced by project; resolve its exact path with `state-manager.sh state_path`
 - Each workflow phase reads prior state at startup
 - Context is automatically restored from files
 

--- a/.claude/skills/flow-discover/flow-discover.tmpl
+++ b/.claude/skills/flow-discover/flow-discover.tmpl
@@ -56,28 +56,23 @@ trigger: |
 - Before synthesis, run `${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh agent-summary` and use only providers reported as `ok`, `degraded`, or `timeout` with usable output.
 - For `standard` and `deep` research, require at least 2 usable provider outputs unless fewer providers are installed; failed/rejected providers are reported as gaps, not cited as evidence.
 
-## Pre-Discovery: Project Initialization
+## Pre-Discovery: Optional Project Persistence
 
-Before starting discovery:
-1. Check if `.octo/` directory exists
-2. If NOT exists: Call `./scripts/octo-state.sh init_project` to create it
-3. Update `.octo/STATE.md`:
-   - current_phase: 1
-   - phase_position: "Discovery"
-   - status: "in_progress"
+Workflow state is stored in the host workspace by default. Only create the
+project-local `.octo/` lifecycle artifacts when the user explicitly opts in by
+setting `OCTOPUS_PROJECT_PERSISTENCE=true`.
 
 ```bash
-# Check and initialize .octo/ state
-if [[ ! -d ".octo" ]]; then
-  echo "📁 Initializing .octo/ project state..."
-  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project
+if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
+  if [[ ! -d ".octo" ]]; then
+    echo "📁 Initializing opt-in .octo/ project state..."
+    "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project
+  fi
+  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+    --phase 1 \
+    --position "Discovery" \
+    --status "in_progress"
 fi
-
-# Update state for Discovery phase
-"${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-  --phase 1 \
-  --position "Discovery" \
-  --status "in_progress"
 ```
 
 ---
@@ -95,7 +90,7 @@ Check if native plan mode is active:
 if [[ -n "${PLAN_MODE_ACTIVE}" ]] || claude-code plan status 2>/dev/null | grep -q "active"; then
     echo "⚠️  Native plan mode detected"
     echo ""
-    echo "   Claude Octopus uses file-based state (.claude-octopus/)"
+    echo "   Resolve Claude Octopus workflow state with: octopus state-path"
     echo "   State will persist across plan mode context clears"
     echo "   Multi-AI orchestration will continue normally"
     echo ""
@@ -833,24 +828,17 @@ See **skill-security-framing.md** for complete documentation on:
 
 ## Post-Discovery: State Update
 
-After discovery completes:
-1. Update `.octo/STATE.md`:
-   - status: "complete" (for this phase)
-   - Add history entry: "Discover phase completed"
-2. Populate `.octo/PROJECT.md` with research findings (vision, requirements)
+After discovery completes, present the synthesis. If project-local persistence
+was explicitly enabled, also update `.octo/PROJECT.md` and `.octo/STATE.md`.
 
 ```bash
-# Update state after Discovery completion
-"${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-  --status "complete" \
-  --history "Discover phase completed"
-
-# Populate PROJECT.md with research findings
-if [[ -f "$SYNTHESIS_FILE" ]]; then
-  echo "📝 Updating .octo/PROJECT.md with discovery findings..."
+if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
   "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_project \
     --section "vision" \
-    --content "$(head -100 "$SYNTHESIS_FILE" | grep -A 10 'Key.*Findings\|Summary' || echo 'See synthesis file')"
+    --content-file "$SYNTHESIS_FILE"
+  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+    --status "complete" \
+    --history "Discover phase completed"
 fi
 ```
 

--- a/.claude/skills/flow-discover/flow-discover.tmpl
+++ b/.claude/skills/flow-discover/flow-discover.tmpl
@@ -66,12 +66,18 @@ setting `OCTOPUS_PROJECT_PERSISTENCE=true`.
 if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
   if [[ ! -d ".octo" ]]; then
     echo "📁 Initializing opt-in .octo/ project state..."
-    "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project
+    if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project; then
+      echo "Discover incomplete: could not initialize opt-in project state." >&2
+      exit 1
+    fi
   fi
-  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-    --phase 1 \
-    --position "Discovery" \
-    --status "in_progress"
+  if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+      --phase 1 \
+      --position "Discovery" \
+      --status "in_progress"; then
+    echo "Discover incomplete: could not persist in-progress state." >&2
+    exit 1
+  fi
 fi
 ```
 
@@ -833,12 +839,18 @@ was explicitly enabled, also update `.octo/PROJECT.md` and `.octo/STATE.md`.
 
 ```bash
 if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
-  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_project \
-    --section "vision" \
-    --content-file "$SYNTHESIS_FILE"
-  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-    --status "complete" \
-    --history "Discover phase completed"
+  if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_project \
+      --section "vision" \
+      --content-file "$SYNTHESIS_FILE"; then
+    echo "Discover incomplete: could not persist findings to .octo/PROJECT.md." >&2
+    exit 1
+  fi
+  if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+      --status "complete" \
+      --history "Discover phase completed"; then
+    echo "Discover incomplete: could not persist completion state." >&2
+    exit 1
+  fi
 fi
 ```
 

--- a/.claude/skills/skill-resume/SKILL.md
+++ b/.claude/skills/skill-resume/SKILL.md
@@ -10,7 +10,7 @@ trigger: |
   AUTOMATICALLY ACTIVATE when user mentions:
   - "resume" or "continue" or "pick up where I left off"
   - "what was I doing" or "restore session"
-  - Detecting .claude-octopus/state.json exists but no prior context in memory
+  - Detecting persistent workflow state exists but no prior context in memory
 ---
 
 # Session Restoration
@@ -506,16 +506,18 @@ Otherwise → User loses previous context and wastes time re-discovering where t
 When context is cleared (compaction, plan mode exit, new session), detect and reload automatically:
 
 ```bash
-# Auto-detect context loss
-if [[ -f .claude-octopus/state.json ]] && [[ -z "${WORKFLOW_CONTEXT_LOADED}" ]]; then
+# Auto-detect context loss without writing into the project checkout.
+# The plugin executable resolves its own installation root on every host.
+WORKFLOW_STATE_FILE="$(octopus state-path)"
+if [[ -f "$WORKFLOW_STATE_FILE" ]] && [[ -z "${WORKFLOW_CONTEXT_LOADED}" ]]; then
     echo "⚠️  Context was cleared — reloading from persistent state..."
     NEEDS_RESUME=true
 fi
 ```
 
 **What survives context clearing:**
-- `.claude-octopus/state.json` (decisions, context, metrics)
-- `.claude-octopus/context/*.md` (phase outputs)
+- Host-workspace project state (decisions, context, metrics; resolve with `state-manager.sh state_path`)
+- The resolved state directory's `context/*.md` files (phase outputs)
 - Native tasks (TaskList still works)
 - Git commits and WIP checkpoints
 - Multi-AI synthesis files in `~/.claude-octopus/results/`

--- a/.claude/skills/skill-resume/SKILL.md
+++ b/.claude/skills/skill-resume/SKILL.md
@@ -482,7 +482,7 @@ User runs /octo:resume
 
 | User Input | Action Required |
 |------------|-----------------|
-| "resume" | Check .octo/ → Read state → Load context → Display summary → Route |
+| "resume" | Resolve state with `octopus state-path` → Load context → Display summary → Route |
 | "continue" | Same as resume |
 | "pick up where I left off" | Same as resume |
 | "what was I doing" | Same as resume, emphasize history |
@@ -493,7 +493,7 @@ User runs /octo:resume
 ## The Bottom Line
 
 ```
-Check .octo/ → Read state → Load adaptive context → Show history + blockers → Route intelligently
+Run `octopus state-path` → Read state → Load adaptive context → Show history + blockers → Route intelligently
 Otherwise → User loses previous context and wastes time re-discovering where they were
 ```
 
@@ -508,7 +508,10 @@ When context is cleared (compaction, plan mode exit, new session), detect and re
 ```bash
 # Auto-detect context loss without writing into the project checkout.
 # The plugin executable resolves its own installation root on every host.
-WORKFLOW_STATE_FILE="$(octopus state-path)"
+if ! WORKFLOW_STATE_FILE="$(octopus state-path)" || [[ -z "$WORKFLOW_STATE_FILE" ]]; then
+    echo "Unable to resolve persistent workflow state; refusing an incomplete resume." >&2
+    exit 1
+fi
 if [[ -f "$WORKFLOW_STATE_FILE" ]] && [[ -z "${WORKFLOW_CONTEXT_LOADED}" ]]; then
     echo "⚠️  Context was cleared — reloading from persistent state..."
     NEEDS_RESUME=true
@@ -516,8 +519,8 @@ fi
 ```
 
 **What survives context clearing:**
-- Host-workspace project state (decisions, context, metrics; resolve with `state-manager.sh state_path`)
-- The resolved state directory's `context/*.md` files (phase outputs)
+- Host-workspace project state (decisions, context, metrics; resolve with `octopus state-path`)
+- `context/*.md` beside the path returned by `octopus state-path` (phase outputs)
 - Native tasks (TaskList still works)
 - Git commits and WIP checkpoints
 - Multi-AI synthesis files in `~/.claude-octopus/results/`

--- a/bin/octopus
+++ b/bin/octopus
@@ -7,6 +7,7 @@
 #   octopus version    — Show version
 #   octopus session    — Show current session info
 #   octopus fleet      — Show provider fleet status
+#   octopus state-path — Show the current project's workflow state path
 #   octopus agent-summary — Show current run provider status
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -39,6 +40,10 @@ case "${1:-help}" in
             echo "Fleet builder not available"
         fi
         ;;
+    state-path)
+        OCTOPUS_STATE_PROJECT_ROOT="$PWD" \
+            "${SCRIPT_DIR}/scripts/state-manager.sh" state_path
+        ;;
     agent-summary|summary)
         shift
         "$ORCHESTRATE" agent-summary "$@"
@@ -53,6 +58,7 @@ case "${1:-help}" in
         echo "  version   Show plugin version"
         echo "  session   Show current session info"
         echo "  fleet     Show provider fleet status"
+        echo "  state-path  Show the current project's workflow state path"
         echo "  agent-summary  Show current run provider status"
         echo "  help      Show this help"
         ;;

--- a/docs/COMMAND-REFERENCE.md
+++ b/docs/COMMAND-REFERENCE.md
@@ -123,6 +123,7 @@ Plugin executables available as bare commands (CC v2.1.91+). Also usable via ful
 | `octopus version` | Show plugin version |
 | `octopus session` | Show current session info |
 | `octopus fleet` | Show provider fleet status |
+| `octopus state-path` | Print the checkout-specific workflow `state.json` path resolved by `OCTOPUS_WORKFLOW_STATE_DIR`, `CLAUDE_PLUGIN_DATA`, `CLAUDE_OCTOPUS_WORKSPACE`, or the default host workspace |
 | `octopus agent-summary` | Show which providers ran, degraded, failed, timed out, or contributed usable output |
 | `octo-compress` | Pipe verbose output for token savings: `npm install 2>&1 \| octo-compress` |
 | `octo-compress json` | Force JSON array/object compression |

--- a/scripts/context-manager.sh
+++ b/scripts/context-manager.sh
@@ -4,8 +4,9 @@
 
 set -euo pipefail
 
-# Configuration
-CONTEXT_DIR=".claude-octopus/context"
+# Configuration. Keep context beside the resolved workflow state when the
+# caller opts into or exports a state directory.
+CONTEXT_DIR="${OCTOPUS_WORKFLOW_STATE_DIR:-.claude-octopus}/context"
 
 # Colors for output
 RED='\033[0;31m'

--- a/scripts/context-manager.sh
+++ b/scripts/context-manager.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # Configuration. Use the same project-namespaced host workspace as every other
 # workflow-state consumer, while preserving explicit state-directory opt-ins.
-SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/state-manager.sh"
 CONTEXT_DIR="$STATE_DIR/context"

--- a/scripts/context-manager.sh
+++ b/scripts/context-manager.sh
@@ -4,9 +4,12 @@
 
 set -euo pipefail
 
-# Configuration. Keep context beside the resolved workflow state when the
-# caller opts into or exports a state directory.
-CONTEXT_DIR="${OCTOPUS_WORKFLOW_STATE_DIR:-.claude-octopus}/context"
+# Configuration. Use the same project-namespaced host workspace as every other
+# workflow-state consumer, while preserving explicit state-directory opt-ins.
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/state-manager.sh"
+CONTEXT_DIR="$STATE_DIR/context"
 
 # Colors for output
 RED='\033[0;31m'

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -819,14 +819,15 @@ doctor_check_updates() {
 
 # --- Category 4: State ---
 doctor_check_state() {
+    local workflow_state_file="${STATE_FILE:-.claude-octopus/state.json}"
     # state.json integrity
-    if [[ -f ".claude-octopus/state.json" ]]; then
-        if jq empty ".claude-octopus/state.json" 2>/dev/null; then
+    if [[ -f "$workflow_state_file" ]]; then
+        if jq empty "$workflow_state_file" 2>/dev/null; then
             doctor_add "state-json" "state" "pass" \
-                "state.json valid" ".claude-octopus/state.json"
+                "state.json valid" "$workflow_state_file"
         else
             doctor_add "state-json" "state" "fail" \
-                "state.json is invalid JSON" "File exists but cannot be parsed"
+                "state.json is invalid JSON" "$workflow_state_file cannot be parsed"
         fi
     else
         doctor_add "state-json" "state" "pass" \

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -819,7 +819,7 @@ doctor_check_updates() {
 
 # --- Category 4: State ---
 doctor_check_state() {
-    local workflow_state_file="${STATE_FILE:-.claude-octopus/state.json}"
+    local workflow_state_file="${STATE_FILE:-}"
     # state.json integrity
     if [[ -f "$workflow_state_file" ]]; then
         if jq empty "$workflow_state_file" 2>/dev/null; then

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -1096,7 +1096,7 @@ ${heuristic_ctx}"
         _octopus_agent_lifecycle_event "completed" "$agent_type" "$task_id" "$role" "$phase" "$BASHPID" "$result_file" "$_spawn_exit" "$_hook_final_status"
 
         # v8.19.0: Cleanup heartbeat (self-terminating monitor handles this too)
-        cleanup_heartbeat "$$" 2>/dev/null || true
+        cleanup_heartbeat "$BASHPID" 2>/dev/null || true
     ) &
 
     local pid=$!

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -729,6 +729,7 @@ ${YELLOW}Examples:${NC}
 
 ${YELLOW}Environment:${NC}
   CLAUDE_OCTOPUS_WORKSPACE  Override workspace (default: ~/.claude-octopus)
+  OCTOPUS_WORKFLOW_STATE_DIR Override project workflow state location (default: workspace/projects/<project-id>)
   OPENAI_API_KEY            Codex CLI (or 'codex login' OAuth)
   COMMAND_CODE_API_KEY       Command Code CLI (or authenticated CLI session)
   AGY_AUTH_TOKEN            Antigravity CLI auth token (optional; run 'agy login' instead when possible)

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -730,6 +730,7 @@ ${YELLOW}Examples:${NC}
 ${YELLOW}Environment:${NC}
   CLAUDE_OCTOPUS_WORKSPACE  Override workspace (default: ~/.claude-octopus)
   OCTOPUS_WORKFLOW_STATE_DIR Override project workflow state location (default: workspace/projects/<project-id>)
+  OCTOPUS_PROJECT_PERSISTENCE Set true to opt into project-local .octo/ lifecycle files
   OPENAI_API_KEY            Codex CLI (or 'codex login' OAuth)
   COMMAND_CODE_API_KEY       Command Code CLI (or authenticated CLI session)
   AGY_AUTH_TOKEN            Antigravity CLI auth token (optional; run 'agy login' instead when possible)

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -23,7 +23,7 @@ validate_workspace_path() {
     local proposed_path="$1"
 
     # Expand ~ if present
-    proposed_path="${proposed_path/#\~/$HOME}"
+    proposed_path="${proposed_path/#\~/${HOME:-$PWD}}"
 
     # Reject paths with path traversal attempts
     if [[ "$proposed_path" =~ \.\. ]]; then
@@ -45,7 +45,8 @@ validate_workspace_path() {
 
     # Restrict to safe locations ($HOME or /tmp)
     local is_safe=false
-    for safe_prefix in "$HOME" "/tmp" "/var/tmp"; do
+    for safe_prefix in "${HOME:-}" "/tmp" "/var/tmp"; do
+        [[ -n "$safe_prefix" ]] || continue
         if [[ "$proposed_path" == "$safe_prefix"* ]]; then
             is_safe=true
             break

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -47,7 +47,8 @@ validate_workspace_path() {
     local is_safe=false
     for safe_prefix in "${HOME:-}" "/tmp" "/var/tmp"; do
         [[ -n "$safe_prefix" ]] || continue
-        if [[ "$proposed_path" == "$safe_prefix"* ]]; then
+        if [[ "$proposed_path" == "$safe_prefix" \
+           || "$proposed_path" == "$safe_prefix/"* ]]; then
             is_safe=true
             break
         fi

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -883,11 +883,15 @@ ${_blind_spot_checklist}"
     log DEBUG "Synthesis marker written: $synthesis_marker"
 
     # Intelligent synthesis (v7.19.0 P1.1: allow with partial results)
-    synthesize_probe_results "$task_group" "$prompt" "$usable_results"
+    local synthesis_status=0
+    synthesize_probe_results "$task_group" "$prompt" "$usable_results" \
+        || synthesis_status=$?
 
-    # Synthesis succeeded — remove the marker
-    rm -f "$synthesis_marker"
-    log DEBUG "Synthesis marker removed (synthesis completed successfully)"
+    # Preserve the marker on failure so synthesize-probe can recover the run.
+    if [[ "$synthesis_status" -eq 0 ]]; then
+        rm -f "$synthesis_marker"
+        log DEBUG "Synthesis marker removed (synthesis completed successfully)"
+    fi
 
     # v7.19.0 P2.4: Stop progressive synthesis monitor
     if [[ -n "$synthesis_monitor_pid" ]]; then
@@ -901,6 +905,7 @@ ${_blind_spot_checklist}"
     display_progress_summary
 
     _octopus_probe_restore_traps "$probe_previous_int_trap" "$probe_previous_term_trap"
+    return "$synthesis_status"
 }
 
 # Phase 2: GRASP (Define) - Consensus building on approach

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -400,6 +400,7 @@ IMPORTANT: If you find yourself searching or grepping more than 3 times in a row
 # still reconcile tasks already appended to the PID ledger.
 OCTOPUS_ACTIVE_PROBE_TASK_GROUP=""
 OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID=""
+OCTOPUS_ACTIVE_PROBE_SYNTHESIS_LAUNCHING="false"
 OCTOPUS_ACTIVE_PROBE_TMUX="false"
 OCTOPUS_ACTIVE_PROBE_PIDS=()
 OCTOPUS_ACTIVE_PROBE_AGENTS=()
@@ -408,6 +409,7 @@ OCTOPUS_ACTIVE_PROBE_TASK_IDS=()
 octopus_probe_clear_active() {
     OCTOPUS_ACTIVE_PROBE_TASK_GROUP=""
     OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID=""
+    OCTOPUS_ACTIVE_PROBE_SYNTHESIS_LAUNCHING="false"
     OCTOPUS_ACTIVE_PROBE_TMUX="false"
     OCTOPUS_ACTIVE_PROBE_PIDS=()
     OCTOPUS_ACTIVE_PROBE_AGENTS=()
@@ -510,6 +512,13 @@ octopus_probe_cancel_active() {
     fi
 
     local synthesis_pid="${OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID:-}"
+    # A trap can run after the monitor has been backgrounded but before the
+    # caller assigns $! to the registered PID. During that tiny handoff window,
+    # the shell's last-background PID is the authoritative value.
+    if [[ ! "$synthesis_pid" =~ ^[0-9]+$ ]] \
+       && [[ "${OCTOPUS_ACTIVE_PROBE_SYNTHESIS_LAUNCHING:-false}" == "true" ]]; then
+        synthesis_pid="${!:-}"
+    fi
     if [[ "$synthesis_pid" =~ ^[0-9]+$ ]]; then
         _octopus_probe_terminate_tree "$synthesis_pid"
         wait "$synthesis_pid" 2>/dev/null || true
@@ -564,6 +573,70 @@ octopus_probe_cancel_active() {
         tmux_cleanup 2>/dev/null || true
     fi
     octopus_probe_clear_active
+}
+
+_octopus_probe_start_synthesis_monitor() {
+    local task_group="$1"
+    local prompt="$2"
+    local interval="${3:-2}"
+
+    OCTOPUS_ACTIVE_PROBE_SYNTHESIS_LAUNCHING="true"
+    progressive_synthesis_monitor "$task_group" "$prompt" "$interval" &
+    local monitor_pid=$!
+
+    # Runtime-only seam for deterministically exercising the signal handoff.
+    if declare -F _octopus_test_after_synthesis_spawn >/dev/null 2>&1; then
+        _octopus_test_after_synthesis_spawn "$monitor_pid"
+    fi
+
+    # A cancellation during the handoff clears the active task group. Reap the
+    # just-launched monitor and do not re-register stale state afterward.
+    if [[ -z "${OCTOPUS_ACTIVE_PROBE_TASK_GROUP:-}" ]]; then
+        _octopus_probe_terminate_tree "$monitor_pid"
+        wait "$monitor_pid" 2>/dev/null || true
+        OCTOPUS_ACTIVE_PROBE_SYNTHESIS_LAUNCHING="false"
+        return 143
+    fi
+
+    OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID="$monitor_pid"
+    OCTOPUS_ACTIVE_PROBE_SYNTHESIS_LAUNCHING="false"
+    return 0
+}
+
+_octopus_probe_finalize_synthesis() {
+    local task_group="$1"
+    local prompt="$2"
+    local usable_results="$3"
+    local synthesis_marker="$4"
+    local synthesis_monitor_pid="$5"
+    local previous_int_trap="${6:-}"
+    local previous_term_trap="${7:-}"
+    local synthesis_status=0
+    local summary_status=0
+
+    synthesize_probe_results "$task_group" "$prompt" "$usable_results" \
+        || synthesis_status=$?
+
+    # Preserve the marker on failure so synthesize-probe can recover the run.
+    if [[ "$synthesis_status" -eq 0 ]]; then
+        rm -f "$synthesis_marker"
+        log DEBUG "Synthesis marker removed (synthesis completed successfully)"
+    fi
+
+    if [[ "$synthesis_monitor_pid" =~ ^[0-9]+$ ]]; then
+        kill "$synthesis_monitor_pid" 2>/dev/null || true
+        wait "$synthesis_monitor_pid" 2>/dev/null || true
+        OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID=""
+        log "DEBUG" "Progressive synthesis monitor stopped"
+    fi
+
+    # Guard summary rendering because orchestrate.sh enables errexit. Cleanup
+    # and trap restoration must happen even when the renderer fails.
+    display_progress_summary || summary_status=$?
+    _octopus_probe_restore_traps "$previous_int_trap" "$previous_term_trap"
+
+    [[ "$synthesis_status" -ne 0 ]] && return "$synthesis_status"
+    return "$summary_status"
 }
 
 octopus_probe_handle_signal() {
@@ -732,17 +805,34 @@ ${_blind_spot_checklist}"
         OCTOPUS_ACTIVE_PROBE_AGENTS+=("$agent")
         OCTOPUS_ACTIVE_PROBE_TASK_IDS+=("$task_id")
 
+        local pid=""
+        local spawn_status=0
         if [[ "$TMUX_MODE" == "true" ]]; then
             # Use async+tmux spawning
-            local pid
-            pid=$(spawn_agent_async "$agent" "$perspective" "$task_id" "researcher" "probe" "${pane_titles[$i]}")
-            pids+=("$pid")
+            if pid=$(spawn_agent_async "$agent" "$perspective" "$task_id" "researcher" "probe" "${pane_titles[$i]}"); then
+                :
+            else
+                spawn_status=$?
+            fi
         else
             # Standard spawning
-            local pid
-            pid=$(spawn_agent_capture_pid "$agent" "$perspective" "$task_id" "researcher" "probe")
-            pids+=("$pid")
+            if pid=$(spawn_agent_capture_pid "$agent" "$perspective" "$task_id" "researcher" "probe"); then
+                :
+            else
+                spawn_status=$?
+            fi
         fi
+        if [[ "$spawn_status" -eq 0 && ! "$pid" =~ ^[0-9]+$ ]]; then
+            spawn_status=1
+        fi
+        if [[ "$spawn_status" -ne 0 ]]; then
+            log ERROR "probe_discover: failed to spawn $agent for $task_id"
+            octopus_probe_cancel_active TERM
+            fleet_dispatch_end
+            _octopus_probe_restore_traps "$probe_previous_int_trap" "$probe_previous_term_trap"
+            return "$spawn_status"
+        fi
+        pids+=("$pid")
         OCTOPUS_ACTIVE_PROBE_PIDS+=("$pid")
         sleep 0.1
     done
@@ -754,9 +844,15 @@ ${_blind_spot_checklist}"
     # v7.19.0 P2.4: Start progressive synthesis monitor in background
     local synthesis_monitor_pid=""
     if [[ "$ENABLE_PROGRESSIVE_SYNTHESIS" == "true" ]]; then
-        progressive_synthesis_monitor "$task_group" "$prompt" 2 &
-        synthesis_monitor_pid=$!
-        OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID="$synthesis_monitor_pid"
+        local monitor_start_status=0
+        _octopus_probe_start_synthesis_monitor "$task_group" "$prompt" 2 \
+            || monitor_start_status=$?
+        if [[ "$monitor_start_status" -ne 0 ]]; then
+            octopus_probe_cancel_active TERM
+            _octopus_probe_restore_traps "$probe_previous_int_trap" "$probe_previous_term_trap"
+            return "$monitor_start_status"
+        fi
+        synthesis_monitor_pid="$OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID"
         log "DEBUG" "Progressive synthesis monitor started (PID: $synthesis_monitor_pid)"
     fi
 
@@ -882,30 +978,14 @@ ${_blind_spot_checklist}"
     } > "$synthesis_marker"
     log DEBUG "Synthesis marker written: $synthesis_marker"
 
-    # Intelligent synthesis (v7.19.0 P1.1: allow with partial results)
-    local synthesis_status=0
-    synthesize_probe_results "$task_group" "$prompt" "$usable_results" \
-        || synthesis_status=$?
-
-    # Preserve the marker on failure so synthesize-probe can recover the run.
-    if [[ "$synthesis_status" -eq 0 ]]; then
-        rm -f "$synthesis_marker"
-        log DEBUG "Synthesis marker removed (synthesis completed successfully)"
-    fi
-
-    # v7.19.0 P2.4: Stop progressive synthesis monitor
-    if [[ -n "$synthesis_monitor_pid" ]]; then
-        kill "$synthesis_monitor_pid" 2>/dev/null || true
-        wait "$synthesis_monitor_pid" 2>/dev/null || true
-        OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID=""
-        log "DEBUG" "Progressive synthesis monitor stopped"
-    fi
-
-    # Display workflow summary (v7.16.0 Feature 2)
-    display_progress_summary
-
-    _octopus_probe_restore_traps "$probe_previous_int_trap" "$probe_previous_term_trap"
-    return "$synthesis_status"
+    # Intelligent synthesis plus cleanup. Keep the call guarded so a nonzero
+    # synthesis or summary status survives orchestrate.sh's errexit setting.
+    local finalize_status=0
+    _octopus_probe_finalize_synthesis "$task_group" "$prompt" "$usable_results" \
+        "$synthesis_marker" "$synthesis_monitor_pid" \
+        "$probe_previous_int_trap" "$probe_previous_term_trap" \
+        || finalize_status=$?
+    return "$finalize_status"
 }
 
 # Phase 2: GRASP (Define) - Consensus building on approach

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -394,6 +394,168 @@ IMPORTANT: If you find yourself searching or grepping more than 3 times in a row
     return "$final_rc"
 }
 
+# Active probe cancellation state is global because Bash signal traps can fire
+# while the main shell is blocked inside a child command or progress loop. The
+# state is populated incrementally, so cancellation during the spawn loop can
+# still reconcile tasks already appended to the PID ledger.
+OCTOPUS_ACTIVE_PROBE_TASK_GROUP=""
+OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID=""
+OCTOPUS_ACTIVE_PROBE_TMUX="false"
+OCTOPUS_ACTIVE_PROBE_PIDS=()
+OCTOPUS_ACTIVE_PROBE_AGENTS=()
+OCTOPUS_ACTIVE_PROBE_TASK_IDS=()
+
+octopus_probe_clear_active() {
+    OCTOPUS_ACTIVE_PROBE_TASK_GROUP=""
+    OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID=""
+    OCTOPUS_ACTIVE_PROBE_TMUX="false"
+    OCTOPUS_ACTIVE_PROBE_PIDS=()
+    OCTOPUS_ACTIVE_PROBE_AGENTS=()
+    OCTOPUS_ACTIVE_PROBE_TASK_IDS=()
+}
+
+_octopus_probe_terminate_tree() {
+    local pid="$1"
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 0
+    kill -0 "$pid" 2>/dev/null || return 0
+
+    if declare -F review_terminate_process_tree >/dev/null 2>&1; then
+        review_terminate_process_tree "$pid" 1
+    else
+        pkill -TERM -P "$pid" 2>/dev/null || true
+        kill -TERM "$pid" 2>/dev/null || true
+        sleep 1
+        pkill -KILL -P "$pid" 2>/dev/null || true
+        kill -KILL "$pid" 2>/dev/null || true
+    fi
+}
+
+_octopus_probe_prune_pid_ledger() {
+    local task_group="$1"
+    [[ -n "${PID_FILE:-}" && -f "$PID_FILE" ]] || return 0
+
+    local tmp_file="${PID_FILE}.cancel.$$"
+    if awk -F: -v prefix="probe-${task_group}-" \
+        'index($3, prefix) != 1 { print }' "$PID_FILE" > "$tmp_file"; then
+        mv -f "$tmp_file" "$PID_FILE"
+    else
+        rm -f "$tmp_file" 2>/dev/null || true
+    fi
+}
+
+octopus_probe_cancel_active() {
+    local signal_name="${1:-TERM}"
+    local task_group="${OCTOPUS_ACTIVE_PROBE_TASK_GROUP:-}"
+    [[ -n "$task_group" ]] || return 0
+
+    local exit_code=143
+    [[ "$signal_name" == "INT" ]] && exit_code=130
+
+    # The + expansion is required for Bash 3.2 with nounset: expanding a
+    # declared-but-empty array directly is treated as an unbound variable.
+    local -a cancel_pids=("${OCTOPUS_ACTIVE_PROBE_PIDS[@]+"${OCTOPUS_ACTIVE_PROBE_PIDS[@]}"}")
+    local -a cancel_agents=("${OCTOPUS_ACTIVE_PROBE_AGENTS[@]+"${OCTOPUS_ACTIVE_PROBE_AGENTS[@]}"}")
+    local -a cancel_tasks=("${OCTOPUS_ACTIVE_PROBE_TASK_IDS[@]+"${OCTOPUS_ACTIVE_PROBE_TASK_IDS[@]}"}")
+    local ledger_pid ledger_agent ledger_task existing found found_idx idx
+
+    for idx in "${!cancel_pids[@]}"; do
+        [[ -n "${cancel_agents[$idx]:-}" ]] || cancel_agents[$idx]="unknown"
+        [[ -n "${cancel_tasks[$idx]:-}" ]] \
+            || cancel_tasks[$idx]="probe-${task_group}-${idx}"
+    done
+
+    # The PID ledger is authoritative for a signal that lands between spawn's
+    # append and the caller's array assignment.
+    if [[ -n "${PID_FILE:-}" && -f "$PID_FILE" ]]; then
+        while IFS=: read -r ledger_pid ledger_agent ledger_task; do
+            [[ "$ledger_task" == "probe-${task_group}-"* ]] || continue
+            found=false
+            found_idx=""
+            for idx in "${!cancel_tasks[@]}"; do
+                existing="${cancel_tasks[$idx]:-}"
+                if [[ "$existing" == "$ledger_task" ]]; then
+                    found=true
+                    found_idx="$idx"
+                    break
+                fi
+            done
+            if [[ "$found" == "true" ]]; then
+                [[ -n "${cancel_pids[$found_idx]:-}" ]] \
+                    || cancel_pids[$found_idx]="$ledger_pid"
+                [[ -n "${cancel_agents[$found_idx]:-}" ]] \
+                    || cancel_agents[$found_idx]="$ledger_agent"
+            else
+                cancel_pids+=("$ledger_pid")
+                cancel_agents+=("$ledger_agent")
+                cancel_tasks+=("$ledger_task")
+            fi
+        done < "$PID_FILE"
+    fi
+
+    local synthesis_pid="${OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID:-}"
+    if [[ "$synthesis_pid" =~ ^[0-9]+$ ]]; then
+        _octopus_probe_terminate_tree "$synthesis_pid"
+        wait "$synthesis_pid" 2>/dev/null || true
+    fi
+
+    for idx in "${!cancel_pids[@]}"; do
+        ledger_pid="${cancel_pids[$idx]:-}"
+        _octopus_probe_terminate_tree "$ledger_pid"
+    done
+
+    local result_file done_file completed task_id agent
+    for idx in "${!cancel_pids[@]}"; do
+        ledger_pid="${cancel_pids[$idx]:-}"
+        agent="${cancel_agents[$idx]:-unknown}"
+        task_id="${cancel_tasks[$idx]:-probe-${task_group}-${idx}}"
+        result_file="${RESULTS_DIR:-}/$agent-$task_id.md"
+        done_file="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents/${task_id}.done"
+        completed=false
+        [[ -f "$done_file" ]] && completed=true
+        if [[ -f "$result_file" ]] \
+           && grep -Eq '^# Completed:|^## Status: (SUCCESS|FAILED|TIMEOUT)' "$result_file" 2>/dev/null; then
+            completed=true
+        fi
+
+        wait "$ledger_pid" 2>/dev/null || true
+        rm -f "${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents/${ledger_pid}.heartbeat" \
+            2>/dev/null || true
+
+        if [[ "$completed" == "false" ]]; then
+            if [[ -f "$result_file" ]] && ! grep -q '^## Status: CANCELLED' "$result_file" 2>/dev/null; then
+                {
+                    echo '```'
+                    echo ""
+                    echo "## Status: CANCELLED - PARTIAL RESULTS"
+                    echo ""
+                    echo "Probe interrupted by SIG${signal_name}; partial output above was preserved."
+                } >> "$result_file"
+            fi
+            if declare -F _octopus_agent_lifecycle_event >/dev/null 2>&1; then
+                _octopus_agent_lifecycle_event "cancelled" "$agent" "$task_id" \
+                    "researcher" "probe" "$ledger_pid" "$result_file" \
+                    "$exit_code" "cancelled"
+            fi
+        fi
+    done
+
+    _octopus_probe_prune_pid_ledger "$task_group"
+    if [[ "${OCTOPUS_ACTIVE_PROBE_TMUX:-false}" == "true" ]] \
+       && declare -F tmux_cleanup >/dev/null 2>&1; then
+        tmux_cleanup 2>/dev/null || true
+    fi
+    octopus_probe_clear_active
+}
+
+octopus_probe_handle_signal() {
+    local signal_name="${1:-TERM}"
+    local exit_code=143
+    [[ "$signal_name" == "INT" ]] && exit_code=130
+    trap - INT TERM
+    octopus_probe_cancel_active "$signal_name"
+    exit "$exit_code"
+}
+
 # Phase 1: PROBE (Discover) - Parallel research with synthesis
 # Like an octopus probing with multiple tentacles simultaneously
 probe_discover() {
@@ -530,6 +692,17 @@ ${_blind_spot_checklist}"
     # Initialize progress tracking with actual agent count (dynamic, may be 5, 6, or 7)
     init_progress_tracking "discover" "${#perspectives[@]}"
 
+    local probe_previous_int_trap probe_previous_term_trap
+    probe_previous_int_trap="$(trap -p INT)"
+    probe_previous_term_trap="$(trap -p TERM)"
+    OCTOPUS_ACTIVE_PROBE_TASK_GROUP="$task_group"
+    OCTOPUS_ACTIVE_PROBE_TMUX="$TMUX_MODE"
+    OCTOPUS_ACTIVE_PROBE_PIDS=()
+    OCTOPUS_ACTIVE_PROBE_AGENTS=()
+    OCTOPUS_ACTIVE_PROBE_TASK_IDS=()
+    trap 'octopus_probe_handle_signal INT' INT
+    trap 'octopus_probe_handle_signal TERM' TERM
+
     fleet_dispatch_begin
 
     local pids=()
@@ -537,6 +710,8 @@ ${_blind_spot_checklist}"
         local perspective="${perspectives[$i]}"
         local agent="${probe_agents[$i]}"
         local task_id="probe-${task_group}-${i}"
+        OCTOPUS_ACTIVE_PROBE_AGENTS+=("$agent")
+        OCTOPUS_ACTIVE_PROBE_TASK_IDS+=("$task_id")
 
         if [[ "$TMUX_MODE" == "true" ]]; then
             # Use async+tmux spawning
@@ -549,6 +724,7 @@ ${_blind_spot_checklist}"
             pid=$(spawn_agent_capture_pid "$agent" "$perspective" "$task_id" "researcher" "probe")
             pids+=("$pid")
         fi
+        OCTOPUS_ACTIVE_PROBE_PIDS+=("$pid")
         sleep 0.1
     done
 
@@ -561,6 +737,7 @@ ${_blind_spot_checklist}"
     if [[ "$ENABLE_PROGRESSIVE_SYNTHESIS" == "true" ]]; then
         progressive_synthesis_monitor "$task_group" "$prompt" 2 &
         synthesis_monitor_pid=$!
+        OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID="$synthesis_monitor_pid"
         log "DEBUG" "Progressive synthesis monitor started (PID: $synthesis_monitor_pid)"
     fi
 
@@ -687,11 +864,24 @@ ${_blind_spot_checklist}"
     if [[ -n "$synthesis_monitor_pid" ]]; then
         kill "$synthesis_monitor_pid" 2>/dev/null || true
         wait "$synthesis_monitor_pid" 2>/dev/null || true
+        OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID=""
         log "DEBUG" "Progressive synthesis monitor stopped"
     fi
 
     # Display workflow summary (v7.16.0 Feature 2)
     display_progress_summary
+
+    octopus_probe_clear_active
+    if [[ -n "$probe_previous_int_trap" ]]; then
+        eval "$probe_previous_int_trap"
+    else
+        trap - INT
+    fi
+    if [[ -n "$probe_previous_term_trap" ]]; then
+        eval "$probe_previous_term_trap"
+    else
+        trap - TERM
+    fi
 }
 
 # Phase 2: GRASP (Define) - Consensus building on approach

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -414,6 +414,23 @@ octopus_probe_clear_active() {
     OCTOPUS_ACTIVE_PROBE_TASK_IDS=()
 }
 
+_octopus_probe_restore_traps() {
+    local previous_int_trap="${1:-}"
+    local previous_term_trap="${2:-}"
+
+    octopus_probe_clear_active
+    if [[ -n "$previous_int_trap" ]]; then
+        eval "$previous_int_trap"
+    else
+        trap - INT
+    fi
+    if [[ -n "$previous_term_trap" ]]; then
+        eval "$previous_term_trap"
+    else
+        trap - TERM
+    fi
+}
+
 _octopus_probe_terminate_tree() {
     local pid="$1"
     [[ "$pid" =~ ^[0-9]+$ ]] || return 0
@@ -458,7 +475,7 @@ octopus_probe_cancel_active() {
     local -a cancel_tasks=("${OCTOPUS_ACTIVE_PROBE_TASK_IDS[@]+"${OCTOPUS_ACTIVE_PROBE_TASK_IDS[@]}"}")
     local ledger_pid ledger_agent ledger_task existing found found_idx idx
 
-    for idx in "${!cancel_pids[@]}"; do
+    for idx in "${!cancel_tasks[@]}"; do
         [[ -n "${cancel_agents[$idx]:-}" ]] || cancel_agents[$idx]="unknown"
         [[ -n "${cancel_tasks[$idx]:-}" ]] \
             || cancel_tasks[$idx]="probe-${task_group}-${idx}"
@@ -498,13 +515,13 @@ octopus_probe_cancel_active() {
         wait "$synthesis_pid" 2>/dev/null || true
     fi
 
-    for idx in "${!cancel_pids[@]}"; do
+    for idx in "${!cancel_tasks[@]}"; do
         ledger_pid="${cancel_pids[$idx]:-}"
         _octopus_probe_terminate_tree "$ledger_pid"
     done
 
     local result_file done_file completed task_id agent
-    for idx in "${!cancel_pids[@]}"; do
+    for idx in "${!cancel_tasks[@]}"; do
         ledger_pid="${cancel_pids[$idx]:-}"
         agent="${cancel_agents[$idx]:-unknown}"
         task_id="${cancel_tasks[$idx]:-probe-${task_group}-${idx}}"
@@ -517,12 +534,14 @@ octopus_probe_cancel_active() {
             completed=true
         fi
 
-        wait "$ledger_pid" 2>/dev/null || true
-        rm -f "${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents/${ledger_pid}.heartbeat" \
-            2>/dev/null || true
+        if [[ "$ledger_pid" =~ ^[0-9]+$ ]]; then
+            wait "$ledger_pid" 2>/dev/null || true
+            rm -f "${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents/${ledger_pid}.heartbeat" \
+                2>/dev/null || true
+        fi
 
         if [[ "$completed" == "false" ]]; then
-            if [[ -f "$result_file" ]] && ! grep -q '^## Status: CANCELLED' "$result_file" 2>/dev/null; then
+            if [[ -f "$result_file" ]] && ! grep -c '^## Status: CANCELLED' "$result_file" >/dev/null 2>&1; then
                 {
                     echo '```'
                     echo ""
@@ -837,7 +856,17 @@ ${_blind_spot_checklist}"
     # can tell which LLMs actually contributed and fail-fast if all providers
     # are required.
     if type render_agent_summary >/dev/null 2>&1; then
-        render_agent_summary || return $?
+        local summary_status=0
+        render_agent_summary || summary_status=$?
+        if [[ "$summary_status" -ne 0 ]]; then
+            if [[ -n "$synthesis_monitor_pid" ]]; then
+                kill "$synthesis_monitor_pid" 2>/dev/null || true
+                wait "$synthesis_monitor_pid" 2>/dev/null || true
+                OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID=""
+            fi
+            _octopus_probe_restore_traps "$probe_previous_int_trap" "$probe_previous_term_trap"
+            return "$summary_status"
+        fi
     fi
 
     # v8.48.0: Write synthesis marker before attempting synthesis
@@ -871,17 +900,7 @@ ${_blind_spot_checklist}"
     # Display workflow summary (v7.16.0 Feature 2)
     display_progress_summary
 
-    octopus_probe_clear_active
-    if [[ -n "$probe_previous_int_trap" ]]; then
-        eval "$probe_previous_int_trap"
-    else
-        trap - INT
-    fi
-    if [[ -n "$probe_previous_term_trap" ]]; then
-        eval "$probe_previous_term_trap"
-    else
-        trap - TERM
-    fi
+    _octopus_probe_restore_traps "$probe_previous_int_trap" "$probe_previous_term_trap"
 }
 
 # Phase 2: GRASP (Define) - Consensus building on approach

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -214,13 +214,12 @@ source "${SCRIPT_DIR}/lib/council.sh" 2>/dev/null || true
 # Prevents path traversal attacks and restricts to safe locations
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Apply workspace path — prefer CLAUDE_PLUGIN_DATA (CC v2.1.78+), then user override, then default
-if [[ -n "${CLAUDE_PLUGIN_DATA:-}" ]]; then
-    WORKSPACE_DIR="${CLAUDE_PLUGIN_DATA}"
-elif [[ -n "${CLAUDE_OCTOPUS_WORKSPACE:-}" ]]; then
-    WORKSPACE_DIR=$(validate_workspace_path "$CLAUDE_OCTOPUS_WORKSPACE") || exit 1
-else
-    WORKSPACE_DIR="${HOME}/.claude-octopus"
+# Use the same workspace resolver as standalone `octopus state-path`. Preserve
+# path validation for the user-controlled override; CLAUDE_PLUGIN_DATA is
+# supplied by the host and retains precedence.
+WORKSPACE_DIR="$(resolve_octopus_workspace)"
+if [[ -z "${CLAUDE_PLUGIN_DATA:-}" && -n "${CLAUDE_OCTOPUS_WORKSPACE:-}" ]]; then
+    WORKSPACE_DIR="$(validate_workspace_path "$WORKSPACE_DIR")" || exit 1
 fi
 
 # Re-derive SESSION_FILE now that WORKSPACE_DIR is known

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -2123,17 +2123,17 @@ show_status() {
     fi
 
     # v8.14.0: Show persistent project state
-    if [[ -f ".claude-octopus/state.json" ]]; then
+    if [[ -f "$STATE_FILE" ]]; then
         echo ""
         echo -e "${BLUE}Project State:${NC}"
         local wf ph pc dc ab
-        wf=$(jq -r '.current_workflow // "none"' .claude-octopus/state.json 2>/dev/null)
-        ph=$(jq -r '.current_phase // "none"' .claude-octopus/state.json 2>/dev/null)
-        pc=$(jq -r '.metrics.phases_completed // 0' .claude-octopus/state.json 2>/dev/null)
-        dc=$(jq -r '.decisions | length // 0' .claude-octopus/state.json 2>/dev/null)
+        wf=$(jq -r '.current_workflow // "none"' "$STATE_FILE" 2>/dev/null)
+        ph=$(jq -r '.current_phase // "none"' "$STATE_FILE" 2>/dev/null)
+        pc=$(jq -r '.metrics.phases_completed // 0' "$STATE_FILE" 2>/dev/null)
+        dc=$(jq -r '.decisions | length // 0' "$STATE_FILE" 2>/dev/null)
         echo -e "  Workflow: ${CYAN}${wf}${NC} | Phase: ${CYAN}${ph}${NC}"
         echo -e "  Phases completed: $pc | Decisions: $dc"
-        ab=$(jq -r '[.blockers[] | select(.status == "active")] | length // 0' .claude-octopus/state.json 2>/dev/null)
+        ab=$(jq -r '[.blockers[] | select(.status == "active")] | length // 0' "$STATE_FILE" 2>/dev/null)
         if [[ "$ab" -gt 0 ]] 2>/dev/null; then
             echo -e "  ${YELLOW}Active blockers: $ab${NC}"
         fi
@@ -2341,6 +2341,16 @@ fi
 # Initialize state management (v7.17.0)
 # Skip for help and non-workflow commands
 if [[ "$COMMAND" != "help" && "$COMMAND" != "setup" && "$COMMAND" != "preflight" && "$COMMAND" != "cost" && "$COMMAND" != "usage" && "$COMMAND" != "-h" && "$COMMAND" != "--help" ]]; then
+    # Keep workflow context outside the project by default, namespaced by a
+    # stable project identity. This is deliberately separate from
+    # OCTOPUS_STATE_DIR, which owns the user-level feature/advisory ledger.
+    # Project-local persistence remains an explicit opt-in.
+    OCTOPUS_STATE_PROJECT_ROOT="$PROJECT_ROOT"
+    if [[ -z "${OCTOPUS_WORKFLOW_STATE_DIR:-}" ]]; then
+        OCTOPUS_WORKFLOW_STATE_DIR="${WORKSPACE_DIR}/projects/$(state_project_id "$PROJECT_ROOT")"
+    fi
+    export OCTOPUS_STATE_PROJECT_ROOT OCTOPUS_WORKFLOW_STATE_DIR
+    configure_state_paths "$OCTOPUS_WORKFLOW_STATE_DIR"
     init_state 2>/dev/null || true
 
     # v8.29.0: Check if ConfigChange hook signaled settings were modified

--- a/scripts/state-manager.sh
+++ b/scripts/state-manager.sh
@@ -7,10 +7,44 @@
 # ${VAR} in the 14K+ line caller and its libraries (#108, #189).
 set -eo pipefail
 
-# Configuration
-STATE_DIR=".claude-octopus"
-STATE_FILE="$STATE_DIR/state.json"
-BACKUP_FILE="$STATE_DIR/state.json.backup"
+# Configuration. Both standalone and orchestrated calls default to the
+# host/plugin-data workspace, namespaced by project, so merely inspecting or
+# starting a workflow never dirties the user's repository (#841). Set
+# OCTOPUS_WORKFLOW_STATE_DIR to opt into a different location.
+configure_state_paths() {
+    STATE_DIR="${1:-.claude-octopus}"
+    STATE_FILE="$STATE_DIR/state.json"
+    BACKUP_FILE="$STATE_DIR/state.json.backup"
+}
+
+state_project_id() {
+    local project_root="${1:-$PWD}"
+    local identity digest
+    identity="$(git -C "$project_root" config --get remote.origin.url 2>/dev/null || true)"
+    identity="${identity:-$(cd "$project_root" 2>/dev/null && pwd -P || printf '%s' "$project_root")}"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        digest="$(printf '%s' "$identity" | sha256sum | awk '{print $1}')"
+    elif command -v shasum >/dev/null 2>&1; then
+        digest="$(printf '%s' "$identity" | shasum -a 256 | awk '{print $1}')"
+    elif command -v md5sum >/dev/null 2>&1; then
+        digest="$(printf '%s' "$identity" | md5sum | awk '{print $1}')"
+    elif command -v md5 >/dev/null 2>&1; then
+        digest="$(printf '%s' "$identity" | md5 -q)"
+    else
+        digest="$(printf '%s' "$identity" | cksum | awk '{print $1 "-" $2}')"
+    fi
+    printf '%s\n' "$digest"
+}
+
+if [[ -n "${OCTOPUS_WORKFLOW_STATE_DIR:-}" ]]; then
+    configure_state_paths "$OCTOPUS_WORKFLOW_STATE_DIR"
+else
+    _octopus_workflow_project_root="${OCTOPUS_STATE_PROJECT_ROOT:-$PWD}"
+    _octopus_workflow_state_base="${CLAUDE_PLUGIN_DATA:-${CLAUDE_OCTOPUS_WORKSPACE:-${HOME:-$PWD}/.claude-octopus}}"
+    configure_state_paths "${_octopus_workflow_state_base}/projects/$(state_project_id "$_octopus_workflow_project_root")"
+    unset _octopus_workflow_project_root _octopus_workflow_state_base
+fi
 
 # Colors for output
 RED='\033[0;31m'
@@ -51,14 +85,9 @@ init_state() {
         fi
     fi
 
-    # Generate project ID from git remote or directory name
-    local remote_url
-    remote_url=$(git config --get remote.origin.url 2>/dev/null || true)
-    if [[ -n "$remote_url" ]]; then
-        project_id=$(printf '%s' "$remote_url" | md5sum | cut -d' ' -f1)
-    else
-        project_id=$(printf '%s' "$(basename "$PWD")" | md5sum | cut -d' ' -f1)
-    fi
+    # Generate a stable project ID without assuming GNU md5sum is installed.
+    local project_id
+    project_id="$(state_project_id "${OCTOPUS_STATE_PROJECT_ROOT:-$PWD}")"
 
     # Create initial state
     cat > "$STATE_FILE" <<EOF
@@ -424,6 +453,9 @@ main() {
         read_state)
             read_state
             ;;
+        state_path)
+            printf '%s\n' "$STATE_FILE"
+            ;;
         get_current_phase)
             get_current_phase
             ;;
@@ -472,6 +504,7 @@ Usage: state-manager.sh <command> [args]
 Commands:
   init_state                                  Initialize state file
   read_state                                  Display current state (JSON)
+  state_path                                  Display the resolved state file path
   get_current_phase                           Get current phase
   get_current_workflow                        Get current workflow
   set_current_workflow <workflow> [phase]     Set current workflow and phase

--- a/scripts/state-manager.sh
+++ b/scripts/state-manager.sh
@@ -17,11 +17,25 @@ configure_state_paths() {
     BACKUP_FILE="$STATE_DIR/state.json.backup"
 }
 
+# Resolve the persistent host workspace identically for standalone commands and
+# the orchestrator. CLAUDE_PLUGIN_DATA is host-owned; the user override remains
+# second in precedence. A missing HOME falls back to the physical caller path.
+resolve_octopus_workspace() {
+    local workspace home_base
+    home_base="${HOME:-$PWD}"
+    workspace="${CLAUDE_PLUGIN_DATA:-${CLAUDE_OCTOPUS_WORKSPACE:-${home_base}/.claude-octopus}}"
+    if [[ "$workspace" == \~* ]]; then
+        workspace="${home_base}${workspace#\~}"
+    fi
+    printf '%s\n' "$workspace"
+}
+
 state_project_id() {
     local project_root="${1:-$PWD}"
-    local identity digest
-    identity="$(git -C "$project_root" config --get remote.origin.url 2>/dev/null || true)"
-    identity="${identity:-$(cd "$project_root" 2>/dev/null && pwd -P || printf '%s' "$project_root")}"
+    local identity digest remote resolved_root
+    remote="$(git -C "$project_root" config --get remote.origin.url 2>/dev/null || true)"
+    resolved_root="$(cd "$project_root" 2>/dev/null && pwd -P || printf '%s' "$project_root")"
+    identity="${remote}|${resolved_root}"
 
     if command -v sha256sum >/dev/null 2>&1; then
         digest="$(printf '%s' "$identity" | sha256sum | awk '{print $1}')"
@@ -41,7 +55,7 @@ if [[ -n "${OCTOPUS_WORKFLOW_STATE_DIR:-}" ]]; then
     configure_state_paths "$OCTOPUS_WORKFLOW_STATE_DIR"
 else
     _octopus_workflow_project_root="${OCTOPUS_STATE_PROJECT_ROOT:-$PWD}"
-    _octopus_workflow_state_base="${CLAUDE_PLUGIN_DATA:-${CLAUDE_OCTOPUS_WORKSPACE:-${HOME:-$PWD}/.claude-octopus}}"
+    _octopus_workflow_state_base="$(resolve_octopus_workspace)"
     configure_state_paths "${_octopus_workflow_state_base}/projects/$(state_project_id "$_octopus_workflow_project_root")"
     unset _octopus_workflow_project_root _octopus_workflow_state_base
 fi

--- a/skills/flow-discover/SKILL.md
+++ b/skills/flow-discover/SKILL.md
@@ -28,12 +28,18 @@ setting `OCTOPUS_PROJECT_PERSISTENCE=true`.
 if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
   if [[ ! -d ".octo" ]]; then
     echo "📁 Initializing opt-in .octo/ project state..."
-    "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project
+    if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project; then
+      echo "Discover incomplete: could not initialize opt-in project state." >&2
+      exit 1
+    fi
   fi
-  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-    --phase 1 \
-    --position "Discovery" \
-    --status "in_progress"
+  if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+      --phase 1 \
+      --position "Discovery" \
+      --status "in_progress"; then
+    echo "Discover incomplete: could not persist in-progress state." >&2
+    exit 1
+  fi
 fi
 ```
 
@@ -805,9 +811,12 @@ if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
     echo "Discover incomplete: could not persist findings to .octo/PROJECT.md." >&2
     exit 1
   fi
-  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-    --status "complete" \
-    --history "Discover phase completed"
+  if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+      --status "complete" \
+      --history "Discover phase completed"; then
+    echo "Discover incomplete: could not persist completion state." >&2
+    exit 1
+  fi
 fi
 ```
 

--- a/skills/flow-discover/SKILL.md
+++ b/skills/flow-discover/SKILL.md
@@ -67,7 +67,7 @@ fi
 
 **How it works:**
 - Native plan mode may clear Claude's memory via `ExitPlanMode`
-- claude-octopus state persists in `.claude-octopus/state.json`
+- Claude Octopus workflow state persists in the host workspace, namespaced by project; resolve its exact path with `state-manager.sh state_path`
 - Each workflow phase reads prior state at startup
 - Context is automatically restored from files
 

--- a/skills/flow-discover/SKILL.md
+++ b/skills/flow-discover/SKILL.md
@@ -18,28 +18,23 @@ description: "Multi-AI research using available external providers (Double Diamo
 - Before synthesis, run `${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh agent-summary` and use only providers reported as `ok`, `degraded`, or `timeout` with usable output.
 - For `standard` and `deep` research, require at least 2 usable provider outputs unless fewer providers are installed; failed/rejected providers are reported as gaps, not cited as evidence.
 
-## Pre-Discovery: Project Initialization
+## Pre-Discovery: Optional Project Persistence
 
-Before starting discovery:
-1. Check if `.octo/` directory exists
-2. If NOT exists: Call `./scripts/octo-state.sh init_project` to create it
-3. Update `.octo/STATE.md`:
-   - current_phase: 1
-   - phase_position: "Discovery"
-   - status: "in_progress"
+Workflow state is stored in the host workspace by default. Only create the
+project-local `.octo/` lifecycle artifacts when the user explicitly opts in by
+setting `OCTOPUS_PROJECT_PERSISTENCE=true`.
 
 ```bash
-# Check and initialize .octo/ state
-if [[ ! -d ".octo" ]]; then
-  echo "📁 Initializing .octo/ project state..."
-  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project
+if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
+  if [[ ! -d ".octo" ]]; then
+    echo "📁 Initializing opt-in .octo/ project state..."
+    "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" init_project
+  fi
+  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+    --phase 1 \
+    --position "Discovery" \
+    --status "in_progress"
 fi
-
-# Update state for Discovery phase
-"${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-  --phase 1 \
-  --position "Discovery" \
-  --status "in_progress"
 ```
 
 
@@ -56,7 +51,7 @@ Check if native plan mode is active:
 if [[ -n "${PLAN_MODE_ACTIVE}" ]] || claude-code plan status 2>/dev/null | grep -q "active"; then
     echo "⚠️  Native plan mode detected"
     echo ""
-    echo "   Claude Octopus uses file-based state (.claude-octopus/)"
+    echo "   Resolve Claude Octopus workflow state with: octopus state-path"
     echo "   State will persist across plan mode context clears"
     echo "   Multi-AI orchestration will continue normally"
     echo ""
@@ -785,8 +780,8 @@ See **skill-security-framing.md** for complete documentation on:
 After discovery completes:
 1. Verify the synthesis file exists and is non-empty.
 2. Present its findings to the user.
-3. Populate `.octo/PROJECT.md` with the research findings.
-4. Only then update `.octo/STATE.md`:
+3. If project-local persistence was explicitly enabled, populate
+   `.octo/PROJECT.md`, then update `.octo/STATE.md`:
    - status: "complete" (for this phase)
    - Add history entry: "Discover phase completed"
 
@@ -801,26 +796,27 @@ fi
 echo "Discovery findings:"
 cat "$SYNTHESIS_FILE"
 
-# Populate PROJECT.md with the complete research synthesis and fail closed.
-echo "📝 Updating .octo/PROJECT.md with discovery findings..."
-if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_project \
-    --section "vision" \
-    --content-file "$SYNTHESIS_FILE"; then
-  echo "Discover incomplete: could not persist findings to .octo/PROJECT.md." >&2
-  exit 1
+# Project-local lifecycle documents are a separate, explicit opt-in.
+if [[ "${OCTOPUS_PROJECT_PERSISTENCE:-false}" == "true" ]]; then
+  echo "📝 Updating opt-in .octo/PROJECT.md with discovery findings..."
+  if ! "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_project \
+      --section "vision" \
+      --content-file "$SYNTHESIS_FILE"; then
+    echo "Discover incomplete: could not persist findings to .octo/PROJECT.md." >&2
+    exit 1
+  fi
+  "${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
+    --status "complete" \
+    --history "Discover phase completed"
 fi
-
-# Mark complete only after the synthesis was presented and persisted.
-"${HOME}/.claude-octopus/plugin/scripts/octo-state.sh" update_state \
-  --status "complete" \
-  --history "Discover phase completed"
 ```
 
 
 ## Terminal State
 
-The Discover phase is complete ONLY when the synthesis file exists, its complete findings
-are presented to the user, and those findings are persisted in `.octo/PROJECT.md`. Then
+The Discover phase is complete ONLY when the synthesis file exists and its complete findings
+are presented to the user. When `OCTOPUS_PROJECT_PERSISTENCE=true`, the findings must also
+be persisted in `.octo/PROJECT.md`. Then
 either invoke `flow-define` (embrace workflow, or the user wants requirements next) or
 stop with research delivered. Do NOT begin scoping, designing, or implementation from
 here — that work belongs to later phases.

--- a/skills/skill-resume/SKILL.md
+++ b/skills/skill-resume/SKILL.md
@@ -463,7 +463,7 @@ User runs /octo:resume
 
 | User Input | Action Required |
 |------------|-----------------|
-| "resume" | Check .octo/ → Read state → Load context → Display summary → Route |
+| "resume" | Resolve state with `octopus state-path` → Load context → Display summary → Route |
 | "continue" | Same as resume |
 | "pick up where I left off" | Same as resume |
 | "what was I doing" | Same as resume, emphasize history |
@@ -473,7 +473,7 @@ User runs /octo:resume
 ## The Bottom Line
 
 ```
-Check .octo/ → Read state → Load adaptive context → Show history + blockers → Route intelligently
+Run `octopus state-path` → Read state → Load adaptive context → Show history + blockers → Route intelligently
 Otherwise → User loses previous context and wastes time re-discovering where they were
 ```
 
@@ -487,7 +487,10 @@ When context is cleared (compaction, plan mode exit, new session), detect and re
 ```bash
 # Auto-detect context loss without writing into the project checkout.
 # The plugin executable resolves its own installation root on every host.
-WORKFLOW_STATE_FILE="$(octopus state-path)"
+if ! WORKFLOW_STATE_FILE="$(octopus state-path)" || [[ -z "$WORKFLOW_STATE_FILE" ]]; then
+    echo "Unable to resolve persistent workflow state; refusing an incomplete resume." >&2
+    exit 1
+fi
 if [[ -f "$WORKFLOW_STATE_FILE" ]] && [[ -z "${WORKFLOW_CONTEXT_LOADED}" ]]; then
     echo "⚠️  Context was cleared — reloading from persistent state..."
     NEEDS_RESUME=true
@@ -495,8 +498,8 @@ fi
 ```
 
 **What survives context clearing:**
-- Host-workspace project state (decisions, context, metrics; resolve with `state-manager.sh state_path`)
-- The resolved state directory's `context/*.md` files (phase outputs)
+- Host-workspace project state (decisions, context, metrics; resolve with `octopus state-path`)
+- `context/*.md` beside the path returned by `octopus state-path` (phase outputs)
 - Native tasks (TaskList still works)
 - Git commits and WIP checkpoints
 - Multi-AI synthesis files in `~/.claude-octopus/results/`

--- a/skills/skill-resume/SKILL.md
+++ b/skills/skill-resume/SKILL.md
@@ -485,16 +485,18 @@ Otherwise → User loses previous context and wastes time re-discovering where t
 When context is cleared (compaction, plan mode exit, new session), detect and reload automatically:
 
 ```bash
-# Auto-detect context loss
-if [[ -f .claude-octopus/state.json ]] && [[ -z "${WORKFLOW_CONTEXT_LOADED}" ]]; then
+# Auto-detect context loss without writing into the project checkout.
+# The plugin executable resolves its own installation root on every host.
+WORKFLOW_STATE_FILE="$(octopus state-path)"
+if [[ -f "$WORKFLOW_STATE_FILE" ]] && [[ -z "${WORKFLOW_CONTEXT_LOADED}" ]]; then
     echo "⚠️  Context was cleared — reloading from persistent state..."
     NEEDS_RESUME=true
 fi
 ```
 
 **What survives context clearing:**
-- `.claude-octopus/state.json` (decisions, context, metrics)
-- `.claude-octopus/context/*.md` (phase outputs)
+- Host-workspace project state (decisions, context, metrics; resolve with `state-manager.sh state_path`)
+- The resolved state directory's `context/*.md` files (phase outputs)
 - Native tasks (TaskList still works)
 - Git commits and WIP checkpoints
 - Multi-AI synthesis files in `~/.claude-octopus/results/`

--- a/tests/unit/fixtures/env-var-effects.tsv
+++ b/tests/unit/fixtures/env-var-effects.tsv
@@ -53,4 +53,6 @@ OCTOPUS_REVIEWER_FLIP	covered-by	test-fable5-escalation.sh
 OCTOPUS_RUN_ID	covered-by	test-agent-summary.sh
 OCTOPUS_SENTINEL_ENABLED	covered-by	test-sentinel.sh
 OCTOPUS_TRACE_MODELS	skip	emits trace lines to stderr; covered indirectly by model-resolver suites
+OCTOPUS_WORKFLOW_STATE_DIR	covered-by	test-probe-cancellation-cleanup.sh
+OCTOPUS_WORKSPACE	covered-by	test-subagent-stop-gate.sh
 OCTOPUS_X_MODEL	placeholder	doc template fragment, not a real variable

--- a/tests/unit/test-phases-1-2-3.sh
+++ b/tests/unit/test-phases-1-2-3.sh
@@ -18,6 +18,7 @@ TESTS_FAILED=0
 
 # Change to plugin directory
 cd "$(dirname "$0")/../.."
+export OCTOPUS_WORKFLOW_STATE_DIR="$PROJECT_ROOT/.claude-octopus"
 
 echo -e "${BLUE}═══════════════════════════════════════════════════════${NC}"
 echo -e "${BLUE}  Phase 1-3 Integration Test Suite${NC}"

--- a/tests/unit/test-phases-1-2-3.sh
+++ b/tests/unit/test-phases-1-2-3.sh
@@ -4,7 +4,6 @@
 
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Comprehensive test suite for Phases 1-3"
 
@@ -18,7 +17,7 @@ TESTS_FAILED=0
 
 # Change to plugin directory
 cd "$(dirname "$0")/../.."
-export OCTOPUS_WORKFLOW_STATE_DIR="$PROJECT_ROOT/.claude-octopus"
+export OCTOPUS_WORKFLOW_STATE_DIR="$TEST_TMP_DIR/.claude-octopus"
 
 echo -e "${BLUE}═══════════════════════════════════════════════════════${NC}"
 echo -e "${BLUE}  Phase 1-3 Integration Test Suite${NC}"
@@ -89,19 +88,19 @@ echo -e "${BLUE}═════════════════════�
 echo ""
 
 # Clean up any existing state
-rm -rf .claude-octopus 2>/dev/null || true
+rm -rf "$OCTOPUS_WORKFLOW_STATE_DIR" 2>/dev/null || true
 
 # Test 1: State initialization
 test_start "State initialization"
 if assert_command_succeeds ./scripts/state-manager.sh init_state; then
-    if assert_file_exists ".claude-octopus/state.json"; then
+    if assert_file_exists "$OCTOPUS_WORKFLOW_STATE_DIR/state.json"; then
         test_pass
     fi
 fi
 
 # Test 2: State file is valid JSON
 test_start "State file is valid JSON"
-if jq empty .claude-octopus/state.json 2>/dev/null; then
+if jq empty "$OCTOPUS_WORKFLOW_STATE_DIR/state.json" 2>/dev/null; then
     test_pass
 else
     test_fail "State file is not valid JSON"
@@ -112,7 +111,7 @@ test_start "State has required fields"
 required_fields=("version" "decisions" "blockers" "context" "metrics")
 all_present=true
 for field in "${required_fields[@]}"; do
-    if ! jq -e ".$field" .claude-octopus/state.json > /dev/null 2>&1; then
+    if ! jq -e ".$field" "$OCTOPUS_WORKFLOW_STATE_DIR/state.json" > /dev/null 2>&1; then
         test_fail "Missing required field: $field"
         all_present=false
     fi
@@ -125,7 +124,7 @@ fi
 test_start "Write decision"
 if assert_command_succeeds ./scripts/state-manager.sh write_decision \
     "define" "React 19 + Next.js 15" "Modern stack with best DX"; then
-    decision_count=$(jq '.decisions | length' .claude-octopus/state.json)
+    decision_count=$(jq '.decisions | length' "$OCTOPUS_WORKFLOW_STATE_DIR/state.json")
     if assert_equals "$decision_count" "1"; then
         test_pass
     fi
@@ -135,7 +134,7 @@ fi
 test_start "Update context"
 if assert_command_succeeds ./scripts/state-manager.sh update_context \
     "discover" "Researched auth patterns, chose JWT"; then
-    discover_context=$(jq -r '.context.discover' .claude-octopus/state.json)
+    discover_context=$(jq -r '.context.discover' "$OCTOPUS_WORKFLOW_STATE_DIR/state.json")
     if assert_equals "$discover_context" "Researched auth patterns, chose JWT"; then
         test_pass
     fi
@@ -144,7 +143,7 @@ fi
 # Test 6: Update metrics
 test_start "Update metrics - phases completed"
 if assert_command_succeeds ./scripts/state-manager.sh update_metrics "phases_completed" "1"; then
-    phases=$(jq '.metrics.phases_completed' .claude-octopus/state.json)
+    phases=$(jq '.metrics.phases_completed' "$OCTOPUS_WORKFLOW_STATE_DIR/state.json")
     if assert_equals "$phases" "1"; then
         test_pass
     fi
@@ -153,7 +152,7 @@ fi
 # Test 7: Update provider metrics
 test_start "Update metrics - provider usage"
 if assert_command_succeeds ./scripts/state-manager.sh update_metrics "provider" "gemini"; then
-    gemini_usage=$(jq '.metrics.provider_usage.gemini' .claude-octopus/state.json)
+    gemini_usage=$(jq '.metrics.provider_usage.gemini' "$OCTOPUS_WORKFLOW_STATE_DIR/state.json")
     if assert_equals "$gemini_usage" "1"; then
         test_pass
     fi
@@ -163,7 +162,7 @@ fi
 test_start "Write blocker"
 if assert_command_succeeds ./scripts/state-manager.sh write_blocker \
     "Waiting for API deployment" "develop" "active"; then
-    blocker_count=$(jq '.blockers | length' .claude-octopus/state.json)
+    blocker_count=$(jq '.blockers | length' "$OCTOPUS_WORKFLOW_STATE_DIR/state.json")
     if assert_equals "$blocker_count" "1"; then
         test_pass
     fi
@@ -178,7 +177,7 @@ fi
 
 # Test 10: State backup created
 test_start "State backup created on write"
-if assert_file_exists ".claude-octopus/state.json.backup"; then
+if assert_file_exists "$OCTOPUS_WORKFLOW_STATE_DIR/state.json.backup"; then
     test_pass
 fi
 
@@ -274,10 +273,10 @@ fi
 # Test 18: Context directory initialization
 test_start "Context directory initialization"
 if assert_command_succeeds ./scripts/context-manager.sh init_context_dir; then
-    if [ -d ".claude-octopus/context" ]; then
+    if [ -d "$OCTOPUS_WORKFLOW_STATE_DIR/context" ]; then
         test_pass
     else
-        test_fail "Directory .claude-octopus/context not created"
+        test_fail "Directory $OCTOPUS_WORKFLOW_STATE_DIR/context not created"
     fi
 fi
 
@@ -285,14 +284,14 @@ fi
 test_start "Create templated context"
 if assert_command_succeeds ./scripts/context-manager.sh create_templated_context \
     "test-workflow" "Test Feature" "Test vision" "Test approach"; then
-    if assert_file_exists ".claude-octopus/context/test-workflow-context.md"; then
+    if assert_file_exists "$OCTOPUS_WORKFLOW_STATE_DIR/context/test-workflow-context.md"; then
         test_pass
     fi
 fi
 
 # Test 20: Context file has required sections
 test_start "Context file has required sections"
-context_file=".claude-octopus/context/test-workflow-context.md"
+context_file="$OCTOPUS_WORKFLOW_STATE_DIR/context/test-workflow-context.md"
 required_sections=("User Vision" "Technical Approach" "Scope" "Decisions Made")
 all_sections_present=true
 for section in "${required_sections[@]}"; do
@@ -399,10 +398,10 @@ fi
 # Test 30: Directory structure is complete
 test_start "Directory structure is complete"
 required_dirs=(
-    ".claude-octopus"
-    ".claude-octopus/context"
-    ".claude-octopus/summaries"
-    ".claude-octopus/quick"
+    "$OCTOPUS_WORKFLOW_STATE_DIR"
+    "$OCTOPUS_WORKFLOW_STATE_DIR/context"
+    "$OCTOPUS_WORKFLOW_STATE_DIR/summaries"
+    "$OCTOPUS_WORKFLOW_STATE_DIR/quick"
 )
 all_dirs_exist=true
 for dir in "${required_dirs[@]}"; do

--- a/tests/unit/test-probe-cancellation-cleanup.sh
+++ b/tests/unit/test-probe-cancellation-cleanup.sh
@@ -242,6 +242,24 @@ else
     test_fail "standalone state manager dirtied the project or lost state"
 fi
 
+test_case "standalone context manager also defaults outside the project"
+context_home="$TEST_TMP_DIR/context-home"
+context_project="$TEST_TMP_DIR/context-project"
+mkdir -p "$context_home" "$context_project"
+(
+    cd "$context_project"
+    env -u OCTOPUS_WORKFLOW_STATE_DIR -u OCTOPUS_STATE_PROJECT_ROOT \
+        -u CLAUDE_PLUGIN_DATA -u CLAUDE_OCTOPUS_WORKSPACE \
+        "HOME=$context_home" \
+        "$PROJECT_ROOT/scripts/context-manager.sh" init_context_dir >/dev/null 2>&1
+)
+context_dir="$(find "$context_home/.claude-octopus/projects" -name context -type d -print -quit 2>/dev/null || true)"
+if [[ ! -d "$context_project/.claude-octopus/context" && -n "$context_dir" ]]; then
+    test_pass
+else
+    test_fail "standalone context manager dirtied the project or lost context state"
+fi
+
 test_case "portable CLI resolves the namespaced workflow state path"
 cli_state_file=$(
     cd "$direct_project"
@@ -320,6 +338,17 @@ if [[ -f "$opt_in_project/.claude-octopus/state.json" ]]; then
     test_pass
 else
     test_fail "explicit project-local state directory was not honored"
+fi
+
+test_case "probe synthesis failure keeps recovery marker and returns non-zero"
+probe_tail="$(sed -n '/# Intelligent synthesis (v7.19.0 P1.1/,/^}/p' "$PROJECT_ROOT/scripts/lib/workflows.sh")"
+if grep -q 'local synthesis_status=0' <<< "$probe_tail" \
+   && grep -q 'synthesize_probe_results.*synthesis_status' <<< "$(tr '\n' ' ' <<< "$probe_tail")" \
+   && grep -q 'if \[\[ "$synthesis_status" -eq 0 \]\]' <<< "$probe_tail" \
+   && grep -q 'return "$synthesis_status"' <<< "$probe_tail"; then
+    test_pass
+else
+    test_fail "probe_discover does not preserve synthesis failure through cleanup"
 fi
 
 test_summary

--- a/tests/unit/test-probe-cancellation-cleanup.sh
+++ b/tests/unit/test-probe-cancellation-cleanup.sh
@@ -38,6 +38,14 @@ cleanup_probe_processes() {
 }
 after_all cleanup_probe_processes
 
+probe_processes_gone() {
+    local pid
+    for pid in "$@"; do
+        kill -0 "$pid" 2>/dev/null && return 1
+    done
+    return 0
+}
+
 test_case "probe cancellation helper is available"
 if declare -F octopus_probe_cancel_active >/dev/null 2>&1; then
     test_pass
@@ -90,6 +98,7 @@ OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID="$synthesis_pid"
 OCTOPUS_ACTIVE_PROBE_TMUX="false"
 OCTOPUS_ACTIVE_PROBE_PIDS=("$provider_pid")
 OCTOPUS_ACTIVE_PROBE_AGENTS=("codex")
+OCTOPUS_ACTIVE_PROBE_TASK_IDS=("$task_id")
 
 if declare -F octopus_probe_cancel_active >/dev/null 2>&1; then
     octopus_probe_cancel_active TERM
@@ -101,9 +110,13 @@ fi
 wait "$provider_pid" 2>/dev/null || true
 wait "$synthesis_pid" 2>/dev/null || true
 
-if ! kill -0 "$provider_pid" 2>/dev/null \
-   && ! kill -0 "$provider_child_pid" 2>/dev/null \
-   && ! kill -0 "$synthesis_pid" 2>/dev/null; then
+attempt=0
+while ! probe_processes_gone "$provider_pid" "$provider_child_pid" "$synthesis_pid" \
+      && [[ "$attempt" -lt 100 ]]; do
+    sleep 0.05
+    attempt=$((attempt + 1))
+done
+if probe_processes_gone "$provider_pid" "$provider_child_pid" "$synthesis_pid"; then
     test_pass
 else
     test_fail "provider tree or synthesis monitor survived cancellation"
@@ -131,6 +144,27 @@ if jq -e --arg task "$task_id" \
     test_pass
 else
     test_fail "agent.cancelled event missing for $task_id"
+fi
+
+test_case "registered task without PID is still marked and terminated logically"
+no_pid_group="841002"
+no_pid_task="probe-${no_pid_group}-0"
+no_pid_result="$RESULTS_DIR/codex-${no_pid_task}.md"
+printf '# Agent: codex\n\npartial before PID assignment\n' > "$no_pid_result"
+OCTOPUS_ACTIVE_PROBE_TASK_GROUP="$no_pid_group"
+OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID=""
+OCTOPUS_ACTIVE_PROBE_TMUX="false"
+OCTOPUS_ACTIVE_PROBE_PIDS=()
+OCTOPUS_ACTIVE_PROBE_AGENTS=("codex")
+OCTOPUS_ACTIVE_PROBE_TASK_IDS=("$no_pid_task")
+octopus_probe_cancel_active TERM
+if grep -q '^## Status: CANCELLED - PARTIAL RESULTS' "$no_pid_result" \
+   && jq -e --arg task "$no_pid_task" \
+        'select(.event == "agent.cancelled" and .attributes.task_id == $task)' \
+        "$OCTO_EVENT_LOG" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "task registered before PID assignment was not reconciled"
 fi
 
 test_case "probe signal handler maps TERM to exit 143"
@@ -195,7 +229,9 @@ direct_project="$TEST_TMP_DIR/direct-project"
 mkdir -p "$direct_home" "$direct_project"
 (
     cd "$direct_project"
-    env "HOME=$direct_home" "$PROJECT_ROOT/scripts/state-manager.sh" init_state \
+    unset OCTOPUS_WORKFLOW_STATE_DIR OCTOPUS_STATE_PROJECT_ROOT \
+        CLAUDE_PLUGIN_DATA CLAUDE_OCTOPUS_WORKSPACE
+    HOME="$direct_home" "$PROJECT_ROOT/scripts/state-manager.sh" init_state \
         >/dev/null 2>&1
 )
 direct_state_file="$(find "$direct_home/.claude-octopus/projects" -name state.json -type f -print -quit 2>/dev/null || true)"
@@ -209,12 +245,65 @@ fi
 test_case "portable CLI resolves the namespaced workflow state path"
 cli_state_file=$(
     cd "$direct_project"
-    env "HOME=$direct_home" "$PROJECT_ROOT/bin/octopus" state-path
+    unset OCTOPUS_WORKFLOW_STATE_DIR OCTOPUS_STATE_PROJECT_ROOT \
+        CLAUDE_PLUGIN_DATA CLAUDE_OCTOPUS_WORKSPACE
+    HOME="$direct_home" "$PROJECT_ROOT/bin/octopus" state-path
 )
 if [[ "$cli_state_file" == "$direct_state_file" ]]; then
     test_pass
 else
     test_fail "octopus state-path returned $cli_state_file instead of $direct_state_file"
+fi
+
+test_case "workspace resolver expands tilde consistently"
+literal_tilde='~'
+tilde_state_file=$(
+    cd "$direct_project"
+    unset OCTOPUS_WORKFLOW_STATE_DIR OCTOPUS_STATE_PROJECT_ROOT CLAUDE_PLUGIN_DATA
+    HOME="$direct_home" CLAUDE_OCTOPUS_WORKSPACE="${literal_tilde}/custom-octopus" \
+        "$PROJECT_ROOT/bin/octopus" state-path
+)
+case "$tilde_state_file" in
+    "$direct_home/custom-octopus/projects/"*/state.json) test_pass ;;
+    *) test_fail "tilde workspace resolved unexpectedly: $tilde_state_file" ;;
+esac
+
+test_case "workspace resolver has a deterministic fallback without HOME"
+no_home_state_file=$(
+    cd "$direct_project"
+    env -u HOME -u OCTOPUS_WORKFLOW_STATE_DIR -u OCTOPUS_STATE_PROJECT_ROOT \
+        -u CLAUDE_PLUGIN_DATA -u CLAUDE_OCTOPUS_WORKSPACE \
+        "$PROJECT_ROOT/bin/octopus" state-path
+)
+case "$no_home_state_file" in
+    "$direct_project/.claude-octopus/projects/"*/state.json) test_pass ;;
+    *) test_fail "HOME-less workspace resolved unexpectedly: $no_home_state_file" ;;
+esac
+
+test_case "same remote in separate checkouts gets separate state namespaces"
+clone_a="$TEST_TMP_DIR/clone-a"
+clone_b="$TEST_TMP_DIR/clone-b"
+mkdir -p "$clone_a" "$clone_b"
+git -C "$clone_a" init -q
+git -C "$clone_b" init -q
+git -C "$clone_a" remote add origin https://example.invalid/shared/repo.git
+git -C "$clone_b" remote add origin https://example.invalid/shared/repo.git
+clone_a_state=$(
+    cd "$clone_a"
+    unset OCTOPUS_WORKFLOW_STATE_DIR OCTOPUS_STATE_PROJECT_ROOT \
+        CLAUDE_PLUGIN_DATA CLAUDE_OCTOPUS_WORKSPACE
+    HOME="$direct_home" "$PROJECT_ROOT/bin/octopus" state-path
+)
+clone_b_state=$(
+    cd "$clone_b"
+    unset OCTOPUS_WORKFLOW_STATE_DIR OCTOPUS_STATE_PROJECT_ROOT \
+        CLAUDE_PLUGIN_DATA CLAUDE_OCTOPUS_WORKSPACE
+    HOME="$direct_home" "$PROJECT_ROOT/bin/octopus" state-path
+)
+if [[ "$clone_a_state" != "$clone_b_state" ]]; then
+    test_pass
+else
+    test_fail "separate checkouts with one remote shared $clone_a_state"
 fi
 
 test_case "project-local workflow state requires explicit opt-in"

--- a/tests/unit/test-probe-cancellation-cleanup.sh
+++ b/tests/unit/test-probe-cancellation-cleanup.sh
@@ -340,15 +340,142 @@ else
     test_fail "explicit project-local state directory was not honored"
 fi
 
-test_case "probe synthesis failure keeps recovery marker and returns non-zero"
-probe_tail="$(sed -n '/# Intelligent synthesis (v7.19.0 P1.1/,/^}/p' "$PROJECT_ROOT/scripts/lib/workflows.sh")"
-if grep -q 'local synthesis_status=0' <<< "$probe_tail" \
-   && grep -q 'synthesize_probe_results.*synthesis_status' <<< "$(tr '\n' ' ' <<< "$probe_tail")" \
-   && grep -q 'if \[\[ "$synthesis_status" -eq 0 \]\]' <<< "$probe_tail" \
-   && grep -q 'return "$synthesis_status"' <<< "$probe_tail"; then
+test_case "failed agent spawn cancels the probe and closes fleet dispatch"
+preflight_check() { return 0; }
+display_workflow_cost_estimate() { return 0; }
+get_cache_key() { printf '%s\n' fixture-key; }
+check_cache() { return 1; }
+cleanup_cache() { :; }
+get_dispatch_strategy() { printf '%s\n' standard:codex; }
+load_blind_spot_checklist() { :; }
+init_progress_tracking() { :; }
+fleet_dispatch_begin() { fleet_begin_count=$((fleet_begin_count + 1)); }
+fleet_dispatch_end() { fleet_end_count=$((fleet_end_count + 1)); }
+spawn_agent_capture_pid() { return 23; }
+fleet_begin_count=0
+fleet_end_count=0
+DRY_RUN=false
+TMUX_MODE=false
+PERPLEXITY_API_KEY=""
+probe_test_magenta="${MAGENTA:-}"
+probe_test_cyan="${CYAN:-}"
+probe_test_green="${GREEN:-}"
+probe_test_yellow="${YELLOW:-}"
+probe_test_red="${RED:-}"
+probe_test_nc="${NC:-}"
+MAGENTA=""
+CYAN=""
+GREEN=""
+YELLOW=""
+RED=""
+NC=""
+RESULTS_DIR="$TEST_TMP_DIR/spawn-failure-results"
+LOGS_DIR="$TEST_TMP_DIR/spawn-failure-logs"
+WORKSPACE_DIR="$TEST_TMP_DIR/spawn-failure-workspace"
+PID_FILE="$WORKSPACE_DIR/pids"
+CACHE_DIR="$TEST_TMP_DIR/spawn-failure-cache"
+mkdir -p "$RESULTS_DIR" "$LOGS_DIR" "$CACHE_DIR"
+spawn_failure_log="$TEST_TMP_DIR/spawn-failure.log"
+if probe_discover "spawn failure fixture" >"$spawn_failure_log" 2>&1; then
+    spawn_failure_status=0
+else
+    spawn_failure_status=$?
+fi
+MAGENTA="$probe_test_magenta"
+CYAN="$probe_test_cyan"
+GREEN="$probe_test_green"
+YELLOW="$probe_test_yellow"
+RED="$probe_test_red"
+NC="$probe_test_nc"
+if [[ "$spawn_failure_status" -eq 23 && "$fleet_begin_count" -eq 1 \
+   && "$fleet_end_count" -eq 1 && -z "$OCTOPUS_ACTIVE_PROBE_TASK_GROUP" ]]; then
     test_pass
 else
-    test_fail "probe_discover does not preserve synthesis failure through cleanup"
+    test_fail "spawn failure was not cancelled cleanly (rc=$spawn_failure_status begin=$fleet_begin_count end=$fleet_end_count)"
+fi
+
+test_case "synthesis monitor cancellation closes the PID handoff window"
+progressive_synthesis_monitor() { sleep 300; }
+handoff_monitor_pid=""
+_octopus_test_after_synthesis_spawn() {
+    handoff_monitor_pid="$1"
+    octopus_probe_cancel_active TERM
+}
+OCTOPUS_ACTIVE_PROBE_TASK_GROUP="handoff-fixture"
+OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID=""
+OCTOPUS_ACTIVE_PROBE_PIDS=()
+OCTOPUS_ACTIVE_PROBE_AGENTS=()
+OCTOPUS_ACTIVE_PROBE_TASK_IDS=()
+if _octopus_probe_start_synthesis_monitor "handoff-fixture" "fixture" 2; then
+    handoff_status=0
+else
+    handoff_status=$?
+fi
+unset -f _octopus_test_after_synthesis_spawn
+if [[ "$handoff_status" -eq 143 && "$handoff_monitor_pid" =~ ^[0-9]+$ ]] \
+   && ! kill -0 "$handoff_monitor_pid" 2>/dev/null \
+   && [[ -z "$OCTOPUS_ACTIVE_PROBE_TASK_GROUP" \
+      && "$OCTOPUS_ACTIVE_PROBE_SYNTHESIS_LAUNCHING" == "false" ]]; then
+    test_pass
+else
+    test_fail "synthesis monitor survived or was re-registered during PID handoff"
+fi
+
+test_case "probe synthesis success removes its recovery marker at runtime"
+success_marker="$TEST_TMP_DIR/synthesis-success.marker"
+touch "$success_marker"
+synthesize_probe_results() { return 0; }
+display_progress_summary() { return 0; }
+OCTOPUS_ACTIVE_PROBE_TASK_GROUP="synthesis-success"
+if _octopus_probe_finalize_synthesis "synthesis-success" "fixture" 1 \
+    "$success_marker" "" "" ""; then
+    synthesis_success_status=0
+else
+    synthesis_success_status=$?
+fi
+if [[ "$synthesis_success_status" -eq 0 && ! -e "$success_marker" \
+   && -z "$OCTOPUS_ACTIVE_PROBE_TASK_GROUP" ]]; then
+    test_pass
+else
+    test_fail "successful synthesis kept its marker or leaked active state"
+fi
+
+test_case "probe synthesis failure keeps recovery marker and returns non-zero"
+failure_marker="$TEST_TMP_DIR/synthesis-failure.marker"
+touch "$failure_marker"
+synthesize_probe_results() { return 41; }
+display_progress_summary() { return 0; }
+OCTOPUS_ACTIVE_PROBE_TASK_GROUP="synthesis-failure"
+if _octopus_probe_finalize_synthesis "synthesis-failure" "fixture" 1 \
+    "$failure_marker" "" "" ""; then
+    synthesis_failure_status=0
+else
+    synthesis_failure_status=$?
+fi
+if [[ "$synthesis_failure_status" -eq 41 && -e "$failure_marker" \
+   && -z "$OCTOPUS_ACTIVE_PROBE_TASK_GROUP" ]]; then
+    test_pass
+else
+    test_fail "failed synthesis lost its marker/status or leaked active state"
+fi
+
+test_case "summary failure restores probe state and returns its status"
+summary_marker="$TEST_TMP_DIR/summary-failure.marker"
+touch "$summary_marker"
+synthesize_probe_results() { return 0; }
+display_progress_summary() { return 37; }
+OCTOPUS_ACTIVE_PROBE_TASK_GROUP="summary-failure"
+if _octopus_probe_finalize_synthesis "summary-failure" "fixture" 1 \
+    "$summary_marker" "" "" ""; then
+    summary_failure_status=0
+else
+    summary_failure_status=$?
+fi
+if [[ "$summary_failure_status" -eq 37 && ! -e "$summary_marker" \
+   && -z "$OCTOPUS_ACTIVE_PROBE_TASK_GROUP" ]]; then
+    test_pass
+else
+    test_fail "summary failure bypassed cleanup or lost its status"
 fi
 
 test_summary

--- a/tests/unit/test-probe-cancellation-cleanup.sh
+++ b/tests/unit/test-probe-cancellation-cleanup.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Regression coverage for #841: cancelling a probe must leave no live process
+# tree or stale runtime metadata, and ordinary orchestration must not write
+# state into the user's project by default.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+log() { :; }
+octo_provider_identity_from_agent_type() { printf '%s\n' "${1%%-*}"; }
+get_agent_model() { printf '%s\n' "fixture-model"; }
+
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/events.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/review.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/spawn.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/workflows.sh"
+
+test_suite "Probe cancellation cleanup (#841)"
+
+provider_pid=""
+provider_child_pid=""
+synthesis_pid=""
+
+cleanup_probe_processes() {
+    for pid in "$provider_child_pid" "$provider_pid" "$synthesis_pid"; do
+        [[ "$pid" =~ ^[0-9]+$ ]] || continue
+        kill -KILL "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+}
+after_all cleanup_probe_processes
+
+test_case "probe cancellation helper is available"
+if declare -F octopus_probe_cancel_active >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "octopus_probe_cancel_active is missing"
+fi
+
+test_case "TERM reaps provider descendants and synthesis monitor"
+WORKSPACE_DIR="$TEST_TMP_DIR/workspace"
+RESULTS_DIR="$WORKSPACE_DIR/results"
+PID_FILE="$WORKSPACE_DIR/pids"
+OCTO_EVENT_LOG="$RESULTS_DIR/events.jsonl"
+mkdir -p "$RESULTS_DIR" "$WORKSPACE_DIR/.octo/agents"
+
+child_pid_file="$TEST_TMP_DIR/provider-child.pid"
+bash -c '
+    trap "" TERM
+    sleep 300 &
+    printf "%s\n" "$!" > "$1"
+    wait
+' _ "$child_pid_file" &
+provider_pid=$!
+
+attempt=0
+while [[ ! -s "$child_pid_file" && "$attempt" -lt 100 ]]; do
+    sleep 0.02
+    attempt=$((attempt + 1))
+done
+provider_child_pid="$(cat "$child_pid_file" 2>/dev/null || true)"
+
+sleep 300 &
+synthesis_pid=$!
+
+task_group="841001"
+task_id="probe-${task_group}-0"
+result_file="$RESULTS_DIR/codex-${task_id}.md"
+cat > "$result_file" <<EOF
+# Agent: codex
+# Task ID: $task_id
+
+## Output
+\`\`\`
+partial output before cancellation
+EOF
+touch "$WORKSPACE_DIR/.octo/agents/${provider_pid}.heartbeat"
+printf '%s:%s:%s\n' "$provider_pid" "codex" "$task_id" > "$PID_FILE"
+
+OCTOPUS_ACTIVE_PROBE_TASK_GROUP="$task_group"
+OCTOPUS_ACTIVE_PROBE_SYNTHESIS_PID="$synthesis_pid"
+OCTOPUS_ACTIVE_PROBE_TMUX="false"
+OCTOPUS_ACTIVE_PROBE_PIDS=("$provider_pid")
+OCTOPUS_ACTIVE_PROBE_AGENTS=("codex")
+
+if declare -F octopus_probe_cancel_active >/dev/null 2>&1; then
+    octopus_probe_cancel_active TERM
+else
+    review_terminate_process_tree "$provider_pid" 0
+    kill -TERM "$synthesis_pid" 2>/dev/null || true
+fi
+
+wait "$provider_pid" 2>/dev/null || true
+wait "$synthesis_pid" 2>/dev/null || true
+
+if ! kill -0 "$provider_pid" 2>/dev/null \
+   && ! kill -0 "$provider_child_pid" 2>/dev/null \
+   && ! kill -0 "$synthesis_pid" 2>/dev/null; then
+    test_pass
+else
+    test_fail "provider tree or synthesis monitor survived cancellation"
+fi
+
+test_case "cancellation reconciles PID and heartbeat records"
+if ! grep -q "$task_id" "$PID_FILE" 2>/dev/null \
+   && [[ ! -e "$WORKSPACE_DIR/.octo/agents/${provider_pid}.heartbeat" ]]; then
+    test_pass
+else
+    test_fail "stale PID or heartbeat metadata remains"
+fi
+
+test_case "partial result is explicitly marked cancelled"
+if grep -q '^## Status: CANCELLED - PARTIAL RESULTS' "$result_file"; then
+    test_pass
+else
+    test_fail "cancelled result lacks an explicit terminal marker"
+fi
+
+test_case "spawned task receives an agent.cancelled terminal event"
+if jq -e --arg task "$task_id" \
+    'select(.event == "agent.cancelled" and .attributes.task_id == $task and .attributes.status == "cancelled")' \
+    "$OCTO_EVENT_LOG" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "agent.cancelled event missing for $task_id"
+fi
+
+test_case "probe signal handler maps TERM to exit 143"
+if env "HOME=$TEST_TMP_DIR/signal-home" bash -c '
+    source "'"$PROJECT_ROOT"'/scripts/lib/workflows.sh"
+    OCTOPUS_ACTIVE_PROBE_TASK_GROUP="signal-term"
+    WORKSPACE_DIR="'"$TEST_TMP_DIR"'/signal-workspace"
+    RESULTS_DIR="$WORKSPACE_DIR/results"
+    PID_FILE="$WORKSPACE_DIR/pids"
+    octopus_probe_handle_signal TERM
+' >/dev/null 2>&1; then
+    signal_rc=0
+else
+    signal_rc=$?
+fi
+if [[ "$signal_rc" -eq 143 ]]; then test_pass; else test_fail "TERM returned $signal_rc instead of 143"; fi
+
+test_case "probe signal handler maps INT to exit 130"
+if env "HOME=$TEST_TMP_DIR/signal-home" bash -c '
+    source "'"$PROJECT_ROOT"'/scripts/lib/workflows.sh"
+    OCTOPUS_ACTIVE_PROBE_TASK_GROUP="signal-int"
+    WORKSPACE_DIR="'"$TEST_TMP_DIR"'/signal-workspace"
+    RESULTS_DIR="$WORKSPACE_DIR/results"
+    PID_FILE="$WORKSPACE_DIR/pids"
+    octopus_probe_handle_signal INT
+' >/dev/null 2>&1; then
+    signal_rc=0
+else
+    signal_rc=$?
+fi
+if [[ "$signal_rc" -eq 130 ]]; then test_pass; else test_fail "INT returned $signal_rc instead of 130"; fi
+
+test_case "dry-run orchestration keeps default state outside the project"
+fixture_home="$TEST_TMP_DIR/home"
+fixture_project="$TEST_TMP_DIR/project"
+mkdir -p "$fixture_home/.claude-octopus" "$fixture_project"
+printf '{"feature_ledger_sentinel":true}\n' > "$fixture_home/.claude-octopus/state.json"
+(
+    unset OCTOPUS_WORKFLOW_STATE_DIR OCTOPUS_STATE_PROJECT_ROOT
+    cd "$fixture_project"
+    env \
+        "HOME=$fixture_home" \
+        "OCTOPUS_NON_INTERACTIVE=1" \
+        "OCTOPUS_HOST=standalone" \
+        "$PROJECT_ROOT/scripts/orchestrate.sh" --dry-run probe "state placement check" \
+        >/dev/null 2>&1
+)
+global_state_file="$(find "$fixture_home/.claude-octopus/projects" -name state.json -type f -print -quit 2>/dev/null || true)"
+if [[ ! -e "$fixture_project/.claude-octopus/state.json" ]] \
+   && [[ -n "$global_state_file" && -f "$global_state_file" ]] \
+   && jq -e '.project_id and .metrics.provider_usage' "$global_state_file" >/dev/null 2>&1 \
+   && jq -e '.feature_ledger_sentinel == true and (keys | length == 1)' \
+        "$fixture_home/.claude-octopus/state.json" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "orchestrate wrote state into the project or failed to create global state"
+fi
+
+test_case "standalone state manager also defaults outside the project"
+direct_home="$TEST_TMP_DIR/direct-home"
+direct_project="$TEST_TMP_DIR/direct-project"
+mkdir -p "$direct_home" "$direct_project"
+(
+    cd "$direct_project"
+    env "HOME=$direct_home" "$PROJECT_ROOT/scripts/state-manager.sh" init_state \
+        >/dev/null 2>&1
+)
+direct_state_file="$(find "$direct_home/.claude-octopus/projects" -name state.json -type f -print -quit 2>/dev/null || true)"
+if [[ ! -e "$direct_project/.claude-octopus/state.json" \
+   && -n "$direct_state_file" && -f "$direct_state_file" ]]; then
+    test_pass
+else
+    test_fail "standalone state manager dirtied the project or lost state"
+fi
+
+test_case "portable CLI resolves the namespaced workflow state path"
+cli_state_file=$(
+    cd "$direct_project"
+    env "HOME=$direct_home" "$PROJECT_ROOT/bin/octopus" state-path
+)
+if [[ "$cli_state_file" == "$direct_state_file" ]]; then
+    test_pass
+else
+    test_fail "octopus state-path returned $cli_state_file instead of $direct_state_file"
+fi
+
+test_case "project-local workflow state requires explicit opt-in"
+opt_in_project="$TEST_TMP_DIR/opt-in-project"
+mkdir -p "$opt_in_project"
+(
+    cd "$opt_in_project"
+    env \
+        "HOME=$direct_home" \
+        "OCTOPUS_WORKFLOW_STATE_DIR=$opt_in_project/.claude-octopus" \
+        "$PROJECT_ROOT/scripts/state-manager.sh" init_state >/dev/null 2>&1
+)
+if [[ -f "$opt_in_project/.claude-octopus/state.json" ]]; then
+    test_pass
+else
+    test_fail "explicit project-local state directory was not honored"
+fi
+
+test_summary

--- a/tests/unit/test-security-functions.sh
+++ b/tests/unit/test-security-functions.sh
@@ -147,6 +147,27 @@ test_url_rejects_long_urls() {
 }
 
 #==============================================================================
+# Test: workspace paths respect directory boundaries
+#==============================================================================
+test_workspace_path_boundaries() {
+    info "\n=== Testing: workspace path safe prefixes require directory boundaries ==="
+
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/scripts/lib/validation.sh"
+    local fixture_home="/safe/octopus-security-home-$$"
+
+    if HOME="$fixture_home" validate_workspace_path "$fixture_home/workspace" >/dev/null 2>&1 \
+       && HOME="$fixture_home" validate_workspace_path "/tmp/octopus-workspace" >/dev/null 2>&1 \
+       && ! HOME="$fixture_home" validate_workspace_path "${fixture_home}-sibling/workspace" >/dev/null 2>&1 \
+       && ! HOME="$fixture_home" validate_workspace_path "/tmp-escape/workspace" >/dev/null 2>&1 \
+       && ! HOME="$fixture_home" validate_workspace_path "/var/tmp-escape/workspace" >/dev/null 2>&1; then
+        pass "Workspace safe prefixes require an exact path or slash boundary"
+    else
+        fail "Workspace validation accepted a similarly-prefixed unsafe path"
+    fi
+}
+
+#==============================================================================
 # Test: transform_twitter_url function exists
 #==============================================================================
 test_transform_twitter_function_exists() {
@@ -283,6 +304,7 @@ test_url_rejects_private_10
 test_url_rejects_private_192
 test_url_rejects_metadata
 test_url_rejects_long_urls
+test_workspace_path_boundaries
 
 # Security skill tests
 test_security_skill_exists

--- a/tests/unit/test-security-functions.sh
+++ b/tests/unit/test-security-functions.sh
@@ -151,6 +151,7 @@ test_url_rejects_long_urls() {
 #==============================================================================
 test_workspace_path_boundaries() {
     info "\n=== Testing: workspace path safe prefixes require directory boundaries ==="
+    test_case "Workspace safe prefixes require an exact path or slash boundary"
 
     # shellcheck source=/dev/null
     source "$PROJECT_ROOT/scripts/lib/validation.sh"
@@ -161,9 +162,9 @@ test_workspace_path_boundaries() {
        && ! HOME="$fixture_home" validate_workspace_path "${fixture_home}-sibling/workspace" >/dev/null 2>&1 \
        && ! HOME="$fixture_home" validate_workspace_path "/tmp-escape/workspace" >/dev/null 2>&1 \
        && ! HOME="$fixture_home" validate_workspace_path "/var/tmp-escape/workspace" >/dev/null 2>&1; then
-        pass "Workspace safe prefixes require an exact path or slash boundary"
+        test_pass
     else
-        fail "Workspace validation accepted a similarly-prefixed unsafe path"
+        test_fail "Workspace validation accepted a similarly-prefixed unsafe path"
     fi
 }
 

--- a/tests/unit/test-workflow-meta-contracts.sh
+++ b/tests/unit/test-workflow-meta-contracts.sh
@@ -90,7 +90,7 @@ else
 fi
 
 test_case "Discovery project persistence fails closed on every lifecycle write"
-discover_pre=$(sed -n '/^## Pre-Discovery: Optional Project Persistence/,/^---$/p' "$DISCOVER")
+discover_pre=$(sed -n '/^## Pre-Discovery: Optional Project Persistence/,/^## /p' "$DISCOVER")
 discover_pre_code=$(extract_bash_fence <<< "$discover_pre")
 discover_post_code=$(extract_bash_fence <<< "$discover_block")
 persistence_home="$TEST_TMP_DIR/persistence-home"
@@ -104,6 +104,21 @@ cat > "$persistence_home/.claude-octopus/plugin/scripts/octo-state.sh" <<'EOF'
 exit 0
 EOF
 chmod +x "$persistence_home/.claude-octopus/plugin/scripts/octo-state.sh"
+
+persistence_baseline_ok=true
+for lifecycle_code in "$discover_pre_code" "$discover_post_code"; do
+    if ! (
+        cd "$persistence_project"
+        rm -rf .octo
+        HOME="$persistence_home" \
+        OCTOPUS_PROJECT_PERSISTENCE=true \
+        SYNTHESIS_FILE="$persistence_synthesis" \
+        bash -c "$lifecycle_code"
+    ) >/dev/null 2>&1; then
+        persistence_baseline_ok=false
+        break
+    fi
+done
 
 persistence_failed_closed=true
 for lifecycle_case in init_project pre_update_state update_project post_update_state; do
@@ -126,7 +141,9 @@ for lifecycle_case in init_project pre_update_state update_project post_update_s
         break
     fi
 done
-if [[ "$persistence_failed_closed" == "true" ]]; then
+if [[ "$persistence_baseline_ok" != "true" ]]; then
+    test_fail "Discover persistence fixture never succeeds; failure injection would prove nothing"
+elif [[ "$persistence_failed_closed" == "true" ]]; then
     test_pass
 else
     test_fail "Discover persistence continued after $lifecycle_case failed"

--- a/tests/unit/test-workflow-meta-contracts.sh
+++ b/tests/unit/test-workflow-meta-contracts.sh
@@ -81,6 +81,17 @@ else
     test_fail "Discover terminal state omitted the project persistence opt-in boundary"
 fi
 
+test_case "Discovery project persistence fails closed on every lifecycle write"
+discover_pre=$(sed -n '/^## Pre-Discovery: Optional Project Persistence/,/^---$/p' "$DISCOVER")
+if grep -q 'if ! .*init_project' <<< "$(tr '\n' ' ' <<< "$discover_pre")" \
+   && grep -q 'if ! .*update_state' <<< "$(tr '\n' ' ' <<< "$discover_pre")" \
+   && grep -q 'if ! .*update_project' <<< "$(tr '\n' ' ' <<< "$discover_block")" \
+   && grep -q 'if ! .*update_state' <<< "$(tr '\n' ' ' <<< "$discover_block")"; then
+    test_pass
+else
+    test_fail "Discover persistence can continue after an init/update failure"
+fi
+
 test_case "Doctor quick-reference commands use the resolved plugin root"
 doctor_quick_ref=$(sed -n '/^## Quick Reference/,$p' "$DOCTOR")
 if grep -q '\$OCTO_PLUGIN_ROOT/scripts/orchestrate\.sh.*doctor auth --verbose' <<< "$doctor_quick_ref" &&

--- a/tests/unit/test-workflow-meta-contracts.sh
+++ b/tests/unit/test-workflow-meta-contracts.sh
@@ -52,6 +52,14 @@ else
 fi
 
 discover_block=$(sed -n '/^## Post-Discovery: State Update/,/^## /p' "$DISCOVER")
+
+extract_bash_fence() {
+    awk '
+        /^```bash$/ { if (!inside) { inside=1; next } }
+        inside && /^```$/ { exit }
+        inside { print }
+    '
+}
 synthesis_line=$(grep -n 'if \[\[ ! -s' <<< "$discover_block" | head -1 | cut -d: -f1 || true)
 exit_line=$(grep -n '^[[:space:]]*exit 1$' <<< "$discover_block" | head -1 | cut -d: -f1 || true)
 present_line=$(grep -nF 'cat "$SYNTHESIS_FILE"' <<< "$discover_block" | head -1 | cut -d: -f1 || true)
@@ -83,13 +91,45 @@ fi
 
 test_case "Discovery project persistence fails closed on every lifecycle write"
 discover_pre=$(sed -n '/^## Pre-Discovery: Optional Project Persistence/,/^---$/p' "$DISCOVER")
-if grep -q 'if ! .*init_project' <<< "$(tr '\n' ' ' <<< "$discover_pre")" \
-   && grep -q 'if ! .*update_state' <<< "$(tr '\n' ' ' <<< "$discover_pre")" \
-   && grep -q 'if ! .*update_project' <<< "$(tr '\n' ' ' <<< "$discover_block")" \
-   && grep -q 'if ! .*update_state' <<< "$(tr '\n' ' ' <<< "$discover_block")"; then
+discover_pre_code=$(extract_bash_fence <<< "$discover_pre")
+discover_post_code=$(extract_bash_fence <<< "$discover_block")
+persistence_home="$TEST_TMP_DIR/persistence-home"
+persistence_project="$TEST_TMP_DIR/persistence-project"
+persistence_synthesis="$TEST_TMP_DIR/persistence-synthesis.md"
+mkdir -p "$persistence_home/.claude-octopus/plugin/scripts" "$persistence_project"
+printf '%s\n' fixture > "$persistence_synthesis"
+cat > "$persistence_home/.claude-octopus/plugin/scripts/octo-state.sh" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "${OCTOPUS_TEST_FAIL_COMMAND:-}" ]] && exit 42
+exit 0
+EOF
+chmod +x "$persistence_home/.claude-octopus/plugin/scripts/octo-state.sh"
+
+persistence_failed_closed=true
+for lifecycle_case in init_project pre_update_state update_project post_update_state; do
+    case "$lifecycle_case" in
+        init_project) failure_command=init_project; lifecycle_code="$discover_pre_code" ;;
+        pre_update_state) failure_command=update_state; lifecycle_code="$discover_pre_code" ;;
+        update_project) failure_command=update_project; lifecycle_code="$discover_post_code" ;;
+        post_update_state) failure_command=update_state; lifecycle_code="$discover_post_code" ;;
+    esac
+    if (
+        cd "$persistence_project"
+        rm -rf .octo
+        HOME="$persistence_home" \
+        OCTOPUS_PROJECT_PERSISTENCE=true \
+        OCTOPUS_TEST_FAIL_COMMAND="$failure_command" \
+        SYNTHESIS_FILE="$persistence_synthesis" \
+        bash -c "$lifecycle_code"
+    ) >/dev/null 2>&1; then
+        persistence_failed_closed=false
+        break
+    fi
+done
+if [[ "$persistence_failed_closed" == "true" ]]; then
     test_pass
 else
-    test_fail "Discover persistence can continue after an init/update failure"
+    test_fail "Discover persistence continued after $lifecycle_case failed"
 fi
 
 test_case "Doctor quick-reference commands use the resolved plugin root"

--- a/tests/unit/test-workflow-meta-contracts.sh
+++ b/tests/unit/test-workflow-meta-contracts.sh
@@ -57,10 +57,11 @@ exit_line=$(grep -n '^[[:space:]]*exit 1$' <<< "$discover_block" | head -1 | cut
 present_line=$(grep -nF 'cat "$SYNTHESIS_FILE"' <<< "$discover_block" | head -1 | cut -d: -f1 || true)
 project_line=$(grep -n 'update_project' <<< "$discover_block" | head -1 | cut -d: -f1 || true)
 complete_line=$(grep -n 'update_state' <<< "$discover_block" | head -1 | cut -d: -f1 || true)
+opt_in_line=$(grep -n 'OCTOPUS_PROJECT_PERSISTENCE' <<< "$discover_block" | head -1 | cut -d: -f1 || true)
 
-test_case "Discovery verifies, presents, and persists synthesis before completion"
-if [[ -n "$synthesis_line" && -n "$exit_line" && -n "$present_line" && -n "$project_line" && -n "$complete_line" ]] &&
-   (( synthesis_line < exit_line && exit_line < present_line && present_line < project_line && project_line < complete_line )) &&
+test_case "Discovery verifies and presents before optional project persistence"
+if [[ -n "$synthesis_line" && -n "$exit_line" && -n "$present_line" && -n "$opt_in_line" && -n "$project_line" && -n "$complete_line" ]] &&
+   (( synthesis_line < exit_line && exit_line < present_line && present_line < opt_in_line && opt_in_line < project_line && project_line < complete_line )) &&
    grep -Fq 'cat "$SYNTHESIS_FILE"' <<< "$discover_block" &&
    grep -Fq -- '--content-file "$SYNTHESIS_FILE"' <<< "$discover_block" &&
    ! grep -q -- '--content ' <<< "$discover_block" &&
@@ -68,15 +69,16 @@ if [[ -n "$synthesis_line" && -n "$exit_line" && -n "$present_line" && -n "$proj
    grep -q 'if ! .*update_project' <<< "$(tr '\n' ' ' <<< "$discover_block")"; then
     test_pass
 else
-    test_fail "Post-Discovery must persist the complete synthesis and fail closed before update_state"
+    test_fail "Post-Discovery must present the complete synthesis and gate project persistence explicitly"
 fi
 
-test_case "Discovery terminal state requires PROJECT.md persistence"
+test_case "Discovery terminal state makes PROJECT.md persistence explicit opt-in"
 discover_terminal=$(sed -n '/^## Terminal State/,/^\*\*Ready to research!/p' "$DISCOVER")
-if grep -q '\.octo/PROJECT\.md' <<< "$discover_terminal"; then
+if grep -q '\.octo/PROJECT\.md' <<< "$discover_terminal" &&
+   grep -q 'OCTOPUS_PROJECT_PERSISTENCE=true' <<< "$discover_terminal"; then
     test_pass
 else
-    test_fail "Discover terminal state omitted PROJECT.md persistence"
+    test_fail "Discover terminal state omitted the project persistence opt-in boundary"
 fi
 
 test_case "Doctor quick-reference commands use the resolved plugin root"


### PR DESCRIPTION
## Summary

- install INT/TERM cancellation handling around active probe fanout and reconcile the PID ledger even when a signal lands between spawn and local bookkeeping
- terminate provider descendants and progressive synthesis, reap waits, remove heartbeats/PID records, preserve partial results with an explicit CANCELLED marker, and emit terminal lifecycle events
- move workflow state out of project checkouts by default into a host-workspace project namespace, while preserving an explicit `OCTOPUS_WORKFLOW_STATE_DIR` opt-in and exposing the portable `octopus state-path` resolver
- fix heartbeat cleanup to use the spawned subshell PID rather than the parent shell PID

## Verification

- cancellation/state regression: 11/11
- focused lifecycle, spawn, timeout, probe, event, crash-recovery, and workflow-contract suites: pass
- Bash syntax, repository ShellCheck warning policy, `git diff --check`, and generated-skill sync: pass
- `OCTOPUS_NON_INTERACTIVE=1 make ci-local`: 16 smoke suites, 251 unit suites, and 7 integration suites passed
- no executable mode changes relative to main

Closes #841


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `octopus state-path` to display the resolved workflow state location.
  * Workflow state now uses project-specific workspace storage by default, with configurable location and optional project-local persistence.
  * Added safe cancellation for active probe workflows, including process cleanup and partial-result preservation.

* **Bug Fixes**
  * Improved heartbeat cleanup for spawned agents.
  * Diagnostics and resume flows now use the resolved state location.

* **Documentation**
  * Updated usage guidance and persistence instructions.

* **Tests**
  * Added coverage for cancellation cleanup, workflow state placement, and workspace path validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->