### PR TITLE
fix: unify provider availability and fleet admission

### DIFF
--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -54,7 +54,14 @@ get_family() {
 # and fleet construction. Do not duplicate binary/auth probes here: that was the
 # source of #799's green-banner/failed-dispatch split.
 AVAILABLE_CLI=()
-PROVIDER_STATUS_OUTPUT="$(bash "${SCRIPT_DIR}/check-providers.sh" 2>/dev/null || true)"
+PROVIDER_CHECKER="${OCTOPUS_PROVIDER_CHECKER:-${SCRIPT_DIR}/check-providers.sh}"
+if PROVIDER_STATUS_OUTPUT="$(bash "$PROVIDER_CHECKER" 2>/dev/null)"; then
+    :
+else
+    provider_checker_status=$?
+    echo "ERROR: provider admission check failed: $PROVIDER_CHECKER" >&2
+    exit "$provider_checker_status"
+fi
 
 provider_status_is_available() {
     local provider="$1"

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -21,14 +21,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
-source "${SCRIPT_DIR}/../lib/auth.sh" 2>/dev/null || true
-source "${SCRIPT_DIR}/../lib/qwen.sh" 2>/dev/null || true
-source "${SCRIPT_DIR}/../lib/grok.sh" 2>/dev/null || true
-# Provider liveness. check-providers.sh reports a quota/auth-dead seat as
-# `degraded`, but nothing downstream consumed that: this script built its fleet
-# from `command -v` plus the allowlist alone, so a seat known to be dead was
-# still handed a role and dispatched into an immediate failure.
-source "${SCRIPT_DIR}/../lib/quota-watcher.sh" 2>/dev/null || true
 
 WORKFLOW="${1:-research}"
 INTENSITY="${2:-standard}"
@@ -39,6 +31,7 @@ get_family() {
     case "$1" in
         codex|codex-*)       echo "openai" ;;
         gemini|gemini-*|agy|agy-*|antigravity) echo "google-antigravity" ;;
+        claude-sdk|claude-sdk-*) echo "anthropic" ;;
         claude-sonnet|claude-opus|claude|claude-*) echo "anthropic" ;;
         perplexity|perplexity-*) echo "perplexity" ;;
         copilot|copilot-*)   echo "microsoft" ;;
@@ -49,70 +42,37 @@ get_family() {
         grok|grok-*)         echo "xai" ;;   # grok-provider (xAI Grok CLI)
         openrouter|openrouter-*) echo "multi" ;;
         commandcode|commandcode-*) echo "multi" ;;
+        openai-compatible|openai-compatible-*) echo "multi" ;;
+        atlascloud|atlascloud-*) echo "multi" ;;
+        vibe|vibe-*)         echo "mistral" ;;
         *)                   echo "unknown" ;;
     esac
 }
 
 # ── Provider Detection ────────────────────────────────────────────────────────
-# Order = preference for primary slot assignment
+# check-providers.sh is the single admission gate for both the activation banner
+# and fleet construction. Do not duplicate binary/auth probes here: that was the
+# source of #799's green-banner/failed-dispatch split.
 AVAILABLE_CLI=()
-if octo_provider_allowed codex && command -v codex >/dev/null 2>&1; then AVAILABLE_CLI+=(codex); fi
-if octo_provider_allowed commandcode; then
-    [[ -n "${COMMAND_CODE_API_KEY:-}" ]] || resolve_provider_env "COMMAND_CODE_API_KEY" 2>/dev/null || true
-    _commandcode_bin="${OCTOPUS_COMMANDCODE_BIN:-}"
-    if [[ -z "$_commandcode_bin" ]]; then
-        if command -v command-code >/dev/null 2>&1; then
-            _commandcode_bin="command-code"
-        elif command -v cmd >/dev/null 2>&1; then
-            _commandcode_bin="cmd"
-        fi
-    fi
-    if [[ -n "$_commandcode_bin" ]] && { [[ -x "$_commandcode_bin" ]] || command -v "$_commandcode_bin" >/dev/null 2>&1; } && { [[ -n "${COMMAND_CODE_API_KEY:-}" ]] || "$_commandcode_bin" status --json >/dev/null 2>&1; }; then
-        AVAILABLE_CLI+=(commandcode)
-    fi
-fi
-if octo_provider_allowed grok && declare -f grok_is_available >/dev/null 2>&1 && grok_is_available; then AVAILABLE_CLI+=(grok); fi
-if octo_provider_allowed agy && command -v agy >/dev/null 2>&1; then AVAILABLE_CLI+=(agy); fi
-if octo_provider_allowed copilot && command -v copilot >/dev/null 2>&1; then AVAILABLE_CLI+=(copilot); fi
-if octo_provider_allowed qwen; then
-    if declare -f qwen_is_usable >/dev/null 2>&1; then
-        qwen_is_usable && AVAILABLE_CLI+=(qwen)
-    elif command -v qwen >/dev/null 2>&1; then
-        AVAILABLE_CLI+=(qwen)
-    fi
-fi
-if octo_provider_allowed opencode && command -v opencode >/dev/null 2>&1; then AVAILABLE_CLI+=(opencode); fi
-if octo_provider_allowed ollama && command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; then AVAILABLE_CLI+=(ollama); fi
-if octo_provider_allowed cursor-agent && declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
-    if [[ -n "${CURSOR_API_KEY:-}" ]] || grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; then
-        AVAILABLE_CLI+=(cursor-agent)
-    fi
-fi
-octo_provider_allowed perplexity && [[ -n "${PERPLEXITY_API_KEY:-}" ]] && AVAILABLE_CLI+=(perplexity)
-octo_provider_allowed openrouter && [[ -n "${OPENROUTER_API_KEY:-}" ]] && AVAILABLE_CLI+=(openrouter)
+PROVIDER_STATUS_OUTPUT="$(bash "${SCRIPT_DIR}/check-providers.sh" 2>/dev/null || true)"
 
-# Drop seats already known quota/auth-dead this session. Applied as a filter over
-# the assembled list rather than as another condition on each detection line: the
-# detection conditions differ per provider (binary, API key, health function), and
-# adding a 13th variant of the same check to each was how the original omission
-# happened. One choke point, same as provider_status() in check-providers.sh.
-if declare -f octo_quota_is_dead >/dev/null 2>&1 && [[ -n "${AVAILABLE_CLI[*]:-}" ]]; then
-    _LIVE_CLI=()
-    for _p in "${AVAILABLE_CLI[@]}"; do
-        if octo_quota_is_dead "$_p"; then
-            [[ "${OCTOPUS_FLEET_DEBUG:-0}" == "1" ]] && \
-                echo "build-fleet: skipping ${_p} (quota/auth-dead this session)" >&2
-            continue
-        fi
-        _LIVE_CLI+=("$_p")
-    done
-    AVAILABLE_CLI=("${_LIVE_CLI[@]:-}")
-    # An all-dead list collapses to a single empty element under bash 3.2's
-    # ${arr[@]:-} expansion; normalise so CLI_COUNT does not report a phantom seat.
-    if [[ ${#AVAILABLE_CLI[@]} -eq 1 && -z "${AVAILABLE_CLI[0]}" ]]; then
-        AVAILABLE_CLI=()
-    fi
-fi
+provider_status_is_available() {
+    local provider="$1"
+    case $'\n'"$PROVIDER_STATUS_OUTPUT"$'\n' in
+        *$'\n'"${provider}:available"$'\n'*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Preference order for primary slot assignment. Every entry is still admitted
+# only when the shared status source reports exactly `available`.
+for _provider in codex commandcode grok agy copilot qwen cursor-agent opencode \
+    ollama vibe claude-sdk openrouter openai-compatible perplexity; do
+    provider_status_is_available "$_provider" && AVAILABLE_CLI+=("$_provider")
+done
+# Atlas Cloud's canonical provider status is `atlascloud`, while its executable
+# agent type is `atlascloud-agent` (the Python tool-loop dispatch shim).
+provider_status_is_available atlascloud && AVAILABLE_CLI+=("atlascloud-agent")
 
 CLI_COUNT=0
 if [[ -n "${AVAILABLE_CLI[*]:-}" ]]; then
@@ -140,9 +100,7 @@ pick_provider() {
     if octo_provider_allowed "$fallback"; then
         echo "$fallback"
     elif [[ -n "${AVAILABLE_CLI[*]:-}" ]]; then
-        # shellcheck disable=SC2086 # Intentional split to read the first provider.
-        set -- ${AVAILABLE_CLI[*]}
-        echo "$1"
+        echo "${AVAILABLE_CLI[0]}"
     else
         echo ""
     fi
@@ -155,8 +113,9 @@ build_diverse_order() {
     local diverse_first=""
     local diverse_rest=""
 
-    # Preferred order for primary diversity: codex, commandcode, agy, copilot, qwen, cursor-agent, opencode, ollama
-    for p in codex commandcode agy copilot qwen grok cursor-agent opencode ollama; do
+    # Preferred order for primary diversity.
+    for p in codex commandcode agy copilot qwen grok cursor-agent opencode ollama \
+        vibe claude-sdk openrouter openai-compatible atlascloud-agent perplexity; do
         is_available "$p" || continue
         local fam
         fam=$(get_family "$p")
@@ -274,7 +233,7 @@ build_research_fleet() {
             octo_provider_allowed claude-sonnet && used_providers="$used_providers claude-sonnet"
             is_available perplexity && used_providers="$used_providers perplexity"
 
-            for extra in ${AVAILABLE_CLI[*]:-}; do
+            for extra in "${AVAILABLE_CLI[@]+"${AVAILABLE_CLI[@]}"}"; do
                 _contains "$used_providers" "$extra" && continue
                 case "$extra" in
                     copilot)
@@ -289,6 +248,12 @@ build_research_fleet() {
                         emit "ollama" "Local Model Perspective" "Analyze: $PROMPT. Provide a grounded, practical perspective focusing on simplicity and maintainability over complexity." ;;
                     openrouter)
                         emit "openrouter" "Diverse Model Check" "Cross-check the analysis of: $PROMPT. Identify any blind spots, groupthink, or consensus bias that other models might share due to similar training data." ;;
+                    vibe)
+                        emit "vibe" "Mistral Perspective" "Analyze: $PROMPT. Focus on pragmatic implementation choices and assumptions worth challenging." ;;
+                    claude-sdk)
+                        emit "claude-sdk" "Agent SDK Perspective" "Analyze: $PROMPT. Focus on long-context integration concerns and reliable agent execution." ;;
+                    openai-compatible|atlascloud-agent)
+                        emit "$extra" "Independent Model Check" "Cross-check the analysis of: $PROMPT. Identify blind spots and implementation trade-offs." ;;
                 esac
             done
             ;;
@@ -332,9 +297,9 @@ build_debate_fleet() {
     local used_families=""
     local debater_count=0
 
-    for p in ${AVAILABLE_CLI[*]:-}; do
+    for p in "${AVAILABLE_CLI[@]+"${AVAILABLE_CLI[@]}"}"; do
         # Skip providers not suited for debate (API-only, local models)
-        case "$p" in perplexity|openrouter|ollama) continue ;; esac
+        case "$p" in perplexity|openrouter|ollama|atlascloud-agent|claude-sdk|vibe) continue ;; esac
 
         local fam
         fam=$(get_family "$p")
@@ -363,7 +328,8 @@ build_architecture_fleet() {
     local used_families=""
     local arch_count=0
 
-    for p in codex agy copilot qwen cursor-agent opencode; do
+    for p in codex agy copilot qwen cursor-agent opencode vibe claude-sdk \
+        openai-compatible atlascloud-agent; do
         is_available "$p" || continue
         local fam
         fam=$(get_family "$p")
@@ -402,8 +368,7 @@ esac
 
 # ── Fleet Summary (stderr — for diagnostic/logging) ──────────────────────────
 if [[ -n "${AVAILABLE_CLI[*]:-}" ]]; then
-    # shellcheck disable=SC2086 # Provider names are single shell words.
-    families=$(count_families ${AVAILABLE_CLI[*]})
+    families=$(count_families "${AVAILABLE_CLI[@]}")
 else
     families=$(count_families)
 fi

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -26,6 +26,12 @@ WORKFLOW="${1:-research}"
 INTENSITY="${2:-standard}"
 PROMPT="${3:-}"
 
+log() {
+    local level="$1"
+    shift
+    printf '[%s] %s\n' "$level" "$*" >&2
+}
+
 # ── Provider → Model Family Mapping ──────────────────────────────────────────
 get_family() {
     case "$1" in
@@ -59,7 +65,7 @@ if PROVIDER_STATUS_OUTPUT="$(bash "$PROVIDER_CHECKER" 2>/dev/null)"; then
     :
 else
     provider_checker_status=$?
-    echo "ERROR: provider admission check failed: $PROVIDER_CHECKER" >&2
+    log ERROR "provider admission check failed: $PROVIDER_CHECKER"
     exit "$provider_checker_status"
 fi
 

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -24,6 +24,7 @@ source "${SCRIPT_DIR}/../lib/grok.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/auth.sh" 2>/dev/null || true   # octo_oauth_token_valid (oco-dar)
 source "${SCRIPT_DIR}/../lib/qwen.sh" 2>/dev/null || true   # qwen_is_usable (oco-dar)
+source "${SCRIPT_DIR}/../lib/openai-compatible.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/events.sh" 2>/dev/null || true  # opt-in JSONL lifecycle stream
 source "${SCRIPT_DIR}/../lib/quota-watcher.sh" 2>/dev/null || true  # octo_quota_is_dead (oco-cbb)
 
@@ -97,6 +98,10 @@ if [[ -n "$cc_bin" ]] && { [[ -x "$cc_bin" ]] || command -v "$cc_bin" >/dev/null
     fi
 fi
 provider_status "commandcode" "$commandcode_state"
+# AGY intentionally remains a local binary check. The CLI exposes no bounded,
+# non-interactive auth-status command, and invoking login/model commands from a
+# startup/banner hook can open a browser or keychain prompt. Runtime quota/auth
+# failures are remembered by provider_status() and suppress later dispatches.
 provider_status "agy" "$(command -v agy >/dev/null 2>&1 && echo available || echo missing)"
 # oco-cbb: opt-in proactive probe for API-key providers (perplexity, openrouter).
 # Only runs when OCTOPUS_PREFLIGHT_PROBE=1; result cached via quota-dead marker
@@ -115,6 +120,41 @@ if [ -n "${ATLASCLOUD_API_KEY:-}" ]; then
     fi
 fi
 provider_status "atlascloud" "$atlascloud_state"
+
+claude_sdk_state="missing"
+if command -v claude-agent >/dev/null 2>&1 || command -v claude >/dev/null 2>&1; then
+    if _octo_value_has_nonwhitespace "${CLAUDE_SDK_API_KEY:-}"; then
+        claude_sdk_state="available"
+    else
+        claude_sdk_state="degraded"
+    fi
+fi
+provider_status "claude-sdk" "$claude_sdk_state"
+
+vibe_state="missing"
+if command -v vibe >/dev/null 2>&1; then
+    if _octo_value_has_nonwhitespace "${MISTRAL_API_KEY:-}" || \
+       _octo_assignment_has_nonempty_value "${HOME}/.vibe/.env" "MISTRAL_API_KEY" || \
+       _octo_assignment_has_nonempty_value "${HOME}/.vibe/config.toml" "api_key"; then
+        vibe_state="available"
+    else
+        vibe_state="degraded"
+    fi
+fi
+provider_status "vibe" "$vibe_state"
+
+openai_compatible_state="missing"
+openai_compatible_key_value="$(openai_compatible_api_key_value 2>/dev/null || true)"
+if [[ -n "${OPENAI_COMPAT_BASE_URL:-}" || -n "${OPENAI_COMPAT_API_KEY:-}" || \
+      -n "$openai_compatible_key_value" ]]; then
+    if openai_compatible_is_available; then
+        openai_compatible_state="available"
+    else
+        openai_compatible_state="degraded"
+    fi
+fi
+provider_status "openai-compatible" "$openai_compatible_state"
+
 # opencode/copilot: same fail-open gap as codex (#799) — reuse the auth
 # signals preflight.sh already checks instead of trusting binary presence.
 opencode_state="missing"

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -23,6 +23,13 @@ source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/grok.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/auth.sh" 2>/dev/null || true   # octo_oauth_token_valid (oco-dar)
+# provider-routing owns the non-interactive shell/profile credential resolver.
+# It normally logs through orchestrate.sh; this standalone status helper stays
+# quiet because its stdout is a machine-readable provider-state protocol.
+if ! declare -f log >/dev/null 2>&1; then
+    log() { :; }
+fi
+source "${SCRIPT_DIR}/../lib/provider-routing.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/qwen.sh" 2>/dev/null || true   # qwen_is_usable (oco-dar)
 source "${SCRIPT_DIR}/../lib/openai-compatible.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/events.sh" 2>/dev/null || true  # opt-in JSONL lifecycle stream
@@ -133,6 +140,10 @@ provider_status "claude-sdk" "$claude_sdk_state"
 
 vibe_state="missing"
 if command -v vibe >/dev/null 2>&1; then
+    if ! _octo_value_has_nonwhitespace "${MISTRAL_API_KEY:-}" && \
+       declare -f resolve_provider_env >/dev/null 2>&1; then
+        resolve_provider_env "MISTRAL_API_KEY" 2>/dev/null || true
+    fi
     if _octo_value_has_nonwhitespace "${MISTRAL_API_KEY:-}" || \
        _octo_assignment_has_nonempty_value "${HOME}/.vibe/.env" "MISTRAL_API_KEY" || \
        _octo_assignment_has_nonempty_value "${HOME}/.vibe/config.toml" "api_key"; then

--- a/scripts/lib/auth.sh
+++ b/scripts/lib/auth.sh
@@ -5,6 +5,56 @@
 # Extracted from orchestrate.sh
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# Shared credential-value parsing. Provider admission surfaces must not trust a
+# file merely because an assignment exists: blank and quoted-empty values are
+# unauthenticated, while a # inside a quoted credential is data, not a comment.
+_octo_value_has_nonwhitespace() {
+    local value
+    value="$(printf '%s\n' "${1:-}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [[ -n "$value" ]]
+}
+
+_octo_strip_unquoted_comment() {
+    local input="$1" output="" quote="" char
+    local index=0 escaped=0 length=${#1}
+    while (( index < length )); do
+        char="${input:index:1}"
+        if (( escaped )); then
+            output="${output}${char}"
+            escaped=0
+        elif [[ "$quote" == '"' && "$char" == "\\" ]]; then
+            output="${output}${char}"
+            escaped=1
+        elif [[ -z "$quote" && "$char" == "#" ]]; then
+            break
+        else
+            output="${output}${char}"
+            if [[ -z "$quote" && ( "$char" == '"' || "$char" == "'" ) ]]; then
+                quote="$char"
+            elif [[ -n "$quote" && "$char" == "$quote" ]]; then
+                quote=""
+            fi
+        fi
+        index=$((index + 1))
+    done
+    printf '%s\n' "$output"
+}
+
+_octo_assignment_has_nonempty_value() {
+    local file="$1" key="$2" value
+    [[ -f "$file" ]] || return 1
+
+    value="$(sed -n "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*//p" "$file" 2>/dev/null | tail -n 1)"
+    value="$(printf '%s\n' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    value="$(_octo_strip_unquoted_comment "$value")"
+    value="$(printf '%s\n' "$value" | sed 's/[[:space:]]*$//')"
+    case "$value" in
+        \"*\") value="${value#\"}"; value="${value%\"}" ;;
+        \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    esac
+    _octo_value_has_nonwhitespace "$value"
+}
+
 # Check if Codex is authenticated
 # Returns auth method: "api_key", "oauth", or "none"
 # Always returns 0 (success) - use the output to determine status

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -20,6 +20,9 @@ fi
 if ! declare -f fable5_maybe_reroute >/dev/null 2>&1; then
     source "${_model_resolver_lib_dir}/fable5.sh" 2>/dev/null || true
 fi
+if ! declare -f _octo_assignment_has_nonempty_value >/dev/null 2>&1; then
+    source "${_model_resolver_lib_dir}/auth.sh" 2>/dev/null || true
+fi
 if ! declare -f is_claude_agent_type >/dev/null 2>&1; then
     source "${_model_resolver_lib_dir}/routing.sh" 2>/dev/null || true
 source "${_model_resolver_lib_dir}/openai-compatible.sh" 2>/dev/null || true
@@ -516,53 +519,6 @@ validate_model_name() {
 
 
 # ── v2 agent helpers (moved from orchestrate.sh v9.22.1) ──
-_octo_value_has_nonwhitespace() {
-    local value
-    value="$(printf '%s\n' "${1:-}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
-    [[ -n "$value" ]]
-}
-
-_octo_strip_unquoted_comment() {
-    local input="$1" output="" quote="" char
-    local index=0 escaped=0 length=${#1}
-    while (( index < length )); do
-        char="${input:index:1}"
-        if (( escaped )); then
-            output="${output}${char}"
-            escaped=0
-        elif [[ "$quote" == '"' && "$char" == "\\" ]]; then
-            output="${output}${char}"
-            escaped=1
-        elif [[ -z "$quote" && "$char" == "#" ]]; then
-            break
-        else
-            output="${output}${char}"
-            if [[ -z "$quote" && ( "$char" == '"' || "$char" == "'" ) ]]; then
-                quote="$char"
-            elif [[ -n "$quote" && "$char" == "$quote" ]]; then
-                quote=""
-            fi
-        fi
-        index=$((index + 1))
-    done
-    printf '%s\n' "$output"
-}
-
-_octo_assignment_has_nonempty_value() {
-    local file="$1" key="$2" value
-    [[ -f "$file" ]] || return 1
-
-    value="$(sed -n "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*//p" "$file" 2>/dev/null | tail -n 1)"
-    value="$(printf '%s\n' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
-    value="$(_octo_strip_unquoted_comment "$value")"
-    value="$(printf '%s\n' "$value" | sed 's/[[:space:]]*$//')"
-    case "$value" in
-        \"*\") value="${value#\"}"; value="${value%\"}" ;;
-        \'*\') value="${value#\'}"; value="${value%\'}" ;;
-    esac
-    _octo_value_has_nonwhitespace "$value"
-}
-
 is_agent_available_v2() {
     local agent="$1"
 

--- a/scripts/lib/openai-compatible.sh
+++ b/scripts/lib/openai-compatible.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Source-safe helpers for generic OpenAI-compatible provider availability.
 
+_openai_compatible_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+if ! declare -f _octo_value_has_nonwhitespace >/dev/null 2>&1; then
+    source "${_openai_compatible_lib_dir}/auth.sh" 2>/dev/null || true
+fi
+
 openai_compatible_api_key_env() {
     echo "${OPENAI_COMPAT_API_KEY_ENV:-OPENAI_API_KEY}"
 }
@@ -15,6 +20,7 @@ openai_compatible_api_key_value() {
 openai_compatible_is_available() {
     local compat_key_value=""
     compat_key_value="$(openai_compatible_api_key_value 2>/dev/null || true)"
-    [[ -n "${OPENAI_COMPAT_BASE_URL:-}" && \
-       ( -n "${OPENAI_COMPAT_API_KEY:-}" || -n "$compat_key_value" ) ]]
+    _octo_value_has_nonwhitespace "${OPENAI_COMPAT_BASE_URL:-}" && \
+        { _octo_value_has_nonwhitespace "${OPENAI_COMPAT_API_KEY:-}" || \
+          _octo_value_has_nonwhitespace "$compat_key_value"; }
 }

--- a/scripts/lib/openai-compatible.sh
+++ b/scripts/lib/openai-compatible.sh
@@ -5,8 +5,16 @@ openai_compatible_api_key_env() {
     echo "${OPENAI_COMPAT_API_KEY_ENV:-OPENAI_API_KEY}"
 }
 
-openai_compatible_is_available() {
+openai_compatible_api_key_value() {
     local compat_key_env
     compat_key_env="$(openai_compatible_api_key_env)"
-    [[ -n "${OPENAI_COMPAT_BASE_URL:-}" && ( -n "${OPENAI_COMPAT_API_KEY:-}" || -n "${!compat_key_env:-}" ) ]]
+    [[ "$compat_key_env" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+    printf '%s\n' "${!compat_key_env:-}"
+}
+
+openai_compatible_is_available() {
+    local compat_key_value=""
+    compat_key_value="$(openai_compatible_api_key_value 2>/dev/null || true)"
+    [[ -n "${OPENAI_COMPAT_BASE_URL:-}" && \
+       ( -n "${OPENAI_COMPAT_API_KEY:-}" || -n "$compat_key_value" ) ]]
 }

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -923,9 +923,9 @@ check_provider_health() {
                 resolve_provider_env "MISTRAL_API_KEY" 2>/dev/null
             fi
             # Check auth: env-file with MISTRAL_API_KEY, env var, or config.toml api_key
-            if [[ -z "${MISTRAL_API_KEY:-}" ]] && \
-               ! { [[ -f "${HOME}/.vibe/.env" ]] && grep -Eq '^[[:space:]]*MISTRAL_API_KEY=' "${HOME}/.vibe/.env" 2>/dev/null; } && \
-               ! { [[ -f "${HOME}/.vibe/config.toml" ]] && grep -Eq '^[[:space:]]*api_key[[:space:]]*=' "${HOME}/.vibe/config.toml" 2>/dev/null; }; then
+            if ! _octo_value_has_nonwhitespace "${MISTRAL_API_KEY:-}" && \
+               ! _octo_assignment_has_nonempty_value "${HOME}/.vibe/.env" "MISTRAL_API_KEY" && \
+               ! _octo_assignment_has_nonempty_value "${HOME}/.vibe/config.toml" "api_key"; then
                 echo "vibe: not authenticated (run: vibe --setup or set MISTRAL_API_KEY)" >&2
                 return 1
             fi
@@ -1217,7 +1217,8 @@ detect_providers() {
     fi
 
     # Detect Claude Agent SDK seat (CLAUDE_SDK_API_KEY unlocks Opus 5 + 1M context)
-    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed claude-sdk; } && [[ -n "${CLAUDE_SDK_API_KEY:-}" ]]; then
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed claude-sdk; } && \
+       _octo_value_has_nonwhitespace "${CLAUDE_SDK_API_KEY:-}"; then
         if command -v claude-agent &>/dev/null; then
             result="${result}claude-sdk:agent-sdk "
         elif command -v claude &>/dev/null; then
@@ -1228,11 +1229,11 @@ detect_providers() {
     # Detect Vibe CLI (Mistral Vibe interactive CLI)
     if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed vibe; } && command -v vibe &>/dev/null; then
         local vibe_auth="none"
-        if [[ -f "${HOME}/.vibe/.env" ]] && grep -Eq '^[[:space:]]*MISTRAL_API_KEY=' "${HOME}/.vibe/.env" 2>/dev/null; then
+        if _octo_assignment_has_nonempty_value "${HOME}/.vibe/.env" "MISTRAL_API_KEY"; then
             vibe_auth="env-file"
-        elif [[ -n "${MISTRAL_API_KEY:-}" ]]; then
+        elif _octo_value_has_nonwhitespace "${MISTRAL_API_KEY:-}"; then
             vibe_auth="api-key"
-        elif [[ -f "${HOME}/.vibe/config.toml" ]] && grep -Eq '^[[:space:]]*api_key[[:space:]]*=' "${HOME}/.vibe/config.toml" 2>/dev/null; then
+        elif _octo_assignment_has_nonempty_value "${HOME}/.vibe/config.toml" "api_key"; then
             vibe_auth="config"
         fi
         result="${result}vibe:${vibe_auth} "

--- a/tests/test-fleet-diversity.sh
+++ b/tests/test-fleet-diversity.sh
@@ -221,7 +221,8 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 check_output=$(bash "$CHECK_SCRIPT" 2>/dev/null)
 
 # 4.1: Checks all supported providers in this detection surface
-for provider in codex agy perplexity opencode copilot qwen ollama openrouter; do
+for provider in codex agy commandcode perplexity atlascloud claude-sdk vibe \
+    openai-compatible opencode copilot qwen cursor-agent grok ollama openrouter; do
     if echo "$check_output" | grep -q "^${provider}:"; then
         pass "4.1.$provider check-providers.sh reports $provider"
     else

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -702,7 +702,8 @@ test_agy_fleet_builder() {
     test_case "build-fleet includes agy as distinct provider family"
 
     if grep -q 'google-antigravity' "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" && \
-       grep -q 'AVAILABLE_CLI+=(agy)' "$PROJECT_ROOT/scripts/helpers/build-fleet.sh"; then
+       grep -q 'for _provider in codex commandcode grok agy' "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" && \
+       grep -q 'provider_status "agy"' "$PROJECT_ROOT/scripts/helpers/check-providers.sh"; then
         test_pass
     else
         test_fail "build-fleet.sh should include agy provider family and availability"

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -699,14 +699,29 @@ test_agy_preflight_visibility() {
 }
 
 test_agy_fleet_builder() {
-    test_case "build-fleet includes agy as distinct provider family"
+    test_case "runtime admission seats agy in the fleet"
 
-    if grep -q 'google-antigravity' "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" && \
-       grep -q 'for _provider in codex commandcode grok agy' "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" && \
-       grep -q 'provider_status "agy"' "$PROJECT_ROOT/scripts/helpers/check-providers.sh"; then
+    local fixture_home="$TEST_TMP_DIR/agy-admission-home"
+    local fixture_bin="$TEST_TMP_DIR/agy-admission-bin"
+    local status fleet
+    mkdir -p "$fixture_home" "$fixture_bin"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$fixture_bin/agy"
+    chmod +x "$fixture_bin/agy"
+    status=$(env \
+        "HOME=$fixture_home" \
+        "PATH=$fixture_bin:/usr/bin:/bin" \
+        "OCTO_ALLOWED_PROVIDERS=agy" \
+        bash "$PROJECT_ROOT/scripts/helpers/check-providers.sh" 2>/dev/null)
+    fleet=$(env \
+        "HOME=$fixture_home" \
+        "PATH=$fixture_bin:/usr/bin:/bin" \
+        "OCTO_ALLOWED_PROVIDERS=agy" \
+        "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" research quick fixture 2>/dev/null)
+
+    if grep -q '^agy:available$' <<< "$status" && grep -q '^agy|' <<< "$fleet"; then
         test_pass
     else
-        test_fail "build-fleet.sh should include agy provider family and availability"
+        test_fail "AGY admission or fleet seating failed: status=$status fleet=$fleet"
     fi
 }
 

--- a/tests/unit/test-provider-availability-parity.sh
+++ b/tests/unit/test-provider-availability-parity.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Regression coverage for the remaining #799 provider-status gaps. The banner
+# and fleet builder must share one auth-aware admission result, and every
+# registered dispatch seat needs an explicit banner state.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=tests/helpers/test-framework.sh
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Provider availability parity (#799)"
+
+CHECK_PROVIDERS="$PROJECT_ROOT/scripts/helpers/check-providers.sh"
+BUILD_FLEET="$PROJECT_ROOT/scripts/helpers/build-fleet.sh"
+FAKE_HOME="$TEST_TMP_DIR/home"
+FAKE_BIN="$TEST_TMP_DIR/bin"
+mkdir -p "$FAKE_HOME" "$FAKE_BIN"
+
+for provider_bin in claude-agent vibe codex; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$FAKE_BIN/$provider_bin"
+    chmod +x "$FAKE_BIN/$provider_bin"
+done
+
+provider_state() {
+    local provider="$1"
+    shift
+    (
+        unset CLAUDE_SDK_API_KEY MISTRAL_API_KEY OPENAI_API_KEY
+        unset OPENAI_COMPAT_API_KEY OPENAI_COMPAT_API_KEY_ENV OPENAI_COMPAT_BASE_URL
+        env \
+            "HOME=$FAKE_HOME" \
+            "PATH=$FAKE_BIN:/usr/bin:/bin" \
+            "OCTO_ALLOWED_PROVIDERS=$provider" \
+            "$@" \
+            bash "$CHECK_PROVIDERS" 2>/dev/null \
+            | grep "^${provider}:" | tail -1
+    )
+}
+
+test_case "Claude SDK binary without its API key is degraded"
+if [[ "$(provider_state claude-sdk)" == "claude-sdk:degraded" ]]; then
+    test_pass
+else
+    test_fail "Claude SDK binary-only state was not reported as degraded"
+fi
+
+test_case "Claude SDK key plus executable shim is available"
+if [[ "$(provider_state claude-sdk CLAUDE_SDK_API_KEY=fixture-key)" == "claude-sdk:available" ]]; then
+    test_pass
+else
+    test_fail "Claude SDK authenticated state was not reported as available"
+fi
+
+mkdir -p "$FAKE_HOME/.vibe"
+printf 'api_key = "" # intentionally blank\n' > "$FAKE_HOME/.vibe/config.toml"
+test_case "Vibe rejects a blank credential file value"
+if [[ "$(provider_state vibe)" == "vibe:degraded" ]]; then
+    test_pass
+else
+    test_fail "Vibe trusted a blank config credential"
+fi
+
+printf 'api_key = "fixture#value" # valid quoted hash\n' > "$FAKE_HOME/.vibe/config.toml"
+test_case "Vibe accepts a nonblank quoted credential"
+if [[ "$(provider_state vibe)" == "vibe:available" ]]; then
+    test_pass
+else
+    test_fail "Vibe did not recognize a valid config credential"
+fi
+
+test_case "partial OpenAI-compatible configuration is degraded"
+if [[ "$(provider_state openai-compatible OPENAI_COMPAT_BASE_URL=https://example.test/v1)" == "openai-compatible:degraded" ]]; then
+    test_pass
+else
+    test_fail "partial OpenAI-compatible configuration was not degraded"
+fi
+
+test_case "complete OpenAI-compatible configuration is available"
+if [[ "$(provider_state openai-compatible OPENAI_COMPAT_BASE_URL=https://example.test/v1 OPENAI_COMPAT_API_KEY=fixture-key)" == "openai-compatible:available" ]]; then
+    test_pass
+else
+    test_fail "complete OpenAI-compatible configuration was not available"
+fi
+
+test_case "fleet rejects an installed but unauthenticated Codex seat"
+unauth_fleet=$(
+    env \
+        "HOME=$FAKE_HOME" \
+        "PATH=$FAKE_BIN:/usr/bin:/bin" \
+        "OCTO_ALLOWED_PROVIDERS=codex" \
+        "$BUILD_FLEET" review standard fixture 2>/dev/null
+)
+if ! grep -q '^codex|' <<<"$unauth_fleet"; then
+    test_pass
+else
+    test_fail "fleet bypassed the banner auth gate: $unauth_fleet"
+fi
+
+mkdir -p "$FAKE_HOME/.codex"
+printf '{}\n' > "$FAKE_HOME/.codex/auth.json"
+test_case "fleet admits Codex after the shared auth gate passes"
+auth_fleet=$(
+    env \
+        "HOME=$FAKE_HOME" \
+        "PATH=$FAKE_BIN:/usr/bin:/bin" \
+        "OCTO_ALLOWED_PROVIDERS=codex" \
+        "$BUILD_FLEET" review standard fixture 2>/dev/null
+)
+if grep -q '^codex|' <<<"$auth_fleet"; then
+    test_pass
+else
+    test_fail "fleet dropped authenticated Codex: $auth_fleet"
+fi
+
+test_case "fleet can seat an authenticated registered Vibe provider"
+vibe_fleet=$(
+    env \
+        "HOME=$FAKE_HOME" \
+        "PATH=$FAKE_BIN:/usr/bin:/bin" \
+        "OCTO_ALLOWED_PROVIDERS=vibe" \
+        "$BUILD_FLEET" research quick fixture 2>/dev/null
+)
+if grep -q '^vibe|' <<<"$vibe_fleet"; then
+    test_pass
+else
+    test_fail "authenticated Vibe was absent from the fleet: $vibe_fleet"
+fi
+
+test_case "fleet can seat an authenticated Claude SDK provider"
+claude_sdk_fleet=$(
+    env \
+        "HOME=$FAKE_HOME" \
+        "PATH=$FAKE_BIN:/usr/bin:/bin" \
+        "OCTO_ALLOWED_PROVIDERS=claude-sdk" \
+        "CLAUDE_SDK_API_KEY=fixture-key" \
+        "$BUILD_FLEET" research quick fixture 2>/dev/null
+)
+if grep -q '^claude-sdk|' <<<"$claude_sdk_fleet"; then
+    test_pass
+else
+    test_fail "authenticated Claude SDK was absent from the fleet: $claude_sdk_fleet"
+fi
+
+test_case "fleet can seat a configured OpenAI-compatible provider"
+openai_compatible_fleet=$(
+    env \
+        "HOME=$FAKE_HOME" \
+        "PATH=$FAKE_BIN:/usr/bin:/bin" \
+        "OCTO_ALLOWED_PROVIDERS=openai-compatible" \
+        "OPENAI_COMPAT_BASE_URL=https://example.test/v1" \
+        "OPENAI_COMPAT_API_KEY=fixture-key" \
+        "$BUILD_FLEET" research quick fixture 2>/dev/null
+)
+if grep -q '^openai-compatible|' <<<"$openai_compatible_fleet"; then
+    test_pass
+else
+    test_fail "configured OpenAI-compatible seat was absent from the fleet: $openai_compatible_fleet"
+fi
+
+test_case "fleet maps configured Atlas Cloud to its executable agent type"
+atlascloud_fleet=$(
+    env \
+        "HOME=$FAKE_HOME" \
+        "PATH=$FAKE_BIN:/usr/bin:/bin" \
+        "OCTO_ALLOWED_PROVIDERS=atlascloud" \
+        "ATLASCLOUD_API_KEY=fixture-key" \
+        "ATLASCLOUD_MODEL=fixture/model" \
+        "$BUILD_FLEET" research quick fixture 2>/dev/null
+)
+if grep -q '^atlascloud-agent|' <<<"$atlascloud_fleet"; then
+    test_pass
+else
+    test_fail "Atlas Cloud did not map to atlascloud-agent: $atlascloud_fleet"
+fi
+
+test_summary

--- a/tests/unit/test-provider-availability-parity.sh
+++ b/tests/unit/test-provider-availability-parity.sh
@@ -62,6 +62,15 @@ else
     test_fail "Vibe trusted a blank config credential"
 fi
 
+printf 'export MISTRAL_API_KEY=profile-fixture-key\n' > "$FAKE_HOME/.profile"
+test_case "Vibe resolves a profile-backed credential before admission"
+if [[ "$(provider_state vibe)" == "vibe:available" ]]; then
+    test_pass
+else
+    test_fail "Vibe ignored a profile-backed credential"
+fi
+rm -f "$FAKE_HOME/.profile"
+
 printf 'api_key = "fixture#value" # valid quoted hash\n' > "$FAKE_HOME/.vibe/config.toml"
 test_case "Vibe accepts a nonblank quoted credential"
 if [[ "$(provider_state vibe)" == "vibe:available" ]]; then
@@ -82,6 +91,34 @@ if [[ "$(provider_state openai-compatible OPENAI_COMPAT_BASE_URL=https://example
     test_pass
 else
     test_fail "complete OpenAI-compatible configuration was not available"
+fi
+
+test_case "OpenAI-compatible provider rejects whitespace-only configuration"
+whitespace_states="$(
+    provider_state openai-compatible OPENAI_COMPAT_BASE_URL='   ' OPENAI_COMPAT_API_KEY=fixture-key
+    provider_state openai-compatible OPENAI_COMPAT_BASE_URL=https://example.test/v1 OPENAI_COMPAT_API_KEY='   '
+    provider_state openai-compatible OPENAI_COMPAT_BASE_URL=https://example.test/v1 OPENAI_COMPAT_API_KEY_ENV=CUSTOM_KEY CUSTOM_KEY='   '
+)"
+if [[ "$(grep -c '^openai-compatible:degraded$' <<< "$whitespace_states")" -eq 3 ]]; then
+    test_pass
+else
+    test_fail "whitespace-only OpenAI-compatible settings were admitted: $whitespace_states"
+fi
+
+failing_checker="$TEST_TMP_DIR/failing-provider-checker.sh"
+printf '#!/usr/bin/env bash\nexit 23\n' > "$failing_checker"
+chmod +x "$failing_checker"
+test_case "fleet fails closed when the shared provider checker fails"
+if checker_error=$(env \
+    "HOME=$FAKE_HOME" \
+    "PATH=$FAKE_BIN:/usr/bin:/bin" \
+    "OCTOPUS_PROVIDER_CHECKER=$failing_checker" \
+    "$BUILD_FLEET" research quick fixture 2>&1); then
+    test_fail "fleet ignored a failed provider admission gate"
+elif grep -q 'provider admission check failed' <<< "$checker_error"; then
+    test_pass
+else
+    test_fail "fleet failed without reporting the provider gate: $checker_error"
 fi
 
 test_case "fleet rejects an installed but unauthenticated Codex seat"

--- a/tests/unit/test-provider-availability-parity.sh
+++ b/tests/unit/test-provider-availability-parity.sh
@@ -47,7 +47,7 @@ else
 fi
 
 test_case "Claude SDK key plus executable shim is available"
-if [[ "$(provider_state claude-sdk CLAUDE_SDK_API_KEY=fixture-key)" == "claude-sdk:available" ]]; then
+if [[ "$(provider_state claude-sdk "CLAUDE_SDK_API_KEY=fixture-key")" == "claude-sdk:available" ]]; then
     test_pass
 else
     test_fail "Claude SDK authenticated state was not reported as available"
@@ -80,14 +80,14 @@ else
 fi
 
 test_case "partial OpenAI-compatible configuration is degraded"
-if [[ "$(provider_state openai-compatible OPENAI_COMPAT_BASE_URL=https://example.test/v1)" == "openai-compatible:degraded" ]]; then
+if [[ "$(provider_state openai-compatible "OPENAI_COMPAT_BASE_URL=https://example.test/v1")" == "openai-compatible:degraded" ]]; then
     test_pass
 else
     test_fail "partial OpenAI-compatible configuration was not degraded"
 fi
 
 test_case "complete OpenAI-compatible configuration is available"
-if [[ "$(provider_state openai-compatible OPENAI_COMPAT_BASE_URL=https://example.test/v1 OPENAI_COMPAT_API_KEY=fixture-key)" == "openai-compatible:available" ]]; then
+if [[ "$(provider_state openai-compatible "OPENAI_COMPAT_BASE_URL=https://example.test/v1" "OPENAI_COMPAT_API_KEY=fixture-key")" == "openai-compatible:available" ]]; then
     test_pass
 else
     test_fail "complete OpenAI-compatible configuration was not available"

--- a/tests/unit/test-provider-availability-parity.sh
+++ b/tests/unit/test-provider-availability-parity.sh
@@ -95,9 +95,9 @@ fi
 
 test_case "OpenAI-compatible provider rejects whitespace-only configuration"
 whitespace_states="$(
-    provider_state openai-compatible OPENAI_COMPAT_BASE_URL='   ' OPENAI_COMPAT_API_KEY=fixture-key
-    provider_state openai-compatible OPENAI_COMPAT_BASE_URL=https://example.test/v1 OPENAI_COMPAT_API_KEY='   '
-    provider_state openai-compatible OPENAI_COMPAT_BASE_URL=https://example.test/v1 OPENAI_COMPAT_API_KEY_ENV=CUSTOM_KEY CUSTOM_KEY='   '
+    provider_state openai-compatible "OPENAI_COMPAT_BASE_URL=   " "OPENAI_COMPAT_API_KEY=fixture-key"
+    provider_state openai-compatible "OPENAI_COMPAT_BASE_URL=https://example.test/v1" "OPENAI_COMPAT_API_KEY=   "
+    provider_state openai-compatible "OPENAI_COMPAT_BASE_URL=https://example.test/v1" "OPENAI_COMPAT_API_KEY_ENV=CUSTOM_KEY" "CUSTOM_KEY=   "
 )"
 if [[ "$(grep -c '^openai-compatible:degraded$' <<< "$whitespace_states")" -eq 3 ]]; then
     test_pass

--- a/tests/unit/test-provider-health-fleet.sh
+++ b/tests/unit/test-provider-health-fleet.sh
@@ -21,7 +21,9 @@ reset_markers() { rm -f "$DEAD_FILE" "$DEAD_FILE.meta"; }
 
 # Mock CLIs so fleet composition does not depend on what the developer has installed.
 mock_bin="$TEST_TMP_DIR/health-bin"
-mkdir -p "$mock_bin"
+mock_home="$TEST_TMP_DIR/health-home"
+mkdir -p "$mock_bin" "$mock_home/.codex"
+printf '{}\n' > "$mock_home/.codex/auth.json"
 for cmd in codex agy; do
     printf '#!/usr/bin/env bash\nexit 0\n' > "$mock_bin/$cmd"
     chmod +x "$mock_bin/$cmd"
@@ -157,7 +159,7 @@ fi
 
 test_case "a healthy Antigravity seat is assigned a fleet role"
 reset_markers
-fleet=$(PATH="$mock_bin:/usr/bin:/bin" WORKSPACE_DIR="$WORKSPACE_DIR" \
+fleet=$(HOME="$mock_home" PATH="$mock_bin:/usr/bin:/bin" WORKSPACE_DIR="$WORKSPACE_DIR" \
     OCTO_ALLOWED_PROVIDERS="codex agy" "$BUILD_FLEET" review standard "x" 2>/dev/null)
 if grep -q "^agy|" <<<"$fleet"; then
     test_pass
@@ -169,7 +171,7 @@ fi
 test_case "a quota-dead Antigravity seat is excluded from the fleet"
 reset_markers
 WORKSPACE_DIR="$WORKSPACE_DIR" bash -c "source '$QUOTA_LIB'; octo_quota_mark_dead agy 0"
-fleet=$(PATH="$mock_bin:/usr/bin:/bin" WORKSPACE_DIR="$WORKSPACE_DIR" \
+fleet=$(HOME="$mock_home" PATH="$mock_bin:/usr/bin:/bin" WORKSPACE_DIR="$WORKSPACE_DIR" \
     OCTO_ALLOWED_PROVIDERS="codex agy" "$BUILD_FLEET" review standard "x" 2>/dev/null)
 if ! grep -q "^agy|" <<<"$fleet"; then
     test_pass
@@ -190,7 +192,7 @@ WORKSPACE_DIR="$WORKSPACE_DIR" bash -c "
     source '$QUOTA_LIB'
     octo_quota_mark_dead agy 0
     octo_quota_mark_dead codex 0"
-if fleet=$(PATH="$mock_bin:/usr/bin:/bin" WORKSPACE_DIR="$WORKSPACE_DIR" \
+if fleet=$(HOME="$mock_home" PATH="$mock_bin:/usr/bin:/bin" WORKSPACE_DIR="$WORKSPACE_DIR" \
     OCTO_ALLOWED_PROVIDERS="codex agy" "$BUILD_FLEET" review standard "x" 2>/dev/null); then
     if ! grep -qE "^(agy|codex)\|" <<<"$fleet"; then
         test_pass


### PR DESCRIPTION
Closes #799

## Summary
- make `check-providers.sh` the single auth-aware admission source for both banners and dynamic fleets
- report and safely seat Vibe, Claude SDK, OpenAI-compatible, and Atlas Cloud providers
- centralize robust nonblank credential parsing and reject partial provider configuration
- keep AGY startup detection binary-only because the CLI has no bounded noninteractive auth-status command; runtime auth/quota failures still suppress redispatch without invoking login or opening keychain/browser UI

## Verification
- provider availability parity: 12/12
- fleet diversity: 42/42
- Antigravity provider: 43/43
- provider health/fleet: 13/13
- provider auth validity: 18/18
- provider banner auth: 10/10
- provider registry contracts/parity: 14/14 and 9/9
- OpenAI-compatible agent/config: 19/19 and 6/6
- Vibe: 5/5
- Claude SDK: 9/9
- provider contract audit: 13/13
- `make sync-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Claude SDK, Vibe, OpenAI-compatible, Atlas Cloud, and additional providers in fleet selection.
  * Improved provider status detection by distinguishing available, missing, and degraded configurations.
  * Added safer validation for credentials, API keys, and environment-variable settings.

* **Bug Fixes**
  * Prevented invalid, blank, or whitespace-only credentials from being treated as available.
  * Fleet construction now stops when provider checks fail.
  * Improved compatibility with older Bash versions.

* **Tests**
  * Expanded coverage for provider availability, authentication states, and fleet admission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->