### PR TITLE
fix: bound Claude bare authentication probes

### DIFF
--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -25,6 +25,11 @@ if ! declare -f octo_plugin_update_load >/dev/null 2>&1; then
     source "${_doctor_lib_dir}/plugin-update.sh" 2>/dev/null || true
 fi
 
+if ! declare -f _octo_bare_auth_probe >/dev/null 2>&1; then
+    _doctor_lib_dir="${_doctor_lib_dir:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+    source "${_doctor_lib_dir}/providers.sh" 2>/dev/null || true
+fi
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # MODULAR DOCTOR SYSTEM (v8.16.0)
 # 14 check categories, structured results, category filtering, JSON output
@@ -1218,13 +1223,19 @@ doctor_check_skills() {
                 "--bare flag disabled via OCTOPUS_DISABLE_BARE=1" \
                 "Subprocess synthesis falls back to standard claude -p (slower but avoids auth issues)"
         else
-            # Probe whether --bare can authenticate (CC v2.1.114 regression, issue #288)
-            local _bare_test
-            _bare_test=$(echo "x" | claude --bare --print --model claude-haiku-4-5-20251001 2>/dev/null | head -1 || true)
+            # Probe whether --bare can authenticate (CC v2.1.114 regression,
+            # issue #288) without allowing auth or Keychain waits to wedge doctor.
+            local _bare_test="" _bare_test_rc=0
+            _bare_test=$(_octo_bare_auth_probe 2>/dev/null) || _bare_test_rc=$?
+            _bare_test="${_bare_test%%$'\n'*}"
             if [[ "$_bare_test" == *"Not logged in"* || "$_bare_test" == *"Please run /login"* ]]; then
                 doctor_add "bare-flag" "skills" "fail" \
                     "--bare flag breaks subprocess auth on this install (issue #288)" \
                     "Set OCTOPUS_DISABLE_BARE=1 in your shell profile or ~/.claude/settings.json env block to fix"
+            elif [[ "$_bare_test_rc" -ne 0 ]]; then
+                doctor_add "bare-flag" "skills" "warn" \
+                    "--bare authentication probe did not complete (exit ${_bare_test_rc})" \
+                    "Octopus disabled --bare for this run instead of waiting indefinitely"
             else
                 doctor_add "bare-flag" "skills" "pass" \
                     "CC v2.1.87 --bare flag active — subprocess synthesis runs faster" \

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -68,19 +68,31 @@ _octo_run_bare_probe_with_timeout() {
         return $?
     fi
 
+    # The portable path must own the whole probe tree, not only the immediate
+    # claude process. A hook may add wrapper processes below claude; killing
+    # direct children can orphan their descendants. Start a fresh session when
+    # the platform provides either setsid(1) or Perl's POSIX::setsid. If neither
+    # safe launcher exists, treat the optional auth probe as unavailable rather
+    # than launching a process tree that cannot be bounded.
     local cmd_pid monitor_pid exit_code
-    "$@" <&0 &
+    if command -v setsid >/dev/null 2>&1; then
+        setsid "$@" <&0 &
+    elif command -v perl >/dev/null 2>&1; then
+        perl -MPOSIX -e \
+            'defined POSIX::setsid() or exit 125; exec @ARGV; exit 126' \
+            -- "$@" <&0 &
+    else
+        return 125
+    fi
     cmd_pid=$!
 
     (
         sleep "$term_timeout"
         if [[ "$kill_grace" -gt 0 ]]; then
-            pkill -TERM -P "$cmd_pid" 2>/dev/null || true
-            kill -TERM "$cmd_pid" 2>/dev/null || true
+            kill -TERM -- "-$cmd_pid" 2>/dev/null || true
             sleep "$kill_grace"
         fi
-        pkill -KILL -P "$cmd_pid" 2>/dev/null || true
-        kill -KILL "$cmd_pid" 2>/dev/null || true
+        kill -KILL -- "-$cmd_pid" 2>/dev/null || true
     ) &
     monitor_pid=$!
 
@@ -92,7 +104,7 @@ _octo_run_bare_probe_with_timeout() {
     pkill -KILL -P "$monitor_pid" 2>/dev/null || true
     kill "$monitor_pid" 2>/dev/null || true
     wait "$monitor_pid" 2>/dev/null || true
-    pkill -KILL -P "$cmd_pid" 2>/dev/null || true
+    kill -KILL -- "-$cmd_pid" 2>/dev/null || true
     return "$exit_code"
 }
 

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -23,6 +23,34 @@ if ! declare -f copilot_is_available >/dev/null 2>&1; then
     source "${_providers_lib_dir}/copilot.sh" 2>/dev/null || true
 fi
 
+# Keep the Claude Code --bare authentication check from wedging every Octopus
+# command when the CLI is waiting on auth, Keychain, or a broken hook. The main
+# orchestrator has run_with_timeout available by the time feature detection
+# runs; the external timeout fallbacks keep this helper safe when providers.sh
+# is sourced on its own.
+_octo_bare_auth_probe() {
+    local probe_timeout="${OCTOPUS_BARE_PROBE_TIMEOUT:-5}"
+    [[ "$probe_timeout" =~ ^[1-9][0-9]*$ ]] || probe_timeout=5
+    if [[ "$probe_timeout" -gt 30 ]]; then probe_timeout=30; fi
+
+    if [[ "${OCTOPUS_SKIP_PROVIDER_PROBES:-false}" == "true" ]]; then
+        return 125
+    fi
+
+    if declare -f run_with_timeout >/dev/null 2>&1; then
+        printf 'x\n' | run_with_timeout "$probe_timeout" \
+            claude --bare --print --model claude-haiku-4-5-20251001
+    elif command -v gtimeout >/dev/null 2>&1; then
+        printf 'x\n' | gtimeout -k 2 "$probe_timeout" \
+            claude --bare --print --model claude-haiku-4-5-20251001
+    elif command -v timeout >/dev/null 2>&1; then
+        printf 'x\n' | timeout -k 2 "$probe_timeout" \
+            claude --bare --print --model claude-haiku-4-5-20251001
+    else
+        return 125
+    fi
+}
+
 # Version comparison utility
 version_compare() {
     local version1="$1"
@@ -582,11 +610,15 @@ detect_claude_code_version() {
     # and honour OCTOPUS_DISABLE_BARE=1 opt-out.
     _BARE_OPT=""
     if [[ "$SUPPORTS_BARE_FLAG" == "true" && "${OCTOPUS_DISABLE_BARE:-0}" != "1" ]]; then
-        # Quick auth probe: pipe a trivial prompt and check for login nag
-        local _bare_probe
-        _bare_probe=$(echo "x" | claude --bare --print --model claude-haiku-4-5-20251001 2>/dev/null | head -1 || true)
+        # Quick bounded auth probe: a CLI waiting on Keychain, auth, or hooks
+        # must not wedge unrelated commands such as `octopus dev` or `status`.
+        local _bare_probe="" _bare_probe_rc=0
+        _bare_probe=$(_octo_bare_auth_probe 2>/dev/null) || _bare_probe_rc=$?
+        _bare_probe="${_bare_probe%%$'\n'*}"
         if [[ "$_bare_probe" == *"Not logged in"* || "$_bare_probe" == *"Please run /login"* ]]; then
             log "WARN" "--bare flag breaks subprocess auth on this install (issue #288) — disabled. Set OCTOPUS_DISABLE_BARE=1 to suppress this probe."
+        elif [[ "$_bare_probe_rc" -ne 0 ]]; then
+            log "WARN" "--bare authentication probe did not complete (exit ${_bare_probe_rc}) — disabled for this run. Set OCTOPUS_DISABLE_BARE=1 to skip it explicitly."
         else
             _BARE_OPT=" --bare"
             log "INFO" "Subprocess synthesis uses --bare flag for faster claude -p calls"

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -23,32 +23,100 @@ if ! declare -f copilot_is_available >/dev/null 2>&1; then
     source "${_providers_lib_dir}/copilot.sh" 2>/dev/null || true
 fi
 
+# Normalize before arithmetic: Bash 3.2 wraps sufficiently long digit strings,
+# which can otherwise turn an oversized value into a small positive timeout.
+_octo_bare_probe_timeout() {
+    local value="${1:-5}"
+
+    case "$value" in
+        ''|*[!0-9]*) printf '%s\n' 5; return ;;
+    esac
+    while [[ "$value" == 0* ]]; do
+        value="${value#0}"
+    done
+    case "$value" in
+        '') printf '%s\n' 5 ;;
+        [1-9]|[1-2][0-9]|30) printf '%s\n' "$value" ;;
+        *) printf '%s\n' 30 ;;
+    esac
+}
+
+# This startup probe has a strict total wall-clock budget. Normal dispatch uses
+# run_with_timeout's ten-second TERM grace, but adding that grace here would let
+# a five-second auth check block startup for up to fifteen seconds. Reserve a
+# two-second grace inside budgets above two seconds; shorter budgets hard-kill
+# at their cap.
+_octo_run_bare_probe_with_timeout() {
+    local total_timeout="$1"
+    local term_timeout="$2"
+    local kill_grace="$3"
+    shift 3
+
+    if command -v gtimeout >/dev/null 2>&1; then
+        if [[ "$kill_grace" -gt 0 ]]; then
+            gtimeout -k "$kill_grace" "$term_timeout" "$@"
+        else
+            gtimeout -s KILL "$total_timeout" "$@"
+        fi
+        return $?
+    elif command -v timeout >/dev/null 2>&1; then
+        if [[ "$kill_grace" -gt 0 ]]; then
+            timeout -k "$kill_grace" "$term_timeout" "$@"
+        else
+            timeout -s KILL "$total_timeout" "$@"
+        fi
+        return $?
+    fi
+
+    local cmd_pid monitor_pid exit_code
+    "$@" <&0 &
+    cmd_pid=$!
+
+    (
+        sleep "$term_timeout"
+        if [[ "$kill_grace" -gt 0 ]]; then
+            pkill -TERM -P "$cmd_pid" 2>/dev/null || true
+            kill -TERM "$cmd_pid" 2>/dev/null || true
+            sleep "$kill_grace"
+        fi
+        pkill -KILL -P "$cmd_pid" 2>/dev/null || true
+        kill -KILL "$cmd_pid" 2>/dev/null || true
+    ) &
+    monitor_pid=$!
+
+    if wait "$cmd_pid" 2>/dev/null; then
+        exit_code=0
+    else
+        exit_code=$?
+    fi
+    pkill -KILL -P "$monitor_pid" 2>/dev/null || true
+    kill "$monitor_pid" 2>/dev/null || true
+    wait "$monitor_pid" 2>/dev/null || true
+    pkill -KILL -P "$cmd_pid" 2>/dev/null || true
+    return "$exit_code"
+}
+
 # Keep the Claude Code --bare authentication check from wedging every Octopus
-# command when the CLI is waiting on auth, Keychain, or a broken hook. The main
-# orchestrator has run_with_timeout available by the time feature detection
-# runs; the external timeout fallbacks keep this helper safe when providers.sh
-# is sourced on its own.
+# command when the CLI is waiting on auth, Keychain, or a broken hook. The
+# dedicated runner keeps its termination grace inside the configured total cap
+# whether providers.sh is loaded by the orchestrator or sourced on its own.
 _octo_bare_auth_probe() {
-    local probe_timeout="${OCTOPUS_BARE_PROBE_TIMEOUT:-5}"
-    [[ "$probe_timeout" =~ ^[1-9][0-9]*$ ]] || probe_timeout=5
-    if [[ "$probe_timeout" -gt 30 ]]; then probe_timeout=30; fi
+    local probe_timeout term_timeout kill_grace
+    probe_timeout="$(_octo_bare_probe_timeout "${OCTOPUS_BARE_PROBE_TIMEOUT:-5}")"
+    term_timeout="$probe_timeout"
+    kill_grace=0
+    if [[ "$probe_timeout" -gt 2 ]]; then
+        kill_grace=2
+        term_timeout=$((probe_timeout - kill_grace))
+    fi
 
     if [[ "${OCTOPUS_SKIP_PROVIDER_PROBES:-false}" == "true" ]]; then
         return 125
     fi
 
-    if declare -f run_with_timeout >/dev/null 2>&1; then
-        printf 'x\n' | run_with_timeout "$probe_timeout" \
-            claude --bare --print --model claude-haiku-4-5-20251001
-    elif command -v gtimeout >/dev/null 2>&1; then
-        printf 'x\n' | gtimeout -k 2 "$probe_timeout" \
-            claude --bare --print --model claude-haiku-4-5-20251001
-    elif command -v timeout >/dev/null 2>&1; then
-        printf 'x\n' | timeout -k 2 "$probe_timeout" \
-            claude --bare --print --model claude-haiku-4-5-20251001
-    else
-        return 125
-    fi
+    printf 'x\n' | _octo_run_bare_probe_with_timeout \
+        "$probe_timeout" "$term_timeout" "$kill_grace" \
+        claude --bare --print --model claude-haiku-4-5-20251001
 }
 
 # Version comparison utility

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -53,7 +53,16 @@ run_test_suite() {
 
     TOTAL_SUITES=$((TOTAL_SUITES + 1))
 
-    if bash "$test_file"; then
+    # Non-live suites must never launch real provider/auth probes. Besides
+    # spending API quota, a CLI blocked on Keychain can stall the entire gate.
+    local test_rc=0
+    if [[ "$test_file" == "$SCRIPT_DIR/live/"* ]]; then
+        bash "$test_file" || test_rc=$?
+    else
+        OCTOPUS_SKIP_PROVIDER_PROBES=true bash "$test_file" || test_rc=$?
+    fi
+
+    if [[ "$test_rc" -eq 0 ]]; then
         PASSED_SUITES=$((PASSED_SUITES + 1))
         echo ""
         echo -e "${GREEN}  PASS: ${test_name}${NC}"

--- a/tests/unit/test-bare-auth-probe-timeout.sh
+++ b/tests/unit/test-bare-auth-probe-timeout.sh
@@ -93,8 +93,11 @@ SH
 chmod +x "$stubborn_probe"
 SECONDS=0
 rc=0
-PATH="$manual_bin" _octo_run_bare_probe_with_timeout 1 1 0 "$stubborn_probe" \
-    >/dev/null 2>&1 || rc=$?
+(
+    PATH="$manual_bin"
+    _octo_run_bare_probe_with_timeout 1 1 0 "$stubborn_probe" \
+        >/dev/null 2>&1
+) || rc=$?
 elapsed=$SECONDS
 if [[ "$rc" -ne 0 && "$elapsed" -le 2 ]]; then
     test_pass
@@ -122,8 +125,11 @@ chmod +x "$descendant_wrapper" "$descendant_probe"
 export OCTO_GRANDCHILD_PID_FILE="$grandchild_pid_file"
 export OCTO_DESCENDANT_WRAPPER="$descendant_wrapper"
 rc=0
-PATH="$manual_bin" _octo_run_bare_probe_with_timeout 1 1 0 "$descendant_probe" \
-    >/dev/null 2>&1 || rc=$?
+(
+    PATH="$manual_bin"
+    _octo_run_bare_probe_with_timeout 1 1 0 "$descendant_probe" \
+        >/dev/null 2>&1
+) || rc=$?
 grandchild_pid=$(cat "$grandchild_pid_file" 2>/dev/null || true)
 if [[ -n "$grandchild_pid" ]] && kill -0 "$grandchild_pid" 2>/dev/null; then
     kill -KILL "$grandchild_pid" 2>/dev/null || true

--- a/tests/unit/test-bare-auth-probe-timeout.sh
+++ b/tests/unit/test-bare-auth-probe-timeout.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+log() { :; }
+source "$PROJECT_ROOT/scripts/lib/providers.sh"
+
+test_suite "Bounded Claude --bare authentication probe"
+
+test_case "non-live test and remote probe suppression never launches Claude"
+probe_marker="$TEST_TMP_DIR/claude-called"
+claude() { : > "$probe_marker"; }
+rc=0
+OCTOPUS_SKIP_PROVIDER_PROBES=true _octo_bare_auth_probe >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 125 && ! -e "$probe_marker" ]]; then test_pass
+else test_fail "suppressed probe rc=$rc launched=$([[ -e "$probe_marker" ]] && echo yes || echo no)"; fi
+unset -f claude
+
+test_case "probe uses the shared timeout with a bounded default"
+timeout_args="$TEST_TMP_DIR/timeout-args"
+run_with_timeout() {
+    printf '%s\n' "$*" > "$timeout_args"
+    return 124
+}
+rc=0
+OCTOPUS_SKIP_PROVIDER_PROBES=false _octo_bare_auth_probe >/dev/null 2>&1 || rc=$?
+args=$(cat "$timeout_args" 2>/dev/null || true)
+if [[ "$rc" -eq 124 && "$args" == "5 claude --bare --print --model claude-haiku-4-5-20251001" ]]; then test_pass
+else test_fail "unexpected timeout contract: rc=$rc args=$args"; fi
+
+test_case "invalid and excessive timeout overrides are clamped"
+OCTOPUS_BARE_PROBE_TIMEOUT=bogus OCTOPUS_SKIP_PROVIDER_PROBES=false _octo_bare_auth_probe >/dev/null 2>&1 || true
+invalid_args=$(cat "$timeout_args" 2>/dev/null || true)
+OCTOPUS_BARE_PROBE_TIMEOUT=999 OCTOPUS_SKIP_PROVIDER_PROBES=false _octo_bare_auth_probe >/dev/null 2>&1 || true
+clamped_args=$(cat "$timeout_args" 2>/dev/null || true)
+if [[ "$invalid_args" == 5\ * && "$clamped_args" == 30\ * ]]; then test_pass
+else test_fail "timeout validation failed: invalid=$invalid_args clamped=$clamped_args"; fi
+
+test_case "non-live suite runner suppresses provider probes without changing live suites"
+runner="$PROJECT_ROOT/tests/run-all-tests.sh"
+if grep -Fq 'if [[ "$test_file" == "$SCRIPT_DIR/live/"* ]]' "$runner" &&
+   grep -Fq 'OCTOPUS_SKIP_PROVIDER_PROBES=true bash "$test_file"' "$runner"; then
+    test_pass
+else
+    test_fail "test runner does not isolate non-live provider probes from live suites"
+fi
+
+test_case "standalone doctor loads the bounded probe helper"
+if bash -c 'source "$1"; declare -f _octo_bare_auth_probe >/dev/null' \
+    _ "$PROJECT_ROOT/scripts/lib/doctor.sh"; then
+    test_pass
+else
+    test_fail "lib/doctor.sh does not provide the bounded bare-auth probe standalone"
+fi
+
+test_summary

--- a/tests/unit/test-bare-auth-probe-timeout.sh
+++ b/tests/unit/test-bare-auth-probe-timeout.sh
@@ -19,25 +19,81 @@ if [[ "$rc" -eq 125 && ! -e "$probe_marker" ]]; then test_pass
 else test_fail "suppressed probe rc=$rc launched=$([[ -e "$probe_marker" ]] && echo yes || echo no)"; fi
 unset -f claude
 
-test_case "probe uses the shared timeout with a bounded default"
+fake_bin="$TEST_TMP_DIR/bin"
 timeout_args="$TEST_TMP_DIR/timeout-args"
-run_with_timeout() {
-    printf '%s\n' "$*" > "$timeout_args"
-    return 124
-}
+mkdir -p "$fake_bin"
+cat > "$fake_bin/gtimeout" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" > "$OCTO_TIMEOUT_ARGS_FILE"
+exit 124
+SH
+chmod +x "$fake_bin/gtimeout"
+export OCTO_TIMEOUT_ARGS_FILE="$timeout_args"
+export PATH="$fake_bin:$PATH"
+
+test_case "probe keeps the TERM-to-KILL grace inside its total default budget"
 rc=0
 OCTOPUS_SKIP_PROVIDER_PROBES=false _octo_bare_auth_probe >/dev/null 2>&1 || rc=$?
 args=$(cat "$timeout_args" 2>/dev/null || true)
-if [[ "$rc" -eq 124 && "$args" == "5 claude --bare --print --model claude-haiku-4-5-20251001" ]]; then test_pass
-else test_fail "unexpected timeout contract: rc=$rc args=$args"; fi
+if [[ "$rc" -eq 124 && "$args" == "-k 2 3 claude --bare --print --model claude-haiku-4-5-20251001" ]]; then
+    test_pass
+else
+    test_fail "unexpected total-budget timeout contract: rc=$rc args=$args"
+fi
 
-test_case "invalid and excessive timeout overrides are clamped"
-OCTOPUS_BARE_PROBE_TIMEOUT=bogus OCTOPUS_SKIP_PROVIDER_PROBES=false _octo_bare_auth_probe >/dev/null 2>&1 || true
+test_case "invalid and arbitrarily large timeout overrides are normalized before arithmetic"
+OCTOPUS_BARE_PROBE_TIMEOUT=bogus OCTOPUS_SKIP_PROVIDER_PROBES=false \
+    _octo_bare_auth_probe >/dev/null 2>&1 || true
 invalid_args=$(cat "$timeout_args" 2>/dev/null || true)
-OCTOPUS_BARE_PROBE_TIMEOUT=999 OCTOPUS_SKIP_PROVIDER_PROBES=false _octo_bare_auth_probe >/dev/null 2>&1 || true
+OCTOPUS_BARE_PROBE_TIMEOUT=999999999999999999999999999999999999999 \
+    OCTOPUS_SKIP_PROVIDER_PROBES=false _octo_bare_auth_probe >/dev/null 2>&1 || true
 clamped_args=$(cat "$timeout_args" 2>/dev/null || true)
-if [[ "$invalid_args" == 5\ * && "$clamped_args" == 30\ * ]]; then test_pass
-else test_fail "timeout validation failed: invalid=$invalid_args clamped=$clamped_args"; fi
+if [[ "$invalid_args" == "-k 2 3 "* && "$clamped_args" == "-k 2 28 "* ]]; then
+    test_pass
+else
+    test_fail "timeout validation failed: invalid=$invalid_args clamped=$clamped_args"
+fi
+
+test_case "zero-padded positive timeout overrides retain their numeric value"
+OCTOPUS_BARE_PROBE_TIMEOUT=00029 OCTOPUS_SKIP_PROVIDER_PROBES=false \
+    _octo_bare_auth_probe >/dev/null 2>&1 || true
+padded_args=$(cat "$timeout_args" 2>/dev/null || true)
+if [[ "$padded_args" == "-k 2 27 "* ]]; then
+    test_pass
+else
+    test_fail "zero-padded timeout did not normalize to 29 seconds: args=$padded_args"
+fi
+
+test_case "one-second probe budgets use a hard cap without extending for grace"
+OCTOPUS_BARE_PROBE_TIMEOUT=1 OCTOPUS_SKIP_PROVIDER_PROBES=false \
+    _octo_bare_auth_probe >/dev/null 2>&1 || true
+short_args=$(cat "$timeout_args" 2>/dev/null || true)
+if [[ "$short_args" == "-s KILL 1 claude --bare --print --model claude-haiku-4-5-20251001" ]]; then
+    test_pass
+else
+    test_fail "short timeout extended past the configured cap: args=$short_args"
+fi
+
+test_case "portable fallback hard-kills a TERM-ignoring probe at the total cap"
+manual_bin="$TEST_TMP_DIR/manual-bin"
+mkdir -p "$manual_bin"
+ln -sf /bin/sleep "$manual_bin/sleep"
+ln -sf /usr/bin/pkill "$manual_bin/pkill"
+stubborn_probe() {
+    trap '' TERM
+    while :; do sleep 1; done
+}
+SECONDS=0
+rc=0
+PATH="$manual_bin" _octo_run_bare_probe_with_timeout 1 1 0 stubborn_probe \
+    >/dev/null 2>&1 || rc=$?
+elapsed=$SECONDS
+unset -f stubborn_probe
+if [[ "$rc" -ne 0 && "$elapsed" -le 2 ]]; then
+    test_pass
+else
+    test_fail "portable fallback exceeded cap or lost failure: rc=$rc elapsed=${elapsed}s"
+fi
 
 test_case "non-live suite runner suppresses provider probes without changing live suites"
 runner="$PROJECT_ROOT/tests/run-all-tests.sh"

--- a/tests/unit/test-bare-auth-probe-timeout.sh
+++ b/tests/unit/test-bare-auth-probe-timeout.sh
@@ -79,20 +79,60 @@ manual_bin="$TEST_TMP_DIR/manual-bin"
 mkdir -p "$manual_bin"
 ln -sf /bin/sleep "$manual_bin/sleep"
 ln -sf /usr/bin/pkill "$manual_bin/pkill"
-stubborn_probe() {
-    trap '' TERM
-    while :; do sleep 1; done
-}
+if command -v setsid >/dev/null 2>&1; then
+    ln -sf "$(command -v setsid)" "$manual_bin/setsid"
+elif command -v perl >/dev/null 2>&1; then
+    ln -sf "$(command -v perl)" "$manual_bin/perl"
+fi
+stubborn_probe="$TEST_TMP_DIR/stubborn-probe.sh"
+cat > "$stubborn_probe" <<'SH'
+#!/bin/sh
+trap '' TERM
+while :; do sleep 1; done
+SH
+chmod +x "$stubborn_probe"
 SECONDS=0
 rc=0
-PATH="$manual_bin" _octo_run_bare_probe_with_timeout 1 1 0 stubborn_probe \
+PATH="$manual_bin" _octo_run_bare_probe_with_timeout 1 1 0 "$stubborn_probe" \
     >/dev/null 2>&1 || rc=$?
 elapsed=$SECONDS
-unset -f stubborn_probe
 if [[ "$rc" -ne 0 && "$elapsed" -le 2 ]]; then
     test_pass
 else
     test_fail "portable fallback exceeded cap or lost failure: rc=$rc elapsed=${elapsed}s"
+fi
+
+test_case "portable fallback kills the complete probe process tree"
+grandchild_pid_file="$TEST_TMP_DIR/grandchild.pid"
+descendant_wrapper="$TEST_TMP_DIR/descendant-wrapper.sh"
+descendant_probe="$TEST_TMP_DIR/descendant-probe.sh"
+cat > "$descendant_wrapper" <<'SH'
+#!/bin/sh
+sleep 30 &
+printf '%s\n' "$!" > "$OCTO_GRANDCHILD_PID_FILE"
+wait
+SH
+cat > "$descendant_probe" <<'SH'
+#!/bin/sh
+trap '' TERM
+"$OCTO_DESCENDANT_WRAPPER" &
+wait
+SH
+chmod +x "$descendant_wrapper" "$descendant_probe"
+export OCTO_GRANDCHILD_PID_FILE="$grandchild_pid_file"
+export OCTO_DESCENDANT_WRAPPER="$descendant_wrapper"
+rc=0
+PATH="$manual_bin" _octo_run_bare_probe_with_timeout 1 1 0 "$descendant_probe" \
+    >/dev/null 2>&1 || rc=$?
+grandchild_pid=$(cat "$grandchild_pid_file" 2>/dev/null || true)
+if [[ -n "$grandchild_pid" ]] && kill -0 "$grandchild_pid" 2>/dev/null; then
+    kill -KILL "$grandchild_pid" 2>/dev/null || true
+    wait "$grandchild_pid" 2>/dev/null || true
+    test_fail "portable fallback left grandchild pid=$grandchild_pid running"
+elif [[ "$rc" -ne 0 && -n "$grandchild_pid" ]]; then
+    test_pass
+else
+    test_fail "portable fallback did not exercise descendant fixture: rc=$rc pid=$grandchild_pid"
 fi
 
 test_case "non-live suite runner suppresses provider probes without changing live suites"


### PR DESCRIPTION
## Summary

- put every Claude `--bare` authentication probe behind a bounded helper with a five-second default and a hard 30-second total wall-clock cap
- reserve TERM-to-KILL grace inside that cap, with complete process-tree supervision when GNU timeout is unavailable
- normalize invalid, zero-padded, and arbitrarily large timeout overrides before Bash arithmetic
- let non-live test suites suppress real provider probes while preserving live-suite behavior
- use the same bounded helper from standalone doctor checks and report a warning when the probe is skipped, times out, or fails

Closes #882.

## Root cause

Provider feature detection and doctor invoked `claude --bare` directly. If Claude waited for login, Keychain approval, or a broken hook, unrelated Octopus commands and test suites could block indefinitely. Test discovery also ran those probes in non-live suites, causing repeated host credential prompts and very long gates.

## Verification

- test-first check against `upstream/main` — initial regression failed 4/4 before implementation
- review-boundary regressions failed before the follow-up fixes, including oversized input, in-budget kill grace, zero-padded values, and a surviving grandchild process
- `bash tests/unit/test-bare-auth-probe-timeout.sh` — 9/9
- `bash tests/unit/test-atomic-lock-recovery.sh` — 10/10
- `bash tests/unit/test-provider-auth-validity.sh` — 18/18
- `bash tests/unit/test-windows-doctor-compat.sh` — 5/5
- Bash syntax, error-level ShellCheck, diff check, and executable-mode check — pass
- `make ci-local` on commit `79b3f7e7` — 16/16 smoke, 259/259 unit, and 7/7 integration suites passed

## Behavior

- normal interactive users still get the fast `--bare` path when the bounded auth probe succeeds
- stale, unauthenticated, remote, and non-live test contexts degrade safely without launching an unbounded prompt
- portable fallback probes run in an isolated session/process group; if safe isolation is unavailable, the optional probe is skipped instead of launching an unbounded descendant tree
- live provider tests remain opt-in and unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bare authentication checks to detect authentication failures and incomplete responses more reliably.
  - Added bounded timeout handling to prevent checks from hanging indefinitely.
  - Incomplete or skipped authentication probes are now reported as warnings instead of being treated as successful.
  - Improved compatibility across environments with different timeout utilities.
  - Prevented non-live test runs from triggering external provider checks.

- **Tests**
  - Expanded coverage for timeout behavior, probe suppression, and authentication-check reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->