### PR TITLE
fix: supersede historical tangle retry results

### DIFF
--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -154,6 +154,59 @@ tangle_quality_retry_limit_reached() {
     [[ "$retry_count" -ge "$retry_limit" ]]
 }
 
+tangle_result_logical_task_id() {
+    local result_file="$1"
+    local task_id base suffix
+    task_id=$(awk '/^# Task ID: / { sub(/^# Task ID: /, ""); print; exit }' "$result_file" 2>/dev/null || true)
+    if [[ -z "$task_id" ]]; then
+        base=$(basename "$result_file" .md)
+        if [[ "$base" == *-tangle-* ]]; then
+            suffix="${base#*-tangle-}"
+            task_id="tangle-${suffix}"
+        fi
+    fi
+    printf '%s\n' "$task_id" | sed -E 's/-retry[0-9]+-([0-9]+)$/-\1/'
+}
+
+tangle_result_retry_rank() {
+    local result_file="$1"
+    local task_id rank
+    task_id=$(awk '/^# Task ID: / { sub(/^# Task ID: /, ""); print; exit }' "$result_file" 2>/dev/null || true)
+    if [[ -z "$task_id" ]]; then
+        task_id=$(basename "$result_file" .md)
+    fi
+    rank=$(printf '%s\n' "$task_id" | sed -nE 's/.*-retry([0-9]+)-[0-9]+$/\1/p')
+    printf '%s\n' "${rank:-0}"
+}
+
+tangle_effective_result_files() {
+    local task_group="$1"
+    local result task_id retry_rank records=""
+
+    for result in "$RESULTS_DIR"/*-tangle-${task_group}*.md; do
+        [[ -f "$result" ]] || continue
+        [[ "$(basename "$result")" == *validation* ]] && continue
+        task_id=$(tangle_result_logical_task_id "$result")
+        retry_rank=$(tangle_result_retry_rank "$result")
+        records+="${task_id}"$'\t'"${retry_rank}"$'\t'"${result}"$'\n'
+    done
+
+    [[ -n "$records" ]] || return 0
+    printf '%s' "$records" | awk -F '\t' '
+        {
+            key[NR]=$1
+            rank[NR]=$2 + 0
+            path[NR]=$3
+            if (!($1 in max_rank) || ($2 + 0) > max_rank[$1]) max_rank[$1]=$2 + 0
+        }
+        END {
+            for (i=1; i<=NR; i++) {
+                if (rank[i] == max_rank[key[i]]) print path[i]
+            }
+        }
+    '
+}
+
 validate_tangle_results() {
     local task_group="$1"
     local original_prompt="$2"
@@ -180,9 +233,9 @@ validate_tangle_results() {
         FAILED_SUBTASKS=""  # Reset for this validation pass (string-based)
         TANGLE_HARD_GATE_RETRY_FEEDBACK=""
 
-        for result in "$RESULTS_DIR"/*-tangle-${task_group}*.md; do
-            [[ -f "$result" ]] || continue
-            [[ "$(basename "$result")" == *validation* ]] && continue
+        local result
+        while IFS= read -r result; do
+            [[ -n "$result" && -f "$result" ]] || continue
 
             # v8.20.0: Run file path validation (non-blocking warnings)
             if [[ "${OCTOPUS_FILE_VALIDATION:-true}" == "true" ]] && type run_file_validation &>/dev/null 2>&1; then
@@ -218,7 +271,7 @@ validate_tangle_results() {
             fi
             results+="$(<"$result")\n\n---\n\n"
             result_outputs+="$(extract_tangle_result_body "$result")"$'\n'
-        done
+        done <<< "$(tangle_effective_result_files "$task_group")"
 
         local worktree_changes=""
         local requires_worktree_changes=false

--- a/tests/unit/test-tangle-retry-quality-accounting.sh
+++ b/tests/unit/test-tangle-retry-quality-accounting.sh
@@ -35,11 +35,8 @@ evaluate_quality_branch() {
     if [[ "$1" -ge 75 ]]; then echo proceed; else echo abort; fi
 }
 
-TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
 RESULTS_DIR="$TEST_TMP_DIR/tangle-retry-quality-accounting"
-rm -rf "$RESULTS_DIR"
 mkdir -p "$RESULTS_DIR"
-trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
 
 write_result() {
     local file="$1"

--- a/tests/unit/test-tangle-retry-quality-accounting.sh
+++ b/tests/unit/test-tangle-retry-quality-accounting.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TESTING="$PROJECT_ROOT/scripts/lib/testing.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+# shellcheck source=/dev/null
+source "$TESTING"
+
+test_suite "tangle retry quality accounting"
+
+RED=""
+GREEN=""
+YELLOW=""
+NC=""
+DIM=""
+_BOX_TOP=""
+_BOX_BOT=""
+LOOP_UNTIL_APPROVED=false
+CI_MODE=true
+OCTOPUS_ANTISYCOPHANCY=false
+OCTOPUS_FILE_VALIDATION=false
+MAX_QUALITY_RETRIES=0
+FAILED_SUBTASKS=""
+
+log() { :; }
+record_task_metric() { :; }
+write_structured_decision() { :; }
+retry_failed_subtasks() { :; }
+get_gate_threshold() { echo 75; }
+evaluate_quality_branch() {
+    if [[ "$1" -ge 75 ]]; then echo proceed; else echo abort; fi
+}
+
+TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
+RESULTS_DIR="$TEST_TMP_DIR/tangle-retry-quality-accounting"
+rm -rf "$RESULTS_DIR"
+mkdir -p "$RESULTS_DIR"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
+
+write_result() {
+    local file="$1"
+    local task_id="$2"
+    local role="$3"
+    local status="$4"
+    cat > "$file" <<EOF_RESULT
+# Agent: commandcode
+# Task ID: $task_id
+# Role: $role
+# Phase: tangle
+# Prompt: retry accounting fixture
+
+## Output
+fixture output for $task_id
+
+## Status: $status
+EOF_RESULT
+}
+
+# Three tasks succeed initially; two coding tasks fail.
+write_result "$RESULTS_DIR/commandcode-tangle-accounting-1.md" "tangle-accounting-1" implementer FAILED
+write_result "$RESULTS_DIR/commandcode-tangle-accounting-2.md" "tangle-accounting-2" implementer FAILED
+write_result "$RESULTS_DIR/commandcode-tangle-accounting-3.md" "tangle-accounting-3" researcher SUCCESS
+write_result "$RESULTS_DIR/commandcode-tangle-accounting-4.md" "tangle-accounting-4" researcher SUCCESS
+write_result "$RESULTS_DIR/commandcode-tangle-accounting-5.md" "tangle-accounting-5" researcher SUCCESS
+
+# Retry 1 supersedes tasks 1 and 2: task 1 recovers, task 2 is still failing.
+write_result "$RESULTS_DIR/commandcode-tangle-accounting-retry1-1.md" "tangle-accounting-retry1-1" implementer SUCCESS
+write_result "$RESULTS_DIR/commandcode-tangle-accounting-retry1-2.md" "tangle-accounting-retry1-2" implementer FAILED
+
+test_case "latest retry supersedes historical result in quality percentage"
+if validate_tangle_results "accounting" "Assess retry quality accounting" >/dev/null 2>&1; then
+    report=$(cat "$RESULTS_DIR/tangle-validation-accounting.md")
+    if [[ "$report" == *"Success Rate: 80%"* ]] && \
+       [[ "$report" == *"Successful: 4/5 result files"* ]] && \
+       [[ "$report" == *"Failed: 1/5 result files"* ]]; then
+        test_pass
+    else
+        test_fail "quality report did not use only the latest result per logical task"
+    fi
+else
+    test_fail "quality gate failed because superseded historical failures were still counted"
+fi
+
+test_case "effective result set excludes superseded originals"
+effective=$(tangle_effective_result_files "accounting")
+if [[ "$effective" == *"retry1-1.md"* ]] && \
+   [[ "$effective" == *"retry1-2.md"* ]] && \
+   [[ "$effective" != *"accounting-1.md"* ]] && \
+   [[ "$effective" != *"accounting-2.md"* ]]; then
+    test_pass
+else
+    test_fail "effective result set retained superseded original task results"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

Fix Tangle quality-gate accounting so retry artifacts supersede historical results for the same logical subtask instead of accumulating in the denominator.

## Bug

`validate_tangle_results()` currently globs every `*-tangle-${task_group}*.md` result file. `retry_failed_subtasks()` writes new `-retryN-` artifacts but leaves earlier results in place, so each retry permanently adds old failures to the quality percentage.

A real run exposed the deterministic degradation:

- initial: 3 success / 5 results = 60%
- retry 1: 3 / 7 = 42%
- retry 2: 3 / 9 = 33%
- retry 3: 3 / 11 = 27%

The denominator grows even though the retry artifacts represent new attempts of the same two logical tasks.

## Fix

- normalize `tangle-...-retryN-<suffix>` to the original logical task id;
- determine the highest retry rank per logical task;
- validate/count only result files at that latest rank;
- preserve all independent results and same-rank artifacts.

This PR intentionally does **not** change retry policy, retry limits, provider selection, or max-turn budgets.

## Regression test

Adds a fixture with five original tasks where two fail, then retry1 recovers one and leaves one failing.

Expected effective score: **4/5 = 80%**.
The old behavior incorrectly counted seven files and produced **4/7 = 57%**.

## Validation

Passed locally:

- `tests/unit/test-tangle-retry-quality-accounting.sh` — 2/2
- `tests/unit/test-tangle-retry-feedback.sh` — 10/10
- `tests/unit/test-tangle-file-coverage.sh` — 6/6
- `tests/unit/test-gate-thresholds.sh` — 9/9
- `tests/unit/test-tangle-worktree-evidence.sh` — 9/9

Total related checks: **36/36 passing**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated result validation to account for retries correctly, using only the latest result for each task.
  * Prevented superseded result files from being counted multiple times.

* **Tests**
  * Added coverage for retry scenarios, including recovered and still-failing tasks.
  * Verified that validation reports accurate quality results after retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->