### PR TITLE
fix(dispatch): sanitize prose roles in reasoning env-key lookup

### DIFF
--- a/scripts/lib/execution-profile.sh
+++ b/scripts/lib/execution-profile.sh
@@ -114,9 +114,9 @@ octopus_normalize_reasoning_level() {
 
 octopus_resolve_reasoning_level() {
   local provider="$1" phase="${2:-}" role="${3:-}" phase_key role_key provider_key name value cfg
-  phase_key=$(printf "%s" "$phase" | tr "[:lower:]-" "[:upper:]_")
-  role_key=$(printf "%s" "$role" | tr "[:lower:]-" "[:upper:]_")
-  provider_key=$(printf "%s" "$provider" | tr "[:lower:]-" "[:upper:]_")
+  phase_key="$(_octopus_profile_env_key "$phase")"
+  role_key="$(_octopus_profile_env_key "$role")"
+  provider_key="$(_octopus_profile_env_key "$provider")"
   for name in     "OCTOPUS_${phase_key}_${role_key}_REASONING"     "OCTOPUS_${role_key}_REASONING"     "OCTOPUS_${phase_key}_REASONING"     "OCTOPUS_${provider_key}_REASONING"     OCTOPUS_REASONING_LEVEL; do
     value="${!name:-}"
     if [[ -n "$value" ]]; then octopus_normalize_reasoning_level "$value"; return $?; fi

--- a/tests/unit/test-execution-profile-dispatch.sh
+++ b/tests/unit/test-execution-profile-dispatch.sh
@@ -36,4 +36,12 @@ unset OCTOPUS_OPENAI_COMPATIBLE_AGENT_REASONING
 # selects its own model/reasoning policy, so Octopus emits only the wrapper.
 cmd=$(get_agent_command gemini research researcher)
 assert_contains "$cmd" "agy-exec.sh"
+# Workflow roles are prose ("Technical implementation analysis"); the resolver
+# must sanitize them into valid env-var names instead of aborting dispatch.
+cmd=$(get_agent_command codex probe "Technical implementation analysis")
+assert_contains "$cmd" "--model gpt-5.6"
+export OCTOPUS_PROBE_TECHNICAL_IMPLEMENTATION_ANALYSIS_REASONING=medium
+cmd=$(get_agent_command codex probe "Technical implementation analysis")
+assert_contains "$cmd" 'model_reasoning_effort="medium"'
+unset OCTOPUS_PROBE_TECHNICAL_IMPLEMENTATION_ANALYSIS_REASONING
 printf "PASS test-execution-profile-dispatch\n"


### PR DESCRIPTION
## Problem

`octopus_resolve_reasoning_level` (scripts/lib/execution-profile.sh) builds env-var override names from raw phase/role strings. Workflow roles are prose — embrace's probe phase passes roles like `Technical implementation analysis` — so the constructed name contains spaces:

```
OCTOPUS_PROBE_TECHNICAL IMPLEMENTATION ANALYSIS_REASONING: invalid variable name
```

The indirect expansion `${!name}` aborts, `get_agent_command` returns 1, and spawn reports a misleading `Unknown agent type: codex` / `Unknown agent type: claude-sonnet` — even though both appear in the "Available agents" list it prints alongside.

**Impact:** every codex and claude seat in a YAML-runtime workflow dies at dispatch. A live `embrace` run on v9.61.2 halts at probe with `1/3 results (threshold: 0.5)`; the only surviving seat was gemini-via-AGY, which short-circuits before reasoning resolution. Introduced by #616.

## Fix

Route phase/role/provider through the existing `_octopus_profile_env_key` sanitizer (already used by the phase/operation agent-override lookups in the same file), instead of the bare `tr "[:lower:]-" "[:upper:]_"` that leaves spaces intact. Sanitized overrides like `OCTOPUS_PROBE_TECHNICAL_IMPLEMENTATION_ANALYSIS_REASONING=high` now resolve as intended.

## Verification

- New regression case in `tests/unit/test-execution-profile-dispatch.sh`: dispatch with a prose role must succeed, and the sanitized env override must apply. Confirmed the test fails on the unfixed code with the exact live error, passes with the fix.
- Full live `embrace` run from a patched v9.61.2 install: all four phases pass their quality gates (probe 3/3 @ 0.5, grasp 1/1 @ 0.75, tangle 3/3 @ 0.75, ink 3/3 @ 0.80), workflow completes.
- Local CI (sync-check, smoke, unit, integration): green apart from 3 pre-existing failures caused by session-local `OCTOPUS_*` env leakage unrelated to this change (they pass with a clean env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of reasoning settings for prose workflow roles.
  * Preserved the selected model while applying role-specific reasoning levels.

* **Tests**
  * Added coverage for sanitized workflow-role lookups and Codex model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->