### PR TITLE
fix: keep Octopus dormant until explicitly invoked

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -23,6 +23,11 @@ You get:    A structured comparison with three independent viewpoints,
 
 This works for research, escalated code review, debugging, TDD, escalated security audits, UI design, PRDs, and full build-to-ship workflows — 54 commands, 63 skills, 32 specialized personas.
 
+Octopus is dormant by default. Installing it does not route ordinary prompts or
+delegate to Octopus agents. Every command and skill is manual-only: use
+`/octo:*` when you want escalation. Plain-prompt routing is available only after
+you set `OCTOPUS_AUTO_ROUTER_MODE=suggest` or `invoke`.
+
 Multi-provider runs show an agent summary before synthesis, so failed, timed out, or oversize-rejected Codex, Antigravity, OpenRouter, and other perspectives are visible instead of being hidden behind a polished final answer.
 
 ## Install

--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -29,7 +29,10 @@ delegate to Octopus agents. Every command and skill is manual-only: use
 you set `OCTOPUS_AUTO_ROUTER_MODE=suggest` or `invoke`. This legacy opt-in
 examines ordinary prompts and can route them into paid external-provider
 workflows; use `suggest` unless you intentionally want automatic invocation and
-are comfortable sharing the routed prompt context with configured providers.
+are comfortable sending the workflow prompt and any context that workflow
+explicitly gathers to configured providers. Provider-side retention follows
+those providers' account policies. Unset the variable (or set it to `off`) to
+opt out; direct `/octo:*` commands remain available.
 
 Multi-provider runs show an agent summary before synthesis, so failed, timed out, or oversize-rejected Codex, Antigravity, OpenRouter, and other perspectives are visible instead of being hidden behind a polished final answer.
 

--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -26,7 +26,10 @@ This works for research, escalated code review, debugging, TDD, escalated securi
 Octopus is dormant by default. Installing it does not route ordinary prompts or
 delegate to Octopus agents. Every command and skill is manual-only: use
 `/octo:*` when you want escalation. Plain-prompt routing is available only after
-you set `OCTOPUS_AUTO_ROUTER_MODE=suggest` or `invoke`.
+you set `OCTOPUS_AUTO_ROUTER_MODE=suggest` or `invoke`. This legacy opt-in
+examines ordinary prompts and can route them into paid external-provider
+workflows; use `suggest` unless you intentionally want automatic invocation and
+are comfortable sharing the routed prompt context with configured providers.
 
 Multi-provider runs show an agent summary before synthesis, so failed, timed out, or oversize-rejected Codex, Antigravity, OpenRouter, and other perspectives are visible instead of being hidden behind a polished final answer.
 

--- a/.claude/agents/backend-architect.md
+++ b/.claude/agents/backend-architect.md
@@ -1,6 +1,6 @@
 ---
 name: backend-architect
-description: Backend architect for scalable API design, microservices, and distributed systems
+description: Backend architect. Delegate only when the user explicitly starts an Octopus workflow.
 model: inherit
 readonly: true
 tools:

--- a/.claude/agents/cloud-architect.md
+++ b/.claude/agents/cloud-architect.md
@@ -1,6 +1,6 @@
 ---
 name: cloud-architect
-description: Cloud architect for AWS/Azure/GCP infrastructure, IaC, FinOps, and multi-cloud strategies
+description: Cloud architect. Delegate only when the user explicitly starts an Octopus workflow.
 model: inherit
 readonly: true
 tools:

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: Code review expert for quality analysis, security vulnerabilities, and production reliability
+description: Code reviewer. Delegate only when the user explicitly starts an Octopus workflow.
 model: opus
 readonly: true
 tools:

--- a/.claude/agents/database-architect.md
+++ b/.claude/agents/database-architect.md
@@ -1,6 +1,6 @@
 ---
 name: database-architect
-description: Database architect for data modeling, technology selection, schema design, and migration planning
+description: Database architect. Delegate only when the user explicitly starts an Octopus workflow.
 model: inherit
 readonly: true
 tools:

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -1,6 +1,6 @@
 ---
 name: debugger
-description: Debugging specialist for errors, test failures, and unexpected behavior
+description: Debugger. Delegate only when the user explicitly starts an Octopus workflow.
 model: opus
 tools:
   - Read

--- a/.claude/agents/docs-architect.md
+++ b/.claude/agents/docs-architect.md
@@ -1,6 +1,6 @@
 ---
 name: docs-architect
-description: Technical documentation architect for comprehensive system docs and architecture guides
+description: Documentation architect. Delegate only when the user explicitly starts an Octopus workflow.
 model: inherit
 tools:
   - Read

--- a/.claude/agents/frontend-developer.md
+++ b/.claude/agents/frontend-developer.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-developer
-description: Frontend developer for React, Next.js, responsive layouts, and accessible UI components
+description: Frontend developer. Delegate only when the user explicitly starts an Octopus workflow.
 model: inherit
 tools:
   - Read

--- a/.claude/agents/performance-engineer.md
+++ b/.claude/agents/performance-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: performance-engineer
-description: Performance engineer for optimization, observability, and scalable system performance
+description: Performance engineer. Delegate only when the user explicitly starts an Octopus workflow.
 model: opus
 readonly: true
 tools:

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: security-auditor
-description: Security auditor for DevSecOps, OWASP compliance, vulnerability assessment, and threat modeling
+description: Security auditor. Delegate only when the user explicitly starts an Octopus workflow.
 model: opus
 readonly: true
 tools:

--- a/.claude/agents/tdd-orchestrator.md
+++ b/.claude/agents/tdd-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: tdd-orchestrator
-description: TDD orchestrator enforcing red-green-refactor discipline and test-driven development
+description: TDD orchestrator. Delegate only when the user explicitly starts an Octopus workflow.
 model: opus
 tools:
   - Read

--- a/.claude/skills/extract-skill/SKILL.md
+++ b/.claude/skills/extract-skill/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-extract
+disable-model-invocation: true
 description: "Reverse-engineer design systems, tokens, and components from live products or screenshots"
 ---
 

--- a/.claude/skills/flow-define/SKILL.md
+++ b/.claude/skills/flow-define/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: flow-define
+disable-model-invocation: true
 aliases:
   - define
   - define-workflow
@@ -25,7 +26,7 @@ validation_gates:
   - orchestrate_sh_executed
   - synthesis_file_exists
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests clarification or scoping:
+  EXPLICITLY USE when user requests clarification or scoping:
   - "define the requirements for X"
   - "clarify the scope of Y"
   - "what exactly does X need to do"
@@ -771,4 +772,4 @@ approved the scope. After approval, invoke `flow-develop` if implementation is r
 Otherwise, deliver the requirements document and stop. Do NOT begin
 implementation from here without an approved scope.
 
-**Ready to define!** This skill activates automatically when users request requirement clarification or problem definition.
+**Ready to define!** This skill is used after explicit invocation when users request requirement clarification or problem definition.

--- a/.claude/skills/flow-define/flow-define.tmpl
+++ b/.claude/skills/flow-define/flow-define.tmpl
@@ -25,7 +25,7 @@ validation_gates:
   - orchestrate_sh_executed
   - synthesis_file_exists
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests clarification or scoping:
+  EXPLICITLY USE when user requests clarification or scoping:
   - "define the requirements for X"
   - "clarify the scope of Y"
   - "what exactly does X need to do"
@@ -748,4 +748,4 @@ fi
 
 ---
 
-**Ready to define!** This skill activates automatically when users request requirement clarification or problem definition.
+**Ready to define!** This skill is used after explicit invocation when users request requirement clarification or problem definition.

--- a/.claude/skills/flow-deliver/SKILL.md
+++ b/.claude/skills/flow-deliver/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: flow-deliver
+disable-model-invocation: true
 aliases:
   - deliver
   - deliver-workflow
@@ -21,7 +22,7 @@ validation_gates:
   - orchestrate_sh_executed
   - validation_file_exists
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests validation, scoring, or review:
+  EXPLICITLY USE when user requests validation, scoring, or review:
   - "review X" or "validate Y" or "test Z"
   - "score this", "quality check", "validate before shipping"
   - "check if X works correctly"
@@ -844,9 +845,9 @@ Ink workflows typically cost $0.02-0.08 per validation depending on codebase siz
 
 After validation passes (go decision), run documentation synchronization to keep project docs current with shipped code. This step is **automatic** when running as part of `/octo:embrace` and **offered** when running standalone.
 
-**Invoke the doc-sync skill:**
+**Load the doc-sync source after delivery has been explicitly requested:**
 ```
-Skill(skill: "octo:auto", args: "sync docs for the changes on this branch")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/skill-doc-sync/SKILL.md and execute it for "sync docs for the changes on this branch"
 ```
 
 The doc-sync skill will:
@@ -869,8 +870,10 @@ The doc-sync skill will:
 After delivery validation and doc-sync complete, route according to the user's explicit
 request:
 
-- **Ship requested:** update `.octo/STATE.md` and invoke `skill-ship`.
-- **Branch wrap-up requested:** invoke `skill-finish-branch`.
+- **Ship requested:** update `.octo/STATE.md`, then read and follow
+  `.claude/skills/skill-ship/SKILL.md` from the stable plugin root.
+- **Branch wrap-up requested:** read and follow
+  `.claude/skills/skill-finish-branch/SKILL.md` from the stable plugin root.
 - **Review only:** deliver the synthesized findings and stop. Do not update the project
   to a ready-to-ship state or display a shipping instruction.
 
@@ -896,11 +899,11 @@ echo "📦 **Project ready! Run \`/octo:ship\` to finalize and archive.**"
 After that block succeeds, perform the requested finalization immediately:
 
 ```text
-Skill(skill: "skill-ship", args: "finalize and archive the validated project")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/skill-ship/SKILL.md and execute it for "finalize and archive the validated project"
 ```
 
 Do not stop after displaying the command. The ship-requested branch is incomplete until
-`skill-ship` has actually been invoked.
+the explicit ship workflow has actually been executed.
 
 ---
 
@@ -908,8 +911,8 @@ Do not stop after displaying the command. The ship-requested branch is incomplet
 
 The Deliver phase is complete ONLY when validation findings are synthesized and
 must-fix items are resolved or explicitly accepted by the user. If the user asked to
-ship or wrap the branch, then invoke `skill-ship` (or `skill-finish-branch` for tests,
+ship or wrap the branch, then read and execute `skill-ship` (or `skill-finish-branch` for tests,
 PR, and merge). For review-only requests, deliver the findings and stop; do NOT expand
 the request into shipping work without user authorization.
 
-**Ready to validate!** This skill activates automatically when users request code review, validation, or quality checks.
+**Ready to validate!** This skill runs only after explicit invocation.

--- a/.claude/skills/flow-deliver/flow-deliver.tmpl
+++ b/.claude/skills/flow-deliver/flow-deliver.tmpl
@@ -21,7 +21,7 @@ validation_gates:
   - orchestrate_sh_executed
   - validation_file_exists
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests validation, scoring, or review:
+  EXPLICITLY USE when user requests validation, scoring, or review:
   - "review X" or "validate Y" or "test Z"
   - "score this", "quality check", "validate before shipping"
   - "check if X works correctly"
@@ -835,9 +835,9 @@ Ink workflows typically cost $0.02-0.08 per validation depending on codebase siz
 
 After validation passes (go decision), run documentation synchronization to keep project docs current with shipped code. This step is **automatic** when running as part of `/octo:embrace` and **offered** when running standalone.
 
-**Invoke the doc-sync skill:**
+**Load the doc-sync source after delivery has been explicitly requested:**
 ```
-Skill(skill: "octo:auto", args: "sync docs for the changes on this branch")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/skill-doc-sync/SKILL.md and execute it for "sync docs for the changes on this branch"
 ```
 
 The doc-sync skill will:
@@ -857,7 +857,8 @@ The doc-sync skill will:
 
 ## Post-Delivery: Route to Ship
 
-After delivery validation and doc-sync complete:
+After delivery validation and doc-sync complete, only continue to shipping when
+the user explicitly requested it:
 1. Update `.octo/STATE.md`:
    - status: "complete"
    - Add history entry: "All phases complete, ready to ship"
@@ -884,4 +885,4 @@ echo "📦 **Project ready! Run \`/octo:ship\` to finalize and archive.**"
 
 ---
 
-**Ready to validate!** This skill activates automatically when users request code review, validation, or quality checks.
+**Ready to validate!** This skill runs only after explicit invocation.

--- a/.claude/skills/flow-develop/SKILL.md
+++ b/.claude/skills/flow-develop/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: flow-develop
+disable-model-invocation: true
 aliases:
   - develop
   - develop-workflow
@@ -24,7 +25,7 @@ validation_gates:
   - orchestrate_sh_executed
   - synthesis_file_exists
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests building or implementation:
+  EXPLICITLY USE when user requests building or implementation:
   - "build X" or "implement Y" or "create Z"
   - "develop a feature for X"
   - "write code to do Y"
@@ -836,4 +837,4 @@ checkpoint tag is created, and targeted tests pass fresh (see `skill-verificatio
 Then invoke `flow-deliver` for validation. Do NOT declare the work done from here —
 completion claims belong to the Deliver phase after review.
 
-**Ready to build!** This skill activates automatically when users request implementation or building features.
+**Ready to build!** This skill is used after explicit invocation when users request implementation or building features.

--- a/.claude/skills/flow-develop/flow-develop.tmpl
+++ b/.claude/skills/flow-develop/flow-develop.tmpl
@@ -24,7 +24,7 @@ validation_gates:
   - orchestrate_sh_executed
   - synthesis_file_exists
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests building or implementation:
+  EXPLICITLY USE when user requests building or implementation:
   - "build X" or "implement Y" or "create Z"
   - "develop a feature for X"
   - "write code to do Y"
@@ -819,4 +819,4 @@ modified_files=$(git diff --name-only HEAD~1 2>/dev/null || echo "See git log")
 
 ---
 
-**Ready to build!** This skill activates automatically when users request implementation or building features.
+**Ready to build!** This skill is used after explicit invocation when users request implementation or building features.

--- a/.claude/skills/flow-discover/SKILL.md
+++ b/.claude/skills/flow-discover/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: flow-discover
+disable-model-invocation: true
 aliases:
   - discover
   - discover-workflow
@@ -28,7 +29,7 @@ validation_gates:
   - orchestrate_sh_executed
   - synthesis_file_exists
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests research or exploration:
+  EXPLICITLY USE when user requests research or exploration:
   - "research X" or "explore Y" or "investigate Z"
   - "what are the options for X" or "what are my choices for Y"
   - "find information about Y" or "look up Z"
@@ -891,4 +892,4 @@ either invoke `flow-define` (embrace workflow, or the user wants requirements ne
 stop with research delivered. Do NOT begin scoping, designing, or implementation from
 here — that work belongs to later phases.
 
-**Ready to research!** This skill activates automatically when users request research or exploration.
+**Ready to research!** This skill is used after explicit invocation when users request research or exploration.

--- a/.claude/skills/flow-discover/flow-discover.tmpl
+++ b/.claude/skills/flow-discover/flow-discover.tmpl
@@ -28,7 +28,7 @@ validation_gates:
   - orchestrate_sh_executed
   - synthesis_file_exists
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests research or exploration:
+  EXPLICITLY USE when user requests research or exploration:
   - "research X" or "explore Y" or "investigate Z"
   - "what are the options for X" or "what are my choices for Y"
   - "find information about Y" or "look up Z"
@@ -856,4 +856,4 @@ fi
 
 ---
 
-**Ready to research!** This skill activates automatically when users request research or exploration.
+**Ready to research!** This skill is used after explicit invocation when users request research or exploration.

--- a/.claude/skills/flow-parallel/SKILL.md
+++ b/.claude/skills/flow-parallel/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: flow-parallel
+disable-model-invocation: true
 effort: high
 aliases:
   - parallel

--- a/.claude/skills/flow-parallel/SKILL.md
+++ b/.claude/skills/flow-parallel/SKILL.md
@@ -15,7 +15,6 @@ validation_gates:
   - instructions_written
   - processes_launched
   - all_work_packages_complete
-invocation: human_only
 ---
 
 # STOP - SKILL ALREADY LOADED

--- a/.claude/skills/flow-spec/SKILL.md
+++ b/.claude/skills/flow-spec/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: flow-spec
+disable-model-invocation: true
 effort: high
 aliases:
   - spec

--- a/.claude/skills/skill-agent-topology/SKILL.md
+++ b/.claude/skills/skill-agent-topology/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-agent-topology
+disable-model-invocation: true
 description: "Audit whether a multi-agent setup earns its coordination cost — use before adding an agent, or when a workflow feels slow or agents agree without adding signal"
 ---
 

--- a/.claude/skills/skill-architecture/SKILL.md
+++ b/.claude/skills/skill-architecture/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: octopus-architecture
+disable-model-invocation: true
 description: System architecture and API design with multi-AI consensus — use for design reviews and new subsystems
 execution_mode: enforced
 pre_execution_contract:

--- a/.claude/skills/skill-audit/SKILL.md
+++ b/.claude/skills/skill-audit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-audit
+disable-model-invocation: true
 effort: high
 aliases:
   - audit
@@ -7,7 +8,7 @@ aliases:
   - comprehensive-audit
 description: "Audit codebases for quality, consistency, and broken patterns — use for pre-release or tech debt review"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests auditing:
+  EXPLICITLY USE when user requests auditing:
   - "audit and check the entire app"
   - "audit X for Y" or "check for broken features"
   - "process to audit" or "systematic check"

--- a/.claude/skills/skill-authoring/SKILL.md
+++ b/.claude/skills/skill-authoring/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-authoring
+disable-model-invocation: true
 description: "Principles for writing skills that behave the same way every run — use when adding, editing, or reviewing a skill in this plugin"
 codex_display_name: "Skill Authoring"
 ---
@@ -38,29 +39,20 @@ agent do differently because this exists?
 
 ## Workflow
 
-### Invocation: how this plugin differs
+### Invocation: explicit by default
 
-Upstream draws a clean line between a **model-invoked** skill (carries a
-description, the agent can fire it autonomously, costs context every turn) and a
-**user-invoked** one (`disable-model-invocation: true`, zero context cost, but
-the user must remember it exists).
+Every shipped command and skill carries `disable-model-invocation: true`.
+Claude Code therefore keeps Octopus out of model context until the user chooses
+an `/octo:*` command. This is a hard platform gate, not a prose reminder.
 
-**That line does not transfer cleanly here, and getting it wrong breaks
-routing.** Six skills in this repo declare `invocation: human_only`. That key is
-custom — `scripts/build-codex-skills.sh` strips it from the generated tree, and
-nothing reads it. The real effect comes from an advisory reminder in
-`hooks/context-reinforcement.sh`, kept in step by
-`tests/unit/test-human-only-skill-list.sh`.
+Command bodies that need reusable instructions load the source file directly
+from `${CLAUDE_PLUGIN_ROOT}/.claude/skills/<name>/SKILL.md`; they do not call the
+Skill tool. That keeps explicit commands composable without reopening automatic
+model invocation.
 
-Do **not** reach for `disable-model-invocation: true` to express "human-only"
-here. Four of those six are named in command bodies (`commands/parallel.md`,
-`factory.md`, `research.md`, `security.md`) and the model reaches them on the
-user's behalf when running those commands. Disabling model invocation would break
-`/octo:parallel`, `/octo:factory`, `/octo:research`, `/octo:security`.
-
-So in this plugin: "human-only" means *do not fire from prompt-keyword
-auto-routing*. Declare it with `invocation: human_only`, add the skill to the
-hook's list, and accept that it is advisory.
+Plain-language routing is a separate, legacy-compatible opt-in controlled by
+`OCTOPUS_AUTO_ROUTER_MODE=suggest|invoke`. Its default is `off`. New skills must
+never depend on prompt-keyword auto-routing for reachability.
 
 ### Writing the description
 
@@ -76,9 +68,8 @@ pruning than the body.
   skill needs this" clause, and nothing else.
 - Beware collision. With this many skills the scarce resource is trigger space,
   not skill count. Before adding a trigger phrase, check whether an existing
-  skill or `hooks/user-prompt-submit.sh` already claims it — that hook
-  auto-invokes on strong matches, and a new overlapping phrase degrades a working
-  route rather than adding one.
+  skill or `hooks/user-prompt-submit.sh` already claims it. The hook is opt-in,
+  but overlapping phrases still degrade routing for users who enable it.
 
 ### Information hierarchy
 
@@ -150,5 +141,6 @@ When reviewing, report:
   skill's description.
 - The skill is registered in `.claude-plugin/plugin.json` and `make sync` is
   clean.
-- If it declares `invocation: human_only`, it is in the hook list and
-  `tests/unit/test-human-only-skill-list.sh` passes.
+- It declares `disable-model-invocation: true`, and any command that composes it
+  loads its source file directly.
+- `tests/unit/test-explicit-activation.sh` passes.

--- a/.claude/skills/skill-authoring/SKILL.md
+++ b/.claude/skills/skill-authoring/SKILL.md
@@ -45,9 +45,15 @@ Every shipped command and skill carries `disable-model-invocation: true`.
 Claude Code therefore keeps Octopus out of model context until the user chooses
 an `/octo:*` command. This is a hard platform gate, not a prose reminder.
 
-Command bodies that need reusable instructions load the source file directly
-from `${CLAUDE_PLUGIN_ROOT}/.claude/skills/<name>/SKILL.md`; they do not call the
-Skill tool. That keeps explicit commands composable without reopening automatic
+Command bodies that need reusable instructions load the entire source file
+directly from
+`${HOME}/.claude-octopus/plugin/.claude/skills/<name>/SKILL.md`; they do not call
+the Skill tool. `${HOME}/.claude-octopus/plugin` is the stable, self-healed path
+available to model tool calls; `CLAUDE_PLUGIN_ROOT` is a hook/runtime variable
+and may be absent from that context. The command must treat the loaded body as
+the active instructions in the current conversation, follow its steps in order,
+and pass the user's text as workflow arguments rather than executable path
+content. This keeps explicit commands composable without reopening automatic
 model invocation.
 
 Plain-language routing is a separate, legacy-compatible opt-in controlled by

--- a/.claude/skills/skill-claw/SKILL.md
+++ b/.claude/skills/skill-claw/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: skill-claw
+disable-model-invocation: true
 aliases:
   - claw
   - openclaw-admin
   - sysadmin
 description: "OpenClaw instance administration — manage hosts across macOS, Ubuntu/Debian, Docker, OCI, and Proxmox"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user asks about:
+  EXPLICITLY USE when user asks about:
   - "manage openclaw" or "openclaw status" or "openclaw health"
   - "update openclaw" or "upgrade openclaw" or "openclaw doctor"
   - "setup openclaw" or "install openclaw" or "deploy openclaw"

--- a/.claude/skills/skill-code-review/SKILL.md
+++ b/.claude/skills/skill-code-review/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-code-review
+disable-model-invocation: true
 aliases:
   - review
   - code-review

--- a/.claude/skills/skill-content-pipeline/SKILL.md
+++ b/.claude/skills/skill-content-pipeline/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-content-pipeline
+disable-model-invocation: true
 aliases:
   - content-pipeline
   - content-analysis
@@ -7,7 +8,7 @@ aliases:
 description: "Extract patterns and anatomy from URLs — use to reverse-engineer content strategies from live pages"
 context: fork
 trigger: |
-  Use PROACTIVELY when user wants to:
+  Invoke explicitly when the user wants to:
   - "analyze this article", "analyze this content"
   - "deconstruct this content", "break down this post"
   - "extract patterns from this", "learn from this example"

--- a/.claude/skills/skill-context-detection/SKILL.md
+++ b/.claude/skills/skill-context-detection/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-context-detection
+disable-model-invocation: true
 effort: low
 description: "Auto-detect work context (Dev vs Knowledge) — use to tailor workflows based on current task type"
 ---

--- a/.claude/skills/skill-copilot-provider/SKILL.md
+++ b/.claude/skills/skill-copilot-provider/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: skill-copilot-provider
+disable-model-invocation: true
 version: 2.0.0
 aliases: [copilot-provider, github-copilot, copilot]
 description: GitHub Copilot CLI as optional zero-cost provider via copilot -p programmatic mode
 trigger: |
-  AUTOMATICALLY ACTIVATE when user says:
+  EXPLICITLY USE when user says:
   "copilot provider" or "add copilot" or "github copilot" or "use copilot"
   DO NOT activate for general copilot IDE usage or copilot chat in editor.
 paths:

--- a/.claude/skills/skill-cost-projections/SKILL.md
+++ b/.claude/skills/skill-cost-projections/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-cost-projections
+disable-model-invocation: true
 effort: low
 aliases:
   - cost-projections
@@ -7,7 +8,7 @@ aliases:
   - budget-projection
 description: "Project remaining workflow cost from per-phase averages — warns on budget ceiling overruns"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user asks about workflow costs:
+  EXPLICITLY USE when user asks about workflow costs:
   - "cost projection", "estimate remaining cost"
   - "budget forecast", "how much will this cost"
   - "project cost", "cost estimate", "spending forecast"

--- a/.claude/skills/skill-coverage-audit/SKILL.md
+++ b/.claude/skills/skill-coverage-audit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-coverage-audit
+disable-model-invocation: true
 paths:
   - "**/*.test.*"
   - "**/*.spec.*"
@@ -9,7 +10,7 @@ aliases:
   - test-coverage
 description: "Trace codepaths in diffs, map against tests, auto-generate missing coverage — use before shipping PRs"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests coverage analysis:
+  EXPLICITLY USE when user requests coverage analysis:
   - "check test coverage" or "coverage audit"
   - "what's not tested" or "find untested code"
   - "generate tests for gaps"

--- a/.claude/skills/skill-debate/SKILL.md
+++ b/.claude/skills/skill-debate/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-debate
+disable-model-invocation: true
 effort: high
 user-invocable: true
 aliases:
@@ -7,7 +8,7 @@ aliases:
 description: Structured multi-provider AI debates between Claude and available advisors — use for critical decisions
 context: fork
 trigger: |
-  AUTOMATICALLY ACTIVATE when user says:
+  EXPLICITLY USE when user says:
   - "/debate <question>"
   - "run a debate about X"
   - "I want Antigravity and Codex to review X"
@@ -95,7 +96,7 @@ You are Claude (Opus), a **participant and moderator** in a multi-provider AI de
 
 ## How Users Invoke This Skill
 
-Users can invoke the debate skill in natural language. You parse the intent and run the debate.
+Users invoke this skill explicitly from the slash menu. Parse the supplied intent and run the debate.
 
 ### Basic Invocation
 ```

--- a/.claude/skills/skill-debug/SKILL.md
+++ b/.claude/skills/skill-debug/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: skill-debug
+disable-model-invocation: true
 aliases:
   - debug
   - systematic-debugging
 description: "Debug issues methodically — use when stuck on errors, test failures, or unexpected behavior"
 trigger: |
-  AUTOMATICALLY ACTIVATE when encountering bugs or failures:
+  EXPLICITLY USE when encountering bugs or failures:
   - "fix this bug" or "debug Y" or "troubleshoot X"
   - "why is X failing" or "why isn't X working" or "why doesn't X work"
   - "why did X not work" or "why didn't X happen"
@@ -315,7 +316,8 @@ If you suspect the issue is with the Claude Code environment itself (e.g., netwo
 
 ## Auto-Freeze on Debug
 
-When debugging a specific module, automatically activate freeze mode to prevent accidental edits outside the investigated area. This is a safety measure that keeps your debugging focused.
+Inside this explicitly invoked debugging workflow, activate freeze mode for the
+specific module before editing. This safety measure keeps the investigation focused.
 
 ### How It Works
 

--- a/.claude/skills/skill-decision-support/SKILL.md
+++ b/.claude/skills/skill-decision-support/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: skill-decision-support
+disable-model-invocation: true
 aliases:
   - decision-support
   - options-presentation
 description: Present options with trade-offs for informed decision-making — use when choosing between approaches
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests options or choices:
+  EXPLICITLY USE when user requests options or choices:
   - "fix or provide options" or "fix them or provide me options"
   - "give me options" or "what are my options"
   - "show me alternatives" or "what else can we do"

--- a/.claude/skills/skill-deck/SKILL.md
+++ b/.claude/skills/skill-deck/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: skill-deck
+disable-model-invocation: true
 aliases:
   - deck
   - slides
   - presentation
 description: Generate slide deck presentations from briefs — use when you need slides, pitch decks, or visual summaries
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests:
+  EXPLICITLY USE when user requests:
   - "create a deck", "build slides", "make a presentation"
   - "generate a pitch deck", "create board presentation"
   - "slide deck for [topic]", "presentation about [topic]"

--- a/.claude/skills/skill-deep-research/SKILL.md
+++ b/.claude/skills/skill-deep-research/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: octopus-research
+disable-model-invocation: true
 effort: high
 aliases:
   - research

--- a/.claude/skills/skill-deep-research/SKILL.md
+++ b/.claude/skills/skill-deep-research/SKILL.md
@@ -19,7 +19,6 @@ pre_execution_contract:
 validation_gates:
   - orchestrate_sh_executed
   - synthesis_file_exists
-invocation: human_only
 trigger: |
   Use this skill when the user wants to "research this topic", "investigate how X works",
   "analyze the architecture", "explore different approaches to Y", or "what are the options for Z".

--- a/.claude/skills/skill-design-lineage/SKILL.md
+++ b/.claude/skills/skill-design-lineage/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: skill-design-lineage
+disable-model-invocation: true
 aliases:
   - design-lineage
   - design-docs
   - design-history
 description: "Persist design documents with branch tracking, revision chains, and cross-session discovery"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user says:
+  EXPLICITLY USE when user says:
   - "save design" or "save this design"
   - "design document" or "create a design doc"
   - "design history" or "show design history"

--- a/.claude/skills/skill-doc-delivery/SKILL.md
+++ b/.claude/skills/skill-doc-delivery/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: skill-doc-delivery
+disable-model-invocation: true
 aliases:
   - docs
   - document-delivery
   - doc-delivery
 description: Convert markdown to DOCX, PPTX, XLSX, PDF office documents — use when you need exportable deliverables
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests:
+  EXPLICITLY USE when user requests:
   - Export knowledge work to office formats (e.g., "export to Word", "create PowerPoint", "convert to DOCX")
   - Generate professional documents from research (e.g., "create presentation from this synthesis")
   - Deliver knowledge work as polished documents (e.g., "make this a business case document")
@@ -334,7 +335,7 @@ Knowledge Work Flow:
 1. Run workflow: /octo:empathize (or advise/synthesize)
 2. Review markdown output in ~/.claude-octopus/results/
 3. Request conversion: "Export to PowerPoint"
-4. This skill activates automatically
+4. This skill is used after explicit invocation
 5. Professional document delivered
 ```
 

--- a/.claude/skills/skill-doc-sync/SKILL.md
+++ b/.claude/skills/skill-doc-sync/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-doc-sync
+disable-model-invocation: true
 paths:
   - "**/*.md"
   - "**/docs/**"

--- a/.claude/skills/skill-doctor/SKILL.md
+++ b/.claude/skills/skill-doctor/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: skill-doctor
+disable-model-invocation: true
 effort: low
 description: "Environment diagnostics — check providers, auth, config, hooks, scheduler, and more"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user asks about:
+  EXPLICITLY USE when user asks about:
   - "doctor" or "run doctor" or "diagnostics"
   - "check my setup" or "is everything working"
   - "health check" or "environment check"

--- a/.claude/skills/skill-factory/SKILL.md
+++ b/.claude/skills/skill-factory/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-factory
+disable-model-invocation: true
 aliases:
   - factory
   - dark-factory

--- a/.claude/skills/skill-factory/SKILL.md
+++ b/.claude/skills/skill-factory/SKILL.md
@@ -12,7 +12,6 @@ validation_gates:
   - spec_file_validated
   - orchestrate_sh_executed
   - factory_report_exists
-invocation: human_only
 ---
 
 # STOP - SKILL ALREADY LOADED

--- a/.claude/skills/skill-finish-branch/SKILL.md
+++ b/.claude/skills/skill-finish-branch/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: skill-finish-branch
+disable-model-invocation: true
 description: "Wrap up a branch — run tests, create PR, merge or discard — use when implementation is done"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests task completion with git operations:
+  EXPLICITLY USE when user requests task completion with git operations:
   - "commit and push" or "git commit and push"
   - "complete all tasks and commit and push"
   - "proceed with all todos in sequence and push"

--- a/.claude/skills/skill-intake/SKILL.md
+++ b/.claude/skills/skill-intake/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-intake
+disable-model-invocation: true
 description: "Move incoming issues and pull requests through triage states until each is actionable or closed — use when the queue has piled up or a report arrives unsorted"
 ---
 

--- a/.claude/skills/skill-intent-contract/SKILL.md
+++ b/.claude/skills/skill-intent-contract/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-intent-contract
+disable-model-invocation: true
 description: "Use when starting a complex or ambiguous task that risks scope drift"
 ---
 

--- a/.claude/skills/skill-issues/SKILL.md
+++ b/.claude/skills/skill-issues/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: skill-issues
+disable-model-invocation: true
 user-invocable: true
 aliases:
   - issues
   - issue-tracking
 description: "Track project blockers, bugs, and gaps across sessions — use when issues pile up or need triage"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user mentions:
+  EXPLICITLY USE when user mentions:
   - "issue" or "issues" or "problem"
   - "track this" or "remember this blocker"
   - "add issue" or "create issue"

--- a/.claude/skills/skill-iterative-loop/SKILL.md
+++ b/.claude/skills/skill-iterative-loop/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: skill-iterative-loop
+disable-model-invocation: true
 aliases:
   - iterative-loop
   - loop-execution
   - repeat-until
 description: "Run tasks in a loop until goals are met — use for iterative refinement, polling, or convergence"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests iterative execution:
+  EXPLICITLY USE when user requests iterative execution:
   - "loop X times" or "loop around N times"
   - "loop around 5 times auditing, enhancing, testing"
   - "keep trying until" or "iterate until"

--- a/.claude/skills/skill-knowledge-work/SKILL.md
+++ b/.claude/skills/skill-knowledge-work/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-knowledge-work
+disable-model-invocation: true
 description: "Switch to Knowledge Work mode for research and writing — use when task is non-code focused"
 triggerPatterns:
   - "switch.*mode"

--- a/.claude/skills/skill-meta-prompt/SKILL.md
+++ b/.claude/skills/skill-meta-prompt/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-meta-prompt
+disable-model-invocation: true
 aliases:
   - meta-prompt
   - prompt-generator
@@ -7,7 +8,7 @@ aliases:
   - prompt-engineering
 description: "Craft better prompts using proven optimization techniques — use when your prompt needs refinement"
 trigger: |
-  Use PROACTIVELY when user wants to:
+  Invoke explicitly when the user wants to:
   - "create a prompt for", "write a prompt for"
   - "optimize this prompt", "improve this prompt"
   - "generate a meta-prompt", "help me write a prompt"

--- a/.claude/skills/skill-native-escalation-routing/SKILL.md
+++ b/.claude/skills/skill-native-escalation-routing/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-native-escalation-routing
+disable-model-invocation: true
 description: "Use when choosing native or multi-LLM handling for init, review, or security requests"
 ---
 

--- a/.claude/skills/skill-parallel-agents/SKILL.md
+++ b/.claude/skills/skill-parallel-agents/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-parallel-agents
+disable-model-invocation: true
 effort: high
 description: Decompose large tasks across parallel agents — use for migrations, multi-file refactors, or batch work
 trigger: |
@@ -9,7 +10,7 @@ trigger: |
   - "I want multiple AI models to look at", "use all providers for"
   - "get multiple perspectives on", "force multi-provider analysis"
 
-  AUTOMATICALLY ACTIVATE (without asking user) when the user requests:
+  EXPLICITLY USE (without asking user) when the user requests:
   - Research, explore, investigate, or analyze topics (e.g., "octo research OAuth patterns", "octo analyze technical debt", "octo explore different approaches")
   - Build, implement, create, or develop features (e.g., "octo build a login system", "octo implement caching", "octo create a dashboard")
   - Review, validate, test, or check code quality (e.g., "octo review this code", "octo validate the API", "octo check for issues")

--- a/.claude/skills/skill-prd/SKILL.md
+++ b/.claude/skills/skill-prd/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-prd
+disable-model-invocation: true
 description: Write an AI-optimized PRD using multi-AI orchestration — use when scoping a new feature or product
 context: fork
 agent: Plan

--- a/.claude/skills/skill-pressure-test/SKILL.md
+++ b/.claude/skills/skill-pressure-test/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-pressure-test
+disable-model-invocation: true
 description: "Interrogate a plan, decision, or design one question at a time until it holds — use to stress-test your own thinking before committing to it"
 ---
 

--- a/.claude/skills/skill-quick/SKILL.md
+++ b/.claude/skills/skill-quick/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: octopus-quick
+disable-model-invocation: true
 effort: low
 description: Quick execution for ad-hoc tasks without full workflow overhead — use for small, self-contained requests
 aliases:

--- a/.claude/skills/skill-resume/SKILL.md
+++ b/.claude/skills/skill-resume/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-resume
+disable-model-invocation: true
 user-invocable: true
 description: "Pick up where you left off from a previous session — use after context resets, compaction, or new conversations"
 aliases:
@@ -7,7 +8,7 @@ aliases:
   - resume-session
   - context-resume
 trigger: |
-  AUTOMATICALLY ACTIVATE when user mentions:
+  EXPLICITLY USE when user mentions:
   - "resume" or "continue" or "pick up where I left off"
   - "what was I doing" or "restore session"
   - Detecting persistent workflow state exists but no prior context in memory

--- a/.claude/skills/skill-review-response/SKILL.md
+++ b/.claude/skills/skill-review-response/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: skill-review-response
+disable-model-invocation: true
 description: "Use when a reviewer, CI bot, or another AI leaves feedback to address"
 trigger: |
-  AUTOMATICALLY ACTIVATE when:
+  EXPLICITLY USE when:
   - Receiving code review feedback (PR comments, review agent output)
   - Processing suggestions from /octo:review or /octo:staged-review
   - Responding to CI failure feedback

--- a/.claude/skills/skill-rollback/SKILL.md
+++ b/.claude/skills/skill-rollback/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: skill-rollback
+disable-model-invocation: true
 user-invocable: true
 description: "Roll back to a previous checkpoint via git — use when a change went wrong and you need to revert"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user mentions:
+  EXPLICITLY USE when user mentions:
   - "rollback" or "revert" or "undo"
   - "go back to" or "restore checkpoint"
 argument-hint: "[list|<checkpoint-tag>]"

--- a/.claude/skills/skill-security-audit/SKILL.md
+++ b/.claude/skills/skill-security-audit/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: octopus-security-audit
+disable-model-invocation: true
 aliases:
   - security
   - security-audit

--- a/.claude/skills/skill-security-audit/SKILL.md
+++ b/.claude/skills/skill-security-audit/SKILL.md
@@ -14,7 +14,6 @@ pre_execution_contract:
 validation_gates:
   - orchestrate_sh_executed
   - output_artifact_exists
-invocation: human_only
 paths:
   - "**/.env*"
   - "**/auth*"

--- a/.claude/skills/skill-security-framing/SKILL.md
+++ b/.claude/skills/skill-security-framing/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-security-framing
+disable-model-invocation: true
 paths:
   - "**/*.env*"
   - "**/auth*"

--- a/.claude/skills/skill-ship/SKILL.md
+++ b/.claude/skills/skill-ship/SKILL.md
@@ -7,7 +7,6 @@ trigger: |
   EXPLICITLY USE when user mentions:
   - "ship" or "deliver" or "finalize"
   - "done" or "complete the project"
-invocation: human_only
 ---
 
 # Ship Project - Multi-AI Delivery Validation

--- a/.claude/skills/skill-ship/SKILL.md
+++ b/.claude/skills/skill-ship/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: skill-ship
+disable-model-invocation: true
 user-invocable: true
 description: "Package and finalize completed work for delivery — use when a feature is done and ready to ship"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user mentions:
+  EXPLICITLY USE when user mentions:
   - "ship" or "deliver" or "finalize"
   - "done" or "complete the project"
 invocation: human_only

--- a/.claude/skills/skill-staged-review/SKILL.md
+++ b/.claude/skills/skill-staged-review/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-staged-review
+disable-model-invocation: true
 aliases:
   - staged-review
   - two-stage-review

--- a/.claude/skills/skill-status/SKILL.md
+++ b/.claude/skills/skill-status/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: skill-status
+disable-model-invocation: true
 effort: low
 user-invocable: true
 description: "Show where you are in the workflow and what to do next — use for progress checks and orientation"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user asks about:
+  EXPLICITLY USE when user asks about:
   - "status" or "progress" or "where am I"
   - "what's next" or "next step"
   - "show status" or "project status"

--- a/.claude/skills/skill-task-management-v2/SKILL.md
+++ b/.claude/skills/skill-task-management-v2/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: skill-task-management
+disable-model-invocation: true
 aliases:
   - task-management
   - todo-orchestration
 description: "Manage tasks with Claude Code native tools — use to track TODOs, delegate work, and monitor progress"
 trigger: |
-  AUTOMATICALLY ACTIVATE when user requests task management:
+  EXPLICITLY USE when user requests task management:
   - "add to the todo's" or "add this to todos"
   - "resume tasks" or "continue tasks" or "pick up where we left off"
   - "save progress" or "save progress for Claude to pick up"

--- a/.claude/skills/skill-tdd/SKILL.md
+++ b/.claude/skills/skill-tdd/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-tdd
+disable-model-invocation: true
 paths:
   - "**/*.test.*"
   - "**/*.spec.*"
@@ -10,8 +11,8 @@ aliases:
   - test-driven-development
 description: "Build features with tests-before-code rigor — use for new features needing test coverage"
 trigger: |
-  Use when implementing any feature, bugfix, or behavior change.
-  Auto-invoke when user says "implement X", "add feature Y", "fix bug Z".
+  Invoke explicitly for a feature, bugfix, or behavior change that needs TDD.
+  Example requests include "implement X", "add feature Y", and "fix bug Z".
   DO NOT use for: throwaway prototypes, config files, documentation.
 ---
 

--- a/.claude/skills/skill-thought-partner/SKILL.md
+++ b/.claude/skills/skill-thought-partner/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-thought-partner
+disable-model-invocation: true
 aliases:
   - thought-partner
   - brainstorm
@@ -7,7 +8,7 @@ aliases:
   - creative-session
 description: "Brainstorm creatively with pattern spotting and paradox hunting — use for ideation and exploration"
 trigger: |
-  Use PROACTIVELY when user wants to:
+  Invoke explicitly when the user wants to:
   - "brainstorm", "think through this with me"
   - "help me explore ideas", "creative session"
   - "thought partner", "thinking partner"

--- a/.claude/skills/skill-ui-ux-design/SKILL.md
+++ b/.claude/skills/skill-ui-ux-design/SKILL.md
@@ -19,7 +19,6 @@ pre_execution_contract:
 validation_gates:
   - search_py_executed
   - design_spec_produced
-invocation: human_only
 trigger: |
   Use this skill when the user wants to "design a UI", "create a design system",
   "pick a color palette", "choose fonts for", "design a dashboard", "create component specs",

--- a/.claude/skills/skill-ui-ux-design/SKILL.md
+++ b/.claude/skills/skill-ui-ux-design/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: octopus-ui-ux-design
+disable-model-invocation: true
 aliases:
   - design-ui-ux
   - ui-ux-design

--- a/.claude/skills/skill-verification-gate/SKILL.md
+++ b/.claude/skills/skill-verification-gate/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: skill-verification-gate
+disable-model-invocation: true
 effort: low
 description: "Use when about to declare work complete, fixed, passing, or done"
 codex_alias_description: "Use when a nontrivial change needs end-to-end verification before committing or shipping"
 trigger: |
-  AUTOMATICALLY ACTIVATE when:
+  EXPLICITLY USE when:
   - About to claim work is complete, fixed, or passing
   - Before committing, creating PRs, or marking tasks done
   - After subagent reports success (verify independently)

--- a/.claude/skills/skill-visual-feedback/SKILL.md
+++ b/.claude/skills/skill-visual-feedback/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: skill-visual-feedback
+disable-model-invocation: true
 aliases:
   - visual-feedback
   - ui-ux-fixes
   - image-feedback
 description: Process screenshot-based UI/UX feedback to fix visual issues — use when users share screenshots of bugs
 trigger: |
-  AUTOMATICALLY ACTIVATE when user provides visual feedback:
+  EXPLICITLY USE when user provides visual feedback:
   - "[Image X] The /settings should be Y"
   - "[Image X] these button styles need to be fixed"
   - "[Image X] When X is set to Y, it shows as Z"

--- a/.claude/skills/skill-work-slicing/SKILL.md
+++ b/.claude/skills/skill-work-slicing/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-work-slicing
+disable-model-invocation: true
 description: "Break a plan or spec into vertical slices that each declare what blocks them — use when work is agreed but not yet cut into fileable pieces"
 ---
 

--- a/.claude/skills/skill-writing-plans/SKILL.md
+++ b/.claude/skills/skill-writing-plans/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: skill-writing-plans
+disable-model-invocation: true
 description: Create zero-context implementation plans with bite-sized tasks — use for multi-step feature planning
 trigger: |
-  Use when you have a spec or requirements for a multi-step task.
-  Auto-invoke when user says "plan how to implement X", "create implementation plan", 
+  Invoke explicitly when you have a spec or requirements for a multi-step task.
+  Example requests include "plan how to implement X", "create implementation plan",
   "break down this feature into tasks".
   Use BEFORE writing any implementation code.
 execution_mode: enforced

--- a/.claude/skills/sys-configure/SKILL.md
+++ b/.claude/skills/sys-configure/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: sys-configure
+disable-model-invocation: true
 effort: low
 user-invocable: true
 aliases:
@@ -21,4 +22,6 @@ This skill is an alias for `/octo:setup`. When triggered, invoke the setup comma
 - Work mode selection
 - First-run onboarding
 
-Do NOT duplicate setup logic here. Just invoke the setup skill.
+Do NOT duplicate setup logic here. Read
+`${HOME}/.claude-octopus/plugin/commands/setup.md` and follow it only because
+the user explicitly invoked this configuration skill.

--- a/.cursor-plugin/commands/octo-auto.md
+++ b/.cursor-plugin/commands/octo-auto.md
@@ -1,5 +1,6 @@
 ---
 description: "Smart router - Single entry point with natural language intent detection"
+disable-model-invocation: true
 ---
 
 # Smart Router (/octo:auto)
@@ -107,9 +108,13 @@ Display:
 Routing to [Workflow Name] (/octo:[command])
 ```
 
-Then display the visual indicator banner (STEP 6) and invoke:
+Then display the visual indicator banner (STEP 6), read the selected command
+file from `${HOME}/.claude-octopus/plugin/commands/[command].md`, and execute it
+with the full query. Do not use the Skill tool; Octopus components are hidden
+from model invocation by design.
 ```
-Skill(skill: "octo:[command]", args: "<full user query>")
+Read: ${HOME}/.claude-octopus/plugin/commands/[command].md
+Arguments: <full user query>
 ```
 
 **STEP 5b — MEDIUM confidence (confirm first):**
@@ -123,7 +128,7 @@ I detected [intent]. Route to:
 Which would you prefer, or rephrase your request?
 ```
 
-Wait for user confirmation before invoking the Skill tool.
+Wait for user confirmation before loading the selected command file.
 
 **STEP 5c — LOW confidence (show complete menu):**
 
@@ -244,7 +249,7 @@ This allows the router to learn user preferences over time.
 - Intent detected via priority-ordered keyword matching
 - Confidence determined via decision tree (not percentage formula)
 - User confirmation obtained (if MEDIUM confidence)
-- Target workflow executed via Skill tool
+- Target workflow executed from its explicit command file
 - Visual indicators displayed (for multi-AI workflows)
 
 ### Prohibited Actions
@@ -253,6 +258,6 @@ This allows the router to learn user preferences over time.
 - Routing without checking keyword priority order
 - Routing to non-existent skills
 - Skipping visual indicators for multi-AI workflows
-- Simulating workflow execution (MUST use Skill tool)
+- Simulating workflow execution instead of following the selected command file
 - Using percentage-based confidence scoring (use the decision tree above)
-- Passing queries to Skill tool without the full original text
+- Dropping any of the full original query when handing off to the command

--- a/.cursor-plugin/commands/octo-auto.md
+++ b/.cursor-plugin/commands/octo-auto.md
@@ -52,7 +52,6 @@ Match the query against keywords below. Check categories **in priority order** �
 | Brainstorm | brainstorm, ideate, ideas, creative, thought experiment, what if | `octo:brainstorm` |
 | Deck | presentation, slides, deck, pitch deck, slide deck | `octo:deck` |
 | Docs | document, documentation, README, API docs, write docs, docstring | `octo:docs` |
-| Agent topology | too many agents, worth the overhead, coordination cost, agents keep agreeing, collapse agents, before adding an agent | `skill-agent-topology` |
 
 #### Priority 2 — Core Workflows
 
@@ -101,6 +100,14 @@ No intent keywords matched
 
 ### STEP 5: Route Based on Confidence
 
+Before loading any route, validate it against this closed allowlist: `embrace`,
+`multi`, `parallel`, `spec`, `security`, `tdd`, `debug`, `design-ui-ux`, `prd`,
+`brainstorm`, `deck`, `docs`, `discover`, `review`, `debate`, `develop`, `plan`, `quick`.
+The token is control data, never user input: do not derive it from the query or
+accept a user-supplied path. Reject `..`, `/`, `\\`, or non-allowlisted values;
+then load exactly `${HOME}/.claude-octopus/plugin/commands/<validated-token>.md`.
+The full query is passed only as workflow arguments.
+
 **STEP 5a — HIGH confidence (auto-route):**
 
 Display:
@@ -108,12 +115,13 @@ Display:
 Routing to [Workflow Name] (/octo:[command])
 ```
 
-Then display the visual indicator banner (STEP 6), read the selected command
-file from `${HOME}/.claude-octopus/plugin/commands/[command].md`, and execute it
-with the full query. Do not use the Skill tool; Octopus components are hidden
-from model invocation by design.
+Then display the visual indicator banner (STEP 6), read the entire validated
+command file, and treat its body as the active instructions in this same
+conversation: follow its workflow in order and supply the full query as its
+arguments. Do not use the Skill tool; Octopus components are hidden from model
+invocation by design.
 ```
-Read: ${HOME}/.claude-octopus/plugin/commands/[command].md
+Read: ${HOME}/.claude-octopus/plugin/commands/<validated-token>.md
 Arguments: <full user query>
 ```
 

--- a/.cursor-plugin/commands/octo-brainstorm.md
+++ b/.cursor-plugin/commands/octo-brainstorm.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Start a creative thought partner brainstorming session\""
+disable-model-invocation: true
 ---
 
 # /octo:brainstorm

--- a/.cursor-plugin/commands/octo-budget-mode.md
+++ b/.cursor-plugin/commands/octo-budget-mode.md
@@ -1,5 +1,6 @@
 ---
 description: "Switch Octopus model routing to the configured budget tier"
+disable-model-invocation: true
 allowed-tools: Bash
 ---
 

--- a/.cursor-plugin/commands/octo-careful.md
+++ b/.cursor-plugin/commands/octo-careful.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Activate destructive command warnings for the session\""
+disable-model-invocation: true
 ---
 
 # Careful Mode - Destructive Command Warnings

--- a/.cursor-plugin/commands/octo-claw.md
+++ b/.cursor-plugin/commands/octo-claw.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] OpenClaw instance administration — manage hosts across macOS, Ubuntu/Debian, Docker, OCI, and Proxmox\""
+disable-model-invocation: true
 ---
 
 # Claw - OpenClaw System Administration

--- a/.cursor-plugin/commands/octo-costs.md
+++ b/.cursor-plugin/commands/octo-costs.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Show cost breakdown by provider and workflow for the current session\""
+disable-model-invocation: true
 allowed-tools: Bash, Read, Glob, Grep
 ---
 

--- a/.cursor-plugin/commands/octo-council.md
+++ b/.cursor-plugin/commands/octo-council.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Multi-LLM council for advice, decision support, implementation plans, and gated implementation\""
+disable-model-invocation: true
 ---
 
 # Council

--- a/.cursor-plugin/commands/octo-debate.md
+++ b/.cursor-plugin/commands/octo-debate.md
@@ -1,5 +1,6 @@
 ---
 description: "\"AI Debate Hub - Structured debates across Claude and available external providers\""
+disable-model-invocation: true
 ---
 
 # Debate

--- a/.cursor-plugin/commands/octo-debug.md
+++ b/.cursor-plugin/commands/octo-debug.md
@@ -1,5 +1,6 @@
 ---
 description: "Systematic debugging with methodical problem investigation"
+disable-model-invocation: true
 ---
 
 # Debug - Systematic Debugging Skill

--- a/.cursor-plugin/commands/octo-deck.md
+++ b/.cursor-plugin/commands/octo-deck.md
@@ -1,5 +1,6 @@
 ---
 description: "Generate slide deck presentations from briefs or research"
+disable-model-invocation: true
 ---
 
 # Deck - Slide Deck Generator

--- a/.cursor-plugin/commands/octo-define.md
+++ b/.cursor-plugin/commands/octo-define.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Definition phase - Clarify and scope problems with multi-AI consensus\""
+disable-model-invocation: true
 ---
 
 # Define - Definition Phase 🎯
@@ -12,7 +13,7 @@ description: "\"Definition phase - Clarify and scope problems with multi-AI cons
 
 ### EXECUTION MECHANISM — NON-NEGOTIABLE
 
-**You MUST execute this command by invoking the corresponding skill via the Skill tool. You are PROHIBITED from:**
+**You MUST execute this command by reading and following the corresponding workflow source. You are PROHIBITED from:**
 - ❌ Using the Agent tool to research/implement yourself instead of invoking the skill
 - ❌ Using WebFetch/Read/Grep as a substitute for multi-provider dispatch
 - ❌ Skipping `orchestrate.sh` calls because "I can do this faster directly"
@@ -24,14 +25,14 @@ description: "\"Definition phase - Clarify and scope problems with multi-AI cons
 
 When the user invokes this command (e.g., `/octo:define <arguments>`):
 
-**✓ CORRECT - Use the Skill tool:**
+**✓ CORRECT - Read the explicit workflow source:**
 ```
-Skill(skill: "octo:define", args: "<user's arguments>")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/flow-define/SKILL.md, then execute it with <user's arguments>
 ```
 
 **✗ INCORRECT:**
 ```
-Skill(skill: "flow-define", ...)  ❌ Wrong! Internal skill name, not resolvable by Skill tool
+Skill(skill: "flow-define", ...)  ❌ Wrong! Octopus skills are model-invocation disabled
 Task(subagent_type: "octo:define", ...)  ❌ Wrong! This is a skill, not an agent type
 ```
 

--- a/.cursor-plugin/commands/octo-deliver.md
+++ b/.cursor-plugin/commands/octo-deliver.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Delivery phase - Review, validate, and test with multi-AI quality assurance\""
+disable-model-invocation: true
 ---
 
 # Deliver - Delivery Phase ✅
@@ -12,7 +13,7 @@ description: "\"Delivery phase - Review, validate, and test with multi-AI qualit
 
 ### EXECUTION MECHANISM — NON-NEGOTIABLE
 
-**You MUST execute this command by invoking the corresponding skill via the Skill tool. You are PROHIBITED from:**
+**You MUST execute this command by reading and following the corresponding workflow source. You are PROHIBITED from:**
 - ❌ Using the Agent tool to research/implement yourself instead of invoking the skill
 - ❌ Using WebFetch/Read/Grep as a substitute for multi-provider dispatch
 - ❌ Skipping `orchestrate.sh` calls because "I can do this faster directly"
@@ -24,14 +25,14 @@ description: "\"Delivery phase - Review, validate, and test with multi-AI qualit
 
 When the user invokes this command (e.g., `/octo:deliver <arguments>`):
 
-**✓ CORRECT - Use the Skill tool:**
+**✓ CORRECT - Read the explicit workflow source:**
 ```
-Skill(skill: "octo:deliver", args: "<user's arguments>")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/flow-deliver/SKILL.md, then execute it with <user's arguments>
 ```
 
 **✗ INCORRECT:**
 ```
-Skill(skill: "flow-deliver", ...)  ❌ Wrong! Internal skill name, not resolvable by Skill tool
+Skill(skill: "flow-deliver", ...)  ❌ Wrong! Octopus skills are model-invocation disabled
 Task(subagent_type: "octo:deliver", ...)  ❌ Wrong! This is a skill, not an agent type
 ```
 

--- a/.cursor-plugin/commands/octo-design-ui-ux.md
+++ b/.cursor-plugin/commands/octo-design-ui-ux.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Design UI/UX systems with style guides, palettes, typography, and component specs\""
+disable-model-invocation: true
 ---
 
 # /octo:design-ui-ux - UI/UX Design Workflow

--- a/.cursor-plugin/commands/octo-dev.md
+++ b/.cursor-plugin/commands/octo-dev.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Switch to Dev Work mode - optimized for software development\""
+disable-model-invocation: true
 ---
 
 # Dev Work Mode

--- a/.cursor-plugin/commands/octo-develop.md
+++ b/.cursor-plugin/commands/octo-develop.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Development phase - Build solutions with multi-AI implementation and quality gates\""
+disable-model-invocation: true
 ---
 
 # Develop - Development Phase 🛠️

--- a/.cursor-plugin/commands/octo-discipline.md
+++ b/.cursor-plugin/commands/octo-discipline.md
@@ -1,5 +1,6 @@
 ---
 description: "Toggle discipline mode — auto-invoke verification, brainstorming-before-coding, and review checks"
+disable-model-invocation: true
 ---
 
 # Discipline Mode
@@ -21,19 +22,21 @@ When **on**, you MUST follow these rules automatically — no user prompt needed
 ### Development Gates
 
 **1. Brainstorm gate** — Before writing ANY code or making changes, check:
-- Has the approach been discussed/planned? If not, invoke `skill-thought-partner` or `skill-writing-plans`
+- Has the approach been discussed/planned? If not, read and follow the
+  `skill-thought-partner` or `skill-writing-plans` source under
+  `${HOME}/.claude-octopus/plugin/.claude/skills/`.
 - This applies even for "simple" changes
 
-**2. Verification gate** — Before saying "done", "fixed", "passing", or committing, invoke `skill-verification-gate`:
+**2. Verification gate** — Before saying "done", "fixed", "passing", or committing, read and follow `skill-verification-gate`:
 - Run the actual verification command, read output, only claim success with evidence
 
 **3. Review gate** — After completing any non-trivial code change, automatically:
 - Spec compliance check + code quality review via subagent
 
-**4. Response gate** — When receiving code review feedback, invoke `skill-review-response`:
+**4. Response gate** — When receiving code review feedback, read and follow `skill-review-response`:
 - Verify feedback against actual code before implementing
 
-**5. Investigation gate** — When encountering ANY bug, error, or test failure, invoke `skill-debug`:
+**5. Investigation gate** — When encountering ANY bug, error, or test failure, read and follow `skill-debug`:
 - Root cause investigation before proposing fixes
 
 ### Knowledge Work Gates

--- a/.cursor-plugin/commands/octo-discover.md
+++ b/.cursor-plugin/commands/octo-discover.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Discovery phase - Multi-AI research and exploration\""
+disable-model-invocation: true
 ---
 
 # Discover - Discovery Phase 🔍

--- a/.cursor-plugin/commands/octo-docs.md
+++ b/.cursor-plugin/commands/octo-docs.md
@@ -1,5 +1,6 @@
 ---
 description: "Document delivery with export to PPTX, DOCX, PDF formats"
+disable-model-invocation: true
 ---
 
 # Docs - Document Delivery Skill

--- a/.cursor-plugin/commands/octo-doctor.md
+++ b/.cursor-plugin/commands/octo-doctor.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Environment diagnostics — check providers, auth, config, hooks, scheduler, and more\""
+disable-model-invocation: true
 allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 ---
 

--- a/.cursor-plugin/commands/octo-embrace.md
+++ b/.cursor-plugin/commands/octo-embrace.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Full Double Diamond workflow - Research → Define → Develop → Deliver\""
+disable-model-invocation: true
 ---
 
 # Embrace - Complete Double Diamond Workflow

--- a/.cursor-plugin/commands/octo-extract.md
+++ b/.cursor-plugin/commands/octo-extract.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Design System & Product Reverse-Engineering - Extract tokens, components, architecture, and PRDs from codebases or live products\""
+disable-model-invocation: true
 ---
 
 # /octo:extract - Design System & Product Reverse-Engineering

--- a/.cursor-plugin/commands/octo-factory.md
+++ b/.cursor-plugin/commands/octo-factory.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Dark Factory Mode - Spec-in, software-out autonomous pipeline\""
+disable-model-invocation: true
 ---
 
 # Factory - Dark Factory Mode (v8.25.0)

--- a/.cursor-plugin/commands/octo-freeze.md
+++ b/.cursor-plugin/commands/octo-freeze.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Restrict file edits to a specific directory boundary\""
+disable-model-invocation: true
 ---
 
 # Freeze Mode - Edit Boundary Enforcement

--- a/.cursor-plugin/commands/octo-guard.md
+++ b/.cursor-plugin/commands/octo-guard.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Activate both careful mode and freeze mode together\""
+disable-model-invocation: true
 ---
 
 # Guard Mode - Full Safety Activation

--- a/.cursor-plugin/commands/octo-history.md
+++ b/.cursor-plugin/commands/octo-history.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Query past workflow results — filter by workflow type, date, or provider\""
+disable-model-invocation: true
 allowed-tools: Bash, Read, Grep
 ---
 

--- a/.cursor-plugin/commands/octo-km.md
+++ b/.cursor-plugin/commands/octo-km.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Switch to Knowledge Work mode (or toggle with off)\""
+disable-model-invocation: true
 ---
 
 # Knowledge Mode Toggle

--- a/.cursor-plugin/commands/octo-loop.md
+++ b/.cursor-plugin/commands/octo-loop.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Execute tasks in loops with conditions, iterative improvements until goals are met\""
+disable-model-invocation: true
 ---
 
 # Loop - Iterative Execution Skill

--- a/.cursor-plugin/commands/octo-meta-prompt.md
+++ b/.cursor-plugin/commands/octo-meta-prompt.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Generate an optimized prompt for any task using meta-prompting techniques\""
+disable-model-invocation: true
 ---
 
 # /octo:meta-prompt

--- a/.cursor-plugin/commands/octo-model-config.md
+++ b/.cursor-plugin/commands/octo-model-config.md
@@ -1,5 +1,6 @@
 ---
 description: "Configure AI provider models for Claude Octopus workflows"
+disable-model-invocation: true
 ---
 
 # Model Configuration

--- a/.cursor-plugin/commands/octo-multi.md
+++ b/.cursor-plugin/commands/octo-multi.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Force multi-provider parallel execution for any task - manual override mode\""
+disable-model-invocation: true
 ---
 
 # Multi - Multi-Provider Override

--- a/.cursor-plugin/commands/octo-parallel.md
+++ b/.cursor-plugin/commands/octo-parallel.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Team of Teams - Decompose compound tasks across independent claude instances\""
+disable-model-invocation: true
 ---
 
 # Parallel - Team of Teams
@@ -8,14 +9,14 @@ description: "\"[advanced] Team of Teams - Decompose compound tasks across indep
 
 When the user invokes this command (e.g., `/octo:parallel <arguments>`):
 
-**CORRECT - Use the Skill tool:**
+**CORRECT - Read the explicit workflow source:**
 ```
-Skill(skill: "octo:parallel", args: "<user's arguments>")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/flow-parallel/SKILL.md, then execute it with <user's arguments>
 ```
 
 **INCORRECT:**
 ```
-Skill(skill: "flow-parallel", ...)  ❌ Wrong! Internal skill name, not resolvable by Skill tool
+Skill(skill: "flow-parallel", ...)  ❌ Wrong! Octopus skills are model-invocation disabled
 Task(subagent_type: "octo:parallel", ...)  ❌ Wrong! This is a skill, not an agent type
 ```
 

--- a/.cursor-plugin/commands/octo-pipeline.md
+++ b/.cursor-plugin/commands/octo-pipeline.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Run content analysis pipeline on URL(s) to extract patterns and create anatomy guides\""
+disable-model-invocation: true
 ---
 
 # /octo:pipeline

--- a/.cursor-plugin/commands/octo-plan.md
+++ b/.cursor-plugin/commands/octo-plan.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Intelligent plan builder - creates strategic execution plans (doesn't execute). Use /octo:embrace to execute plans.\""
+disable-model-invocation: true
 ---
 
 # Plan - Intelligent Plan Builder
@@ -11,7 +12,7 @@ description: "\"Intelligent plan builder - creates strategic execution plans (do
 - **Creates plans** - Captures intent, analyzes requirements, generates weighted execution strategy
 - **Saves to files** - Stores plan (`.claude/session-plan.md`) and intent contract (`.claude/session-intent.md`)
 - **Doesn't execute** - Plans are saved for review; execution requires user confirmation
-- **Optional execution** - Can invoke `/octo:embrace` immediately or user can execute later
+- **Optional execution** - Can load `/octo:embrace` after explicit user approval or execute later
 
 ## 🤖 INSTRUCTIONS FOR CLAUDE
 
@@ -455,12 +456,12 @@ AskUserQuestion({
 - Return to Step 6 (ask again what to do)
 
 **If "Execute now":**
-- Invoke `/octo:embrace` skill with the user's goal
+- Read `${HOME}/.claude-octopus/plugin/commands/embrace.md` and execute it with the user's goal
 - Pass the intent contract and phase weights
 - Let embrace workflow handle execution
 
 **If "Multi-LLM debate the plan first":**
-- Invoke `/octo:debate` with the plan as context (Claude plus available providers deliberate):
+- Read `${HOME}/.claude-octopus/plugin/commands/debate.md` and execute it with the plan as context (Claude plus available providers deliberate):
   - Topic: "Should we proceed with this plan? What are the risks and blind spots?"
   - `--rounds 2 --debate-style adversarial --context-file .claude/session-plan.md`
 - After the Multi-LLM debate completes, present the synthesis and return to Step 6
@@ -476,7 +477,7 @@ AskUserQuestion({
 
 **If user chose "Execute now" in Step 6:**
 
-The plan command should invoke the `/octo:embrace` skill, which handles:
+The plan command should load the explicit `/octo:embrace` command source, which handles:
 - Execution of all 4 phases (Discover → Define → Develop → Deliver)
 - Using the phase weights from the plan
 - Referencing the intent contract
@@ -490,7 +491,7 @@ The plan command should invoke the `/octo:embrace` skill, which handles:
 **The plan command exits after:**
 - Creating and saving the plan (`.claude/session-plan.md`)
 - Creating the intent contract (`.claude/session-intent.md`)
-- Optionally invoking `/octo:embrace` if user requested immediate execution
+- Optionally loading `/octo:embrace` if user requested immediate execution
 
 **The plan command does NOT:**
 - Execute workflows directly (delegates to `/octo:embrace`)

--- a/.cursor-plugin/commands/octo-prd-score.md
+++ b/.cursor-plugin/commands/octo-prd-score.md
@@ -1,5 +1,6 @@
 ---
 description: "Score an existing PRD against the 100-point AI-optimization framework"
+disable-model-invocation: true
 ---
 
 ## STOP - DO NOT INVOKE /skill OR Skill() AGAIN

--- a/.cursor-plugin/commands/octo-prd.md
+++ b/.cursor-plugin/commands/octo-prd.md
@@ -1,5 +1,6 @@
 ---
 description: "Write an AI-optimized PRD using multi-AI orchestration and 100-point scoring framework"
+disable-model-invocation: true
 ---
 
 ### MANDATORY COMPLIANCE — DO NOT SKIP

--- a/.cursor-plugin/commands/octo-preflight.md
+++ b/.cursor-plugin/commands/octo-preflight.md
@@ -1,5 +1,6 @@
 ---
 description: "Check provider health before running multi-LLM workflows"
+disable-model-invocation: true
 allowed-tools: Bash
 ---
 

--- a/.cursor-plugin/commands/octo-premium-mode.md
+++ b/.cursor-plugin/commands/octo-premium-mode.md
@@ -1,5 +1,6 @@
 ---
 description: "Switch Octopus model routing to the configured premium tier"
+disable-model-invocation: true
 allowed-tools: Bash
 ---
 

--- a/.cursor-plugin/commands/octo-quick.md
+++ b/.cursor-plugin/commands/octo-quick.md
@@ -1,5 +1,6 @@
 ---
 description: "Quick execution mode for ad-hoc tasks without full workflow overhead"
+disable-model-invocation: true
 ---
 
 # Quick Mode Command

--- a/.cursor-plugin/commands/octo-research.md
+++ b/.cursor-plugin/commands/octo-research.md
@@ -1,5 +1,6 @@
 ---
 description: "Deep research with multi-source synthesis and comprehensive analysis"
+disable-model-invocation: true
 ---
 
 # Research - Deep Multi-AI Research
@@ -14,7 +15,7 @@ description: "Deep research with multi-source synthesis and comprehensive analys
 
 ### EXECUTION MECHANISM — NON-NEGOTIABLE
 
-**You MUST execute this command by invoking the corresponding skill via the Skill tool. You are PROHIBITED from:**
+**You MUST execute this command by reading and following the dedicated research source. You are PROHIBITED from:**
 - ❌ Using the Agent tool to research/implement yourself instead of invoking the skill
 - ❌ Using WebFetch/Read/Grep as a substitute for multi-provider dispatch
 - ❌ Skipping `orchestrate.sh` calls because "I can do this faster directly"
@@ -61,16 +62,16 @@ Map the answer to an intensity value:
 - "Standard" → `standard`
 - "Deep" → `deep`
 
-### Step 2: Invoke Skill with Intensity
+### Step 2: Load Research Workflow with Intensity
 
-**✓ CORRECT - Use the Skill tool:**
+**✓ CORRECT - Read the explicit workflow source:**
 ```
-Skill(skill: "octopus-research", args: "[breadth=light|standard|exhaustive] [intensity=quick|standard|deep] <user's arguments without routing flags>")
+Read `${HOME}/.claude-octopus/plugin/.claude/skills/skill-deep-research/SKILL.md`, then execute it with `[breadth=light|standard|exhaustive] [intensity=quick|standard|deep] <user's arguments without routing flags>`.
 ```
 
 Examples:
-- `Skill(skill: "octopus-research", args: "[breadth=standard] [intensity=standard] OAuth 2.0 authentication patterns")`
-- `/octo:research --breadth=exhaustive current agent orchestration patterns` -> `Skill(skill: "octopus-research", args: "[breadth=exhaustive] [intensity=deep] current agent orchestration patterns")`
+- Read the source above and execute with `[breadth=standard] [intensity=standard] OAuth 2.0 authentication patterns`.
+- `/octo:research --breadth=exhaustive current agent orchestration patterns` -> execute the source with `[breadth=exhaustive] [intensity=deep] current agent orchestration patterns`.
 
 **✗ INCORRECT - Do NOT use these:**
 ```
@@ -82,7 +83,7 @@ Task(subagent_type: "octo:discover", ...)  ❌ Wrong! This is a skill, not an ag
 
 ---
 
-**Auto-loads the dedicated research skill for comprehensive multi-provider research tasks.**
+**Loads the dedicated research workflow only after this explicit command.**
 
 ## Quick Usage
 

--- a/.cursor-plugin/commands/octo-resume.md
+++ b/.cursor-plugin/commands/octo-resume.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Resume a previous agent by ID — continue an interrupted task where it left off\""
+disable-model-invocation: true
 ---
 
 # /octo:resume — Agent Resume

--- a/.cursor-plugin/commands/octo-retro.md
+++ b/.cursor-plugin/commands/octo-retro.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Generate engineering retrospectives from git history with trends and team analysis\""
+disable-model-invocation: true
 allowed-tools: Bash, Read, Glob, Grep, Write
 ---
 

--- a/.cursor-plugin/commands/octo-review.md
+++ b/.cursor-plugin/commands/octo-review.md
@@ -1,5 +1,6 @@
 ---
 description: "Enhanced multi-LLM review with inline PR comments — escalation path beyond Claude-native /review"
+disable-model-invocation: true
 ---
 
 # /octo:review

--- a/.cursor-plugin/commands/octo-schedule.md
+++ b/.cursor-plugin/commands/octo-schedule.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Manage scheduled workflow jobs (add via wizard, dashboard, list, remove, enable, disable, logs)\""
+disable-model-invocation: true
 ---
 
 # Schedule

--- a/.cursor-plugin/commands/octo-scheduler.md
+++ b/.cursor-plugin/commands/octo-scheduler.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Manage the scheduled workflow runner daemon (start/stop/status)\""
+disable-model-invocation: true
 ---
 
 # Scheduler

--- a/.cursor-plugin/commands/octo-security.md
+++ b/.cursor-plugin/commands/octo-security.md
@@ -1,5 +1,6 @@
 ---
 description: "Enhanced multi-LLM or adversarial security audit — escalation path beyond Claude-native /security-review"
+disable-model-invocation: true
 ---
 
 # Security - Security Audit Skill

--- a/.cursor-plugin/commands/octo-sentinel.md
+++ b/.cursor-plugin/commands/octo-sentinel.md
@@ -1,5 +1,6 @@
 ---
 description: "GitHub-aware work monitor - triages issues, PRs, and CI failures"
+disable-model-invocation: true
 ---
 
 # Sentinel (/octo:sentinel)

--- a/.cursor-plugin/commands/octo-setup.md
+++ b/.cursor-plugin/commands/octo-setup.md
@@ -1,5 +1,6 @@
 ---
 description: "Interactive setup wizard — install providers, configure auth, RTK, token optimization"
+disable-model-invocation: true
 allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 ---
 
@@ -9,7 +10,8 @@ allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 
 Interactive setup wizard. Detects what's installed, offers to install what's missing, configures auth, and optimizes token usage.
 
-**This command auto-runs on first install** (via SessionStart hook). It also runs when users invoke `/octo:setup` manually.
+**This command runs only when the user invokes `/octo:setup`.** SessionStart may
+offer the command once after installation, but never starts it.
 
 **CRITICAL: This command MUST always run its interactive flow when invoked.** Never silently dismiss the user. Never say "you're already set up" without showing the dashboard and offering choices via AskUserQuestion. Even if everything is configured, the user invoked this command for a reason — show them their status and ask what they want to do.
 

--- a/.cursor-plugin/commands/octo-spec.md
+++ b/.cursor-plugin/commands/octo-spec.md
@@ -1,5 +1,6 @@
 ---
 description: "\"NLSpec authoring - Structured specification from multi-AI research\""
+disable-model-invocation: true
 ---
 
 # Spec - NLSpec Authoring
@@ -8,14 +9,14 @@ description: "\"NLSpec authoring - Structured specification from multi-AI resear
 
 When the user invokes this command (e.g., `/octo:spec <arguments>`):
 
-**CORRECT - Use the Skill tool:**
+**CORRECT - Read the explicit workflow source:**
 ```
-Skill(skill: "octo:spec", args: "<user's arguments>")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/flow-spec/SKILL.md, then execute it with <user's arguments>
 ```
 
 **INCORRECT:**
 ```
-Skill(skill: "flow-spec", ...)  ❌ Wrong! Internal skill name, not resolvable by Skill tool
+Skill(skill: "flow-spec", ...)  ❌ Wrong! Octopus skills are model-invocation disabled
 Task(subagent_type: "octo:spec", ...)  ❌ Wrong! This is a skill, not an agent type
 ```
 

--- a/.cursor-plugin/commands/octo-staged-review.md
+++ b/.cursor-plugin/commands/octo-staged-review.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Two-stage review: spec compliance then code quality\""
+disable-model-invocation: true
 ---
 
 # Staged Review — Two-Stage Pipeline

--- a/.cursor-plugin/commands/octo-standard-mode.md
+++ b/.cursor-plugin/commands/octo-standard-mode.md
@@ -1,5 +1,6 @@
 ---
 description: "Switch Octopus model routing to the configured standard tier"
+disable-model-invocation: true
 allowed-tools: Bash
 ---
 

--- a/.cursor-plugin/commands/octo-tdd.md
+++ b/.cursor-plugin/commands/octo-tdd.md
@@ -1,5 +1,6 @@
 ---
 description: "Test-driven development with red-green-refactor discipline"
+disable-model-invocation: true
 ---
 
 # TDD - Test-Driven Development Skill

--- a/.cursor-plugin/commands/octo-unfreeze.md
+++ b/.cursor-plugin/commands/octo-unfreeze.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Remove freeze mode edit restriction\""
+disable-model-invocation: true
 ---
 
 # Unfreeze - Remove Edit Boundary

--- a/.cursor-plugin/commands/octo-usage.md
+++ b/.cursor-plugin/commands/octo-usage.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[advanced] Per-provider, per-skill, and per-MCP-server cost and token breakdown (Claude Code /usage schema)\""
+disable-model-invocation: true
 allowed-tools: Bash, Read, Glob
 ---
 

--- a/.cursor-plugin/commands/octo-whats-new.md
+++ b/.cursor-plugin/commands/octo-whats-new.md
@@ -1,5 +1,6 @@
 ---
 description: "\"Review and enable Claude Octopus features added since you installed\""
+disable-model-invocation: true
 allowed-tools: Bash, Read
 ---
 

--- a/.cursor-plugin/commands/octo.md
+++ b/.cursor-plugin/commands/octo.md
@@ -1,5 +1,6 @@
 ---
 description: "\"[Legacy] Redirects to /octo:auto — the smart router\""
+disable-model-invocation: true
 ---
 
 # /octo:octo → /octo:auto (Legacy Redirect)
@@ -11,7 +12,9 @@ This command has been renamed to `/octo:auto`. Invoking `/octo:octo` still works
 When the user invokes `/octo:octo <query>`, you MUST:
 
 1. Inform the user: "Note: `/octo:octo` has been renamed to `/octo:auto`. Routing your request now."
-2. Immediately invoke: `Skill(skill: "octo:auto", args: "<full user query>")`
+2. Immediately read `${HOME}/.claude-octopus/plugin/commands/auto.md` and
+   execute it with the full user query. Do not use the Skill tool; Octopus
+   commands are explicit-only and hidden from model invocation.
 3. If the routed workflow dispatches multiple providers, surface `${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh agent-summary` before final synthesis when available.
 
 Do NOT duplicate the routing logic here — delegate entirely to `/octo:auto`.

--- a/.github/agents/backend-architect.agent.md
+++ b/.github/agents/backend-architect.agent.md
@@ -1,6 +1,6 @@
 ---
 name: backend-architect
-description: Backend architect for scalable API design, microservices, and distributed systems
+description: Octopus-only backend architect. Use only when the user explicitly selects this agent or starts an Octopus workflow; never for an ordinary request.
 tools:
   - read
   - search

--- a/.github/agents/cloud-architect.agent.md
+++ b/.github/agents/cloud-architect.agent.md
@@ -1,6 +1,6 @@
 ---
 name: cloud-architect
-description: Cloud architect for AWS/Azure/GCP infrastructure, IaC, FinOps, and multi-cloud strategies
+description: Octopus-only cloud architect. Use only when the user explicitly selects this agent or starts an Octopus workflow; never for an ordinary request.
 tools:
   - read
   - search

--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: Code review expert for quality analysis, security vulnerabilities, and production reliability
+description: Octopus-only code reviewer. Use only when the user explicitly selects this agent or starts an Octopus workflow; never for an ordinary request.
 tools:
   - read
   - search

--- a/.github/agents/database-architect.agent.md
+++ b/.github/agents/database-architect.agent.md
@@ -1,6 +1,6 @@
 ---
 name: database-architect
-description: Database architect for data modeling, technology selection, schema design, and migration planning
+description: Octopus-only database architect. Use only when the user explicitly selects this agent or starts an Octopus workflow; never for an ordinary request.
 tools:
   - read
   - search

--- a/.github/agents/debugger.agent.md
+++ b/.github/agents/debugger.agent.md
@@ -1,6 +1,6 @@
 ---
 name: debugger
-description: Debugging specialist for errors, test failures, and unexpected behavior
+description: Octopus-only debugger. Use only when the user explicitly selects this agent or starts an Octopus workflow; never for an ordinary request.
 tools:
   - read
   - edit

--- a/.github/agents/docs-architect.agent.md
+++ b/.github/agents/docs-architect.agent.md
@@ -1,6 +1,6 @@
 ---
 name: docs-architect
-description: Technical documentation architect for comprehensive system docs and architecture guides
+description: Octopus-only documentation architect. Use only when the user explicitly selects this agent or starts an Octopus workflow; never for an ordinary request.
 tools:
   - read
   - search

--- a/.github/agents/frontend-developer.agent.md
+++ b/.github/agents/frontend-developer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-developer
-description: Frontend developer for React, Next.js, responsive layouts, and accessible UI components
+description: Octopus-only frontend developer. Use only when the user explicitly selects this agent or starts an Octopus workflow; never for an ordinary request.
 tools:
   - read
   - edit

--- a/.github/agents/performance-engineer.agent.md
+++ b/.github/agents/performance-engineer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: performance-engineer
-description: Performance engineer for optimization, observability, and scalable system performance
+description: Octopus-only performance engineer. Use only when the user explicitly selects this agent or starts an Octopus workflow; never for an ordinary request.
 tools:
   - read
   - search

--- a/.github/agents/security-auditor.agent.md
+++ b/.github/agents/security-auditor.agent.md
@@ -1,6 +1,6 @@
 ---
 name: security-auditor
-description: Security auditor for DevSecOps, OWASP compliance, vulnerability assessment, and threat modeling
+description: Octopus-only security auditor. Use only when the user explicitly selects this agent or starts an Octopus workflow; never for an ordinary request.
 tools:
   - read
   - search

--- a/.github/agents/tdd-orchestrator.agent.md
+++ b/.github/agents/tdd-orchestrator.agent.md
@@ -1,6 +1,6 @@
 ---
 name: tdd-orchestrator
-description: TDD orchestrator enforcing red-green-refactor discipline and test-driven development
+description: Octopus-only TDD orchestrator. Use only when the user explicitly selects this agent or starts an Octopus workflow; never for an ordinary request.
 tools:
   - read
   - edit

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,22 +1,74 @@
 # AI Agent Handoff
 
-Last updated: 2026-08-12
-Status: Issues #885, #886, and #888 through #894 are resolved and released in
-v9.63.0.
-The implementation adds persistent budget, standard, and premium model-cost
-toggles and repairs Factory/Cursor generation so the Doctor adapter and full
-command set cannot silently disappear. First-party automation now uses its
-configured Claude OAuth credential, and provider output capture cannot be held
-open by a descendant that inherited stdout. Direct Qwen prompting with unusable
-credentials and retired Gemini execution remain blocked; Google-family workflow
-seats execute through AGY. If the Claude subscription reaches its independent
-weekly quota, first-party PR review retries through GitHub Copilot CLI with the
-short-lived Actions token and an empty model-tool inventory, while remaining
-fail-closed. Lifecycle hooks now treat malformed shared session state as an
-optional-cache miss, and every shared session writer publishes through a unique
-temporary file and atomic rename.
-Branch: `main`
-Release: [v9.63.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.63.0)
+Last updated: 2026-08-13
+Status: Issue #898 is implemented and passes the complete local gate on branch
+`fix/898-explicit-activation`; PR, merge, and release are the remaining steps.
+Octopus is now dormant until explicit invocation. Native command/skill gates,
+session-affine workflow hooks, passive startup notices, host-filtered tool
+hooks, and opt-in automation replace the previous install-wide engagement.
+The stable plugin entrypoint also advances to the host-loaded version so an old
+but still-present cache cannot strand explicit commands on stale hooks.
+Branch: `fix/898-explicit-activation`
+Current release: [v9.63.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.63.0)
+Tracking: [issue #898](https://github.com/nyldn/claude-octopus/issues/898)
+
+## Issue #898: Explicit Activation and Hook Latency
+
+- Root cause: every prompt ran two classifiers plus a GitHub queue watcher;
+  common phrases defaulted to workflow invocation; every tool call could spawn
+  provider, quality, guard, and PostToolUse hooks; SessionStart injected router,
+  memory, update, and setup instructions into model context; and all shipped
+  skills remained eligible for model invocation. A valid
+  `~/.claude-octopus/session.json` from another Claude session could also keep
+  enforcement alive.
+- Native activation boundary: every canonical command, source skill, generated
+  Codex skill, and generated Cursor command carries
+  `disable-model-invocation: true`. Explicit commands compose reusable method by
+  loading the canonical skill source rather than asking the model to invoke a
+  disabled skill. Claude and Copilot agent descriptions require an explicitly
+  started Octopus workflow.
+- Hook boundary: plain-language routing defaults to `off`; done-criteria,
+  session memory, context reinforcement, GitHub work-queue checks, remote
+  autonomy, output compression, strategy rotation, and statusline context are
+  opt-in or tied to the active matching host session. First-run, version, and
+  update notices use passive `systemMessage` output and never instruct the
+  model to act. Statusline repair only repairs an existing Octopus statusline.
+- Speed: current Claude Code uses handler-level permission-rule `if` filters so
+  provider validation and quality checks do not spawn outside
+  `orchestrate.sh`, while direct-provider guards spawn only for Codex, Qwen, or
+  retired Gemini commands. Stale clients that predate conditional hooks retain
+  in-process fast exits. The PostToolUse matcher no longer includes Read,
+  WebFetch, or Grep.
+- Stale-version recovery: `scripts/helpers/ensure-plugin-root.sh` compares the
+  physical stable entrypoint with `CLAUDE_PLUGIN_ROOT` on SessionStart. It now
+  replaces a valid old symlink when the host loaded a newer cache, closing the
+  gap where an update succeeded but `/octo:*` continued to execute old hooks.
+  Host-owned auto-update remains opt-in and startup hooks remain local-only and
+  non-mutating.
+- Official platform verification: Anthropic documents
+  `disable-model-invocation: true` as the manual-only skill control; custom
+  agents have no equivalent flag and are selected from their descriptions;
+  UserPromptSubmit cannot be matcher-filtered; and handler-level `if` avoids
+  process spawn for tool events on Claude Code v2.1.85 and newer.
+- TDD evidence: the new activation regression began with 9 of 12 cases failing.
+  It now passes 18/18, stable-entrypoint coverage passes 2/2, plugin assembly
+  validates every manual gate, and affected legacy suites have been updated to
+  assert the native contract rather than the removed advisory behavior.
+- Performance evidence: before the fix, inactive user-prompt and done-criteria
+  hooks averaged roughly 38-41 ms each, PostToolUse averaged 39 ms, and one
+  unrelated provider-validator path blocked for about 18 seconds per call.
+  After the fix, defense-in-depth inactive paths measured roughly 6-14 ms each;
+  supported Claude Code versions skip the filtered process spawn entirely.
+- Verification: `make sync`, `git diff --check`, `make sync-check`, and a fresh
+  `make ci-local` all pass. The final complete run passed every smoke, unit,
+  integration, and CI-only verification group. The first complete sweep exposed
+  five stale tests whose old contracts required auto-invocation plus one
+  pre-existing one-second macOS process-fixture race; the contracts now assert
+  explicit activation, and the unchanged process-tree behavior has a reliable
+  three-second fixture setup window.
+- Tracking blocker: Beads remains unreadable on schema v49 because the `leases`
+  table requires the reserved v65 migration. No migration was run. GitHub issue
+  #898 is the temporary tracker and this handoff records the blocked `bd` state.
 
 ## Start Here
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Octopus is dormant by default. All shipped commands and skills use Claude
+  Code's native `disable-model-invocation` gate, and Claude/Copilot agent
+  adapters require an explicitly started Octopus workflow. Plain-prompt
+  routing remains available through an explicit
+  `OCTOPUS_AUTO_ROUTER_MODE=suggest|invoke` preference. (#898)
+- Completion coaching, output compression, strategy rotation, statusline
+  context injection, session-memory restoration, GitHub queue checks, remote
+  workflow behavior, and statusline installation no longer engage merely
+  because the plugin is installed. Each is scoped to an active workflow or an
+  explicit opt-in. First-run, upgrade, and update-health notices are passive
+  system messages rather than model instructions. (#898)
+
+### Performance
+
+- Provider routing validation now uses Claude Code's host-side `if` filter and
+  no longer spawns for every Bash call. Direct Codex/Qwen/Gemini safety checks
+  are likewise host-filtered to those provider commands, blanket PostToolUse
+  matching is narrower, and inactive hook paths exit before JSON parsing,
+  provider discovery, state mutation, or network access. (#898)
+
+### Fixed
+
+- Session-affine workflow state prevents a stale workflow record from
+  injecting enforcement into a different Claude session. Explicit command
+  composition loads manual-only skill sources directly, preserving workflows
+  without reopening automatic model invocation. (#898)
+- The stable `~/.claude-octopus/plugin` entrypoint now advances to the plugin
+  version loaded by the host, even when its previous cache directory remains
+  valid. Older cached releases can no longer keep explicit commands pinned to
+  stale hooks after a successful update. (#898)
+
 ## [9.63.0] - 2026-08-12
 
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,7 +6,7 @@ last_reviewed: 2026-08-12
 
 ## Mission
 
-Put up to 9 external AI integrations on every task so blind spots surface before you ship — not after.
+Make up to 9 external AI integrations available for explicit escalation, so blind spots surface on the work that warrants multi-model scrutiny without taxing every ordinary task.
 
 ## Vision
 
@@ -39,7 +39,7 @@ Claude Octopus is a **multi-runtime orchestration plugin** with three architectu
 | **Workflow engine** (`skills/`) | Structures every task into Discover → Define → Develop → Deliver with quality gates | Stops ad-hoc "just ask Claude" from shipping low-confidence output |
 | **Consensus layer** | 75% gate: flags disagreements across providers before code is finalized | The actual blind-spot catcher — surfaces the 1-in-5 case where Claude was wrong |
 
-54 slash commands, 63 skills, 32 specialized personas activate the right layer for the right job.
+54 slash commands, 63 skills, and 32 specialized personas provide explicit escalation entrypoints. Installation alone activates none of them.
 
 ## Core Value Propositions
 
@@ -58,6 +58,7 @@ Claude Octopus is a **multi-runtime orchestration plugin** with three architectu
 3. **Cost transparency always** — Display provider indicators (🔴🟡🔵) and per-provider cost context before every multi-model dispatch
 4. **Consensus gate, not consensus override** — 75% agreement flags disagreement; it does not suppress the minority view
 5. **Zero providers to start** — Claude is built in; every additional provider is opt-in, not required
+6. **Dormant until asked** — Ordinary prompts stay on Claude's native path; only `/octo:*` or an explicit automation preference activates Octopus
 
 ## Competitive Positioning
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ export OCTOPUS_CONTEXT_AWARENESS=on      # statusline-to-context reinforcement
 export OCTOPUS_SESSION_MEMORY=on         # SessionStart preference restoration
 ```
 
+This legacy opt-in examines ordinary prompts. `invoke` can start paid
+external-provider workflows and share the routed prompt context with configured
+providers; prefer `suggest` unless that behavior is intentional.
+
 Safety guards that prevent invalid direct Codex, Qwen, or retired Gemini CLI
 dispatch remain available, but host-side command filters keep them out of
 unrelated tool calls.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
 
-🐙 **Research, build, review, and ship — with nine external providers checking the host's work.** Say what you need, and the right workflow runs. Claude-native handles the ordinary path; Octopus handles the escalated path. A 75% consensus gate catches disagreements before they reach production. No single model's blind spots slip through.
+🐙 **Research, build, review, and ship — with nine external providers checking the host's work.** Claude-native handles the ordinary path. Octopus remains dormant until you explicitly run `/octo:*`, then handles the escalated path. A 75% consensus gate catches disagreements before they reach production.
 
 🧠 **Remembers across sessions.** Integrates with [claude-mem](https://github.com/thedotmack/claude-mem) and [agentmemory](https://github.com/rohitg00/agentmemory) for persistent memory — past decisions, research, and context survive session boundaries.
 
@@ -24,9 +24,9 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
 
 🔄 **Four-phase methodology, not just tools.** Every task moves through Discover → Define → Develop → Deliver, with quality gates between phases. Other orchestrators give you infrastructure. Octopus gives you the workflows.
 
-🐙 **32 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **54 commands** (slash commands you type), **63 skills** (reusable workflow modules). Say "audit my API" and the right expert activates. Don't know the command? The smart router figures it out.
+🐙 **32 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **54 commands** (slash commands you type), **63 skills** (reusable workflow modules). Explicit workflows select the experts they need; ordinary Claude requests do not activate Octopus.
 
-🐙 **Works with just Claude. Adds up to nine external provider integrations.** Zero external providers are needed to start. Add them one at a time — each activates automatically when detected.
+🐙 **Works with just Claude. Adds up to nine external provider integrations.** Zero external providers are needed to start. Add them one at a time — each becomes available when detected and runs only inside an explicit workflow.
 
 💰 **Four providers cost nothing extra when you already have access.** Codex, Antigravity CLI, and Copilot use existing subscriptions or local auth. Ollama runs locally for free. Qwen now requires API-key or Coding-Plan auth; its free OAuth tier ended on 2026-04-15.
 
@@ -58,7 +58,7 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
 | **v9.63.0** (new) | Add cost modes and harden provider and hook reliability. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
-| **v9** | Up to 9 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Smart router — just say what you need. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Discipline mode with 8 auto-invoke gates. Two-stage review. Circuit breakers with automatic provider recovery. Cursor + OpenCode + Codex cross-compatibility. Token compression: `bin/octo-compress` pipe + auto PostToolUse hook save ~7,300 tokens/session. PostCompact context recovery. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |
+| **v9** | Up to 9 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Explicit-only activation by default, with an optional smart router. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Opt-in discipline gates and token compression. Two-stage review. Circuit breakers with automatic provider recovery inside active workflows. Cursor + OpenCode + Codex cross-compatibility. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |
 | **v8** | Multi-LLM code review with inline PR comments. Parallel workstreams in isolated git worktrees. Reaction engine — auto-responds to CI failures. 32 specialized personas. Dark Factory autonomous pipeline. |
 | **v7** | Double Diamond workflow. Multi-provider dispatch. Quality gates and consensus scoring. Configurable sandbox modes. |
 
@@ -88,6 +88,28 @@ claude plugin install octo@nyldn-plugins
 ```
 
 That's it. Setup detects installed providers, shows what's missing, and walks you through configuration. You need **zero** external providers to start — Claude is built in.
+
+### Dormant by default
+
+Installing Octopus does not route ordinary prompts, launch provider workflows,
+or delegate to Octopus agents. Every shipped command and skill uses Claude
+Code's native manual-invocation gate. Start it with `/octo:*`.
+
+Optional automation remains available, but it is explicit opt-in:
+
+```bash
+export OCTOPUS_AUTO_ROUTER_MODE=suggest  # suggest a route for plain prompts
+# or: OCTOPUS_AUTO_ROUTER_MODE=invoke    # load the matched command route
+export OCTO_DONE_CRITERIA=on             # compound-task completion coaching
+export OCTOPUS_COMPRESS_ENABLED=true     # PostToolUse output compression
+export OCTO_STRATEGY_ROTATION=on         # failure strategy rotation
+export OCTOPUS_CONTEXT_AWARENESS=on      # statusline-to-context reinforcement
+export OCTOPUS_SESSION_MEMORY=on         # SessionStart preference restoration
+```
+
+Safety guards that prevent invalid direct Codex, Qwen, or retired Gemini CLI
+dispatch remain available, but host-side command filters keep them out of
+unrelated tool calls.
 
 Claude Code **v2.1.14+** is the minimum supported runtime. Newer Claude Code releases unlock additional Octopus diagnostics and release checks automatically; the current plugin tracks 182 Claude Code capability flags through **Claude Code v2.1.219**.
 
@@ -248,7 +270,7 @@ Claude Code v2.1.129+ also supports `skillOverrides` in Claude settings. Use it 
 
 ## Claude Code Web and Remote Sessions
 
-When Claude Code is running in a hosted, web, or remote-control environment, set `OCTOPUS_REMOTE_SESSION=true` in that environment. If Claude Code itself exports `CLAUDE_CODE_REMOTE=true` or `CLAUDE_CODE_WEB=true`, Octopus detects that automatically. Remote sessions are treated as unattended by default:
+When an explicit Octopus workflow is running in a hosted, web, or remote-control environment, set `OCTOPUS_REMOTE_SESSION=true` in that environment. Claude hosting alone does not activate Octopus. Once a workflow starts, `orchestrate.sh` also recognizes `CLAUDE_CODE_REMOTE=true` or `CLAUDE_CODE_WEB=true` and applies unattended-safe runtime defaults:
 
 - `CLAUDE_OCTOPUS_AUTONOMY=autonomous` / `OCTOPUS_AUTONOMY=autonomous` unless already set
 - provider smoke tests and Codex tier probes are skipped
@@ -341,7 +363,7 @@ Not sure which command to use? Pick by goal:
 | Reduce token usage | `/octo:doctor` (includes RTK install + token tips) |
 | Just run something quick | `/octo:quick` |
 
-Or skip the table — type `/octo:auto <what you want>` or just say `octo <what you want>`, and the smart router picks for you. 🔍
+Or type `/octo:auto <what you want>` and the smart router picks for you. Plain-prompt routing stays off unless you explicitly set `OCTOPUS_AUTO_ROUTER_MODE=suggest|invoke`. 🔍
 
 <details>
 <summary><strong>How does this compare to Superpowers or plain Claude Code?</strong></summary>
@@ -403,7 +425,7 @@ Run phases individually or all four with `/octo:embrace`. Configure autonomy: su
 
 ### 32 Specialist Personas
 
-Specialized agents that activate automatically based on your request. When you say "audit my API for vulnerabilities," security-auditor activates. When you say "design a dashboard," ui-ux-designer takes over.
+Specialized agents selected by explicit Octopus workflows. `/octo:security` can select security-auditor and `/octo:design-ui-ux` can select ui-ux-designer; ordinary requests never delegate to these agents merely because keywords match.
 
 Categories: Software Engineering (11), Specialized Development (6), Documentation & Communication (5), Research & Strategy (3), Business & Compliance (3), Creative & Design (4).
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ export OCTOPUS_SESSION_MEMORY=on         # SessionStart preference restoration
 
 This legacy opt-in examines ordinary prompts. `invoke` can start paid
 external-provider workflows and share the routed prompt context with configured
-providers; prefer `suggest` unless that behavior is intentional.
+providers; prefer `suggest` unless that behavior is intentional. Provider-side
+retention follows each provider account's policy. Unset the variable (or set it
+to `off`) to opt out without disabling direct `/octo:*` commands.
 
 Safety guards that prevent invalid direct Codex, Qwen, or retired Gemini CLI
 dispatch remain available, but host-side command filters keep them out of

--- a/agents/droids/octo-backend-architect.md
+++ b/agents/droids/octo-backend-architect.md
@@ -1,6 +1,6 @@
 ---
 name: octo-backend-architect
-description: "Backend architect for scalable API design, microservices, and distributed systems"
+description: "Backend architect. Delegate only when the user explicitly starts an Octopus workflow."
 model: inherit
 ---
 

--- a/agents/droids/octo-cloud-architect.md
+++ b/agents/droids/octo-cloud-architect.md
@@ -1,6 +1,6 @@
 ---
 name: octo-cloud-architect
-description: "Cloud architect for AWS/Azure/GCP infrastructure, IaC, FinOps, and multi-cloud strategies"
+description: "Cloud architect. Delegate only when the user explicitly starts an Octopus workflow."
 model: inherit
 ---
 

--- a/agents/droids/octo-code-reviewer.md
+++ b/agents/droids/octo-code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: octo-code-reviewer
-description: "Code review expert for quality analysis, security vulnerabilities, and production reliability"
+description: "Code reviewer. Delegate only when the user explicitly starts an Octopus workflow."
 model: opus
 ---
 

--- a/agents/droids/octo-database-architect.md
+++ b/agents/droids/octo-database-architect.md
@@ -1,6 +1,6 @@
 ---
 name: octo-database-architect
-description: "Database architect for data modeling, technology selection, schema design, and migration planning"
+description: "Database architect. Delegate only when the user explicitly starts an Octopus workflow."
 model: inherit
 ---
 

--- a/agents/droids/octo-debugger.md
+++ b/agents/droids/octo-debugger.md
@@ -1,6 +1,6 @@
 ---
 name: octo-debugger
-description: "Debugging specialist for errors, test failures, and unexpected behavior"
+description: "Debugger. Delegate only when the user explicitly starts an Octopus workflow."
 model: opus
 ---
 

--- a/agents/droids/octo-docs-architect.md
+++ b/agents/droids/octo-docs-architect.md
@@ -1,6 +1,6 @@
 ---
 name: octo-docs-architect
-description: "Technical documentation architect for comprehensive system docs and architecture guides"
+description: "Documentation architect. Delegate only when the user explicitly starts an Octopus workflow."
 model: inherit
 ---
 

--- a/agents/droids/octo-frontend-developer.md
+++ b/agents/droids/octo-frontend-developer.md
@@ -1,6 +1,6 @@
 ---
 name: octo-frontend-developer
-description: "Frontend developer for React, Next.js, responsive layouts, and accessible UI components"
+description: "Frontend developer. Delegate only when the user explicitly starts an Octopus workflow."
 model: inherit
 ---
 

--- a/agents/droids/octo-performance-engineer.md
+++ b/agents/droids/octo-performance-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: octo-performance-engineer
-description: "Performance engineer for optimization, observability, and scalable system performance"
+description: "Performance engineer. Delegate only when the user explicitly starts an Octopus workflow."
 model: opus
 ---
 

--- a/agents/droids/octo-security-auditor.md
+++ b/agents/droids/octo-security-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: octo-security-auditor
-description: "Security auditor for DevSecOps, OWASP compliance, vulnerability assessment, and threat modeling"
+description: "Security auditor. Delegate only when the user explicitly starts an Octopus workflow."
 model: opus
 ---
 

--- a/agents/droids/octo-tdd-orchestrator.md
+++ b/agents/droids/octo-tdd-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: octo-tdd-orchestrator
-description: "TDD orchestrator enforcing red-green-refactor discipline and test-driven development"
+description: "TDD orchestrator. Delegate only when the user explicitly starts an Octopus workflow."
 model: opus
 ---
 

--- a/commands/auto.md
+++ b/commands/auto.md
@@ -58,7 +58,6 @@ Match the query against keywords below. Check categories **in priority order** �
 | Brainstorm | brainstorm, ideate, ideas, creative, thought experiment, what if | `octo:brainstorm` |
 | Deck | presentation, slides, deck, pitch deck, slide deck | `octo:deck` |
 | Docs | document, documentation, README, API docs, write docs, docstring | `octo:docs` |
-| Agent topology | too many agents, worth the overhead, coordination cost, agents keep agreeing, collapse agents, before adding an agent | `skill-agent-topology` |
 
 #### Priority 2 — Core Workflows
 
@@ -107,6 +106,14 @@ No intent keywords matched
 
 ### STEP 5: Route Based on Confidence
 
+Before loading any route, validate it against this closed allowlist: `embrace`,
+`multi`, `parallel`, `spec`, `security`, `tdd`, `debug`, `design-ui-ux`, `prd`,
+`brainstorm`, `deck`, `docs`, `discover`, `review`, `debate`, `develop`, `plan`, `quick`.
+The token is control data, never user input: do not derive it from the query or
+accept a user-supplied path. Reject `..`, `/`, `\\`, or non-allowlisted values;
+then load exactly `${HOME}/.claude-octopus/plugin/commands/<validated-token>.md`.
+The full query is passed only as workflow arguments.
+
 **STEP 5a — HIGH confidence (auto-route):**
 
 Display:
@@ -114,12 +121,13 @@ Display:
 Routing to [Workflow Name] (/octo:[command])
 ```
 
-Then display the visual indicator banner (STEP 6), read the selected command
-file from `${HOME}/.claude-octopus/plugin/commands/[command].md`, and execute it
-with the full query. Do not use the Skill tool; Octopus components are hidden
-from model invocation by design.
+Then display the visual indicator banner (STEP 6), read the entire validated
+command file, and treat its body as the active instructions in this same
+conversation: follow its workflow in order and supply the full query as its
+arguments. Do not use the Skill tool; Octopus components are hidden from model
+invocation by design.
 ```
-Read: ${HOME}/.claude-octopus/plugin/commands/[command].md
+Read: ${HOME}/.claude-octopus/plugin/commands/<validated-token>.md
 Arguments: <full user query>
 ```
 

--- a/commands/auto.md
+++ b/commands/auto.md
@@ -1,5 +1,6 @@
 ---
 command: auto
+disable-model-invocation: true
 description: Smart router - Single entry point with natural language intent detection
 version: 3.0.0
 category: workflow
@@ -113,9 +114,13 @@ Display:
 Routing to [Workflow Name] (/octo:[command])
 ```
 
-Then display the visual indicator banner (STEP 6) and invoke:
+Then display the visual indicator banner (STEP 6), read the selected command
+file from `${HOME}/.claude-octopus/plugin/commands/[command].md`, and execute it
+with the full query. Do not use the Skill tool; Octopus components are hidden
+from model invocation by design.
 ```
-Skill(skill: "octo:[command]", args: "<full user query>")
+Read: ${HOME}/.claude-octopus/plugin/commands/[command].md
+Arguments: <full user query>
 ```
 
 **STEP 5b — MEDIUM confidence (confirm first):**
@@ -129,7 +134,7 @@ I detected [intent]. Route to:
 Which would you prefer, or rephrase your request?
 ```
 
-Wait for user confirmation before invoking the Skill tool.
+Wait for user confirmation before loading the selected command file.
 
 **STEP 5c — LOW confidence (show complete menu):**
 
@@ -250,7 +255,7 @@ This allows the router to learn user preferences over time.
 - Intent detected via priority-ordered keyword matching
 - Confidence determined via decision tree (not percentage formula)
 - User confirmation obtained (if MEDIUM confidence)
-- Target workflow executed via Skill tool
+- Target workflow executed from its explicit command file
 - Visual indicators displayed (for multi-AI workflows)
 
 ### Prohibited Actions
@@ -259,6 +264,6 @@ This allows the router to learn user preferences over time.
 - Routing without checking keyword priority order
 - Routing to non-existent skills
 - Skipping visual indicators for multi-AI workflows
-- Simulating workflow execution (MUST use Skill tool)
+- Simulating workflow execution instead of following the selected command file
 - Using percentage-based confidence scoring (use the decision tree above)
-- Passing queries to Skill tool without the full original text
+- Dropping any of the full original query when handing off to the command

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,5 +1,6 @@
 ---
 command: brainstorm
+disable-model-invocation: true
 description: "Start a creative thought partner brainstorming session"
 ---
 

--- a/commands/budget-mode.md
+++ b/commands/budget-mode.md
@@ -1,5 +1,6 @@
 ---
 command: budget-mode
+disable-model-invocation: true
 description: Switch Octopus model routing to the configured budget tier
 allowed-tools: Bash
 ---

--- a/commands/careful.md
+++ b/commands/careful.md
@@ -1,5 +1,6 @@
 ---
 command: careful
+disable-model-invocation: true
 description: "[advanced] Activate destructive command warnings for the session"
 ---
 

--- a/commands/claw.md
+++ b/commands/claw.md
@@ -1,5 +1,6 @@
 ---
 command: claw
+disable-model-invocation: true
 description: "[advanced] OpenClaw instance administration — manage hosts across macOS, Ubuntu/Debian, Docker, OCI, and Proxmox"
 ---
 

--- a/commands/costs.md
+++ b/commands/costs.md
@@ -1,5 +1,6 @@
 ---
 command: costs
+disable-model-invocation: true
 description: "[advanced] Show cost breakdown by provider and workflow for the current session"
 allowed-tools: Bash, Read, Glob, Grep
 ---

--- a/commands/council.md
+++ b/commands/council.md
@@ -1,5 +1,6 @@
 ---
 command: council
+disable-model-invocation: true
 description: "Multi-LLM council for advice, decision support, implementation plans, and gated implementation"
 skill: skill-council
 ---

--- a/commands/debate.md
+++ b/commands/debate.md
@@ -1,5 +1,6 @@
 ---
 command: debate
+disable-model-invocation: true
 description: "AI Debate Hub - Structured debates across Claude and available external providers"
 skill: skill-debate
 ---

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -1,5 +1,6 @@
 ---
 command: debug
+disable-model-invocation: true
 description: Systematic debugging with methodical problem investigation
 ---
 

--- a/commands/deck.md
+++ b/commands/deck.md
@@ -1,5 +1,6 @@
 ---
 command: deck
+disable-model-invocation: true
 description: Generate slide deck presentations from briefs or research
 ---
 

--- a/commands/define.md
+++ b/commands/define.md
@@ -1,5 +1,6 @@
 ---
 command: define
+disable-model-invocation: true
 description: "Definition phase - Clarify and scope problems with multi-AI consensus"
 aliases:
   - grasp
@@ -16,7 +17,7 @@ aliases:
 
 ### EXECUTION MECHANISM — NON-NEGOTIABLE
 
-**You MUST execute this command by invoking the corresponding skill via the Skill tool. You are PROHIBITED from:**
+**You MUST execute this command by reading and following the corresponding workflow source. You are PROHIBITED from:**
 - ❌ Using the Agent tool to research/implement yourself instead of invoking the skill
 - ❌ Using WebFetch/Read/Grep as a substitute for multi-provider dispatch
 - ❌ Skipping `orchestrate.sh` calls because "I can do this faster directly"
@@ -28,14 +29,14 @@ aliases:
 
 When the user invokes this command (e.g., `/octo:define <arguments>`):
 
-**✓ CORRECT - Use the Skill tool:**
+**✓ CORRECT - Read the explicit workflow source:**
 ```
-Skill(skill: "octo:define", args: "<user's arguments>")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/flow-define/SKILL.md, then execute it with <user's arguments>
 ```
 
 **✗ INCORRECT:**
 ```
-Skill(skill: "flow-define", ...)  ❌ Wrong! Internal skill name, not resolvable by Skill tool
+Skill(skill: "flow-define", ...)  ❌ Wrong! Octopus skills are model-invocation disabled
 Task(subagent_type: "octo:define", ...)  ❌ Wrong! This is a skill, not an agent type
 ```
 

--- a/commands/deliver.md
+++ b/commands/deliver.md
@@ -1,5 +1,6 @@
 ---
 command: deliver
+disable-model-invocation: true
 description: "Delivery phase - Review, validate, and test with multi-AI quality assurance"
 aliases:
   - ink
@@ -16,7 +17,7 @@ aliases:
 
 ### EXECUTION MECHANISM — NON-NEGOTIABLE
 
-**You MUST execute this command by invoking the corresponding skill via the Skill tool. You are PROHIBITED from:**
+**You MUST execute this command by reading and following the corresponding workflow source. You are PROHIBITED from:**
 - ❌ Using the Agent tool to research/implement yourself instead of invoking the skill
 - ❌ Using WebFetch/Read/Grep as a substitute for multi-provider dispatch
 - ❌ Skipping `orchestrate.sh` calls because "I can do this faster directly"
@@ -28,14 +29,14 @@ aliases:
 
 When the user invokes this command (e.g., `/octo:deliver <arguments>`):
 
-**✓ CORRECT - Use the Skill tool:**
+**✓ CORRECT - Read the explicit workflow source:**
 ```
-Skill(skill: "octo:deliver", args: "<user's arguments>")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/flow-deliver/SKILL.md, then execute it with <user's arguments>
 ```
 
 **✗ INCORRECT:**
 ```
-Skill(skill: "flow-deliver", ...)  ❌ Wrong! Internal skill name, not resolvable by Skill tool
+Skill(skill: "flow-deliver", ...)  ❌ Wrong! Octopus skills are model-invocation disabled
 Task(subagent_type: "octo:deliver", ...)  ❌ Wrong! This is a skill, not an agent type
 ```
 

--- a/commands/design-ui-ux.md
+++ b/commands/design-ui-ux.md
@@ -1,5 +1,6 @@
 ---
 command: design-ui-ux
+disable-model-invocation: true
 description: "Design UI/UX systems with style guides, palettes, typography, and component specs"
 aliases:
   - design

--- a/commands/dev.md
+++ b/commands/dev.md
@@ -1,5 +1,6 @@
 ---
 command: dev
+disable-model-invocation: true
 description: "[advanced] Switch to Dev Work mode - optimized for software development"
 aliases:
   - dev-mode

--- a/commands/develop.md
+++ b/commands/develop.md
@@ -1,5 +1,6 @@
 ---
 command: develop
+disable-model-invocation: true
 description: "Development phase - Build solutions with multi-AI implementation and quality gates"
 aliases:
   - tangle

--- a/commands/discipline.md
+++ b/commands/discipline.md
@@ -1,5 +1,6 @@
 ---
 command: discipline
+disable-model-invocation: true
 description: Toggle discipline mode — auto-invoke verification, brainstorming-before-coding, and review checks
 ---
 
@@ -22,19 +23,21 @@ When **on**, you MUST follow these rules automatically — no user prompt needed
 ### Development Gates
 
 **1. Brainstorm gate** — Before writing ANY code or making changes, check:
-- Has the approach been discussed/planned? If not, invoke `skill-thought-partner` or `skill-writing-plans`
+- Has the approach been discussed/planned? If not, read and follow the
+  `skill-thought-partner` or `skill-writing-plans` source under
+  `${HOME}/.claude-octopus/plugin/.claude/skills/`.
 - This applies even for "simple" changes
 
-**2. Verification gate** — Before saying "done", "fixed", "passing", or committing, invoke `skill-verification-gate`:
+**2. Verification gate** — Before saying "done", "fixed", "passing", or committing, read and follow `skill-verification-gate`:
 - Run the actual verification command, read output, only claim success with evidence
 
 **3. Review gate** — After completing any non-trivial code change, automatically:
 - Spec compliance check + code quality review via subagent
 
-**4. Response gate** — When receiving code review feedback, invoke `skill-review-response`:
+**4. Response gate** — When receiving code review feedback, read and follow `skill-review-response`:
 - Verify feedback against actual code before implementing
 
-**5. Investigation gate** — When encountering ANY bug, error, or test failure, invoke `skill-debug`:
+**5. Investigation gate** — When encountering ANY bug, error, or test failure, read and follow `skill-debug`:
 - Root cause investigation before proposing fixes
 
 ### Knowledge Work Gates

--- a/commands/discover.md
+++ b/commands/discover.md
@@ -1,5 +1,6 @@
 ---
 command: discover
+disable-model-invocation: true
 description: "Discovery phase - Multi-AI research and exploration"
 aliases:
   - probe

--- a/commands/docs.md
+++ b/commands/docs.md
@@ -1,5 +1,6 @@
 ---
 command: docs
+disable-model-invocation: true
 description: Document delivery with export to PPTX, DOCX, PDF formats
 ---
 

--- a/commands/embrace.md
+++ b/commands/embrace.md
@@ -1,5 +1,6 @@
 ---
 command: embrace
+disable-model-invocation: true
 description: "Full Double Diamond workflow - Research → Define → Develop → Deliver"
 aliases:
   - full-cycle

--- a/commands/extract.md
+++ b/commands/extract.md
@@ -1,5 +1,6 @@
 ---
 command: extract
+disable-model-invocation: true
 description: "Design System & Product Reverse-Engineering - Extract tokens, components, architecture, and PRDs from codebases or live products"
 aliases:
   - reverse-engineer

--- a/commands/factory.md
+++ b/commands/factory.md
@@ -1,5 +1,6 @@
 ---
 command: factory
+disable-model-invocation: true
 description: "[advanced] Dark Factory Mode - Spec-in, software-out autonomous pipeline"
 aliases:
   - dark-factory

--- a/commands/freeze.md
+++ b/commands/freeze.md
@@ -1,5 +1,6 @@
 ---
 command: freeze
+disable-model-invocation: true
 description: "[advanced] Restrict file edits to a specific directory boundary"
 ---
 

--- a/commands/guard.md
+++ b/commands/guard.md
@@ -1,5 +1,6 @@
 ---
 command: guard
+disable-model-invocation: true
 description: "[advanced] Activate both careful mode and freeze mode together"
 ---
 

--- a/commands/history.md
+++ b/commands/history.md
@@ -1,5 +1,6 @@
 ---
 command: history
+disable-model-invocation: true
 description: "[advanced] Query past workflow results — filter by workflow type, date, or provider"
 allowed-tools: Bash, Read, Grep
 ---

--- a/commands/km.md
+++ b/commands/km.md
@@ -1,5 +1,6 @@
 ---
 command: km
+disable-model-invocation: true
 description: "[advanced] Switch to Knowledge Work mode (or toggle with off)"
 usage: "/octo:km [on|off]"
 examples:

--- a/commands/loop.md
+++ b/commands/loop.md
@@ -1,5 +1,6 @@
 ---
 command: loop
+disable-model-invocation: true
 description: "[advanced] Execute tasks in loops with conditions, iterative improvements until goals are met"
 ---
 

--- a/commands/meta-prompt.md
+++ b/commands/meta-prompt.md
@@ -1,5 +1,6 @@
 ---
 command: meta-prompt
+disable-model-invocation: true
 description: "[advanced] Generate an optimized prompt for any task using meta-prompting techniques"
 ---
 

--- a/commands/model-config.md
+++ b/commands/model-config.md
@@ -1,5 +1,6 @@
 ---
 command: model-config
+disable-model-invocation: true
 description: Configure AI provider models for Claude Octopus workflows
 version: 4.0.1
 category: configuration

--- a/commands/multi.md
+++ b/commands/multi.md
@@ -1,5 +1,6 @@
 ---
 command: multi
+disable-model-invocation: true
 description: "[advanced] Force multi-provider parallel execution for any task - manual override mode"
 ---
 

--- a/commands/octo.md
+++ b/commands/octo.md
@@ -1,5 +1,6 @@
 ---
 command: octo
+disable-model-invocation: true
 description: "[Legacy] Redirects to /octo:auto — the smart router"
 version: 3.0.0
 category: workflow
@@ -17,7 +18,9 @@ This command has been renamed to `/octo:auto`. Invoking `/octo:octo` still works
 When the user invokes `/octo:octo <query>`, you MUST:
 
 1. Inform the user: "Note: `/octo:octo` has been renamed to `/octo:auto`. Routing your request now."
-2. Immediately invoke: `Skill(skill: "octo:auto", args: "<full user query>")`
+2. Immediately read `${HOME}/.claude-octopus/plugin/commands/auto.md` and
+   execute it with the full user query. Do not use the Skill tool; Octopus
+   commands are explicit-only and hidden from model invocation.
 3. If the routed workflow dispatches multiple providers, surface `${HOME}/.claude-octopus/plugin/scripts/orchestrate.sh agent-summary` before final synthesis when available.
 
 Do NOT duplicate the routing logic here — delegate entirely to `/octo:auto`.

--- a/commands/parallel.md
+++ b/commands/parallel.md
@@ -1,5 +1,6 @@
 ---
 command: parallel
+disable-model-invocation: true
 description: "[advanced] Team of Teams - Decompose compound tasks across independent claude instances"
 aliases:
   - team
@@ -12,14 +13,14 @@ aliases:
 
 When the user invokes this command (e.g., `/octo:parallel <arguments>`):
 
-**CORRECT - Use the Skill tool:**
+**CORRECT - Read the explicit workflow source:**
 ```
-Skill(skill: "octo:parallel", args: "<user's arguments>")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/flow-parallel/SKILL.md, then execute it with <user's arguments>
 ```
 
 **INCORRECT:**
 ```
-Skill(skill: "flow-parallel", ...)  ❌ Wrong! Internal skill name, not resolvable by Skill tool
+Skill(skill: "flow-parallel", ...)  ❌ Wrong! Octopus skills are model-invocation disabled
 Task(subagent_type: "octo:parallel", ...)  ❌ Wrong! This is a skill, not an agent type
 ```
 

--- a/commands/pipeline.md
+++ b/commands/pipeline.md
@@ -1,5 +1,6 @@
 ---
 command: pipeline
+disable-model-invocation: true
 description: "Run content analysis pipeline on URL(s) to extract patterns and create anatomy guides"
 ---
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1,5 +1,6 @@
 ---
 command: plan
+disable-model-invocation: true
 description: "Intelligent plan builder - creates strategic execution plans (doesn't execute). Use /octo:embrace to execute plans."
 aliases:
   - build-plan
@@ -15,7 +16,7 @@ aliases:
 - **Creates plans** - Captures intent, analyzes requirements, generates weighted execution strategy
 - **Saves to files** - Stores plan (`.claude/session-plan.md`) and intent contract (`.claude/session-intent.md`)
 - **Doesn't execute** - Plans are saved for review; execution requires user confirmation
-- **Optional execution** - Can invoke `/octo:embrace` immediately or user can execute later
+- **Optional execution** - Can load `/octo:embrace` after explicit user approval or execute later
 
 ## 🤖 INSTRUCTIONS FOR CLAUDE
 
@@ -459,12 +460,12 @@ AskUserQuestion({
 - Return to Step 6 (ask again what to do)
 
 **If "Execute now":**
-- Invoke `/octo:embrace` skill with the user's goal
+- Read `${HOME}/.claude-octopus/plugin/commands/embrace.md` and execute it with the user's goal
 - Pass the intent contract and phase weights
 - Let embrace workflow handle execution
 
 **If "Multi-LLM debate the plan first":**
-- Invoke `/octo:debate` with the plan as context (Claude plus available providers deliberate):
+- Read `${HOME}/.claude-octopus/plugin/commands/debate.md` and execute it with the plan as context (Claude plus available providers deliberate):
   - Topic: "Should we proceed with this plan? What are the risks and blind spots?"
   - `--rounds 2 --debate-style adversarial --context-file .claude/session-plan.md`
 - After the Multi-LLM debate completes, present the synthesis and return to Step 6
@@ -480,7 +481,7 @@ AskUserQuestion({
 
 **If user chose "Execute now" in Step 6:**
 
-The plan command should invoke the `/octo:embrace` skill, which handles:
+The plan command should load the explicit `/octo:embrace` command source, which handles:
 - Execution of all 4 phases (Discover → Define → Develop → Deliver)
 - Using the phase weights from the plan
 - Referencing the intent contract
@@ -494,7 +495,7 @@ The plan command should invoke the `/octo:embrace` skill, which handles:
 **The plan command exits after:**
 - Creating and saving the plan (`.claude/session-plan.md`)
 - Creating the intent contract (`.claude/session-intent.md`)
-- Optionally invoking `/octo:embrace` if user requested immediate execution
+- Optionally loading `/octo:embrace` if user requested immediate execution
 
 **The plan command does NOT:**
 - Execute workflows directly (delegates to `/octo:embrace`)

--- a/commands/prd-score.md
+++ b/commands/prd-score.md
@@ -1,5 +1,6 @@
 ---
 command: prd-score
+disable-model-invocation: true
 description: Score an existing PRD against the 100-point AI-optimization framework
 arguments:
   - name: file

--- a/commands/prd.md
+++ b/commands/prd.md
@@ -1,5 +1,6 @@
 ---
 command: prd
+disable-model-invocation: true
 description: Write an AI-optimized PRD using multi-AI orchestration and 100-point scoring framework
 arguments:
   - name: feature

--- a/commands/preflight.md
+++ b/commands/preflight.md
@@ -1,5 +1,6 @@
 ---
 command: preflight
+disable-model-invocation: true
 description: Check provider health before running multi-LLM workflows
 allowed-tools: Bash
 ---

--- a/commands/premium-mode.md
+++ b/commands/premium-mode.md
@@ -1,5 +1,6 @@
 ---
 command: premium-mode
+disable-model-invocation: true
 description: Switch Octopus model routing to the configured premium tier
 allowed-tools: Bash
 ---

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -1,5 +1,6 @@
 ---
 command: quick
+disable-model-invocation: true
 description: Quick execution mode for ad-hoc tasks without full workflow overhead
 skill: octopus-quick
 ---

--- a/commands/research.md
+++ b/commands/research.md
@@ -1,5 +1,6 @@
 ---
 command: research
+disable-model-invocation: true
 description: Deep research with multi-source synthesis and comprehensive analysis
 ---
 
@@ -15,7 +16,7 @@ description: Deep research with multi-source synthesis and comprehensive analysi
 
 ### EXECUTION MECHANISM — NON-NEGOTIABLE
 
-**You MUST execute this command by invoking the corresponding skill via the Skill tool. You are PROHIBITED from:**
+**You MUST execute this command by reading and following the dedicated research source. You are PROHIBITED from:**
 - ❌ Using the Agent tool to research/implement yourself instead of invoking the skill
 - ❌ Using WebFetch/Read/Grep as a substitute for multi-provider dispatch
 - ❌ Skipping `orchestrate.sh` calls because "I can do this faster directly"
@@ -62,16 +63,16 @@ Map the answer to an intensity value:
 - "Standard" → `standard`
 - "Deep" → `deep`
 
-### Step 2: Invoke Skill with Intensity
+### Step 2: Load Research Workflow with Intensity
 
-**✓ CORRECT - Use the Skill tool:**
+**✓ CORRECT - Read the explicit workflow source:**
 ```
-Skill(skill: "octopus-research", args: "[breadth=light|standard|exhaustive] [intensity=quick|standard|deep] <user's arguments without routing flags>")
+Read `${HOME}/.claude-octopus/plugin/.claude/skills/skill-deep-research/SKILL.md`, then execute it with `[breadth=light|standard|exhaustive] [intensity=quick|standard|deep] <user's arguments without routing flags>`.
 ```
 
 Examples:
-- `Skill(skill: "octopus-research", args: "[breadth=standard] [intensity=standard] OAuth 2.0 authentication patterns")`
-- `/octo:research --breadth=exhaustive current agent orchestration patterns` -> `Skill(skill: "octopus-research", args: "[breadth=exhaustive] [intensity=deep] current agent orchestration patterns")`
+- Read the source above and execute with `[breadth=standard] [intensity=standard] OAuth 2.0 authentication patterns`.
+- `/octo:research --breadth=exhaustive current agent orchestration patterns` -> execute the source with `[breadth=exhaustive] [intensity=deep] current agent orchestration patterns`.
 
 **✗ INCORRECT - Do NOT use these:**
 ```
@@ -83,7 +84,7 @@ Task(subagent_type: "octo:discover", ...)  ❌ Wrong! This is a skill, not an ag
 
 ---
 
-**Auto-loads the dedicated research skill for comprehensive multi-provider research tasks.**
+**Loads the dedicated research workflow only after this explicit command.**
 
 ## Quick Usage
 

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -1,5 +1,6 @@
 ---
 command: resume
+disable-model-invocation: true
 description: "[advanced] Resume a previous agent by ID — continue an interrupted task where it left off"
 ---
 

--- a/commands/retro.md
+++ b/commands/retro.md
@@ -1,5 +1,6 @@
 ---
 command: retro
+disable-model-invocation: true
 description: "[advanced] Generate engineering retrospectives from git history with trends and team analysis"
 allowed-tools: Bash, Read, Glob, Grep, Write
 ---

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,5 +1,6 @@
 ---
 command: review
+disable-model-invocation: true
 description: Enhanced multi-LLM review with inline PR comments — escalation path beyond Claude-native /review
 ---
 

--- a/commands/schedule.md
+++ b/commands/schedule.md
@@ -1,5 +1,6 @@
 ---
 command: schedule
+disable-model-invocation: true
 description: "[advanced] Manage scheduled workflow jobs (add via wizard, dashboard, list, remove, enable, disable, logs)"
 aliases:
   - jobs

--- a/commands/scheduler.md
+++ b/commands/scheduler.md
@@ -1,5 +1,6 @@
 ---
 command: scheduler
+disable-model-invocation: true
 description: "[advanced] Manage the scheduled workflow runner daemon (start/stop/status)"
 aliases:
   - sched

--- a/commands/security.md
+++ b/commands/security.md
@@ -1,5 +1,6 @@
 ---
 command: security
+disable-model-invocation: true
 description: Enhanced multi-LLM or adversarial security audit — escalation path beyond Claude-native /security-review
 ---
 

--- a/commands/sentinel.md
+++ b/commands/sentinel.md
@@ -1,5 +1,6 @@
 ---
 command: sentinel
+disable-model-invocation: true
 description: GitHub-aware work monitor - triages issues, PRs, and CI failures
 version: 1.0.0
 category: monitoring

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,5 +1,6 @@
 ---
 command: setup
+disable-model-invocation: true
 description: Interactive setup wizard — install providers, configure auth, RTK, token optimization
 aliases:
   - sys-setup
@@ -12,7 +13,8 @@ allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 
 Interactive setup wizard. Detects what's installed, offers to install what's missing, configures auth, and optimizes token usage.
 
-**This command auto-runs on first install** (via SessionStart hook). It also runs when users invoke `/octo:setup` manually.
+**This command runs only when the user invokes `/octo:setup`.** SessionStart may
+offer the command once after installation, but never starts it.
 
 **CRITICAL: This command MUST always run its interactive flow when invoked.** Never silently dismiss the user. Never say "you're already set up" without showing the dashboard and offering choices via AskUserQuestion. Even if everything is configured, the user invoked this command for a reason — show them their status and ask what they want to do.
 

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -1,5 +1,6 @@
 ---
 command: spec
+disable-model-invocation: true
 description: "NLSpec authoring - Structured specification from multi-AI research"
 aliases:
   - nlspec
@@ -12,14 +13,14 @@ aliases:
 
 When the user invokes this command (e.g., `/octo:spec <arguments>`):
 
-**CORRECT - Use the Skill tool:**
+**CORRECT - Read the explicit workflow source:**
 ```
-Skill(skill: "octo:spec", args: "<user's arguments>")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/flow-spec/SKILL.md, then execute it with <user's arguments>
 ```
 
 **INCORRECT:**
 ```
-Skill(skill: "flow-spec", ...)  ❌ Wrong! Internal skill name, not resolvable by Skill tool
+Skill(skill: "flow-spec", ...)  ❌ Wrong! Octopus skills are model-invocation disabled
 Task(subagent_type: "octo:spec", ...)  ❌ Wrong! This is a skill, not an agent type
 ```
 

--- a/commands/staged-review.md
+++ b/commands/staged-review.md
@@ -1,5 +1,6 @@
 ---
 command: staged-review
+disable-model-invocation: true
 description: "[advanced] Two-stage review: spec compliance then code quality"
 aliases:
   - two-stage-review

--- a/commands/standard-mode.md
+++ b/commands/standard-mode.md
@@ -1,5 +1,6 @@
 ---
 command: standard-mode
+disable-model-invocation: true
 description: Switch Octopus model routing to the configured standard tier
 allowed-tools: Bash
 ---

--- a/commands/tdd.md
+++ b/commands/tdd.md
@@ -1,5 +1,6 @@
 ---
 command: tdd
+disable-model-invocation: true
 description: Test-driven development with red-green-refactor discipline
 ---
 

--- a/commands/unfreeze.md
+++ b/commands/unfreeze.md
@@ -1,5 +1,6 @@
 ---
 command: unfreeze
+disable-model-invocation: true
 description: "[advanced] Remove freeze mode edit restriction"
 ---
 

--- a/commands/usage.md
+++ b/commands/usage.md
@@ -1,5 +1,6 @@
 ---
 command: usage
+disable-model-invocation: true
 description: "[advanced] Per-provider, per-skill, and per-MCP-server cost and token breakdown (Claude Code /usage schema)"
 allowed-tools: Bash, Read, Glob
 ---

--- a/commands/whats-new.md
+++ b/commands/whats-new.md
@@ -1,5 +1,6 @@
 ---
 command: whats-new
+disable-model-invocation: true
 description: "Review and enable Claude Octopus features added since you installed"
 allowed-tools: Bash, Read
 ---

--- a/docs/COMMAND-REFERENCE.md
+++ b/docs/COMMAND-REFERENCE.md
@@ -1,6 +1,6 @@
 # Command and Usage Reference
 
-Complete reference for all 49 Claude Octopus slash commands, CLI tools (`octopus` + `octo-compress`), plus activation rules, provider indicators, and the project-lifecycle features that are triggered by natural language rather than slash commands.
+Complete reference for all 49 Claude Octopus slash commands, CLI tools (`octopus` + `octo-compress`), plus activation rules, provider indicators, and manual-only project-lifecycle skills.
 
 ---
 
@@ -134,9 +134,11 @@ Plugin executables available as bare commands (CC v2.1.91+). Also usable via ful
 
 ### Project Lifecycle (Skill-Based)
 
-These are invoked via natural language or skill triggers — not slash commands.
+These are manual-only plugin skills, not standalone `/octo:*` commands. Choose
+one explicitly from the host's skill menu or start an Octopus workflow that
+loads it as a source; ordinary natural-language prompts do not activate them.
 
-| Feature | Natural Language | Description |
+| Feature | Example request after explicit selection | Description |
 |---------|-----------------|-------------|
 | Status | "show status", "where am I" | Project progress dashboard |
 | Resume | "resume", "continue", "pick up where I left off" | Restore context from previous session |
@@ -150,11 +152,13 @@ These are invoked via natural language or skill triggers — not slash commands.
 
 ### `/octo:auto`
 
-Single entry point with natural language intent detection. Analyzes your request and routes to the optimal workflow automatically.
+Explicit single entry point with natural language intent detection. Analyzes the
+request supplied to `/octo:auto` and routes to the optimal workflow.
 
-**You can invoke the router in two ways:**
-- Slash command: `/octo:auto <request>`
-- Plain language: `octo <request>`
+**Default invocation:** `/octo:auto <request>`
+
+Plain-prompt routing is disabled by default. Users who deliberately want it can
+set `OCTOPUS_AUTO_ROUTER_MODE=suggest` or `invoke`.
 
 **Usage:**
 ```
@@ -1452,13 +1456,15 @@ Toggle discipline mode — automatic verification, brainstorming, and review gat
 
 ## Project Lifecycle (Skill-Based)
 
-These features are triggered by natural language — they are not slash commands. Claude auto-activates them based on context.
+These lifecycle skills are manual-only. Choose the plugin-scoped skill from the
+host's slash or skill menu, or let an explicitly started Octopus workflow load
+it as a source. Ordinary natural-language prompts do not auto-activate them.
 
 ### `Status`
 
 Show where you are in the workflow and what to do next.
 
-**Invocation:** Skill-based — triggered by natural language: "show status", "where am I", "what's next", "progress", "what have I been working on"
+**Invocation:** Select the skill explicitly; example requests include "show status", "where am I", "what's next", "progress", and "what have I been working on".
 
 **Output:**
 - Current phase and position

--- a/docs/PLUGIN-ASSEMBLY-STANDARD.md
+++ b/docs/PLUGIN-ASSEMBLY-STANDARD.md
@@ -102,9 +102,11 @@ the markdown as a shell script.
 
 Use `${HOME}/.claude-octopus/plugin` in model-facing command instructions. That
 stable symlink is repaired at SessionStart and remains available to model tool
-calls. Reserve `CLAUDE_PLUGIN_ROOT` for hooks and runtime scripts, where Claude
-Code supplies it. This distinction is intentional rather than an interchangeable
-path convention.
+calls. The repair target is the plugin root loaded by the host, so direct source
+loading does not introduce a second plugin trust boundary. Reserve
+`CLAUDE_PLUGIN_ROOT` for hooks and runtime scripts, where Claude Code supplies
+it. This distinction is intentional rather than an interchangeable path
+convention.
 
 Routers may load only literal command names from a closed allowlist. Never use
 free-form prompt text as a path segment; reject path separators and traversal

--- a/docs/PLUGIN-ASSEMBLY-STANDARD.md
+++ b/docs/PLUGIN-ASSEMBLY-STANDARD.md
@@ -25,6 +25,9 @@ Each skill must include YAML frontmatter with:
   file name.
 - `description`: a concise trigger/use statement. Prefer one direct sentence
   over a broad capability list.
+- `disable-model-invocation: true`: Octopus is an explicit escalation surface;
+  installed skills must not enter model context or self-activate on an ordinary
+  request.
 
 Skill bodies should use this shape when practical:
 
@@ -66,10 +69,16 @@ Agent configuration must keep referenced files resolvable from the plugin root.
 If `agents/config.yaml` references `file: personas/foo.md`, the validator must
 be able to prove that file exists.
 
+Claude Code has no manual-only frontmatter field for subagents: it delegates
+from their descriptions. Plugin subagent descriptions must state that they are
+available only after the user explicitly starts an Octopus workflow. Ordinary
+requests stay on the host's native path.
+
 ## Command Assembly Contract
 
-Commands are explicit entrypoints. They should be thin, predictable, and easy to
-scan. A command can gather arguments, choose a mode, and invoke a skill or
+Commands are explicit entrypoints and must set
+`disable-model-invocation: true`. They should be thin, predictable, and easy to
+scan. A command can gather arguments, choose a mode, and load a skill source or
 orchestration script. It should not silently fork into a separate product.
 
 Every command markdown file in `.cursor-plugin/commands/*.md` or `commands/*.md` must

--- a/docs/PLUGIN-ASSEMBLY-STANDARD.md
+++ b/docs/PLUGIN-ASSEMBLY-STANDARD.md
@@ -90,6 +90,26 @@ include YAML frontmatter with:
 Legacy `commands/*.md` files should also keep their `command:` field
 because the existing tests and compatibility surface rely on it.
 
+### Manual composition contract
+
+Because Octopus skills are model-invocation disabled, an explicit command may
+compose a skill by reading its complete source from
+`${HOME}/.claude-octopus/plugin/.claude/skills/<name>/SKILL.md`. The command must
+then treat that body as the active instruction source in the same conversation,
+follow its ordered workflow and safety checkpoints, and pass command arguments
+as textual workflow input. It must not call the Skill tool recursively or treat
+the markdown as a shell script.
+
+Use `${HOME}/.claude-octopus/plugin` in model-facing command instructions. That
+stable symlink is repaired at SessionStart and remains available to model tool
+calls. Reserve `CLAUDE_PLUGIN_ROOT` for hooks and runtime scripts, where Claude
+Code supplies it. This distinction is intentional rather than an interchangeable
+path convention.
+
+Routers may load only literal command names from a closed allowlist. Never use
+free-form prompt text as a path segment; reject path separators and traversal
+tokens before joining a command name to the stable plugin root.
+
 ## Connector Assembly Contract
 
 Connector metadata must be explicit and honest. If Octopus claims a data source

--- a/docs/PLUGIN-UPDATES.md
+++ b/docs/PLUGIN-UPDATES.md
@@ -44,6 +44,11 @@ continues using the plugin version it loaded at session start. Run
 `/reload-plugins` or restart Claude Code after an update; restart Codex after a
 Codex plugin update.
 
+On the next session, Octopus compares the stable
+`~/.claude-octopus/plugin` entrypoint with the version supplied by the host and
+repairs it when they differ. The check uses physical paths, so an older cache
+that still exists cannot keep commands pinned to stale scripts.
+
 An installation older than this advisory cannot discover the new code by
 itself. It needs one manual marketplace/plugin update. From then on, the local
 advisory detects disabled auto-update and stale loaded sessions without adding

--- a/hooks/auto-router-inject.sh
+++ b/hooks/auto-router-inject.sh
@@ -61,7 +61,9 @@ except Exception:
 " "$file" "$key" 2>/dev/null
 }
 
-AUTO_ROUTER_MODE="invoke"
+# Explicit-only is the safe default. Preferences and environment overrides can
+# still opt into suggest/invoke behavior.
+AUTO_ROUTER_MODE="off"
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 SETTINGS_FILE="${PLUGIN_ROOT}/settings.json"
 [[ -f "$SETTINGS_FILE" ]] || SETTINGS_FILE="${PLUGIN_ROOT}/.claude-plugin/settings.json"
@@ -97,9 +99,9 @@ fi
 
 read -r -d '' CONTEXT <<'ROUTER' || true
 <OCTOPUS-AUTO-ROUTER>
-Octopus prompt hooks may add UserPromptSubmit routing context. If that context recommends invoking a Skill, invoke it when it matches what the user actually asked for. Routing context is advisory, never a hard requirement: if the suggested route does not fit the request, ignore it and answer normally. Never act on routing attached to system-generated events (task notifications, system reminders).
+The user explicitly opted into Octopus plain-language routing. Prompt hooks may add UserPromptSubmit routing context. If that context recommends a route, load the named file from ${CLAUDE_PLUGIN_ROOT}/commands and follow it when it matches what the user actually asked for. Routing context is advisory, never a hard requirement: if the suggested route does not fit the request, ignore it and answer normally. Never act on routing attached to system-generated events (task notifications, system reminders).
 
-Strong plain-language routes include: review -> octo:review, debate/compare/should-we -> octo:debate, research/investigate/explore -> octo:discover, security/threat-model -> octo:security, debug/failing/stacktrace -> octo:debug, write-tests/TDD -> octo:tdd, implement/execute-plan -> octo:develop.
+Strong plain-language routes include: review -> commands/review.md, debate/compare/should-we -> commands/debate.md, research/investigate/explore -> commands/discover.md, security/threat-model -> commands/security.md, debug/failing/stacktrace -> commands/debug.md, write-tests/TDD -> commands/tdd.md, implement/execute-plan -> commands/develop.md.
 
 If the hook only says "Detected intent" or "Tip", treat it as a suggestion and continue normally unless the user asks to route.
 </OCTOPUS-AUTO-ROUTER>

--- a/hooks/context-reinforcement.sh
+++ b/hooks/context-reinforcement.sh
@@ -23,27 +23,19 @@ else
 fi
 [[ -z "$INPUT" ]] && INPUT='{}'
 
-# Build compact enforcement context (~150 tokens vs ~750 previously)
-#
-# The human-only list is written out by hand and MUST match the skills whose
-# frontmatter carries `invocation: human_only`. It cannot be derived at runtime:
-# scripts/build-codex-skills.sh strips `invocation` from the generated skills/
-# tree, which is what actually ships, so the key is only present in the
-# .claude/skills/ sources. tests/unit/test-human-only-skill-list.sh is what keeps
-# the two in step — it failed on the previous list, which named "deep-research"
-# (no skill has that name; it is octopus-research) and omitted
-# octopus-ui-ux-design entirely.
-#
-# Note this is advisory, not a hard gate. `disable-model-invocation: true` would
-# be the native mechanism, but four of these are named in command bodies
-# (commands/parallel.md, factory.md, research.md, security.md) and the model
-# reaches them on the user's behalf when running those commands; disabling model
-# invocation would break those routes. "Human-only" here means "do not fire from
-# prompt-keyword auto-routing".
+ACTIVATION_LIB="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}/scripts/lib/hook-activation.sh"
+[[ -r "$ACTIVATION_LIB" ]] || exit 0
+# shellcheck source=../scripts/lib/hook-activation.sh
+source "$ACTIVATION_LIB" 2>/dev/null || exit 0
+octo_hook_workflow_active "$INPUT" || exit 0
+
+# Build compact enforcement context only for the active, matching workflow.
+# Native disable-model-invocation frontmatter is the hard activation gate; this
+# reminder only helps an explicitly started workflow survive compaction.
 read -r -d '' CONTEXT <<'RULES' || true
 <CONTEXT-REINFORCEMENT source="🐙 Octopus">
 Hard gates: no-stubs (verify before claiming done), test-first (failing test before code), debug-protocol (root cause before fix), orchestrate-only (use orchestrate.sh for research), factory-pipeline (no skipping steps).
-Human-only skills (never auto-trigger from keywords; the user asks for them): skill-factory, octopus-research, octopus-security-audit, flow-parallel, skill-ship, octopus-ui-ux-design.
+All Octopus commands and skills are explicit-only. Continue only the active workflow recorded for this Claude session.
 </CONTEXT-REINFORCEMENT>
 RULES
 

--- a/hooks/discipline-inject.sh
+++ b/hooks/discipline-inject.sh
@@ -15,8 +15,7 @@ DISCIPLINE_CONF="${HOME}/.claude-octopus/config/discipline.conf"
 
 # Check if discipline mode is enabled
 if [[ ! -f "$DISCIPLINE_CONF" ]] || ! grep -q "OCTOPUS_DISCIPLINE=on" "$DISCIPLINE_CONF" 2>/dev/null; then
-    # Not enabled — output empty JSON (no injection)
-    echo '{}'
+    # Not enabled — silence is the current pass-through contract.
     exit 0
 fi
 

--- a/hooks/done-criteria.sh
+++ b/hooks/done-criteria.sh
@@ -6,7 +6,8 @@
 # Compound task detection uses heuristics (numbered lists, bullet lists,
 # multiple action verbs with conjunctions) — no LLM calls.
 #
-# Kill switch: OCTO_DONE_CRITERIA=off
+# Opt in with OCTO_DONE_CRITERIA=on. An active, session-affine Octopus workflow
+# also enables it automatically.
 #
 # Hook event: UserPromptSubmit
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -20,6 +21,12 @@ _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "
 trap _octo_hook_exit EXIT
 
 
+# Default-off fast path: avoid reading/parsing every ordinary user prompt.
+if [[ "${OCTO_DONE_CRITERIA:-}" != "on" ]]; then
+    _activation_lib="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}/scripts/lib/hook-activation.sh"
+    [[ -r "$_activation_lib" ]] || exit 0
+fi
+
 # Read input with timeout guard
 if [ -t 0 ]; then exit 0; fi
 if command -v timeout &>/dev/null; then
@@ -29,8 +36,12 @@ else
 fi
 [[ -z "$input" ]] && exit 0
 
-# Kill switch
-[[ "${OCTO_DONE_CRITERIA:-on}" == "off" ]] && exit 0
+# Require an explicit preference or a session-affine active workflow.
+if [[ "${OCTO_DONE_CRITERIA:-}" != "on" ]]; then
+    # shellcheck source=../scripts/lib/hook-activation.sh
+    source "$_activation_lib" 2>/dev/null || exit 0
+    octo_hook_workflow_active "$input" || exit 0
+fi
 
 # Extract user prompt text from JSON
 prompt=""

--- a/hooks/github-work-queue-watch.sh
+++ b/hooks/github-work-queue-watch.sh
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# Maintainer convenience must never make network requests for ordinary plugin
+# users. Enable explicitly in a maintainer environment when desired.
+[[ "${OCTOPUS_GITHUB_WORK_QUEUE:-off}" == "on" ]] || exit 0
+
 _octo_hook_exit() {
     local c=$?
     if [[ $c -ne 0 ]]; then

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,6 +7,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/provider-routing-validator.sh",
+            "if": "Bash(*orchestrate.sh*)",
             "additionalContext": "Session: ${CLAUDE_SESSION_ID}, Workflow: ${OCTOPUS_WORKFLOW_PHASE:-unknown}",
             "timeout": 10
           }
@@ -25,11 +26,24 @@
       {
         "matcher": "Bash",
         "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/codex-exec-guard.sh",
-            "timeout": 5
-          }
+      {
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/codex-exec-guard.sh",
+        "if": "Bash(codex *)",
+        "timeout": 5
+      },
+      {
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/codex-exec-guard.sh",
+        "if": "Bash(qwen *)",
+        "timeout": 5
+      },
+      {
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/codex-exec-guard.sh",
+        "if": "Bash(gemini *)",
+        "timeout": 5
+      }
         ]
       },
       {
@@ -77,7 +91,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|Agent|Write|Edit|Read|WebFetch|Grep",
+        "matcher": "Bash|Agent|Write|Edit",
         "hooks": [
           {
             "type": "command",
@@ -92,6 +106,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/quality-gate.sh",
+            "if": "Bash(*orchestrate.sh*)",
             "timeout": 60
           }
         ]
@@ -123,9 +138,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/session-manager.sh export",
-            "additionalContext": "Initializing Octopus session variables for multi-provider orchestration",
-            "timeout": 60
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/helpers/ensure-plugin-root.sh",
+            "timeout": 5
           },
           {
             "type": "command",

--- a/hooks/plugin-update-advisory.sh
+++ b/hooks/plugin-update-advisory.sh
@@ -49,7 +49,7 @@ Enable auto-update in /plugin → Marketplaces → nyldn-plugins → Enable auto
 fi
 if [[ "$OCTO_PLUGIN_UPDATE_AVAILABLE" == "true" ]]; then
     MESSAGE="${MESSAGE}
-A newer version is already known locally. Ask to run 'orchestrate.sh update-plugin' explicitly; this startup hook will never update by itself."
+A newer version is already known locally. Run /octo:doctor to review the explicit update path; this startup hook never updates by itself."
 fi
 MESSAGE="${MESSAGE}
 After an update, run /reload-plugins or restart Claude Code so this session stops using the stale loaded copy."
@@ -65,5 +65,5 @@ if [[ -n "$TMP_FILE" ]]; then
     fi
 fi
 
-jq -cn --arg ctx "$MESSAGE" '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$ctx}}'
+jq -cn --arg msg "$MESSAGE" '{systemMessage:$msg}'
 exit 0

--- a/hooks/post-tool-dispatch.sh
+++ b/hooks/post-tool-dispatch.sh
@@ -21,6 +21,17 @@ trap _octo_hook_exit EXIT
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 HOOKS_DIR="${PLUGIN_ROOT}/hooks"
 
+# Opinionated global behavior is disabled unless the user explicitly opts in.
+# A statusline context bridge is display state, not consent to PostToolUse
+# model-context injection.
+SESSION="${CLAUDE_SESSION_ID:-unknown}"
+BRIDGE="/tmp/octopus-ctx-${SESSION}.json"
+if [[ "${OCTOPUS_CONTEXT_AWARENESS:-off}" != "on" \
+      && "${OCTO_STRATEGY_ROTATION:-off}" != "on" \
+      && "${OCTOPUS_COMPRESS_ENABLED:-false}" != "true" ]]; then
+    exit 0
+fi
+
 # Read stdin once (tool output from CC hook protocol)
 STDIN_DATA=""
 if [[ ! -t 0 ]]; then
@@ -34,10 +45,8 @@ fi
 # Collect additionalContext from sub-hooks
 CONTEXTS=""
 
-# 1. Context awareness — only when bridge file exists
-SESSION="${CLAUDE_SESSION_ID:-unknown}"
-BRIDGE="/tmp/octopus-ctx-${SESSION}.json"
-if [[ -f "$BRIDGE" ]]; then
+# 1. Context awareness — only after explicit opt-in and when bridge state exists
+if [[ "${OCTOPUS_CONTEXT_AWARENESS:-off}" == "on" && -f "$BRIDGE" ]]; then
     ctx=$("$HOOKS_DIR/context-awareness.sh" <<< "" 2>/dev/null || echo "")
     if [[ -n "$ctx" ]] && echo "$ctx" | grep -q 'additionalContext'; then
         msg=$(echo "$ctx" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('hookSpecificOutput',{}).get('additionalContext',''))" 2>/dev/null || echo "")
@@ -46,10 +55,12 @@ if [[ -f "$BRIDGE" ]]; then
 fi
 
 # 2. Strategy rotation — pass stdin data for failure tracking
-bash "$HOOKS_DIR/strategy-rotation.sh" <<< "$STDIN_DATA" 2>/dev/null || true
+if [[ "${OCTO_STRATEGY_ROTATION:-off}" == "on" ]]; then
+    OCTO_STRATEGY_ROTATION=on bash "$HOOKS_DIR/strategy-rotation.sh" <<< "$STDIN_DATA" 2>/dev/null || true
+fi
 
 # 3. Output compressor — only on large outputs (>3K chars)
-if [[ ${#STDIN_DATA} -gt 3000 && "${OCTOPUS_COMPRESS_ENABLED:-true}" == "true" ]]; then
+if [[ ${#STDIN_DATA} -gt 3000 && "${OCTOPUS_COMPRESS_ENABLED:-false}" == "true" ]]; then
     comp=$("$HOOKS_DIR/output-compressor.sh" <<< "$STDIN_DATA" 2>/dev/null || echo "")
     if [[ -n "$comp" ]] && echo "$comp" | grep -q 'additionalContext'; then
         msg=$(echo "$comp" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('hookSpecificOutput',{}).get('additionalContext',''))" 2>/dev/null || echo "")

--- a/hooks/provider-routing-validator.sh
+++ b/hooks/provider-routing-validator.sh
@@ -103,12 +103,10 @@ check_smoke_test_status() {
 
 # Main validation logic
 main() {
-    log "INFO" "Provider routing validation hook triggered"
-
     # Read hook input from stdin (CC hook protocol: JSON with tool_input.command)
     local stdin_data=""
     if [[ ! -t 0 ]]; then
-        stdin_data=$(cat 2>/dev/null || true)
+        IFS= read -r stdin_data || true
     fi
 
     # Extract the bash command from hook JSON input
@@ -127,10 +125,11 @@ print(d.get('tool_input', {}).get('command', ''))" 2>/dev/null) || true
     # Fallback to positional arg (for manual testing)
     [[ -z "$bash_command" ]] && bash_command="${1:-}"
 
-    if [[ -z "$bash_command" ]]; then
-        log "DEBUG" "No command to validate, proceeding"
-        exit 0
-    fi
+    # Defense in depth for hosts that do not support hook-level `if`: unrelated
+    # Bash commands are silent and never probe providers.
+    [[ "$bash_command" == *"orchestrate.sh"* ]] || exit 0
+
+    log "INFO" "Provider routing validation hook triggered"
 
     # Check smoke test status (non-blocking warning)
     check_smoke_test_status

--- a/hooks/quality-gate.sh
+++ b/hooks/quality-gate.sh
@@ -11,6 +11,21 @@ set -euo pipefail
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
+# Claude Code before v2.1.85 ignores hook-handler `if` filters. Keep the same
+# guard in-process so stale clients do not scan the workspace after every Bash
+# command. Current clients avoid spawning this hook altogether.
+HOOK_INPUT=""
+if [[ ! -t 0 ]]; then
+    if command -v timeout >/dev/null 2>&1; then
+        HOOK_INPUT=$(timeout 3 cat 2>/dev/null || true)
+    else
+        HOOK_INPUT=$(cat 2>/dev/null || true)
+    fi
+fi
+case "$HOOK_INPUT" in
+    *orchestrate.sh*) ;;
+    *) exit 0 ;;
+esac
 
 VALIDATION_FILE=$(ls -t ~/.claude-octopus/results/tangle-validation-*.md 2>/dev/null | head -1 || true)
 

--- a/hooks/session-start-memory.sh
+++ b/hooks/session-start-memory.sh
@@ -15,6 +15,11 @@ set -euo pipefail
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
+SESSION_INPUT=""
+if [[ ! -t 0 ]]; then
+    SESSION_INPUT="$(cat 2>/dev/null || true)"
+fi
+
 _publish_session_state() {
     local destination="$1"
     shift
@@ -29,7 +34,9 @@ _publish_session_state() {
 }
 
 REMOTE_SESSION=false
-if [[ "${CLAUDE_CODE_REMOTE:-}" == "true" || "${CLAUDE_CODE_WEB:-}" == "true" || "${OCTOPUS_REMOTE_SESSION:-false}" == "true" ]]; then
+# Remote hosting alone is not consent to autonomous Octopus behavior. Hosted
+# routines that need it set OCTOPUS_REMOTE_SESSION=true explicitly.
+if [[ "${OCTOPUS_REMOTE_SESSION:-false}" == "true" ]]; then
     REMOTE_SESSION=true
     export OCTOPUS_REMOTE_SESSION=true
     export CLAUDE_OCTOPUS_AUTONOMY="${CLAUDE_OCTOPUS_AUTONOMY:-${OCTOPUS_AUTONOMY:-autonomous}}"
@@ -46,7 +53,8 @@ if [[ "${CLAUDE_CODE_REMOTE:-}" == "true" || "${CLAUDE_CODE_WEB:-}" == "true" ||
                 _publish_session_state "$SESSION_FILE" jq -n \
                     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
                     --arg autonomy "$OCTOPUS_AUTONOMY" \
-                    '{"remote_session": true, "autonomy": $autonomy, "session_start": $ts}' || true
+                    --arg host_session_id "${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}" \
+                    '{"remote_session": true, "autonomy": $autonomy, "session_start": $ts, "host_session_id": $host_session_id}' || true
             fi
         elif [[ ! -f "$SESSION_FILE" ]]; then
             _publish_session_state "$SESSION_FILE" printf \
@@ -62,23 +70,25 @@ if [[ ! -f "$SETUP_MARKER" ]]; then
     mkdir -p "${HOME}/.claude-octopus"
     touch "$SETUP_MARKER"
     [[ "$REMOTE_SESSION" == "true" ]] && exit 0
-    # This has to be a hookSpecificOutput object, not bare text. The comment here
-    # used to claim "this additionalContext triggers Claude to invoke the setup
-    # skill" while the hook only echoed a plain line, which SessionStart does not
-    # accept as context on v2.1.178+ (see hooks/version-advisory.sh). The welcome
-    # message was therefore never injected and the intended auto-setup never
-    # fired. Falls back to the plain line when jq is unavailable so a user without
-    # jq still sees something.
+    # First run is an offer, never an invocation. Installation must not take over
+    # an unrelated first prompt.
     if command -v jq >/dev/null 2>&1; then
-        jq -cn --arg ctx "🐙 Welcome to Claude Octopus. This is a first run and nothing is configured yet.
-Invoke the octo:setup skill now to walk the user through provider setup, unless
-their first message is urgent, in which case answer that first and offer setup
-immediately after." \
-            '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$ctx}}'
+        jq -cn --arg msg "🐙 Claude Octopus is installed but dormant. Run /octo:setup when you want to configure providers; nothing will start automatically." \
+            '{systemMessage:$msg}'
     else
         echo "[🐙] Welcome to Claude Octopus! Run /octo:setup for first-time configuration."
     fi
     exit 0
+fi
+
+# Outside an active workflow, memory injection and managed-settings writes are
+# opt-in. The prompt router reads its own preference file directly.
+ACTIVATION_LIB="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd -P)}/scripts/lib/hook-activation.sh"
+if [[ "${OCTOPUS_SESSION_MEMORY:-off}" != "on" ]]; then
+    [[ -r "$ACTIVATION_LIB" ]] || exit 0
+    # shellcheck source=../scripts/lib/hook-activation.sh
+    source "$ACTIVATION_LIB" 2>/dev/null || exit 0
+    octo_hook_workflow_active "$SESSION_INPUT" || exit 0
 fi
 
 # --- 0b. Session sync (merged from session-sync.sh to reduce hook spawns) ---

--- a/hooks/statusline-auto-repair.sh
+++ b/hooks/statusline-auto-repair.sh
@@ -18,6 +18,16 @@ RESOLVER_DST="$HOME/.claude-octopus/statusline.sh"
 SETTINGS="$HOME/.claude/settings.json"
 STABLE_CMD="bash ~/.claude-octopus/statusline.sh"
 
+# Do not install or configure a statusline merely because Octopus is present.
+# Repair only an existing Octopus statusline installation or a stale settings
+# entry left by an older version.
+has_existing_octopus_statusline=false
+[[ -f "$RESOLVER_DST" ]] && has_existing_octopus_statusline=true
+if [[ -f "$SETTINGS" ]] && grep -qE 'claude-octopus/statusline\.sh|plugins/cache/nyldn-plugins/octo/[0-9].*octopus-statusline\.sh' "$SETTINGS" 2>/dev/null; then
+    has_existing_octopus_statusline=true
+fi
+[[ "$has_existing_octopus_statusline" == "true" ]] || exit 0
+
 # ── Step 1: Install/update the resolver if missing or outdated ────────────────
 if [[ -f "$RESOLVER_SRC" ]]; then
     needs_update=false

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 # Claude Octopus — UserPromptSubmit Hook (v9.11.0)
-# Fires before user prompt is processed. Classifies task intent
-# with confidence levels, injects routing context, and optionally
-# auto-invokes matching /octo: workflows.
+# Explicit /octo:* commands always get alias/title handling. Plain-language
+# classification and routing are opt-in.
 #
-# v9.11.0: Auto-invoke mode — strong signals fire immediately,
+# v9.11.0: Opt-in auto-invoke mode — strong signals fire immediately,
 # weak signals fire on repeat intent in the same session.
 # Controlled by OCTOPUS_AUTO_ROUTER_MODE=off|suggest|invoke.
 # Legacy OCTOPUS_AUTO_INVOKE remains supported.
@@ -91,6 +90,27 @@ else
     INPUT=$(cat 2>/dev/null || true)
 fi
 [[ -z "$INPUT" ]] && exit 0
+
+# Fast path for the default-off mode. Avoid starting Python/jq on ordinary
+# prompts; only explicit /octo:* input needs parsing when no opt-in is present.
+_router_override="${OCTOPUS_AUTO_ROUTER_MODE:-${OCTOPUS_AUTO_INVOKE:-}}"
+_router_setting_present=false
+for _router_file in \
+    "${CLAUDE_PLUGIN_ROOT:-.}/settings.json" \
+    "${CLAUDE_PLUGIN_ROOT:-.}/.claude-plugin/settings.json" \
+    "${HOME}/.claude-octopus/preferences.json"
+do
+    if [[ -r "$_router_file" ]] && grep -qE '"(OCTOPUS_AUTO_ROUTER_MODE|OCTOPUS_AUTO_INVOKE|auto_router_mode|auto_invoke)"' "$_router_file" 2>/dev/null; then
+        _router_setting_present=true
+        break
+    fi
+done
+if [[ -z "$_router_override" && "$_router_setting_present" == "false" ]]; then
+    case "$INPUT" in
+        *'"prompt":"/octo:'*|*'"prompt": "/octo:'*|*'"prompt":"octo:'*|*'"prompt": "octo:'*) ;;
+        *) exit 0 ;;
+    esac
+fi
 
 # Extract the user's prompt text (python3 preferred, jq fallback)
 if command -v python3 &>/dev/null; then
@@ -202,7 +222,7 @@ if [[ "$PROMPT_LOWER" == /octo:* ]] || [[ "$PROMPT_LOWER" == "octo:"* ]]; then
     if [[ -n "$_CMD" ]] && ! octo_command_exists "$_CMD"; then
         if _ALIAS=$(octo_alias_for "$_CMD") && octo_command_exists "$_ALIAS"; then
             octo_log_alias_event "alias" "$_RAW_CMD" "$_ALIAS"
-            emit_user_prompt_context "[🐙 Octopus] Alias resolved: /octo:${_RAW_CMD} -> /octo:${_ALIAS}. Treat this invocation as /octo:${_ALIAS}; invoke Skill(skill: \"octo:${_ALIAS}\", args: \"$(escape_for_json "$_ARGS")\") before responding."
+            emit_user_prompt_context "[🐙 Octopus] Alias resolved: /octo:${_RAW_CMD} -> /octo:${_ALIAS}. Treat this explicit invocation as /octo:${_ALIAS}; load and follow ${OCTO_COMMANDS_DIR}/${_ALIAS}.md with arguments \"$(escape_for_json "$_ARGS")\" before responding."
             exit 0
         fi
         _SUGGESTIONS=$(octo_fuzzy_suggestions "$_CMD" || true)
@@ -240,7 +260,7 @@ fi
 # SETTINGS: Load auto-router preference
 # Precedence (highest wins): Env var > preferences.json > settings.json > default
 # ═══════════════════════════════════════════════════════════════════════════════
-AUTO_ROUTER_MODE="invoke"  # Default preserves legacy strong-signal auto-invoke.
+AUTO_ROUTER_MODE="off"
 
 # Tier 1: settings.json (plugin default). Prefer the current plugin-root
 # settings.json path, but keep the old .claude-plugin/settings.json fallback.
@@ -461,7 +481,8 @@ if [[ -n "$INTENT" ]]; then
         # Escape the prompt once for the Skill args string inside JSON output.
         ESCAPED_ARGS=$(escape_for_json "$PROMPT")
 
-        CONTEXT_MSG="[🐙 Octopus] Auto-route: ${INTENT} (${CONFIDENCE}, ${SIGNAL_STRENGTH}). Recommended: invoke Skill(skill: \"${SKILL_NAME}\", args: \"${ESCAPED_ARGS}\") if that matches what the user asked for. If this routing does not fit the request, ignore it and answer normally."
+        _ROUTED_COMMAND="${SKILL_NAME#octo:}"
+        CONTEXT_MSG="[🐙 Octopus] Opt-in auto-route: ${INTENT} (${CONFIDENCE}, ${SIGNAL_STRENGTH}). If that matches what the user asked for, load and follow ${OCTO_COMMANDS_DIR}/${_ROUTED_COMMAND}.md with arguments \"${ESCAPED_ARGS}\". If this routing does not fit the request, ignore it and answer normally."
     else
         # Standard behavior: inject persona context only
         CONTEXT_MSG="[🐙 Octopus] Detected intent: ${INTENT} (${CONFIDENCE} confidence)."

--- a/hooks/version-advisory.sh
+++ b/hooks/version-advisory.sh
@@ -88,71 +88,18 @@ if declare -f octo_features_seed_watermark >/dev/null 2>&1; then
         _noun="features are"; [[ "$_actionable" == "1" ]] && _noun="feature is"
         _plural="s"; [[ "$_actionable" == "1" ]] && _plural=""
 
-        # Pointing at a command is the weak form of this: users do not run
-        # commands they have to remember, and they do not hand-edit env vars
-        # either. A SessionStart hook cannot raise a picker itself, but the
-        # context it injects is acted on by the assistant — the same mechanism
-        # auto-router-inject.sh uses to trigger a Skill. So ask the assistant to
-        # raise the picker on the first turn.
-        #
-        # Gated on three things, because an unwanted prompt is worse than a
-        # missed one:
-        #   - an interactive session (a cron/headless/remote run has nobody to
-        #     answer, and prompting there burns or stalls the turn);
-        #   - a remaining prompt budget for this version (an unanswered prompt
-        #     leaves everything undecided, which would otherwise re-ask forever);
-        #   - the assistant actually honouring the directive, which is advisory.
-        # When any of those fails, the plain pointer below is still emitted, so
-        # discoverability degrades rather than disappears.
-        if declare -f octo_features_session_interactive >/dev/null 2>&1 \
-           && octo_features_session_interactive \
-           && octo_features_prompt_allowed "$CURRENT_VERSION"; then
-            _offers="$(octo_features_prompt_manifest 2>/dev/null || true)"
-            if [[ -n "$_offers" ]]; then
-                octo_features_record_prompt_attempt "$CURRENT_VERSION" 2>/dev/null || true
-                FEATURE_LINE="
-<OCTOPUS-NEW-FEATURES>
-This upgrade added ${_actionable} setting${_plural} the user has not chosen yet.
-Each one is a real policy question, not an announcement.
-
-Before doing anything else this session, call AskUserQuestion ONCE with one
-question per feature below. Use each feature's own question text and its own
-choices verbatim; do not invent options, and do not collapse them into a yes/no.
-Keep each choice description's cost note, because that is what the choice turns
-on.
-
-The lines below are tab-separated:
-  Q<TAB>id<TAB>question
-  C<TAB>id<TAB>value<TAB>label<TAB>description
-
-${_offers}
-
-Record every answer, including any that picks the default:
-  source \"\${CLAUDE_PLUGIN_ROOT:-.}/scripts/lib/features.sh\"
-  octo_features_record <id> <chosen value> ${CURRENT_VERSION}
-
-Recording is what stops the question being asked again, so record all of them.
-Tell the user /octo:whats-new can change any of it later. Apply nothing they did
-not pick. If their first message is urgent, answer it first and ask right after.
-</OCTOPUS-NEW-FEATURES>"
-            fi
-        fi
-
-        # Fallback pointer, also used when the picker is suppressed or spent.
-        if [[ -z "$FEATURE_LINE" ]]; then
-            FEATURE_LINE="
-   ${_actionable} new ${_noun} available to enable: /octo:whats-new"
-        fi
+        # SessionStart must not interrupt unrelated work or cause model actions.
+        # Surface a compact user-visible pointer only.
+        FEATURE_LINE="
+   ${_actionable} new ${_noun} available to review explicitly: /octo:whats-new"
     fi
 fi
 
-# Version changed — advisory. Keep it to one or two lines, non-blocking. Emit a
-# valid SessionStart hook-output object (bare text fails v2.1.178 validation); jq
-# JSON-escapes the multi-line message.
-jq -cn --arg ctx "🐙 Claude Octopus updated: ${LAST_SEEN} → ${CURRENT_VERSION}
-   Review changes: /octo:setup (or see CHANGELOG for role routing / default model shifts).
-   Opt out of new routing: export OCTOPUS_LEGACY_ROLES=1${FEATURE_LINE}" \
-    '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$ctx}}'
+# Version changed — advisory. Use systemMessage so the user sees it without
+# injecting instructions into the model or taking over the first prompt.
+jq -cn --arg msg "🐙 Claude Octopus updated: ${LAST_SEEN} → ${CURRENT_VERSION}
+   Review changes with /octo:whats-new or CHANGELOG. Octopus stays dormant until you run /octo:*; optional automation is opt-in.${FEATURE_LINE}" \
+    '{systemMessage:$msg}'
 
 # Persist new version so we don't advise again next session
 TMP=$(mktemp "${STATE_FILE}.XXXXXX")

--- a/scripts/build-codex-skills.sh
+++ b/scripts/build-codex-skills.sh
@@ -362,6 +362,8 @@ write_skill() {
     local codex_desc="$4"
     local codex_display_name="${5:-}"
     local codex_short_desc="${6:-}"
+    local disable_model
+    disable_model="$(extract_field "$file" "disable-model-invocation")"
 
     if [[ -z "$codex_display_name" ]]; then
         codex_display_name="$(display_name "$codex_name")"
@@ -376,6 +378,7 @@ write_skill() {
         echo "---"
         echo "name: $codex_name"
         echo "description: \"$codex_desc\""
+        [[ -n "$disable_model" ]] && echo "disable-model-invocation: $disable_model"
         echo "---"
         host_preamble
         adapt_body_for_codex "$file"

--- a/scripts/helpers/ensure-plugin-root.sh
+++ b/scripts/helpers/ensure-plugin-root.sh
@@ -20,9 +20,17 @@ if [[ -f "$PLUGIN_ROOT_LIB" ]]; then
     source "$PLUGIN_ROOT_LIB"
 fi
 
-# Fast path — already exists and points to a valid directory
+# Fast path — already points to the version that invoked this helper. Merely
+# checking that the old target still exists strands users on a stale cache after
+# the host installs a newer version but keeps older cache directories around.
 if [[ -d "$STABLE_ROOT" && -x "$STABLE_ROOT/scripts/orchestrate.sh" ]]; then
-    exit 0
+    expected_root="${CLAUDE_PLUGIN_ROOT:-}"
+    [[ -n "$expected_root" ]] || expected_root="$(dirname "$(dirname "$SCRIPT_DIR")")"
+    expected_physical="$(cd "$expected_root" 2>/dev/null && pwd -P || true)"
+    stable_physical="$(cd "$STABLE_ROOT" 2>/dev/null && pwd -P || true)"
+    if [[ -n "$expected_physical" && "$stable_physical" == "$expected_physical" ]]; then
+        exit 0
+    fi
 fi
 
 # --- Resolve plugin root ---

--- a/scripts/lib/hook-activation.sh
+++ b/scripts/lib/hook-activation.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Source-safe activation helpers for hooks that must stay dormant by default.
+
+[[ -n "${_OCTOPUS_HOOK_ACTIVATION_LOADED:-}" ]] && return 0
+_OCTOPUS_HOOK_ACTIVATION_LOADED=true
+
+octo_hook_session_id() {
+    local input="${1:-}" sid=""
+    sid="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+
+    if [[ -z "$sid" && -n "$input" ]]; then
+        if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+            sid="${BASH_REMATCH[1]}"
+        elif command -v jq >/dev/null 2>&1; then
+            sid="$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null || true)"
+        fi
+    fi
+
+    [[ -n "$sid" ]] || return 1
+    printf '%s\n' "$sid"
+}
+
+octo_hook_workflow_active() {
+    local input="${1:-}" state_file="${2:-${HOME}/.claude-octopus/session.json}"
+    local hook_session="" state_session="" state_status="" state_phase=""
+
+    case "${OCTOPUS_ACTIVE_WORKFLOW:-}" in
+        1|true|on|yes) return 0 ;;
+    esac
+
+    [[ -r "$state_file" ]] || return 1
+    command -v jq >/dev/null 2>&1 || return 1
+    jq -e 'type == "object"' "$state_file" >/dev/null 2>&1 || return 1
+
+    hook_session="$(octo_hook_session_id "$input" 2>/dev/null || true)"
+    [[ -n "$hook_session" ]] || return 1
+    state_session="$(jq -r '.host_session_id // empty' "$state_file" 2>/dev/null || true)"
+    [[ -n "$state_session" && "$state_session" == "$hook_session" ]] || return 1
+
+    state_status="$(jq -r '.status // .workflow_status // .phase_status // empty' "$state_file" 2>/dev/null || true)"
+    state_phase="$(jq -r '.current_phase // .phase // empty' "$state_file" 2>/dev/null || true)"
+    case "$state_status" in
+        in_progress|active|running|started) ;;
+        *) return 1 ;;
+    esac
+    case "$state_phase" in
+        complete|completed|finished|done) return 1 ;;
+    esac
+    return 0
+}

--- a/scripts/lib/session.sh
+++ b/scripts/lib/session.sh
@@ -443,11 +443,12 @@ init_session() {
     }
     if ! jq -n \
         --arg session_id "$session_id" \
+        --arg host_session_id "${CLAUDE_CODE_SESSION:-}" \
         --arg session_name "$session_name" \
         --arg workflow "$workflow" \
         --arg started_at "$started_at" \
         --arg prompt "$prompt" \
-        '{session_id: $session_id, session_name: $session_name,
+        '{session_id: $session_id, host_session_id: $host_session_id, session_name: $session_name,
           workflow: $workflow, status: "in_progress", current_phase: null,
           started_at: $started_at, last_checkpoint: null,
           prompt: $prompt, phases: {}}' > "$session_tmp" 2>/dev/null; then

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -3903,11 +3903,12 @@ ${obs_ctx}"
                 --arg phase "$phase" \
                 --arg status "$status" \
                 --arg workflow "embrace" \
+                --arg host_session_id "${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-${CLAUDE_CODE_SESSION:-}}}" \
                 --arg group "$task_group" \
                 --arg autonomy "$AUTONOMY_MODE" \
                 --argjson completed "$OCTOPUS_COMPLETED_PHASES" \
                 --argjson total "$OCTOPUS_TOTAL_PHASES" \
-                '{workflow: $workflow, current_phase: $phase, phase_status: $status,
+                '{workflow: $workflow, host_session_id: $host_session_id, current_phase: $phase, phase_status: $status,
                   task_group: $group, autonomy_mode: $autonomy,
                   completed_phases: $completed, total_phases: $total,
                   phase_map: {probe: "grasp", grasp: "tangle", tangle: "ink", ink: "complete"},

--- a/scripts/validate-plugin-assembly.py
+++ b/scripts/validate-plugin-assembly.py
@@ -75,6 +75,7 @@ def require_frontmatter(
     errors: list[str],
     *,
     validate_name: bool = False,
+    expected: dict[str, str] | None = None,
 ) -> None:
     text = file.read_text(encoding="utf-8", errors="replace")
     meta, err = extract_frontmatter(text)
@@ -85,6 +86,12 @@ def require_frontmatter(
     for field in required:
         if not meta.get(field):
             errors.append(f"{rel(root, file)}: missing required frontmatter field: {field}")
+
+    for field, value in (expected or {}).items():
+        if meta.get(field) != value:
+            errors.append(
+                f"{rel(root, file)}: frontmatter {field} must be {value}"
+            )
 
     if validate_name and meta.get("name") and not KEBAB_RE.match(meta["name"]):
         errors.append(f"{rel(root, file)}: name must be kebab-case: {meta['name']}")
@@ -128,14 +135,22 @@ def validate_json_files(root: Path, errors: list[str]) -> None:
 
 def validate_skills(root: Path, errors: list[str]) -> int:
     checked = 0
-    for file in sorted(root.glob("skills/*/SKILL.md")):
-        require_frontmatter(root, file, ("name", "description"), errors, validate_name=True)
+    for file in sorted((root / "skills").rglob("SKILL.md")):
+        require_frontmatter(
+            root, file, ("name", "description"), errors,
+            validate_name=True,
+            expected={"disable-model-invocation": "true"},
+        )
         checked += 1
 
     legacy = root / ".claude" / "skills"
     if legacy.is_dir():
-        for file in sorted(legacy.glob("*.md")):
-            require_frontmatter(root, file, ("name", "description"), errors, validate_name=True)
+        for file in sorted(legacy.rglob("SKILL.md")):
+            require_frontmatter(
+                root, file, ("name", "description"), errors,
+                validate_name=True,
+                expected={"disable-model-invocation": "true"},
+            )
             checked += 1
 
     return checked
@@ -147,7 +162,10 @@ def validate_commands(root: Path, errors: list[str]) -> int:
         if not directory.is_dir():
             continue
         for file in sorted(directory.glob("*.md")):
-            require_frontmatter(root, file, ("description",), errors)
+            require_frontmatter(
+                root, file, ("description",), errors,
+                expected={"disable-model-invocation": "true"},
+            )
             checked += 1
 
     return checked
@@ -163,6 +181,12 @@ def validate_agents(root: Path, errors: list[str]) -> int:
     for pattern in patterns:
         for file in sorted(root.glob(pattern)):
             require_frontmatter(root, file, ("name", "description"), errors, validate_name=True)
+            if pattern in ("agents/droids/*.md", ".claude/agents/*.md"):
+                meta, _ = extract_frontmatter(file.read_text(encoding="utf-8", errors="replace"))
+                if "explicitly starts an Octopus workflow" not in meta.get("description", ""):
+                    errors.append(
+                        f"{rel(root, file)}: subagent description must require an explicit Octopus workflow"
+                    )
             checked += 1
     return checked
 

--- a/skills/flow-define/SKILL.md
+++ b/skills/flow-define/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: flow-define
 description: "Multi-AI requirements scoping using available external providers (Double Diamond Define phase)"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.
@@ -721,4 +722,4 @@ approved the scope. After approval, invoke `flow-develop` if implementation is r
 Otherwise, deliver the requirements document and stop. Do NOT begin
 implementation from here without an approved scope.
 
-**Ready to define!** This skill activates automatically when users request requirement clarification or problem definition.
+**Ready to define!** This skill is used after explicit invocation when users request requirement clarification or problem definition.

--- a/skills/flow-deliver/SKILL.md
+++ b/skills/flow-deliver/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: flow-deliver
 description: "Multi-AI validation, scoring, and review using available external providers (Double Diamond Deliver phase)"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.
@@ -795,9 +796,9 @@ Ink workflows typically cost $0.02-0.08 per validation depending on codebase siz
 
 After validation passes (go decision), run documentation synchronization to keep project docs current with shipped code. This step is **automatic** when running as part of `/octo:embrace` and **offered** when running standalone.
 
-**Invoke the doc-sync skill:**
+**Load the doc-sync source after delivery has been explicitly requested:**
 ```
-Skill(skill: "octo:auto", args: "sync docs for the changes on this branch")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/skill-doc-sync/SKILL.md and execute it for "sync docs for the changes on this branch"
 ```
 
 The doc-sync skill will:
@@ -819,8 +820,10 @@ The doc-sync skill will:
 After delivery validation and doc-sync complete, route according to the user's explicit
 request:
 
-- **Ship requested:** update `.octo/STATE.md` and invoke `skill-ship`.
-- **Branch wrap-up requested:** invoke `skill-finish-branch`.
+- **Ship requested:** update `.octo/STATE.md`, then read and follow
+  `.claude/skills/skill-ship/SKILL.md` from the stable plugin root.
+- **Branch wrap-up requested:** read and follow
+  `.claude/skills/skill-finish-branch/SKILL.md` from the stable plugin root.
 - **Review only:** deliver the synthesized findings and stop. Do not update the project
   to a ready-to-ship state or display a shipping instruction.
 
@@ -846,19 +849,19 @@ echo "📦 **Project ready! Run \`/octo:ship\` to finalize and archive.**"
 After that block succeeds, perform the requested finalization immediately:
 
 ```text
-Skill(skill: "skill-ship", args: "finalize and archive the validated project")
+Read ${HOME}/.claude-octopus/plugin/.claude/skills/skill-ship/SKILL.md and execute it for "finalize and archive the validated project"
 ```
 
 Do not stop after displaying the command. The ship-requested branch is incomplete until
-`skill-ship` has actually been invoked.
+the explicit ship workflow has actually been executed.
 
 
 ## Terminal State
 
 The Deliver phase is complete ONLY when validation findings are synthesized and
 must-fix items are resolved or explicitly accepted by the user. If the user asked to
-ship or wrap the branch, then invoke `skill-ship` (or `skill-finish-branch` for tests,
+ship or wrap the branch, then read and execute `skill-ship` (or `skill-finish-branch` for tests,
 PR, and merge). For review-only requests, deliver the findings and stop; do NOT expand
 the request into shipping work without user authorization.
 
-**Ready to validate!** This skill activates automatically when users request code review, validation, or quality checks.
+**Ready to validate!** This skill runs only after explicit invocation.

--- a/skills/flow-develop/SKILL.md
+++ b/skills/flow-develop/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: flow-develop
 description: "Multi-AI implementation using available external providers (Double Diamond Develop phase)"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.
@@ -784,4 +785,4 @@ checkpoint tag is created, and targeted tests pass fresh (see `skill-verificatio
 Then invoke `flow-deliver` for validation. Do NOT declare the work done from here —
 completion claims belong to the Deliver phase after review.
 
-**Ready to build!** This skill activates automatically when users request implementation or building features.
+**Ready to build!** This skill is used after explicit invocation when users request implementation or building features.

--- a/skills/flow-discover/SKILL.md
+++ b/skills/flow-discover/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: flow-discover
 description: "Multi-AI research using available external providers (Double Diamond Discover phase)"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.
@@ -830,4 +831,4 @@ either invoke `flow-define` (embrace workflow, or the user wants requirements ne
 stop with research delivered. Do NOT begin scoping, designing, or implementation from
 here — that work belongs to later phases.
 
-**Ready to research!** This skill activates automatically when users request research or exploration.
+**Ready to research!** This skill is used after explicit invocation when users request research or exploration.

--- a/skills/flow-parallel/SKILL.md
+++ b/skills/flow-parallel/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: flow-parallel
 description: "Decompose and execute large changes, migrations, or multi-issue fixes in parallel with quality gates"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/flow-spec/SKILL.md
+++ b/skills/flow-spec/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: flow-spec
 description: "NLSpec authoring — use when you need a structured specification from multi-AI research and consensus"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/octopus-architecture/SKILL.md
+++ b/skills/octopus-architecture/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: octopus-architecture
 description: "System architecture and API design with multi-AI consensus — use for design reviews and new subsystems"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/octopus-quick/SKILL.md
+++ b/skills/octopus-quick/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: octopus-quick
 description: "Quick execution for ad-hoc tasks without full workflow overhead — use for small, self-contained requests"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/octopus-research/SKILL.md
+++ b/skills/octopus-research/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: octopus-research
 description: "Thorough research across multiple sources — use for complex topics needing broad synthesis"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/octopus-security-audit/SKILL.md
+++ b/skills/octopus-security-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: octopus-security-audit
 description: "OWASP compliance, vulnerability scanning, and adversarial red team testing — use for security reviews"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/octopus-starter-pack/council-verdicts/SKILL.md
+++ b/skills/octopus-starter-pack/council-verdicts/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: council-verdicts
+disable-model-invocation: true
 description: "Starter: interpret a council run's verdict artifacts — quorum, dissent, cross-lab validity, and what to do next"
 ---
 

--- a/skills/octopus-starter-pack/debate-kickoff/SKILL.md
+++ b/skills/octopus-starter-pack/debate-kickoff/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: debate-kickoff
+disable-model-invocation: true
 description: "Starter: frame a decision as a multi-model debate — picks sides, seats providers, and launches /octo:debate with a well-formed motion"
 ---
 

--- a/skills/octopus-starter-pack/model-cost-compare/SKILL.md
+++ b/skills/octopus-starter-pack/model-cost-compare/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: model-cost-compare
+disable-model-invocation: true
 description: "Starter: compare model costs for a described task — maps task shape to the cheapest adequate seat and shows the price spread"
 ---
 

--- a/skills/octopus-starter-pack/provider-health/SKILL.md
+++ b/skills/octopus-starter-pack/provider-health/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: provider-health
+disable-model-invocation: true
 description: "Starter: one-screen provider health summary — availability, auth method, version drift, and cost posture for every seatable provider"
 ---
 

--- a/skills/octopus-ui-ux-design/SKILL.md
+++ b/skills/octopus-ui-ux-design/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: octopus-ui-ux-design
 description: "Design UI/UX systems with style guides, palettes, typography, and component specs for new interfaces"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-agent-topology/SKILL.md
+++ b/skills/skill-agent-topology/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-agent-topology
 description: "Audit whether a multi-agent setup earns its coordination cost — use before adding an agent, or when a workflow feels slow or agents agree without adding signal"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-audit/SKILL.md
+++ b/skills/skill-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-audit
 description: "Audit codebases for quality, consistency, and broken patterns — use for pre-release or tech debt review"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-authoring/SKILL.md
+++ b/skills/skill-authoring/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-authoring
 description: "Principles for writing skills that behave the same way every run — use when adding, editing, or reviewing a skill in this plugin"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.
@@ -43,29 +44,20 @@ agent do differently because this exists?
 
 ## Workflow
 
-### Invocation: how this plugin differs
+### Invocation: explicit by default
 
-Upstream draws a clean line between a **model-invoked** skill (carries a
-description, the agent can fire it autonomously, costs context every turn) and a
-**user-invoked** one (`disable-model-invocation: true`, zero context cost, but
-the user must remember it exists).
+Every shipped command and skill carries `disable-model-invocation: true`.
+Claude Code therefore keeps Octopus out of model context until the user chooses
+an `/octo:*` command. This is a hard platform gate, not a prose reminder.
 
-**That line does not transfer cleanly here, and getting it wrong breaks
-routing.** Six skills in this repo declare `invocation: human_only`. That key is
-custom — `scripts/build-codex-skills.sh` strips it from the generated tree, and
-nothing reads it. The real effect comes from an advisory reminder in
-`hooks/context-reinforcement.sh`, kept in step by
-`tests/unit/test-human-only-skill-list.sh`.
+Command bodies that need reusable instructions load the source file directly
+from `${CLAUDE_PLUGIN_ROOT}/.claude/skills/<name>/SKILL.md`; they do not call the
+Skill tool. That keeps explicit commands composable without reopening automatic
+model invocation.
 
-Do **not** reach for `disable-model-invocation: true` to express "human-only"
-here. Four of those six are named in command bodies (`commands/parallel.md`,
-`factory.md`, `research.md`, `security.md`) and the model reaches them on the
-user's behalf when running those commands. Disabling model invocation would break
-`/octo:parallel`, `/octo:factory`, `/octo:research`, `/octo:security`.
-
-So in this plugin: "human-only" means *do not fire from prompt-keyword
-auto-routing*. Declare it with `invocation: human_only`, add the skill to the
-hook's list, and accept that it is advisory.
+Plain-language routing is a separate, legacy-compatible opt-in controlled by
+`OCTOPUS_AUTO_ROUTER_MODE=suggest|invoke`. Its default is `off`. New skills must
+never depend on prompt-keyword auto-routing for reachability.
 
 ### Writing the description
 
@@ -81,9 +73,8 @@ pruning than the body.
   skill needs this" clause, and nothing else.
 - Beware collision. With this many skills the scarce resource is trigger space,
   not skill count. Before adding a trigger phrase, check whether an existing
-  skill or `hooks/user-prompt-submit.sh` already claims it — that hook
-  auto-invokes on strong matches, and a new overlapping phrase degrades a working
-  route rather than adding one.
+  skill or `hooks/user-prompt-submit.sh` already claims it. The hook is opt-in,
+  but overlapping phrases still degrade routing for users who enable it.
 
 ### Information hierarchy
 
@@ -155,5 +146,6 @@ When reviewing, report:
   skill's description.
 - The skill is registered in `.claude-plugin/plugin.json` and `make sync` is
   clean.
-- If it declares `invocation: human_only`, it is in the hook list and
-  `tests/unit/test-human-only-skill-list.sh` passes.
+- It declares `disable-model-invocation: true`, and any command that composes it
+  loads its source file directly.
+- `tests/unit/test-explicit-activation.sh` passes.

--- a/skills/skill-authoring/SKILL.md
+++ b/skills/skill-authoring/SKILL.md
@@ -50,9 +50,15 @@ Every shipped command and skill carries `disable-model-invocation: true`.
 Claude Code therefore keeps Octopus out of model context until the user chooses
 an `/octo:*` command. This is a hard platform gate, not a prose reminder.
 
-Command bodies that need reusable instructions load the source file directly
-from `${CLAUDE_PLUGIN_ROOT}/.claude/skills/<name>/SKILL.md`; they do not call the
-Skill tool. That keeps explicit commands composable without reopening automatic
+Command bodies that need reusable instructions load the entire source file
+directly from
+`${HOME}/.claude-octopus/plugin/.claude/skills/<name>/SKILL.md`; they do not call
+the Skill tool. `${HOME}/.claude-octopus/plugin` is the stable, self-healed path
+available to model tool calls; `CLAUDE_PLUGIN_ROOT` is a hook/runtime variable
+and may be absent from that context. The command must treat the loaded body as
+the active instructions in the current conversation, follow its steps in order,
+and pass the user's text as workflow arguments rather than executable path
+content. This keeps explicit commands composable without reopening automatic
 model invocation.
 
 Plain-language routing is a separate, legacy-compatible opt-in controlled by

--- a/skills/skill-claw/SKILL.md
+++ b/skills/skill-claw/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-claw
 description: "OpenClaw instance administration — manage hosts across macOS, Ubuntu/Debian, Docker, OCI, and Proxmox"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-code-review/SKILL.md
+++ b/skills/skill-code-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-code-review
 description: "Expert multi-AI code review with inline PR comments — use for thorough quality and security analysis"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-content-pipeline/SKILL.md
+++ b/skills/skill-content-pipeline/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-content-pipeline
 description: "Extract patterns and anatomy from URLs — use to reverse-engineer content strategies from live pages"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-context-detection/SKILL.md
+++ b/skills/skill-context-detection/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-context-detection
 description: "Auto-detect work context (Dev vs Knowledge) — use to tailor workflows based on current task type"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-copilot-provider/SKILL.md
+++ b/skills/skill-copilot-provider/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-copilot-provider
 description: "GitHub Copilot CLI as optional zero-cost provider via copilot -p programmatic mode"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-cost-projections/SKILL.md
+++ b/skills/skill-cost-projections/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-cost-projections
 description: "Project remaining workflow cost from per-phase averages — warns on budget ceiling overruns"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-council/SKILL.md
+++ b/skills/skill-council/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: skill-council
+disable-model-invocation: true
 description: "Run a configurable multi-LLM council with personas, budget caps, synthesis, veto gates, and optional implementation handoff."
 ---
 

--- a/skills/skill-coverage-audit/SKILL.md
+++ b/skills/skill-coverage-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-coverage-audit
 description: "Trace codepaths in diffs, map against tests, auto-generate missing coverage — use before shipping PRs"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-debate/SKILL.md
+++ b/skills/skill-debate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-debate
 description: "Structured multi-provider AI debates between Claude and available advisors — use for critical decisions"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.
@@ -75,7 +76,7 @@ You are current host model, a **participant and moderator** in a multi-provider 
 
 ## How Users Invoke This Skill
 
-Users can invoke the debate skill in natural language. You parse the intent and run the debate.
+Users invoke this skill explicitly from the slash menu. Parse the supplied intent and run the debate.
 
 ### Basic Invocation
 ```

--- a/skills/skill-debug/SKILL.md
+++ b/skills/skill-debug/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-debug
 description: "Debug issues methodically — use when stuck on errors, test failures, or unexpected behavior"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.
@@ -286,7 +287,8 @@ If you suspect the issue is with the Claude Code environment itself (e.g., netwo
 
 ## Auto-Freeze on Debug
 
-When debugging a specific module, automatically activate freeze mode to prevent accidental edits outside the investigated area. This is a safety measure that keeps your debugging focused.
+Inside this explicitly invoked debugging workflow, activate freeze mode for the
+specific module before editing. This safety measure keeps the investigation focused.
 
 ### How It Works
 

--- a/skills/skill-decision-support/SKILL.md
+++ b/skills/skill-decision-support/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-decision-support
 description: "Present options with trade-offs for informed decision-making — use when choosing between approaches"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-deck/SKILL.md
+++ b/skills/skill-deck/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-deck
 description: "Generate slide deck presentations from briefs — use when you need slides, pitch decks, or visual summaries"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-design-lineage/SKILL.md
+++ b/skills/skill-design-lineage/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-design-lineage
 description: "Persist design documents with branch tracking, revision chains, and cross-session discovery"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-doc-delivery/SKILL.md
+++ b/skills/skill-doc-delivery/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-doc-delivery
 description: "Convert markdown to DOCX, PPTX, XLSX, PDF office documents — use when you need exportable deliverables"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.
@@ -317,7 +318,7 @@ Knowledge Work Flow:
 1. Run workflow: /octo:empathize (or advise/synthesize)
 2. Review markdown output in ~/.claude-octopus/results/
 3. Request conversion: "Export to PowerPoint"
-4. This skill activates automatically
+4. This skill is used after explicit invocation
 5. Professional document delivered
 ```
 

--- a/skills/skill-doc-sync/SKILL.md
+++ b/skills/skill-doc-sync/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-doc-sync
 description: "Post-ship doc sync across project markdown. Use when: sync docs, update docs, document changes, release notes."
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-doctor
 description: "Environment diagnostics — check providers, auth, config, hooks, scheduler, and more"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-extract/SKILL.md
+++ b/skills/skill-extract/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-extract
 description: "Reverse-engineer design systems, tokens, and components from live products or screenshots"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-factory/SKILL.md
+++ b/skills/skill-factory/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-factory
 description: "Run a full build-and-ship pipeline from a spec — use for hands-off project generation"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-finish-branch/SKILL.md
+++ b/skills/skill-finish-branch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-finish-branch
 description: "Wrap up a branch — run tests, create PR, merge or discard — use when implementation is done"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-intake/SKILL.md
+++ b/skills/skill-intake/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-intake
 description: "Move incoming issues and pull requests through triage states until each is actionable or closed — use when the queue has piled up or a report arrives unsorted"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-intent-contract/SKILL.md
+++ b/skills/skill-intent-contract/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-intent-contract
 description: "Use when starting a complex or ambiguous task that risks scope drift"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-issues/SKILL.md
+++ b/skills/skill-issues/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-issues
 description: "Track project blockers, bugs, and gaps across sessions — use when issues pile up or need triage"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-iterative-loop/SKILL.md
+++ b/skills/skill-iterative-loop/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-iterative-loop
 description: "Run tasks in a loop until goals are met — use for iterative refinement, polling, or convergence"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-knowledge-work/SKILL.md
+++ b/skills/skill-knowledge-work/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-knowledge-work
 description: "Switch to Knowledge Work mode for research and writing — use when task is non-code focused"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-meta-prompt/SKILL.md
+++ b/skills/skill-meta-prompt/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-meta-prompt
 description: "Craft better prompts using proven optimization techniques — use when your prompt needs refinement"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-native-escalation-routing/SKILL.md
+++ b/skills/skill-native-escalation-routing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-native-escalation-routing
 description: "Use when choosing native or multi-LLM handling for init, review, or security requests"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-parallel-agents/SKILL.md
+++ b/skills/skill-parallel-agents/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-parallel-agents
 description: "Decompose large tasks across parallel agents — use for migrations, multi-file refactors, or batch work"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-prd/SKILL.md
+++ b/skills/skill-prd/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-prd
 description: "Write an AI-optimized PRD using multi-AI orchestration — use when scoping a new feature or product"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-pressure-test/SKILL.md
+++ b/skills/skill-pressure-test/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-pressure-test
 description: "Interrogate a plan, decision, or design one question at a time until it holds — use to stress-test your own thinking before committing to it"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-resume/SKILL.md
+++ b/skills/skill-resume/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-resume
 description: "Pick up where you left off from a previous session — use after context resets, compaction, or new conversations"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-review-response/SKILL.md
+++ b/skills/skill-review-response/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-review-response
 description: "Use when a reviewer, CI bot, or another AI leaves feedback to address"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-rollback/SKILL.md
+++ b/skills/skill-rollback/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-rollback
 description: "Roll back to a previous checkpoint via git — use when a change went wrong and you need to revert"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-security-framing/SKILL.md
+++ b/skills/skill-security-framing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-security-framing
 description: "URL validation and content sanitization for untrusted sources — use when handling external input safely"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-ship/SKILL.md
+++ b/skills/skill-ship/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-ship
 description: "Package and finalize completed work for delivery — use when a feature is done and ready to ship"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-staged-review/SKILL.md
+++ b/skills/skill-staged-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-staged-review
 description: "Use when a PR or feature needs both specification and code-quality review"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-status/SKILL.md
+++ b/skills/skill-status/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-status
 description: "Show where you are in the workflow and what to do next — use for progress checks and orientation"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-task-management/SKILL.md
+++ b/skills/skill-task-management/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-task-management
 description: "Manage tasks with Claude Code native tools — use to track TODOs, delegate work, and monitor progress"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-tdd/SKILL.md
+++ b/skills/skill-tdd/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-tdd
 description: "Build features with tests-before-code rigor — use for new features needing test coverage"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-thought-partner/SKILL.md
+++ b/skills/skill-thought-partner/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-thought-partner
 description: "Brainstorm creatively with pattern spotting and paradox hunting — use for ideation and exploration"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-verification-gate/SKILL.md
+++ b/skills/skill-verification-gate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-verification-gate
 description: "Use when about to declare work complete, fixed, passing, or done"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-verify/SKILL.md
+++ b/skills/skill-verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-verify
 description: "Use when a nontrivial change needs end-to-end verification before committing or shipping"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-visual-feedback/SKILL.md
+++ b/skills/skill-visual-feedback/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-visual-feedback
 description: "Process screenshot-based UI/UX feedback to fix visual issues — use when users share screenshots of bugs"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-work-slicing/SKILL.md
+++ b/skills/skill-work-slicing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-work-slicing
 description: "Break a plan or spec into vertical slices that each declare what blocks them — use when work is agreed but not yet cut into fileable pieces"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/skill-writing-plans/SKILL.md
+++ b/skills/skill-writing-plans/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-writing-plans
 description: "Create zero-context implementation plans with bite-sized tasks — use for multi-step feature planning"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.

--- a/skills/sys-configure/SKILL.md
+++ b/skills/sys-configure/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sys-configure
 description: "Configure Claude Octopus — redirects to /octo:setup interactive wizard"
+disable-model-invocation: true
 ---
 
 > **Host: Codex CLI** — This skill was designed for Claude Code and adapted for Codex.
@@ -19,4 +20,6 @@ This skill is an alias for `/octo:setup`. When triggered, invoke the setup comma
 - Work mode selection
 - First-run onboarding
 
-Do NOT duplicate setup logic here. Just invoke the setup skill.
+Do NOT duplicate setup logic here. Read
+`${HOME}/.claude-octopus/plugin/commands/setup.md` and follow it only because
+the user explicitly invoked this configuration skill.

--- a/tests/unit/fixtures/env-var-effects.tsv
+++ b/tests/unit/fixtures/env-var-effects.tsv
@@ -19,6 +19,7 @@ OCTOPUS_AGENT_LIFECYCLE_HOOK	covered-by	test-agent-lifecycle-events.sh
 OCTOPUS_AGENT_LIFECYCLE_HOOK_LOG	covered-by	test-agent-lifecycle-events.sh
 OCTOPUS_AGY_MODEL	covered-by	test-agy-provider.sh
 OCTOPUS_AUTO_TITLE	skip	sets the Claude Code session title; observable only in the host UI
+OCTOPUS_AUTO_ROUTER_MODE	covered-by	test-explicit-activation.sh
 OCTOPUS_CLAUDE_SDK_MODEL	covered-by	test-claude-sdk-provider.sh
 OCTOPUS_CODEX_MODEL	covered-by	test-role-mapping-v929.sh
 OCTOPUS_COMMANDCODE_ALLOWED_MODELS	skip	allowlist for a provider with no CLI on CI runners

--- a/tests/unit/test-adapted-workflow-skills.sh
+++ b/tests/unit/test-adapted-workflow-skills.sh
@@ -108,11 +108,13 @@ else
     test_fail "must require completion criteria the agent can actually evaluate"
 fi
 
-test_case "authoring: records this repo's real invocation constraint"
-if [[ -f "$AU" ]] && grep -q "disable-model-invocation" "$AU" && grep -qi "invocation: human_only" "$AU"; then
+test_case "authoring: records the native explicit-invocation contract"
+if [[ -f "$AU" ]] \
+    && grep -q "disable-model-invocation: true" "$AU" \
+    && grep -q '\.claude/skills/<name>/SKILL\.md' "$AU"; then
     test_pass
 else
-    test_fail "must explain that human_only is advisory here and why disable-model-invocation would break command routes"
+    test_fail "must require the native invocation gate and direct source loading for explicit command composition"
 fi
 
 test_case "authoring: points at the repo's own structural standard"

--- a/tests/unit/test-auto-router-hooks.sh
+++ b/tests/unit/test-auto-router-hooks.sh
@@ -41,23 +41,23 @@ fail() { test_case "$1"; test_fail "${2:-$1}"; }
 
 test_case "routes decision prompts to debate"
 output="$(run_prompt_hook "should we use Redis or Memcached for session state?")"
-if [[ "$output" == *'Skill(skill: \"octo:debate\"'* ]]; then
+if [[ "$output" == *'Opt-in auto-route: debate'* ]] && [[ "$output" == *'/commands/debate.md'* ]]; then
     test_pass
 else
-    test_fail "expected octo:debate auto-invoke, got: ${output:-<empty>}"
+    test_fail "expected opt-in debate command route, got: ${output:-<empty>}"
 fi
 
-test_case "routes research prompts to discover skill"
+test_case "routes research prompts to discover command"
 output="$(run_prompt_hook "research options for OAuth authentication patterns")"
-if [[ "$output" == *'Skill(skill: \"octo:discover\"'* ]] && [[ "$output" != *'octo:research'* ]]; then
+if [[ "$output" == *'Opt-in auto-route: discover'* ]] && [[ "$output" == *'/commands/discover.md'* ]] && [[ "$output" != *'/commands/research.md'* ]]; then
     test_pass
 else
-    test_fail "expected octo:discover and no octo:research, got: ${output:-<empty>}"
+    test_fail "expected discover command and no research command, got: ${output:-<empty>}"
 fi
 
 test_case "resolves setup aliases before session title"
 output="$(run_prompt_hook "/octo:configure providers")"
-if [[ "$output" == *'Alias resolved: /octo:configure -> /octo:setup'* ]] && [[ "$output" == *'Skill(skill: \"octo:setup\"'* ]]; then
+if [[ "$output" == *'Alias resolved: /octo:configure -> /octo:setup'* ]] && [[ "$output" == *'/commands/setup.md'* ]]; then
     test_pass
 else
     test_fail "expected configure alias to setup, got: ${output:-<empty>}"
@@ -73,23 +73,23 @@ fi
 
 test_case "promotes named option prompts to debate"
 output="$(run_prompt_hook "Redis or Memcached for session state?")"
-if [[ "$output" == *'Skill(skill: \"octo:debate\"'* ]]; then
+if [[ "$output" == *'Opt-in auto-route: debate'* ]] && [[ "$output" == *'/commands/debate.md'* ]]; then
     test_pass
 else
     test_fail "expected proper-noun option prompt to route to debate, got: ${output:-<empty>}"
 fi
 
-test_case "suggest mode does not inject mandatory skill call"
+test_case "suggest mode does not inject a command route"
 output="$(run_prompt_hook "review this PR for regressions" "suggest")"
-if [[ "$output" == *"Detected intent: review"* ]] && [[ "$output" != *"MANDATORY: Invoke Skill"* ]]; then
+if [[ "$output" == *"Detected intent: review"* ]] && [[ "$output" != *"Opt-in auto-route"* ]]; then
     test_pass
 else
     test_fail "expected suggest-only context, got: ${output:-<empty>}"
 fi
 
-test_case "auto-invoke wording is advisory, never MANDATORY"
+test_case "opt-in routing wording is advisory, never mandatory"
 output="$(run_prompt_hook "should we use Redis or Memcached for session state?")"
-if [[ "$output" == *"Auto-route: debate"* ]] && [[ "$output" != *"MANDATORY"* ]]; then
+if [[ "$output" == *"Opt-in auto-route: debate"* ]] && [[ "$output" != *"MANDATORY"* ]]; then
     test_pass
 else
     test_fail "expected advisory auto-route without MANDATORY, got: ${output:-<empty>}"
@@ -135,16 +135,24 @@ else
     test_fail "expected Cursor-style additional_context only, got: ${output:-<empty>}"
 fi
 
-test_case "SessionStart auto-router injection hook exists and emits routing contract"
+test_case "SessionStart auto-router is silent by default"
 if [[ -x "$SESSION_HOOK" ]]; then
     output="$(HOME="$TEST_TMP_DIR/home-session" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$SESSION_HOOK" <<< '{"hook_event_name":"SessionStart"}')"
-    if [[ "$output" == *"OCTOPUS-AUTO-ROUTER"* ]] && [[ "$output" == *"octo:debate"* ]]; then
+    if [[ -z "$output" ]]; then
         test_pass
     else
-        test_fail "expected routing contract output, got: ${output:-<empty>}"
+        test_fail "expected no default routing contract, got: ${output:-<empty>}"
     fi
 else
     test_fail "missing executable hook: $SESSION_HOOK"
+fi
+
+test_case "SessionStart auto-router emits a contract after explicit opt-in"
+output="$(HOME="$TEST_TMP_DIR/home-session-opt-in" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" OCTOPUS_AUTO_ROUTER_MODE=invoke "$SESSION_HOOK" <<< '{"hook_event_name":"SessionStart"}')"
+if [[ "$output" == *"OCTOPUS-AUTO-ROUTER"* ]] && [[ "$output" == *"commands/debate.md"* ]]; then
+    test_pass
+else
+    test_fail "expected opt-in routing contract output, got: ${output:-<empty>}"
 fi
 
 test_summary

--- a/tests/unit/test-bare-auth-probe-timeout.sh
+++ b/tests/unit/test-bare-auth-probe-timeout.sh
@@ -127,7 +127,9 @@ export OCTO_DESCENDANT_WRAPPER="$descendant_wrapper"
 rc=0
 (
     PATH="$manual_bin"
-    _octo_run_bare_probe_with_timeout 1 1 0 "$descendant_probe" \
+    # Process creation can exceed one second on loaded macOS CI hosts. Give the
+    # fixture enough time to publish its PID before asserting whole-tree kill.
+    _octo_run_bare_probe_with_timeout 3 3 0 "$descendant_probe" \
         >/dev/null 2>&1
 ) || rc=$?
 grandchild_pid=$(cat "$grandchild_pid_file" 2>/dev/null || true)

--- a/tests/unit/test-done-criteria.sh
+++ b/tests/unit/test-done-criteria.sh
@@ -110,10 +110,26 @@ else
     fail "Has OCTO_DONE_CRITERIA kill switch" "missing kill switch"
 fi
 
-if grep -qE 'OCTO_DONE_CRITERIA.*off' "$HOOK" 2>/dev/null; then
-    pass "Kill switch disables on 'off'"
+if grep -qE 'OCTO_DONE_CRITERIA.*on' "$HOOK" 2>/dev/null; then
+    pass "Feature requires explicit 'on' opt-in"
 else
-    fail "Kill switch disables on 'off'" "kill switch not wired to off"
+    fail "Feature requires explicit 'on' opt-in" "opt-in gate not wired to on"
+fi
+
+test_case "ordinary prompts are silent by default"
+output=$(printf '%s' '{"session_id":"ordinary","prompt":"fix the parser and then add regression tests for it"}' | HOME="$TEST_TMP_DIR/done-default" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$HOOK")
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "expected default silence, got: $output"
+fi
+
+test_case "explicit opt-in enables compound-task guidance"
+output=$(printf '%s' '{"session_id":"opt-in","prompt":"fix the parser and then add regression tests for it"}' | HOME="$TEST_TMP_DIR/done-opt-in" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" OCTO_DONE_CRITERIA=on "$HOOK")
+if [[ "$output" == *'completion criteria'* ]]; then
+    test_pass
+else
+    test_fail "expected opt-in guidance, got: ${output:-<empty>}"
 fi
 
 # ── Timeout guard on stdin ────────────────────────────────────────────────────

--- a/tests/unit/test-ensure-plugin-root.sh
+++ b/tests/unit/test-ensure-plugin-root.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Stable plugin entrypoint must advance to the version loaded by the host.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Stable plugin root follows the loaded version"
+
+TEST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/octo-plugin-root.XXXXXX")"
+trap 'rm -rf "$TEST_HOME"' EXIT
+OLD_ROOT="$TEST_HOME/cache/9.63.0"
+NEW_ROOT="$TEST_HOME/cache/9.64.0"
+mkdir -p "$OLD_ROOT/scripts" "$NEW_ROOT/scripts" "$TEST_HOME/.claude-octopus"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$OLD_ROOT/scripts/orchestrate.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$NEW_ROOT/scripts/orchestrate.sh"
+chmod +x "$OLD_ROOT/scripts/orchestrate.sh" "$NEW_ROOT/scripts/orchestrate.sh"
+ln -s "$OLD_ROOT" "$TEST_HOME/.claude-octopus/plugin"
+NEW_ROOT_PHYSICAL="$(cd "$NEW_ROOT" && pwd -P)"
+
+test_case "a valid but stale symlink advances to CLAUDE_PLUGIN_ROOT"
+HOME="$TEST_HOME" CLAUDE_PLUGIN_ROOT="$NEW_ROOT" \
+    bash "$PROJECT_ROOT/scripts/helpers/ensure-plugin-root.sh" >/dev/null 2>&1 || true
+resolved="$(cd "$TEST_HOME/.claude-octopus/plugin" 2>/dev/null && pwd -P || true)"
+if [[ "$resolved" == "$NEW_ROOT_PHYSICAL" ]]; then
+    test_pass
+else
+    test_fail "stable root still resolves to ${resolved:-missing}; expected $NEW_ROOT_PHYSICAL"
+fi
+
+test_case "the refreshed stable entrypoint remains executable"
+if [[ -x "$TEST_HOME/.claude-octopus/plugin/scripts/orchestrate.sh" ]]; then
+    test_pass
+else
+    test_fail "refreshed stable root has no executable orchestrator"
+fi
+
+test_summary

--- a/tests/unit/test-explicit-activation.sh
+++ b/tests/unit/test-explicit-activation.sh
@@ -80,6 +80,25 @@ else
     test_fail "opt-in router did not route: ${output:-<empty>}"
 fi
 
+test_case "explicit router constrains command paths to a closed allowlist"
+if grep -q 'closed allowlist' "$PROJECT_ROOT/commands/auto.md" \
+    && grep -q 'Reject `\.\.`, `/`, `\\\\`, or non-allowlisted values' "$PROJECT_ROOT/commands/auto.md" \
+    && grep -q 'commands/<validated-token>\.md' "$PROJECT_ROOT/commands/auto.md"; then
+    test_pass
+else
+    test_fail "smart router does not document validated command selection"
+fi
+
+test_case "manual composition contract separates model and hook roots"
+if grep -q 'Manual composition contract' "$PROJECT_ROOT/docs/PLUGIN-ASSEMBLY-STANDARD.md" \
+    && grep -q 'Reserve `CLAUDE_PLUGIN_ROOT` for hooks and runtime scripts' "$PROJECT_ROOT/docs/PLUGIN-ASSEMBLY-STANDARD.md" \
+    && ! rg '^[^#]*Skill\(' "$PROJECT_ROOT/commands"/*.md \
+        | grep -vE '❌|Wrong|wrong|PROHIBITED|DO NOT|not resolvable|loops|INSTEAD' >/dev/null; then
+    test_pass
+else
+    test_fail "manual composition contract is missing or a positive Skill() caller remains"
+fi
+
 test_case "SessionStart router reinforcement is silent by default"
 output="$(printf '%s' '{"hook_event_name":"SessionStart","session_id":"plain"}' \
     | env -u OCTOPUS_AUTO_ROUTER_MODE -u OCTOPUS_AUTO_INVOKE \

--- a/tests/unit/test-explicit-activation.sh
+++ b/tests/unit/test-explicit-activation.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #898: Octopus stays dormant until explicitly used.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Explicit-only Octopus activation"
+
+pass() { test_case "$1"; test_pass; }
+fail() { test_case "$1"; test_fail "${2:-$1}"; }
+
+frontmatter_value() {
+    local file="$1" key="$2"
+    awk -v key="$key" '
+        BEGIN { in_frontmatter = 0 }
+        /^---$/ { if (in_frontmatter) exit; in_frontmatter = 1; next }
+        in_frontmatter && index($0, key ":") == 1 {
+            sub("^" key ":[[:space:]]*", "")
+            print
+            exit
+        }
+    ' "$file"
+}
+
+test_case "every shipped command is manual-only"
+bad=""
+for file in "$PROJECT_ROOT"/commands/*.md; do
+    [[ "$(frontmatter_value "$file" disable-model-invocation)" == "true" ]] || bad="$bad ${file##*/}"
+done
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "commands missing disable-model-invocation: true:$bad"
+fi
+
+test_case "every source and generated skill is manual-only"
+bad=""
+while IFS= read -r file; do
+    [[ "$(frontmatter_value "$file" disable-model-invocation)" == "true" ]] || bad="$bad ${file#$PROJECT_ROOT/}"
+done < <(find "$PROJECT_ROOT/.claude/skills" "$PROJECT_ROOT/skills" -name SKILL.md -type f | sort)
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "skills missing disable-model-invocation: true:$bad"
+fi
+
+test_case "ordinary prompts are silent when router mode is unset"
+home_dir="$TEST_TMP_DIR/default-router-home"
+mkdir -p "$home_dir/.claude-octopus"
+output="$(printf '%s' '{"hook_event_name":"UserPromptSubmit","session_id":"plain","prompt":"research options for OAuth"}' \
+    | env -u OCTOPUS_AUTO_ROUTER_MODE -u OCTOPUS_AUTO_INVOKE \
+        HOME="$home_dir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+        "$PROJECT_ROOT/hooks/user-prompt-submit.sh")"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "default router injected context: $output"
+fi
+
+test_case "explicit commands still receive alias handling when router is off"
+output="$(printf '%s' '{"hook_event_name":"UserPromptSubmit","session_id":"explicit","prompt":"/octo:configure providers"}' \
+    | HOME="$home_dir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" OCTOPUS_AUTO_ROUTER_MODE=off \
+        "$PROJECT_ROOT/hooks/user-prompt-submit.sh")"
+if [[ "$output" == *"Alias resolved: /octo:configure -> /octo:setup"* ]]; then
+    test_pass
+else
+    test_fail "explicit alias handling was lost: ${output:-<empty>}"
+fi
+
+test_case "router remains available as an explicit opt-in"
+output="$(printf '%s' '{"hook_event_name":"UserPromptSubmit","session_id":"opt-in","prompt":"research options for OAuth"}' \
+    | HOME="$home_dir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" OCTOPUS_AUTO_ROUTER_MODE=invoke \
+        "$PROJECT_ROOT/hooks/user-prompt-submit.sh")"
+if [[ "$output" == *"Opt-in auto-route: discover"* ]] \
+   && [[ "$output" == *"commands/discover.md"* ]]; then
+    test_pass
+else
+    test_fail "opt-in router did not route: ${output:-<empty>}"
+fi
+
+test_case "SessionStart router reinforcement is silent by default"
+output="$(printf '%s' '{"hook_event_name":"SessionStart","session_id":"plain"}' \
+    | env -u OCTOPUS_AUTO_ROUTER_MODE -u OCTOPUS_AUTO_INVOKE \
+        HOME="$home_dir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+        "$PROJECT_ROOT/hooks/auto-router-inject.sh")"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "default SessionStart injected router context: $output"
+fi
+
+test_case "compound-task coaching is opt-in outside a workflow"
+compound='{"hook_event_name":"UserPromptSubmit","session_id":"plain","prompt":"fix the parser and then update the tests"}'
+output="$(printf '%s' "$compound" | HOME="$home_dir" "$PROJECT_ROOT/hooks/done-criteria.sh")"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "default done-criteria hook engaged: $output"
+fi
+
+test_case "compound-task coaching remains available by explicit opt-in"
+output="$(printf '%s' "$compound" | HOME="$home_dir" OCTO_DONE_CRITERIA=on "$PROJECT_ROOT/hooks/done-criteria.sh")"
+if [[ "$output" == *"Compound task detected"* ]]; then
+    test_pass
+else
+    test_fail "opt-in done criteria did not engage: ${output:-<empty>}"
+fi
+
+test_case "global context reinforcement is silent without an active matching workflow"
+output="$(printf '%s' '{"hook_event_name":"SessionStart","session_id":"plain"}' \
+    | HOME="$home_dir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$PROJECT_ROOT/hooks/context-reinforcement.sh")"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "inactive session received workflow enforcement: $output"
+fi
+
+test_case "first-run message offers setup but never auto-invokes it"
+first_home="$TEST_TMP_DIR/first-run-home"
+mkdir -p "$first_home"
+output="$(printf '%s' '{"hook_event_name":"SessionStart","session_id":"first"}' \
+    | HOME="$first_home" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$PROJECT_ROOT/hooks/session-start-memory.sh")"
+if [[ "$output" == *"/octo:setup"* ]] \
+   && [[ "$output" != *"Invoke the octo:setup skill now"* ]] \
+   && [[ "$output" != *"auto-runs"* ]]; then
+    test_pass
+else
+    test_fail "first-run setup was not a manual offer: ${output:-<empty>}"
+fi
+
+test_case "provider validator is host-filtered to orchestrate.sh commands"
+if python3 - "$PROJECT_ROOT/hooks/hooks.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))["hooks"]["PreToolUse"]
+matches = [h for group in d for h in group.get("hooks", [])
+           if h.get("command", "").endswith("provider-routing-validator.sh")]
+raise SystemExit(0 if len(matches) == 1 and "orchestrate.sh" in matches[0].get("if", "") else 1)
+PY
+then
+    test_pass
+else
+    test_fail "provider validator still spawns for every Bash call"
+fi
+
+test_case "provider validator itself fast-exits on unrelated commands"
+output="$(printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"pwd"}}' \
+    | "$PROJECT_ROOT/hooks/provider-routing-validator.sh" 2>&1)"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "unrelated Bash command triggered provider validation: $output"
+fi
+
+test_case "quality gate is host-filtered and stale-client safe"
+if jq -e '
+    .hooks.PostToolUse[].hooks[]
+    | select(.command == "${CLAUDE_PLUGIN_ROOT}/hooks/quality-gate.sh")
+    | .if == "Bash(*orchestrate.sh*)"
+' "$PROJECT_ROOT/hooks/hooks.json" >/dev/null 2>&1 \
+    && [[ -z "$(printf '%s\n' '{"tool_name":"Bash","tool_input":{"command":"pwd"}}' \
+        | HOME="$home_dir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$PROJECT_ROOT/hooks/quality-gate.sh" 2>/dev/null)" ]]; then
+    test_pass
+else
+    test_fail "quality gate can still run for unrelated Bash calls"
+fi
+
+test_case "direct-provider guard is host-filtered to provider commands"
+if python3 - "$PROJECT_ROOT/hooks/hooks.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))["hooks"]["PreToolUse"]
+filters = sorted(h.get("if", "") for group in d for h in group.get("hooks", [])
+                 if h.get("command", "").endswith("codex-exec-guard.sh"))
+expected = ["Bash(codex *)", "Bash(gemini *)", "Bash(qwen *)"]
+raise SystemExit(0 if filters == expected else 1)
+PY
+then
+    test_pass
+else
+    test_fail "direct-provider guard still spawns for unrelated Bash commands"
+fi
+
+test_case "plugin subagents require an explicit Octopus workflow"
+bad=""
+for file in "$PROJECT_ROOT"/.claude/agents/*.md; do
+    grep -q 'Delegate only when the user explicitly starts an Octopus workflow' "$file" || bad="$bad ${file##*/}"
+done
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "subagents still advertise automatic delegation:$bad"
+fi
+
+test_case "Copilot agent adapters also require explicit selection"
+bad=""
+for file in "$PROJECT_ROOT"/.github/agents/*.agent.md; do
+    grep -q 'Use only when the user explicitly selects this agent or starts an Octopus workflow' "$file" || bad="$bad ${file##*/}"
+done
+if [[ -z "$bad" ]]; then
+    test_pass
+else
+    test_fail "Copilot adapters still advertise automatic delegation:$bad"
+fi
+
+test_case "statusline repair does not install a statusline for ordinary users"
+status_home="$TEST_TMP_DIR/statusline-default-off"
+mkdir -p "$status_home/.claude"
+printf '{}\n' > "$status_home/.claude/settings.json"
+HOME="$status_home" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$PROJECT_ROOT/hooks/statusline-auto-repair.sh"
+if [[ ! -e "$status_home/.claude-octopus/statusline.sh" ]]; then
+    test_pass
+else
+    test_fail "SessionStart installed an unrequested Octopus statusline"
+fi
+
+test_case "inactive hook defense paths stay below the latency ceiling"
+if python3 - "$PROJECT_ROOT" "$home_dir" <<'PY'
+import json, os, subprocess, sys, time
+root, home = sys.argv[1:]
+env = os.environ.copy()
+env.update(HOME=home, CLAUDE_PLUGIN_ROOT=root)
+cases = [
+    (root + "/hooks/user-prompt-submit.sh", {"session_id":"bench","prompt":"explain this function"}),
+    (root + "/hooks/provider-routing-validator.sh", {"tool_name":"Bash","tool_input":{"command":"pwd"}}),
+]
+start = time.monotonic()
+for path, payload in cases:
+    data = json.dumps(payload).encode()
+    for _ in range(25):
+        result = subprocess.run([path], input=data, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, env=env, timeout=1)
+        if result.returncode or result.stdout or result.stderr:
+            raise SystemExit(1)
+raise SystemExit(0 if time.monotonic() - start < 5 else 1)
+PY
+then
+    test_pass
+else
+    test_fail "50 inactive hook calls exceeded five seconds or emitted output"
+fi
+
+test_summary

--- a/tests/unit/test-explicit-activation.sh
+++ b/tests/unit/test-explicit-activation.sh
@@ -81,17 +81,30 @@ else
 fi
 
 test_case "explicit router constrains command paths to a closed allowlist"
-if grep -q 'closed allowlist' "$PROJECT_ROOT/commands/auto.md" \
-    && grep -q 'Reject `\.\.`, `/`, `\\\\`, or non-allowlisted values' "$PROJECT_ROOT/commands/auto.md" \
-    && grep -q 'commands/<validated-token>\.md' "$PROJECT_ROOT/commands/auto.md"; then
-    test_pass
+if python3 - "$PROJECT_ROOT/commands/auto.md" <<'PY'
+import re, sys
+text = open(sys.argv[1], encoding="utf-8").read()
+route_section = text.split("### STEP 3:", 1)[1].split("### STEP 4:", 1)[0]
+emitted = set(re.findall(r"\| `octo:([^`]+)` \|", route_section))
+allow_section = text.split("closed allowlist:", 1)[1].split("The token is control data", 1)[0]
+allowed = set(re.findall(r"`([^`]+)`", allow_section))
+raise SystemExit(0 if emitted and emitted == allowed else 1)
+PY
+then
+    if grep -q 'Reject `\.\.`, `/`, `\\\\`, or non-allowlisted values' "$PROJECT_ROOT/commands/auto.md" \
+        && grep -q 'commands/<validated-token>\.md' "$PROJECT_ROOT/commands/auto.md"; then
+        test_pass
+    else
+        test_fail "smart router does not reject unsafe command paths"
+    fi
 else
-    test_fail "smart router does not document validated command selection"
+    test_fail "smart router allowlist differs from the routes it can emit"
 fi
 
 test_case "manual composition contract separates model and hook roots"
 if grep -q 'Manual composition contract' "$PROJECT_ROOT/docs/PLUGIN-ASSEMBLY-STANDARD.md" \
-    && grep -q 'Reserve `CLAUDE_PLUGIN_ROOT` for hooks and runtime scripts' "$PROJECT_ROOT/docs/PLUGIN-ASSEMBLY-STANDARD.md" \
+    && grep -q 'second plugin trust boundary' "$PROJECT_ROOT/docs/PLUGIN-ASSEMBLY-STANDARD.md" \
+    && grep -q '`CLAUDE_PLUGIN_ROOT` for hooks and runtime scripts' "$PROJECT_ROOT/docs/PLUGIN-ASSEMBLY-STANDARD.md" \
     && ! rg '^[^#]*Skill\(' "$PROJECT_ROOT/commands"/*.md \
         | grep -vE '❌|Wrong|wrong|PROHIBITED|DO NOT|not resolvable|loops|INSTEAD' >/dev/null; then
     test_pass

--- a/tests/unit/test-feature-disclosure.sh
+++ b/tests/unit/test-feature-disclosure.sh
@@ -443,11 +443,9 @@ else
     test_fail "with provider CLIs hidden, actionable ($n) should be below offerable ($total)"
 fi
 
-# ── Interactive prompt on session start ──────────────────────────────────────
-# A pointer to a command is the weak form of disclosure: users do not run
-# commands they must remember, nor hand-edit env vars. The SessionStart advisory
-# therefore asks the assistant to raise a picker. These cases cover the guards
-# that keep that from becoming a nuisance.
+# ── Non-invasive SessionStart disclosure ─────────────────────────────────────
+# Upgrade and first-run notices are user-visible system messages. They must not
+# inject model context, call AskUserQuestion, or take over an unrelated prompt.
 
 ADVISORY_HOOK="$PROJECT_ROOT/hooks/version-advisory.sh"
 MEMORY_HOOK="$PROJECT_ROOT/hooks/session-start-memory.sh"
@@ -466,94 +464,62 @@ advisory() {
     fi
     touch "$state/.setup-complete"
     env "$@" OCTOPUS_STATE_DIR="$state" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
-        bash "$ADVISORY_HOOK" 2>/dev/null | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null
+        bash "$ADVISORY_HOOK" 2>/dev/null | jq -r '.systemMessage // .hookSpecificOutput.additionalContext // empty' 2>/dev/null
 }
 
-test_case "advisory emits an interactive picker directive on an upgrade"
+test_case "upgrade advisory is a user-visible system message"
 adv_state="$TEST_TMP_DIR/adv-a"; mkdir -p "$adv_state"
-out=$(advisory "$adv_state" -u CI -u OCTOPUS_NON_INTERACTIVE -u CLAUDE_CODE_REMOTE)
-if grep -q "OCTOPUS-NEW-FEATURES" <<<"$out" && grep -q "AskUserQuestion" <<<"$out"; then
+printf '{"last_seen_version":"9.55.0"}\n' > "$adv_state/state.json"
+touch "$adv_state/.setup-complete"
+raw=$(env -u CI -u OCTOPUS_NON_INTERACTIVE -u CLAUDE_CODE_REMOTE \
+    OCTOPUS_STATE_DIR="$adv_state" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+    bash "$ADVISORY_HOOK" 2>/dev/null)
+out=$(jq -r '.systemMessage // empty' <<<"$raw")
+if grep -q "Claude Octopus updated" <<<"$out" && jq -e 'has("systemMessage") and (has("hookSpecificOutput") | not)' <<<"$raw" >/dev/null; then
     test_pass
 else
-    test_fail "expected an AskUserQuestion directive, got: $(head -5 <<<"$out")"
+    test_fail "expected a systemMessage-only advisory, got: $(head -5 <<<"$raw")"
 fi
 
-test_case "the directive names each offerable feature"
-if grep -q "fable5-routing" <<<"$out"; then
+test_case "upgrade advisory never directs the model to act"
+if ! grep -qE "AskUserQuestion|Before doing anything else|OCTOPUS-NEW-FEATURES" <<<"$out" \
+   && grep -q "/octo:whats-new" <<<"$out"; then
     test_pass
 else
-    test_fail "directive must carry the feature ids so the picker can be built"
+    test_fail "advisory should be a passive explicit-command pointer: $(head -5 <<<"$out")"
 fi
 
-# Choosing the default is an answer. If the directive let the assistant skip
-# recording it, the user who said "not at all" would be asked again every upgrade.
-test_case "the directive requires recording every answer, defaults included"
-if grep -q "octo_features_record" <<<"$out" && grep -qi "including any that picks the default" <<<"$out"; then
+test_case "upgrade advisory records the version after one notice"
+if jq -e --arg v "$(jq -r .version "$PROJECT_ROOT/.claude-plugin/plugin.json")" '.last_seen_version == $v' "$adv_state/state.json" >/dev/null; then
     test_pass
 else
-    test_fail "an unrecorded default choice would be re-asked forever"
+    test_fail "last_seen_version was not advanced"
 fi
 
-# A literal tab, not "\t" in the pattern: BSD grep -E (macOS) expands \t to a
-# tab while GNU grep -E (Linux) does not, so a \t pattern matches locally and
-# silently fails on the runner.
-TAB=$'\t'
-
-test_case "the directive carries each feature's own choices, not a yes/no"
-if grep -qE "^C${TAB}fable5-routing${TAB}escalate${TAB}" <<<"$out" \
-   && grep -qE "^C${TAB}fable5-routing${TAB}on-demand${TAB}" <<<"$out"; then
+test_case "second SessionStart is silent after the upgrade notice"
+second=$(env OCTOPUS_STATE_DIR="$adv_state" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$ADVISORY_HOOK" 2>/dev/null)
+if [[ -z "$second" ]]; then
     test_pass
 else
-    test_fail "policy choices must reach the picker verbatim"
+    test_fail "upgrade advisory repeated: $second"
 fi
 
-test_case "the directive carries the question text, not just the feature title"
-if grep -qE "^Q${TAB}fable5-routing${TAB}How should Claude Fable 5 be used\?" <<<"$out"; then
-    test_pass
-else
-    test_fail "the picker needs the feature's own question"
-fi
-
-# A cron or headless run has nobody to answer; prompting there burns the turn.
-test_case "a non-interactive session gets the pointer, never the picker"
+test_case "non-interactive upgrades also avoid model directives"
 adv_state="$TEST_TMP_DIR/adv-ci"; mkdir -p "$adv_state"
 out=$(advisory "$adv_state" CI=1)
-if ! grep -q "OCTOPUS-NEW-FEATURES" <<<"$out" && grep -q "whats-new" <<<"$out"; then
+if ! grep -qE "AskUserQuestion|OCTOPUS-NEW-FEATURES" <<<"$out"; then
     test_pass
 else
-    test_fail "CI run should degrade to the pointer, got: $(head -5 <<<"$out")"
+    test_fail "CI run received a model directive: $(head -5 <<<"$out")"
 fi
 
-test_case "a remote session gets the pointer, never the picker"
+test_case "remote upgrades also avoid model directives"
 adv_state="$TEST_TMP_DIR/adv-remote"; mkdir -p "$adv_state"
 out=$(advisory "$adv_state" -u CI CLAUDE_CODE_REMOTE=true)
-if ! grep -q "OCTOPUS-NEW-FEATURES" <<<"$out"; then
+if ! grep -qE "AskUserQuestion|OCTOPUS-NEW-FEATURES" <<<"$out"; then
     test_pass
 else
-    test_fail "remote sessions must not raise a picker"
-fi
-
-# Anti-nagware: an unanswered prompt leaves everything undecided, which is
-# indistinguishable from never-offered, so without a cap it re-asks forever.
-test_case "the picker is spent after OCTOPUS_FEATURES_PROMPT_MAX attempts"
-adv_state="$TEST_TMP_DIR/adv-budget"; mkdir -p "$adv_state"
-results=""
-for _ in 1 2 3; do
-    o=$(advisory "$adv_state" -u CI -u OCTOPUS_NON_INTERACTIVE -u CLAUDE_CODE_REMOTE)
-    if grep -q "OCTOPUS-NEW-FEATURES" <<<"$o"; then results="${results}P"; else results="${results}f"; fi
-done
-if [[ "$results" == "PPf" ]]; then
-    test_pass
-else
-    test_fail "expected prompt,prompt,fallback (PPf), got '$results'"
-fi
-
-test_case "a spent budget still emits the pointer rather than going silent"
-o=$(advisory "$adv_state" -u CI -u OCTOPUS_NON_INTERACTIVE -u CLAUDE_CODE_REMOTE)
-if grep -q "whats-new" <<<"$o"; then
-    test_pass
-else
-    test_fail "discoverability must degrade, not disappear"
+    test_fail "remote run received a model directive"
 fi
 
 test_case "a newer plugin version resets the prompt budget"
@@ -585,21 +551,22 @@ fi
 
 # The first-run welcome claimed to trigger setup via additionalContext while only
 # echoing bare text, which SessionStart does not accept as context.
-test_case "first-run welcome emits a valid SessionStart object, not bare text"
+test_case "first-run welcome is a user-visible system message"
 fr_home="$TEST_TMP_DIR/firstrun-home"
 rm -rf "$fr_home"; mkdir -p "$fr_home"
 out=$(env HOME="$fr_home" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$MEMORY_HOOK" 2>/dev/null)
-if printf '%s' "$out" | jq -e '.hookSpecificOutput.hookEventName == "SessionStart"' >/dev/null 2>&1; then
+if printf '%s' "$out" | jq -e 'has("systemMessage") and (has("hookSpecificOutput") | not)' >/dev/null 2>&1; then
     test_pass
 else
-    test_fail "first-run must emit hookSpecificOutput, got: $(printf '%s' "$out" | head -2)"
+    test_fail "first-run must emit systemMessage only, got: $(printf '%s' "$out" | head -2)"
 fi
 
-test_case "first-run directs the assistant to run setup"
-if printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null | grep -qi "octo:setup"; then
+test_case "first-run offers setup without directing model action"
+message=$(printf '%s' "$out" | jq -r '.systemMessage // empty' 2>/dev/null)
+if grep -qi "octo:setup" <<<"$message" && ! grep -qiE "invoke|before doing anything|auto-run" <<<"$message"; then
     test_pass
 else
-    test_fail "the welcome must name the setup skill"
+    test_fail "the welcome must passively offer setup: $message"
 fi
 
 test_case "first-run stays silent on the second session"

--- a/tests/unit/test-github-work-queue-hook.sh
+++ b/tests/unit/test-github-work-queue-hook.sh
@@ -26,6 +26,14 @@ else
     test_fail "github-work-queue-watch.sh not registered in UserPromptSubmit hooks"
 fi
 
+test_case "hook is silent unless explicitly enabled"
+output=$(HOME="$TEST_TMP_DIR/github-work-queue-default-off" "$HOOK" <<<'{"prompt":"what should we work on"}')
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "default hook output: $output"
+fi
+
 mock_bin="$TEST_TMP_DIR/github-work-queue-bin"
 mock_home="$TEST_TMP_DIR/github-work-queue-home"
 mkdir -p "$mock_bin" "$mock_home"
@@ -51,7 +59,7 @@ SH
 chmod +x "$mock_bin/gh"
 
 test_case "hook emits open issues and PRs as additional context"
-output=$(cd "$PROJECT_ROOT" && HOME="$mock_home" PATH="$mock_bin:$PATH" OCTOPUS_GITHUB_WORK_QUEUE_FORCE=1 OCTOPUS_GITHUB_WORK_QUEUE_ISSUE=370 "$HOOK" <<'JSON'
+output=$(cd "$PROJECT_ROOT" && HOME="$mock_home" PATH="$mock_bin:$PATH" OCTOPUS_GITHUB_WORK_QUEUE=on OCTOPUS_GITHUB_WORK_QUEUE_FORCE=1 OCTOPUS_GITHUB_WORK_QUEUE_ISSUE=370 "$HOOK" <<'JSON'
 {"prompt":"what should we work on"}
 JSON
 )
@@ -65,11 +73,11 @@ fi
 test_case "hook debounces repeated checks"
 debounce_home="$TEST_TMP_DIR/github-work-queue-debounce-home"
 mkdir -p "$debounce_home"
-first=$(cd "$PROJECT_ROOT" && HOME="$debounce_home" PATH="$mock_bin:$PATH" "$HOOK" <<'JSON'
+first=$(cd "$PROJECT_ROOT" && HOME="$debounce_home" PATH="$mock_bin:$PATH" OCTOPUS_GITHUB_WORK_QUEUE=on "$HOOK" <<'JSON'
 {"prompt":"first"}
 JSON
 )
-second=$(cd "$PROJECT_ROOT" && HOME="$debounce_home" PATH="$mock_bin:$PATH" "$HOOK" <<'JSON'
+second=$(cd "$PROJECT_ROOT" && HOME="$debounce_home" PATH="$mock_bin:$PATH" OCTOPUS_GITHUB_WORK_QUEUE=on "$HOOK" <<'JSON'
 {"prompt":"second"}
 JSON
 )

--- a/tests/unit/test-human-only-skill-list.sh
+++ b/tests/unit/test-human-only-skill-list.sh
@@ -1,99 +1,46 @@
 #!/usr/bin/env bash
-# The human-only skill list must be derived from skill frontmatter, not retyped.
-#
-# Six skills declare `invocation: human_only`. The only thing that acts on that
-# intent is a prose reminder injected by hooks/context-reinforcement.sh, and its
-# list was hardcoded — it named five, omitting octopus-ui-ux-design, so a skill
-# that declared itself human-only was never reinforced as such.
-#
-# Note what this is NOT: `disable-model-invocation: true` would be the native
-# mechanism, but four of these skills are named in command bodies
-# (commands/parallel.md, factory.md, research.md, security.md) and are reached
-# by the model on the user's behalf when it runs those commands. Disabling model
-# invocation would break those routes. "Human-only" here means "do not fire from
-# prompt-keyword auto-routing", which is advisory by nature — so the fix is to
-# stop the advisory drifting from the declaration, not to change mechanisms.
+# Compatibility filename: verifies the native explicit-invocation gate that
+# replaced the old advisory human-only list.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd)"
 
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
-test_suite "Human-only skill list stays in sync with frontmatter"
+test_suite "Native manual-only skill gate"
 
-HOOK="$PROJECT_ROOT/hooks/context-reinforcement.sh"
+frontmatter_value() {
+    local file="$1" key="$2"
+    awk -v key="$key" '
+        BEGIN { fm = 0 }
+        /^---$/ { if (fm) exit; fm = 1; next }
+        fm && index($0, key ":") == 1 {
+            sub("^" key ":[[:space:]]*", "")
+            print
+            exit
+        }
+    ' "$file"
+}
 
-# The declared set: every skill whose frontmatter asks not to be auto-triggered.
-declared=$(grep -l "^invocation: human_only" "$PROJECT_ROOT"/.claude/skills/*/SKILL.md 2>/dev/null \
-    | while IFS= read -r f; do sed -n 's/^name: *//p' "$f" | head -1; done | sort)
-
-test_case "at least one skill declares invocation: human_only"
-if [[ -n "$declared" ]]; then
-    test_pass
-else
-    test_fail "no skill declares human_only — this suite would be vacuous; delete it or restore the declarations"
-fi
-
-test_case "the hook emits a human-only line"
-emitted=$(echo '{}' | bash "$HOOK" 2>/dev/null | python3 -c "
-import sys, json
-try:
-    d = json.load(sys.stdin)
-    print(d['hookSpecificOutput']['additionalContext'])
-except Exception:
-    pass
-" 2>/dev/null || true)
-if grep -q "Human-only skills" <<< "$emitted"; then
-    test_pass
-else
-    test_fail "hook output carries no human-only line; got: $(head -c 200 <<< "$emitted")"
-fi
-
-# The real assertion. Every declaring skill must appear in what the hook emits.
-# The hook lists exact skill names, so both directions can be checked precisely.
-# Substring matching would have hidden the original bug: "deep-research" reads
-# plausibly but matches no skill, because that skill is named octopus-research.
-hook_names=$(grep -o "Human-only skills[^:]*: *[^.]*" <<< "$emitted" \
-    | sed 's/.*: *//' | tr ',' '\n' | tr -d ' ' | grep -v '^$' | sort)
-
-test_case "every skill declaring human_only is named in the hook output"
-missing=$(comm -23 <(echo "$declared") <(echo "$hook_names"))
-if [[ -z "$missing" ]]; then
-    test_pass
-else
-    test_fail "declared human-only but absent from the hook reminder: $(echo $missing)"
-fi
-
-# The other direction: a name in the hook that no skill declares is either a
-# typo or an entry that outlived its skill.
-test_case "the hook names no skill that stopped declaring human_only"
-stray=$(comm -13 <(echo "$declared") <(echo "$hook_names"))
-if [[ -z "$stray" ]]; then
-    test_pass
-else
-    test_fail "hook names skills that do not declare human_only: $(echo $stray)"
-fi
-
-test_case "the hook uses real skill names, not directory names"
+test_case "all source skills disable model invocation"
 bad=""
-while IFS= read -r n; do
-    [[ -n "$n" ]] || continue
-    grep -rqx "name: $n" "$PROJECT_ROOT"/.claude/skills/*/SKILL.md || bad="$bad $n"
-done <<< "$hook_names"
-if [[ -z "$bad" ]]; then
-    test_pass
-else
-    test_fail "not resolvable to any skill's frontmatter name:$bad"
-fi
+while IFS= read -r file; do
+    [[ "$(frontmatter_value "$file" disable-model-invocation)" == "true" ]] || bad="$bad ${file#$PROJECT_ROOT/}"
+done < <(find "$PROJECT_ROOT/.claude/skills" -name SKILL.md -type f | sort)
+if [[ -z "$bad" ]]; then test_pass; else test_fail "missing native gate:$bad"; fi
 
-# The key must stay meaningful. build-factory-skills.sh strips `invocation` from
-# generated output, so nothing downstream reads it — this suite is the only
-# thing that makes the declaration load-bearing.
-test_case "the declaration is documented as advisory, not as a native gate"
-if grep -q "disable-model-invocation" "$HOOK" || grep -qi "advisory\|auto-trigger" "$HOOK"; then
+test_case "all generated skills preserve the native gate"
+bad=""
+while IFS= read -r file; do
+    [[ "$(frontmatter_value "$file" disable-model-invocation)" == "true" ]] || bad="$bad ${file#$PROJECT_ROOT/}"
+done < <(find "$PROJECT_ROOT/skills" -name SKILL.md -type f | sort)
+if [[ -z "$bad" ]]; then test_pass; else test_fail "generated gate drift:$bad"; fi
+
+test_case "workflow reinforcement is session-affine"
+if grep -q 'octo_hook_workflow_active' "$PROJECT_ROOT/hooks/context-reinforcement.sh"; then
     test_pass
 else
-    test_fail "the hook should state what human-only actually enforces, so the next reader does not assume it is a hard gate"
+    test_fail "context reinforcement lacks an active-session gate"
 fi
 
 test_summary

--- a/tests/unit/test-lifecycle-commands.sh
+++ b/tests/unit/test-lifecycle-commands.sh
@@ -170,10 +170,10 @@ echo "Test 12: Checking COMMAND-REFERENCE.md updated..."
 CMD_REF="$PROJECT_ROOT/docs/COMMAND-REFERENCE.md"
 if [[ -f "$CMD_REF" ]]; then
     lifecycle_features=("Status" "Issues" "Rollback" "Resume" "Ship")
-    if grep -q "These features are triggered by natural language — they are not slash commands." "$CMD_REF"; then
-        pass "COMMAND-REFERENCE.md marks lifecycle features as non-slash commands"
+    if grep -q "These are manual-only plugin skills, not standalone.*commands" "$CMD_REF"; then
+        pass "COMMAND-REFERENCE.md marks lifecycle features as explicit-only skills"
     else
-        fail "COMMAND-REFERENCE.md missing lifecycle note" "Should explain these are natural-language skill triggers"
+        fail "COMMAND-REFERENCE.md missing lifecycle note" "Should explain these are explicit-only skills"
     fi
     for feature in "${lifecycle_features[@]}"; do
         if grep -q "### \`$feature\`" "$CMD_REF"; then

--- a/tests/unit/test-plugin-update-health.sh
+++ b/tests/unit/test-plugin-update-health.sh
@@ -157,6 +157,13 @@ test_case "hook gives host UI remediation"
 if assert_contains "$HOOK_OUTPUT" "Enable auto-update"; then test_pass; fi
 test_case "hook explains loaded-session refresh"
 if assert_contains "$HOOK_OUTPUT" "/reload-plugins"; then test_pass; fi
+test_case "hook is user-visible and never directs model action"
+if jq -e 'has("systemMessage") and (has("hookSpecificOutput") | not)' <<<"$HOOK_OUTPUT" >/dev/null 2>&1 \
+   && ! grep -q 'Ask to run' <<<"$HOOK_OUTPUT"; then
+    test_pass
+else
+    test_fail "update advisory should be a passive systemMessage: $HOOK_OUTPUT"
+fi
 test_case "SessionStart advisory performs no CLI or network calls"
 if [[ ! -s "$CALL_LOG" ]]; then test_pass; else test_fail "advisory invoked forbidden tools"; fi
 

--- a/tests/unit/test-post-tool-dispatch.sh
+++ b/tests/unit/test-post-tool-dispatch.sh
@@ -30,7 +30,7 @@ PAYLOAD="$(build_verbose_payload)"
 output=""
 # output-compressor.sh only analyzes every 3rd call (debounce); drive it there.
 for _ in 1 2 3; do
-    output="$(CLAUDE_SESSION_ID="$SESSION" printf '%s' "$PAYLOAD" | CLAUDE_SESSION_ID="$SESSION" bash "$HOOK")"
+    output="$(printf '%s' "$PAYLOAD" | CLAUDE_SESSION_ID="$SESSION" OCTOPUS_COMPRESS_ENABLED=true bash "$HOOK")"
 done
 rm -f "$DEBOUNCE_FILE"
 
@@ -60,6 +60,26 @@ if [[ -z "$output" ]]; then
     test_pass
 else
     test_fail "expected silence for small/uninteresting output, got: ${output:-<empty>}"
+fi
+
+
+test_case "large output is also silent when compression is not opted in"
+output="$(build_verbose_payload | CLAUDE_SESSION_ID="$SESSION-default-off" bash "$HOOK")"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "expected default silence for large output, got: ${output:-<empty>}"
+fi
+
+test_case "statusline bridge alone does not activate context injection"
+bridge="/tmp/octopus-ctx-${SESSION-default-off}.json"
+printf '{"used_pct":60}\n' > "$bridge"
+output="$(printf 'ok' | CLAUDE_SESSION_ID="$SESSION-default-off" bash "$HOOK")"
+rm -f "$bridge"
+if [[ -z "$output" ]]; then
+    test_pass
+else
+    test_fail "statusline state activated PostToolUse context: ${output:-<empty>}"
 fi
 
 test_summary

--- a/tests/unit/test-remote-session.sh
+++ b/tests/unit/test-remote-session.sh
@@ -84,28 +84,28 @@ else
     fail "Node HUD exits early in remote sessions" "HUD remote early exit missing"
 fi
 
-if grep -q 'remote_session.*true' "$SESSION_START" && grep -q 'setup-complete' "$SESSION_START"; then
-    pass "SessionStart records remote sessions without first-run setup"
+if grep -q 'OCTOPUS_REMOTE_SESSION.*true' "$SESSION_START" && grep -q 'setup-complete' "$SESSION_START"; then
+    pass "SessionStart requires an explicit remote-workflow signal"
 else
-    fail "SessionStart records remote sessions without first-run setup" "remote session state missing"
+    fail "SessionStart requires an explicit remote-workflow signal" "explicit remote gate missing"
 fi
 
 tmp_home=$(mktemp -d)
 session_output=$(HOME="$tmp_home" CLAUDE_CODE_REMOTE=true "$SESSION_START" 2>/dev/null || true)
 session_file="$tmp_home/.claude-octopus/session.json"
-if [[ -f "$tmp_home/.claude-octopus/.setup-complete" && -f "$session_file" && -z "$session_output" ]] &&
-   jq -e '.remote_session == true and .autonomy == "autonomous"' "$session_file" >/dev/null 2>&1; then
-    pass "SessionStart remote mode records state and suppresses first-run prompt"
+if [[ -f "$tmp_home/.claude-octopus/.setup-complete" && ! -f "$session_file" ]] &&
+   grep -q '/octo:setup' <<<"$session_output"; then
+    pass "Claude hosting alone does not activate a remote Octopus workflow"
 else
-    fail "SessionStart remote mode records state and suppresses first-run prompt" "remote state was not recorded correctly"
+    fail "Claude hosting alone does not activate a remote Octopus workflow" "unexpected automatic remote state"
 fi
 
 tmp_home=$(mktemp -d)
-HOME="$tmp_home" CLAUDE_CODE_REMOTE=true OCTOPUS_AUTONOMY=supervised "$SESSION_START" >/dev/null 2>&1 || true
+HOME="$tmp_home" CLAUDE_CODE_REMOTE=true OCTOPUS_REMOTE_SESSION=true OCTOPUS_AUTONOMY=supervised "$SESSION_START" >/dev/null 2>&1 || true
 if jq -e '.remote_session == true and .autonomy == "supervised"' "$tmp_home/.claude-octopus/session.json" >/dev/null 2>&1; then
-    pass "SessionStart preserves explicit remote autonomy"
+    pass "explicit remote workflow preserves explicit autonomy"
 else
-    fail "SessionStart preserves explicit remote autonomy" "explicit autonomy was not preserved"
+    fail "explicit remote workflow preserves explicit autonomy" "explicit remote state was not recorded"
 fi
 
 readme_content=$(read_repo_file "README.md")

--- a/tests/unit/test-research-fanout-static.sh
+++ b/tests/unit/test-research-fanout-static.sh
@@ -17,10 +17,11 @@ else
 fi
 
 test_case "research command routes to dedicated research skill"
-if [[ "$research_cmd" == *'Skill(skill: "octopus-research"'* && "$research_cmd" != *'Skill(skill: "octo:discover"'* ]]; then
+if [[ "$research_cmd" == *'.claude/skills/skill-deep-research/SKILL.md'* \
+   && "$research_cmd" != *'Read `${HOME}/.claude-octopus/plugin/.claude/skills/flow-discover/'* ]]; then
     test_pass
 else
-    test_fail "expected /octo:research to invoke octopus-research, not octo:discover"
+    test_fail "expected /octo:research to load its dedicated source, not discover"
 fi
 
 test_case "discover skill requires dynamic multi-provider fleet"

--- a/tests/unit/test-skill-frontmatter.sh
+++ b/tests/unit/test-skill-frontmatter.sh
@@ -122,11 +122,12 @@ validate_frontmatter() {
     if echo "$frontmatter" | grep -A 1 "^trigger:" | grep -q "|"; then
       pass "$filename: 'trigger' uses multi-line format"
 
-      # Check for "AUTOMATICALLY ACTIVATE" pattern
-      if echo "$frontmatter" | grep -q "AUTOMATICALLY ACTIVATE"; then
-        pass "$filename: 'trigger' contains activation pattern"
+      # Manual-only skills use the trigger field as slash-menu guidance, never
+      # as permission for model invocation.
+      if echo "$frontmatter" | grep -q "EXPLICITLY USE"; then
+        pass "$filename: 'trigger' contains explicit-use pattern"
       else
-        warn "$filename: 'trigger' missing 'AUTOMATICALLY ACTIVATE' pattern"
+        warn "$filename: 'trigger' missing 'EXPLICITLY USE' pattern"
       fi
 
       # Check for "DO NOT activate" pattern

--- a/tests/unit/test-smart-router.sh
+++ b/tests/unit/test-smart-router.sh
@@ -149,7 +149,7 @@ assert_contains "$OCTO_MD" "CLAUDE OCTOPUS ACTIVATED" "has visual indicator bann
 # ── Prohibited actions ────────────────────────────────────────────────────────
 
 assert_contains "$OCTO_MD" "Prohibited" "has Prohibited Actions section"
-assert_contains "$OCTO_MD" "MUST use Skill tool" "prohibits simulating workflow execution"
+assert_contains "$OCTO_MD" "following the selected command file" "prohibits simulating workflow execution"
 
 # ── No chain workflows documentation (removed — not implemented) ──────────────
 

--- a/tests/unit/test-v8.27.0-superpowers-hardening.sh
+++ b/tests/unit/test-v8.27.0-superpowers-hardening.sh
@@ -130,10 +130,10 @@ suite "4. Human-Only Invocation Flag"
 # 4.1-4.5 Check each skill for human_only
 for skill in skill-factory skill-deep-research skill-security-audit flow-parallel skill-ship; do
   SKILL_FILE="$(resolve_claude_skill_path "$skill")"
-  if grep -q 'invocation: human_only' "$SKILL_FILE"; then
-    pass "${skill} has invocation: human_only"
+  if grep -q 'disable-model-invocation: true' "$SKILL_FILE"; then
+    pass "${skill} has native manual-only invocation"
   else
-    fail "${skill} missing invocation: human_only"
+    fail "${skill} missing disable-model-invocation: true"
   fi
 done
 

--- a/tests/unit/test-v8.27.0-superpowers-hardening.sh
+++ b/tests/unit/test-v8.27.0-superpowers-hardening.sh
@@ -52,12 +52,12 @@ else
   fail "hooks.json missing context-reinforcement.sh reference"
 fi
 
-# 1.4 Hook outputs valid JSON when given empty stdin
+# 1.4 Hook stays dormant without an active, matching workflow
 HOOK_OUTPUT=$(echo '{}' | bash "$PLUGIN_DIR/hooks/context-reinforcement.sh" 2>/dev/null || true)
-if echo "$HOOK_OUTPUT" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
-  pass "context-reinforcement.sh outputs valid JSON"
+if [[ -z "$HOOK_OUTPUT" ]]; then
+  pass "context-reinforcement.sh is silent outside an active workflow"
 else
-  fail "context-reinforcement.sh does not output valid JSON"
+  fail "context-reinforcement.sh engaged outside an active workflow" "$HOOK_OUTPUT"
 fi
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/unit/test-workflow-meta-contracts.sh
+++ b/tests/unit/test-workflow-meta-contracts.sh
@@ -31,7 +31,7 @@ if grep -q "route according to the user's explicit" <<< "$delivery_block" &&
    grep -q '^\- \*\*Review only:\*\*' <<< "$delivery_block" &&
    grep -q 'Do not update the project' <<< "$delivery_block" &&
    grep -q 'Run this block only when the user explicitly requested shipping' <<< "$delivery_block" &&
-   grep -q 'Skill(skill: "skill-ship"' <<< "$delivery_block" &&
+   grep -q 'Read .*skill-ship/SKILL.md' <<< "$delivery_block" &&
    ! grep -q '^Suggest:' <<< "$delivery_block"; then
     test_pass
 else

--- a/tests/unit/test-write-intent.sh
+++ b/tests/unit/test-write-intent.sh
@@ -204,11 +204,11 @@ test_version_advisory_emits_on_version_change() {
     rm -rf "$tmpdir"
     if version_ge "$current_version" "$min_version" &&
        jq -e --arg old "$min_version" --arg current "$current_version" '
-           (.hookSpecificOutput.additionalContext // "") as $ctx
-           | .hookSpecificOutput.hookEventName == "SessionStart"
-             and ($ctx | contains($old))
-             and ($ctx | contains($current))
-             and (($ctx | contains("/octo:setup")) or ($ctx | contains("OCTOPUS_LEGACY_ROLES")))
+           (.systemMessage // "") as $msg
+           | (has("hookSpecificOutput") | not)
+             and ($msg | contains($old))
+             and ($msg | contains($current))
+             and ($msg | contains("/octo:whats-new"))
        ' <<<"$output" >/dev/null 2>&1; then
         test_pass
     else


### PR DESCRIPTION
## Summary

- make every Octopus command and skill native manual-only, and gate Octopus agents behind explicit workflows
- default routing, coaching, memory/context injection, remote autonomy, statusline mutation, work-queue checks, and PostToolUse behavior to off unless explicitly enabled or bound to the active host session
- use Claude Code handler-level `if` filters plus stale-client fast exits to avoid unrelated provider/quality hook work
- advance the stable plugin entrypoint to the host-loaded version so valid old caches cannot strand users on stale hooks

## Root cause

Installation registered broad prompt, tool, and session hooks. Plain-language routing defaulted to invoke, multiple hooks parsed every prompt/tool call, startup output instructed the model to act, and skills remained model-invocable. Shared workflow state was not tied to the current Claude session. Separately, `~/.claude-octopus/plugin` accepted any still-valid old cache target after an update.

## Performance

Before: common inactive hook paths averaged roughly 38–41 ms; an unrelated provider-validation path could block for about 18 seconds per call.

After: defense-in-depth inactive script paths measure roughly 6–14 ms. Claude Code 2.1.85+ skips the filtered process spawn entirely.

## Verification

- `make sync`
- `make sync-check`
- `git diff --check`
- fresh `make ci-local`: all smoke, unit, integration, and CI-only verification groups passed
- explicit activation regression: 18/18
- stale stable-entrypoint regression: 2/2

Closes #898
