### PR TITLE
chore: release v9.62.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.61.3 - Auth-aware provider status for codex/opencode/copilot, direct Google CLI retirement in favor of Antigravity, capped Codex default prompts, and stale-install detection/repair. 32 personas, 51 commands, 63 skills. Run /octo:setup.",
-      "version": "9.61.3",
+      "description": "v9.62.0 - Permanent workflow reliability: bounded retries and auth probes, race-safe progress hooks, and AGY fleet guards. 32 personas, 51 commands, 63 skills. Run /octo:setup.",
+      "version": "9.62.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.61.3"
+    "version": "9.62.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": "2026-06",
   "name": "octo",
   "displayName": "Claude Octopus",
-  "version": "9.61.3",
+  "version": "9.62.0",
   "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
   "author": {
     "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.61.3",
-  "description": "v9.61.3 \u2014 Auth-aware provider status for codex/opencode/copilot, direct Google CLI retirement in favor of Antigravity, capped Codex default prompts, and stale-install detection/repair. Run /octo:setup.",
+  "version": "9.62.0",
+  "description": "v9.62.0 \u2014 Permanent workflow reliability: bounded retries and auth probes, race-safe progress hooks, and AGY fleet guards. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Claude Octopus routine manifest (v9.61.3). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "$comment": "Claude Octopus routine manifest (v9.62.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
   "schemaVersion": 1,
   "routines": [
     {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.61.3",
+  "version": "9.62.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Antigravity, Grok, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.61.3",
+  "version": "9.62.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.61.3"
+    "version": "9.62.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.61.3 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 51 commands, 63 skills. Run /octo:setup after install.",
-      "version": "9.61.3",
+      "description": "v9.62.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 51 commands, 63 skills. Run /octo:setup after install.",
+      "version": "9.62.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.61.3",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.61.3. 32 expert personas, 51 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.62.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.62.0. 32 expert personas, 51 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -116,7 +116,9 @@ claimed or recorded in `bd`; use this handoff for the blocked tracking record.
   diagnostics. The strengthened regression failed first against the raw-output
   path, then passed 17/17 after routing both version diagnostics through the
   logger; release wording now distinguishes generation from check-only
-  validation.
+  validation. The final review strengthened the same fixture to prove update
+  mode also repairs entry-only drift and that the repaired manifest passes a
+  subsequent `--check`, with warning assertions derived from fixture data.
 
 ## Release v9.61.3
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -111,7 +111,12 @@ claimed or recorded in `bd`; use this handoff for the blocked tracking record.
   but neither validated nor regenerated `.metadata.version`. The behavioral
   regression failed first with plugin `9.99.0` versus metadata `1.0.0`, then
   passed 17/17 after the generator and `--check` contract were corrected. The
-  amended tree passed the complete 16/259/7 local gate again.
+  amended tree passed the complete 16/259/7 local gate again. Follow-up review
+  confirmed that entry-only drift needed independent coverage and WARN-level
+  diagnostics. The strengthened regression failed first against the raw-output
+  path, then passed 17/17 after routing both version diagnostics through the
+  logger; release wording now distinguishes generation from check-only
+  validation.
 
 ## Release v9.61.3
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,14 +1,13 @@
 # AI Agent Handoff
 
-Last updated: 2026-08-11
-Status: v9.61.3 is published with the completed hook, provider, stale-install,
-lifecycle, and model-metadata repairs from PRs #852, #854 through #857, #859,
-PR #861, and PR #863. Release PR #858 is merged, all implementation issues are
-closed, the shared marketplace is synchronized, Claude/Codex installed-host
-verification passed, and the external release E2E runner's retired Gemini
-assertion is permanently replaced with an AGY contract check.
+Last updated: 2026-08-12
+Status: v9.62.0 consolidates the completed timeout, progress-hook, and AGY
+reliability pass from issues #868 through #872, #880, and #882. Direct Qwen
+prompting with unusable credentials and retired Gemini execution remain blocked;
+Google-family workflow seats execute through AGY. The release retains the local
+stale-install advisory and Claude Code's explicit host-managed update path.
 Branch: `main`
-Release: [v9.61.3](https://github.com/nyldn/claude-octopus/releases/tag/v9.61.3)
+Release: [v9.62.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.62.0)
 
 ## Start Here
 
@@ -66,6 +65,48 @@ Beads is readable but not writable. The remote-backed database is on schema
 v49 with four pending migrations to v53. Repository rules reserve migration for
 the designated migrator. No migration was run, so this work could not be
 claimed or recorded in `bd`; use this handoff for the blocked tracking record.
+
+## Release v9.62.0
+
+- **PR #873 / #868:** definition seats use realistic reasoning budgets instead
+  of terminating mid-answer; squash merge `3a096728`.
+- **PR #874 / #871:** preflight explicitly reports that legacy `gemini*` seats
+  require AGY. Octopus does not restore direct Gemini CLI dispatch; squash merge
+  `65960ced`.
+- **PR #875 / #870:** grasp, ink, and embrace-gate check AGY fleet availability
+  and retain safe empty-result synthesis fallbacks; squash merge `d7d74647`.
+- **PR #876 / #869:** one wall-clock deadline covers every auth retry; timeout
+  and termination exits are terminal, `TIMEOUT=0` stays unlimited, positive
+  tangle implementer budgets have a configurable 1200-second floor, and
+  recovered output is counted consistently. Restricted hosts receive the same
+  effective phase budget. Positive bounded dispatches and continuation retries
+  use the supervised subprocess because native Agent Teams exposes no
+  plugin-accessible cancellation handle; squash merge `cc28531e`.
+- **PR #879 / #872:** `progress.json` is a task-keyed monotonic ledger. Terminal
+  totals are idempotent, estimated API spend is distinguished from subscription
+  seats, phase and output identity reach every dispatch path, and the handoff
+  reads the canonical file. `SubagentStop` and shell lifecycle writers share
+  one atomic directory-lock protocol; squash merge `c5eb5bfb`.
+- **PR #881 / #880:** atomic progress writes cannot replace caller EXIT, INT,
+  or TERM traps. Bash 3.2 records the real lock owner, interrupted writes clean
+  up and re-raise the signal, and abandoned initialization locks are reclaimable;
+  squash merge `cc790499`. Exact `main` Test Suite run `31567827995` passed.
+- **PR #883 / #882:** every Claude `--bare` authentication probe has a
+  five-second default and hard 30-second total cap. The portable path supervises
+  the complete process group, skips rather than launches when safe isolation is
+  unavailable, and non-live tests never invoke the real provider. Exact PR head
+  `79b3f7e7` passed 16/259/7 locally, Test Suite run `31573941934`, the Claude
+  Octopus review workflow, and CodeRabbit approval. Squash merge `332282c8`
+  passed exact `main` Test Suite run `31575017498`.
+- Claude Code owns third-party marketplace mutation. Users enable automatic
+  updates in `/plugin` under **Marketplaces → nyldn-plugins → Enable
+  auto-update**, then run `/reload-plugins` or restart after an update. An
+  installation older than v9.61.3 needs one manual marketplace/plugin update;
+  a newer plugin cannot retroactively install itself into an older loaded copy.
+- The v9.62.0 release-candidate tree passed `make sync-check`,
+  `./scripts/validate-release.sh 9.62.0`, the handoff/README/version release
+  regressions, and `OCTOPUS_DISABLE_BARE=1 make ci-local`: 16 smoke suites,
+  259 unit suites, and 7 integration suites.
 
 ## Release v9.61.3
 
@@ -347,10 +388,13 @@ were removed with that worktree and did not contaminate the task branch.
 
 ## Next Action
 
-No active implementation or release work remains. After closing post-release
-E2E issue #865 and merging the external runner fix, live queries found no open
-issues or pull requests in either repository. If streamlining work resumes, the
-unstarted candidates are:
+No issue-backed implementation remains; the live issue query was empty after
+#882 closed with PR #883. Contributor PRs #867 (reasoning-role env-key
+sanitization) and #877 (OrcaRouter provider) were intentionally not folded into
+this issue-driven reliability release. Re-query their current review and base
+state before acting on either one.
+
+If streamlining work resumes, the unstarted candidates are:
 
 1. Remaining streamlining work:
    - **4c:** remove obsolete drift detection, its unreachable duplicate, and

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -107,6 +107,11 @@ claimed or recorded in `bd`; use this handoff for the blocked tracking record.
   `./scripts/validate-release.sh 9.62.0`, the handoff/README/version release
   regressions, and `OCTOPUS_DISABLE_BARE=1 make ci-local`: 16 smoke suites,
   259 unit suites, and 7 integration suites.
+- Release review exposed that `sync-marketplace.sh` updated the Octopus entry
+  but neither validated nor regenerated `.metadata.version`. The behavioral
+  regression failed first with plugin `9.99.0` versus metadata `1.0.0`, then
+  passed 17/17 after the generator and `--check` contract were corrected. The
+  amended tree passed the complete 16/259/7 local gate again.
 
 ## Release v9.61.3
 
@@ -389,7 +394,7 @@ were removed with that worktree and did not contaminate the task branch.
 ## Next Action
 
 No issue-backed implementation remains; the live issue query was empty after
-#882 closed with PR #883. Contributor PRs #867 (reasoning-role env-key
+issue #882 closed with PR #883. Contributor PRs #867 (reasoning-role env-key
 sanitization) and #877 (OrcaRouter provider) were intentionally not folded into
 this issue-driven reliability release. Re-query their current review and base
 state before acting on either one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## [Unreleased]
 
+## [9.62.0] - 2026-08-12
+
+### Added
+
+- Positive tangle-implementer timeouts have a configurable floor through
+  `OCTOPUS_TANGLE_TIMEOUT` (default 1200 seconds); `TIMEOUT=0` remains
+  explicitly unlimited. (#869)
+
+### Fixed
+
+- Definition seats receive realistic reasoning budgets instead of terminating
+  mid-answer. (#868)
+- One wall-clock agent deadline now covers every authentication retry; timeout
+  and termination exits are terminal, recovered output is counted consistently,
+  and restricted hosts receive the same effective phase budget. (#869)
+- Preflight explains that legacy `gemini*` inputs require AGY, while grasp,
+  ink, and embrace-gate skip unavailable AGY seats and retain safe synthesis
+  fallbacks. Direct Gemini CLI execution remains retired. (#870, #871)
+- Workflow progress is a task-keyed monotonic ledger with idempotent terminal
+  totals, honest API-cost attribution, subscription-seat labels, and one atomic
+  lock protocol shared by shell and `SubagentStop` writers. (#872)
+- Atomic progress updates preserve caller signal traps, use a real lock-owner
+  PID on Bash 3.2, reclaim abandoned initialization locks, and re-raise
+  interruptions instead of reporting a cancelled write as successful. (#880)
+- Claude `--bare` authentication probes have a five-second default and hard
+  30-second total cap, terminate their complete process tree, and are suppressed
+  in non-live tests. Doctor degrades safely when an optional probe cannot run,
+  preventing stale auth, Keychain, or hook state from hanging unrelated work.
+  (#882)
+
+### Documentation
+
+- Update guidance retains Claude Code's host-managed third-party marketplace
+  auto-update opt-in, the manual recovery path required for installs older than
+  v9.61.3, and the required `/reload-plugins` or restart step.
+
 ## [9.61.3] - 2026-08-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@
   auto-update opt-in, the manual recovery path required for installs older than
   v9.61.3, and the required `/reload-plugins` or restart step.
 
+### Internal
+
+- Marketplace generation and `--check` now synchronize both the Octopus entry
+  and top-level metadata version, preventing one release manifest from
+  publishing conflicting versions.
+
 ## [9.61.3] - 2026-08-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,8 @@
 
 ### Internal
 
-- Marketplace generation and `--check` now synchronize both the Octopus entry
-  and top-level metadata version, preventing one release manifest from
-  publishing conflicting versions.
+- Marketplace generation now synchronizes the Octopus entry and top-level
+  metadata version; `--check` validates both values before release.
 
 ## [9.61.3] - 2026-08-10
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-10
+last_reviewed: 2026-08-12
 ---
 
 # PRODUCT.md
@@ -78,7 +78,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 - GitHub stars: 3,889
 - GitHub forks: 365
 - Local CI parity: `make ci-local` runs the same smoke, unit, and integration suites as CI
-- Version: 9.61.3 (active release cadence)
+- Version: 9.62.0 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Antigravity CLI
 
 **Measured Impact:**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
 <p align="center">
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/Version-9.61.3-blue" alt="Version 9.61.3">
+  <img src="https://img.shields.io/badge/Version-9.62.0-blue" alt="Version 9.62.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -35,7 +35,7 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
 ## What's New
 
 <!-- BEGIN CURRENT RELEASE -->
-> 🆕 **v9.61.3 — Auth-aware provider status for codex/opencode/copilot, direct Google CLI retirement in favor of Antigravity, capped Codex default prompts, and stale-install detection/repair.**
+> 🆕 **v9.62.0 — Permanent workflow reliability: bounded retries and auth probes, race-safe progress hooks, and AGY fleet guards.**
 >
 > **Default roster:** Claude Opus 5 leads architecture, planning, security reasoning, and final judgment; GPT-5.6 Sol is the independent implementation/review peer; Claude Sonnet 5 is the standard Claude seat; Fable 5 remains an opt-in judgment escalation. Existing model pins and provider configuration still win. See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md).
 <!-- END CURRENT RELEASE -->
@@ -55,7 +55,7 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
 
 | Version | Best Features |
 |---------|--------------|
-| **v9.61.3** (new) | Auth-aware provider status for codex/opencode/copilot, direct Google CLI retirement in favor of Antigravity, capped Codex default prompts, and stale-install detection/repair. |
+| **v9.62.0** (new) | Permanent workflow reliability: bounded retries and auth probes, race-safe progress hooks, and AGY fleet guards. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
 | **v9** | Up to 9 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.61.3",
+  "version": "9.62.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -240,6 +240,7 @@ ${YELLOW}Quality Gates:${NC}
 ${YELLOW}Environment:${NC}
   OCTOPUS_TANGLE_CODE_REVIEW=false              Skip contextual code review
   OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=unbounded Progress-supervised loop (default)
+  OCTOPUS_TANGLE_TIMEOUT=1200                    Minimum positive implementer budget; TIMEOUT=0 stays unlimited
   OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded   Opt into explicit round cap
   OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=3       Bound count when mode=bounded
   OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW=1800     Stop only after silence/no progress

--- a/scripts/sync-marketplace.sh
+++ b/scripts/sync-marketplace.sh
@@ -69,6 +69,21 @@ for p in m.get('plugins', []):
 else:
     sys.exit(1)
 ")
+CURRENT_ENTRY_VERSION=$(python3 -c "
+import json, sys
+m = json.load(open('$ROOT_DIR/.claude-plugin/marketplace.json'))
+for p in m.get('plugins', []):
+    if p.get('name') == 'octo':
+        print(p.get('version', ''))
+        break
+else:
+    sys.exit(1)
+")
+CURRENT_METADATA_VERSION=$(python3 -c "
+import json
+m = json.load(open('$ROOT_DIR/.claude-plugin/marketplace.json'))
+print(m.get('metadata', {}).get('version', ''))
+")
 # Note: match the dash via alternation, not a `[-—]` bracket expression — under
 # the C/POSIX locale (no LANG/LC_ALL set), sed's bracket-expression handling of
 # the multi-byte em-dash is unreliable and silently fails to match, leaving the
@@ -78,7 +93,10 @@ FEATURE_SUMMARY=$(echo "$PLUGIN_DESC" | sed -E 's/^v[0-9]+\.[0-9]+\.[0-9]+ (-|�
 # Build expected description — version prefix derived from version field
 EXPECTED_DESC="v${VERSION} - ${FEATURE_SUMMARY}. ${PERSONA_COUNT} personas, ${COMMAND_COUNT} commands, ${SKILL_COUNT} skills. Run /octo:setup."
 
-if [[ "$CURRENT_DESC" == "$EXPECTED_DESC" && "$CURRENT_KEYWORDS" == "$PLUGIN_KEYWORDS" ]]; then
+if [[ "$CURRENT_DESC" == "$EXPECTED_DESC" &&
+      "$CURRENT_KEYWORDS" == "$PLUGIN_KEYWORDS" &&
+      "$CURRENT_ENTRY_VERSION" == "$VERSION" &&
+      "$CURRENT_METADATA_VERSION" == "$VERSION" ]]; then
     echo "✓ marketplace.json is up to date (${PERSONA_COUNT} personas, ${COMMAND_COUNT} commands, ${SKILL_COUNT} skills)"
     exit 0
 fi
@@ -88,6 +106,8 @@ if $CHECK_ONLY; then
     echo "  Current:  $CURRENT_DESC"
     echo "  Expected: $EXPECTED_DESC"
     [[ "$CURRENT_KEYWORDS" == "$PLUGIN_KEYWORDS" ]] || echo "  Plugin keywords differ from plugin.json"
+    [[ "$CURRENT_ENTRY_VERSION" == "$VERSION" ]] || echo "  Plugin version: $CURRENT_ENTRY_VERSION (expected $VERSION)"
+    [[ "$CURRENT_METADATA_VERSION" == "$VERSION" ]] || echo "  Metadata version: $CURRENT_METADATA_VERSION (expected $VERSION)"
     exit 1
 fi
 
@@ -97,6 +117,8 @@ import json, os
 
 with open('$ROOT_DIR/.claude-plugin/marketplace.json') as f:
     m = json.load(f)
+
+m.setdefault('metadata', {})['version'] = '$VERSION'
 
 for p in m.get('plugins', []):
     if p.get('name') == 'octo':

--- a/scripts/sync-marketplace.sh
+++ b/scripts/sync-marketplace.sh
@@ -106,8 +106,8 @@ if $CHECK_ONLY; then
     echo "  Current:  $CURRENT_DESC"
     echo "  Expected: $EXPECTED_DESC"
     [[ "$CURRENT_KEYWORDS" == "$PLUGIN_KEYWORDS" ]] || echo "  Plugin keywords differ from plugin.json"
-    [[ "$CURRENT_ENTRY_VERSION" == "$VERSION" ]] || echo "  Plugin version: $CURRENT_ENTRY_VERSION (expected $VERSION)"
-    [[ "$CURRENT_METADATA_VERSION" == "$VERSION" ]] || echo "  Metadata version: $CURRENT_METADATA_VERSION (expected $VERSION)"
+    [[ "$CURRENT_ENTRY_VERSION" == "$VERSION" ]] || log WARN "Plugin version: $CURRENT_ENTRY_VERSION (expected $VERSION)"
+    [[ "$CURRENT_METADATA_VERSION" == "$VERSION" ]] || log WARN "Metadata version: $CURRENT_METADATA_VERSION (expected $VERSION)"
     exit 1
 fi
 

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -223,7 +223,9 @@ test_local_marketplace_sync_aligns_all_versions() {
     local check_before_rc=0
     local check_after_rc=0
     local check_entry_rc=0
-    local plugin_version metadata_version entry_version
+    local check_entry_repaired_rc=0
+    local plugin_version metadata_version stale_entry_version
+    local repaired_metadata_version repaired_entry_version
 
     mkdir -p "$fixture/scripts" "$fixture/.claude-plugin" "$fixture/agents/personas"
     cp "$LOCAL_SYNC_SCRIPT" "$fixture/scripts/sync-marketplace.sh"
@@ -263,17 +265,26 @@ JSON
 
     plugin_version="$(jq -r '.version' "$fixture/.claude-plugin/plugin.json")"
     metadata_version="$(jq -r '.metadata.version' "$fixture/.claude-plugin/marketplace.json")"
-    entry_version="$(jq -r '.plugins[] | select(.name == "octo") | .version' "$fixture/.claude-plugin/marketplace.json")"
+    stale_entry_version="$(jq -r '.plugins[] | select(.name == "octo") | .version' "$fixture/.claude-plugin/marketplace.json")"
+
+    bash "$fixture/scripts/sync-marketplace.sh" > "$TMP_DIR/local-sync-entry-repair.out" 2>&1
+    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TMP_DIR/local-sync-check-entry-repaired.out" 2>&1 || check_entry_repaired_rc=$?
+    repaired_metadata_version="$(jq -r '.metadata.version' "$fixture/.claude-plugin/marketplace.json")"
+    repaired_entry_version="$(jq -r '.plugins[] | select(.name == "octo") | .version' "$fixture/.claude-plugin/marketplace.json")"
 
     if [[ "$check_before_rc" -ne 0 &&
           "$check_after_rc" -eq 0 &&
           "$check_entry_rc" -ne 0 &&
+          "$check_entry_repaired_rc" -eq 0 &&
           "$metadata_version" == "$plugin_version" &&
-          "$entry_version" != "$plugin_version" ]] &&
-       grep -q '^\[WARN\] Plugin version: 1.0.0 (expected 9.99.0)$' "$TMP_DIR/local-sync-check-entry.out"; then
+          "$stale_entry_version" != "$plugin_version" &&
+          "$repaired_metadata_version" == "$plugin_version" &&
+          "$repaired_entry_version" == "$plugin_version" ]] &&
+       grep -Fqx "[WARN] Plugin version: $stale_entry_version (expected $plugin_version)" \
+           "$TMP_DIR/local-sync-check-entry.out"; then
         test_pass
     else
-        test_fail "expected independent entry-version rejection through WARN logger; before=$check_before_rc after=$check_after_rc entry_check=$check_entry_rc plugin=$plugin_version metadata=$metadata_version entry=$entry_version"
+        test_fail "expected independent entry-version rejection and repair; before=$check_before_rc after=$check_after_rc entry_check=$check_entry_rc entry_repaired=$check_entry_repaired_rc plugin=$plugin_version metadata=$metadata_version stale_entry=$stale_entry_version repaired_metadata=$repaired_metadata_version repaired_entry=$repaired_entry_version"
     fi
 }
 

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -222,6 +222,7 @@ test_local_marketplace_sync_aligns_all_versions() {
     local fixture="$TMP_DIR/local-sync"
     local check_before_rc=0
     local check_after_rc=0
+    local check_entry_rc=0
     local plugin_version metadata_version entry_version
 
     mkdir -p "$fixture/scripts" "$fixture/.claude-plugin" "$fixture/agents/personas"
@@ -255,17 +256,24 @@ JSON
     bash "$fixture/scripts/sync-marketplace.sh" > "$TMP_DIR/local-sync-update.out" 2>&1
     bash "$fixture/scripts/sync-marketplace.sh" --check > "$TMP_DIR/local-sync-check-after.out" 2>&1 || check_after_rc=$?
 
+    jq '(.plugins[] | select(.name == "octo") | .version) = "1.0.0"' \
+        "$fixture/.claude-plugin/marketplace.json" > "$TMP_DIR/local-sync-entry-stale.json"
+    mv "$TMP_DIR/local-sync-entry-stale.json" "$fixture/.claude-plugin/marketplace.json"
+    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TMP_DIR/local-sync-check-entry.out" 2>&1 || check_entry_rc=$?
+
     plugin_version="$(jq -r '.version' "$fixture/.claude-plugin/plugin.json")"
     metadata_version="$(jq -r '.metadata.version' "$fixture/.claude-plugin/marketplace.json")"
     entry_version="$(jq -r '.plugins[] | select(.name == "octo") | .version' "$fixture/.claude-plugin/marketplace.json")"
 
     if [[ "$check_before_rc" -ne 0 &&
           "$check_after_rc" -eq 0 &&
+          "$check_entry_rc" -ne 0 &&
           "$metadata_version" == "$plugin_version" &&
-          "$entry_version" == "$plugin_version" ]]; then
+          "$entry_version" != "$plugin_version" ]] &&
+       grep -q '^\[WARN\] Plugin version: 1.0.0 (expected 9.99.0)$' "$TMP_DIR/local-sync-check-entry.out"; then
         test_pass
     else
-        test_fail "expected stale metadata rejection and synchronized versions; before=$check_before_rc after=$check_after_rc plugin=$plugin_version metadata=$metadata_version entry=$entry_version"
+        test_fail "expected independent entry-version rejection through WARN logger; before=$check_before_rc after=$check_after_rc entry_check=$check_entry_rc plugin=$plugin_version metadata=$metadata_version entry=$entry_version"
     fi
 }
 

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -12,6 +12,7 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Shared Marketplace Sync"
 
 SYNC_SCRIPT="$PROJECT_ROOT/scripts/sync-shared-marketplace.sh"
+LOCAL_SYNC_SCRIPT="$PROJECT_ROOT/scripts/sync-marketplace.sh"
 RELEASE_SCRIPT="$PROJECT_ROOT/scripts/release.sh"
 CHANGELOG_LIB="$PROJECT_ROOT/scripts/lib/release-changelog.sh"
 CI_LIB="$PROJECT_ROOT/scripts/lib/release-ci.sh"
@@ -215,6 +216,59 @@ test_marketplace_description_error_uses_logger() {
     fi
 }
 
+test_local_marketplace_sync_aligns_all_versions() {
+    test_case "sync-marketplace rejects and repairs stale marketplace version fields"
+
+    local fixture="$TMP_DIR/local-sync"
+    local check_before_rc=0
+    local check_after_rc=0
+    local plugin_version metadata_version entry_version
+
+    mkdir -p "$fixture/scripts" "$fixture/.claude-plugin" "$fixture/agents/personas"
+    cp "$LOCAL_SYNC_SCRIPT" "$fixture/scripts/sync-marketplace.sh"
+
+    cat > "$fixture/.claude-plugin/plugin.json" <<'JSON'
+{
+  "version": "9.99.0",
+  "description": "v9.99.0 — Fixture release. Run /octo:setup.",
+  "keywords": ["fixture"],
+  "skills": ["./skills/fixture"],
+  "commands": ["./commands/fixture"]
+}
+JSON
+
+    cat > "$fixture/.claude-plugin/marketplace.json" <<'JSON'
+{
+  "metadata": {"version": "1.0.0"},
+  "plugins": [
+    {
+      "name": "octo",
+      "description": "v9.99.0 - Fixture release. 0 personas, 1 commands, 1 skills. Run /octo:setup.",
+      "version": "9.99.0",
+      "keywords": ["fixture"]
+    }
+  ]
+}
+JSON
+
+    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TMP_DIR/local-sync-check-before.out" 2>&1 || check_before_rc=$?
+    bash "$fixture/scripts/sync-marketplace.sh" > "$TMP_DIR/local-sync-update.out" 2>&1
+    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TMP_DIR/local-sync-check-after.out" 2>&1 || check_after_rc=$?
+
+    plugin_version="$(jq -r '.version' "$fixture/.claude-plugin/plugin.json")"
+    metadata_version="$(jq -r '.metadata.version' "$fixture/.claude-plugin/marketplace.json")"
+    entry_version="$(jq -r '.plugins[] | select(.name == "octo") | .version' "$fixture/.claude-plugin/marketplace.json")"
+
+    if [[ "$check_before_rc" -ne 0 &&
+          "$check_after_rc" -eq 0 &&
+          "$metadata_version" == "$plugin_version" &&
+          "$entry_version" == "$plugin_version" ]]; then
+        test_pass
+    else
+        test_fail "expected stale metadata rejection and synchronized versions; before=$check_before_rc after=$check_after_rc plugin=$plugin_version metadata=$metadata_version entry=$entry_version"
+    fi
+}
+
 test_release_promotes_unreleased_changelog_notes() {
     test_case "release changelog helper promotes Unreleased notes into version entry"
 
@@ -383,6 +437,7 @@ test_release_file_updates_are_portable
 test_release_description_uses_current_summary
 test_readme_provider_and_cost_contract
 test_marketplace_description_error_uses_logger
+test_local_marketplace_sync_aligns_all_versions
 test_release_promotes_unreleased_changelog_notes
 test_release_ci_parser_matches_exact_aggregate_checks
 test_shared_marketplace_sync_updates_only_octo


### PR DESCRIPTION
## Summary

- release the completed reliability fixes from issues #868-#872, #880, and #882
- synchronize the Claude, Codex, Cursor, Factory, package, README, PRODUCT, and marketplace version surfaces at v9.62.0
- document the permanent AGY routing, Qwen credential guard, bounded Claude auth probes, race-safe progress hooks, and the host-managed stale-install update path

## Included fixes

- realistic definition and tangle timeout budgets, with one wall-clock deadline across authentication retries (#868, #869)
- AGY availability checks and safe synthesis fallbacks; retired Gemini inputs remain compatibility aliases rather than executable seats (#870, #871)
- task-consistent, idempotent progress tracking with atomic shell/SubagentStop updates (#872)
- signal-safe Bash 3.2 progress locks with real ownership and abandoned-initialization recovery (#880)
- bounded Claude `--bare` authentication probes, whole-process-tree termination, and non-live test suppression (#882)
- marketplace generation now validates and synchronizes both the Octopus entry and top-level metadata version after a review-found release inconsistency

## Update behavior

Claude Code owns third-party marketplace mutation. Users can enable **Marketplaces → nyldn-plugins → Enable auto-update** in `/plugin`, then run `/reload-plugins` or restart after an update. Installs older than v9.61.3 require one manual marketplace/plugin update because a newer plugin cannot retroactively modify an older loaded cache.

## Verification

- exact base `main` commit `332282c8` passed Test Suite run `31575017498`
- `make sync-check` — pass
- `./scripts/validate-release.sh 9.62.0` — pass; only expected pre-tag/pre-release notices
- release regressions: handoff 13/13, README sync 8/8, version smoke 15/15, nested skill validation 3/3
- marketplace generator regression failed first with plugin `9.99.0` versus metadata `1.0.0`, then passed 17/17 after the source fix
- `OCTOPUS_DISABLE_BARE=1 make ci-local` — 16/16 smoke, 259/259 unit, and 7/7 integration suites passed
- `git diff --check` and executable-mode audit — pass

## After merge

1. verify the exact squash-merge commit with the full `main` Test Suite
2. create annotated tag `v9.62.0` on that squash-merge commit
3. publish the non-draft, non-prerelease GitHub Release from the changelog
4. run `scripts/sync-shared-marketplace.sh` and verify both Claude and Codex selectors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable implementer timeout budgets, including unlimited operation when set to `0`.
  - Added bounded authentication retries and safer provider readiness checks.
  - Improved workflow progress tracking and protection against duplicate updates.
  - Added fleet safeguards for Antigravity workflows.

- **Bug Fixes**
  - Improved handling of locks, signals, timeouts, reasoning budgets, and authentication failures.
  - Improved marketplace metadata version validation and synchronization.

- **Documentation**
  - Updated release notes, product guidance, handoff materials, and command help for version 9.62.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->