### PR TITLE
feat(providers): add OrcaRouter as a named dispatch provider

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -2,7 +2,7 @@
 
 # Claude Octopus
 
-**One prompt. Up to nine external AI integrations checking each other's work.** Claude Octopus turns Claude Code into a multi-LLM orchestration engine — Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok all contribute perspectives, then a 75% consensus gate catches disagreements before they ship.
+**One prompt. Up to ten external AI integrations checking each other's work.** Claude Octopus turns Claude Code into a multi-LLM orchestration engine — Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, and Grok all contribute perspectives, then a 75% consensus gate catches disagreements before they ship.
 
 **Claude-native first, Octopus for escalation.** Use Claude-native `/init`, `/review`, and `/security-review` when Claude is enough. Use Octopus when you want multiple model opinions, adversarial review, or stricter multi-LLM workflows.
 
@@ -69,7 +69,7 @@ Don't know the command? Describe what you need — `/octo:auto <anything>` route
 
 - Claude Code v2.1.14+
 - Zero external providers needed (Claude is built in)
-- Optional: Codex CLI, Antigravity CLI (`agy`), Copilot, Qwen, Ollama, Perplexity API key, OpenRouter API key, OpenCode CLI, and xAI API key (Grok)
+- Optional: Codex CLI, Antigravity CLI (`agy`), Copilot, Qwen, Ollama, Perplexity API key, OpenRouter API key, OrcaRouter API key, OpenCode CLI, and xAI API key (Grok)
 - Five external integrations cost nothing extra when you already have the relevant subscriptions or local runtime (OAuth or local)
 
 ## One Limitation

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,6 +34,7 @@
         "antigravity",
         "agy",
         "copilot",
+        "orcarouter",
         "code-review",
         "automation"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,6 +19,7 @@
     "antigravity",
     "agy",
     "copilot",
+    "orcarouter",
     "code-review",
     "automation"
   ],

--- a/.claude/skills/skill-parallel-agents/SKILL.md
+++ b/.claude/skills/skill-parallel-agents/SKILL.md
@@ -624,6 +624,7 @@ The `tangle` phase enforces quality gates:
 | `agy-research` | service-selected default | Research-focused Antigravity seat |
 | `codex-review` | gpt-5.6-sol | Code review mode |
 | `openrouter` | Various | Universal fallback (400+ models) |
+| `orcarouter` | Various | Universal fallback via OrcaRouter gateway |
 
 ## Provider-Aware Routing (v4.8)
 
@@ -637,6 +638,7 @@ Claude Octopus now intelligently routes tasks based on your subscription tiers a
 | **Antigravity** | Google access/subscription | Included with access | code, analysis, external review |
 | **Claude** | Pro, Max 5x, Max 20x, API | $20-200 | code, chat, analysis, long-context |
 | **OpenRouter** | Pay-per-use | Variable | 400+ models, routing variants |
+| **OrcaRouter** | Pay-per-use | Variable | Single gateway, namespaced model IDs |
 
 ### Cost Optimization Strategies
 
@@ -698,6 +700,9 @@ providers:
     enabled: false
     routing_preference: "default"   # default|nitro|floor
 
+  orcarouter:
+    enabled: false
+
 cost_optimization:
   strategy: "balanced"  # cost-first|quality-first|balanced
 ```
@@ -709,6 +714,18 @@ OpenRouter provides 400+ models as a universal fallback when direct external CLI
 ```bash
 # Set up OpenRouter API key
 export OPENROUTER_API_KEY="sk-or-..."
+
+# Re-run setup to configure
+${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh setup
+```
+
+### OrcaRouter Fallback
+
+OrcaRouter provides a single gateway to many models as a universal fallback when direct external CLIs are unavailable:
+
+```bash
+# Set up OrcaRouter API key
+export ORCAROUTER_API_KEY="sk-orca-..."
 
 # Re-run setup to configure
 ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh setup

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-octopus",
   "version": "9.64.0",
-  "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Antigravity, Grok, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
+  "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Antigravity, Grok, Copilot, Qwen, Perplexity, OpenRouter, OrcaRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"
   },
@@ -22,6 +22,7 @@
     "ollama",
     "perplexity",
     "openrouter",
+    "orcarouter",
     "multi-provider",
     "provider-routing",
     "adversarial-review",
@@ -33,8 +34,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Claude Octopus",
-    "shortDescription": "Multi-LLM orchestration \u2014 dispatch to 9 providers from one plugin.",
-    "longDescription": "Claude Octopus orchestrates nine external AI providers (Codex, Antigravity, Grok, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode) through structured Double Diamond workflows. 32 personas, 54 commands, 63 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch includes prompt-size preflight, agent summary tables, circuit breakers, cost tracking, and model routing.",
+    "shortDescription": "Multi-LLM orchestration \u2014 dispatch to 10 providers from one plugin.",
+    "longDescription": "Claude Octopus orchestrates ten external AI providers (Codex, Antigravity, Grok, Copilot, Qwen, Perplexity, OpenRouter, OrcaRouter, Ollama, and OpenCode) through structured Double Diamond workflows. 32 personas, 54 commands, 63 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch includes prompt-size preflight, agent summary tables, circuit breakers, cost tracking, and model routing.",
     "composerIcon": "./assets/octopus-icon.svg",
     "developerName": "nyldn",
     "category": "Orchestration",

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,15 +1,50 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-14
-Status: Issue #916 and all current review findings are implemented and locally
-verified; the revoked credential alert remains open until the fix is merged and
-the alert is marked resolved.
-Branch: `fix/916-safe-github-comments`
+Status: PR #877's OrcaRouter provider and all verified review remediations are
+rebased onto current `upstream/main`; the final combined local gate passes.
+Branch: `fix/877-orcarouter-review`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
-Tracking: [issue #916](https://github.com/nyldn/claude-octopus/issues/916) and
-[PR #918](https://github.com/nyldn/claude-octopus/pull/918)
-Next action: wait for matching-head remote checks, merge PR #918, then resolve
-GitHub secret-scanning alert #1 as revoked. Release remains deferred.
+Tracking: [PR #877](https://github.com/nyldn/claude-octopus/pull/877)
+Next action: resolve current review threads, wait for matching-head remote
+checks, and merge PR #877. Release remains deferred.
+
+## PR #877: OrcaRouter Provider
+
+- Provider contract: OrcaRouter is an explicit, named, API-only integration;
+  it does not auto-activate. Dispatch uses the configured allowlist and
+  cheapest-first model fallback through the OpenAI-compatible gateway.
+- Configuration safety: setup reads keys silently, stores them through the
+  persistent-secret helper with mode `0600`, updates atomically, and does not
+  leak the caller's `umask`. Stale shell configuration is parsed as literal
+  assignments only; dynamic shell expressions are rejected rather than run.
+- Wiring: detection, health, status, council, smoke, routing, quota reporting,
+  marketplace metadata, public provider facts, and generated skill surfaces
+  all share the suffixed `orcarouter*` resolver and enabled-plus-key contract.
+- Review response: model execution is allowlisted, retry arithmetic is safe
+  under `set -e`, provider resolution is loaded before standalone detection,
+  status capture and paths are quoted, and release/documentation assertions
+  are explicit. The first combined gate then exposed that dispatch emitted the
+  new shell function while command validation rejected it; the validator now
+  accepts only the two exact OrcaRouter function names and rejects lookalikes.
+  The round-trip regression passes 6/6 and command validation passes 44/44.
+  No known review finding remains unaddressed in the local head.
+- Focused evidence: OrcaRouter passes 17/17; release sync 8/8; provider registry
+  contracts 14/14; shipped model resolution 7/7; shared marketplace 17/17; AGY
+  50/50; availability 15/15; provider contract audit 4/4; auth validity 18/18;
+  and council model selection 10/10. `make sync-check`, ShellCheck error-level
+  analysis, and `git diff --check` pass.
+- Final-gate evidence: after reproducing and fixing the dispatch-validator gap,
+  a fresh `make ci-local` passed 16/16 smoke suites, 273/273 unit suites, and
+  7/7 integration suites plus all CI-only verifications. Council passed 73/74
+  cases with its one documented macOS PTY skip.
+- Delivery constraint: the GitHub PR head belongs to contributor
+  `Marc-oss-hub`. Its pre-update SHA is
+  `32d6ee861cab98bafe2d1d7ee26b974e306fb113`; push only with an exact
+  force-with-lease after re-verifying that SHA. A contributor-owned branch may
+  remain after merge if repository maintainers cannot delete it.
+- Tracking blocker: Beads remains blocked by its pending schema migration. No
+  migration was run.
 
 ## Issue #916: Fail-Closed Outbound GitHub Text
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,13 +1,14 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-14
-Status: PR #877's OrcaRouter provider and all verified review remediations are
+Status: PR #877's OrcaRouter provider and all current review remediations are
 rebased onto current `upstream/main`; the final combined local gate passes.
 Branch: `fix/877-orcarouter-review`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [PR #877](https://github.com/nyldn/claude-octopus/pull/877)
-Next action: resolve current review threads, wait for matching-head remote
-checks, and merge PR #877. Release remains deferred.
+Next action: commit and push the current review-fix head, resolve the seven
+verified review threads, wait for matching-head remote checks, and merge PR
+#877. Release remains deferred.
 
 ## PR #877: OrcaRouter Provider
 
@@ -28,8 +29,14 @@ checks, and merge PR #877. Release remains deferred.
   new shell function while command validation rejected it; the validator now
   accepts only the two exact OrcaRouter function names and rejects lookalikes.
   The round-trip regression passes 6/6 and command validation passes 44/44.
-  No known review finding remains unaddressed in the local head.
-- Focused evidence: OrcaRouter passes 17/17; release sync 8/8; provider registry
+  CodeRabbit's next review produced seven findings. Each was checked against
+  the current code before editing: provider status and Council now share one
+  explicit enabled-plus-key gate; secret persistence replaces both plain and
+  `export` assignments; Sonnet 4.6 records its verified 1M context; empty API
+  responses fail; interrupt cleanup runs through an isolated EXIT trap; and
+  the resolver/temp-fixture tests use their documented contracts. No known
+  review finding remains unaddressed in the local head.
+- Focused evidence: OrcaRouter passes 22/22; release sync 8/8; provider registry
   contracts 14/14; shipped model resolution 7/7; shared marketplace 17/17; AGY
   50/50; availability 15/15; provider contract audit 4/4; auth validity 18/18;
   and council model selection 10/10. `make sync-check`, ShellCheck error-level
@@ -39,8 +46,8 @@ checks, and merge PR #877. Release remains deferred.
   7/7 integration suites plus all CI-only verifications. Council passed 73/74
   cases with its one documented macOS PTY skip.
 - Delivery constraint: the GitHub PR head belongs to contributor
-  `Marc-oss-hub`. Its pre-update SHA is
-  `32d6ee861cab98bafe2d1d7ee26b974e306fb113`; push only with an exact
+  `Marc-oss-hub`. Its current remote SHA before this review-fix push is
+  `4d61e17ef896b9ade3440bc19a766e1496d6d1ed`; push only with an exact
   force-with-lease after re-verifying that SHA. A contributor-owned branch may
   remain after merge if repository maintainers cannot delete it.
 - Tracking blocker: Beads remains blocked by its pending schema migration. No

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,7 +6,7 @@ last_reviewed: 2026-08-13
 
 ## Mission
 
-Make up to 9 external AI integrations available for explicit escalation, so blind spots surface on the work that warrants multi-model scrutiny without taxing every ordinary task.
+Make up to 10 external AI integrations available for explicit escalation, so blind spots surface on the work that warrants multi-model scrutiny without taxing every ordinary task.
 
 ## Vision
 
@@ -35,7 +35,7 @@ Claude Octopus is a **multi-runtime orchestration plugin** with three architectu
 
 | Layer | What it does | Gap it closes |
 |-------|-------------|---------------|
-| **Provider adapters** (`scripts/orchestrate.sh`, `bin/check-providers.sh`) | Detects, authenticates, and dispatches to up to 9 external AI integrations | Eliminates manual per-provider boilerplate |
+| **Provider adapters** (`scripts/orchestrate.sh`, `bin/check-providers.sh`) | Detects, authenticates, and dispatches to up to 10 external AI integrations | Eliminates manual per-provider boilerplate |
 | **Workflow engine** (`skills/`) | Structures every task into Discover → Define → Develop → Deliver with quality gates | Stops ad-hoc "just ask Claude" from shipping low-confidence output |
 | **Consensus layer** | 75% gate: flags disagreements across providers before code is finalized | The actual blind-spot catcher — surfaces the 1-in-5 case where Claude was wrong |
 
@@ -43,7 +43,7 @@ Claude Octopus is a **multi-runtime orchestration plugin** with three architectu
 
 ## Core Value Propositions
 
-- **Blind spot elimination:** Any model can be wrong; 9 external integrations rarely agree on the same wrong answer
+- **Blind spot elimination:** Any model can be wrong; 10 external integrations rarely agree on the same wrong answer
 - **Zero-friction escalation:** Claude-native for ordinary tasks, Octopus for anything that deserves a second opinion
 - **Four providers can cost nothing extra when you already have access:** Codex (OAuth), Antigravity CLI, Copilot (GitHub subscription), and Ollama (local) — Qwen now requires API-key or Coding-Plan auth, while Perplexity and OpenRouter are metered
 - **Dark Factory autonomy:** Spec in, software out — full Discover→Define→Develop→Deliver pipeline without step-by-step prompting

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐙 Claude Octopus
 
-Every AI model has blind spots. Claude Octopus supports nine external provider integrations — Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok — alongside the built-in Claude Code host, with consensus gates that flag disagreements before you ship.
+Every AI model has blind spots. Claude Octopus supports ten external provider integrations — Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, and Grok — alongside the built-in Claude Code host, with consensus gates that flag disagreements before you ship.
 
 **Claude-native first, Octopus for escalation.** Use Claude-native `/init`, `/review`, and `/security-review` when Claude is enough. Use Octopus when you want multiple model opinions, adversarial review, or stricter multi-LLM workflows.
 
@@ -16,7 +16,7 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
 
-🐙 **Research, build, review, and ship — with nine external providers checking the host's work.** Claude-native handles the ordinary path. Octopus remains dormant until you explicitly run `/octo:*`, then handles the escalated path. A 75% consensus gate catches disagreements before they reach production.
+🐙 **Research, build, review, and ship — with ten external providers checking the host's work.** Claude-native handles the ordinary path. Octopus remains dormant until you explicitly run `/octo:*`, then handles the escalated path. A 75% consensus gate catches disagreements before they reach production.
 
 🧠 **Remembers across sessions.** Integrates with [claude-mem](https://github.com/thedotmack/claude-mem) and [agentmemory](https://github.com/rohitg00/agentmemory) for persistent memory — past decisions, research, and context survive session boundaries.
 
@@ -26,7 +26,7 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
 
 🐙 **32 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **54 commands** (slash commands you type), **63 skills** (reusable workflow modules). Explicit workflows select the experts they need; ordinary Claude requests do not activate Octopus.
 
-🐙 **Works with just Claude. Adds up to nine external provider integrations.** Zero external providers are needed to start. Add them one at a time — each becomes available when detected and runs only inside an explicit workflow.
+🐙 **Works with just Claude. Adds up to ten external provider integrations.** Zero external providers are needed to start. Add them one at a time — each becomes available when detected and runs only inside an explicit workflow.
 
 💰 **Four providers cost nothing extra when you already have access.** Codex, Antigravity CLI, and Copilot use existing subscriptions or local auth. Ollama runs locally for free. Qwen now requires API-key or Coding-Plan auth; its free OAuth tier ended on 2026-04-15.
 
@@ -58,7 +58,7 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
 | **v9.64.0** (new) | Keep Octopus dormant until explicitly invoked. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
-| **v9** | Up to 9 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Explicit-only activation by default, with an optional smart router. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Opt-in discipline gates and token compression. Two-stage review. Circuit breakers with automatic provider recovery inside active workflows. Cursor + OpenCode + Codex cross-compatibility. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |
+| **v9** | Up to 10 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Explicit-only activation by default, with an optional smart router. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Opt-in discipline gates and token compression. Two-stage review. Circuit breakers with automatic provider recovery inside active workflows. Cursor + OpenCode + Codex cross-compatibility. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |
 | **v8** | Multi-LLM code review with inline PR comments. Parallel workstreams in isolated git worktrees. Reaction engine — auto-responds to CI failures. 32 specialized personas. Dark Factory autonomous pipeline. |
 | **v7** | Double Diamond workflow. Multi-provider dispatch. Quality gates and consensus scoring. Configurable sandbox modes. |
 
@@ -394,7 +394,7 @@ Or type `/octo:auto <what you want>` and the smart router picks for you. Plain-p
 
 ### How 10 External Providers Work Together
 
-Claude Octopus coordinates nine external provider integrations alongside the built-in Claude Code host. The optional `claude-sdk` route is a second Anthropic seat, so it is shown below but is not counted as a separate provider family.
+Claude Octopus coordinates ten external provider integrations alongside the built-in Claude Code host. The optional `claude-sdk` route is a second Anthropic seat, so it is shown below but is not counted as a separate provider family.
 
 | Provider | Role |
 |----------|------|

--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Claude Octopus coordinates ten external provider integrations alongside the buil
 | 🧭 Antigravity CLI (`agy`) | Google Antigravity perspective via native stdin print-mode dispatch |
 | 🟣 Perplexity | Live web search — CVE lookups, dependency research, current docs |
 | 🌐 OpenRouter | Alternative model routing — access 100+ models via single API |
+| 🐋 OrcaRouter | OpenAI-compatible gateway routing with policy enforcement and model fallbacks |
 | 🟢 Copilot (GitHub) | Zero-cost research — uses existing GitHub Copilot subscription |
 | 🟤 Qwen (Alibaba) | Qwen3-Coder research via API-key or Coding-Plan auth |
 | ⚫ Ollama (Local) | Zero-cost local LLM — offline, privacy-sensitive, fallback |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,6 +37,7 @@ Claude Octopus coordinates **ten external AI integrations** alongside its built-
 | **Claude** | Built-in | Claude Sonnet 5 / Opus 5 | Your Claude Code subscription or API account |
 | **Perplexity** | API-only | Sonar Pro / Sonar | Your `PERPLEXITY_API_KEY` |
 | **OpenRouter** | API-only | 100+ models (GLM-5, Kimi K2.5, DeepSeek R1, etc.) | Your `OPENROUTER_API_KEY` |
+| **OrcaRouter** | API-only | Namespaced Claude models via an OpenAI-compatible gateway | Your `ORCAROUTER_API_KEY` |
 | **Ollama** *(optional)* | `ollama run <model>` | Local models (llama3.3, mistral, etc.) | Free (local) |
 | **Copilot** *(optional)* | `copilot -p` | GitHub models (Claude/GPT/Google models) | GitHub Copilot subscription |
 | **Qwen** *(optional)* | `qwen -p` | Qwen3-Coder | `QWEN_API_KEY` or Coding-Plan auth |
@@ -75,6 +76,7 @@ Role defaults follow the accepted [frontier model routing strategy](./MODEL-ROUT
 | **Claude (Sonnet 5)** | Aggregation, final synthesis, workhorse summarization | `synthesizer`; included where the user's Claude Code subscription covers it |
 | **Perplexity** | Live web search, CVE lookups, current docs | Discover phase research, dependency analysis |
 | **OpenRouter** | Access to 100+ models, cost routing | Alternative perspectives, budget-conscious workflows |
+| **OrcaRouter** | Policy-enforced gateway routing | Governed fallback dispatch and independent model perspectives |
 | **Ollama** *(optional)* | Zero-cost, offline, privacy | Brainstorming, fallback, air-gapped environments |
 | **Qwen** *(optional)* | Qwen3-Coder via API-key or Coding-Plan auth, Chinese language support | Research and code review when Qwen credentials are configured |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This document explains how Claude Octopus orchestrates multiple AI providers and
 
 ## Overview
 
-Claude Octopus coordinates **nine external AI integrations** alongside its built-in Claude host to give you multi-perspective analysis. The diagram shows the representative execution path; the full roster follows it.
+Claude Octopus coordinates **ten external AI integrations** alongside its built-in Claude host to give you multi-perspective analysis. The diagram shows the representative execution path; the full roster follows it.
 
 ```
     +------------------+

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -32,7 +32,7 @@ Plus, usually:
 
 ## Current providers
 
-codex, agy (Antigravity, Google seat), claude, claude-sdk (Agent SDK seat), perplexity, openrouter, atlascloud, openai-compatible-agent, ollama, copilot, qwen, cursor-agent, grok, vibe, opencode.
+codex, agy (Antigravity, Google seat), claude, claude-sdk (Agent SDK seat), perplexity, openrouter, orcarouter, atlascloud, openai-compatible-agent, ollama, copilot, qwen, cursor-agent, grok, vibe, opencode.
 
 Retired `gemini` and `gemini-*` IDs are accepted only as compatibility aliases and canonicalize to `agy`. They are not executable providers, are never probed, and are not written to new configuration.
 

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -233,6 +233,9 @@ if [[ "${OCTOPUS_PREFLIGHT_PROBE:-0}" == "1" ]] && declare -f octo_provider_prob
 fi
 provider_status "openrouter" "$([ -n "${OPENROUTER_API_KEY:-}" ] && echo available || echo missing)"
 # orcarouter: API-key gateway (OpenAI-compatible), same shape as openrouter.
+if [[ -z "${ORCAROUTER_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
+    resolve_provider_env "ORCAROUTER_API_KEY" 2>/dev/null || true
+fi
 if [[ "${OCTOPUS_PREFLIGHT_PROBE:-0}" == "1" ]] && declare -f octo_provider_probe >/dev/null 2>&1 \
    && { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "orcarouter"; }; then
     [ -n "${ORCAROUTER_API_KEY:-}" ] && octo_provider_probe "orcarouter" || true

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -233,12 +233,14 @@ if [[ "${OCTOPUS_PREFLIGHT_PROBE:-0}" == "1" ]] && declare -f octo_provider_prob
 fi
 provider_status "openrouter" "$([ -n "${OPENROUTER_API_KEY:-}" ] && echo available || echo missing)"
 # orcarouter: API-key gateway (OpenAI-compatible), same shape as openrouter.
-if [[ -z "${ORCAROUTER_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
-    resolve_provider_env "ORCAROUTER_API_KEY" 2>/dev/null || true
+orcarouter_state="missing"
+if declare -f octo_api_key_provider_is_available >/dev/null 2>&1 && \
+   octo_api_key_provider_is_available "orcarouter" "ORCAROUTER_API_KEY"; then
+    orcarouter_state="available"
 fi
 if [[ "${OCTOPUS_PREFLIGHT_PROBE:-0}" == "1" ]] && declare -f octo_provider_probe >/dev/null 2>&1 \
-   && { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "orcarouter"; }; then
-    [ -n "${ORCAROUTER_API_KEY:-}" ] && octo_provider_probe "orcarouter" || true
+   && [[ "$orcarouter_state" == "available" ]]; then
+    octo_provider_probe "orcarouter" || true
 fi
-provider_status "orcarouter" "$([ -n "${ORCAROUTER_API_KEY:-}" ] && echo available || echo missing)"
+provider_status "orcarouter" "$orcarouter_state"
 echo "PROVIDER_CHECK_END"

--- a/scripts/helpers/check-providers.sh
+++ b/scripts/helpers/check-providers.sh
@@ -232,4 +232,10 @@ if [[ "${OCTOPUS_PREFLIGHT_PROBE:-0}" == "1" ]] && declare -f octo_provider_prob
     [ -n "${OPENROUTER_API_KEY:-}" ] && octo_provider_probe "openrouter" || true
 fi
 provider_status "openrouter" "$([ -n "${OPENROUTER_API_KEY:-}" ] && echo available || echo missing)"
+# orcarouter: API-key gateway (OpenAI-compatible), same shape as openrouter.
+if [[ "${OCTOPUS_PREFLIGHT_PROBE:-0}" == "1" ]] && declare -f octo_provider_probe >/dev/null 2>&1 \
+   && { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed "orcarouter"; }; then
+    [ -n "${ORCAROUTER_API_KEY:-}" ] && octo_provider_probe "orcarouter" || true
+fi
+provider_status "orcarouter" "$([ -n "${ORCAROUTER_API_KEY:-}" ] && echo available || echo missing)"
 echo "PROVIDER_CHECK_END"

--- a/scripts/lib/config-display.sh
+++ b/scripts/lib/config-display.sh
@@ -268,6 +268,42 @@ toggle_knowledge_work_mode() {
 # Extracted from orchestrate.sh (v9.7.8)
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# Persist one provider secret without echoing it to the terminal. The existing
+# non-interactive resolver reads ~/.env, so values stored here are also visible
+# to health checks and provider detection in later sessions.
+persist_provider_secret() (
+    local var_name="$1"
+    local value="$2"
+    local env_file="${OCTOPUS_SECRET_ENV_FILE:-${HOME}/.env}"
+    local env_dir=""
+    local temp_file=""
+
+    [[ "$var_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+    [[ -n "$value" && "$value" != *$'\n'* && "$value" != *$'\r'* ]] || return 1
+
+    env_dir=$(dirname "$env_file")
+    umask 077
+    mkdir -p "$env_dir" || return 1
+    temp_file=$(mktemp "${env_file}.tmp.XXXXXX") || return 1
+
+    if [[ -f "$env_file" ]]; then
+        awk -v name="$var_name" 'index($0, name "=") != 1 { print }' \
+            "$env_file" > "$temp_file" || {
+            rm -f "$temp_file"
+            return 1
+        }
+    fi
+    printf '%s=%s\n' "$var_name" "$value" >> "$temp_file" || {
+        rm -f "$temp_file"
+        return 1
+    }
+    chmod 600 "$temp_file" || {
+        rm -f "$temp_file"
+        return 1
+    }
+    mv -f "$temp_file" "$env_file"
+)
+
 # Interactive setup wizard
 setup_wizard() {
     # Detect if running in non-interactive mode (e.g., called by Claude Code)
@@ -557,18 +593,27 @@ setup_wizard() {
         if [[ "${NON_INTERACTIVE}" != "true" ]] && [[ $REPLY =~ ^[Yy]$ ]]; then
             echo -e "  ${CYAN}→${NC} Get an API key from: https://www.orcarouter.ai"
             echo ""
-            read -p "  Paste your OrcaRouter API key (starts with 'sk-orca-'): " orcarouter_key
+            read -r -s -p "  Paste your OrcaRouter API key (starts with 'sk-orca-'): " orcarouter_key
+            echo
             if [[ -n "$orcarouter_key" ]]; then
-                export ORCAROUTER_API_KEY="$orcarouter_key"
-                keys_to_add="${keys_to_add}export ORCAROUTER_API_KEY=\"$orcarouter_key\"\n"
+                export "ORCAROUTER_API_KEY=${orcarouter_key}"
                 PROVIDER_ORCAROUTER_ENABLED="true"
                 PROVIDER_ORCAROUTER_API_KEY_SET="true"
                 echo -e "  ${GREEN}✓${NC} ORCAROUTER_API_KEY set for this session"
+                read -p "  Save it to ~/.env with mode 600? [Y/n] " -n 1 -r
+                echo
+                if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+                    if persist_provider_secret "ORCAROUTER_API_KEY" "$orcarouter_key"; then
+                        echo -e "  ${GREEN}✓${NC} Saved ORCAROUTER_API_KEY securely to ~/.env"
+                    else
+                        echo -e "  ${RED}✗${NC} Could not persist ORCAROUTER_API_KEY" >&2
+                    fi
+                fi
             else
                 echo -e "  ${YELLOW}⚠${NC} Skipped OrcaRouter configuration"
             fi
         else
-            echo -e "  ${YELLOW}⚠${NC} OrcaRouter skipped. Add later: export ORCAROUTER_API_KEY=\"your-key\""
+            echo -e "  ${YELLOW}⚠${NC} OrcaRouter skipped. Add later: export \"ORCAROUTER_API_KEY=your-key\""
         fi
     fi
     echo ""

--- a/scripts/lib/config-display.sh
+++ b/scripts/lib/config-display.sh
@@ -107,6 +107,22 @@ show_config_summary() {
     fi
     echo ""
 
+    # OrcaRouter Status
+    echo -e "  ${CYAN}┌─ ORCAROUTER (Universal Fallback)${NC}"
+    if [[ "$PROVIDER_ORCAROUTER_ENABLED" == "true" && "$PROVIDER_ORCAROUTER_API_KEY_SET" == "true" ]]; then
+        echo -e "  ${CYAN}│${NC}  ${GREEN}✓${NC} Configured (Optional)"
+        if [[ -n "${ORCAROUTER_API_KEY:-}" ]]; then
+            local masked_orca_key
+            masked_orca_key=$(mask_api_key "$ORCAROUTER_API_KEY")
+            echo -e "  ${CYAN}│${NC}  API Key:   ${YELLOW}$masked_orca_key${NC}"
+        fi
+    else
+        echo -e "  ${CYAN}│${NC}  ${YELLOW}○${NC} Not configured (Optional)"
+        echo -e "  ${CYAN}│${NC}  ${YELLOW}→${NC} Sign up: ${CYAN}https://www.orcarouter.ai${NC}"
+        echo -e "  ${CYAN}│${NC}  ${YELLOW}→${NC} Set: ${CYAN}export ORCAROUTER_API_KEY='sk-orca-...'${NC}"
+    fi
+    echo ""
+
     # Cost Optimization Strategy
     echo -e "  ${CYAN}┌─ COST OPTIMIZATION${NC}"
     echo -e "  ${CYAN}│${NC}  Strategy:  ${GREEN}$COST_OPTIMIZATION_STRATEGY${NC}"
@@ -271,7 +287,7 @@ setup_wizard() {
     echo -e "  This wizard will help you install dependencies and configure API keys."
     echo ""
 
-    local total_steps=10
+    local total_steps=11
     local current_step=0
     local shell_profile=""
     local keys_to_add=""
@@ -291,6 +307,8 @@ setup_wizard() {
     PROVIDER_CLAUDE_COST_TIER="medium"
     PROVIDER_OPENROUTER_ENABLED="false"
     PROVIDER_OPENROUTER_API_KEY_SET="false"
+    PROVIDER_ORCAROUTER_ENABLED="false"
+    PROVIDER_ORCAROUTER_API_KEY_SET="false"
     COST_OPTIMIZATION_STRATEGY="balanced"
 
     # Detect shell profile
@@ -511,6 +529,46 @@ setup_wizard() {
             fi
         else
             echo -e "  ${YELLOW}⚠${NC} OpenRouter skipped. Add later: export OPENROUTER_API_KEY=\"your-key\""
+        fi
+    fi
+    echo ""
+
+    # ═══════════════════════════════════════════════════════════════════════════
+    # STEP 8b: OrcaRouter (Universal Fallback, OpenAI-compatible)
+    # ═══════════════════════════════════════════════════════════════════════════
+    ((++current_step))
+    echo -e "${CYAN}Step $current_step/$total_steps: OrcaRouter (Universal Fallback)${NC}"
+    echo -e "  ${YELLOW}OrcaRouter provides a single gateway to many models as a backup when other CLIs are unavailable.${NC}"
+    echo ""
+
+    if [[ -n "${ORCAROUTER_API_KEY:-}" ]]; then
+        PROVIDER_ORCAROUTER_ENABLED="true"
+        PROVIDER_ORCAROUTER_API_KEY_SET="true"
+        echo -e "  ${GREEN}✓${NC} ORCAROUTER_API_KEY already set"
+    else
+        if [[ "$NON_INTERACTIVE" == "true" ]]; then
+            echo -e "  ${YELLOW}⚠${NC} OrcaRouter not configured (optional - skipping in auto mode)"
+        else
+            echo -e "  ${YELLOW}✗${NC} ORCAROUTER_API_KEY not set (optional)"
+            echo ""
+            read -p "  Configure OrcaRouter? [y/N] " -n 1 -r
+            echo
+        fi
+        if [[ "${NON_INTERACTIVE}" != "true" ]] && [[ $REPLY =~ ^[Yy]$ ]]; then
+            echo -e "  ${CYAN}→${NC} Get an API key from: https://www.orcarouter.ai"
+            echo ""
+            read -p "  Paste your OrcaRouter API key (starts with 'sk-orca-'): " orcarouter_key
+            if [[ -n "$orcarouter_key" ]]; then
+                export ORCAROUTER_API_KEY="$orcarouter_key"
+                keys_to_add="${keys_to_add}export ORCAROUTER_API_KEY=\"$orcarouter_key\"\n"
+                PROVIDER_ORCAROUTER_ENABLED="true"
+                PROVIDER_ORCAROUTER_API_KEY_SET="true"
+                echo -e "  ${GREEN}✓${NC} ORCAROUTER_API_KEY set for this session"
+            else
+                echo -e "  ${YELLOW}⚠${NC} Skipped OrcaRouter configuration"
+            fi
+        else
+            echo -e "  ${YELLOW}⚠${NC} OrcaRouter skipped. Add later: export ORCAROUTER_API_KEY=\"your-key\""
         fi
     fi
     echo ""

--- a/scripts/lib/config-display.sh
+++ b/scripts/lib/config-display.sh
@@ -287,7 +287,14 @@ persist_provider_secret() (
     temp_file=$(mktemp "${env_file}.tmp.XXXXXX") || return 1
 
     if [[ -f "$env_file" ]]; then
-        awk -v name="$var_name" 'index($0, name "=") != 1 { print }' \
+        awk -v name="$var_name" '
+            {
+                assignment = $0
+                sub(/^[[:space:]]+/, "", assignment)
+                sub(/^export[[:space:]]+/, "", assignment)
+                if (index(assignment, name "=") != 1) print
+            }
+        ' \
             "$env_file" > "$temp_file" || {
             rm -f "$temp_file"
             return 1

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2437,6 +2437,9 @@ council_detect_providers() {
                     # API-key provider, not a CLI binary — no `orcarouter` executable
                     # ships with the plugin. Dispatch goes through the shell function
                     # orcarouter_execute, so probe the key instead of `command -v`.
+                    if [[ -z "${ORCAROUTER_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
+                        resolve_provider_env "ORCAROUTER_API_KEY" 2>/dev/null || true
+                    fi
                     if [[ -n "${ORCAROUTER_API_KEY:-}" ]]; then
                         status="available"
                     else

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2433,6 +2433,16 @@ council_detect_providers() {
                         status="missing"
                     fi
                     ;;
+                orcarouter)
+                    # API-key provider, not a CLI binary — no `orcarouter` executable
+                    # ships with the plugin. Dispatch goes through the shell function
+                    # orcarouter_execute, so probe the key instead of `command -v`.
+                    if [[ -n "${ORCAROUTER_API_KEY:-}" ]]; then
+                        status="available"
+                    else
+                        status="missing"
+                    fi
+                    ;;
                 *)
                     cmd="$(council_provider_command "$provider")"
                     if command -v "$cmd" >/dev/null 2>&1; then

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -65,6 +65,9 @@ _council_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=scripts/lib/benchmark-routing.sh
 source "${_council_lib_dir}/benchmark-routing.sh" 2>/dev/null || true
 source "${_council_lib_dir}/openai-compatible.sh" 2>/dev/null || true
+if ! declare -f octo_api_key_provider_is_available >/dev/null 2>&1; then
+    source "${_council_lib_dir}/provider-routing.sh" 2>/dev/null || true
+fi
 source "${_council_lib_dir}/agent-sync.sh" 2>/dev/null || true
 source "${_council_lib_dir}/features.sh" 2>/dev/null || true
 unset _council_lib_dir
@@ -2436,11 +2439,9 @@ council_detect_providers() {
                 orcarouter)
                     # API-key provider, not a CLI binary — no `orcarouter` executable
                     # ships with the plugin. Dispatch goes through the shell function
-                    # orcarouter_execute, so probe the key instead of `command -v`.
-                    if [[ -z "${ORCAROUTER_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
-                        resolve_provider_env "ORCAROUTER_API_KEY" 2>/dev/null || true
-                    fi
-                    if [[ -n "${ORCAROUTER_API_KEY:-}" ]]; then
+                    # orcarouter_execute, so use the shared enabled-plus-key gate.
+                    if declare -f octo_api_key_provider_is_available >/dev/null 2>&1 && \
+                       octo_api_key_provider_is_available "orcarouter" "ORCAROUTER_API_KEY"; then
                         status="available"
                     else
                         status="missing"

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -298,6 +298,7 @@ get_agent_command() {
             ;;
         claude-opus-legacy) echo "${_claude_bin}${_BARE_OPT} --print --model claude-opus-4-6 ${claude_perm}" ;; # v9.23: explicit 4.6 opt-in
         openrouter) echo "openrouter_execute" ;;                 # OpenRouter API (v4.8)
+        orcarouter) echo "orcarouter_execute" ;;                 # OrcaRouter gateway (OpenAI-compatible)
         openrouter-glm5) echo "openrouter_execute_model z-ai/glm-5" ;;           # v8.11.0: GLM-5 via OpenRouter
         openrouter-kimi) echo "openrouter_execute_model moonshotai/kimi-k2.5" ;; # v8.11.0: Kimi K2.5 via OpenRouter
         openrouter-deepseek) echo "openrouter_execute_model deepseek/deepseek-v4-pro" ;;
@@ -519,6 +520,7 @@ get_provider_context_limit() {
         claude)     echo "${OCTOPUS_CLAUDE_CONTEXT_BUDGET:-${default_budget}}" ;;
         perplexity) echo "${OCTOPUS_PERPLEXITY_CONTEXT_BUDGET:-${default_budget}}" ;;
         openrouter) echo "${OCTOPUS_OPENROUTER_CONTEXT_BUDGET:-${default_budget}}" ;;
+        orcarouter) echo "${OCTOPUS_ORCAROUTER_CONTEXT_BUDGET:-${default_budget}}" ;;
         atlascloud) echo "${OCTOPUS_ATLASCLOUD_CONTEXT_BUDGET:-${default_budget}}" ;;
         copilot)    echo "${OCTOPUS_COPILOT_CONTEXT_BUDGET:-${default_budget}}" ;;
         qwen)       echo "${OCTOPUS_QWEN_CONTEXT_BUDGET:-${default_budget}}" ;;
@@ -702,6 +704,7 @@ get_agent_model() {
         claude-sdk*) provider="claude-sdk" ;;  # v9.50.0: must precede claude* glob
         claude*)     provider="claude" ;;
         openrouter*) provider="openrouter" ;;
+        orcarouter*) provider="orcarouter" ;;
         atlascloud*) provider="atlascloud" ;;
         openai-compatible|openai-tools|openai-compatible-agent*) provider="openai-compatible-agent" ;;
         commandcode*) provider="commandcode" ;;
@@ -755,6 +758,7 @@ validate_model_allowed() {
         claude-sdk) allowlist_var="OCTOPUS_CLAUDE_SDK_ALLOWED_MODELS" ;;
         claude)     allowlist_var="OCTOPUS_CLAUDE_ALLOWED_MODELS" ;;
         openrouter) allowlist_var="OCTOPUS_OPENROUTER_ALLOWED_MODELS" ;;
+        orcarouter) allowlist_var="OCTOPUS_ORCAROUTER_ALLOWED_MODELS" ;;
         atlascloud) allowlist_var="ATLASCLOUD_ALLOWED_MODELS" ;;
         openai-compatible|openai-tools|openai-compatible-agent) allowlist_var="OPENAI_COMPAT_ALLOWED_MODELS" ;;
         perplexity) allowlist_var="OCTOPUS_PERPLEXITY_ALLOWED_MODELS" ;;
@@ -939,6 +943,8 @@ find_capable_fallback() {
             candidates=(claude-haiku-4.5 claude-sonnet-5 claude-opus-4.8 claude-opus-5) ;;
         openrouter)
             candidates=(z-ai/glm-5 moonshotai/kimi-k2.5 deepseek/deepseek-v4-pro deepseek/deepseek-r1-0528) ;;
+        orcarouter)
+            candidates=(anthropic/claude-haiku-4.5 anthropic/claude-sonnet-4.6 anthropic/claude-opus-4.8) ;;
         perplexity)
             candidates=(sonar sonar-pro) ;;
         cursor-agent)

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -183,7 +183,7 @@ validate_model_name_for_provider() {
 
 _octo_is_known_provider_name() {
     case "$1" in
-        codex|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|cursor-agent|commandcode|vibe|agy|agy-research|antigravity)
+        codex|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|orcarouter|cursor-agent|commandcode|vibe|agy|agy-research|antigravity)
             return 0 ;;
         *)
             return 1 ;;
@@ -513,6 +513,7 @@ resolve_octopus_model() {
             openrouter-kimi*) resolved_model="moonshotai/kimi-k2.5" ;;
             openrouter-deepseek*) resolved_model="deepseek/deepseek-v4-pro" ;;
             openrouter)      resolved_model="anthropic/claude-sonnet-4" ;; # bare OpenRouter needs a namespaced ID, not an OpenAI model string (#797)
+            orcarouter*)     resolved_model="anthropic/claude-sonnet-4.6" ;; # bare OrcaRouter needs a namespaced ID, not an OpenAI model string (#797)
             openai-compatible|openai-tools|openai-compatible-agent*)
                 if [[ -z "${OPENAI_COMPAT_MODEL:-}" ]]; then
                     log ERROR "OPENAI_COMPAT_MODEL or providers.json openai-compatible-agent.default is required"
@@ -630,6 +631,9 @@ is_agent_available_v2() {
             ;;
         openrouter|openrouter-*)
             [[ "$PROVIDER_OPENROUTER_ENABLED" == "true" && "$PROVIDER_OPENROUTER_API_KEY_SET" == "true" ]]
+            ;;
+        orcarouter|orcarouter-*)
+            [[ "$PROVIDER_ORCAROUTER_ENABLED" == "true" && "$PROVIDER_ORCAROUTER_API_KEY_SET" == "true" ]]
             ;;
         openai-compatible|openai-tools|openai-compatible-agent*)
             declare -f openai_compatible_is_available >/dev/null 2>&1 && openai_compatible_is_available

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -60,6 +60,10 @@ get_model_catalog() {
         moonshotai/kimi-k2.5)   echo "262|yes|yes|no|openrouter|standard|active" ;;
         deepseek/deepseek-v4-pro)  echo "1000|yes|no|yes|openrouter|standard|active" ;;
         deepseek/deepseek-r1-0528) echo "164|yes|no|yes|openrouter|standard|legacy" ;;
+        # OrcaRouter (gateway exposes anthropic/* namespace)
+        anthropic/claude-sonnet-4.6) echo "200|yes|yes|no|orcarouter|standard|active" ;;
+        anthropic/claude-opus-4.8)   echo "1000|yes|yes|yes|orcarouter|premium|active" ;;
+        anthropic/claude-haiku-4.5)  echo "200|yes|yes|yes|orcarouter|budget|active" ;;
         # OpenCode (multi-provider router — models use opencode/<model> namespace)
         opencode/deepseek-v4-flash-free) echo "128|yes|no|no|opencode|budget|active" ;;
         opencode/gpt-5.4)       echo "400|yes|yes|no|opencode|premium|active" ;;

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -61,7 +61,7 @@ get_model_catalog() {
         deepseek/deepseek-v4-pro)  echo "1000|yes|no|yes|openrouter|standard|active" ;;
         deepseek/deepseek-r1-0528) echo "164|yes|no|yes|openrouter|standard|legacy" ;;
         # OrcaRouter (gateway exposes anthropic/* namespace)
-        anthropic/claude-sonnet-4.6) echo "200|yes|yes|no|orcarouter|standard|active" ;;
+        anthropic/claude-sonnet-4.6) echo "1000|yes|yes|no|orcarouter|standard|active" ;;
         anthropic/claude-opus-4.8)   echo "1000|yes|yes|yes|orcarouter|premium|active" ;;
         anthropic/claude-haiku-4.5)  echo "200|yes|yes|yes|orcarouter|budget|active" ;;
         # OpenCode (multi-provider router — models use opencode/<model> namespace)

--- a/scripts/lib/perplexity.sh
+++ b/scripts/lib/perplexity.sh
@@ -176,7 +176,7 @@ openrouter_execute() {
 # First arg is the fixed model ID, remaining args are prompt/task/complexity/output
 # Features: --max-time 60, HTTP status code handling (429 retry w/ Retry-After,
 #           502/503/524 error reporting)
-orcarouter_execute_model() {
+orcarouter_execute_model() (
     local model="$1"
     local prompt="$2"
     local task_type="${3:-general}"
@@ -212,7 +212,10 @@ EOF
 
     # Temporary file for response headers (needed for Retry-After parsing)
     local header_file
-    header_file=$(mktemp "${TMPDIR:-/tmp}/octo-orca-headers.XXXXXX")
+    header_file=$(mktemp "${TMPDIR:-/tmp}/octo-orca-headers.XXXXXX") || return 1
+    trap 'rm -f "$header_file"' EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
 
     local raw_response http_code response
     local attempt=0
@@ -230,7 +233,6 @@ EOF
             -H "X-Title: Claude Octopus" \
             -d "$payload") || {
             log ERROR "OrcaRouter curl failed (timeout or network error, model=$model)"
-            rm -f "$header_file"
             return 1
         }
 
@@ -243,7 +245,6 @@ EOF
             429)
                 if (( attempt + 1 >= max_attempts )); then
                     log ERROR "OrcaRouter rate limited (429) after retry (model=$model)"
-                    rm -f "$header_file"
                     return 1
                 fi
                 # Parse Retry-After header (seconds); default to 5s if absent
@@ -260,31 +261,25 @@ EOF
                 ;;
             502)
                 log ERROR "OrcaRouter bad gateway (502) — upstream provider down (model=$model)"
-                rm -f "$header_file"
                 return 1
                 ;;
             503)
                 log ERROR "OrcaRouter service unavailable (503) — model may be overloaded (model=$model)"
-                rm -f "$header_file"
                 return 1
                 ;;
             524)
                 log ERROR "OrcaRouter timeout (524) — upstream request took too long (model=$model)"
-                rm -f "$header_file"
                 return 1
                 ;;
             *)
                 if [[ "${http_code:0:1}" != "2" ]]; then
                     log ERROR "OrcaRouter HTTP $http_code (model=$model)"
-                    rm -f "$header_file"
                     return 1
                 fi
                 break ;;
         esac
         (( ++attempt ))
     done
-
-    rm -f "$header_file"
 
     # Extract content from OpenAI-compatible nested path .choices[0].message.content.
     local content=""
@@ -299,6 +294,7 @@ EOF
         fi
         log WARN "Empty response from OrcaRouter ($model)"
         echo "$response"
+        return 1
     else
         local result
         result=$(echo "$content" | sed 's/\\n/\n/g; s/\\t/\t/g; s/\\"/"/g')
@@ -308,7 +304,7 @@ EOF
             echo "$result"
         fi
     fi
-}
+)
 
 # OrcaRouter agent wrapper for spawn_agent compatibility
 # Resolves model from task_type/complexity, then calls the core implementation

--- a/scripts/lib/perplexity.sh
+++ b/scripts/lib/perplexity.sh
@@ -169,6 +169,171 @@ openrouter_execute() {
     openrouter_execute_model "$model" "$prompt" "$task_type" "$complexity" "$output_file"
 }
 
+# OrcaRouter model-specific agent wrapper
+# Mirrors openrouter_execute_model against the OrcaRouter gateway
+# (https://api.orcarouter.ai), which is OpenAI-compatible on
+# /v1/chat/completions and accepts namespaced model IDs (anthropic/*, etc.).
+# First arg is the fixed model ID, remaining args are prompt/task/complexity/output
+# Features: --max-time 60, HTTP status code handling (429 retry w/ Retry-After,
+#           502/503/524 error reporting)
+orcarouter_execute_model() {
+    local model="$1"
+    local prompt="$2"
+    local task_type="${3:-general}"
+    local complexity="${4:-2}"
+    local output_file="${5:-}"
+
+    # stdin fallback: probe_single_agent pipes prompt via stdin (#305)
+    if [[ -z "$prompt" && ! -t 0 ]]; then
+        prompt=$(cat)
+    fi
+
+    if [[ -z "${ORCAROUTER_API_KEY:-}" ]]; then
+        log ERROR "ORCAROUTER_API_KEY not set"
+        return 1
+    fi
+
+    [[ "$VERBOSE" == "true" ]] && log DEBUG "OrcaRouter request: model=$model" || true
+
+    # Build JSON payload
+    local escaped_prompt
+    escaped_prompt=$(json_escape "$prompt")
+
+    local payload
+    payload=$(cat << EOF
+{
+  "model": "$model",
+  "messages": [
+    {"role": "user", "content": "$escaped_prompt"}
+  ]
+}
+EOF
+)
+
+    # Temporary file for response headers (needed for Retry-After parsing)
+    local header_file
+    header_file=$(mktemp "${TMPDIR:-/tmp}/octo-orca-headers.XXXXXX")
+
+    local raw_response http_code response
+    local attempt=0
+    local max_attempts=2  # Initial + 1 retry on 429
+
+    while (( attempt < max_attempts )); do
+        raw_response=$(curl -s -X POST "https://api.orcarouter.ai/v1/chat/completions" \
+            --max-time 60 \
+            -w "%{http_code}" \
+            -D "$header_file" \
+            -H "Authorization: Bearer ${ORCAROUTER_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -H "Connection: keep-alive" \
+            -H "HTTP-Referer: https://github.com/nyldn/claude-octopus" \
+            -H "X-Title: Claude Octopus" \
+            -d "$payload") || {
+            log ERROR "OrcaRouter curl failed (timeout or network error, model=$model)"
+            rm -f "$header_file"
+            return 1
+        }
+
+        # Split response body from HTTP status code (last 3 chars)
+        http_code="${raw_response: -3}"
+        response="${raw_response:0:${#raw_response}-3}"
+
+        case "$http_code" in
+            200) break ;;  # Success
+            429)
+                if (( attempt + 1 >= max_attempts )); then
+                    log ERROR "OrcaRouter rate limited (429) after retry (model=$model)"
+                    rm -f "$header_file"
+                    return 1
+                fi
+                # Parse Retry-After header (seconds); default to 5s if absent
+                local retry_after=5
+                local header_val
+                header_val=$(grep -i '^retry-after:' "$header_file" 2>/dev/null | tr -d '\r' | sed 's/[^:]*: *//' | head -n1) || true
+                if [[ -n "$header_val" && "$header_val" =~ ^[0-9]+$ ]]; then
+                    retry_after="$header_val"
+                    # Cap at 30s to avoid hanging
+                    (( retry_after > 30 )) && retry_after=30
+                fi
+                log WARN "OrcaRouter rate limited (429), retrying in ${retry_after}s (model=$model)"
+                sleep "$retry_after"
+                ;;
+            502)
+                log ERROR "OrcaRouter bad gateway (502) — upstream provider down (model=$model)"
+                rm -f "$header_file"
+                return 1
+                ;;
+            503)
+                log ERROR "OrcaRouter service unavailable (503) — model may be overloaded (model=$model)"
+                rm -f "$header_file"
+                return 1
+                ;;
+            524)
+                log ERROR "OrcaRouter timeout (524) — upstream request took too long (model=$model)"
+                rm -f "$header_file"
+                return 1
+                ;;
+            *)
+                if [[ "${http_code:0:1}" != "2" ]]; then
+                    log ERROR "OrcaRouter HTTP $http_code (model=$model)"
+                    rm -f "$header_file"
+                    return 1
+                fi
+                break ;;
+        esac
+        (( attempt++ ))
+    done
+
+    rm -f "$header_file"
+
+    # Extract content from OpenAI-compatible nested path .choices[0].message.content.
+    local content=""
+    if command -v jq &>/dev/null; then
+        content=$(printf '%s' "$response" | jq -re '.choices[0].message.content // empty' 2>/dev/null) || content=""
+    fi
+
+    if [[ -z "$content" ]]; then
+        if [[ "$response" =~ \"error\":\{([^\}]*)\} ]]; then
+            log ERROR "OrcaRouter error: ${BASH_REMATCH[1]}"
+            return 1
+        fi
+        log WARN "Empty response from OrcaRouter ($model)"
+        echo "$response"
+    else
+        local result
+        result=$(echo "$content" | sed 's/\\n/\n/g; s/\\t/\t/g; s/\\"/"/g')
+        if [[ -n "$output_file" ]]; then
+            echo "$result" > "$output_file"
+        else
+            echo "$result"
+        fi
+    fi
+}
+
+# OrcaRouter agent wrapper for spawn_agent compatibility
+# Resolves model from task_type/complexity, then calls the core implementation
+orcarouter_execute() {
+    local prompt="$1"
+    local task_type="${2:-general}"
+
+    # stdin fallback: probe_single_agent pipes prompt via stdin (#305)
+    if [[ -z "$prompt" && ! -t 0 ]]; then
+        prompt=$(cat)
+    fi
+    local complexity="${3:-2}"
+    local output_file="${4:-}"
+
+    # Prefer the configured model (OCTOPUS_ORCAROUTER_MODEL / providers.json) over
+    # the hardcoded task-type table, so the roster's advertised model actually runs.
+    local model="${OCTOPUS_ORCAROUTER_MODEL:-}"
+    if [[ -z "$model" ]] && declare -f resolve_octopus_model >/dev/null 2>&1; then
+        model="$(resolve_octopus_model orcarouter orcarouter "" "" 2>/dev/null || true)"
+    fi
+    [[ -z "$model" ]] && model=$(get_orcarouter_model "$task_type" "$complexity")
+
+    orcarouter_execute_model "$model" "$prompt" "$task_type" "$complexity" "$output_file"
+}
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # PERPLEXITY SONAR API (v8.24.0 - Issue #22)
 # Web-grounded research provider — live internet search with citations

--- a/scripts/lib/perplexity.sh
+++ b/scripts/lib/perplexity.sh
@@ -113,7 +113,7 @@ EOF
                 fi
                 break ;;
         esac
-        (( attempt++ ))
+        (( ++attempt ))
     done
 
     rm -f "$header_file"
@@ -281,7 +281,7 @@ EOF
                 fi
                 break ;;
         esac
-        (( attempt++ ))
+        (( ++attempt ))
     done
 
     rm -f "$header_file"
@@ -330,6 +330,22 @@ orcarouter_execute() {
         model="$(resolve_octopus_model orcarouter orcarouter "" "" 2>/dev/null || true)"
     fi
     [[ -z "$model" ]] && model=$(get_orcarouter_model "$task_type" "$complexity")
+
+    if declare -f _octopus_allowed_model_or_fallback >/dev/null 2>&1; then
+        model=$(_octopus_allowed_model_or_fallback "orcarouter" "$model") || return 1
+    elif declare -f validate_model_allowed >/dev/null 2>&1; then
+        local fallback=""
+        if fallback=$(validate_model_allowed "orcarouter" "$model"); then
+            : # The configured model is allowed; keep it unchanged.
+        elif [[ -n "$fallback" ]]; then
+            model="$fallback"
+        else
+            return 1
+        fi
+    elif [[ -n "${OCTOPUS_ORCAROUTER_ALLOWED_MODELS:-}" ]]; then
+        log ERROR "Cannot enforce OCTOPUS_ORCAROUTER_ALLOWED_MODELS: validator unavailable"
+        return 1
+    fi
 
     orcarouter_execute_model "$model" "$prompt" "$task_type" "$complexity" "$output_file"
 }

--- a/scripts/lib/provider-policy.sh
+++ b/scripts/lib/provider-policy.sh
@@ -9,7 +9,7 @@ _provider_policy_registry_dir="$(cd "$_provider_policy_registry_dir" && pwd)"
 source "${_provider_policy_registry_dir}/provider-registry.sh" 2>/dev/null || true
 
 OCTOPUS_COUNCIL_DEFAULT_PROVIDERS_DEFAULT="claude,codex,agy,qwen,opencode,openrouter,openai-compatible,openai-tools"
-OCTOPUS_SMOKE_ROUTING_PROVIDERS_DEFAULT="codex agy claude opencode openrouter"
+OCTOPUS_SMOKE_ROUTING_PROVIDERS_DEFAULT="codex agy claude opencode openrouter orcarouter"
 
 octo_validate_provider_policy_list() {
     local raw="$1" capability="$2" label="$3"

--- a/scripts/lib/provider-registry.sh
+++ b/scripts/lib/provider-registry.sh
@@ -20,6 +20,7 @@ agy|antigravity*,gemini,gemini-*|agy|google|model-config,council,health,detect,d
 perplexity||perplexity|perplexity|model-config,health,detect,dispatch,env
 opencode||opencode|opencode|model-config,council,detect,dispatch,env
 openrouter||openrouter|openrouter|model-config,council,health,detect,dispatch,env
+orcarouter||orcarouter|orcarouter|model-config,council,health,detect,dispatch,env
 atlascloud|atlas,atlas-cloud|atlascloud|atlascloud|model-config,health,detect,dispatch,env
 openai-compatible||openai-compatible|openai-compatible|model-config,council,detect,dispatch,env
 openai-tools||openai-compatible|openai-compatible|model-config,council,dispatch,env

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -290,12 +290,20 @@ resolve_provider_env() {
         fi
     fi
 
-    # Try sourcing from project .env or ~/.env
+    # Try static assignments from project/user env files and legacy shell rc
+    # files. Do not source .bashrc/.zshrc: they may contain interactive commands
+    # or arbitrary startup code. Reject dynamic values rather than evaluating
+    # substitutions while recovering credentials from older installations.
     local env_file
-    for env_file in "$PWD/.env" "$HOME/.env"; do
+    for env_file in "$PWD/.env" "$HOME/.env" "$HOME/.bashrc" "$HOME/.zshrc"; do
         if [[ -f "$env_file" ]]; then
-            local val
-            val=$(grep -m1 -E "^${var_name}=" "$env_file" 2>/dev/null | cut -d= -f2- | sed 's/^["'\'']\|["'\''"]$//g')
+            local assignment val
+            assignment=$(grep -m1 -E "^[[:space:]]*(export[[:space:]]+)?${var_name}=" "$env_file" 2>/dev/null || true)
+            val="${assignment#*=}"
+            val=$(printf '%s' "$val" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//; s/^["'\'']\|["'\''"]$//g')
+            if [[ "$val" == *'$'* || "$val" == *'`'* ]]; then
+                continue
+            fi
             if [[ -n "$val" ]]; then
                 export "$var_name=$val"
                 log DEBUG "Resolved $var_name from $env_file (non-interactive shell fallback)"

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -220,6 +220,13 @@ _octo_build_provider_env_impl() {
             fi
             return 0
             ;;
+        orcarouter*)
+            # orcarouter_execute is a shell function — env -i cannot exec it (#300)
+            if [[ -z "${ORCAROUTER_API_KEY:-}" ]]; then
+                resolve_provider_env "ORCAROUTER_API_KEY" 2>/dev/null || true
+            fi
+            return 0
+            ;;
         claude-sdk*)
             # v9.50.0: Agent SDK seat — the shim strips session markers and sets
             # ANTHROPIC_API_KEY itself; just make sure the SDK key is resolvable.

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -315,6 +315,55 @@ resolve_provider_env() {
     return 1
 }
 
+# API-key providers are dispatchable only when the key exists and an explicit
+# providers-config entry has both availability flags enabled. A missing provider
+# section remains backward compatible with pre-provider config files: the live
+# key is authoritative until the user explicitly configures the provider.
+octo_api_key_provider_is_available() {
+    local provider="$1"
+    local env_var="$2"
+    local config_file="${PROVIDERS_CONFIG_FILE:-${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.providers-config}"
+    local configured_state="absent"
+
+    provider="$(octo_provider_canonical "$provider" 2>/dev/null || printf '%s' "$provider")"
+    if declare -f octo_provider_allowed >/dev/null 2>&1 && ! octo_provider_allowed "$provider"; then
+        return 1
+    fi
+    if [[ -z "${!env_var:-}" ]]; then
+        resolve_provider_env "$env_var" 2>/dev/null || true
+    fi
+    [[ -n "${!env_var:-}" ]] || return 1
+
+    if [[ -f "$config_file" ]]; then
+        configured_state="$(awk -v target="$provider" '
+            /^  [[:alnum:]_-]+:[[:space:]]*$/ {
+                section = $0
+                sub(/^  /, "", section)
+                sub(/:[[:space:]]*$/, "", section)
+                in_target = (section == target)
+                if (in_target) seen = 1
+                next
+            }
+            in_target && /^    enabled:[[:space:]]*/ {
+                enabled = $0
+                sub(/^    enabled:[[:space:]]*/, "", enabled)
+                gsub(/[[:space:]\"]/, "", enabled)
+            }
+            in_target && /^    api_key_set:[[:space:]]*/ {
+                key_set = $0
+                sub(/^    api_key_set:[[:space:]]*/, "", key_set)
+                gsub(/[[:space:]\"]/, "", key_set)
+            }
+            END {
+                if (seen) print enabled "|" key_set
+                else print "absent"
+            }
+        ' "$config_file" 2>/dev/null)" || return 1
+    fi
+
+    [[ "$configured_state" == "absent" || "$configured_state" == "true|true" ]]
+}
+
 # [EXTRACTED to lib/dispatch.sh in v9.7.7]
 
 # [EXTRACTED to lib/dispatch.sh in v9.7.7]

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -13,6 +13,13 @@ if ! declare -f _is_cursor_agent_binary >/dev/null 2>&1; then
 fi
 source "${_providers_lib_dir}/provider-allowlist.sh" 2>/dev/null || true
 source "${_providers_lib_dir}/provider-registry.sh" 2>/dev/null || true
+# Provider detection can run standalone in tests and helper scripts, before the
+# main orchestrator reaches its later provider-routing import. Load the shared
+# non-interactive credential resolver here so API-backed providers can discover
+# keys persisted in ~/.env without depending on caller source order.
+if ! declare -f resolve_provider_env >/dev/null 2>&1; then
+    source "${_providers_lib_dir}/provider-routing.sh" 2>/dev/null || true
+fi
 source "${_providers_lib_dir}/auth.sh" 2>/dev/null || true
 source "${_providers_lib_dir}/qwen.sh" 2>/dev/null || true
 source "${_providers_lib_dir}/openai-compatible.sh" 2>/dev/null || true
@@ -918,6 +925,9 @@ check_provider_health() {
             fi
             ;;
         orcarouter)
+            if [[ -z "${ORCAROUTER_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
+                resolve_provider_env "ORCAROUTER_API_KEY" 2>/dev/null || true
+            fi
             if [[ -z "${ORCAROUTER_API_KEY:-}" ]]; then
                 echo "orcarouter: ORCAROUTER_API_KEY not set" >&2
                 return 1
@@ -1282,7 +1292,10 @@ detect_providers() {
         result="${result}openrouter:api-key "
     fi
 
-    # Detect OrcaRouter (API key only)
+    # Detect OrcaRouter (API key only, including ~/.env/profile resolution)
+    if [[ -z "${ORCAROUTER_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
+        resolve_provider_env "ORCAROUTER_API_KEY" 2>/dev/null || true
+    fi
     if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed orcarouter; } && [[ -n "${ORCAROUTER_API_KEY:-}" ]]; then
         result="${result}orcarouter:api-key "
     fi

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -917,6 +917,12 @@ check_provider_health() {
                 return 1
             fi
             ;;
+        orcarouter)
+            if [[ -z "${ORCAROUTER_API_KEY:-}" ]]; then
+                echo "orcarouter: ORCAROUTER_API_KEY not set" >&2
+                return 1
+            fi
+            ;;
         atlascloud)
             if [[ -z "${ATLASCLOUD_API_KEY:-}" ]]; then
                 resolve_provider_env "ATLASCLOUD_API_KEY" 2>/dev/null
@@ -1170,6 +1176,38 @@ EOF
     fi
 }
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# ORCAROUTER INTEGRATION
+# Universal fallback via the OrcaRouter gateway (https://www.orcarouter.ai),
+# which serves OpenAI-compatible /v1/chat/completions and accepts namespaced
+# model IDs (anthropic/*, deepseek/*, ...).
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Select OrcaRouter model based on task type
+get_orcarouter_model() {
+    local task_type="$1"
+    local complexity="${2:-2}"
+
+    case "$task_type" in
+        coding|review)
+            case "$complexity" in
+                3) echo "anthropic/claude-opus-4.8" ;;   # premium tier
+                1) echo "anthropic/claude-haiku-4.5" ;;
+                *) echo "anthropic/claude-sonnet-4.6" ;;
+            esac
+            ;;
+        image)
+            echo "anthropic/claude-sonnet-4.6"
+            ;;
+        research|design)
+            echo "anthropic/claude-sonnet-4.6"
+            ;;
+        *)
+            echo "anthropic/claude-sonnet-4.6"
+            ;;
+    esac
+}
+
 # ── agy_current_model: resolve the model the Antigravity CLI will actually use ──
 # agy-exec.sh runs `agy --print` with `--model default` (no --model flag) unless
 # OCTOPUS_AGY_MODEL is set, so agy uses whatever is selected in its own /model UI —
@@ -1242,6 +1280,11 @@ detect_providers() {
     # Detect OpenRouter (API key only)
     if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed openrouter; } && [[ -n "${OPENROUTER_API_KEY:-}" ]]; then
         result="${result}openrouter:api-key "
+    fi
+
+    # Detect OrcaRouter (API key only)
+    if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed orcarouter; } && [[ -n "${ORCAROUTER_API_KEY:-}" ]]; then
+        result="${result}orcarouter:api-key "
     fi
 
     # Detect generic OpenAI-compatible tool-loop provider (API key only)
@@ -1374,6 +1417,7 @@ detect_providers() {
         log WARN "  - Antigravity (Google seat): install agy, then launch plain agy and complete browser sign-in"
         log WARN "  - Claude: Available in Claude Code context"
         log WARN "  - OpenRouter: Set OPENROUTER_API_KEY environment variable"
+        log WARN "  - OrcaRouter: Set ORCAROUTER_API_KEY environment variable"
         log WARN "  - Atlas Cloud: Set ATLASCLOUD_API_KEY and ATLASCLOUD_MODEL"
         log WARN "  - Copilot: brew install copilot-cli (zero additional cost)"
         log WARN "  - Ollama: brew install ollama (free local LLM)"

--- a/scripts/lib/quota-watcher.sh
+++ b/scripts/lib/quota-watcher.sh
@@ -261,6 +261,15 @@ octo_provider_probe() {
                 -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
                 2>/dev/null) || curl_exit=$?
             ;;
+        orcarouter)
+            [[ -n "${ORCAROUTER_API_KEY:-}" ]] || return 0
+            # GET /v1/models returns 200 with model list or 401 on bad key.
+            http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+                --max-time 10 \
+                -X GET "https://api.orcarouter.ai/v1/models" \
+                -H "Authorization: Bearer ${ORCAROUTER_API_KEY}" \
+                2>/dev/null) || curl_exit=$?
+            ;;
         *)
             # Unknown provider: no probe defined, fail open.
             return 0

--- a/scripts/lib/routing.sh
+++ b/scripts/lib/routing.sh
@@ -43,6 +43,8 @@ resolve_provider_to_agent() {
                                 agent="$provider" ;;
         openrouter|openrouter-glm5|openrouter-kimi|openrouter-deepseek)
                                 agent="$provider" ;;
+        orcarouter)
+                                agent="$provider" ;;
         openai-compatible|openai-tools|openai-compatible-agent)
                                 agent="$provider" ;;
         perplexity|perplexity-fast)
@@ -72,6 +74,7 @@ agent_display_label() {
         gemini*) echo "Antigravity" ;;
         agy*|antigravity) echo "Antigravity" ;;
         openrouter*) echo "OpenRouter" ;;
+        orcarouter*) echo "OrcaRouter" ;;
         openai-compatible|openai-tools|openai-compatible-agent) echo "OpenAI-compatible" ;;
         qwen*) echo "Qwen" ;;
         perplexity*) echo "Perplexity" ;;

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -42,6 +42,10 @@ PROVIDER_OPENROUTER_API_KEY_SET="false"
 PROVIDER_OPENROUTER_ROUTING_PREF="default"
 PROVIDER_OPENROUTER_PRIORITY=99
 
+PROVIDER_ORCAROUTER_ENABLED="false"
+PROVIDER_ORCAROUTER_API_KEY_SET="false"
+PROVIDER_ORCAROUTER_PRIORITY=99
+
 # Cost optimization strategy: cost-first, quality-first, balanced
 COST_OPTIMIZATION_STRATEGY="balanced"
 
@@ -72,6 +76,9 @@ get_provider_capabilities() {
             echo "code,chat,analysis"
             ;;
         openrouter)
+            echo "code,chat,vision,analysis,long-context"
+            ;;
+        orcarouter)
             echo "code,chat,vision,analysis,long-context"
             ;;
         *)
@@ -105,6 +112,9 @@ get_provider_context_limit() {
             echo "128000"  # Varies by backend model (generic)
             ;;
         openrouter:*)
+            echo "128000"  # Varies by model (generic)
+            ;;
+        orcarouter:*)
             echo "128000"  # Varies by model (generic)
             ;;
         openrouter-glm5:*)
@@ -142,7 +152,7 @@ load_providers_config() {
         [[ -z "${line// }" ]] && continue
 
         # Detect provider section headers (e.g., "  codex:")
-        if [[ "$line" =~ ^[[:space:]]*(codex|agy|claude|opencode|openrouter): ]]; then
+        if [[ "$line" =~ ^[[:space:]]*(codex|agy|claude|opencode|openrouter|orcarouter): ]]; then
             current_provider="${BASH_REMATCH[1]}"
             continue
         fi
@@ -207,6 +217,13 @@ load_providers_config() {
                         priority) PROVIDER_OPENROUTER_PRIORITY="$value" ;;
                     esac
                     ;;
+                orcarouter)
+                    case "$key" in
+                        enabled) PROVIDER_ORCAROUTER_ENABLED="$value" ;;
+                        api_key_set) PROVIDER_ORCAROUTER_API_KEY_SET="$value" ;;
+                        priority) PROVIDER_ORCAROUTER_PRIORITY="$value" ;;
+                    esac
+                    ;;
                 cost_optimization)
                     case "$key" in
                         strategy) COST_OPTIMIZATION_STRATEGY="$value" ;;
@@ -251,6 +268,10 @@ load_providers_config() {
     PROVIDER_OPENROUTER_API_KEY_SET="${PROVIDER_OPENROUTER_API_KEY_SET:-false}"
     PROVIDER_OPENROUTER_ROUTING_PREF="${PROVIDER_OPENROUTER_ROUTING_PREF:-default}"
     PROVIDER_OPENROUTER_PRIORITY="${PROVIDER_OPENROUTER_PRIORITY:-99}"
+
+    PROVIDER_ORCAROUTER_ENABLED="${PROVIDER_ORCAROUTER_ENABLED:-false}"
+    PROVIDER_ORCAROUTER_API_KEY_SET="${PROVIDER_ORCAROUTER_API_KEY_SET:-false}"
+    PROVIDER_ORCAROUTER_PRIORITY="${PROVIDER_ORCAROUTER_PRIORITY:-99}"
 
     COST_OPTIMIZATION_STRATEGY="${COST_OPTIMIZATION_STRATEGY:-balanced}"
 
@@ -297,6 +318,10 @@ auto_detect_provider_config() {
             openrouter)
                 PROVIDER_OPENROUTER_ENABLED="true"
                 PROVIDER_OPENROUTER_API_KEY_SET="true"
+                ;;
+            orcarouter)
+                PROVIDER_ORCAROUTER_ENABLED="true"
+                PROVIDER_ORCAROUTER_API_KEY_SET="true"
                 ;;
         esac
     done
@@ -546,6 +571,11 @@ providers:
     routing_preference: "$PROVIDER_OPENROUTER_ROUTING_PREF"
     priority: $PROVIDER_OPENROUTER_PRIORITY
 
+  orcarouter:
+    enabled: $PROVIDER_ORCAROUTER_ENABLED
+    api_key_set: $PROVIDER_ORCAROUTER_API_KEY_SET
+    priority: $PROVIDER_ORCAROUTER_PRIORITY
+
 cost_optimization:
   strategy: "$COST_OPTIMIZATION_STRATEGY"
 EOF
@@ -598,6 +628,12 @@ score_provider() {
             cost_tier="pay-per-use"
             sub_tier="api-only"
             priority="$PROVIDER_OPENROUTER_PRIORITY"
+            ;;
+        orcarouter)
+            [[ "$PROVIDER_ORCAROUTER_ENABLED" == "true" && "$PROVIDER_ORCAROUTER_API_KEY_SET" == "true" ]] && is_available="true"
+            cost_tier="pay-per-use"
+            sub_tier="api-only"
+            priority="$PROVIDER_ORCAROUTER_PRIORITY"
             ;;
     esac
 
@@ -743,6 +779,8 @@ select_provider() {
             echo "agy"
         elif [[ "$PROVIDER_OPENROUTER_ENABLED" == "true" ]]; then
             echo "openrouter"
+        elif [[ "$PROVIDER_ORCAROUTER_ENABLED" == "true" ]]; then
+            echo "orcarouter"
         else
             echo "codex"  # Default fallback
         fi
@@ -789,6 +827,11 @@ show_provider_status() {
     local openrouter_status="${RED}✗${NC}"
     [[ "$PROVIDER_OPENROUTER_ENABLED" == "true" ]] && openrouter_status="${GREEN}✓${NC}"
     echo -e "${CYAN}║${NC}  OpenRouter:     $openrouter_status  [api-key]  $PROVIDER_OPENROUTER_ROUTING_PREF (pay-per-use)  ${CYAN}║${NC}"
+
+    # OrcaRouter
+    local orcarouter_status="${RED}✗${NC}"
+    [[ "$PROVIDER_ORCAROUTER_ENABLED" == "true" ]] && orcarouter_status="${GREEN}✓${NC}"
+    echo -e "${CYAN}║${NC}  OrcaRouter:     $orcarouter_status  [api-key]  pay-per-use  ${CYAN}║${NC}"
 
     # Perplexity (v8.24.0)
     local perplexity_status="${RED}✗${NC}"

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -779,7 +779,7 @@ select_provider() {
             echo "agy"
         elif [[ "$PROVIDER_OPENROUTER_ENABLED" == "true" ]]; then
             echo "openrouter"
-        elif [[ "$PROVIDER_ORCAROUTER_ENABLED" == "true" ]]; then
+        elif [[ "$PROVIDER_ORCAROUTER_ENABLED" == "true" && "$PROVIDER_ORCAROUTER_API_KEY_SET" == "true" ]]; then
             echo "orcarouter"
         else
             echo "codex"  # Default fallback
@@ -830,7 +830,7 @@ show_provider_status() {
 
     # OrcaRouter
     local orcarouter_status="${RED}✗${NC}"
-    [[ "$PROVIDER_ORCAROUTER_ENABLED" == "true" ]] && orcarouter_status="${GREEN}✓${NC}"
+    [[ "$PROVIDER_ORCAROUTER_ENABLED" == "true" && "$PROVIDER_ORCAROUTER_API_KEY_SET" == "true" ]] && orcarouter_status="${GREEN}✓${NC}"
     echo -e "${CYAN}║${NC}  OrcaRouter:     $orcarouter_status  [api-key]  pay-per-use  ${CYAN}║${NC}"
 
     # Perplexity (v8.24.0)

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -344,6 +344,8 @@ validate_agent_command() {
             return 0 ;;
         "openrouter_execute"*) # openrouter_execute and openrouter_execute_model
             return 0 ;;
+        "orcarouter_execute"|"orcarouter_execute "*|"orcarouter_execute_model"|"orcarouter_execute_model "*)
+            return 0 ;;
         "perplexity_execute"*) # v8.24.0: Perplexity Sonar API (Issue #22)
             return 0 ;;
         "copilot "*|"copilot")   # GitHub Copilot CLI

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -657,7 +657,7 @@ CODEX_SUBAGENT_PREAMBLE="IMPORTANT: You are running as a non-interactive subagen
 
 "
 
-AVAILABLE_AGENTS="codex codex-standard codex-max codex-mini codex-general codex-spark codex-reasoning codex-large-context agy agy-research antigravity codex-review claude claude-sonnet claude-opus claude-opus-fast openrouter openrouter-glm5 openrouter-kimi openrouter-deepseek openai-compatible openai-tools openai-compatible-agent perplexity perplexity-fast ollama copilot copilot-research qwen qwen-research cursor-agent vibe vibe-research"
+AVAILABLE_AGENTS="codex codex-standard codex-max codex-mini codex-general codex-spark codex-reasoning codex-large-context agy agy-research antigravity codex-review claude claude-sonnet claude-opus claude-opus-fast openrouter openrouter-glm5 openrouter-kimi openrouter-deepseek orcarouter openai-compatible openai-tools openai-compatible-agent perplexity perplexity-fast ollama copilot copilot-research qwen qwen-research cursor-agent vibe vibe-research"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # USAGE TRACKING & COST REPORTING (v4.1)

--- a/scripts/sync-readme.py
+++ b/scripts/sync-readme.py
@@ -28,6 +28,7 @@ PUBLIC_EXTERNAL_PROVIDERS = (
     ("Ollama", "Ollama"),
     ("Perplexity", "Perplexity API key"),
     ("OpenRouter", "OpenRouter API key"),
+    ("OrcaRouter", "OrcaRouter API key"),
     ("OpenCode", "OpenCode CLI"),
     ("Grok", "xAI API key (Grok)"),
 )

--- a/skills/skill-parallel-agents/SKILL.md
+++ b/skills/skill-parallel-agents/SKILL.md
@@ -599,6 +599,7 @@ The `tangle` phase enforces quality gates:
 | `agy-research` | service-selected default | Research-focused Antigravity seat |
 | `codex-review` | gpt-5.6-sol | Code review mode |
 | `openrouter` | Various | Universal fallback (400+ models) |
+| `orcarouter` | Various | Universal fallback via OrcaRouter gateway |
 
 ## Provider-Aware Routing (v4.8)
 
@@ -612,6 +613,7 @@ Claude Octopus now intelligently routes tasks based on your subscription tiers a
 | **Antigravity** | Google access/subscription | Included with access | code, analysis, external review |
 | **Claude** | Pro, Max 5x, Max 20x, API | $20-200 | code, chat, analysis, long-context |
 | **OpenRouter** | Pay-per-use | Variable | 400+ models, routing variants |
+| **OrcaRouter** | Pay-per-use | Variable | Single gateway, namespaced model IDs |
 
 ### Cost Optimization Strategies
 
@@ -673,6 +675,9 @@ providers:
     enabled: false
     routing_preference: "default"   # default|nitro|floor
 
+  orcarouter:
+    enabled: false
+
 cost_optimization:
   strategy: "balanced"  # cost-first|quality-first|balanced
 ```
@@ -684,6 +689,18 @@ OpenRouter provides 400+ models as a universal fallback when direct external CLI
 ```bash
 # Set up OpenRouter API key
 export OPENROUTER_API_KEY="sk-or-..."
+
+# Re-run setup to configure
+${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh setup
+```
+
+### OrcaRouter Fallback
+
+OrcaRouter provides a single gateway to many models as a universal fallback when direct external CLIs are unavailable:
+
+```bash
+# Set up OrcaRouter API key
+export ORCAROUTER_API_KEY="sk-orca-..."
 
 # Re-run setup to configure
 ${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh setup

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -128,6 +128,21 @@ else
     test_pass
 fi
 
+test_case "validate_agent_command allows OrcaRouter dispatch functions"
+if validate_agent_command "orcarouter_execute" &&
+        validate_agent_command "orcarouter_execute_model anthropic/claude-sonnet-4.5"; then
+    test_pass
+else
+    test_fail "expected OrcaRouter dispatch functions to be accepted"
+fi
+
+test_case "validate_agent_command rejects OrcaRouter lookalike function names"
+if validate_agent_command "orcarouter_execute_attacker payload" >/dev/null 2>&1; then
+    test_fail "expected an OrcaRouter lookalike function name to be rejected"
+else
+    test_pass
+fi
+
 test_case "validate_agent_command allows reasoning flags before cwd"
 if validate_agent_command "$PROJECT_ROOT/scripts/helpers/openai-compatible-agent.py --provider generic --model minimax/minimax-m3 --reasoning-effort medium --reasoning-policy best_effort --cwd /tmp/test"; then
     test_pass

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -1234,7 +1234,7 @@ test_agy_slash_command_visibility() {
        grep -q 'Antigravity CLI' "$PROJECT_ROOT/.claude/skills/skill-debate/SKILL.md" && \
        grep -q 'Antigravity CLI' "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md" && \
        grep -q 'Antigravity CLI' "$PROJECT_ROOT/SECURITY.md" && \
-       grep -q 'up to 9 external AI integrations' "$PROJECT_ROOT/PRODUCT.md" && \
+       grep -q 'up to 10 external AI integrations' "$PROJECT_ROOT/PRODUCT.md" && \
        grep -q 'Four providers can cost nothing extra' "$PROJECT_ROOT/PRODUCT.md" && \
        grep -q 'codex agy' "$PROJECT_ROOT/tests/test-fleet-diversity.sh" && \
        grep -q 'codex, agy' "$PROJECT_ROOT/tests/unit/test-research-fanout-static.sh"; then

--- a/tests/unit/test-orcarouter-provider.sh
+++ b/tests/unit/test-orcarouter-provider.sh
@@ -56,6 +56,13 @@ else
     test_fail "expected anthropic/claude-sonnet-4.6"
 fi
 
+test_case "suffixed orcarouter agents keep a namespaced OrcaRouter ID"
+if [[ "$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="orcarouter-suffix" resolve_octopus_model orcarouter-reviewer orcarouter 2>/dev/null)" == "anthropic/claude-sonnet-4.6" ]]; then
+    test_pass
+else
+    test_fail "suffixed OrcaRouter agent fell through to another provider default"
+fi
+
 test_case "model catalog includes the orcarouter fallback models"
 if is_known_model "anthropic/claude-sonnet-4.6" &&
    is_known_model "anthropic/claude-opus-4.8" &&
@@ -78,18 +85,156 @@ else
     test_fail "expected 'orcarouter_execute', got: '$cmd'"
 fi
 
+
+source "$PROJECT_ROOT/scripts/lib/perplexity.sh"
+ORCAROUTER_CAPTURED_MODEL=""
+orcarouter_execute_model() {
+    ORCAROUTER_CAPTURED_MODEL="$1"
+}
+test_case "orcarouter execution enforces its model allowlist"
+OCTOPUS_ORCAROUTER_MODEL="anthropic/claude-sonnet-4.6"
+OCTOPUS_ORCAROUTER_ALLOWED_MODELS="anthropic/claude-haiku-4.5"
+if orcarouter_execute "review this" review 2 >/dev/null 2>&1 &&
+        [[ "$ORCAROUTER_CAPTURED_MODEL" == "anthropic/claude-haiku-4.5" ]]; then
+    test_pass
+else
+    test_fail "blocked model reached execution: ${ORCAROUTER_CAPTURED_MODEL:-none}"
+fi
+unset OCTOPUS_ORCAROUTER_MODEL OCTOPUS_ORCAROUTER_ALLOWED_MODELS
+
+test_case "orcarouter retry increment is safe under errexit"
+if grep -Ec -- '\(\([[:space:]]*\+\+attempt[[:space:]]*\)\)' \
+        "$PROJECT_ROOT/scripts/lib/perplexity.sh" >/dev/null &&
+        ! grep -Eq -- '\(\([[:space:]]*attempt\+\+[[:space:]]*\)\)' \
+            "$PROJECT_ROOT/scripts/lib/perplexity.sh"; then
+    test_pass
+else
+    test_fail "OrcaRouter retry still uses a zero-valued post-increment"
+fi
+
 # Detection: an ORCAROUTER_API_KEY alone must surface orcarouter in the
 # provider inventory, mirroring the openrouter api-key detection.
 test_case "detect_providers surfaces orcarouter with an API key"
 stub_dir=$(mktemp -d)
 set +e
-detected=$(env "HOME=$stub_dir" "PATH=$PATH" "ORCAROUTER_API_KEY=sk-orca-test" OCTO_ALLOWED_PROVIDERS=orcarouter bash -c 'log(){ :; }; source "'$PROJECT_ROOT'/scripts/lib/providers.sh"; detect_providers')
+detected=$(env "HOME=$stub_dir" "PATH=$PATH" "ORCAROUTER_API_KEY=sk-orca-test" \
+    "OCTO_ALLOWED_PROVIDERS=orcarouter" bash -c \
+    'log(){ :; }; source "$1/scripts/lib/providers.sh"; detect_providers' \
+    _ "$PROJECT_ROOT")
+detected_rc=$?
 set -e
 rm -rf "$stub_dir"
-if [[ "$detected" == *"orcarouter:api-key"* ]]; then
+if [[ "$detected_rc" -eq 0 && "$detected" == *"orcarouter:api-key"* ]]; then
     test_pass
 else
-    test_fail "orcarouter not detected: $detected"
+    test_fail "orcarouter detection failed (status=$detected_rc): $detected"
+fi
+
+test_case "detect_providers resolves a profile-backed OrcaRouter key"
+profile_home="$TEST_TMP_DIR/profile-backed-home"
+mkdir -p "$profile_home"
+printf '%s\n' 'ORCAROUTER_API_KEY=sk-orca-profile-test' > "$profile_home/.env"
+set +e
+profile_detected=$(env -u ORCAROUTER_API_KEY "HOME=$profile_home" "PATH=$PATH" \
+    "OCTO_ALLOWED_PROVIDERS=orcarouter" bash -c \
+    'log(){ :; }; source "$1/scripts/lib/providers.sh"; detect_providers' \
+    _ "$PROJECT_ROOT")
+profile_detected_rc=$?
+set -e
+if [[ "$profile_detected_rc" -eq 0 && "$profile_detected" == *"orcarouter:api-key"* ]]; then
+    test_pass
+else
+    test_fail "profile-backed OrcaRouter key was not resolved"
+fi
+
+test_case "detect_providers resolves a legacy zshrc-backed OrcaRouter key"
+zshrc_home="$TEST_TMP_DIR/zshrc-backed-home"
+mkdir -p "$zshrc_home"
+printf '%s\n' 'export ORCAROUTER_API_KEY=sk-orca-zshrc-test' > "$zshrc_home/.zshrc"
+set +e
+zshrc_detected=$(env -u ORCAROUTER_API_KEY "HOME=$zshrc_home" "PATH=$PATH" \
+    "OCTO_ALLOWED_PROVIDERS=orcarouter" bash -c \
+    'log(){ :; }; source "$1/scripts/lib/providers.sh"; detect_providers' \
+    _ "$PROJECT_ROOT")
+zshrc_detected_rc=$?
+set -e
+if [[ "$zshrc_detected_rc" -eq 0 && "$zshrc_detected" == *"orcarouter:api-key"* ]]; then
+    test_pass
+else
+    test_fail "legacy zshrc-backed OrcaRouter key was not resolved"
+fi
+
+test_case "provider status resolves a legacy zshrc-backed OrcaRouter key"
+set +e
+zshrc_status=$(env -u ORCAROUTER_API_KEY "HOME=$zshrc_home" "PATH=$PATH" \
+    "OCTO_ALLOWED_PROVIDERS=orcarouter" \
+    bash "$PROJECT_ROOT/scripts/helpers/check-providers.sh")
+zshrc_status_rc=$?
+set -e
+if [[ "$zshrc_status_rc" -eq 0 && "$zshrc_status" == *"orcarouter:available"* ]]; then
+    test_pass
+else
+    test_fail "provider status did not resolve the legacy OrcaRouter key"
+fi
+
+test_case "OrcaRouter setup keeps the API key out of terminal output"
+config_display="$PROJECT_ROOT/scripts/lib/config-display.sh"
+if grep -Eq -- 'read -r -s -p .*OrcaRouter API key' "$config_display" &&
+        grep -Ec -- 'export "ORCAROUTER_API_KEY=[$][{]orcarouter_key[}]"' \
+            "$config_display" >/dev/null &&
+        grep -Eq -- 'persist_provider_secret .*ORCAROUTER_API_KEY' "$config_display" &&
+        ! grep -Eq -- 'keys_to_add=.*ORCAROUTER_API_KEY' "$config_display"; then
+    test_pass
+else
+    test_fail "OrcaRouter setup still exposes or prints the raw API key"
+fi
+
+source "$config_display"
+test_case "OrcaRouter secret persistence is private, atomic, and silent"
+secret_env="$TEST_TMP_DIR/provider-secrets.env"
+secret_output="$TEST_TMP_DIR/provider-secrets.out"
+printf '%s\n' 'KEEP_ME=yes' 'ORCAROUTER_API_KEY=old-value' > "$secret_env"
+chmod 644 "$secret_env"
+umask_before=$(umask)
+set +e
+OCTOPUS_SECRET_ENV_FILE="$secret_env" \
+    persist_provider_secret "ORCAROUTER_API_KEY" "sk-orca-replacement" \
+    > "$secret_output" 2>&1
+persist_rc=$?
+set -e
+umask_after=$(umask)
+umask "$umask_before"
+if stat -f '%Lp' "$secret_env" >/dev/null 2>&1; then
+    secret_mode=$(stat -f '%Lp' "$secret_env")
+else
+    secret_mode=$(stat -c '%a' "$secret_env")
+fi
+secret_count=$(grep -Ec -- '^ORCAROUTER_API_KEY=' "$secret_env")
+if [[ "$persist_rc" -eq 0 && ! -s "$secret_output" && \
+        "$umask_before" == "$umask_after" && "$secret_mode" == "600" && \
+        "$secret_count" -eq 1 ]] && \
+        grep -Fxq -- 'KEEP_ME=yes' "$secret_env" && \
+        grep -Fxq -- 'ORCAROUTER_API_KEY=sk-orca-replacement' "$secret_env"; then
+    test_pass
+else
+    test_fail "secret persistence changed umask, permissions, content, or terminal output"
+fi
+
+test_case "OrcaRouter smoke selection and status require an API key"
+smoke_file="$PROJECT_ROOT/scripts/lib/smoke.sh"
+smoke_guard_count=$(grep -Ec -- 'PROVIDER_ORCAROUTER_ENABLED.*true.*PROVIDER_ORCAROUTER_API_KEY_SET.*true' "$smoke_file")
+if [[ "$smoke_guard_count" -ge 3 ]]; then
+    test_pass
+else
+    test_fail "only $smoke_guard_count OrcaRouter smoke paths require both flags"
+fi
+
+test_case "Council resolves the OrcaRouter key before availability checks"
+if grep -A8 -E '^[[:space:]]*orcarouter\)' "$PROJECT_ROOT/scripts/lib/council.sh" |
+        grep -Ec -- 'resolve_provider_env "ORCAROUTER_API_KEY"' >/dev/null; then
+    test_pass
+else
+    test_fail "Council does not resolve profile-backed OrcaRouter credentials"
 fi
 
 test_summary

--- a/tests/unit/test-orcarouter-provider.sh
+++ b/tests/unit/test-orcarouter-provider.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Tests for the OrcaRouter provider: registry capabilities, model resolution,
+# model catalog entries, dispatch command, and API-key detection.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "OrcaRouter provider"
+
+pass() { test_case "$1"; test_pass; }
+fail() { test_case "$1"; test_fail "${2:-$1}"; }
+
+source "$PROJECT_ROOT/scripts/lib/provider-registry.sh"
+
+test_case "registry declares orcarouter with full provider capabilities"
+if octo_provider_valid "orcarouter" &&
+   octo_provider_has_capability "orcarouter" dispatch &&
+   octo_provider_has_capability "orcarouter" health &&
+   octo_provider_has_capability "orcarouter" detect &&
+   octo_provider_has_capability "orcarouter" model-config &&
+   octo_provider_has_capability "orcarouter" env; then
+    test_pass
+else
+    test_fail "orcarouter registry capabilities incomplete"
+fi
+
+test_case "registry command and organization resolve for orcarouter"
+if [[ "$(octo_provider_command "orcarouter")" == "orcarouter" ]] &&
+   [[ "$(octo_provider_org "orcarouter")" == "orcarouter" ]]; then
+    test_pass
+else
+    test_fail "orcarouter command/org metadata missing"
+fi
+
+MODEL_RESOLVER="$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+MODEL_CATALOG="$PROJECT_ROOT/scripts/lib/models.sh"
+
+if bash -n "$MODEL_RESOLVER" "$MODEL_CATALOG"; then
+    pass "orcarouter model scripts have valid bash syntax"
+else
+    fail "orcarouter model scripts have valid bash syntax" "syntax error"
+fi
+
+TEST_HOME="$TEST_TMP_DIR/orca-home"
+mkdir -p "$TEST_HOME"
+
+source "$MODEL_RESOLVER"
+source "$MODEL_CATALOG"
+
+test_case "bare orcarouter resolves to a namespaced OrcaRouter ID"
+if [[ "$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="orcarouter-default" resolve_octopus_model orcarouter orcarouter 2>/dev/null)" == "anthropic/claude-sonnet-4.6" ]]; then
+    test_pass
+else
+    test_fail "expected anthropic/claude-sonnet-4.6"
+fi
+
+test_case "model catalog includes the orcarouter fallback models"
+if is_known_model "anthropic/claude-sonnet-4.6" &&
+   is_known_model "anthropic/claude-opus-4.8" &&
+   is_known_model "anthropic/claude-haiku-4.5" &&
+   [[ "$(get_model_capability "anthropic/claude-sonnet-4.6" provider)" == "orcarouter" ]] &&
+   [[ "$(get_model_capability "anthropic/claude-opus-4.8" context_k)" == "1000" ]]; then
+    test_pass
+else
+    test_fail "orcarouter models missing or mislabeled in catalog"
+fi
+
+# Dispatch: the command builder must emit the shell-function executor for the
+# orcarouter agent type, the same shape openrouter uses.
+source "$PROJECT_ROOT/scripts/lib/dispatch.sh"
+test_case "get_agent_command emits orcarouter_execute"
+cmd="$(get_agent_command orcarouter tangle implementer 2>/dev/null)" || cmd=""
+if [[ "$cmd" == "orcarouter_execute" ]]; then
+    test_pass
+else
+    test_fail "expected 'orcarouter_execute', got: '$cmd'"
+fi
+
+# Detection: an ORCAROUTER_API_KEY alone must surface orcarouter in the
+# provider inventory, mirroring the openrouter api-key detection.
+test_case "detect_providers surfaces orcarouter with an API key"
+stub_dir=$(mktemp -d)
+set +e
+detected=$(env "HOME=$stub_dir" "PATH=$PATH" "ORCAROUTER_API_KEY=sk-orca-test" OCTO_ALLOWED_PROVIDERS=orcarouter bash -c 'log(){ :; }; source "'$PROJECT_ROOT'/scripts/lib/providers.sh"; detect_providers')
+set -e
+rm -rf "$stub_dir"
+if [[ "$detected" == *"orcarouter:api-key"* ]]; then
+    test_pass
+else
+    test_fail "orcarouter not detected: $detected"
+fi
+
+test_summary

--- a/tests/unit/test-orcarouter-provider.sh
+++ b/tests/unit/test-orcarouter-provider.sh
@@ -57,7 +57,7 @@ else
 fi
 
 test_case "suffixed orcarouter agents keep a namespaced OrcaRouter ID"
-if [[ "$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="orcarouter-suffix" resolve_octopus_model orcarouter-reviewer orcarouter 2>/dev/null)" == "anthropic/claude-sonnet-4.6" ]]; then
+if [[ "$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="orcarouter-suffix" resolve_octopus_model orcarouter orcarouter-reviewer 2>/dev/null)" == "anthropic/claude-sonnet-4.6" ]]; then
     test_pass
 else
     test_fail "suffixed OrcaRouter agent fell through to another provider default"
@@ -68,6 +68,7 @@ if is_known_model "anthropic/claude-sonnet-4.6" &&
    is_known_model "anthropic/claude-opus-4.8" &&
    is_known_model "anthropic/claude-haiku-4.5" &&
    [[ "$(get_model_capability "anthropic/claude-sonnet-4.6" provider)" == "orcarouter" ]] &&
+   [[ "$(get_model_capability "anthropic/claude-sonnet-4.6" context_k)" == "1000" ]] &&
    [[ "$(get_model_capability "anthropic/claude-opus-4.8" context_k)" == "1000" ]]; then
     test_pass
 else
@@ -101,6 +102,7 @@ else
     test_fail "blocked model reached execution: ${ORCAROUTER_CAPTURED_MODEL:-none}"
 fi
 unset OCTOPUS_ORCAROUTER_MODEL OCTOPUS_ORCAROUTER_ALLOWED_MODELS
+source "$PROJECT_ROOT/scripts/lib/perplexity.sh"
 
 test_case "orcarouter retry increment is safe under errexit"
 if grep -Ec -- '\(\([[:space:]]*\+\+attempt[[:space:]]*\)\)' \
@@ -112,10 +114,78 @@ else
     test_fail "OrcaRouter retry still uses a zero-valued post-increment"
 fi
 
+test_case "orcarouter execution fails when a successful response has no message content"
+curl() {
+    printf '%s' '{"choices":[{"message":{"content":""}}]}200'
+}
+ORCAROUTER_API_KEY="sk-orca-empty-response-test"
+VERBOSE="false"
+set +e
+empty_response_output=$(orcarouter_execute_model \
+    "anthropic/claude-sonnet-4.6" "review this" review 2 2>/dev/null)
+empty_response_rc=$?
+set -e
+unset -f curl
+unset ORCAROUTER_API_KEY
+if [[ "$empty_response_rc" -ne 0 && "$empty_response_output" == *'"choices"'* ]]; then
+    test_pass
+else
+    test_fail "empty OrcaRouter content returned status=$empty_response_rc"
+fi
+
+test_case "orcarouter execution removes its header file when interrupted"
+interrupt_tmp="$TEST_TMP_DIR/orcarouter-interrupt"
+mkdir -p "$interrupt_tmp"
+TMPDIR="$interrupt_tmp" ORCAROUTER_API_KEY="sk-orca-interrupt-test" \
+    bash -c '
+        log() { :; }
+        json_escape() { printf "%s" "$1"; }
+        curl() {
+            local header_file=""
+            printf "%s\n" "$BASHPID" > "$TMPDIR/request.pid"
+            while [[ $# -gt 0 ]]; do
+                if [[ "$1" == "-D" ]]; then
+                    header_file="$2"
+                    shift 2
+                else
+                    shift
+                fi
+            done
+            printf "Retry-After: 2\r\n" > "$header_file"
+            printf "%s" "{}429"
+        }
+        VERBOSE=false
+        source "$1/scripts/lib/perplexity.sh"
+        orcarouter_execute_model "anthropic/claude-sonnet-4.6" "review this" review 2
+    ' _ "$PROJECT_ROOT" > "$interrupt_tmp/output" 2>&1 &
+interrupt_pid=$!
+header_created="false"
+for _attempt in {1..100}; do
+    if [[ -s "$interrupt_tmp/request.pid" ]] &&
+            find "$interrupt_tmp" -maxdepth 1 -name 'octo-orca-headers.*' -print -quit | grep -q .; then
+        header_created="true"
+        break
+    fi
+    sleep 0.02
+done
+request_pid=""
+[[ -s "$interrupt_tmp/request.pid" ]] && request_pid="$(<"$interrupt_tmp/request.pid")"
+[[ -n "$request_pid" ]] && kill -TERM "$request_pid" 2>/dev/null || true
+set +e
+wait "$interrupt_pid" 2>/dev/null
+interrupt_rc=$?
+set -e
+if [[ "$header_created" == "true" && "$interrupt_rc" -ne 0 ]] &&
+        ! find "$interrupt_tmp" -maxdepth 1 -name 'octo-orca-headers.*' -print -quit | grep -q .; then
+    test_pass
+else
+    test_fail "interrupted OrcaRouter call left a response-header file"
+fi
+
 # Detection: an ORCAROUTER_API_KEY alone must surface orcarouter in the
 # provider inventory, mirroring the openrouter api-key detection.
 test_case "detect_providers surfaces orcarouter with an API key"
-stub_dir=$(mktemp -d)
+stub_dir=$(mktemp -d "$TEST_TMP_DIR/orcarouter-detect.XXXXXX")
 set +e
 detected=$(env "HOME=$stub_dir" "PATH=$PATH" "ORCAROUTER_API_KEY=sk-orca-test" \
     "OCTO_ALLOWED_PROVIDERS=orcarouter" bash -c \
@@ -177,6 +247,65 @@ else
     test_fail "provider status did not resolve the legacy OrcaRouter key"
 fi
 
+test_case "provider status does not advertise disabled OrcaRouter configuration"
+disabled_workspace="$TEST_TMP_DIR/orcarouter-disabled"
+mkdir -p "$disabled_workspace"
+printf '%s\n' \
+    'providers:' \
+    '  orcarouter:' \
+    '    enabled: false' \
+    '    api_key_set: true' \
+    > "$disabled_workspace/.providers-config"
+set +e
+disabled_status=$(env "HOME=$TEST_TMP_DIR" "PATH=$PATH" \
+    "WORKSPACE_DIR=$disabled_workspace" \
+    "ORCAROUTER_API_KEY=sk-orca-disabled-test" \
+    "OCTO_ALLOWED_PROVIDERS=orcarouter" \
+    bash "$PROJECT_ROOT/scripts/helpers/check-providers.sh")
+disabled_status_rc=$?
+set -e
+if [[ "$disabled_status_rc" -eq 0 && "$disabled_status" == *"orcarouter:missing"* ]]; then
+    test_pass
+else
+    test_fail "disabled OrcaRouter configuration was advertised as available"
+fi
+
+test_case "OrcaRouter availability requires api_key_set in explicit configuration"
+old_providers_config_file="${PROVIDERS_CONFIG_FILE:-}"
+printf '%s\n' \
+    'providers:' \
+    '  orcarouter:' \
+    '    enabled: true' \
+    '    api_key_set: false' \
+    > "$disabled_workspace/.providers-config"
+PROVIDERS_CONFIG_FILE="$disabled_workspace/.providers-config"
+ORCAROUTER_API_KEY="sk-orca-unconfigured-test"
+if octo_api_key_provider_is_available "orcarouter" "ORCAROUTER_API_KEY"; then
+    test_fail "api_key_set=false was ignored"
+else
+    test_pass
+fi
+unset ORCAROUTER_API_KEY
+
+source "$PROJECT_ROOT/scripts/lib/council.sh"
+test_case "Council does not seat disabled OrcaRouter configuration"
+printf '%s\n' \
+    'providers:' \
+    '  orcarouter:' \
+    '    enabled: false' \
+    '    api_key_set: true' \
+    > "$disabled_workspace/.providers-config"
+COUNCIL_PROVIDERS="orcarouter"
+ORCAROUTER_API_KEY="sk-orca-disabled-test"
+council_detect_providers
+if [[ "$(jq -r '.orcarouter' <<< "$COUNCIL_PROVIDER_STATUS_JSON")" == "missing" ]]; then
+    test_pass
+else
+    test_fail "Council seated OrcaRouter despite enabled=false"
+fi
+PROVIDERS_CONFIG_FILE="$old_providers_config_file"
+unset ORCAROUTER_API_KEY
+
 test_case "OrcaRouter setup keeps the API key out of terminal output"
 config_display="$PROJECT_ROOT/scripts/lib/config-display.sh"
 if grep -Eq -- 'read -r -s -p .*OrcaRouter API key' "$config_display" &&
@@ -193,7 +322,11 @@ source "$config_display"
 test_case "OrcaRouter secret persistence is private, atomic, and silent"
 secret_env="$TEST_TMP_DIR/provider-secrets.env"
 secret_output="$TEST_TMP_DIR/provider-secrets.out"
-printf '%s\n' 'KEEP_ME=yes' 'ORCAROUTER_API_KEY=old-value' > "$secret_env"
+printf '%s\n' \
+    'KEEP_ME=yes' \
+    'export ORCAROUTER_API_KEY=older-exported-value' \
+    'ORCAROUTER_API_KEY=old-value' \
+    > "$secret_env"
 chmod 644 "$secret_env"
 umask_before=$(umask)
 set +e
@@ -209,7 +342,7 @@ if stat -f '%Lp' "$secret_env" >/dev/null 2>&1; then
 else
     secret_mode=$(stat -c '%a' "$secret_env")
 fi
-secret_count=$(grep -Ec -- '^ORCAROUTER_API_KEY=' "$secret_env")
+secret_count=$(grep -Ec -- '^[[:space:]]*(export[[:space:]]+)?ORCAROUTER_API_KEY=' "$secret_env")
 if [[ "$persist_rc" -eq 0 && ! -s "$secret_output" && \
         "$umask_before" == "$umask_after" && "$secret_mode" == "600" && \
         "$secret_count" -eq 1 ]] && \
@@ -229,12 +362,12 @@ else
     test_fail "only $smoke_guard_count OrcaRouter smoke paths require both flags"
 fi
 
-test_case "Council resolves the OrcaRouter key before availability checks"
+test_case "Council uses the shared OrcaRouter availability gate"
 if grep -A8 -E '^[[:space:]]*orcarouter\)' "$PROJECT_ROOT/scripts/lib/council.sh" |
-        grep -Ec -- 'resolve_provider_env "ORCAROUTER_API_KEY"' >/dev/null; then
+        grep -Ec -- 'octo_api_key_provider_is_available "orcarouter" "ORCAROUTER_API_KEY"' >/dev/null; then
     test_pass
 else
-    test_fail "Council does not resolve profile-backed OrcaRouter credentials"
+    test_fail "Council bypasses the shared enabled-plus-key gate"
 fi
 
 test_summary

--- a/tests/unit/test-provider-registry-contracts.sh
+++ b/tests/unit/test-provider-registry-contracts.sh
@@ -8,18 +8,18 @@ source "$PROJECT_ROOT/scripts/lib/provider-registry.sh"
 test_suite "Provider registry consumer contracts"
 
 test_case "health capability matches implemented health cases"
-expected="codex commandcode claude claude-sdk agy perplexity openrouter atlascloud cursor-agent grok qwen ollama copilot vibe"
+expected="codex commandcode claude claude-sdk agy perplexity openrouter orcarouter atlascloud cursor-agent grok qwen ollama copilot vibe"
 actual="$(octo_provider_ids health)"
 if [[ "$actual" == "$expected" ]]; then test_pass; else test_fail "health set drift: $actual"; fi
 
 test_case "Council capability preserves current providers and adds commandcode"
-expected="codex commandcode claude agy opencode openrouter openai-compatible openai-tools qwen"
+expected="codex commandcode claude agy opencode openrouter orcarouter openai-compatible openai-tools qwen"
 actual="$(octo_provider_ids council)"
 if [[ "$actual" == "$expected" ]]; then test_pass; else test_fail "Council set drift: $actual"; fi
 
 test_case "model-config capability unifies both former allowlists"
 failed=false
-for provider in codex commandcode claude claude-sdk agy perplexity opencode openrouter atlascloud openai-compatible openai-tools openai-compatible-agent cursor-agent grok qwen ollama copilot vibe; do
+for provider in codex commandcode claude claude-sdk agy perplexity opencode openrouter orcarouter atlascloud openai-compatible openai-tools openai-compatible-agent cursor-agent grok qwen ollama copilot vibe; do
     if ! octo_provider_has_capability "$provider" model-config; then test_fail "model-config missing $provider"; failed=true; break; fi
 done
 [[ "$failed" == true ]] || test_pass
@@ -91,12 +91,12 @@ fi
 
 
 test_case "detect capability matches the complete implemented detection inventory"
-expected="codex commandcode claude claude-sdk agy perplexity opencode openrouter atlascloud openai-compatible cursor-agent grok qwen ollama copilot vibe"
+expected="codex commandcode claude claude-sdk agy perplexity opencode openrouter orcarouter atlascloud openai-compatible cursor-agent grok qwen ollama copilot vibe"
 actual="$(octo_provider_ids detect)"
 if [[ "$actual" == "$expected" ]]; then test_pass; else test_fail "detect set drift: $actual"; fi
 
 test_case "canonical provider inventory is explicit and complete"
-expected="codex commandcode claude claude-sdk agy perplexity opencode openrouter atlascloud openai-compatible openai-tools openai-compatible-agent cursor-agent grok qwen ollama copilot vibe"
+expected="codex commandcode claude claude-sdk agy perplexity opencode openrouter orcarouter atlascloud openai-compatible openai-tools openai-compatible-agent cursor-agent grok qwen ollama copilot vibe"
 actual="$(octo_provider_ids)"
 if [[ "$actual" == "$expected" ]]; then test_pass; else test_fail "canonical provider inventory drift: $actual"; fi
 

--- a/tests/unit/test-readme-release-sync.sh
+++ b/tests/unit/test-readme-release-sync.sh
@@ -132,11 +132,13 @@ if "$SYNC_SCRIPT" --root "$fixture" >/tmp/octo-readme-sync-update.out 2>&1 &&
    grep -q "Version-${CURRENT_VERSION}-blue" "$fixture/README.md" &&
    grep -q "v${CURRENT_VERSION}.*(new)" "$fixture/README.md" &&
    grep -q 'supports ten external provider integrations.*Grok' "$fixture/README.md" &&
+   grep -q 'OrcaRouter' "$fixture/README.md" &&
    grep -q 'GPT-5.6 Sol' "$fixture/README.md" &&
    grep -q 'Claude Opus 5' "$fixture/README.md" &&
    grep -q 'Claude Sonnet 5' "$fixture/README.md" &&
    grep -qE '[0-9]+ Claude Code capability flags through.*v[0-9]+\.[0-9]+\.[0-9]+' "$fixture/README.md" &&
    grep -q 'OpenCode CLI, and xAI API key (Grok)' "$fixture/.claude-plugin/README.md" &&
+   grep -q 'OrcaRouter' "$fixture/.claude-plugin/README.md" &&
    grep -q 'up to 10 external AI integrations' "$fixture/PRODUCT.md" &&
    grep -qF 'Local CI parity: `make ci-local` runs the same smoke, unit, and integration suites as CI' "$fixture/PRODUCT.md" &&
    ! grep -qE 'Local CI parity: [0-9]+ smoke' "$fixture/PRODUCT.md" &&
@@ -199,9 +201,12 @@ fi
 
 test_case "public documentation names all ten external integrations"
 if grep -q 'ten external provider integrations' "$PROJECT_ROOT/README.md" &&
+   grep -q '| .*OrcaRouter' "$PROJECT_ROOT/README.md" &&
    grep -q 'Up to ten external AI integrations' "$PROJECT_ROOT/.claude-plugin/README.md" &&
+   grep -q 'OrcaRouter' "$PROJECT_ROOT/.claude-plugin/README.md" &&
    grep -q 'Grok' "$PROJECT_ROOT/.claude-plugin/README.md" &&
-   grep -q 'ten external AI integrations' "$PROJECT_ROOT/docs/ARCHITECTURE.md"; then
+   grep -q 'ten external AI integrations' "$PROJECT_ROOT/docs/ARCHITECTURE.md" &&
+   grep -q '| .*OrcaRouter' "$PROJECT_ROOT/docs/ARCHITECTURE.md"; then
     test_pass
 else
     test_fail "provider count/list differs across public documentation"

--- a/tests/unit/test-readme-release-sync.sh
+++ b/tests/unit/test-readme-release-sync.sh
@@ -75,7 +75,7 @@ text = readme.read_text()
 text = re.sub(r"Version-\d+\.\d+\.\d+-blue", "Version-0.0.0-blue", text)
 text = re.sub(r"Version \d+\.\d+\.\d+", "Version 0.0.0", text)
 text = text.replace(
-    "supports nine external provider integrations",
+    "supports ten external provider integrations",
     "supports eight external provider integrations",
     1,
 )
@@ -106,7 +106,7 @@ plugin_readme.write_text(plugin_text)
 product = root / "PRODUCT.md"
 product_text = product.read_text()
 product_text = product_text.replace(
-    "up to 9 external AI integrations",
+    "up to 10 external AI integrations",
     "up to 8 AI CLIs",
 )
 # Any historical count line must normalise back to the stable phrase, so an
@@ -131,13 +131,13 @@ if "$SYNC_SCRIPT" --root "$fixture" >/tmp/octo-readme-sync-update.out 2>&1 &&
    "$SYNC_SCRIPT" --root "$fixture" --check >/tmp/octo-readme-sync-recheck.out 2>&1 &&
    grep -q "Version-${CURRENT_VERSION}-blue" "$fixture/README.md" &&
    grep -q "v${CURRENT_VERSION}.*(new)" "$fixture/README.md" &&
-   grep -q 'supports nine external provider integrations.*Grok' "$fixture/README.md" &&
+   grep -q 'supports ten external provider integrations.*Grok' "$fixture/README.md" &&
    grep -q 'GPT-5.6 Sol' "$fixture/README.md" &&
    grep -q 'Claude Opus 5' "$fixture/README.md" &&
    grep -q 'Claude Sonnet 5' "$fixture/README.md" &&
    grep -qE '[0-9]+ Claude Code capability flags through.*v[0-9]+\.[0-9]+\.[0-9]+' "$fixture/README.md" &&
    grep -q 'OpenCode CLI, and xAI API key (Grok)' "$fixture/.claude-plugin/README.md" &&
-   grep -q 'up to 9 external AI integrations' "$fixture/PRODUCT.md" &&
+   grep -q 'up to 10 external AI integrations' "$fixture/PRODUCT.md" &&
    grep -qF 'Local CI parity: `make ci-local` runs the same smoke, unit, and integration suites as CI' "$fixture/PRODUCT.md" &&
    ! grep -qE 'Local CI parity: [0-9]+ smoke' "$fixture/PRODUCT.md" &&
    ! grep -qE 'Version-0\.0\.0-blue|stale release copy|v2\.1\.157' "$fixture/README.md"; then
@@ -197,11 +197,11 @@ else
     test_fail "model-config command still presents pre-GPT-5.6 defaults"
 fi
 
-test_case "public documentation names all nine external integrations"
-if grep -q 'nine external provider integrations' "$PROJECT_ROOT/README.md" &&
-   grep -q 'Up to nine external AI integrations' "$PROJECT_ROOT/.claude-plugin/README.md" &&
+test_case "public documentation names all ten external integrations"
+if grep -q 'ten external provider integrations' "$PROJECT_ROOT/README.md" &&
+   grep -q 'Up to ten external AI integrations' "$PROJECT_ROOT/.claude-plugin/README.md" &&
    grep -q 'Grok' "$PROJECT_ROOT/.claude-plugin/README.md" &&
-   grep -q 'nine external AI integrations' "$PROJECT_ROOT/docs/ARCHITECTURE.md"; then
+   grep -q 'ten external AI integrations' "$PROJECT_ROOT/docs/ARCHITECTURE.md"; then
     test_pass
 else
     test_fail "provider count/list differs across public documentation"

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -188,7 +188,7 @@ test_release_description_uses_current_summary() {
 test_readme_provider_and_cost_contract() {
     test_case "README defines provider counting and auditable cost assumptions"
 
-    if grep -q 'nine external provider integrations' "$PROJECT_ROOT/README.md" &&
+    if grep -q 'ten external provider integrations' "$PROJECT_ROOT/README.md" &&
        ! grep -q 'Up to 9 providers' "$PROJECT_ROOT/README.md" &&
        grep -q 'developers.openai.com/api/docs/models/gpt-5.6-sol' "$PROJECT_ROOT/README.md" &&
        grep -q 'docs.perplexity.ai/docs/getting-started/pricing' "$PROJECT_ROOT/README.md" &&

--- a/tests/unit/test-shipped-state-model-resolution.sh
+++ b/tests/unit/test-shipped-state-model-resolution.sh
@@ -85,6 +85,17 @@ test_bare_openrouter_no_config() {
     fi
 }
 
+test_bare_orcarouter_no_config() {
+    test_case "bare orcarouter resolves to a namespaced OrcaRouter ID with no config"
+    local resolved
+    resolved="$(_resolve_in_empty_home orcarouter orcarouter)"
+    if [[ "$resolved" == "anthropic/claude-sonnet-4.6" ]]; then
+        test_pass
+    else
+        test_fail "expected anthropic/claude-sonnet-4.6, got: '$resolved'"
+    fi
+}
+
 test_vibe_no_config() {
     test_case "vibe resolves to its own default (config lives in ~/.vibe/config.toml), not an OpenAI model"
     local resolved
@@ -127,6 +138,7 @@ test_registry_providers_do_not_inherit_codex_default() {
 test_grok_no_config
 test_grok_dispatch_resolution_no_config
 test_bare_openrouter_no_config
+test_bare_orcarouter_no_config
 test_vibe_no_config
 test_atlascloud_no_config_fails_closed
 test_registry_providers_do_not_inherit_codex_default


### PR DESCRIPTION
## Summary

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a first-class, named provider alongside the existing OpenRouter wiring, so Claude Octopus can dispatch to the OrcaRouter gateway exactly like it dispatches to OpenRouter today.

OrcaRouter is an AI gateway that exposes an OpenAI-compatible `/v1/chat/completions` endpoint (plus an Anthropic-compatible `/v1/messages`) and routes namespaced model IDs (`anthropic/claude-sonnet-4.6`, `anthropic/claude-opus-4.8`, `anthropic/claude-haiku-4.5`) to upstream providers. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Wiring (mirrors the existing `openrouter` integration)

- **Executor** — `orcarouter_execute_model` in `scripts/lib/perplexity.sh`: curl POST to `https://api.orcarouter.ai/v1/chat/completions`, `ORCAROUTER_API_KEY` auth, 429 retry with `Retry-After` backoff, and explicit 502/503/524 handling.
- **Dispatch** — `get_agent_command` emits `orcarouter_execute`; context budget, agent→provider mapping, allowlist var (`OCTOPUS_ORCAROUTER_ALLOWED_MODELS`), and blocked-model fallback candidates are all wired in `scripts/lib/dispatch.sh`.
- **Model resolution** — bare `orcarouter` resolves to a namespaced `anthropic/claude-sonnet-4.6` (never an OpenAI model string); availability gates on `PROVIDER_ORCAROUTER_ENABLED && PROVIDER_ORCAROUTER_API_KEY_SET` in `scripts/lib/model-resolver.sh`.
- **Model catalog** — `anthropic/claude-sonnet-4.6`, `anthropic/claude-opus-4.8`, `anthropic/claude-haiku-4.5` registered in `scripts/lib/models.sh`.
- **Registry** — new provider row with `model-config,council,health,detect,dispatch,env` capabilities in `scripts/lib/provider-registry.sh`.
- **Config/smoke** — defaults, capabilities, context limit, section parsing, YAML output, scoring, selection fallback, and status display in `scripts/lib/smoke.sh`; wizard step + summary block in `scripts/lib/config-display.sh`.
- **Detection/health** — `detect_providers` surfaces `orcarouter:api-key`; `check_provider_health` case; `council.sh` availability arm; `octo_provider_probe` `GET /v1/models` health probe in `quota-watcher.sh`; `check-providers.sh` status line.
- **Docs/derived** — `docs/PROVIDERS.md`, README/PRODUCT/.claude-plugin README counts (nine → ten external integrations), plugin keywords, and `marketplace.json` regenerated via `make sync`.

### Tests

- New `tests/unit/test-orcarouter-provider.sh` — 7 cases, all passing (registry capabilities, command/org metadata, syntax, bare model resolution, catalog entries, dispatch command, API-key detection).
- Updated existing suites for the new provider: `test-provider-registry-contracts.sh`, `test-shipped-state-model-resolution.sh`, `test-readme-release-sync.sh`, `test-shared-marketplace-sync.sh`, `test-agy-provider.sh` — all pass.
- Verified locally: provider-registry parity (9/9), governance (11/11), health probe (12/12) and fleet (13/13), smoke dispatch exclusion (9/9), issue-738 council seat (8/8), README sync (8/8).
- Live L3 check against `https://api.orcarouter.ai/v1/chat/completions` with `anthropic/claude-haiku-4.5` returned content successfully.

`make ci-local` equivalent steps (sync-check, smoke, unit) are green in this environment.

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a supported external AI provider and universal fallback.
  * Added task-based model selection, capability-aware routing, health checks, and provider status reporting.
  * Added setup wizard support for configuring and securely storing an OrcaRouter API key.
  * Added three OrcaRouter models to the available model catalog.

* **Documentation**
  * Updated product, architecture, provider, marketplace, and setup documentation.
  * Increased the documented integration count from nine to ten.

* **Tests**
  * Added coverage for OrcaRouter registration, routing, model resolution, configuration, and detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->