### PR TITLE
fix: guard agy dispatch with fleet availability check in grasp/ink/embrace-gate

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1029,7 +1029,6 @@ grasp_define() {
     local def1 def2="" def3
     def1=$(run_agent_sync "codex" "Based on: $prompt\n${context}Define the core problem statement in 2-3 sentences. What is the essential challenge?" 300 "backend-architect" "grasp") || {
         log WARN "Codex failed for problem definition, falling back to Claude"
-        echo -e " ${YELLOW}⚠${NC}  Codex unavailable for problem definition — falling back to Claude"
         def1=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define the core problem statement in 2-3 sentences. What is the essential challenge?" 300 "backend-architect" "grasp") || true
     }
     if octo_provider_allowed agy && command -v agy >/dev/null 2>&1; then

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1026,7 +1026,7 @@ grasp_define() {
     # Multiple agents define the problem from their perspective
     log INFO "Gathering problem definitions from multiple perspectives..."
 
-    local def1 def2 def3
+    local def1 def2="" def3
     def1=$(run_agent_sync "codex" "Based on: $prompt\n${context}Define the core problem statement in 2-3 sentences. What is the essential challenge?" 120 "backend-architect" "grasp") || {
         log WARN "Codex failed for problem definition, falling back to Claude"
         echo -e " ${YELLOW}⚠${NC}  Codex unavailable for problem definition — falling back to Claude"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1034,13 +1034,11 @@ grasp_define() {
     }
     if octo_provider_allowed agy && command -v agy >/dev/null 2>&1; then
         def2=$(run_agent_sync "agy" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || {
-            log WARN "Antigravity (agy) failed for success criteria, falling back to Claude"
-            echo -e " ${YELLOW}⚠${NC}  Antigravity (agy) unavailable for success criteria — falling back to Claude"
+            log WARN "Antigravity (agy) dispatch failed for success criteria, falling back to Claude"
             def2=""
         }
     else
-        log WARN "Antigravity (agy) not installed/allowed, using Claude for success criteria"
-        echo -e " ${YELLOW}⚠${NC}  Antigravity (agy) not installed — using Claude for success criteria"
+        log WARN "Antigravity (agy) unavailable or not allowed, using Claude for success criteria"
     fi
     if [[ -z "$def2" ]]; then
         def2=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || true
@@ -1073,11 +1071,23 @@ Output a single, clear problem definition document with:
     local consensus
     if octo_provider_allowed agy && command -v agy >/dev/null 2>&1; then
         consensus=$(run_agent_sync "agy" "$consensus_prompt" 180 "synthesizer" "grasp") || {
-            consensus="[Auto-consensus failed - manual review required]\n\nProblem: $def1\n\nSuccess Criteria: $def2\n\nConstraints: $def3"
+            consensus="[Auto-consensus failed - manual review required]
+
+Problem: $def1
+
+Success Criteria: $def2
+
+Constraints: $def3"
         }
     else
-        log WARN "Antigravity (agy) not installed/allowed, skipping automated consensus synthesis"
-        consensus="[Auto-consensus skipped - Antigravity (agy) not installed]\n\nProblem: $def1\n\nSuccess Criteria: $def2\n\nConstraints: $def3"
+        log WARN "Antigravity (agy) unavailable or not allowed, skipping automated consensus synthesis"
+        consensus="[Auto-consensus skipped - Antigravity (agy) unavailable or not allowed]
+
+Problem: $def1
+
+Success Criteria: $def2
+
+Constraints: $def3"
     fi
 
     cat > "$consensus_file" << EOF
@@ -3515,7 +3525,7 @@ $all_results"
             delivery=$(build_ink_fallback_delivery "$prompt" "$sonnet_review" "$all_results")
         }
     else
-        log WARN "Antigravity (agy) not installed/allowed, using fallback delivery synthesis"
+        log WARN "Antigravity (agy) unavailable or not allowed, using fallback delivery synthesis"
         delivery=$(build_ink_fallback_delivery "$prompt" "$sonnet_review" "$all_results")
     fi
 
@@ -3692,11 +3702,15 @@ Return a concise gate review with:
         fi
     fi
     # Antigravity (agy) is the Google seat since the Gemini CLI sunset (#524)
-    if octo_provider_allowed agy && command -v agy >/dev/null 2>&1 && agy_view=$(run_agent_sync "agy" "$gate_prompt" 120 "researcher" "embrace-gate" 2>/dev/null); then
-        if [[ -n "$agy_view" ]]; then
-            agy_status="ok"
-            successful=$((successful + 1))
+    if octo_provider_allowed agy && command -v agy >/dev/null 2>&1; then
+        if agy_view=$(run_agent_sync "agy" "$gate_prompt" 120 "researcher" "embrace-gate" 2>/dev/null); then
+            if [[ -n "$agy_view" ]]; then
+                agy_status="ok"
+                successful=$((successful + 1))
+            fi
         fi
+    else
+        agy_status="skipped"
     fi
     if claude_view=$(run_agent_sync "claude-sonnet" "$gate_prompt" 120 "code-reviewer" "embrace-gate" 2>/dev/null); then
         if [[ -n "$claude_view" ]]; then

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1032,11 +1032,19 @@ grasp_define() {
         echo -e " ${YELLOW}⚠${NC}  Codex unavailable for problem definition — falling back to Claude"
         def1=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define the core problem statement in 2-3 sentences. What is the essential challenge?" 120 "backend-architect" "grasp") || true
     }
-    def2=$(run_agent_sync "agy" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || {
-        log WARN "Antigravity (agy) failed for success criteria, falling back to Claude"
-        echo -e " ${YELLOW}⚠${NC}  Antigravity (agy) unavailable for success criteria — falling back to Claude"
+    if octo_provider_allowed agy && command -v agy >/dev/null 2>&1; then
+        def2=$(run_agent_sync "agy" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || {
+            log WARN "Antigravity (agy) failed for success criteria, falling back to Claude"
+            echo -e " ${YELLOW}⚠${NC}  Antigravity (agy) unavailable for success criteria — falling back to Claude"
+            def2=""
+        }
+    else
+        log WARN "Antigravity (agy) not installed/allowed, using Claude for success criteria"
+        echo -e " ${YELLOW}⚠${NC}  Antigravity (agy) not installed — using Claude for success criteria"
+    fi
+    if [[ -z "$def2" ]]; then
         def2=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define success criteria. How will we know when this is solved correctly? List 3-5 measurable criteria." 120 "researcher" "grasp") || true
-    }
+    fi
     def3=$(run_agent_sync "claude-sonnet" "Based on: $prompt\n${context}Define constraints and boundaries. What are we NOT solving? What are hard limits?" 120 "researcher" "grasp")
 
     # Build consensus
@@ -1063,9 +1071,14 @@ Output a single, clear problem definition document with:
 4. Recommended Approach"
 
     local consensus
-    consensus=$(run_agent_sync "agy" "$consensus_prompt" 180 "synthesizer" "grasp") || {
-        consensus="[Auto-consensus failed - manual review required]\n\nProblem: $def1\n\nSuccess Criteria: $def2\n\nConstraints: $def3"
-    }
+    if octo_provider_allowed agy && command -v agy >/dev/null 2>&1; then
+        consensus=$(run_agent_sync "agy" "$consensus_prompt" 180 "synthesizer" "grasp") || {
+            consensus="[Auto-consensus failed - manual review required]\n\nProblem: $def1\n\nSuccess Criteria: $def2\n\nConstraints: $def3"
+        }
+    else
+        log WARN "Antigravity (agy) not installed/allowed, skipping automated consensus synthesis"
+        consensus="[Auto-consensus skipped - Antigravity (agy) not installed]\n\nProblem: $def1\n\nSuccess Criteria: $def2\n\nConstraints: $def3"
+    fi
 
     cat > "$consensus_file" << EOF
 # GRASP Phase - Problem Definition Consensus
@@ -3497,9 +3510,14 @@ Compact source context to synthesize:
 $all_results"
 
     local delivery
-    delivery=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="ink-delivery-watchdog" run_agent_sync "agy" "$synthesis_prompt" 0 "synthesizer" "ink") || {
+    if octo_provider_allowed agy && command -v agy >/dev/null 2>&1; then
+        delivery=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="ink-delivery-watchdog" run_agent_sync "agy" "$synthesis_prompt" 0 "synthesizer" "ink") || {
+            delivery=$(build_ink_fallback_delivery "$prompt" "$sonnet_review" "$all_results")
+        }
+    else
+        log WARN "Antigravity (agy) not installed/allowed, using fallback delivery synthesis"
         delivery=$(build_ink_fallback_delivery "$prompt" "$sonnet_review" "$all_results")
-    }
+    fi
 
     # Step 3: Generate final document
     local delivery_file="${RESULTS_DIR}/delivery-${task_group}.md"
@@ -3674,7 +3692,7 @@ Return a concise gate review with:
         fi
     fi
     # Antigravity (agy) is the Google seat since the Gemini CLI sunset (#524)
-    if agy_view=$(run_agent_sync "agy" "$gate_prompt" 120 "researcher" "embrace-gate" 2>/dev/null); then
+    if octo_provider_allowed agy && command -v agy >/dev/null 2>&1 && agy_view=$(run_agent_sync "agy" "$gate_prompt" 120 "researcher" "embrace-gate" 2>/dev/null); then
         if [[ -n "$agy_view" ]]; then
             agy_status="ok"
             successful=$((successful + 1))

--- a/tests/unit/test-grasp-empty-synthesis.sh
+++ b/tests/unit/test-grasp-empty-synthesis.sh
@@ -13,10 +13,8 @@ test_suite "grasp empty synthesis fallback"
 # shellcheck source=/dev/null
 source "$PROJECT_ROOT/scripts/lib/workflows.sh"
 
-TEST_ROOT="$(mktemp -d)"
-RESULTS_DIR="$TEST_ROOT/results"
-LOGS_DIR="$TEST_ROOT/logs"
-trap 'rm -rf "$TEST_ROOT"' EXIT
+RESULTS_DIR="$TEST_TMP_DIR/results"
+LOGS_DIR="$TEST_TMP_DIR/logs"
 mkdir -p "$RESULTS_DIR" "$LOGS_DIR"
 
 CYAN=""


### PR DESCRIPTION
## Description
Four `run_agent_sync "agy"` call sites in `scripts/lib/workflows.sh` (`grasp_define` success-criteria, `grasp_define` consensus synthesizer, `ink_deliver`, and the embrace debate gate) dispatched to Antigravity unconditionally, unlike every other agy call site in the codebase, which gates on `octo_provider_allowed agy && command -v agy >/dev/null 2>&1` (see `embrace.sh:45`, `parallel.sh:40-41`, `providers.sh:1111`). `build-fleet.sh` correctly excludes `agy` from the fleet when it's unavailable, but these four seats bypass the fleet entirely.

On a host without Antigravity installed, each call wastes a dispatch attempt that fails instantly (`Provider unavailable: agy CLI not found in PATH`) before falling back — 16 occurrences across the reporter's three embrace runs. The fallbacks already existed and did fire, so nothing crashed, but the failed attempts were pure overhead, and the grasp consensus fallback message ("Auto-consensus failed - manual review required") didn't distinguish "agy tried and failed" from "agy was never available."

## Type of Change
- [x] Bug fix

## Fix
Wired the same `octo_provider_allowed agy && command -v agy >/dev/null 2>&1` guard used elsewhere in the codebase at all four call sites (`scripts/lib/workflows.sh:1035`, `:1074`, `:3513`, `:3695`). When agy is unavailable, each site now skips straight to its existing fallback path instead of attempting the dispatch, and the grasp consensus fallback message now reads "Auto-consensus skipped - Antigravity (agy) not installed" when agy was never available, vs. the original "...failed - manual review required" message when a dispatch was attempted and failed mid-run.

No new abstraction — this mirrors the exact check already used in `embrace.sh`, `parallel.sh`, and `providers.sh`, applied at the four sites called out in the issue.

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [ ] OpenClaw registry in sync: `scripts/build-openclaw.sh --check` (n/a — no skill/command/registry changes)
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` (n/a)
- [ ] Version bump (n/a — patch fix, no release cut in this PR)
- [ ] Documentation updated (n/a — internal dispatch behavior only)
- [ ] CHANGELOG.md updated (n/a — deferred to release PR per daily-triage process)

## Testing
```bash
bash -n scripts/orchestrate.sh
bash -n scripts/*.sh scripts/lib/*.sh scripts/helpers/*.sh
bash tests/unit/test-agy-parallel-synthesis.sh    # 9/9 pass
bash tests/unit/test-agy-workflow-routing.sh      # 4/4 pass
bash tests/test-v8.2.0-sonnet-workflows.sh        # 21/21 pass
bash tests/unit/test-openclaw-compat.sh           # 32/32 pass
./tests/run-all.sh unit                           # 250/254 suites pass
```

The full unit run has 4 pre-existing failures (`test-feature-disclosure.sh`, `test-hud-smart-mode.sh`, `test-provider-auth-validity.sh`, `test-skill-doctor-stable-link.sh`) — none reference `workflows.sh` and none are touched by this diff (SessionStart hook JSON shape, HUD status-line output, a SIGKILL-timing flake, and a stale codegen check).

## Related Issues
Closes #870

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg6hYuXnhHEerEQFHZByXi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the Antigravity tool is unavailable, unauthorized, fails, or returns no content.
  * Added reliable fallbacks for success-criteria generation, consensus synthesis, and narrative delivery.
  * Debate validation now skips unavailable tools, improving workflow reliability.
  * Clear outcomes are recorded when consensus is skipped or requires manual review.
  * Prevented successful but empty results from producing blank deliveries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->