### PR TITLE
fix: refresh provider model metadata

### DIFF
--- a/.claude/skills/skill-copilot-provider/SKILL.md
+++ b/.claude/skills/skill-copilot-provider/SKILL.md
@@ -132,7 +132,7 @@ When missing: `ℹ Copilot CLI not installed (optional)`
 2. **Premium request quota** — Each `copilot -p` prompt = 1 premium request from your monthly allowance
 3. **Graceful degradation** — When unavailable, silently skip with no errors or warnings
 4. **No provider cascade** — If unavailable, the role is reassigned to another provider
-5. **Model selection** — Copilot CLI selects the model internally (default: Claude Sonnet 4.5, configurable via `/model`)
+5. **Model selection** — Octopus uses Copilot's `auto` selector by default; pin `OCTOPUS_COPILOT_MODEL` to pass an explicit `--model` value
 6. **Multi-model access** — Copilot subscription includes access to Claude, GPT, and Gemini models
 
 ---

--- a/commands/model-config.md
+++ b/commands/model-config.md
@@ -173,7 +173,7 @@ AskUserQuestion({
     options: [
       {label: "z-ai/glm-5", description: "GLM-5 — 203K context, $0.80/$2.56 MTok, code review specialist"},
       {label: "moonshotai/kimi-k2.5", description: "Kimi K2.5 — 262K context, $0.45/$2.25 MTok, research & multimodal"},
-      {label: "deepseek/deepseek-r1-0528", description: "DeepSeek R1 — 164K context, $0.70/$2.50 MTok, deep reasoning"},
+      {label: "deepseek/deepseek-v4-pro", description: "DeepSeek V4 Pro — 1M context, $0.435/$0.87 MTok, reasoning"},
       {label: "Custom", description: "Enter a custom model ID"}
     ]
   }]

--- a/config/model-pricing.tsv
+++ b/config/model-pricing.tsv
@@ -1,0 +1,73 @@
+# Canonical estimated pricing in USD per million input/output tokens.
+# kind<TAB>id<TAB>input<TAB>output<TAB>notes
+# Model rows take precedence; provider rows cover legacy records and dynamic IDs.
+# Provider-override rows distinguish subscription routes from direct API routes
+# when the same model name can be used by both.
+model	gpt-5.6	5.00	30.00	Codex frontier alias
+model	gpt-5.6-sol	5.00	30.00	Codex frontier
+model	gpt-5.6-terra	2.50	15.00	Codex balanced
+model	gpt-5.6-luna	1.00	6.00	Codex budget
+model	gpt-5.5	5.00	30.00	OpenAI
+model	gpt-5.5-pro	30.00	180.00	OpenAI Pro
+model	gpt-5.4	2.50	15.00	OpenAI
+model	gpt-5.4-pro	30.00	180.00	OpenAI Pro
+model	gpt-5.3-codex	1.75	14.00	OpenAI Codex
+model	gpt-5.3-codex-spark	1.75	14.00	OpenAI Codex Spark
+model	gpt-5.2-codex	1.75	14.00	OpenAI Codex
+model	gpt-5.1-codex-max	1.25	10.00	OpenAI Codex
+model	gpt-5.4-mini	0.25	2.00	OpenAI budget
+model	gpt-5	1.25	10.00	OpenAI legacy
+model	gpt-5.2	1.75	14.00	OpenAI legacy
+model	gpt-5.1	1.25	10.00	OpenAI legacy
+model	gpt-5-codex	1.25	10.00	OpenAI legacy
+model	o3	2.00	8.00	OpenAI reasoning
+model	o3-pro	20.00	80.00	OpenAI reasoning Pro
+model	o3-mini	1.10	4.40	OpenAI reasoning budget
+model	agy/default	0.00	0.00	Antigravity access
+model	auto	0.00	0.00	Copilot subscription auto selector
+model	claude-haiku-4.5	1.00	5.00	Anthropic
+model	claude-sonnet-5	3.00	15.00	Anthropic
+model	claude-sonnet-4.5	3.00	15.00	Anthropic legacy
+model	claude-sonnet-4.6	3.00	15.00	Anthropic
+model	claude-fable-5	10.00	50.00	Anthropic opt-in
+model	claude-opus-5	5.00	25.00	Anthropic
+model	claude-opus-5-fast	10.00	50.00	Anthropic fast
+model	claude-opus-4.8	5.00	25.00	Anthropic
+model	claude-opus-4.8-fast	10.00	50.00	Anthropic fast
+model	claude-opus-4.7	5.00	25.00	Anthropic legacy
+model	claude-opus-4.6	5.00	25.00	Anthropic legacy
+model	claude-opus-4.6-fast	30.00	150.00	Anthropic legacy fast
+model	grok-4-20	0.00	0.00	Cursor subscription route
+model	grok-4-20-thinking	0.00	0.00	Cursor subscription route
+model	composer-2-fast	0.00	0.00	Cursor subscription route
+model	composer-2	0.00	0.00	Cursor subscription route
+model	z-ai/glm-5	0.80	2.56	OpenRouter
+model	moonshotai/kimi-k2.5	0.45	2.25	OpenRouter
+model	deepseek/deepseek-v4-pro	0.435	0.87	OpenRouter current DeepSeek route
+model	deepseek/deepseek-r1-0528	0.70	2.50	OpenRouter legacy DeepSeek route
+model	opencode/deepseek-v4-flash-free	0.00	0.00	OpenCode free model
+model	opencode/gpt-5.4	0.00	0.00	OpenCode provider accounting
+model	opencode/gpt-5.4-mini	0.00	0.00	OpenCode provider accounting
+model	opencode/glm-5.1	0.00	0.00	OpenCode provider accounting
+model	sonar-pro	3.00	15.00	Perplexity
+model	sonar	1.00	1.00	Perplexity
+provider	claude	5.00	25.00	Legacy provider-only records
+provider	claude-sdk	5.00	25.00	Agent SDK
+provider	codex	5.00	30.00	Legacy provider-only records
+provider	agy	0.00	0.00	Antigravity access
+provider	gemini	0.00	0.00	Sunset legacy records only
+provider	perplexity	3.00	15.00	Legacy provider-only records
+provider	openrouter	2.00	8.00	Blended fallback
+provider	atlascloud	2.00	8.00	Blended fallback
+provider	openai-compatible-agent	2.00	8.00	Generic compatible fallback
+provider	ollama	0.00	0.00	Local compute
+provider	copilot	0.00	0.00	Subscription
+provider	qwen	0.00	0.00	OAuth or free tier
+provider	grok	3.00	15.00	Standalone metered xAI route
+provider	cursor-agent	0.00	0.00	Subscription
+provider	opencode	0.00	0.00	Native free models
+provider	vibe	0.00	0.00	Local subscription or configured account
+provider	default	1.00	5.00	Unknown fallback
+provider-override	copilot	0.00	0.00	Subscription pricing wins over pinned model API pricing
+provider-override	cursor-agent	0.00	0.00	Cursor subscription pricing wins over model API pricing
+provider-override	grok	3.00	15.00	Standalone xAI pricing wins over Cursor model metadata

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -32,6 +32,7 @@ fi
 source "${SCRIPT_DIR}/../lib/provider-routing.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/qwen.sh" 2>/dev/null || true   # qwen_is_usable (oco-dar)
 source "${SCRIPT_DIR}/../lib/openai-compatible.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/../lib/copilot.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/events.sh" 2>/dev/null || true  # opt-in JSONL lifecycle stream
 source "${SCRIPT_DIR}/../lib/quota-watcher.sh" 2>/dev/null || true  # octo_quota_is_dead (oco-cbb)
 
@@ -188,8 +189,7 @@ fi
 provider_status "opencode" "$opencode_state"
 copilot_state="missing"
 if command -v copilot >/dev/null 2>&1; then
-    if [[ -n "${COPILOT_GITHUB_TOKEN:-}" ]] || [[ -n "${GH_TOKEN:-}" ]] || [[ -n "${GITHUB_TOKEN:-}" ]] || \
-       [[ -f "${HOME}/.copilot/config.json" ]] || { command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; }; then
+    if declare -f copilot_is_available >/dev/null 2>&1 && copilot_is_available; then
         copilot_state="available"
     else
         copilot_state="degraded"

--- a/scripts/helpers/copilot-exec.sh
+++ b/scripts/helpers/copilot-exec.sh
@@ -14,4 +14,5 @@ if [[ -z "${prompt//[[:space:]]/}" ]]; then
     echo "copilot-exec: no prompt provided on stdin" >&2
     exit 64
 fi
-exec copilot -p "$prompt" --no-ask-user -s --disable-builtin-mcps
+model="${OCTOPUS_COPILOT_MODEL:-auto}"
+exec copilot -p "$prompt" --model "$model" --no-ask-user -s --disable-builtin-mcps

--- a/scripts/helpers/octo-model-config.sh
+++ b/scripts/helpers/octo-model-config.sh
@@ -8,6 +8,7 @@ CONFIG_FILE="${HOME}/.claude-octopus/config/providers.json"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" || { echo "ERROR: failed to load provider-allowlist.sh" >&2; exit 1; }
 source "${SCRIPT_DIR}/../lib/provider-registry.sh" || { echo "ERROR: failed to load provider-registry.sh" >&2; exit 1; }
+source "${SCRIPT_DIR}/../lib/models.sh" || { echo "ERROR: failed to load models.sh" >&2; exit 1; }
 source "${SCRIPT_DIR}/../lib/model-cache-path.sh" 2>/dev/null || true
 # Must match the path lib/model-resolver.sh writes; this was hardcoded to /tmp
 # while the resolver honoured $TMPDIR, so `clear_cache` was a no-op on macOS.
@@ -646,45 +647,11 @@ cmd_models() {
     printf "  %-24s %-8s %-6s %-6s %-5s %-10s %-8s %s\n" "Model" "Ctx(K)" "Tools" "Image" "Reas" "Provider" "Tier" "Status"
     echo "  ───────────────────────────────────────────────────────────────────────────"
 
-    # Inline catalog (matches orchestrate.sh get_model_catalog)
-    local -a models=(
-        "gpt-5.6-sol|1050|yes|yes|yes|codex|premium|active"
-        "gpt-5.6-terra|1050|yes|yes|yes|codex|standard|active"
-        "gpt-5.6-luna|1050|yes|yes|yes|codex|budget|active"
-        "gpt-5.4|400|yes|yes|no|codex|standard|active"
-        "gpt-5.4-pro|400|yes|yes|no|codex|premium|active"
-        "gpt-5.3-codex|400|yes|yes|no|codex|standard|active"
-        "gpt-5.2-codex|400|yes|yes|no|codex|standard|active"
-        "gpt-5.4-mini|400|yes|no|no|codex|budget|active"
-        "gpt-5.1-codex-max|400|yes|yes|no|codex|premium|active"
-        "o3|200|yes|no|yes|codex|premium|active"
-        "o3-mini|200|yes|no|yes|codex|budget|active"
-        "claude-haiku-4.5|200|yes|yes|yes|claude|budget|active"
-        "claude-sonnet-5|1000|yes|yes|yes|claude|standard|active"
-        "claude-sonnet-4.6|200|yes|yes|no|claude|standard|active"
-        "claude-fable-5|1000|yes|yes|yes|claude|premium|active"
-        "claude-opus-5|1000|yes|yes|yes|claude|premium|active"
-        "claude-opus-4.8|1000|yes|yes|yes|claude|premium|active"
-        "claude-opus-4.7|1000|yes|yes|yes|claude|premium|legacy"
-        "claude-opus-4.6|200|yes|yes|yes|claude|premium|legacy"
-        "grok-4-20|200|yes|no|no|cursor-agent|standard|active"
-        "grok-4-20-thinking|200|yes|no|yes|cursor-agent|premium|active"
-        "composer-2-fast|200|yes|no|no|cursor-agent|standard|active"
-        "composer-2|200|yes|no|no|cursor-agent|premium|active"
-        "sonar-pro|128|no|no|no|perplexity|standard|active"
-        "sonar|128|no|no|no|perplexity|budget|active"
-        "z-ai/glm-5|203|yes|no|no|openrouter|standard|active"
-        "moonshotai/kimi-k2.5|262|yes|yes|no|openrouter|standard|active"
-        "deepseek/deepseek-r1-0528|164|yes|no|yes|openrouter|standard|active"
-        "opencode/deepseek-v4-flash-free|128|yes|no|no|opencode|budget|active"
-        "opencode/gpt-5.4|400|yes|yes|no|opencode|premium|active"
-        "opencode/gpt-5.4-mini|400|yes|no|no|opencode|budget|active"
-        "opencode/glm-5.1|203|yes|no|no|opencode|standard|active"
-    )
-
-    for entry in "${models[@]}"; do
-        local name ctx tools images reasoning provider tier status
-        IFS='|' read -r name ctx tools images reasoning provider tier status <<< "$entry"
+    local name catalog ctx tools images reasoning provider tier status
+    while IFS= read -r name; do
+        [[ -n "$name" ]] || continue
+        catalog="$(get_model_catalog "$name")"
+        IFS='|' read -r ctx tools images reasoning provider tier status <<< "$catalog"
 
         # Apply filter
         if [[ -n "$filter" ]]; then
@@ -700,7 +667,7 @@ cmd_models() {
 
         printf "  %-24s %-8s %-6s %-6s %-5s %-10s %-8s %s\n" \
             "$name" "${ctx}K" "$tools" "$images" "$reasoning" "$provider" "$tier" "$status"
-    done
+    done < <(octo_model_ids)
     echo ""
     echo "  Filters: --tools, --images, --reasoning, --budget, --premium, or text search"
 }

--- a/scripts/helpers/usage-report.sh
+++ b/scripts/helpers/usage-report.sh
@@ -10,32 +10,46 @@
 set -euo pipefail
 
 FORMAT="table"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODEL_PRICING_FILE="${OCTOPUS_MODEL_PRICING_FILE:-${SCRIPT_DIR}/../../config/model-pricing.tsv}"
 WORKSPACE_DIR="${OCTOPUS_WORKSPACE:-${HOME}/.claude-octopus}"
 USAGE_DIR="${WORKSPACE_DIR}/usage"
 RESULTS_DIR="${WORKSPACE_DIR}/results"
+
+log() {
+    local level="$1"
+    shift
+    printf 'usage-report: %s\n' "$*" >&2
+}
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --format)      FORMAT="${2:-table}"; shift 2 ;;
         --usage-dir)   USAGE_DIR="${2:?}"; shift 2 ;;
         --results-dir) RESULTS_DIR="${2:?}"; shift 2 ;;
-        *) echo "usage-report: unknown argument: $1" >&2; exit 64 ;;
+        *) log ERROR "unknown argument: $1"; exit 64 ;;
     esac
 done
 
 if [[ "$FORMAT" != "table" && "$FORMAT" != "json" ]]; then
-    echo "usage-report: --format must be 'table' or 'json'" >&2
+    log ERROR "--format must be 'table' or 'json'"
     exit 64
 fi
 
 if ! command -v python3 &>/dev/null; then
-    echo "usage-report: python3 is required" >&2
+    log ERROR "python3 is required"
+    exit 69
+fi
+if [[ ! -r "$MODEL_PRICING_FILE" ]]; then
+    log ERROR "pricing table not found: $MODEL_PRICING_FILE"
     exit 69
 fi
 
-_OCTOPUS_USAGE_DIR="$USAGE_DIR" \
-_OCTOPUS_RESULTS_DIR="$RESULTS_DIR" \
-_OCTOPUS_FORMAT="$FORMAT" \
+env \
+"_OCTOPUS_USAGE_DIR=${USAGE_DIR}" \
+"_OCTOPUS_RESULTS_DIR=${RESULTS_DIR}" \
+"_OCTOPUS_FORMAT=${FORMAT}" \
+"_OCTOPUS_MODEL_PRICING_FILE=${MODEL_PRICING_FILE}" \
 python3 - <<'PYEOF'
 import glob, json, os, sys
 from collections import defaultdict
@@ -43,45 +57,28 @@ from collections import defaultdict
 usage_dir = os.environ["_OCTOPUS_USAGE_DIR"]
 results_dir = os.environ["_OCTOPUS_RESULTS_DIR"]
 fmt = os.environ["_OCTOPUS_FORMAT"]
+pricing_file = os.environ["_OCTOPUS_MODEL_PRICING_FILE"]
 
-# $/MTok (input, output) — keep in sync with cost table in CLAUDE.md
-RATES = {
-    "claude":       (5.00, 25.00),   # Opus 5 premium seat
-    "claude-sdk":   (5.00, 25.00),   # Agent SDK, Opus 5
-    "codex":        (5.00, 30.00),   # GPT-5.6 Sol frontier default
-    "agy":          (0.00, 0.00),    # included with Antigravity access
-    "gemini":       (0.00, 0.00),    # sunset; legacy records only
-    "perplexity":   (3.00, 15.00),   # Sonar Pro
-    "openrouter":   (2.00, 8.00),    # blended estimate
-    "atlascloud":   (2.00, 8.00),    # blended estimate
-    "openai-compatible-agent": (2.00, 8.00),
-    "ollama":       (0.00, 0.00),    # local
-    "copilot":      (0.00, 0.00),    # subscription
-    "qwen":         (0.00, 0.00),    # oauth/free tier
-    "grok":         (3.00, 15.00),
-    "cursor-agent": (0.00, 0.00),    # subscription
-    "opencode":     (0.00, 0.00),    # native models free
-    "vibe":         (0.00, 0.00),
-}
-# Model-specific $/MTok rates take precedence over provider defaults. Provider
-# rates remain the compatibility fallback for older records that did not carry
-# a model identifier.
-MODEL_RATES = {
-    "gpt-5.6-sol":        (5.00, 30.00),
-    "gpt-5.6-terra":      (2.50, 15.00),
-    "gpt-5.6-luna":       (1.00, 6.00),
-    "claude-fable-5":     (10.00, 50.00),
-    "claude-opus-5-fast": (10.00, 50.00),
-    "claude-opus-5":      (5.00, 25.00),
-    "claude-opus-4.8":    (5.00, 25.00),
-    "claude-opus-4.7":    (5.00, 25.00),
-    "claude-opus-4.6":    (5.00, 25.00),
-    "claude-sonnet-5":    (3.00, 15.00),
-    "claude-sonnet-4.6":  (3.00, 15.00),
-    "claude-sonnet-4.5":  (3.00, 15.00),
-    "claude-haiku-4.5":   (1.00, 5.00),
-}
-DEFAULT_RATE = (2.00, 8.00)
+# One checked-in table is shared with scripts/lib/cost.sh. Model-specific rates
+# take precedence; provider rows cover legacy records without model identifiers.
+RATES = {}
+MODEL_RATES = {}
+PROVIDER_OVERRIDES = {}
+DEFAULT_RATE = (1.00, 5.00)
+with open(pricing_file, encoding="utf-8") as pricing:
+    for raw in pricing:
+        if not raw.strip() or raw.startswith("#"):
+            continue
+        kind, ident, input_rate, output_rate, *_ = raw.rstrip("\n").split("\t")
+        rate = (float(input_rate), float(output_rate))
+        if kind == "model":
+            MODEL_RATES[ident.lower()] = rate
+        elif kind == "provider-override":
+            PROVIDER_OVERRIDES[ident.lower()] = rate
+        elif kind == "provider" and ident == "default":
+            DEFAULT_RATE = rate
+        elif kind == "provider":
+            RATES[ident.lower()] = rate
 
 records = []
 for path in sorted(glob.glob(os.path.join(usage_dir, "*.jsonl"))):
@@ -117,6 +114,36 @@ for path in sorted(glob.glob(os.path.join(results_dir, "**", "summary.json"),
 def bucket():
     return {"queries": 0, "tokens_in": 0, "tokens_out": 0, "est_cost_usd": 0.0}
 
+def pricing_provider(provider):
+    """Match the provider-family normalization used by scripts/lib/cost.sh."""
+    provider = provider.lower().replace("_", "-")
+    prefixes = (
+        ("claude-sdk", "claude-sdk"),
+        ("claude", "claude"),
+        ("codex", "codex"),
+        ("agy", "agy"),
+        ("gemini", "agy"),
+        ("openrouter", "openrouter"),
+        ("openai-compatible", "openai-compatible-agent"),
+        ("atlascloud", "atlascloud"),
+        ("perplexity", "perplexity"),
+        ("cursor-agent", "cursor-agent"),
+        ("copilot", "copilot"),
+        ("ollama", "ollama"),
+        ("qwen", "qwen"),
+        ("grok", "grok"),
+        ("opencode", "opencode"),
+        ("vibe", "vibe"),
+    )
+    if provider in ("antigravity",):
+        return "agy"
+    if provider in ("openai-tools",):
+        return "openai-compatible-agent"
+    for prefix, canonical in prefixes:
+        if provider.startswith(prefix):
+            return canonical
+    return provider
+
 by_provider = defaultdict(bucket)
 by_skill = defaultdict(bucket)
 by_mcp = defaultdict(bucket)
@@ -124,10 +151,12 @@ totals = bucket()
 
 for r in records:
     prov = (r.get("provider") or "unknown").lower()
+    price_prov = pricing_provider(prov)
     model = (r.get("model") or "").lower()
     tin = int(r.get("est_tokens_in") or r.get("tokens_in") or 0)
     tout = int(r.get("est_tokens_out") or r.get("tokens_out") or 0)
-    rate = MODEL_RATES.get(model, RATES.get(prov, DEFAULT_RATE))
+    rate = PROVIDER_OVERRIDES.get(
+        price_prov, MODEL_RATES.get(model, RATES.get(price_prov, DEFAULT_RATE)))
     cost = tin / 1e6 * rate[0] + tout / 1e6 * rate[1]
     for target in (by_provider[prov], totals):
         target["queries"] += 1

--- a/scripts/lib/copilot.sh
+++ b/scripts/lib/copilot.sh
@@ -5,12 +5,27 @@
 # Source-safe: no main execution block.
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Check if Copilot CLI is available and authenticated
+# Check that the installed CLI exposes every flag the non-interactive adapter
+# relies on. Capability detection is safer than inventing an undocumented
+# version floor and remains correct if GitHub backports or changes versions.
+copilot_has_required_capabilities() {
+    local help_text="" required=""
+    if ! help_text="$(copilot --help </dev/null 2>/dev/null)" || [[ -z "$help_text" ]]; then
+        return 1
+    fi
+    for required in --prompt --model --silent --no-ask-user --disable-builtin-mcps; do
+        grep -E -c -- "(^|[[:space:],])${required}([[:space:],=]|$)" <<< "$help_text" >/dev/null || return 1
+    done
+    return 0
+}
+
+# Check if Copilot CLI is available, capable, and authenticated.
 # Returns 0 if ready, 1 if not
 copilot_is_available() {
     if ! command -v copilot &>/dev/null; then
         return 1
     fi
+    copilot_has_required_capabilities || return 1
     # Check auth: env vars first (fast), then keychain/gh (slower)
     if [[ -n "${COPILOT_GITHUB_TOKEN:-}" ]] || \
        [[ -n "${GH_TOKEN:-}" ]] || \
@@ -49,7 +64,7 @@ copilot_auth_method() {
 
 # Execute a prompt via Copilot CLI programmatic mode
 # Args: $1=model (agent type, e.g. copilot, copilot-research), $2=prompt, $3=output_file (optional)
-# The model arg is used for logging/tracking; copilot -p uses whatever model is configured.
+# OCTOPUS_COPILOT_MODEL defaults to the CLI's service-owned auto selector.
 copilot_execute() {
     local agent_type="$1"
     local prompt="$2"
@@ -71,14 +86,15 @@ copilot_execute() {
     fi
 
     local timeout="${OCTOPUS_COPILOT_TIMEOUT:-90}"
+    local model="${OCTOPUS_COPILOT_MODEL:-auto}"
 
     [[ "${VERBOSE:-}" == "true" ]] && log DEBUG "copilot_execute: type=$agent_type, timeout=${timeout}s, auth=$(copilot_auth_method)" || true
 
     local response exit_code
     if [[ ${#auth_env[@]} -gt 0 ]]; then
-        response=$("${auth_env[@]}" timeout "$timeout" copilot -p "$prompt" --no-ask-user -s --disable-builtin-mcps 2>&1) && exit_code=0 || exit_code=$?
+        response=$("${auth_env[@]}" timeout "$timeout" copilot -p "$prompt" --model "$model" --no-ask-user -s --disable-builtin-mcps 2>&1) && exit_code=0 || exit_code=$?
     else
-        response=$(timeout "$timeout" copilot -p "$prompt" --no-ask-user -s --disable-builtin-mcps 2>&1) && exit_code=0 || exit_code=$?
+        response=$(timeout "$timeout" copilot -p "$prompt" --model "$model" --no-ask-user -s --disable-builtin-mcps 2>&1) && exit_code=0 || exit_code=$?
     fi
 
     # Handle errors

--- a/scripts/lib/cost.sh
+++ b/scripts/lib/cost.sh
@@ -3,6 +3,9 @@
 # Extracted from orchestrate.sh
 # Source-safe: no main execution block.
 
+_octopus_cost_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OCTOPUS_MODEL_PRICING_FILE="${OCTOPUS_MODEL_PRICING_FILE:-${_octopus_cost_lib_dir}/../../config/model-pricing.tsv}"
+
 # Session usage tracking file
 USAGE_FILE="${WORKSPACE_DIR}/usage-session.json"
 USAGE_HISTORY_DIR="${WORKSPACE_DIR}/usage-history"
@@ -104,7 +107,7 @@ calculate_agent_cost() {
     local output_tokens=$((input_tokens * 2))
 
     local pricing
-    pricing=$(get_model_pricing "$model")
+    pricing=$(get_model_pricing "$model" "$agent_type")
     local input_price="${pricing%%:*}"
     local output_price="${pricing##*:}"
 
@@ -349,7 +352,7 @@ record_agent_call() {
 
     # Calculate estimated cost
     local pricing
-    pricing=$(get_model_pricing "$model")
+    pricing=$(get_model_pricing "$model" "$agent_type")
     local input_price="${pricing%%:*}"
     local output_price="${pricing##*:}"
 
@@ -612,7 +615,7 @@ record_agent_complete() {
 
         # Calculate cost with actual tokens
         local pricing
-        pricing=$(get_model_pricing "$model")
+        pricing=$(get_model_pricing "$model" "$agent_type")
         local input_price="${pricing%%:*}"
         local output_price="${pricing##*:}"
         # Assume 40% input, 60% output split for actual tokens
@@ -833,49 +836,44 @@ get_cost_tier_for_subscription() {
 
 get_model_pricing() {
     local model="$1"
-    case "$model" in
-        # OpenAI GPT-5.x models (v9.44: updated to Jun 2026 pricing)
-        gpt-5.6|gpt-5.6-sol)    echo "5.00:30.00" ;;
-        gpt-5.6-terra)          echo "2.50:15.00" ;;
-        gpt-5.6-luna)           echo "1.00:6.00" ;;
-        gpt-5.5)                echo "5.00:30.00" ;;   # v9.44: GPT-5.5 (OAuth + API) — new premium default
-        gpt-5.5-pro)            echo "30.00:180.00" ;; # v9.44: GPT-5.5 Pro (API-key only)
-        gpt-5.4)                echo "2.50:15.00" ;;   # v8.39.0: GPT-5.4 (OAuth + API)
-        gpt-5.4-pro)            echo "30.00:180.00" ;; # v8.39.0: GPT-5.4 Pro (API-key only)
-        gpt-5.3-codex)          echo "1.75:14.00" ;;
-        gpt-5.3-codex-spark)    echo "1.75:14.00" ;;   # Spark - same API price, Pro-only
-        gpt-5.2-codex)          echo "1.75:14.00" ;;
-        gpt-5.1-codex-max)      echo "1.25:10.00" ;;
-        gpt-5.4-mini)           echo "0.25:2.00" ;;    # v8.39.0: Budget tier
-        gpt-5)                  echo "1.25:10.00" ;;   # v8.39.0: GPT-5 base
-        gpt-5.2)                echo "1.75:14.00" ;;
-        gpt-5.1)                echo "1.25:10.00" ;;
-        gpt-5-codex)            echo "1.25:10.00" ;;
-        # OpenAI Reasoning models (v8.9.0; v8.39.0: added o3-pro, o3-mini — all API-key only)
-        o3)                     echo "2.00:8.00" ;;
-        o3-pro)                 echo "20.00:80.00" ;;  # v8.39.0: API-key only
-        o3-mini)                echo "1.10:4.40" ;;    # v8.39.0: API-key only
-        # Claude models
-        claude-haiku-4.5)       echo "1.00:5.00" ;;
-        claude-sonnet-5)        echo "3.00:15.00" ;;
-        claude-sonnet-4.5)      echo "3.00:15.00" ;;
-        claude-sonnet-4.6)      echo "3.00:15.00" ;;   # v8.17: Sonnet 4.6 (same pricing as 4.5)
-        claude-fable-5)         echo "10.00:50.00" ;;  # v9.44: Fable 5 (Mythos-class) — opt-in, 1M ctx, 128K output
-        claude-opus-5)          echo "5.00:25.00" ;;
-        claude-opus-5-fast)     echo "10.00:50.00" ;;
-        claude-opus-4.8)        echo "5.00:25.00" ;;   # v9.42: Opus 4.8 — same standard price as 4.7
-        claude-opus-4.8-fast)   echo "10.00:50.00" ;;  # v9.42: Fast mode - 2x cost for ~2.5x output speed
-        claude-opus-4.7)        echo "5.00:25.00" ;;   # legacy current-minus-one
-        claude-opus-4.6)        echo "5.00:25.00" ;;   # legacy — still available for --fast use case
-        claude-opus-4.6-fast)   echo "30.00:150.00" ;;  # legacy fast mode - 6x cost for lower latency
-        # OpenRouter models (v8.11.0)
-        z-ai/glm-5)             echo "0.80:2.56" ;;    # GLM-5: code review specialist
-        moonshotai/kimi-k2.5)   echo "0.45:2.25" ;;    # Kimi K2.5: research, 262K context
-        deepseek/deepseek-r1-0528) echo "0.70:2.50" ;; # DeepSeek R1: visible reasoning traces
-        # Perplexity Sonar models (v8.24.0 - Issue #22)
-        sonar-pro)              echo "3.00:15.00" ;;   # Sonar Pro: deep web research
-        sonar)                  echo "1.00:1.00" ;;    # Sonar: fast web search
-        # Default fallback
-        *)                      echo "1.00:5.00" ;;
+    local provider="${2:-}" kind="" id="" input_price="" output_price="" _notes=""
+    local model_price="" provider_price="" provider_override="" default_price="1.00:5.00"
+
+    case "$provider" in
+        claude-sdk*) provider="claude-sdk" ;;
+        claude*) provider="claude" ;;
+        codex*) provider="codex" ;;
+        agy*|antigravity|gemini*) provider="agy" ;;
+        openrouter*) provider="openrouter" ;;
+        openai-compatible*|openai-tools) provider="openai-compatible-agent" ;;
+        atlascloud*) provider="atlascloud" ;;
+        perplexity*) provider="perplexity" ;;
+        cursor-agent*) provider="cursor-agent" ;;
+        copilot*) provider="copilot" ;;
+        ollama*) provider="ollama" ;;
+        qwen*) provider="qwen" ;;
+        grok*) provider="grok" ;;
+        opencode*) provider="opencode" ;;
+        vibe*) provider="vibe" ;;
     esac
+
+    if [[ ! -r "$OCTOPUS_MODEL_PRICING_FILE" ]]; then
+        printf '%s\n' "$default_price"
+        return 0
+    fi
+
+    while IFS=$'\t' read -r kind id input_price output_price _notes; do
+        [[ -n "$kind" && "$kind" != \#* ]] || continue
+        if [[ "$kind" == "model" && "$id" == "$model" ]]; then
+            model_price="${input_price}:${output_price}"
+        elif [[ "$kind" == "provider-override" && "$id" == "$provider" ]]; then
+            provider_override="${input_price}:${output_price}"
+        elif [[ "$kind" == "provider" && "$id" == "$provider" ]]; then
+            provider_price="${input_price}:${output_price}"
+        elif [[ "$kind" == "provider" && "$id" == "default" ]]; then
+            default_price="${input_price}:${output_price}"
+        fi
+    done < "$OCTOPUS_MODEL_PRICING_FILE"
+
+    printf '%s\n' "${provider_override:-${model_price:-${provider_price:-$default_price}}}"
 }

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -300,7 +300,7 @@ get_agent_command() {
         openrouter) echo "openrouter_execute" ;;                 # OpenRouter API (v4.8)
         openrouter-glm5) echo "openrouter_execute_model z-ai/glm-5" ;;           # v8.11.0: GLM-5 via OpenRouter
         openrouter-kimi) echo "openrouter_execute_model moonshotai/kimi-k2.5" ;; # v8.11.0: Kimi K2.5 via OpenRouter
-        openrouter-deepseek) echo "openrouter_execute_model deepseek/deepseek-r1-0528" ;; # v8.11.0: DeepSeek R1 via OpenRouter
+        openrouter-deepseek) echo "openrouter_execute_model deepseek/deepseek-v4-pro" ;;
         openai-compatible|openai-tools|openai-compatible-agent)  # Generic OpenAI-compatible tool-loop agent
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
                 return 1
@@ -364,7 +364,10 @@ get_agent_command() {
             # contract feeds the prompt via stdin. The shim bridges stdin -> -p so the
             # advisor does not open an interactive session and hang (silent drop).
             # -s: silent (no footer noise); --disable-builtin-mcps: skip MCP startup latency.
-            echo "${PLUGIN_DIR}/scripts/helpers/copilot-exec.sh"
+            if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                return 1
+            fi
+            echo "env OCTOPUS_COPILOT_MODEL=${model} ${PLUGIN_DIR}/scripts/helpers/copilot-exec.sh"
             ;;
         ollama|ollama-*)  # v9.9.0: Ollama local LLM — ollama run
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
@@ -930,7 +933,7 @@ find_capable_fallback() {
         claude)
             candidates=(claude-haiku-4.5 claude-sonnet-5 claude-opus-4.8 claude-opus-5) ;;
         openrouter)
-            candidates=(z-ai/glm-5 moonshotai/kimi-k2.5 deepseek/deepseek-r1-0528) ;;
+            candidates=(z-ai/glm-5 moonshotai/kimi-k2.5 deepseek/deepseek-v4-pro deepseek/deepseek-r1-0528) ;;
         perplexity)
             candidates=(sonar sonar-pro) ;;
         cursor-agent)

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -23,6 +23,9 @@ fi
 if ! declare -f _octo_assignment_has_nonempty_value >/dev/null 2>&1; then
     source "${_model_resolver_lib_dir}/auth.sh" 2>/dev/null || true
 fi
+if ! declare -f copilot_is_available >/dev/null 2>&1; then
+    source "${_model_resolver_lib_dir}/copilot.sh" 2>/dev/null || true
+fi
 if ! declare -f is_claude_agent_type >/dev/null 2>&1; then
     source "${_model_resolver_lib_dir}/routing.sh" 2>/dev/null || true
 source "${_model_resolver_lib_dir}/openai-compatible.sh" 2>/dev/null || true
@@ -68,6 +71,31 @@ sonnet_default_model() {
 
 codex_default_model() {
     echo "gpt-5.6-sol"
+}
+
+# Select only from the live local Ollama inventory. A hardcoded fallback can
+# make `ollama run` pull many gigabytes, so an empty/unreachable inventory must
+# fail closed and ask the user for an explicit installed model.
+ollama_default_model() {
+    local tags="" model=""
+    if ! tags="$(curl -sf --max-time 3 http://localhost:11434/api/tags 2>/dev/null)" || [[ -z "$tags" ]]; then
+        log ERROR "Ollama is unavailable; start it and set OCTOPUS_OLLAMA_MODEL to an installed model"
+        return 1
+    fi
+
+    if command -v jq >/dev/null 2>&1; then
+        model="$(printf '%s' "$tags" | jq -r '.models[0].name // empty' 2>/dev/null)"
+    elif command -v python3 >/dev/null 2>&1; then
+        model="$(printf '%s' "$tags" | python3 -c 'import json,sys; d=json.load(sys.stdin); print((d.get("models") or [{}])[0].get("name", ""))' 2>/dev/null)"
+    else
+        model="$(printf '%s' "$tags" | sed -n 's/.*"models"[[:space:]]*:[[:space:]]*\[[[:space:]]*{[^}]*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)"[^}]*}.*/\1/p' | head -1)"
+    fi
+
+    if [[ -z "$model" ]]; then
+        log ERROR "No local Ollama models are installed; install one or set OCTOPUS_OLLAMA_MODEL to an installed model"
+        return 1
+    fi
+    printf '%s\n' "$model"
 }
 
 # Validate Antigravity CLI model labels against the live CLI catalog.
@@ -435,11 +463,21 @@ resolve_octopus_model() {
             perplexity*)       resolved_model="sonar-pro" ;;
             openrouter-glm*)  resolved_model="z-ai/glm-5" ;;
             openrouter-kimi*) resolved_model="moonshotai/kimi-k2.5" ;;
-            openrouter-deepseek*) resolved_model="deepseek/deepseek-r1-0528" ;;
+            openrouter-deepseek*) resolved_model="deepseek/deepseek-v4-pro" ;;
             openrouter)      resolved_model="anthropic/claude-sonnet-4" ;; # bare OpenRouter needs a namespaced ID, not an OpenAI model string (#797)
-            openai-compatible|openai-tools|openai-compatible-agent*) resolved_model="${OPENAI_COMPAT_MODEL:-gpt-5.4}" ;;
-            ollama*)         resolved_model="llama3.3" ;;
-            copilot*)        resolved_model="claude-sonnet-4.5" ;; # Copilot default; actual model selected by copilot CLI
+            openai-compatible|openai-tools|openai-compatible-agent*)
+                if [[ -z "${OPENAI_COMPAT_MODEL:-}" ]]; then
+                    log ERROR "OPENAI_COMPAT_MODEL or providers.json openai-compatible-agent.default is required"
+                    return 1
+                fi
+                resolved_model="$OPENAI_COMPAT_MODEL"
+                ;;
+            ollama*)
+                if ! resolved_model="$(ollama_default_model)"; then
+                    return 1
+                fi
+                ;;
+            copilot*)        resolved_model="auto" ;; # Let the current Copilot CLI choose its supported default.
             qwen*)           resolved_model="qwen3-coder" ;;
             cursor-agent*)   resolved_model="grok-4-20" ;;
             opencode-research*) resolved_model="opencode/glm-5.1" ;;
@@ -555,11 +593,7 @@ is_agent_available_v2() {
             command -v ollama &>/dev/null && curl -sf http://localhost:11434/api/tags &>/dev/null
             ;;
         copilot|copilot-research)
-            command -v copilot &>/dev/null && {
-                [[ -n "${COPILOT_GITHUB_TOKEN:-}" ]] || [[ -n "${GH_TOKEN:-}" ]] || \
-                [[ -n "${GITHUB_TOKEN:-}" ]] || [[ -f "${HOME}/.copilot/config.json" ]] || \
-                { command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; }
-            }
+            declare -f copilot_is_available >/dev/null 2>&1 && copilot_is_available
             ;;
         qwen|qwen-research)
             command -v qwen &>/dev/null && {

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -36,6 +36,8 @@ get_model_catalog() {
         o3-mini)                echo "200|yes|no|yes|codex|budget|active" ;;
         # Antigravity CLI (agy routes to the user's configured Antigravity default)
         agy/default|default)       echo "1000|yes|yes|no|agy|standard|active" ;;
+        # GitHub Copilot CLI service-owned automatic model selection
+        auto)                      echo "128|yes|no|no|copilot|standard|active" ;;
         # Claude
         claude-haiku-4.5)      echo "200|yes|yes|yes|claude|budget|active" ;;
         claude-sonnet-5)       echo "1000|yes|yes|yes|claude|standard|active" ;;
@@ -56,7 +58,8 @@ get_model_catalog() {
         # OpenRouter
         z-ai/glm-5)             echo "203|yes|no|no|openrouter|standard|active" ;;
         moonshotai/kimi-k2.5)   echo "262|yes|yes|no|openrouter|standard|active" ;;
-        deepseek/deepseek-r1-0528) echo "164|yes|no|yes|openrouter|standard|active" ;;
+        deepseek/deepseek-v4-pro)  echo "1000|yes|no|yes|openrouter|standard|active" ;;
+        deepseek/deepseek-r1-0528) echo "164|yes|no|yes|openrouter|standard|legacy" ;;
         # OpenCode (multi-provider router — models use opencode/<model> namespace)
         opencode/deepseek-v4-flash-free) echo "128|yes|no|no|opencode|budget|active" ;;
         opencode/gpt-5.4)       echo "400|yes|yes|no|opencode|premium|active" ;;
@@ -99,6 +102,55 @@ get_model_capability() {
     esac
 }
 
+# Print every canonical model ID, one per line. Consumers such as model-config
+# must use this instead of maintaining another hand-written catalog.
+octo_model_ids() {
+    cat <<'EOF'
+gpt-5.6-sol
+gpt-5.6-terra
+gpt-5.6-luna
+gpt-5.5
+gpt-5.5-pro
+gpt-5.4
+gpt-5.4-pro
+gpt-5.3-codex
+gpt-5.3-codex-spark
+gpt-5.2-codex
+gpt-5.4-mini
+gpt-5.1-codex-max
+o3
+o3-pro
+o3-mini
+agy/default
+auto
+claude-haiku-4.5
+claude-sonnet-5
+claude-sonnet-4.6
+claude-fable-5
+claude-opus-5
+claude-opus-5-fast
+claude-opus-4.8
+claude-opus-4.8-fast
+claude-opus-4.7
+claude-opus-4.6
+claude-opus-4.6-fast
+grok-4-20
+grok-4-20-thinking
+composer-2-fast
+composer-2
+z-ai/glm-5
+moonshotai/kimi-k2.5
+deepseek/deepseek-v4-pro
+deepseek/deepseek-r1-0528
+opencode/deepseek-v4-flash-free
+opencode/gpt-5.4
+opencode/gpt-5.4-mini
+opencode/glm-5.1
+sonar-pro
+sonar
+EOF
+}
+
 # List all known models for a provider, optionally filtered by capability
 # Usage: list_models [provider] [--tools] [--images] [--reasoning] [--tier budget|standard|premium]
 # Note: calls get_model_pricing() which remains in orchestrate.sh or lib/cost-tracking.sh
@@ -116,19 +168,9 @@ list_models() {
         shift
     done
 
-    local -a all_models=(
-        gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna gpt-5.5 gpt-5.5-pro gpt-5.4 gpt-5.4-pro gpt-5.3-codex gpt-5.2-codex
-        gpt-5.4-mini gpt-5.1-codex-max
-        o3 o3-pro o3-mini
-        agy/default
-        claude-haiku-4.5 claude-sonnet-5 claude-sonnet-4.6 claude-fable-5 claude-opus-5 claude-opus-5-fast claude-opus-4.8 claude-opus-4.8-fast claude-opus-4.7 claude-opus-4.6 claude-opus-4.6-fast
-        grok-4-20 grok-4-20-thinking composer-2-fast composer-2
-        z-ai/glm-5 moonshotai/kimi-k2.5 deepseek/deepseek-r1-0528
-        opencode/deepseek-v4-flash-free opencode/gpt-5.4 opencode/gpt-5.4-mini opencode/glm-5.1
-        sonar-pro sonar
-    )
-
-    for model in "${all_models[@]}"; do
+    local model
+    while IFS= read -r model; do
+        [[ -n "$model" ]] || continue
         local catalog
         catalog=$(get_model_catalog "$model")
         local ctx tools images reasoning provider tier status
@@ -147,5 +189,5 @@ list_models() {
         local out_price="${pricing##*:}"
         printf "%-25s %5sK  tools=%-3s img=%-3s rsn=%-3s  \$%s/\$%s MTok  [%s]\n" \
             "$model" "$ctx" "$tools" "$images" "$reasoning" "$in_price" "$out_price" "$tier"
-    done
+    done < <(octo_model_ids)
 }

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -19,6 +19,9 @@ source "${_providers_lib_dir}/openai-compatible.sh" 2>/dev/null || true
 if ! declare -f grok_is_available >/dev/null 2>&1 || ! declare -f grok_auth_method >/dev/null 2>&1; then
     source "${_providers_lib_dir}/grok.sh" 2>/dev/null || true
 fi
+if ! declare -f copilot_is_available >/dev/null 2>&1; then
+    source "${_providers_lib_dir}/copilot.sh" 2>/dev/null || true
+fi
 
 # Version comparison utility
 version_compare() {
@@ -831,15 +834,14 @@ check_provider_health() {
                 echo "copilot CLI not found in PATH" >&2
                 return 1
             fi
-            # Check auth via the same precedence chain as copilot_is_available()
-            if [[ -z "${COPILOT_GITHUB_TOKEN:-}" ]] && \
-               [[ -z "${GH_TOKEN:-}" ]] && \
-               [[ -z "${GITHUB_TOKEN:-}" ]] && \
-               [[ ! -f "${HOME}/.copilot/config.json" ]]; then
-                if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null 2>&1; then
-                    echo "copilot: not authenticated (run: copilot login)" >&2
-                    return 1
-                fi
+            if ! declare -f copilot_has_required_capabilities >/dev/null 2>&1 || \
+               ! copilot_has_required_capabilities; then
+                echo "copilot: installed CLI lacks required non-interactive flags; update Copilot CLI" >&2
+                return 1
+            fi
+            if ! copilot_is_available; then
+                echo "copilot: not authenticated (run: copilot login)" >&2
+                return 1
             fi
             ;;
         qwen)

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -207,7 +207,7 @@ _octopus_is_safe_openai_compatible_value() {
     return 0
 }
 
-# Grok/claude-sdk dispatch commands take the shape
+# Grok/Copilot/claude-sdk dispatch commands take the shape
 # `env OCTOPUS_<PROVIDER>_MODEL=<model> <shim path>` with nothing else — bind
 # the env assignment to the shim being the *next* token (not merely appearing
 # later in the string), so `env OCTOPUS_GROK_MODEL=x echo pwned <shim>` is
@@ -316,6 +316,9 @@ validate_agent_command() {
     fi
     if [[ "$cmd_executable" == "env" ]]; then
         if _validate_env_prefixed_shim_command "$cmd" "OCTOPUS_GROK_MODEL" "/scripts/helpers/grok-exec.sh"; then
+            return 0
+        fi
+        if _validate_env_prefixed_shim_command "$cmd" "OCTOPUS_COPILOT_MODEL" "/scripts/helpers/copilot-exec.sh"; then
             return 0
         fi
         if _validate_env_prefixed_shim_command "$cmd" "OCTOPUS_CLAUDE_SDK_MODEL" "/scripts/helpers/claude-sdk-exec.sh"; then

--- a/skills/skill-copilot-provider/SKILL.md
+++ b/skills/skill-copilot-provider/SKILL.md
@@ -123,7 +123,7 @@ When missing: `ℹ Copilot CLI not installed (optional)`
 2. **Premium request quota** — Each `copilot -p` prompt = 1 premium request from your monthly allowance
 3. **Graceful degradation** — When unavailable, silently skip with no errors or warnings
 4. **No provider cascade** — If unavailable, the role is reassigned to another provider
-5. **Model selection** — Copilot CLI selects the model internally (default: Claude Sonnet 4.5, configurable via `/model`)
+5. **Model selection** — Octopus uses Copilot's `auto` selector by default; pin `OCTOPUS_COPILOT_MODEL` to pass an explicit `--model` value
 6. **Multi-model access** — Copilot subscription includes access to Claude, GPT, and Gemini models
 
 

--- a/tests/test-model-config-v849.sh
+++ b/tests/test-model-config-v849.sh
@@ -470,7 +470,8 @@ else
     fail "models subcommand not wired in dispatch"
 fi
 
-if grep -A 70 'cmd_models()' "$HELPER" | grep -q 'claude-fable-5|1000|yes|yes|yes|claude|premium|active'; then
+model_catalog_output="$(env "HOME=${TMPDIR:-/tmp}/octopus-model-config-v849-$$" bash "$HELPER" models 2>/dev/null)"
+if grep -q 'claude-fable-5.*1000K.*yes.*yes.*yes.*claude.*premium.*active' <<< "$model_catalog_output"; then
     pass "interactive model catalog includes active claude-fable-5"
 else
     fail "interactive model catalog omits claude-fable-5"

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -54,9 +54,30 @@ else
     test_fail "expected copilot-exec shim path to be accepted"
 fi
 
+test_case "validate_agent_command allows copilot-exec shim path with model env prefix"
+if validate_agent_command "env OCTOPUS_COPILOT_MODEL=auto $PROJECT_ROOT/scripts/helpers/copilot-exec.sh"; then
+    test_pass
+else
+    test_fail "expected env-prefixed copilot-exec shim path to be accepted"
+fi
+
 test_case "validate_agent_command rejects embedded copilot-exec shim path"
 if validate_agent_command "echo $PROJECT_ROOT/scripts/helpers/copilot-exec.sh" >/dev/null 2>&1; then
     test_fail "expected embedded copilot-exec shim path to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects env-prefixed copilot command with wrong executable"
+if validate_agent_command "env OCTOPUS_COPILOT_MODEL=auto echo pwned" >/dev/null 2>&1; then
+    test_fail "expected env-prefixed command without the copilot-exec shim to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects copilot command with wrong executable trailed by the shim path"
+if validate_agent_command "env OCTOPUS_COPILOT_MODEL=auto echo pwned $PROJECT_ROOT/scripts/helpers/copilot-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected wrong-executable-then-shim-path to be rejected"
 else
     test_pass
 fi

--- a/tests/unit/test-current-provider-model-defaults.sh
+++ b/tests/unit/test-current-provider-model-defaults.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #800: provider-owned defaults and explicit pins.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Current provider model defaults (#800)"
+export "TMPDIR=${TEST_TMP_DIR}/runtime"
+export "USER=octo-issue800-$$"
+export "CLAUDE_CODE_SESSION=issue800-$$"
+mkdir -p "$TMPDIR"
+
+log() { :; }
+PLUGIN_DIR="$PROJECT_ROOT"
+source "$PROJECT_ROOT/scripts/lib/provider-registry.sh"
+source "$PROJECT_ROOT/scripts/lib/utils.sh"
+source "$PROJECT_ROOT/scripts/lib/models.sh"
+source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+source "$PROJECT_ROOT/scripts/lib/provider-routing.sh"
+source "$PROJECT_ROOT/scripts/lib/dispatch.sh"
+source "$PROJECT_ROOT/scripts/lib/copilot.sh"
+
+empty_home="$TEST_TMP_DIR/home"
+mkdir -p "$empty_home"
+
+test_case "Copilot delegates its unpinned model choice to CLI auto selection"
+copilot_model="$(HOME="$empty_home" resolve_octopus_model copilot copilot "" "")"
+if [[ "$copilot_model" == "auto" ]]; then
+    test_pass
+else
+    test_fail "expected Copilot auto model selection, got: $copilot_model"
+fi
+
+test_case "Copilot dispatch forwards an explicit OCTOPUS_COPILOT_MODEL pin"
+copilot_command="$(HOME="$empty_home" OCTOPUS_COPILOT_MODEL="gpt-5.4" get_agent_command copilot probe researcher)"
+if [[ "$copilot_command" == *"OCTOPUS_COPILOT_MODEL=gpt-5.4"* ]] &&
+   [[ "$copilot_command" == *"copilot-exec.sh"* ]]; then
+    test_pass
+else
+    test_fail "Copilot model pin did not reach its shim: $copilot_command"
+fi
+
+test_case "Copilot shim passes its resolved model to the CLI"
+fake_bin="$TEST_TMP_DIR/bin"
+capture="$TEST_TMP_DIR/copilot-argv"
+mkdir -p "$fake_bin"
+cat > "$fake_bin/copilot" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$OCTOPUS_TEST_CAPTURE"
+EOF
+chmod +x "$fake_bin/copilot"
+printf 'fixture prompt' | PATH="$fake_bin:/usr/bin:/bin" \
+    OCTOPUS_TEST_CAPTURE="$capture" \
+    OCTOPUS_COPILOT_MODEL="gpt-5.4" \
+    "$PROJECT_ROOT/scripts/helpers/copilot-exec.sh"
+if grep -Fxq -- '--model' "$capture" && grep -Fxq -- 'gpt-5.4' "$capture" &&
+   grep -Fxq -- '-s' "$capture"; then
+    test_pass
+else
+    test_fail "Copilot shim omitted the model argument: $(tr '\n' ' ' < "$capture")"
+fi
+
+test_case "Copilot availability fails closed when required CLI flags are absent"
+mkdir -p "$empty_home/.copilot"
+printf '{}\n' > "$empty_home/.copilot/config.json"
+cat > "$fake_bin/copilot" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--help" ]]; then
+    printf '%s\n' "${OCTOPUS_TEST_COPILOT_HELP:-}"
+    exit 0
+fi
+exit 0
+EOF
+chmod +x "$fake_bin/copilot"
+required_help='--prompt --model --silent --no-ask-user --disable-builtin-mcps'
+if PATH="$fake_bin:/usr/bin:/bin" HOME="$empty_home" OCTOPUS_TEST_COPILOT_HELP='--prompt --no-ask-user' copilot_is_available; then
+    test_fail "an outdated Copilot CLI missing --model was admitted"
+elif PATH="$fake_bin:/usr/bin:/bin" HOME="$empty_home" \
+    OCTOPUS_TEST_COPILOT_HELP='--prompt-file --model-file --silent-mode --no-ask-user-help --disable-builtin-mcps-config' \
+    copilot_is_available; then
+    test_fail "suffixed Copilot option names were mistaken for required exact flags"
+elif PATH="$fake_bin:/usr/bin:/bin" HOME="$empty_home" OCTOPUS_TEST_COPILOT_HELP="$required_help" copilot_is_available; then
+    test_pass
+else
+    test_fail "a Copilot CLI with every required capability was rejected"
+fi
+
+test_case "Ollama selects an already-installed local model instead of a stale pin"
+ollama_model="$({
+    curl() { printf '%s\n' '{"models":[{"name":"qwen3-coder:30b"},{"name":"local-second:latest"}]}'; }
+    HOME="$empty_home" resolve_octopus_model ollama ollama installed ""
+})"
+if [[ "$ollama_model" == "qwen3-coder:30b" ]]; then
+    test_pass
+else
+    test_fail "expected first installed Ollama model, got: $ollama_model"
+fi
+
+test_case "Ollama fails closed when no local model is installed"
+if {
+    curl() { printf '%s\n' '{"models":[]}'; }
+    HOME="$empty_home" resolve_octopus_model ollama ollama empty ""
+} >/dev/null 2>&1; then
+    test_fail "Ollama guessed or pulled a model despite an empty local inventory"
+else
+    test_pass
+fi
+
+test_case "Ollama sed fallback selects the first model when jq and python3 are unavailable"
+fallback_model="$({
+    command() {
+        if [[ "${1:-}" == "-v" && ( "${2:-}" == "jq" || "${2:-}" == "python3" ) ]]; then
+            return 1
+        fi
+        builtin command "$@"
+    }
+    curl() { printf '%s\n' '{"models":[{"name":"first-local:latest"},{"name":"second-local:latest"}]}'; }
+    ollama_default_model
+})"
+if [[ "$fallback_model" == "first-local:latest" ]]; then
+    test_pass
+else
+    test_fail "sed fallback did not select the first installed model: $fallback_model"
+fi
+
+test_case "OpenRouter DeepSeek uses the current V4 Pro route"
+deepseek_model="$(HOME="$empty_home" resolve_octopus_model openrouter openrouter-deepseek "" "")"
+deepseek_command="$(HOME="$empty_home" get_agent_command openrouter-deepseek probe researcher)"
+if [[ "$deepseek_model" == "deepseek/deepseek-v4-pro" ]] && is_known_model "$deepseek_model" &&
+   [[ "$deepseek_command" == *"deepseek/deepseek-v4-pro"* ]]; then
+    test_pass
+else
+    test_fail "expected cataloged current DeepSeek V4 Pro, got model=$deepseek_model command=$deepseek_command"
+fi
+
+test_case "Copilot auto selector has provider metadata"
+if [[ "$(get_model_capability auto provider)" == "copilot" ]]; then
+    test_pass
+else
+    test_fail "Copilot auto selector is missing from the model catalog"
+fi
+
+test_case "Generic OpenAI-compatible routing requires an explicit model"
+if HOME="$empty_home" env -u OPENAI_COMPAT_MODEL \
+    bash -c 'source "$1/scripts/lib/utils.sh"; log(){ :; }; source "$1/scripts/lib/model-resolver.sh"; resolve_octopus_model openai-compatible-agent openai-compatible-agent "" ""' _ "$PROJECT_ROOT" \
+    >/dev/null 2>&1; then
+    test_fail "generic OpenAI-compatible routing silently guessed a model"
+else
+    test_pass
+fi
+
+test_summary

--- a/tests/unit/test-model-metadata-parity.sh
+++ b/tests/unit/test-model-metadata-parity.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #801: one catalog and one pricing source.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Model metadata parity (#801)"
+
+source "$PROJECT_ROOT/scripts/lib/models.sh"
+
+test_case "model-config renders every ID from the canonical model catalog"
+catalog_output="$(env "HOME=${TEST_TMP_DIR}" bash "$PROJECT_ROOT/scripts/helpers/octo-model-config.sh" models 2>/dev/null)"
+catalog_ids="$(awk '$2 ~ /^[0-9]+K$/ { print $1 }' <<< "$catalog_output")"
+missing=""
+while IFS= read -r model; do
+    [[ -n "$model" ]] || continue
+    grep -F -x -c -- "$model" <<< "$catalog_ids" >/dev/null || missing="$missing $model"
+done < <(octo_model_ids)
+if [[ -z "$missing" ]] && ! grep -q 'Inline catalog' "$PROJECT_ROOT/scripts/helpers/octo-model-config.sh"; then
+    test_pass
+else
+    test_fail "model-config diverges from canonical model IDs:$missing"
+fi
+
+test_case "one checked-in pricing table drives Bash and Python reports"
+pricing_file="$PROJECT_ROOT/config/model-pricing.tsv"
+if [[ -f "$pricing_file" ]] &&
+   grep -Fq 'config/model-pricing.tsv' "$PROJECT_ROOT/scripts/lib/cost.sh" &&
+   grep -Fq 'config/model-pricing.tsv' "$PROJECT_ROOT/scripts/helpers/usage-report.sh" &&
+   ! grep -q '"grok":[[:space:]]*(' "$PROJECT_ROOT/scripts/helpers/usage-report.sh" &&
+   ! grep -q '"gpt-5\.6-sol":[[:space:]]*(' "$PROJECT_ROOT/scripts/helpers/usage-report.sh"; then
+    test_pass
+else
+    test_fail "cost.sh and usage-report.sh do not share config/model-pricing.tsv"
+fi
+
+test_case "every canonical model has exactly one pricing row"
+missing=""
+while IFS= read -r model; do
+    [[ -n "$model" ]] || continue
+    count="$(awk -F '\t' -v id="$model" '$1 == "model" && $2 == id { n++ } END { print n + 0 }' "$pricing_file")"
+    [[ "$count" -eq 1 ]] || missing="$missing $model($count)"
+done < <(octo_model_ids)
+if [[ -z "$missing" ]]; then
+    test_pass
+else
+    test_fail "canonical models with missing/duplicate pricing rows:$missing"
+fi
+
+test_case "subscription Cursor Grok and metered standalone Grok stay distinct"
+export "WORKSPACE_DIR=${TEST_TMP_DIR}"
+source "$PROJECT_ROOT/scripts/lib/cost.sh"
+cursor_price="$(get_model_pricing grok-4-20 cursor-agent)"
+standalone_price="$(get_model_pricing grok-4-20 grok)"
+if [[ "$cursor_price" == "0.00:0.00" && "$standalone_price" == "3.00:15.00" ]]; then
+    test_pass
+else
+    test_fail "provider-aware Grok pricing drifted: cursor=$cursor_price standalone=$standalone_price"
+fi
+
+test_case "Copilot subscription overrides explicit model API pricing"
+if [[ "$(get_model_pricing gpt-5.4 copilot)" == "0.00:0.00" ]]; then
+    test_pass
+else
+    test_fail "Copilot model pin was priced as direct API usage"
+fi
+
+test_case "current DeepSeek V4 Pro price comes from the shared table"
+if [[ "$(get_model_pricing deepseek/deepseek-v4-pro openrouter)" == "0.435:0.87" ]]; then
+    test_pass
+else
+    test_fail "DeepSeek V4 Pro pricing is missing or stale"
+fi
+
+test_summary

--- a/tests/unit/test-openai-compatible-agent.sh
+++ b/tests/unit/test-openai-compatible-agent.sh
@@ -123,7 +123,7 @@ else
 fi
 
 
-test_case "openai-compatible-agent reads valid memory cache and replaces unsafe entries"
+test_case "openai-compatible-agent reads valid memory cache and clears unsafe entries"
 cache_key="MC_openai_compatible_agent_A_openai_compatible_agent_P_memcache_R__C_no_config"
 cache_var="_OCTO_MODEL_CACHE_${cache_key}"
 out_file="$TEST_TMP_DIR/openai-compatible-memory-cache-model.out"
@@ -134,12 +134,12 @@ elif [[ "$(cat "$out_file")" != "vendor/model-fast" ]]; then
     test_fail "expected resolver to return the seeded valid memory cache entry"
 else
     printf -v "$cache_var" "%s" "bad;touch"
-    if ! HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-memcache" resolve_octopus_model openai-compatible-agent openai-compatible-agent memcache "" >"$out_file" 2>/dev/null; then
-        test_fail "expected resolver to self-heal unsafe memory cache entry"
+    if HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-memcache" resolve_octopus_model openai-compatible-agent openai-compatible-agent memcache "" >"$out_file" 2>/dev/null; then
+        test_fail "expected resolver to fail closed after rejecting an unsafe cache entry without an explicit generic model"
     elif [[ "$(cat "$out_file")" == "bad;touch" ]]; then
         test_fail "expected unsafe memory cache model not to be returned"
-    elif [[ "${!cache_var:-}" == "bad;touch" ]]; then
-        test_fail "expected unsafe memory cache entry to be replaced after being read"
+    elif [[ -n "${!cache_var:-}" ]]; then
+        test_fail "expected unsafe memory cache entry to be cleared after being read"
     else
         test_pass
     fi

--- a/tests/unit/test-provider-banner-auth.sh
+++ b/tests/unit/test-provider-banner-auth.sh
@@ -15,10 +15,16 @@ FAKE_HOME="$TEST_TMP_DIR/home"
 FAKE_BIN="$TEST_TMP_DIR/bin"
 mkdir -p "$FAKE_HOME" "$FAKE_BIN"
 
-for provider_bin in codex copilot; do
-    printf '#!/usr/bin/env bash\nexit 0\n' > "$FAKE_BIN/$provider_bin"
-    chmod +x "$FAKE_BIN/$provider_bin"
-done
+printf '#!/usr/bin/env bash\nexit 0\n' > "$FAKE_BIN/codex"
+chmod +x "$FAKE_BIN/codex"
+cat > "$FAKE_BIN/copilot" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--help" ]]; then
+    printf '%s\n' '--prompt --model --silent --no-ask-user --disable-builtin-mcps'
+fi
+exit 0
+EOF
+chmod +x "$FAKE_BIN/copilot"
 cat > "$FAKE_BIN/opencode" <<'EOF'
 #!/usr/bin/env bash
 [[ "${1:-}" == "auth" && "${2:-}" == "list" ]] || exit 64

--- a/tests/unit/test-usage-report.sh
+++ b/tests/unit/test-usage-report.sh
@@ -18,6 +18,10 @@ cat > "$TMP_DIR/usage/subagent-usage.jsonl" <<'EOF'
 {"provider":"codex","model":"gpt-5.6-terra","skill":"flow-develop","est_tokens_in":5000,"est_tokens_out":1000,"quality":70}
 {"provider":"claude","model":"claude-sonnet-5","skill":"flow-discover","mcp_server":"perplexity-mcp","est_tokens_in":20000,"est_tokens_out":4000,"quality":90}
 {"provider":"agy","skill":"flow-discover","est_tokens_in":8000,"est_tokens_out":3000,"quality":60}
+{"provider":"cursor-agent","model":"grok-4-20","skill":"flow-review","est_tokens_in":1000000,"est_tokens_out":0,"quality":75}
+{"provider":"cursor-agent-preview","model":"gpt-5.4","skill":"flow-review","est_tokens_in":1000000,"est_tokens_out":0,"quality":75}
+{"provider":"grok","model":"default","skill":"flow-review","est_tokens_in":1000000,"est_tokens_out":0,"quality":75}
+{"provider":"copilot","model":"gpt-5.4","skill":"flow-review","est_tokens_in":1000000,"est_tokens_out":0,"quality":75}
 EOF
 
 cat > "$TMP_DIR/results/run1/summary.json" <<'EOF'
@@ -68,6 +72,21 @@ assert prov['agy']['est_cost_usd'] == 0
     test_pass
 else
     test_fail "cost computation wrong: $out"
+fi
+
+test_case "distinguishes subscription Cursor Grok from standalone metered Grok"
+if python3 -c "
+import json, sys
+d = json.loads(sys.argv[1])
+prov = {p['name']: p for p in d['byProvider']}
+assert prov['cursor-agent']['est_cost_usd'] == 0, prov['cursor-agent']
+assert prov['cursor-agent-preview']['est_cost_usd'] == 0, prov['cursor-agent-preview']
+assert prov['grok']['est_cost_usd'] == 3.0, prov['grok']
+assert prov['copilot']['est_cost_usd'] == 0, prov['copilot']
+" "$out" 2>/dev/null; then
+    test_pass
+else
+    test_fail "provider-aware Grok pricing wrong: $out"
 fi
 
 test_case "groups by skill and by mcp server"


### PR DESCRIPTION
Closes #800.
Closes #801.

## Summary
- delegate unpinned Copilot model selection to the CLI and forward explicit pins safely
- fail Copilot admission closed unless the installed CLI supports Octopus required flags
- choose an already-installed Ollama model instead of pulling a stale hard-coded model
- update the DeepSeek OpenRouter route and require explicit generic OpenAI-compatible models
- centralize model IDs and pricing, with provider-specific subscription overrides

For providers without a documented stable semantic-version contract, this uses capability and authentication probes instead of invented version floors.

## Verification
- `make sync`
- `tests/unit/test-agent-command-validation.sh` (40/40)
- `tests/unit/test-dispatch-round-trip.sh` (6/6)
- `tests/unit/test-current-provider-model-defaults.sh` (9/9)
- `tests/unit/test-model-metadata-parity.sh` (6/6)
- `tests/unit/test-provider-health-fleet.sh` (13/13)
- `tests/unit/test-provider-health-probe.sh` (12/12)
- `tests/unit/test-provider-availability-parity.sh` (15/15)
- `tests/unit/test-usage-report.sh` (8/8)
- `tests/test-model-config-v849.sh` (93/93)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copilot now selects models automatically, with optional explicit model overrides.
  * Ollama automatically selects an installed local model.
  * Added DeepSeek V4 Pro to model options and routing.
  * Added provider-aware pricing, including subscription and provider-specific rates.
  * OpenAI-compatible providers now support explicitly configured models.

* **Bug Fixes**
  * Improved provider availability and unsupported-tool checks.
  * Improved handling of unavailable models and usage-pricing calculations.

* **Documentation**
  * Updated Copilot model-selection guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->