### PR TITLE
fix(hooks): block direct Qwen and retired Gemini dispatch

### DIFF
--- a/hooks/codex-exec-guard.sh
+++ b/hooks/codex-exec-guard.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-# Codex exec guard — blocks bare `codex "prompt"` calls (missing `exec` subcommand)
+# Provider CLI guard — blocks unsafe direct non-interactive provider dispatch.
 # PreToolUse hook on Bash. Returns block decision with correction message.
 # WHY: `codex "prompt"` launches interactive TUI which fails in non-TTY (Claude Code Bash tool).
 #      `codex exec "prompt"` is the correct non-interactive mode.
+#      Direct Qwen dispatch can enter OAuth device authorization and open a browser.
+#      Direct Gemini dispatch uses a retired individual client. Both bypass Octopus
+#      provider admission and authentication checks.
 set -euo pipefail
 # EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
 # the Claude Code harness error "No stderr output" can never recur. EXIT (not
@@ -12,8 +15,8 @@ _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "
 trap _octo_hook_exit EXIT
 
 
-# Note: this gate guards correctness (bare `codex "prompt"` hangs in non-TTY),
-# not user permission policy — so it runs regardless of bypassPermissions.
+# Note: this gate guards correctness, not user permission policy, so it runs
+# regardless of bypassPermissions.
 
 INPUT=$(cat 2>/dev/null || true)
 [[ -z "$INPUT" ]] && exit 0
@@ -25,6 +28,136 @@ else
     COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | head -1 | cut -d'"' -f4)
 fi
 [[ -z "$COMMAND" ]] && exit 0
+
+# Emit unquoted shell command segments, one per line. This deliberately ignores
+# provider names in prompt/data strings while recognizing subshell, pipeline,
+# background, chained, and multiline command positions. Bash 3.2 compatible.
+_octo_command_segments() {
+    local source="$1" segment="" state="plain" escaped="false"
+    local i char
+
+    for ((i = 0; i < ${#source}; i++)); do
+        char="${source:i:1}"
+
+        if [[ "$escaped" == "true" ]]; then
+            segment="${segment} "
+            escaped="false"
+            continue
+        fi
+
+        case "$state" in
+            single)
+                [[ "$char" == "'" ]] && state="plain"
+                segment="${segment} "
+                ;;
+            double)
+                if [[ "$char" == '"' ]]; then
+                    state="plain"
+                elif [[ "$char" == "\\" ]]; then
+                    escaped="true"
+                fi
+                segment="${segment} "
+                ;;
+            plain)
+                case "$char" in
+                    "'") state="single"; segment="${segment} " ;;
+                    '"') state="double"; segment="${segment} " ;;
+                    "\\") escaped="true"; segment="${segment} " ;;
+                    ';'|'&'|'|'|'('|')'|'{'|'}'|$'\n')
+                        printf '%s\n' "$segment"
+                        segment=""
+                        ;;
+                    *) segment="${segment}${char}" ;;
+                esac
+                ;;
+        esac
+    done
+
+    printf '%s\n' "$segment"
+}
+
+_octo_segment_provider() {
+    local segment="$1" token="" provider="" first_arg=""
+    local saw_env="false"
+
+    # Shell word splitting is intentional here; glob expansion is not.
+    set -f
+    # shellcheck disable=SC2086
+    set -- $segment
+    set +f
+
+    while [[ $# -gt 0 ]]; do
+        token="$1"
+        shift
+
+        case "$token" in
+            if|then|elif|else|while|until|do|!|time)
+                continue
+                ;;
+            env)
+                saw_env="true"
+                continue
+                ;;
+            -*)
+                [[ "$saw_env" == "true" ]] && continue
+                return 1
+                ;;
+            [A-Za-z_][A-Za-z0-9_]*=*)
+                continue
+                ;;
+            command)
+                # `command -v qwen` and `command -V qwen` are introspection.
+                if [[ "${1:-}" == "-v" || "${1:-}" == "-V" ]]; then
+                    return 1
+                fi
+                continue
+                ;;
+            nohup)
+                continue
+                ;;
+            *)
+                provider="${token##*/}"
+                first_arg="${1:-}"
+                break
+                ;;
+        esac
+    done
+
+    case "$provider" in
+        qwen|gemini)
+            case "$first_arg" in
+                --version|--help|-h|-v|version|help)
+                    return 1
+                    ;;
+            esac
+            printf '%s\n' "$provider"
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+DIRECT_PROVIDER=""
+while IFS= read -r segment; do
+    if DIRECT_PROVIDER=$(_octo_segment_provider "$segment"); then
+        break
+    fi
+done < <(_octo_command_segments "$COMMAND")
+
+if [[ "$DIRECT_PROVIDER" == "qwen" ]]; then
+    cat <<'BLOCK'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: direct Qwen CLI prompt dispatch bypasses Octopus provider admission and authentication checks. If Qwen OAuth is absent or expired, the CLI opens chat.qwen.ai and waits for interactive authorization.\n\nRun the workflow through an Octopus command or skill so Qwen is invoked non-interactively only after authentication is validated. Use `qwen --version` or `qwen --help` only for harmless inspection."}}
+BLOCK
+    exit 0
+fi
+
+if [[ "$DIRECT_PROVIDER" == "gemini" ]]; then
+    cat <<'BLOCK'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: the direct Gemini CLI individual client is retired and must not be dispatched by Octopus workflows. It can trigger obsolete OAuth/keychain flows before failing.\n\nUse the Antigravity provider through an Octopus command or skill. `gemini --version` and `gemini --help` remain available for harmless inspection."}}
+BLOCK
+    exit 0
+fi
 
 # Match: starts with `codex` but NOT `codex exec`, `codex --version`, `codex --help`, `codex login`, `codex auth`
 # Also allow: `which codex`, `command -v codex`, variable assignments containing "codex"

--- a/hooks/codex-exec-guard.sh
+++ b/hooks/codex-exec-guard.sh
@@ -29,15 +29,95 @@ else
 fi
 [[ -z "$COMMAND" ]] && exit 0
 
-# Emit unquoted shell command segments, one per line. This deliberately ignores
-# provider names in prompt/data strings while recognizing subshell, pipeline,
-# background, chained, and multiline command positions. Bash 3.2 compatible.
+# Find the closing parenthesis for a $(...) command substitution. Parentheses
+# inside quotes/backticks do not close the substitution; nested substitutions
+# and grouping parentheses increase its depth. Bash 3.2 compatible.
+_octo_command_sub_end() {
+    local source="$1" start="$2" state="plain" escaped="false" depth=1
+    local i char next
+
+    for ((i = start; i < ${#source}; i++)); do
+        char="${source:i:1}"
+        next="${source:i+1:1}"
+
+        if [[ "$escaped" == "true" ]]; then
+            escaped="false"
+            continue
+        fi
+
+        case "$state" in
+            single)
+                [[ "$char" == "'" ]] && state="plain"
+                ;;
+            double)
+                case "$char" in
+                    '"') state="plain" ;;
+                    "\\") escaped="true" ;;
+                    '$')
+                        if [[ "$next" == '(' ]]; then
+                            depth=$((depth + 1))
+                            i=$((i + 1))
+                        fi
+                        ;;
+                esac
+                ;;
+            backtick)
+                case "$char" in
+                    '`') state="plain" ;;
+                    "\\") escaped="true" ;;
+                esac
+                ;;
+            plain)
+                case "$char" in
+                    "'") state="single" ;;
+                    '"') state="double" ;;
+                    '`') state="backtick" ;;
+                    "\\") escaped="true" ;;
+                    '(') depth=$((depth + 1)) ;;
+                    ')')
+                        depth=$((depth - 1))
+                        if [[ $depth -eq 0 ]]; then
+                            printf '%s\n' "$i"
+                            return 0
+                        fi
+                        ;;
+                esac
+                ;;
+        esac
+    done
+
+    return 1
+}
+
+_octo_backtick_end() {
+    local source="$1" start="$2" escaped="false" i char
+
+    for ((i = start; i < ${#source}; i++)); do
+        char="${source:i:1}"
+        if [[ "$escaped" == "true" ]]; then
+            escaped="false"
+        elif [[ "$char" == "\\" ]]; then
+            escaped="true"
+        elif [[ "$char" == '`' ]]; then
+            printf '%s\n' "$i"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# Emit shell command segments, one per line. Quoted text remains a single
+# sanitized word, so a quoted executable is visible without treating provider
+# names in prompt/data strings as command positions. Command substitutions are
+# scanned recursively because they execute even inside double quotes.
 _octo_command_segments() {
     local source="$1" segment="" state="plain" escaped="false"
-    local i char
+    local i char next end inner
 
     for ((i = 0; i < ${#source}; i++)); do
         char="${source:i:1}"
+        next="${source:i+1:1}"
 
         if [[ "$escaped" == "true" ]]; then
             # An unquoted backslash preserves the next character as part of the
@@ -53,23 +133,55 @@ _octo_command_segments() {
             continue
         fi
 
+        if [[ "$state" != "single" && "$char" == '$' && "$next" == '(' ]]; then
+            if end=$(_octo_command_sub_end "$source" "$((i + 2))"); then
+                printf '%s\n' "$segment"
+                inner="${source:i+2:end-i-2}"
+                _octo_command_segments "$inner"
+                segment="${segment}_"
+                i="$end"
+                continue
+            fi
+        fi
+
+        if [[ "$state" != "single" && "$char" == '`' ]]; then
+            if end=$(_octo_backtick_end "$source" "$((i + 1))"); then
+                printf '%s\n' "$segment"
+                inner="${source:i+1:end-i-1}"
+                _octo_command_segments "$inner"
+                segment="${segment}_"
+                i="$end"
+                continue
+            fi
+        fi
+
         case "$state" in
             single)
-                [[ "$char" == "'" ]] && state="plain"
-                segment="${segment} "
+                if [[ "$char" == "'" ]]; then
+                    state="plain"
+                else
+                    case "$char" in
+                        ' '|$'\t'|';'|'&'|'|'|'('|')'|'{'|'}'|$'\n') segment="${segment}_" ;;
+                        *) segment="${segment}${char}" ;;
+                    esac
+                fi
                 ;;
             double)
                 if [[ "$char" == '"' ]]; then
                     state="plain"
                 elif [[ "$char" == "\\" ]]; then
                     escaped="true"
+                else
+                    case "$char" in
+                        ' '|$'\t'|';'|'&'|'|'|'('|')'|'{'|'}'|$'\n') segment="${segment}_" ;;
+                        *) segment="${segment}${char}" ;;
+                    esac
                 fi
-                segment="${segment} "
                 ;;
             plain)
                 case "$char" in
-                    "'") state="single"; segment="${segment} " ;;
-                    '"') state="double"; segment="${segment} " ;;
+                    "'") state="single" ;;
+                    '"') state="double" ;;
                     "\\") escaped="true" ;;
                     ';'|'&'|'|'|'('|')'|'{'|'}'|$'\n')
                         printf '%s\n' "$segment"
@@ -86,7 +198,7 @@ _octo_command_segments() {
 
 _octo_segment_provider() {
     local segment="$1" token="" provider="" first_arg=""
-    local saw_env="false" saw_command="false"
+    local saw_env="false" saw_command="false" saw_exec="false"
 
     # Shell word splitting is intentional here; glob expansion is not.
     set -f
@@ -110,6 +222,10 @@ _octo_segment_provider() {
                 saw_command="true"
                 continue
                 ;;
+            exec)
+                saw_exec="true"
+                continue
+                ;;
             -v|-V)
                 # `command -v/-V provider` is harmless introspection.
                 [[ "$saw_command" == "true" ]] && return 1
@@ -117,10 +233,22 @@ _octo_segment_provider() {
                 return 1
                 ;;
             -p|--)
-                # Both are valid `command` prefixes; env also accepts `--`.
-                if [[ "$saw_command" == "true" || "$saw_env" == "true" ]]; then
+                # Both are valid `command` prefixes; env/exec accept `--`.
+                if [[ "$saw_command" == "true" || "$saw_env" == "true" || "$saw_exec" == "true" ]]; then
                     continue
                 fi
+                return 1
+                ;;
+            -a)
+                # `exec -a name command` supplies an alternate argv[0].
+                if [[ "$saw_exec" == "true" && $# -gt 0 ]]; then
+                    shift
+                    continue
+                fi
+                return 1
+                ;;
+            -c|-l)
+                [[ "$saw_exec" == "true" ]] && continue
                 return 1
                 ;;
             -*)

--- a/hooks/codex-exec-guard.sh
+++ b/hooks/codex-exec-guard.sh
@@ -40,7 +40,15 @@ _octo_command_segments() {
         char="${source:i:1}"
 
         if [[ "$escaped" == "true" ]]; then
-            segment="${segment} "
+            # An unquoted backslash preserves the next character as part of the
+            # same shell word. Keep ordinary characters (`q\wen` -> `qwen`),
+            # but use a non-separator placeholder when the escaped character
+            # would otherwise create a false token boundary.
+            case "$char" in
+                $'\n') ;;
+                ' '|$'\t'|';'|'&'|'|'|'('|')'|'{'|'}') segment="${segment}_" ;;
+                *) segment="${segment}${char}" ;;
+            esac
             escaped="false"
             continue
         fi
@@ -62,7 +70,7 @@ _octo_command_segments() {
                 case "$char" in
                     "'") state="single"; segment="${segment} " ;;
                     '"') state="double"; segment="${segment} " ;;
-                    "\\") escaped="true"; segment="${segment} " ;;
+                    "\\") escaped="true" ;;
                     ';'|'&'|'|'|'('|')'|'{'|'}'|$'\n')
                         printf '%s\n' "$segment"
                         segment=""
@@ -78,7 +86,7 @@ _octo_command_segments() {
 
 _octo_segment_provider() {
     local segment="$1" token="" provider="" first_arg=""
-    local saw_env="false"
+    local saw_env="false" saw_command="false"
 
     # Shell word splitting is intentional here; glob expansion is not.
     set -f
@@ -98,18 +106,28 @@ _octo_segment_provider() {
                 saw_env="true"
                 continue
                 ;;
+            command)
+                saw_command="true"
+                continue
+                ;;
+            -v|-V)
+                # `command -v/-V provider` is harmless introspection.
+                [[ "$saw_command" == "true" ]] && return 1
+                [[ "$saw_env" == "true" ]] && continue
+                return 1
+                ;;
+            -p|--)
+                # Both are valid `command` prefixes; env also accepts `--`.
+                if [[ "$saw_command" == "true" || "$saw_env" == "true" ]]; then
+                    continue
+                fi
+                return 1
+                ;;
             -*)
                 [[ "$saw_env" == "true" ]] && continue
                 return 1
                 ;;
             [A-Za-z_][A-Za-z0-9_]*=*)
-                continue
-                ;;
-            command)
-                # `command -v qwen` and `command -V qwen` are introspection.
-                if [[ "${1:-}" == "-v" || "${1:-}" == "-V" ]]; then
-                    return 1
-                fi
                 continue
                 ;;
             nohup)
@@ -133,6 +151,15 @@ _octo_segment_provider() {
             printf '%s\n' "$provider"
             return 0
             ;;
+        codex)
+            case "$first_arg" in
+                exec|--version|--help|-h|login|auth|completion)
+                    return 1
+                    ;;
+            esac
+            printf '%s\n' "$provider"
+            return 0
+            ;;
     esac
 
     return 1
@@ -145,6 +172,13 @@ while IFS= read -r segment; do
     fi
 done < <(_octo_command_segments "$COMMAND")
 
+if [[ "$DIRECT_PROVIDER" == "codex" ]]; then
+    cat <<'BLOCK'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: bare `codex \"prompt\"` launches interactive TUI and fails without a TTY. Flags such as `--approval-mode`, `--full-auto`, `-q`, and `--quiet` are not valid for current non-interactive Codex dispatch.\n\nUse `codex exec` instead:\n```bash\ncodex exec --skip-git-repo-check \"YOUR PROMPT\"\n```\n\nWith model: `codex exec --skip-git-repo-check --model gpt-5.4 \"YOUR PROMPT\"`\n\nFor long prompts, pipe stdin to `codex exec --skip-git-repo-check -`."}}
+BLOCK
+    exit 0
+fi
+
 if [[ "$DIRECT_PROVIDER" == "qwen" ]]; then
     cat <<'BLOCK'
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: direct Qwen CLI prompt dispatch bypasses Octopus provider admission and authentication checks. If Qwen OAuth is absent or expired, the CLI opens chat.qwen.ai and waits for interactive authorization.\n\nRun the workflow through an Octopus command or skill so Qwen is invoked non-interactively only after authentication is validated. Use `qwen --version` or `qwen --help` only for harmless inspection."}}
@@ -155,16 +189,6 @@ fi
 if [[ "$DIRECT_PROVIDER" == "gemini" ]]; then
     cat <<'BLOCK'
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: the direct Gemini CLI individual client is retired and must not be dispatched by Octopus workflows. It can trigger obsolete OAuth/keychain flows before failing.\n\nUse the Antigravity provider through an Octopus command or skill. `gemini --version` and `gemini --help` remain available for harmless inspection."}}
-BLOCK
-    exit 0
-fi
-
-# Match: starts with `codex` but NOT `codex exec`, `codex --version`, `codex --help`, `codex login`, `codex auth`
-# Also allow: `which codex`, `command -v codex`, variable assignments containing "codex"
-if echo "$COMMAND" | grep -qE '^\s*codex\s' && \
-   ! echo "$COMMAND" | grep -qE '^\s*codex\s+(exec|--version|--help|-h|login|auth|completion)\b'; then
-    cat <<'BLOCK'
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: bare `codex \"prompt\"` launches interactive TUI and fails without a TTY. Flags such as `--approval-mode`, `--full-auto`, `-q`, and `--quiet` are not valid for current non-interactive Codex dispatch.\n\nUse `codex exec` instead:\n```bash\ncodex exec --skip-git-repo-check \"YOUR PROMPT\"\n```\n\nWith model: `codex exec --skip-git-repo-check --model gpt-5.4 \"YOUR PROMPT\"`\n\nFor long prompts, pipe stdin to `codex exec --skip-git-repo-check -`."}}
 BLOCK
     exit 0
 fi

--- a/tests/unit/test-codex-exec-guard.sh
+++ b/tests/unit/test-codex-exec-guard.sh
@@ -100,8 +100,8 @@ fi
 
 test_case "blocks provider dispatch in shell substitutions"
 for command in \
-    'echo `qwen -p hello`' \
-    'echo "$(qwen -p hello)"' \
+    'printf "%s" "`gemini -p hello`"' \
+    'printf "%s" "$(qwen -p hello)"' \
     'echo $(gemini -p hello)'; do
     output="$(run_hook "$command")"
     if [[ "$output" != *'"permissionDecision":"deny"'* ]]; then

--- a/tests/unit/test-codex-exec-guard.sh
+++ b/tests/unit/test-codex-exec-guard.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Tests for Codex exec guard hook.
+# Tests for direct provider CLI guard hook.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
-test_suite "Codex exec guard"
+test_suite "Provider CLI guard"
 
 HOOK="$PROJECT_ROOT/hooks/codex-exec-guard.sh"
 
@@ -31,6 +31,60 @@ if [[ -z "$output" ]]; then
     test_pass
 else
     test_fail "expected allow for codex exec, got: ${output:-<empty>}"
+fi
+
+test_case "blocks direct Qwen prompt dispatch before OAuth can open a browser"
+output="$(run_hook '( qwen -p "$PROMPT" > raw-qwen.md ) &')"
+if [[ "$output" == *'"permissionDecision":"deny"'* ]] \
+   && [[ "$output" == *'Qwen CLI'* ]] \
+   && [[ "$output" == *'Octopus'* ]]; then
+    test_pass
+else
+    test_fail "expected direct Qwen dispatch to be denied, got: ${output:-<empty>}"
+fi
+
+test_case "blocks environment-prefixed Qwen prompt dispatch"
+output="$(run_hook 'NO_BROWSER=1 qwen --prompt "hello"')"
+if [[ "$output" == *'"permissionDecision":"deny"'* ]]; then
+    test_pass
+else
+    test_fail "expected prefixed Qwen dispatch to be denied, got: ${output:-<empty>}"
+fi
+
+test_case "blocks direct Gemini dispatch and points to Antigravity"
+output="$(run_hook 'cd /tmp && (gemini -p "hello")')"
+if [[ "$output" == *'"permissionDecision":"deny"'* ]] \
+   && [[ "$output" == *'retired'* ]] \
+   && [[ "$output" == *'Antigravity'* ]]; then
+    test_pass
+else
+    test_fail "expected direct Gemini dispatch to be denied, got: ${output:-<empty>}"
+fi
+
+test_case "blocks direct provider dispatch in a multiline generated workflow"
+output="$(run_hook $'PROMPT="hello"\n( codex exec "$PROMPT" ) &\n( qwen -p "$PROMPT" ) &\nwait')"
+if [[ "$output" == *'"permissionDecision":"deny"'* ]]; then
+    test_pass
+else
+    test_fail "expected multiline direct Qwen dispatch to be denied, got: ${output:-<empty>}"
+fi
+
+test_case "allows harmless provider introspection"
+for command in 'qwen --version' '/opt/homebrew/bin/qwen --help' 'gemini --version' 'command -v qwen'; do
+    output="$(run_hook "$command")"
+    if [[ -n "$output" ]]; then
+        test_fail "expected introspection to be allowed for $command, got: $output"
+        break
+    fi
+done
+[[ -z "${output:-}" ]] && test_pass
+
+test_case "does not block provider names inside data"
+output="$(run_hook 'printf "%s\\n" "qwen -p is unsafe"')"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "expected quoted provider text to be allowed, got: ${output:-<empty>}"
 fi
 
 test_summary

--- a/tests/unit/test-codex-exec-guard.sh
+++ b/tests/unit/test-codex-exec-guard.sh
@@ -51,6 +51,28 @@ else
     test_fail "expected prefixed Qwen dispatch to be denied, got: ${output:-<empty>}"
 fi
 
+test_case "blocks escaped and command-wrapped provider dispatch"
+for command in \
+    'q\wen -p hello' \
+    'command -- qwen -p hello' \
+    'command -p qwen -p hello' \
+    'command -p codex "hello"'; do
+    output="$(run_hook "$command")"
+    if [[ "$output" != *'"permissionDecision":"deny"'* ]]; then
+        test_fail "expected wrapped provider dispatch to be denied for $command, got: ${output:-<empty>}"
+        break
+    fi
+done
+[[ "$output" == *'"permissionDecision":"deny"'* ]] && test_pass
+
+test_case "allows safe command-wrapped Codex exec"
+output="$(run_hook 'command -p codex exec --skip-git-repo-check "hello"')"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "expected command-wrapped codex exec to be allowed, got: $output"
+fi
+
 test_case "blocks direct Gemini dispatch and points to Antigravity"
 output="$(run_hook 'cd /tmp && (gemini -p "hello")')"
 if [[ "$output" == *'"permissionDecision":"deny"'* ]] \

--- a/tests/unit/test-codex-exec-guard.sh
+++ b/tests/unit/test-codex-exec-guard.sh
@@ -56,7 +56,10 @@ for command in \
     'q\wen -p hello' \
     'command -- qwen -p hello' \
     'command -p qwen -p hello' \
-    'command -p codex "hello"'; do
+    'command -p codex "hello"' \
+    'exec qwen -p hello' \
+    'exec -- gemini -p hello' \
+    'exec -a provider codex "hello"'; do
     output="$(run_hook "$command")"
     if [[ "$output" != *'"permissionDecision":"deny"'* ]]; then
         test_fail "expected wrapped provider dispatch to be denied for $command, got: ${output:-<empty>}"
@@ -66,12 +69,16 @@ done
 [[ "$output" == *'"permissionDecision":"deny"'* ]] && test_pass
 
 test_case "allows safe command-wrapped Codex exec"
-output="$(run_hook 'command -p codex exec --skip-git-repo-check "hello"')"
-if [[ -z "$output" ]]; then
-    test_pass
-else
-    test_fail "expected command-wrapped codex exec to be allowed, got: $output"
-fi
+for command in \
+    'command -p codex exec --skip-git-repo-check "hello"' \
+    'exec codex exec --skip-git-repo-check "hello"'; do
+    output="$(run_hook "$command")"
+    if [[ -n "$output" ]]; then
+        test_fail "expected command-wrapped codex exec to be allowed for $command, got: $output"
+        break
+    fi
+done
+[[ -z "${output:-}" ]] && test_pass
 
 test_case "blocks direct Gemini dispatch and points to Antigravity"
 output="$(run_hook 'cd /tmp && (gemini -p "hello")')"
@@ -91,6 +98,29 @@ else
     test_fail "expected multiline direct Qwen dispatch to be denied, got: ${output:-<empty>}"
 fi
 
+test_case "blocks provider dispatch in shell substitutions"
+for command in \
+    'echo `qwen -p hello`' \
+    'echo "$(qwen -p hello)"' \
+    'echo $(gemini -p hello)'; do
+    output="$(run_hook "$command")"
+    if [[ "$output" != *'"permissionDecision":"deny"'* ]]; then
+        test_fail "expected substitution dispatch to be denied for $command, got: ${output:-<empty>}"
+        break
+    fi
+done
+[[ "$output" == *'"permissionDecision":"deny"'* ]] && test_pass
+
+test_case "blocks quoted and absolute provider executables"
+for command in '"qwen" -p hello' '/opt/homebrew/bin/qwen -p hello'; do
+    output="$(run_hook "$command")"
+    if [[ "$output" != *'"permissionDecision":"deny"'* ]]; then
+        test_fail "expected executable to be denied for $command, got: ${output:-<empty>}"
+        break
+    fi
+done
+[[ "$output" == *'"permissionDecision":"deny"'* ]] && test_pass
+
 test_case "allows harmless provider introspection"
 for command in 'qwen --version' '/opt/homebrew/bin/qwen --help' 'gemini --version' 'command -v qwen'; do
     output="$(run_hook "$command")"
@@ -102,7 +132,7 @@ done
 [[ -z "${output:-}" ]] && test_pass
 
 test_case "does not block provider names inside data"
-output="$(run_hook 'printf "%s\\n" "qwen -p is unsafe"')"
+output="$(run_hook 'printf "%s\\n" "safe; qwen -p is unsafe text"')"
 if [[ -z "$output" ]]; then
     test_pass
 else


### PR DESCRIPTION
## Summary
- extend the existing Bash PreToolUse guard to deny direct Qwen prompt dispatch before expired OAuth can open a browser
- deny direct retired Gemini dispatch and point workflows to Antigravity
- retain harmless provider version/help introspection and existing Codex exec guidance
- cover the exact subshell, environment-prefixed, chained, and multiline incident forms

## Incident evidence
- the reproduced Qwen CLI process waited on OAuth device authorization and opened chat.qwen.ai
- the local OAuth credential was expired
- the direct Gemini CLI returned UNSUPPORTED_CLIENT for the retired individual client
- the generated workflow invoked both providers directly, bypassing Octopus admission/auth checks

## Verification
- /bin/bash 3.2 syntax and unit regression suite: 8/8
- safety hooks smoke suite: 26/26
- make sync-check
- git diff --check

Closes #860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeguards against direct Qwen command usage, with guidance toward authenticated managed workflows.
  * Added safeguards against direct Gemini command usage, directing users to the supported Antigravity workflow.
  * Preserved access to harmless provider version and help commands.
  * Improved command detection across complex and multiline command formats.
  * Codex safeguards now apply regardless of permission-bypass settings.

* **Documentation**
  * Clarified supported provider dispatch and permission safeguards.

* **Tests**
  * Expanded coverage for provider command blocking and allowed introspection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->