### PR TITLE
fix: enforce one agent timeout budget across auth retries

### DIFF
--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -34,10 +34,29 @@ fleet_dispatch_end() {
     unset OCTOPUS_FORCE_LEGACY_DISPATCH
 }
 
+# Claude Code's native Agent Teams API does not expose a provider PID or a
+# timeout/cancellation handle to plugin scripts. A positive Octopus timeout
+# therefore cannot be enforced on that path: Claude Code documents that team
+# shutdown waits for the teammate's current request/tool call. Keep native
+# dispatch only for explicitly unlimited work; bounded work uses the supervised
+# provider subprocess where run_with_timeout owns the process tree.
+octopus_agent_teams_can_honor_timeout() {
+    local effective_timeout="${1:-}"
+    [[ "$effective_timeout" =~ ^[0-9]+$ ]] || return 1
+    [[ "$effective_timeout" -eq 0 ]]
+}
+
 # Check if an agent should use Agent Teams dispatch
 # Returns 0 (true) if agent should use native teams, 1 (false) for legacy bash
 should_use_agent_teams() {
     local agent_type="$1"
+
+    # Keep every caller (including retry/resume routing) consistent with
+    # spawn_agent(): a bounded task needs the subprocess watchdog and PID tree.
+    if ! octopus_agent_teams_can_honor_timeout "${TIMEOUT:-0}"; then
+        log "DEBUG" "Bounded dispatch (${TIMEOUT}s) requires the supervised provider subprocess"
+        return 1
+    fi
 
     # P0-B fix: When orchestrate.sh runs as a Bash tool subprocess (not inside
     # Claude Code's native context), Agent Teams JSON instruction files are never

--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -1028,6 +1028,20 @@ resume_agent() {
         return 1
     fi
 
+    # Native continuation has the same Claude Code limitation as a fresh
+    # teammate: plugins receive no PID or cancellation handle. A bounded retry
+    # must cold-spawn through the supervised subprocess instead of escaping its
+    # timeout budget via SendMessage.
+    if declare -F octopus_agent_teams_can_honor_timeout >/dev/null 2>&1; then
+        if ! octopus_agent_teams_can_honor_timeout "${TIMEOUT:-0}"; then
+            log "DEBUG" "resume_agent: bounded dispatch requires the supervised provider subprocess"
+            return 1
+        fi
+    elif [[ "${TIMEOUT:-0}" =~ ^[1-9][0-9]*$ ]]; then
+        log "DEBUG" "resume_agent: timeout policy unavailable; refusing bounded native continuation"
+        return 1
+    fi
+
     # Gate: agent_id must be non-empty
     if [[ -z "$agent_id" ]]; then
         log "DEBUG" "resume_agent: empty agent_id, falling back"

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -713,6 +713,18 @@ ${heuristic_ctx}"
             # workflows supervise progress/stalls.
             local _eff_timeout="${TIMEOUT:-0}"
 
+            # #869: TIMEOUT's global default (600s) is tuned for probe researchers,
+            # not tangle implementers writing multi-file diffs — those were being
+            # SIGTERMed mid-write with real, unmerged work already on disk. Give
+            # tangle implementers a longer floor without touching the global
+            # default other phases rely on.
+            if [[ "$phase" == "tangle" && "$role" == "implementer" ]]; then
+                local _tangle_floor="${OCTOPUS_TANGLE_TIMEOUT:-1200}"
+                if [[ "$_tangle_floor" =~ ^[0-9]+$ ]] && [[ "$_tangle_floor" -gt "$_eff_timeout" ]]; then
+                    _eff_timeout="$_tangle_floor"
+                fi
+            fi
+
             # oco-48z: quota/terminal-error fast-fail watcher for ALL providers (was
             # provider-specific). Greps temp files every 2s; on match it kills the provider
             # early and marks it quota-dead for the session (oco-cbb), so preflight and
@@ -985,8 +997,15 @@ ${heuristic_ctx}"
             end_time_ms=$(( $(date +%s) * 1000 ))
             elapsed_ms=$((end_time_ms - start_time_ms))
             update_agent_status "$agent_type" "timeout" "$elapsed_ms" 0.0
+            # #869: tokens_out must be estimated from whichever file was actually
+            # salvaged into result_file above (temp_output, falling back to
+            # raw_output) — otherwise a timeout whose real content only reached
+            # raw_output gets reported as tokens_out=0 next to a result_file full of
+            # preserved output, making completed work look discarded.
+            local _tokens_out_source="$temp_output"
+            [[ ! -s "$_tokens_out_source" ]] && _tokens_out_source="$raw_output"
             local tokens_out
-            tokens_out=$(octo_estimate_tokens_for_file "$temp_output" 2>/dev/null || echo 0)
+            tokens_out=$(octo_estimate_tokens_for_file "$_tokens_out_source" 2>/dev/null || echo 0)
             type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "timeout" "$tokens_in" "$tokens_out" "Timed out before completion" "$elapsed_ms" "$result_file" "${role:-none}" || true
             # v8.20.0: Record timeout for provider intelligence
             record_outcome "$agent_type" "$agent_type" "${task_type:-unknown}" "${phase:-unknown}" "timeout" "$elapsed_ms" 2>/dev/null || true

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -2,9 +2,12 @@
 # spawn_agent — extracted from orchestrate.sh (v9.7.x)
 # Agent spawning and lifecycle management
 
+_octopus_spawn_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if ! type start_quota_watcher >/dev/null 2>&1; then
-    _octopus_spawn_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     source "${_octopus_spawn_lib_dir}/quota-watcher.sh" 2>/dev/null || true
+fi
+if ! type octopus_agent_teams_can_honor_timeout >/dev/null 2>&1; then
+    source "${_octopus_spawn_lib_dir}/agent-sync.sh" 2>/dev/null || true
 fi
 
 quota_watcher_kill_spawn_children() {
@@ -621,8 +624,18 @@ ${heuristic_ctx}"
     mkdir -p "$RESULTS_DIR" "$LOGS_DIR"
     touch "$PID_FILE"
 
-    # v8.5: Agent Teams dispatch for Claude agents
+    # v8.5: Agent Teams dispatch for Claude agents. Native teammates have no
+    # plugin-accessible cancellation handle, so positive bounded work must stay
+    # on the supervised subprocess path where the timeout is enforceable.
+    local _use_agent_teams=false
     if should_use_agent_teams "$agent_type"; then
+        if octopus_agent_teams_can_honor_timeout "$_eff_timeout"; then
+            _use_agent_teams=true
+        else
+            log "INFO" "Bounded dispatch (${_eff_timeout}s) uses the supervised provider subprocess; native Agent Teams cannot enforce a wall-clock timeout"
+        fi
+    fi
+    if [[ "$_use_agent_teams" == "true" ]]; then
         log "INFO" "Dispatching via Agent Teams: $agent_type (task: $task_id)"
 
         # Write structured agent instruction for Claude Code's native team dispatch
@@ -642,10 +655,12 @@ ${heuristic_ctx}"
                 --arg result_file "$result_file" \
                 --arg effort "${effort_level:-medium}" \
                 --arg model_override "$SUPPORTS_AGENT_MODEL_OVERRIDE" \
+                --argjson timeout_seconds "$_eff_timeout" \
                 '{agent_type: $agent_type, task_id: $task_id, role: $role,
                   phase: $phase, model: $model, prompt: $prompt,
                   result_file: $result_file, dispatch_method: "agent_teams",
                   effort: $effort,
+                  timeout_seconds: $timeout_seconds,
                   model_override_supported: ($model_override == "true"),
                   agent_id: "", dispatched_at: now | todate}' \
                 > "$agent_instruction_file" 2>/dev/null
@@ -669,7 +684,7 @@ ${heuristic_ctx}"
             echo "# Result-capture: SubagentStop hook" >> "$result_file"
         fi
         echo "" >> "$result_file"
-        type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "running" "$tokens_in" 0 "Dispatched via Agent Teams" 0 "$result_file" "${role:-none}" || true
+        type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "running" "$tokens_in" 0 "Dispatched via Agent Teams" "$_eff_timeout" "$result_file" "${role:-none}" || true
 
         log "DEBUG" "Agent Teams instruction written to: $agent_instruction_file"
         if [[ "$SUPPORTS_HOOK_LAST_MESSAGE" == "true" ]]; then

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -172,6 +172,41 @@ write_agent_result_header() {
     } > "$result_file"
 }
 
+# Resolve the single wall-clock budget owned by spawn_agent. TIMEOUT=0 remains
+# explicitly unlimited; phase floors only raise positive configured budgets.
+octopus_effective_agent_timeout() {
+    local configured_timeout="${1:-0}"
+    local phase="${2:-}"
+    local role="${3:-}"
+
+    if [[ "$phase" == "tangle" && "$role" == "implementer" ]]; then
+        local tangle_floor="${OCTOPUS_TANGLE_TIMEOUT:-1200}"
+        if ! [[ "$tangle_floor" =~ ^[1-9][0-9]*$ ]]; then
+            log "WARN" "OCTOPUS_TANGLE_TIMEOUT='$tangle_floor' is not a positive integer; using default 1200s floor"
+            tangle_floor=1200
+        fi
+        if [[ "$configured_timeout" =~ ^[0-9]+$ ]] && \
+           [[ "$configured_timeout" -gt 0 ]] && \
+           [[ "$tangle_floor" -gt "$configured_timeout" ]]; then
+            configured_timeout="$tangle_floor"
+        fi
+    fi
+
+    printf '%s\n' "$configured_timeout"
+}
+
+# Print the positive number of seconds left before a fixed deadline. Returning
+# nonzero at/after the deadline prevents callers from accidentally translating
+# an expired budget to run_with_timeout's special unlimited value (0).
+octopus_timeout_remaining() {
+    local deadline="$1"
+    local now="${2:-$(date +%s)}"
+
+    [[ "$deadline" =~ ^[0-9]+$ && "$now" =~ ^[0-9]+$ ]] || return 1
+    [[ "$deadline" -gt "$now" ]] || return 1
+    printf '%s\n' "$((deadline - now))"
+}
+
 spawn_agent() {
     local agent_type="$1"
     local prompt="$2"
@@ -681,11 +716,20 @@ ${heuristic_ctx}"
             update_task_progress "$CLAUDE_TASK_ID" "$active_verb"
         fi
 
+        # Resolve one effective wall-clock budget before recording progress.
+        # Auth retries consume the same budget rather than resetting it.
+        local _eff_timeout
+        _eff_timeout=$(octopus_effective_agent_timeout "${TIMEOUT:-0}" "$phase" "$role")
+
         # Mark agent as running and capture start time (v7.16.0 Feature 2)
-        local start_time_ms
+        local start_time_secs start_time_ms _timeout_deadline=0
         # Use seconds instead of milliseconds for compatibility (macOS date doesn't support %N)
-        start_time_ms=$(( $(date +%s) * 1000 ))
-        update_agent_status "$agent_type" "running" 0 0.0
+        start_time_secs=$(date +%s)
+        start_time_ms=$((start_time_secs * 1000))
+        if [[ "$_eff_timeout" =~ ^[0-9]+$ ]] && [[ "$_eff_timeout" -gt 0 ]]; then
+            _timeout_deadline=$((start_time_secs + _eff_timeout))
+        fi
+        update_agent_status "$agent_type" "running" 0 0.0 "$_eff_timeout"
         type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "running" "$tokens_in" 0 "" 0 "$result_file" "${role:-none}" || true
 
         # v7.19.0 P0.1: Use tee to stream output to both temp file and raw backup
@@ -708,27 +752,11 @@ ${heuristic_ctx}"
         local exit_code=0
         while true; do
             exit_code=0
-
-            # Per-provider timeout. TIMEOUT=0 means no absolute timeout; higher-level
-            # workflows supervise progress/stalls.
-            local _eff_timeout="${TIMEOUT:-0}"
-
-            # #869: TIMEOUT's global default (600s) is tuned for probe researchers,
-            # not tangle implementers writing multi-file diffs — those were being
-            # SIGTERMed mid-write with real, unmerged work already on disk. Give
-            # tangle implementers a longer floor without touching the global
-            # default other phases rely on.
-            if [[ "$phase" == "tangle" && "$role" == "implementer" ]]; then
-                local _tangle_floor="${OCTOPUS_TANGLE_TIMEOUT:-1200}"
-                if ! [[ "$_tangle_floor" =~ ^[0-9]+$ ]]; then
-                    log "WARN" "OCTOPUS_TANGLE_TIMEOUT='$_tangle_floor' is not a positive integer; using default 1200s floor"
-                    _tangle_floor=1200
-                fi
-                # _eff_timeout=0 means unlimited (see comment above) — the floor
-                # must never turn "unlimited" into "capped at 1200s".
-                if [[ "$_eff_timeout" =~ ^[0-9]+$ ]] && [[ "$_eff_timeout" -gt 0 ]] && [[ "$_tangle_floor" -gt "$_eff_timeout" ]]; then
-                    _eff_timeout="$_tangle_floor"
-                fi
+            local _attempt_timeout="$_eff_timeout"
+            if [[ "$_timeout_deadline" -gt 0 ]] && \
+               ! _attempt_timeout=$(octopus_timeout_remaining "$_timeout_deadline"); then
+                exit_code=124
+                break
             fi
 
             # oco-48z: quota/terminal-error fast-fail watcher for ALL providers (was
@@ -750,9 +778,9 @@ ${heuristic_ctx}"
             # v9.2.2: All agents use stdin-based prompt delivery to avoid ARG_MAX limits (Issue #173).
             # Legacy gemini* IDs execute via the same AGY path.
             if [[ "$agent_type" == agy* || "$agent_type" == "antigravity" || "$agent_type" == gemini* ]]; then
-                printf '%s' "$enhanced_prompt" | OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="spawn-agent-heartbeat" run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"
+                printf '%s' "$enhanced_prompt" | OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="spawn-agent-heartbeat" run_with_timeout "$_attempt_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"
                 exit_code=${PIPESTATUS[1]:-0}
-            elif printf '%s' "$enhanced_prompt" | OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="spawn-agent-heartbeat" run_with_timeout "$_eff_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then
+            elif printf '%s' "$enhanced_prompt" | OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="spawn-agent-heartbeat" run_with_timeout "$_attempt_timeout" "${cmd_array[@]}" 2> "$temp_errors" | tee "$raw_output" > "$temp_output"; then
                 exit_code=0
             else
                 exit_code=$?
@@ -761,7 +789,8 @@ ${heuristic_ctx}"
             stop_quota_watcher "$_quota_watcher_pid"
 
             # v8.16: Check if failure is auth-related and retryable
-            if [[ $exit_code -ne 0 ]] && [[ $auth_attempt -lt $max_auth_retries ]]; then
+            if [[ $exit_code -ne 0 ]] && [[ $exit_code -ne 124 ]] && [[ $exit_code -ne 143 ]] && \
+               [[ $auth_attempt -lt $max_auth_retries ]]; then
                 local stderr_content=""
                 [[ -s "$temp_errors" ]] && stderr_content=$(<"$temp_errors")
                 if [[ "$stderr_content" == *"unauthorized"* ]] || \
@@ -772,6 +801,15 @@ ${heuristic_ctx}"
                    [[ "$stderr_content" == *"refresh"* ]]; then
                     ((auth_attempt++)) || true
                     local backoff=$((auth_attempt * 5))
+                    if [[ "$_timeout_deadline" -gt 0 ]]; then
+                        local _retry_remaining
+                        if ! _retry_remaining=$(octopus_timeout_remaining "$_timeout_deadline") || \
+                           [[ "$_retry_remaining" -le "$backoff" ]]; then
+                            log "WARN" "Auth retry skipped: agent wall-clock budget exhausted"
+                            exit_code=124
+                            break
+                        fi
+                    fi
                     log "WARN" "Auth failure detected (attempt $auth_attempt/$max_auth_retries), retrying in ${backoff}s..."
                     sleep "$backoff"
                     # Clear temp files for retry
@@ -919,12 +957,12 @@ ${heuristic_ctx}"
             end_time_ms=$(( $(date +%s) * 1000 ))
             elapsed_ms=$((end_time_ms - start_time_ms))
             if [[ "$_octo_success_status" == "failed" ]]; then
-                update_agent_status "$agent_type" "failed" "$elapsed_ms" 0.0
+                update_agent_status "$agent_type" "failed" "$elapsed_ms" 0.0 "$_eff_timeout"
                 record_outcome "$agent_type" "$agent_type" "${task_type:-unknown}" "${phase:-unknown}" "fail" "$elapsed_ms" 2>/dev/null || true
                 type record_failure &>/dev/null && record_failure "$provider_prefix" "provider_rejection" 2>/dev/null || true
                 type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "failed" "$tokens_in" "$_octo_tokens_out" "${_octo_success_reason:-unusable output}" "$elapsed_ms" "$result_file" "${role:-none}" || true
             else
-                update_agent_status "$agent_type" "completed" "$elapsed_ms" 0.0
+                update_agent_status "$agent_type" "completed" "$elapsed_ms" 0.0 "$_eff_timeout"
                 # v8.18.0: Record provider learning
                 local result_summary
                 result_summary=$(head -c 200 "$result_file" 2>/dev/null | tr '\n' ' ')
@@ -1002,7 +1040,7 @@ ${heuristic_ctx}"
             local end_time_ms elapsed_ms
             end_time_ms=$(( $(date +%s) * 1000 ))
             elapsed_ms=$((end_time_ms - start_time_ms))
-            update_agent_status "$agent_type" "timeout" "$elapsed_ms" 0.0
+            update_agent_status "$agent_type" "timeout" "$elapsed_ms" 0.0 "$_eff_timeout"
             # #869: tokens_out must be estimated from whichever file actually holds
             # more of the salvaged content — otherwise a timeout whose real output
             # only reached raw_output (or whose result_file gets a later raw_output
@@ -1058,7 +1096,7 @@ ${heuristic_ctx}"
             local end_time_ms elapsed_ms
             end_time_ms=$(( $(date +%s) * 1000 ))
             elapsed_ms=$((end_time_ms - start_time_ms))
-            update_agent_status "$agent_type" "failed" "$elapsed_ms" 0.0
+            update_agent_status "$agent_type" "failed" "$elapsed_ms" 0.0 "$_eff_timeout"
             local tokens_out
             tokens_out=$(octo_estimate_tokens_for_file "$temp_output" 2>/dev/null || echo 0)
             type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "failed" "$tokens_in" "$tokens_out" "Exit code $exit_code" "$elapsed_ms" "$result_file" "${role:-none}" || true

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -720,7 +720,13 @@ ${heuristic_ctx}"
             # default other phases rely on.
             if [[ "$phase" == "tangle" && "$role" == "implementer" ]]; then
                 local _tangle_floor="${OCTOPUS_TANGLE_TIMEOUT:-1200}"
-                if [[ "$_tangle_floor" =~ ^[0-9]+$ ]] && [[ "$_tangle_floor" -gt "$_eff_timeout" ]]; then
+                if ! [[ "$_tangle_floor" =~ ^[0-9]+$ ]]; then
+                    log "WARN" "OCTOPUS_TANGLE_TIMEOUT='$_tangle_floor' is not a positive integer; using default 1200s floor"
+                    _tangle_floor=1200
+                fi
+                # _eff_timeout=0 means unlimited (see comment above) — the floor
+                # must never turn "unlimited" into "capped at 1200s".
+                if [[ "$_eff_timeout" =~ ^[0-9]+$ ]] && [[ "$_eff_timeout" -gt 0 ]] && [[ "$_tangle_floor" -gt "$_eff_timeout" ]]; then
                     _eff_timeout="$_tangle_floor"
                 fi
             fi
@@ -997,13 +1003,17 @@ ${heuristic_ctx}"
             end_time_ms=$(( $(date +%s) * 1000 ))
             elapsed_ms=$((end_time_ms - start_time_ms))
             update_agent_status "$agent_type" "timeout" "$elapsed_ms" 0.0
-            # #869: tokens_out must be estimated from whichever file was actually
-            # salvaged into result_file above (temp_output, falling back to
-            # raw_output) — otherwise a timeout whose real content only reached
-            # raw_output gets reported as tokens_out=0 next to a result_file full of
-            # preserved output, making completed work look discarded.
+            # #869: tokens_out must be estimated from whichever file actually holds
+            # more of the salvaged content — otherwise a timeout whose real output
+            # only reached raw_output (or whose result_file gets a later raw_output
+            # append below, when it's under 1KB) gets reported as tokens_out=0 or an
+            # undercount next to a result_file full of preserved output, making
+            # completed work look discarded.
             local _tokens_out_source="$temp_output"
-            [[ ! -s "$_tokens_out_source" ]] && _tokens_out_source="$raw_output"
+            local _tos_size=0 _ros_size=0
+            [[ -s "$temp_output" ]] && _tos_size=$(wc -c < "$temp_output" 2>/dev/null || echo 0)
+            [[ -s "$raw_output" ]] && _ros_size=$(wc -c < "$raw_output" 2>/dev/null || echo 0)
+            [[ "$_ros_size" -gt "$_tos_size" ]] && _tokens_out_source="$raw_output"
             local tokens_out
             tokens_out=$(octo_estimate_tokens_for_file "$_tokens_out_source" 2>/dev/null || echo 0)
             type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "timeout" "$tokens_in" "$tokens_out" "Timed out before completion" "$elapsed_ms" "$result_file" "${role:-none}" || true

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -522,11 +522,17 @@ ${heuristic_ctx}"
         return 0
     fi
 
+    # Resolve one effective wall-clock budget before selecting a persistence
+    # path. The degraded synchronous fallback must enforce the same phase floor
+    # as the normal subprocess, while TIMEOUT=0 remains unlimited.
+    local _eff_timeout
+    _eff_timeout=$(octopus_effective_agent_timeout "${TIMEOUT:-0}" "$phase" "$role")
+
     # A restricted host may deny the selected state root. Preserve the provider
     # result by degrading this background/persistent path to synchronous stdout.
     if [[ "${OCTOPUS_PERSISTENCE_AVAILABLE:-true}" == "false" ]]; then
         octopus_run_provider_without_persistence \
-            "$agent_type" "$enhanced_prompt" "${TIMEOUT:-0}" "$cmd"
+            "$agent_type" "$enhanced_prompt" "$_eff_timeout" "$cmd"
         return $?
     fi
 
@@ -715,11 +721,6 @@ ${heuristic_ctx}"
             active_verb=$(get_active_form_verb "$phase" "$agent_type" "$prompt")
             update_task_progress "$CLAUDE_TASK_ID" "$active_verb"
         fi
-
-        # Resolve one effective wall-clock budget before recording progress.
-        # Auth retries consume the same budget rather than resetting it.
-        local _eff_timeout
-        _eff_timeout=$(octopus_effective_agent_timeout "${TIMEOUT:-0}" "$phase" "$role")
 
         # Mark agent as running and capture start time (v7.16.0 Feature 2)
         local start_time_secs start_time_ms _timeout_deadline=0

--- a/tests/unit/test-agent-timeout-budget.sh
+++ b/tests/unit/test-agent-timeout-budget.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Regression checks for #869: one wall-clock budget must cover all auth retries.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "agent timeout budget"
+
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/spawn.sh"
+log() { :; }
+
+test_case "tangle implementers receive the phase timeout floor"
+if declare -F octopus_effective_agent_timeout >/dev/null 2>&1 && \
+   [[ "$(octopus_effective_agent_timeout 600 tangle implementer)" == "1200" ]] && \
+   [[ "$(OCTOPUS_TANGLE_TIMEOUT=1500 octopus_effective_agent_timeout 600 tangle implementer)" == "1500" ]] && \
+   [[ "$(OCTOPUS_TANGLE_TIMEOUT=invalid octopus_effective_agent_timeout 600 tangle implementer)" == "1200" ]] && \
+   [[ "$(octopus_effective_agent_timeout 0 tangle implementer)" == "0" ]] && \
+   [[ "$(octopus_effective_agent_timeout 600 probe researcher)" == "600" ]]; then
+    test_pass
+else
+    test_fail "effective timeout helper is missing or does not preserve phase/unlimited semantics"
+fi
+
+test_case "retry attempts receive only the remaining wall-clock budget"
+if declare -F octopus_timeout_remaining >/dev/null 2>&1 && \
+   [[ "$(octopus_timeout_remaining 160 100)" == "60" ]] && \
+   ! octopus_timeout_remaining 100 100 >/dev/null 2>&1 && \
+   ! octopus_timeout_remaining 90 100 >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "deadline helper did not shrink or expire the retry budget"
+fi
+
+test_case "spawn retry loop excludes timed-out attempts and reports effective timeout"
+spawn_source="$(cat "$PROJECT_ROOT/scripts/lib/spawn.sh")"
+if [[ "$spawn_source" == *'exit_code -ne 124'* ]] && \
+   [[ "$spawn_source" == *'exit_code -ne 143'* ]] && \
+   [[ "$spawn_source" == *'run_with_timeout "$_attempt_timeout"'* ]] && \
+   [[ "$spawn_source" == *'update_agent_status "$agent_type" "running" 0 0.0 "$_eff_timeout"'* ]]; then
+    test_pass
+else
+    test_fail "spawn does not yet enforce and report one shared effective timeout"
+fi
+
+test_summary

--- a/tests/unit/test-agent-timeout-budget.sh
+++ b/tests/unit/test-agent-timeout-budget.sh
@@ -12,6 +12,10 @@ test_suite "agent timeout budget"
 
 # shellcheck source=/dev/null
 source "$PROJECT_ROOT/scripts/lib/spawn.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/heartbeat.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/state-root.sh"
 log() { :; }
 
 test_case "tangle implementers receive the phase timeout floor"
@@ -45,6 +49,32 @@ if [[ "$spawn_source" == *'exit_code -ne 124'* ]] && \
     test_pass
 else
     test_fail "spawn does not yet enforce and report one shared effective timeout"
+fi
+
+test_case "non-persistence fallback receives and enforces the effective phase budget"
+fallback_provider="$TEST_TMP_DIR/fallback-timeout-provider.sh"
+cat > "$fallback_provider" <<'EOF'
+#!/usr/bin/env bash
+sleep 2
+printf 'FALLBACK_COMPLETED\n'
+EOF
+chmod +x "$fallback_provider"
+build_provider_env() { PROVIDER_ENV_ARRAY=(); }
+octopus_persistence_diagnostic() { :; }
+fallback_timeout=$(OCTOPUS_TANGLE_TIMEOUT=4 octopus_effective_agent_timeout 1 tangle implementer)
+fallback_started=$(date +%s)
+set +e
+fallback_output=$(octopus_run_provider_without_persistence \
+    claude "fallback prompt" "$fallback_timeout" "$fallback_provider")
+fallback_rc=$?
+set -e
+fallback_elapsed=$(( $(date +%s) - fallback_started ))
+if [[ "$spawn_source" == *'"$agent_type" "$enhanced_prompt" "$_eff_timeout" "$cmd"'* ]] && \
+   [[ "$fallback_timeout" == "4" ]] && [[ "$fallback_rc" -eq 0 ]] && \
+   [[ "$fallback_output" == "FALLBACK_COMPLETED" ]] && [[ "$fallback_elapsed" -ge 2 ]]; then
+    test_pass
+else
+    test_fail "non-persistence dispatch bypassed the effective tangle timeout floor"
 fi
 
 test_summary

--- a/tests/unit/test-agent-timeout-budget.sh
+++ b/tests/unit/test-agent-timeout-budget.sh
@@ -51,6 +51,21 @@ else
     test_fail "spawn does not yet enforce and report one shared effective timeout"
 fi
 
+test_case "bounded agents use the supervised subprocess instead of native Agent Teams"
+agent_sync_source="$(cat "$PROJECT_ROOT/scripts/lib/agent-sync.sh")"
+agent_utils_source="$(cat "$PROJECT_ROOT/scripts/lib/agent-utils.sh")"
+if declare -F octopus_agent_teams_can_honor_timeout >/dev/null 2>&1 && \
+   octopus_agent_teams_can_honor_timeout 0 && \
+   ! octopus_agent_teams_can_honor_timeout 600 && \
+   [[ "$agent_sync_source" == *'octopus_agent_teams_can_honor_timeout "${TIMEOUT:-0}"'* ]] && \
+   [[ "$agent_utils_source" == *'octopus_agent_teams_can_honor_timeout "${TIMEOUT:-0}"'* ]] && \
+   [[ "$spawn_source" == *'octopus_agent_teams_can_honor_timeout "$_eff_timeout"'* ]] && \
+   [[ "$spawn_source" == *'write_agent_status "$agent_type" "running" "$tokens_in" 0 "Dispatched via Agent Teams" "$_eff_timeout"'* ]]; then
+    test_pass
+else
+    test_fail "bounded Agent Teams dispatch can bypass the enforceable provider watchdog"
+fi
+
 test_case "non-persistence fallback receives and enforces the effective phase budget"
 fallback_provider="$TEST_TMP_DIR/fallback-timeout-provider.sh"
 cat > "$fallback_provider" <<'EOF'
@@ -75,6 +90,24 @@ if [[ "$spawn_source" == *'"$agent_type" "$enhanced_prompt" "$_eff_timeout" "$cm
     test_pass
 else
     test_fail "non-persistence dispatch bypassed the effective tangle timeout floor"
+fi
+
+test_case "non-persistence fallback terminates work beyond the effective timeout"
+timeout_provider="$TEST_TMP_DIR/fallback-timeout-enforcement.sh"
+cat > "$timeout_provider" <<'EOF'
+#!/usr/bin/env bash
+sleep 6
+printf 'SHOULD_NOT_COMPLETE\n'
+EOF
+chmod +x "$timeout_provider"
+timeout_rc=0
+octopus_run_provider_without_persistence \
+    claude "timeout prompt" "$fallback_timeout" "$timeout_provider" \
+    >/dev/null 2>&1 || timeout_rc=$?
+if [[ "$timeout_rc" -eq 124 || "$timeout_rc" -eq 143 ]]; then
+    test_pass
+else
+    test_fail "fallback executor did not enforce the effective timeout (rc=$timeout_rc)"
 fi
 
 test_summary

--- a/tests/unit/test-quota-fast-fail.sh
+++ b/tests/unit/test-quota-fast-fail.sh
@@ -83,8 +83,8 @@ test_is_agent_available_skips_dead() {
 test_retired_gemini_timeout_override_absent() {
     test_case "spawn.sh uses the supervised workflow timeout without a Gemini-only override"
     if ! grep -q 'OCTOPUS_GEMINI_TIMEOUT' "$PROJECT_ROOT/scripts/lib/spawn.sh" && \
-       grep -q 'local _eff_timeout="${TIMEOUT:-0}"' "$PROJECT_ROOT/scripts/lib/spawn.sh" && \
-       grep -q 'run_with_timeout "\$_eff_timeout"' "$PROJECT_ROOT/scripts/lib/spawn.sh"; then
+       grep -q 'octopus_effective_agent_timeout "${TIMEOUT:-0}"' "$PROJECT_ROOT/scripts/lib/spawn.sh" && \
+       grep -q 'run_with_timeout "\$_attempt_timeout"' "$PROJECT_ROOT/scripts/lib/spawn.sh"; then
         test_pass
     else test_fail "spawn.sh still exposes retired Gemini timeout behavior"; fi
 }

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -202,8 +202,8 @@ assert_contains "$QUALITY" "_design_timeout_label" "design review reports effect
 HEARTBEAT="$PROJECT_ROOT/scripts/lib/heartbeat.sh"
 assert_contains "$HEARTBEAT" "timeout_secs=0 means no absolute timeout" "timeout zero disables absolute timeout"
 SPAWN="$PROJECT_ROOT/scripts/lib/spawn.sh"
-assert_contains "$SPAWN" "TIMEOUT=0 means no absolute timeout" "spawn respects TIMEOUT=0"
-assert_contains "$SPAWN" 'local _eff_timeout="${TIMEOUT:-0}"' "all providers use the supervised workflow timeout"
+assert_contains "$SPAWN" "TIMEOUT=0 remains" "spawn respects TIMEOUT=0"
+assert_contains "$SPAWN" 'octopus_effective_agent_timeout "${TIMEOUT:-0}"' "all providers use the supervised workflow timeout"
 
 TESTING="$PROJECT_ROOT/scripts/lib/testing.sh"
 assert_contains "$TESTING" "OCTOPUS_TANGLE_VALIDATION_CORRECTION_FILE" "post-correction validation overlay is wired"


### PR DESCRIPTION
## Root cause

`spawn_agent()` applied the same global `TIMEOUT=600` to probe researchers and tangle implementers. More importantly, each auth retry received a fresh timeout, so a nominal 600-second agent could run for two or three complete timeout windows. Timeout exit codes could also enter the auth-retry classifier, while recovered output could be reported as zero tokens.

## Fix

- Resolve one effective wall-clock budget per agent before dispatch.
- Keep `TIMEOUT=0` unlimited and give positive tangle-implementer budgets a configurable `OCTOPUS_TANGLE_TIMEOUT` floor (default 1200 seconds).
- Pass only the remaining budget to each auth retry and skip retries when the deadline is exhausted.
- Resolve that same effective budget before choosing the persistent or degraded synchronous executor, so restricted hosts cannot bypass the tangle floor.
- Route positive bounded work (including continuation retries) through the supervised provider subprocess because Claude Code's native Agent Teams API exposes no plugin cancellation handle; explicit `TIMEOUT=0` remains eligible for native teams.
- Never auth-retry timeout/termination exit codes 124 or 143.
- Report the effective budget in lifecycle status and estimate timed-out output from the larger recovered stream.
- Add regression coverage for phase floors, unlimited mode, shrinking retry budgets, terminal timeout handling, and the retired Gemini timeout override.

This closes both directions reported in #869: premature termination of substantial tangle work and retry-driven execution beyond the documented budget.

## Verification

- `bash tests/unit/test-agent-timeout-budget.sh` — 6/6, including a real non-persistence fixture that exceeds the effective bound and bounded Agent Teams routing
- `bash tests/unit/test-agent-predicates.sh` — 13/13
- `bash tests/unit/test-tangle-retry-feedback.sh` — 10/10
- `bash tests/unit/test-quota-fast-fail.sh` — 11/11
- `bash tests/unit/test-tangle-context-review-loop.sh` — 54/54
- `make ci-local` — 16/16 smoke, 256/256 unit, 7/7 integration

Fixes #869


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent timeout handling for agent execution, including unlimited-timeout support and validated default limits.
  * Timeout budgets now carry across authentication retries and fallback attempts.
  * Status updates provide clearer timeout information.

* **Bug Fixes**
  * Prevented timed-out operations from triggering unnecessary authentication retries.
  * Ensured fallback execution respects the remaining timeout budget.
  * Routed time-limited tasks through execution paths that can reliably enforce deadlines.

* **Tests**
  * Added regression coverage for timeout limits, retries, deadline expiry, fallback behavior, and status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->