### PR TITLE
fix: give grasp_define seats a realistic timeout budget

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1027,17 +1027,17 @@ grasp_define() {
     log INFO "Gathering problem definitions from multiple perspectives..."
 
     local def1 def2 def3
-    def1=$(run_agent_sync "codex" "Based on: $prompt\n${context}Define the core problem statement in 2-3 sentences. What is the essential challenge?" 120 "backend-architect" "grasp") || {
+    def1=$(run_agent_sync "codex" "Based on: $prompt\n${context}Define the core problem statement in 2-3 sentences. What is the essential challenge?" 300 "backend-architect" "grasp") || {
         log WARN "Codex failed for problem definition, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Codex unavailable for problem definition — falling back to Claude"
-        def1=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define the core problem statement in 2-3 sentences. What is the essential challenge?" 120 "backend-architect" "grasp") || true
+        def1=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define the core problem statement in 2-3 sentences. What is the essential challenge?" 300 "backend-architect" "grasp") || true
     }
-    def2=$(run_agent_sync "agy" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || {
+    def2=$(run_agent_sync "agy" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 300 "researcher" "grasp") || {
         log WARN "Antigravity (agy) failed for success criteria, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Antigravity (agy) unavailable for success criteria — falling back to Claude"
-        def2=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || true
+        def2=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 300 "researcher" "grasp") || true
     }
-    def3=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define constraints and boundaries. What are we NOT solving? What are hard limits?" 120 "researcher" "grasp")
+    def3=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define constraints and boundaries. What are we NOT solving? What are hard limits?" 300 "researcher" "grasp")
 
     # Build consensus
     local consensus_file="${RESULTS_DIR}/grasp-consensus-${task_group}.md"
@@ -1063,7 +1063,7 @@ Output a single, clear problem definition document with:
 4. Recommended Approach"
 
     local consensus
-    consensus=$(run_agent_sync "agy" "$consensus_prompt" 180 "synthesizer" "grasp") || {
+    consensus=$(run_agent_sync "agy" "$consensus_prompt" 300 "synthesizer" "grasp") || {
         consensus="[Auto-consensus failed - manual review required]\n\nProblem: $def1\n\nSuccess Criteria: $def2\n\nConstraints: $def3"
     }
 


### PR DESCRIPTION
## Description
`grasp_define()` in `scripts/lib/workflows.sh` passed literal `120`/`180` second timeouts to `run_agent_sync` for its three definition seats and the consensus synthesizer, regardless of how much probe/repo context was appended to the prompt. On real codebases these seats were consistently SIGTERMed at 173–190s with `tokens_out=0-3` — the seat got as far as a heading before being killed.

Root cause: the literal `120` these call sites pass is treated by `run_agent_sync` (`scripts/lib/agent-sync.sh:180-192`) as the "caller used the default" sentinel, routing into `compute_dynamic_timeout()`. But the task types these define-phase prompts classify into (`diamond-define` / generic fallback) hit `compute_dynamic_timeout`'s default case — the same ~120-180s budget given to lightweight tasks — even though the prompt carries full probe/repo context. The consensus call passes a literal `180` and bypasses the dynamic path entirely. `OCTOPUS_AGENT_TIMEOUT` was the only escape, but it's a global override that would also inflate every other phase's budget.

## Type of Change
- [x] Bug fix

## Fix
Bumped all four `run_agent_sync` call sites in `grasp_define()` (`scripts/lib/workflows.sh:1030,1033,1035,1038,1040,1066`) from `120`/`180` to `300` seconds — matching the "full/premium/complex" tier `compute_dynamic_timeout()` already uses elsewhere in the codebase for comparably heavy reasoning tasks. This is a minimal, mechanical change (6 numeric literals) with no logic changes.

## Testing
This is a 6-line numeric-constant change with no logic changes, so testing was scoped to directly affected tests plus template-required checks rather than the full multi-hour suite:

```
bash -n scripts/orchestrate.sh                        # PASS
bash -n scripts/lib/workflows.sh                       # PASS
bash tests/unit/test-cli-flag-after-subcommand.sh       # 18/18 PASS (grasp --timeout / define flag guard)
bash tests/unit/test-embrace-fail-fast.sh                # 6/6 PASS
bash tests/unit/test-heartbeat-timeout.sh                # 12/12 PASS (compute_dynamic_timeout, unaffected)
bash tests/unit/test-openclaw-compat.sh                  # 32/32 PASS
```

A full `make test-unit` run was also started in the background and reached ~90 files (through the `council` test group) with zero failures before this PR was opened; nothing in the affected code path (`grasp_define`, `run_agent_sync`, `compute_dynamic_timeout`) showed any regression.

## Related Issues
Closes #868

---
_Generated by [Claude Code](https://claude.ai/code/session_01UauozCBKmZLQp6DCqYZPBR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased processing time limits for problem definition, success criteria, constraints, and consensus generation to improve completion of longer-running operations.
  * Existing fallback behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->