### PR TITLE
fix: preserve signal semantics during progress writes

### DIFF
--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -404,7 +404,7 @@ _atomic_release_owned_lock() {
     rm -rf "$lockfile" 2>/dev/null || true
 }
 
-atomic_json_update() {
+atomic_json_update() (
     local json_file="$1"
     local jq_expression="$2"
     shift 2
@@ -447,39 +447,48 @@ atomic_json_update() {
     done
 
     # #559: record ownership so a later contender can tell a live holder from a
-    # crashed one. The token also keeps an old writer from releasing a successor.
-    local lock_token="${BASHPID:-$$}-$(date +%s)-${RANDOM:-0}"
-    printf '%s\n' "${BASHPID:-$$}" > "$lockfile/pid" 2>/dev/null || true
+    # crashed one. BASHPID does not exist on the supported macOS Bash 3.2; in
+    # that case a direct child reports its real parent (this function subshell)
+    # into the lock. Unlike $$, that value is not pinned to the top-level shell.
+    local owner_pid
+    if [[ -n "${BASHPID:-}" ]]; then
+        owner_pid="$BASHPID"
+        printf '%s\n' "$owner_pid" > "$lockfile/pid" 2>/dev/null || true
+    else
+        sh -c 'printf "%s\n" "$PPID"' > "$lockfile/pid" 2>/dev/null || true
+        owner_pid=$(cat "$lockfile/pid" 2>/dev/null || true)
+        [[ "$owner_pid" =~ ^[0-9]+$ ]] || owner_pid="$$"
+    fi
+    # The token keeps an old writer from releasing a successor.
+    local lock_token="${owner_pid}-$(date +%s)-${RANDOM:-0}"
     date +%s > "$lockfile/ts" 2>/dev/null || true
     printf '%s\n' "$lock_token" > "$lockfile/token" 2>/dev/null || true
 
-    # This function can run in the same shell as a caller's own long-lived
-    # EXIT/INT/TERM traps (e.g. orchestrate.sh's temp-dir cleanup), so save
-    # and restore them instead of clobbering them with `trap - EXIT`.
-    local prev_exit_trap prev_int_trap prev_term_trap
-    prev_exit_trap=$(trap -p EXIT)
-    prev_int_trap=$(trap -p INT)
-    prev_term_trap=$(trap -p TERM)
-    local lock_cleanup_cmd
-    printf -v lock_cleanup_cmd '_atomic_release_owned_lock %q %q' "$lockfile" "$lock_token"
-    # shellcheck disable=SC2064 # Intentionally freeze these local values before the function returns.
-    trap "$lock_cleanup_cmd" EXIT INT TERM
+    local tmp_file="${json_file}.tmp.${owner_pid}"
+    # Run the whole critical section in this function's subshell, so these
+    # handlers never replace the caller's EXIT/INT/TERM traps. EXIT owns the
+    # idempotent cleanup; signal handlers clean, restore the default action,
+    # and re-raise so an interrupted update cannot continue successfully.
+    local lock_cleanup_cmd lock_int_cmd lock_term_cmd
+    printf -v lock_cleanup_cmd 'rm -f %q; _atomic_release_owned_lock %q %q' \
+        "$tmp_file" "$lockfile" "$lock_token"
+    printf -v lock_int_cmd '%s; trap - INT; kill -s INT %q; exit 130' \
+        "$lock_cleanup_cmd" "$owner_pid"
+    printf -v lock_term_cmd '%s; trap - TERM; kill -s TERM %q; exit 143' \
+        "$lock_cleanup_cmd" "$owner_pid"
+    # shellcheck disable=SC2064 # Freeze subshell-local paths and token in each handler.
+    trap "$lock_cleanup_cmd" EXIT
+    # shellcheck disable=SC2064 # Freeze subshell-local paths, token, and PID.
+    trap "$lock_int_cmd" INT
+    # shellcheck disable=SC2064 # Freeze subshell-local paths, token, and PID.
+    trap "$lock_term_cmd" TERM
 
-    # BASHPID (not $$, which stays constant across every subshell spawned
-    # from the same parent) keeps concurrent callers from colliding on one
-    # temp file name.
-    local tmp_file="${json_file}.tmp.${BASHPID:-$$}"
     jq "$jq_expression" "$@" "$json_file" > "$tmp_file" && mv "$tmp_file" "$json_file"
     local result=$?
     [[ $result -ne 0 ]] && rm -f "$tmp_file"
 
-    _atomic_release_owned_lock "$lockfile" "$lock_token"
-    eval "${prev_exit_trap:-trap - EXIT}"
-    eval "${prev_int_trap:-trap - INT}"
-    eval "${prev_term_trap:-trap - TERM}"
-
     return $result
-}
+)
 
 # Validate Claude Code task integration features
 validate_claude_code_task_features() {

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -360,6 +360,13 @@ _atomic_lock_is_stale() {
     local pid ts now age
     pid=$(cat "$lockfile/pid" 2>/dev/null || true)
     ts=$(cat "$lockfile/ts" 2>/dev/null || true)
+    if [[ ! "$ts" =~ ^[0-9]+$ ]]; then
+        if stat -c %Y "$lockfile" >/dev/null 2>&1; then
+            ts=$(stat -c %Y "$lockfile" 2>/dev/null || true)
+        else
+            ts=$(stat -f %m "$lockfile" 2>/dev/null || true)
+        fi
+    fi
     now=$(date +%s 2>/dev/null || echo 0)
 
     if [[ "$pid" =~ ^[0-9]+$ ]]; then
@@ -404,6 +411,17 @@ _atomic_release_owned_lock() {
     rm -rf "$lockfile" 2>/dev/null || true
 }
 
+_atomic_reraise_signal() {
+    local signal="$1" owner_pid="$2" exit_code=1
+    case "$signal" in
+        INT) exit_code=130 ;;
+        TERM) exit_code=143 ;;
+    esac
+    trap - "$signal"
+    kill -s "$signal" "$owner_pid" 2>/dev/null || true
+    exit "$exit_code"
+}
+
 atomic_json_update() (
     local json_file="$1"
     local jq_expression="$2"
@@ -433,10 +451,21 @@ atomic_json_update() (
     printf -v retry_sleep '%d.%03d' "$((retry_ms / 1000))" "$((retry_ms % 1000))"
     local stale_age="${OCTO_LOCK_STALE_SECS:-30}"
     [[ "$stale_age" =~ ^[1-9][0-9]*$ ]] || stale_age=30
+    local pending_signal=""
+    trap 'pending_signal=INT' INT
+    trap 'pending_signal=TERM' TERM
 
     while ! mkdir "$lockfile" 2>/dev/null; do
+        case "$pending_signal" in
+            INT) exit 130 ;;
+            TERM) exit 143 ;;
+        esac
         # #559: a leaked lock from a crashed holder would otherwise block forever.
         _atomic_reclaim_stale_lock "$lockfile" "$stale_age"
+        case "$pending_signal" in
+            INT) exit 130 ;;
+            TERM) exit 143 ;;
+        esac
         mkdir "$lockfile" 2>/dev/null && break
         waited=$((waited + 1))
         if [[ $waited -ge $max_waits ]]; then
@@ -472,9 +501,9 @@ atomic_json_update() (
     local lock_cleanup_cmd lock_int_cmd lock_term_cmd
     printf -v lock_cleanup_cmd 'rm -f %q; _atomic_release_owned_lock %q %q' \
         "$tmp_file" "$lockfile" "$lock_token"
-    printf -v lock_int_cmd '%s; trap - INT; kill -s INT %q; exit 130' \
+    printf -v lock_int_cmd '%s; _atomic_reraise_signal INT %q' \
         "$lock_cleanup_cmd" "$owner_pid"
-    printf -v lock_term_cmd '%s; trap - TERM; kill -s TERM %q; exit 143' \
+    printf -v lock_term_cmd '%s; _atomic_reraise_signal TERM %q' \
         "$lock_cleanup_cmd" "$owner_pid"
     # shellcheck disable=SC2064 # Freeze subshell-local paths and token in each handler.
     trap "$lock_cleanup_cmd" EXIT
@@ -482,6 +511,10 @@ atomic_json_update() (
     trap "$lock_int_cmd" INT
     # shellcheck disable=SC2064 # Freeze subshell-local paths, token, and PID.
     trap "$lock_term_cmd" TERM
+    case "$pending_signal" in
+        INT) _atomic_reraise_signal INT "$owner_pid" ;;
+        TERM) _atomic_reraise_signal TERM "$owner_pid" ;;
+    esac
 
     jq "$jq_expression" "$@" "$json_file" > "$tmp_file" && mv "$tmp_file" "$json_file"
     local result=$?

--- a/tests/unit/test-atomic-lock-recovery.sh
+++ b/tests/unit/test-atomic-lock-recovery.sh
@@ -144,31 +144,30 @@ EOF
 test_signal_during_lock_initialization() {
     test_case "TERM during post-mkdir initialization does not leak an empty lock"
     local f="$FIXTURE/h.json"; echo '{"n":1}' > "$f"
-    local fake_bin="$FIXTURE/init-signal-bin"
     local pid_marker="$FIXTURE/init-owner.pid" release_marker="$FIXTURE/init-release"
-    mkdir -p "$fake_bin"
-    cat > "$fake_bin/sh" <<'EOF'
-#!/usr/bin/env bash
-if [[ -n "${OCTO_TEST_PID_MARKER:-}" ]]; then
-    printf '%s\n' "$PPID" > "$OCTO_TEST_PID_MARKER"
-    i=0
-    while [[ ! -f "${OCTO_TEST_RELEASE_MARKER:-}" && "$i" -lt 100 ]]; do
-        sleep 0.1
-        i=$((i + 1))
-    done
-fi
-exec /bin/sh "$@"
-EOF
-    chmod +x "$fake_bin/sh"
 
     local rc=0
     (
-        PATH="$fake_bin:$PATH"
-        hash -r
-        export OCTO_TEST_PID_MARKER="$pid_marker"
-        export OCTO_TEST_RELEASE_MARKER="$release_marker"
+        # Pause the successful lock mkdir after the directory exists but before
+        # atomic_json_update can initialize pid/ts/token. Intercepting the
+        # Bash-3-only owner-PID fallback misses this window on Bash 4+, where
+        # BASHPID is available (and made this regression test fail on Ubuntu).
+        mkdir() {
+            command mkdir "$@"
+            local mkdir_rc=$?
+            if [[ "$mkdir_rc" -eq 0 && "$1" == "$f.lock" ]]; then
+                /bin/sh -c 'printf "%s\n" "$PPID"' > "$pid_marker"
+                local i=0
+                while [[ ! -f "$release_marker" && "$i" -lt 100 ]]; do
+                    sleep 0.1
+                    i=$((i + 1))
+                done
+            fi
+            return "$mkdir_rc"
+        }
         atomic_json_update "$f" '.n=2' 2>/dev/null
-    ) & local worker=$!
+    ) &
+    local worker=$!
     local i=0
     while [[ ! -s "$pid_marker" && "$i" -lt 100 ]]; do sleep 0.1; i=$((i + 1)); done
     local target=""; target=$(cat "$pid_marker" 2>/dev/null || true)

--- a/tests/unit/test-atomic-lock-recovery.sh
+++ b/tests/unit/test-atomic-lock-recovery.sh
@@ -101,6 +101,32 @@ test_release_requires_matching_owner_token() {
     else test_fail "release removed the wrong owner or retained the matching owner"; fi
 }
 
+test_signal_cleanup_terminates_operation() {
+    test_case "TERM cleans the lock and terminates the interrupted update"
+    local f="$FIXTURE/g.json"; echo '{"n":1}' > "$f"
+    local fake_bin="$FIXTURE/signal-bin"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/jq" <<'EOF'
+#!/usr/bin/env bash
+last=""
+for arg in "$@"; do last="$arg"; done
+kill -TERM "$PPID"
+sleep 0.1
+/bin/cat "$last"
+EOF
+    chmod +x "$fake_bin/jq"
+
+    trap ':' TERM
+    local trap_before trap_after
+    trap_before=$(trap -p TERM)
+    local rc=0
+    PATH="$fake_bin:$PATH" atomic_json_update "$f" '.n=2' 2>/dev/null || rc=$?
+    trap_after=$(trap -p TERM)
+    trap - TERM
+    if [[ "$rc" -ne 0 && ! -e "$f.lock" && "$trap_after" == "$trap_before" ]]; then test_pass
+    else test_fail "interrupted update returned rc=$rc lock=$([[ -e "$f.lock" ]] && echo left || echo clean) caller_trap_preserved=$([[ "$trap_after" == "$trap_before" ]] && echo yes || echo no)"; fi
+}
+
 test_empty_path_guard
 test_normal_update_no_lock_left
 test_reclaims_dead_holder_lock
@@ -108,5 +134,6 @@ test_respects_live_holder
 test_reclaims_hard_aged_live_pid_lock
 test_reclaims_aged_out_lock
 test_release_requires_matching_owner_token
+test_signal_cleanup_terminates_operation
 
 test_summary

--- a/tests/unit/test-atomic-lock-recovery.sh
+++ b/tests/unit/test-atomic-lock-recovery.sh
@@ -90,6 +90,15 @@ test_reclaims_aged_out_lock() {
     if [[ ! -e "$f.lock" ]]; then test_pass; else test_fail "aged lock not reclaimed"; fi
 }
 
+test_reclaims_aged_empty_lock() {
+    test_case "an aged lock with no initialized metadata is reclaimed"
+    local f="$FIXTURE/i.json"; echo '{"n":1}' > "$f"
+    mkdir -p "$f.lock"
+    touch -t 202001010000 "$f.lock"
+    _atomic_reclaim_stale_lock "$f.lock" 30
+    if [[ ! -e "$f.lock" ]]; then test_pass; else test_fail "aged empty lock not reclaimed"; fi
+}
+
 test_release_requires_matching_owner_token() {
     test_case "an old writer cannot release a successor's lock"
     local f="$FIXTURE/f.json"; echo '{"n":1}' > "$f"
@@ -116,15 +125,58 @@ sleep 0.1
 EOF
     chmod +x "$fake_bin/jq"
 
+    local prior_term_trap
+    prior_term_trap=$(trap -p TERM)
     trap ':' TERM
     local trap_before trap_after
     trap_before=$(trap -p TERM)
     local rc=0
-    PATH="$fake_bin:$PATH" atomic_json_update "$f" '.n=2' 2>/dev/null || rc=$?
+    (
+        PATH="$fake_bin:$PATH"
+        atomic_json_update "$f" '.n=2' 2>/dev/null
+    ) || rc=$?
     trap_after=$(trap -p TERM)
-    trap - TERM
+    if [[ -n "$prior_term_trap" ]]; then eval "$prior_term_trap"; else trap - TERM; fi
     if [[ "$rc" -ne 0 && ! -e "$f.lock" && "$trap_after" == "$trap_before" ]]; then test_pass
     else test_fail "interrupted update returned rc=$rc lock=$([[ -e "$f.lock" ]] && echo left || echo clean) caller_trap_preserved=$([[ "$trap_after" == "$trap_before" ]] && echo yes || echo no)"; fi
+}
+
+test_signal_during_lock_initialization() {
+    test_case "TERM during post-mkdir initialization does not leak an empty lock"
+    local f="$FIXTURE/h.json"; echo '{"n":1}' > "$f"
+    local fake_bin="$FIXTURE/init-signal-bin"
+    local pid_marker="$FIXTURE/init-owner.pid" release_marker="$FIXTURE/init-release"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/sh" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${OCTO_TEST_PID_MARKER:-}" ]]; then
+    printf '%s\n' "$PPID" > "$OCTO_TEST_PID_MARKER"
+    i=0
+    while [[ ! -f "${OCTO_TEST_RELEASE_MARKER:-}" && "$i" -lt 100 ]]; do
+        sleep 0.1
+        i=$((i + 1))
+    done
+fi
+exec /bin/sh "$@"
+EOF
+    chmod +x "$fake_bin/sh"
+
+    local rc=0
+    (
+        PATH="$fake_bin:$PATH"
+        hash -r
+        export OCTO_TEST_PID_MARKER="$pid_marker"
+        export OCTO_TEST_RELEASE_MARKER="$release_marker"
+        atomic_json_update "$f" '.n=2' 2>/dev/null
+    ) & local worker=$!
+    local i=0
+    while [[ ! -s "$pid_marker" && "$i" -lt 100 ]]; do sleep 0.1; i=$((i + 1)); done
+    local target=""; target=$(cat "$pid_marker" 2>/dev/null || true)
+    if [[ "$target" =~ ^[0-9]+$ ]]; then kill -TERM "$target" 2>/dev/null || true; fi
+    : > "$release_marker"
+    wait "$worker" || rc=$?
+    if [[ "$target" =~ ^[0-9]+$ && "$rc" -ne 0 && ! -e "$f.lock" ]]; then test_pass
+    else test_fail "initialization signal target=${target:-missing} returned rc=$rc lock=$([[ -e "$f.lock" ]] && echo left || echo clean)"; fi
 }
 
 test_empty_path_guard
@@ -133,7 +185,9 @@ test_reclaims_dead_holder_lock
 test_respects_live_holder
 test_reclaims_hard_aged_live_pid_lock
 test_reclaims_aged_out_lock
+test_reclaims_aged_empty_lock
 test_release_requires_matching_owner_token
 test_signal_cleanup_terminates_operation
+test_signal_during_lock_initialization
 
 test_summary


### PR DESCRIPTION
## Summary

- isolate atomic progress updates in a function subshell so caller EXIT, INT, and TERM traps are never replaced
- record the real lock-owner PID on macOS Bash 3.2, where `BASHPID` is unavailable and `$$` is pinned to the top-level shell
- clean temporary files and owner-token locks on exit, then re-raise INT or TERM so interrupted writes cannot report success
- cover the post-`mkdir` initialization gap and reclaim aged, uninitialized locks without letting an old writer release a successor's lock
- make the initialization-race regression portable across Bash 3.2 and Bash 4+

Closes #880.

## Verification

- `bash tests/unit/test-atomic-lock-recovery.sh` — 10/10
- `bash tests/unit/test-v8.40.0-cc-feature-sync.sh` — 21/21
- `shellcheck -S error tests/unit/test-atomic-lock-recovery.sh` — pass
- `OCTOPUS_DISABLE_BARE=1 make ci-local` — all smoke, unit, and 7/7 integration suites passed
- GitHub Actions run 31567145168 — portability, Ubuntu/macOS smoke and unit matrices, symlinked path, and integration all passed
- Claude Octopus run 31567145297 — passed
