### PR TITLE
fix: guard direct Qwen and retired Gemini CLI dispatch

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -37,6 +37,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/qwen-gemini-exec-guard.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scheduler-security-gate.sh",
             "additionalContext": "Scheduler job: ${OCTOPUS_JOB_ID:-none}",
             "timeout": 10

--- a/hooks/qwen-gemini-exec-guard.sh
+++ b/hooks/qwen-gemini-exec-guard.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Qwen/Gemini direct-dispatch guard — blocks bare `qwen "prompt"` and any direct
+# `gemini` CLI invocation from Bash, including chained/subshelled forms.
+# PreToolUse hook on Bash. Returns block decision with correction message.
+# WHY: direct qwen dispatch enters OAuth device authorization and opens a browser;
+#      direct gemini dispatch fails with UNSUPPORTED_CLIENT (obsolete individual
+#      auth) since the CLI is retired in favor of Antigravity (AGY). Both bypass
+#      Octopus's provider availability, auth-expiry, and no-browser admission
+#      checks. See issue #860.
+set -euo pipefail
+# EXIT trap — emits diagnostic stderr ONLY when the hook exits non-zero, so
+# the Claude Code harness error "No stderr output" can never recur. EXIT (not
+# ERR) avoids over-firing on intermediate `grep -o`/`cmd | ...` inside $() that
+# the hook's logic already handles. See issue #313.
+_octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
+trap _octo_hook_exit EXIT
+
+
+# Note: this gate guards correctness/safety (unwanted browser launches, calls to
+# a retired CLI), not user permission policy — so it runs regardless of
+# bypassPermissions.
+
+INPUT=$(cat 2>/dev/null || true)
+[[ -z "$INPUT" ]] && exit 0
+
+# Extract command
+if command -v jq &>/dev/null; then
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+else
+    COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | head -1 | cut -d'"' -f4)
+fi
+[[ -z "$COMMAND" ]] && exit 0
+
+# Split on command separators/subshell openers so a guarded binary anywhere in a
+# chained or subshelled command (e.g. `true && qwen "x"`, `(gemini "x")`,
+# `$(qwen "x")`, backticks) is caught — not only a command that starts with it.
+NORMALIZED=$(printf '%s\n' "$COMMAND" | sed -E 's/(\|\||&&|;|\|)/\n/g; s/`/\n/g; s/\$\(/\n/g; s/\(/\n/g; s/\)/\n/g')
+
+ALLOWED='--version|-v|--help|-h|help|completion'
+
+blocked=""
+while IFS= read -r segment; do
+    trimmed=$(echo "$segment" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+    [[ -z "$trimmed" ]] && continue
+
+    if echo "$trimmed" | grep -qE '^qwen([[:space:]]|$)' && \
+       ! echo "$trimmed" | grep -qE "^qwen[[:space:]]+($ALLOWED)([[:space:]]|\$)"; then
+        blocked="qwen"
+        break
+    fi
+
+    if echo "$trimmed" | grep -qE '^gemini([[:space:]]|$)' && \
+       ! echo "$trimmed" | grep -qE "^gemini[[:space:]]+($ALLOWED)([[:space:]]|\$)"; then
+        blocked="gemini"
+        break
+    fi
+done <<< "$NORMALIZED"
+
+case "$blocked" in
+    qwen)
+        cat <<'BLOCK'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: direct `qwen` dispatch bypasses Octopus's provider availability, auth-expiry, and no-browser admission checks, and can enter OAuth device authorization that opens a browser.\n\nRoute the request through Octopus instead:\n```bash\nscripts/orchestrate.sh probe-single qwen <perspective> <task_id> \"YOUR PROMPT\"\n```\n\nIntrospection is still allowed: `qwen --version`, `qwen --help`."}}
+BLOCK
+        exit 0
+        ;;
+    gemini)
+        cat <<'BLOCK'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: the `gemini` CLI is retired — direct dispatch fails with UNSUPPORTED_CLIENT (obsolete individual auth) and bypasses Octopus's admission checks. Google-seat requests route through Antigravity (AGY) instead.\n\nUse Octopus's AGY path:\n```bash\nscripts/orchestrate.sh probe-single agy <perspective> <task_id> \"YOUR PROMPT\"\n```\n\nIntrospection is still allowed: `gemini --version`, `gemini --help`."}}
+BLOCK
+        exit 0
+        ;;
+esac
+
+: # pass-through — current hook schema treats silence as continue

--- a/tests/unit/test-qwen-gemini-exec-guard.sh
+++ b/tests/unit/test-qwen-gemini-exec-guard.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Tests for Qwen/Gemini direct-dispatch guard hook (issue #860).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Qwen/Gemini direct-dispatch guard"
+
+HOOK="$PROJECT_ROOT/hooks/qwen-gemini-exec-guard.sh"
+
+run_hook() {
+    local command="$1"
+    printf '{"tool_input":{"command":%s}}\n' "$(printf '%s' "$command" | jq -Rs .)" | bash "$HOOK"
+}
+
+assert_denied() {
+    local desc="$1" command="$2" needle="$3"
+    test_case "$desc"
+    output="$(run_hook "$command")"
+    if [[ "$output" == *'"permissionDecision":"deny"'* ]] && [[ "$output" == *"$needle"* ]]; then
+        test_pass
+    else
+        test_fail "expected deny mentioning '$needle', got: ${output:-<empty>}"
+    fi
+}
+
+assert_allowed() {
+    local desc="$1" command="$2"
+    test_case "$desc"
+    output="$(run_hook "$command")"
+    if [[ -z "$output" ]]; then
+        test_pass
+    else
+        test_fail "expected allow (silent pass-through), got: ${output:-<empty>}"
+    fi
+}
+
+assert_denied "blocks bare qwen prompt dispatch" \
+    'qwen "summarize this repo"' \
+    'orchestrate.sh probe-single qwen'
+
+assert_denied "blocks bare gemini invocation" \
+    'gemini "summarize this repo"' \
+    'orchestrate.sh probe-single agy'
+
+assert_allowed "allows qwen --version introspection" 'qwen --version'
+assert_allowed "allows qwen --help introspection" 'qwen --help'
+assert_allowed "allows gemini --version introspection" 'gemini --version'
+assert_allowed "allows gemini --help introspection" 'gemini --help'
+assert_allowed "allows which qwen" 'which qwen'
+assert_allowed "allows command -v qwen" 'command -v qwen'
+assert_allowed "allows unrelated command mentioning qwen in text" 'echo "ask qwen about this"'
+assert_allowed "allows unrelated command" 'ls -la'
+
+assert_denied "blocks qwen after && chain" \
+    'true && qwen "prompt"' \
+    'orchestrate.sh probe-single qwen'
+
+assert_denied "blocks gemini inside a subshell" \
+    '(gemini "prompt")' \
+    'orchestrate.sh probe-single agy'
+
+assert_denied "blocks qwen after ; chain" \
+    'echo hi; qwen "prompt"' \
+    'orchestrate.sh probe-single qwen'
+
+assert_denied "blocks qwen inside command substitution" \
+    'echo $(qwen "prompt")' \
+    'orchestrate.sh probe-single qwen'
+
+assert_denied "blocks qwen inside backticks" \
+    'echo `qwen "prompt"`' \
+    'orchestrate.sh probe-single qwen'
+
+test_summary


### PR DESCRIPTION
## Description
Adds a PreToolUse Bash hook (`hooks/qwen-gemini-exec-guard.sh`) that denies direct `qwen "prompt"` dispatch and any direct `gemini` invocation from a Bash tool call, before it can open a browser or hit a retired CLI path.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Root cause
A generated multi-provider workflow invoked `qwen` and `gemini` directly from a Bash tool call instead of going through the Octopus adapters (`scripts/orchestrate.sh probe-single ...` / the AGY path). Direct `qwen` dispatch enters OAuth device authorization and opens `chat.qwen.ai` in the user's browser; direct `gemini` dispatch fails with `UNSUPPORTED_CLIENT` because the CLI is retired in favor of Antigravity (AGY) — see `scripts/lib/dispatch.sh:196-200`, which already routes all internal `gemini*`/`agy*` dispatch through `scripts/helpers/agy-exec.sh`. Neither guard existed for the Bash tool itself, so a stale/generated workflow could still shell out to the bare CLIs and skip Octopus's provider availability, auth-expiry, and no-browser admission checks entirely.

There was no existing enforcement point for this — `codex-exec-guard.sh` (`hooks/codex-exec-guard.sh`) is the closest existing pattern (a PreToolUse Bash guard for a different CLI-dispatch correctness issue), so the new hook follows the same structure and is registered in `hooks/hooks.json` next to it.

## Fix
- New hook `hooks/qwen-gemini-exec-guard.sh`, registered as a `PreToolUse`/`Bash` hook in `hooks/hooks.json`.
- Denies any command segment that starts with `qwen` or `gemini` (word-boundary matched), except introspection (`--version`, `-v`, `--help`, `-h`, `help`, `completion`).
- The command is split on shell separators/subshell openers (`&&`, `||`, `;`, `|`, backticks, `$(`, `(`, `)`) before matching, so chained and subshelled forms are covered too — e.g. `true && qwen "x"`, `(gemini "x")`, `` `qwen "x"` ``, `echo $(qwen "x")` — not just a command that starts with the binary.
- The deny message points the caller at the correct path (`scripts/orchestrate.sh probe-single qwen ...` for Qwen, `scripts/orchestrate.sh probe-single agy ...` for the Gemini/AGY seat).
- `which qwen`, `command -v qwen`, and text that merely mentions "qwen"/"gemini" (not in command position) are left untouched.

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (32/32)
- [x] OpenClaw registry in sync: `scripts/build-openclaw.sh --check` (up to date, 110 entries — this change doesn't touch skills/commands)
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` (not applicable — hook only, no new skill/command)
- [ ] Version bump (not applicable — patch-level hook fix, not a release)
- [ ] Documentation updated (not applicable)
- [ ] CHANGELOG.md updated (left for the release step, per this repo's daily-triage convention)

## Testing
```bash
bash -n hooks/qwen-gemini-exec-guard.sh tests/unit/test-qwen-gemini-exec-guard.sh   # syntax OK
bash tests/unit/test-qwen-gemini-exec-guard.sh   # new regression suite: 15/15 passed
bash tests/unit/test-hook-err-traps.sh           # 8/8 — confirms the new hook follows the required EXIT-trap pattern (#313)
bash tests/unit/test-docs-sync.sh                # 141/141
bash tests/unit/test-codex-hook-compat.sh        # 6/6
bash tests/unit/test-openclaw-compat.sh          # 32/32
scripts/build-openclaw.sh --check                # registry up to date, no skills/commands touched
git diff origin/main...HEAD --summary | grep "mode change"   # empty
```

Manually exercised the guard against 13 cases (bare dispatch, `--version`/`--help`, `which`/`command -v`, plain-text mentions, and five chained/subshell/substitution forms) — all behaved as intended before the regression suite was written to lock them in.

`make sync-check` currently fails on an unrelated, pre-existing `skills/` drift (`CHECK: skills/ is out of date`) — reproduced independently on an unmodified `origin/main` checkout before this branch existed, so it isn't caused by this change. `make test-unit` (full suite) was kicked off but didn't finish within this session's time budget; the targeted suites above cover every file this PR touches.

## Related Issues
Closes #860

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4bujVWsa3YsWnsTKKd4jG)_