### PR TITLE
chore: release v9.64.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.63.0"
+    "version": "9.64.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.63.0 - Add cost modes and harden provider and hook reliability. 32 personas, 54 commands, 63 skills. Run /octo:setup.",
-      "version": "9.63.0",
+      "description": "v9.64.0 - Keep Octopus dormant until explicitly invoked. 32 personas, 54 commands, 63 skills. Run /octo:setup.",
+      "version": "9.64.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": "2026-06",
   "name": "octo",
   "displayName": "Claude Octopus",
-  "version": "9.63.0",
+  "version": "9.64.0",
   "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
   "author": {
     "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.63.0",
-  "description": "v9.63.0 \u2014 Add cost modes and harden provider and hook reliability. Run /octo:setup.",
+  "version": "9.64.0",
+  "description": "v9.64.0 \u2014 Keep Octopus dormant until explicitly invoked. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Claude Octopus routine manifest (v9.63.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "$comment": "Claude Octopus routine manifest (v9.64.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
   "schemaVersion": 1,
   "routines": [
     {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.63.0",
+  "version": "9.64.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Antigravity, Grok, Copilot, Qwen, Perplexity, OpenRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.63.0",
+  "version": "9.64.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.63.0"
+    "version": "9.64.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.63.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 54 commands, 63 skills. Run /octo:setup after install.",
-      "version": "9.63.0",
+      "description": "v9.64.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 54 commands, 63 skills. Run /octo:setup after install.",
+      "version": "9.64.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.63.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.63.0. 32 expert personas, 54 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.64.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.64.0. 32 expert personas, 54 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [9.64.0] - 2026-08-13
+
+
 ### Changed
 
 - Octopus is dormant by default. All shipped commands and skills use Claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ## [9.64.0] - 2026-08-13
 
-
 ### Changed
 
 - Octopus is dormant by default. All shipped commands and skills use Claude

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-12
+last_reviewed: 2026-08-13
 ---
 
 # PRODUCT.md
@@ -79,7 +79,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 - GitHub stars: 3,889
 - GitHub forks: 365
 - Local CI parity: `make ci-local` runs the same smoke, unit, and integration suites as CI
-- Version: 9.63.0 (active release cadence)
+- Version: 9.64.0 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Antigravity CLI
 
 **Measured Impact:**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
 <p align="center">
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/Version-9.63.0-blue" alt="Version 9.63.0">
+  <img src="https://img.shields.io/badge/Version-9.64.0-blue" alt="Version 9.64.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -35,7 +35,7 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
 ## What's New
 
 <!-- BEGIN CURRENT RELEASE -->
-> 🆕 **v9.63.0 — Add cost modes and harden provider and hook reliability.**
+> 🆕 **v9.64.0 — Keep Octopus dormant until explicitly invoked.**
 >
 > **Default roster:** Claude Opus 5 leads architecture, planning, security reasoning, and final judgment; GPT-5.6 Sol is the independent implementation/review peer; Claude Sonnet 5 is the standard Claude seat; Fable 5 remains an opt-in judgment escalation. Existing model pins and provider configuration still win. See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md).
 <!-- END CURRENT RELEASE -->
@@ -55,7 +55,7 @@ Every AI model has blind spots. Claude Octopus supports nine external provider i
 
 | Version | Best Features |
 |---------|--------------|
-| **v9.63.0** (new) | Add cost modes and harden provider and hook reliability. |
+| **v9.64.0** (new) | Keep Octopus dormant until explicitly invoked. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
 | **v9** | Up to 9 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Explicit-only activation by default, with an optional smart router. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Opt-in discipline gates and token compression. Two-stage review. Circuit breakers with automatic provider recovery inside active workflows. Cursor + OpenCode + Codex cross-compatibility. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.63.0",
+  "version": "9.64.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/scripts/lib/release-changelog.sh
+++ b/scripts/lib/release-changelog.sh
@@ -48,10 +48,19 @@ octo_release_update_changelog() {
                 printf "## [Unreleased]\n\n"
                 printf "## [%s] - %s\n\n", version, release_date
 
-                trimmed = body
-                gsub(/^[[:space:]\n]+|[[:space:]\n]+$/, "", trimmed)
-                if (saw_unreleased && trimmed != "") {
-                    printf "%s\n\n", trimmed
+                content = body
+                while (substr(content, 1, 1) == "\n") {
+                    content = substr(content, 2)
+                }
+                while (length(content) > 1 && substr(content, length(content) - 1, 2) == "\n\n") {
+                    content = substr(content, 1, length(content) - 1)
+                }
+                if (saw_unreleased && content != "") {
+                    printf "%s", content
+                    if (content !~ /\n$/) {
+                        printf "\n"
+                    }
+                    printf "\n"
                 } else {
                     printf "### Changed\n\n"
                     printf "- %s\n\n", summary

--- a/scripts/lib/release-changelog.sh
+++ b/scripts/lib/release-changelog.sh
@@ -51,13 +51,7 @@ octo_release_update_changelog() {
                 trimmed = body
                 gsub(/^[[:space:]\n]+|[[:space:]\n]+$/, "", trimmed)
                 if (saw_unreleased && trimmed != "") {
-                    printf "%s", body
-                    if (body !~ /\n$/) {
-                        printf "\n"
-                    }
-                    if (body !~ /\n\n$/) {
-                        printf "\n"
-                    }
+                    printf "%s\n\n", trimmed
                 } else {
                     printf "### Changed\n\n"
                     printf "- %s\n\n", summary

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -17,12 +17,6 @@ RELEASE_SCRIPT="$PROJECT_ROOT/scripts/release.sh"
 CHANGELOG_LIB="$PROJECT_ROOT/scripts/lib/release-changelog.sh"
 CI_LIB="$PROJECT_ROOT/scripts/lib/release-ci.sh"
 LOCAL_MARKETPLACE="$PROJECT_ROOT/.claude-plugin/marketplace.json"
-TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/octo-shared-marketplace-test.XXXXXX")"
-
-cleanup() {
-    rm -rf "$TMP_DIR"
-}
-trap cleanup EXIT
 
 pass() { test_case "$1"; test_pass; }
 fail() { test_case "$1"; test_fail "${2:-$1}"; }
@@ -219,7 +213,7 @@ test_marketplace_description_error_uses_logger() {
 test_local_marketplace_sync_aligns_all_versions() {
     test_case "sync-marketplace rejects and repairs stale marketplace version fields"
 
-    local fixture="$TMP_DIR/local-sync"
+    local fixture="$TEST_TMP_DIR/local-sync"
     local check_before_rc=0
     local check_after_rc=0
     local check_entry_rc=0
@@ -254,21 +248,21 @@ JSON
 }
 JSON
 
-    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TMP_DIR/local-sync-check-before.out" 2>&1 || check_before_rc=$?
-    bash "$fixture/scripts/sync-marketplace.sh" > "$TMP_DIR/local-sync-update.out" 2>&1
-    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TMP_DIR/local-sync-check-after.out" 2>&1 || check_after_rc=$?
+    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TEST_TMP_DIR/local-sync-check-before.out" 2>&1 || check_before_rc=$?
+    bash "$fixture/scripts/sync-marketplace.sh" > "$TEST_TMP_DIR/local-sync-update.out" 2>&1
+    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TEST_TMP_DIR/local-sync-check-after.out" 2>&1 || check_after_rc=$?
 
     jq '(.plugins[] | select(.name == "octo") | .version) = "1.0.0"' \
-        "$fixture/.claude-plugin/marketplace.json" > "$TMP_DIR/local-sync-entry-stale.json"
-    mv "$TMP_DIR/local-sync-entry-stale.json" "$fixture/.claude-plugin/marketplace.json"
-    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TMP_DIR/local-sync-check-entry.out" 2>&1 || check_entry_rc=$?
+        "$fixture/.claude-plugin/marketplace.json" > "$TEST_TMP_DIR/local-sync-entry-stale.json"
+    mv "$TEST_TMP_DIR/local-sync-entry-stale.json" "$fixture/.claude-plugin/marketplace.json"
+    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TEST_TMP_DIR/local-sync-check-entry.out" 2>&1 || check_entry_rc=$?
 
     plugin_version="$(jq -r '.version' "$fixture/.claude-plugin/plugin.json")"
     metadata_version="$(jq -r '.metadata.version' "$fixture/.claude-plugin/marketplace.json")"
     stale_entry_version="$(jq -r '.plugins[] | select(.name == "octo") | .version' "$fixture/.claude-plugin/marketplace.json")"
 
-    bash "$fixture/scripts/sync-marketplace.sh" > "$TMP_DIR/local-sync-entry-repair.out" 2>&1
-    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TMP_DIR/local-sync-check-entry-repaired.out" 2>&1 || check_entry_repaired_rc=$?
+    bash "$fixture/scripts/sync-marketplace.sh" > "$TEST_TMP_DIR/local-sync-entry-repair.out" 2>&1
+    bash "$fixture/scripts/sync-marketplace.sh" --check > "$TEST_TMP_DIR/local-sync-check-entry-repaired.out" 2>&1 || check_entry_repaired_rc=$?
     repaired_metadata_version="$(jq -r '.metadata.version' "$fixture/.claude-plugin/marketplace.json")"
     repaired_entry_version="$(jq -r '.plugins[] | select(.name == "octo") | .version' "$fixture/.claude-plugin/marketplace.json")"
 
@@ -281,7 +275,7 @@ JSON
           "$repaired_metadata_version" == "$plugin_version" &&
           "$repaired_entry_version" == "$plugin_version" ]] &&
        grep -Fqx "[WARN] Plugin version: $stale_entry_version (expected $plugin_version)" \
-           "$TMP_DIR/local-sync-check-entry.out"; then
+           "$TEST_TMP_DIR/local-sync-check-entry.out"; then
         test_pass
     else
         test_fail "expected independent entry-version rejection and repair; before=$check_before_rc after=$check_after_rc entry_check=$check_entry_rc entry_repaired=$check_entry_repaired_rc plugin=$plugin_version metadata=$metadata_version stale_entry=$stale_entry_version repaired_metadata=$repaired_metadata_version repaired_entry=$repaired_entry_version"
@@ -291,7 +285,7 @@ JSON
 test_release_promotes_unreleased_changelog_notes() {
     test_case "release changelog helper promotes Unreleased notes into version entry"
 
-    local changelog="$TMP_DIR/CHANGELOG.md"
+    local changelog="$TEST_TMP_DIR/CHANGELOG.md"
     local release_version="9.42.0"
     local release_date="2026-06-02"
     local expected_header="## [${release_version}] - ${release_date}"
@@ -321,16 +315,25 @@ MD
 
     # shellcheck disable=SC1090
     source "$CHANGELOG_LIB"
-    octo_release_update_changelog "$changelog" "$release_version" "$release_date" "Release summary" >"$TMP_DIR/octo-release-changelog.out"
+    octo_release_update_changelog "$changelog" "$release_version" "$release_date" "Release summary" >"$TEST_TMP_DIR/octo-release-changelog.out"
 
     unreleased_block="$(awk '$0 == "## [Unreleased]" {flag=1; next} /^## \[/ && flag {flag=0} flag {print}' "$changelog")"
     version_block="$(awk -v heading="$expected_header" '$0 == heading {flag=1; next} /^## \[/ && flag {flag=0} flag {print}' "$changelog")"
 
-    if ! grep -q "Add Opus 4.8 routing" <<<"$unreleased_block" &&
-       grep -q "Add Opus 4.8 routing" <<<"$version_block" &&
-       grep -q "Make council runner-backed" <<<"$version_block" &&
-       ! grep -q '^      preserve this indented example$' <<<"$unreleased_block" &&
-       grep -q '^      preserve this indented example$' <<<"$version_block" &&
+    local boundary_blank_lines
+    boundary_blank_lines="$(awk -v heading="$expected_header" '
+        $0 == heading { in_version = 1; next }
+        in_version && /^## \[/ { print blank_lines; exit }
+        in_version && $0 == "" { blank_lines++; next }
+        in_version { blank_lines = 0 }
+    ' "$changelog")"
+
+    if ! grep -Fqx -- "- Add Opus 4.8 routing." <<<"$unreleased_block" &&
+       grep -Fqx -- "- Add Opus 4.8 routing." <<<"$version_block" &&
+       grep -Fqx -- "- Make council runner-backed by default." <<<"$version_block" &&
+       ! grep -Fqx -- "      preserve this indented example" <<<"$unreleased_block" &&
+       grep -Fqx -- "      preserve this indented example" <<<"$version_block" &&
+       [[ "$boundary_blank_lines" == "1" ]] &&
        python3 -c 'from pathlib import Path; import sys; text = Path(sys.argv[1]).read_text(); header = sys.argv[2]; raise SystemExit(0 if f"{header}\n\n### Added" in text and f"{header}\n\n\n" not in text else 1)' "$changelog" "$expected_header" &&
        grep -q "Previous patch release" "$changelog"; then
         test_pass
@@ -373,15 +376,15 @@ test_release_ci_parser_matches_exact_aggregate_checks() {
 }
 
 test_shared_marketplace_sync_updates_only_octo() {
-    local remote="$TMP_DIR/plugins.git"
-    local seed="$TMP_DIR/seed"
-    local work="$TMP_DIR/work"
-    local stale_output="$TMP_DIR/octo-shared-marketplace-check.out"
-    local sync_output="$TMP_DIR/octo-shared-marketplace-sync.out"
-    local check_output="$TMP_DIR/octo-shared-marketplace-check2.out"
-    local drift_output="$TMP_DIR/octo-shared-marketplace-codex-drift.out"
-    local duplicate_output="$TMP_DIR/octo-shared-marketplace-codex-duplicate.out"
-    local source_output="$TMP_DIR/octo-shared-marketplace-codex-source.out"
+    local remote="$TEST_TMP_DIR/plugins.git"
+    local seed="$TEST_TMP_DIR/seed"
+    local work="$TEST_TMP_DIR/work"
+    local stale_output="$TEST_TMP_DIR/octo-shared-marketplace-check.out"
+    local sync_output="$TEST_TMP_DIR/octo-shared-marketplace-sync.out"
+    local check_output="$TEST_TMP_DIR/octo-shared-marketplace-check2.out"
+    local drift_output="$TEST_TMP_DIR/octo-shared-marketplace-codex-drift.out"
+    local duplicate_output="$TEST_TMP_DIR/octo-shared-marketplace-codex-duplicate.out"
+    local source_output="$TEST_TMP_DIR/octo-shared-marketplace-codex-source.out"
     create_shared_marketplace_remote "$remote" "$seed"
 
     test_case "--check fails when shared octo entry is stale"

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -329,7 +329,8 @@ MD
     if ! grep -q "Add Opus 4.8 routing" <<<"$unreleased_block" &&
        grep -q "Add Opus 4.8 routing" <<<"$version_block" &&
        grep -q "Make council runner-backed" <<<"$version_block" &&
-       grep -q '^      preserve this indented example$' "$changelog" &&
+       ! grep -q '^      preserve this indented example$' <<<"$unreleased_block" &&
+       grep -q '^      preserve this indented example$' <<<"$version_block" &&
        python3 -c 'from pathlib import Path; import sys; text = Path(sys.argv[1]).read_text(); header = sys.argv[2]; raise SystemExit(0 if f"{header}\n\n### Added" in text and f"{header}\n\n\n" not in text else 1)' "$changelog" "$expected_header" &&
        grep -q "Previous patch release" "$changelog"; then
         test_pass

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -292,6 +292,9 @@ test_release_promotes_unreleased_changelog_notes() {
     test_case "release changelog helper promotes Unreleased notes into version entry"
 
     local changelog="$TMP_DIR/CHANGELOG.md"
+    local release_version="9.42.0"
+    local release_date="2026-06-02"
+    local expected_header="## [${release_version}] - ${release_date}"
     local unreleased_block version_block
 
     cat > "$changelog" <<'MD'
@@ -318,16 +321,16 @@ MD
 
     # shellcheck disable=SC1090
     source "$CHANGELOG_LIB"
-    octo_release_update_changelog "$changelog" "9.42.0" "2026-06-02" "Release summary" >"$TMP_DIR/octo-release-changelog.out"
+    octo_release_update_changelog "$changelog" "$release_version" "$release_date" "Release summary" >"$TMP_DIR/octo-release-changelog.out"
 
-    unreleased_block="$(awk '/^## \[Unreleased\]/{flag=1; next} /^## \[9\.42\.0\]/{flag=0} flag {print}' "$changelog")"
-    version_block="$(awk '/^## \[9\.42\.0\]/{flag=1; next} /^## \[9\.41\.2\]/{flag=0} flag {print}' "$changelog")"
+    unreleased_block="$(awk '$0 == "## [Unreleased]" {flag=1; next} /^## \[/ && flag {flag=0} flag {print}' "$changelog")"
+    version_block="$(awk -v heading="$expected_header" '$0 == heading {flag=1; next} /^## \[/ && flag {flag=0} flag {print}' "$changelog")"
 
     if ! grep -q "Add Opus 4.8 routing" <<<"$unreleased_block" &&
        grep -q "Add Opus 4.8 routing" <<<"$version_block" &&
        grep -q "Make council runner-backed" <<<"$version_block" &&
        grep -q '^      preserve this indented example$' "$changelog" &&
-       python3 -c 'from pathlib import Path; import sys; text = Path(sys.argv[1]).read_text(); raise SystemExit(0 if "## [9.42.0] - 2026-06-02\n\n### Added" in text and "## [9.42.0] - 2026-06-02\n\n\n" not in text else 1)' "$changelog" &&
+       python3 -c 'from pathlib import Path; import sys; text = Path(sys.argv[1]).read_text(); header = sys.argv[2]; raise SystemExit(0 if f"{header}\n\n### Added" in text and f"{header}\n\n\n" not in text else 1)' "$changelog" "$expected_header" &&
        grep -q "Previous patch release" "$changelog"; then
         test_pass
     else

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -324,6 +324,7 @@ MD
     if ! grep -q "Add Opus 4.8 routing" <<<"$unreleased_block" &&
        grep -q "Add Opus 4.8 routing" <<<"$version_block" &&
        grep -q "Make council runner-backed" <<<"$version_block" &&
+       python3 -c 'from pathlib import Path; import sys; text = Path(sys.argv[1]).read_text(); raise SystemExit(0 if "## [9.42.0] - 2026-06-02\n\n### Added" in text and "## [9.42.0] - 2026-06-02\n\n\n" not in text else 1)' "$changelog" &&
        grep -q "Previous patch release" "$changelog"; then
         test_pass
     else

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -307,6 +307,8 @@ test_release_promotes_unreleased_changelog_notes() {
 
 - Make council runner-backed by default.
 
+      preserve this indented example
+
 ## [9.41.2] - 2026-05-28
 
 ### Fixed
@@ -324,6 +326,7 @@ MD
     if ! grep -q "Add Opus 4.8 routing" <<<"$unreleased_block" &&
        grep -q "Add Opus 4.8 routing" <<<"$version_block" &&
        grep -q "Make council runner-backed" <<<"$version_block" &&
+       grep -q '^      preserve this indented example$' "$changelog" &&
        python3 -c 'from pathlib import Path; import sys; text = Path(sys.argv[1]).read_text(); raise SystemExit(0 if "## [9.42.0] - 2026-06-02\n\n### Added" in text and "## [9.42.0] - 2026-06-02\n\n\n" not in text else 1)' "$changelog" &&
        grep -q "Previous patch release" "$changelog"; then
         test_pass

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -329,6 +329,8 @@ MD
     ' "$changelog")"
 
     if ! grep -Fqx -- "- Add Opus 4.8 routing." <<<"$unreleased_block" &&
+       grep -Fqx -- "## [Unreleased]" "$changelog" &&
+       ! grep -q '[^[:space:]]' <<<"$unreleased_block" &&
        grep -Fqx -- "- Add Opus 4.8 routing." <<<"$version_block" &&
        grep -Fqx -- "- Make council runner-backed by default." <<<"$version_block" &&
        ! grep -Fqx -- "      preserve this indented example" <<<"$unreleased_block" &&


### PR DESCRIPTION
## Release v9.64.0

Keep Octopus dormant until explicitly invoked

---
🤖 Generated with release.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Octopus remains dormant until explicitly invoked through `/octo:setup`.

* **Documentation**
  * Updated release information and version references to 9.64.0.
  * Added the 9.64.0 changelog entry dated August 13, 2026.

* **Bug Fixes**
  * Improved changelog formatting during release promotion, including consistent spacing, preserved indentation, and reliable release headers.

* **Tests**
  * Expanded coverage for changelog promotion and marketplace synchronization.
  * Standardized temporary test file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->