### PR TITLE
fix: reap Tangle workers and recover stalled progress

### DIFF
--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -5,16 +5,18 @@ Status: Issues #900 and #902 are implemented on
 `fix/900-tangle-lifecycle`. Tangle workers now run in dedicated process groups,
 INT/TERM and unexpected orchestrator exits cancel active work, completion
 watchers recover from idle wrappers, and redirected progress changes only when
-the count changes. Commit `9126cf3c` is pushed to both remotes and
-[PR #909](https://github.com/nyldn/claude-octopus/pull/909) is open. Release
-remains explicitly deferred.
+the count changes. The implementation commits through `696aafd2` are pushed to
+both remotes and [PR #909](https://github.com/nyldn/claude-octopus/pull/909) is
+open. The review response is complete and passes the final full local gate; its
+commit and push are the remaining branch actions. Release remains explicitly
+deferred.
 Branch: `fix/900-tangle-lifecycle`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #900](https://github.com/nyldn/claude-octopus/issues/900),
 [issue #902](https://github.com/nyldn/claude-octopus/issues/902)
 PR: [#909](https://github.com/nyldn/claude-octopus/pull/909)
-Next action: review PR #909 checks and feedback, then merge when approved.
-Release remains deferred.
+Next action: commit and push the PR #909 review response, answer its review
+threads, and verify the rerun checks. Merge and release remain deferred.
 
 ## Issues #900 and #902: Tangle Lifecycle Ownership
 
@@ -36,17 +38,25 @@ Release remains deferred.
   `stalled-worker`; non-TTY progress is emitted only when its count changes.
 - Run isolation: default Tangle IDs now use an atomic reservation instead of
   `date +%s` plus `$$`, preventing same-second worktree and branch collisions
-  exposed when the old final two-second sleep was removed.
-- TDD evidence: lifecycle cancellation passes 8/8, missing-marker recovery 4/4,
-  Markdown plan/run-ID resolution 12/12, run-worktree isolation 13/13, stdin
-  isolation 3/3, Probe cancellation 21/21, spawn PID capture 9/9, and heartbeat
-  ordering 12/12.
-- Full-gate evidence: the final non-interactive `make ci-local` sweep passed
-  16/16 smoke suites and 267/268 unit suites. The sole failure was a brittle
-  five-line static heartbeat assertion; production ordering was correct, the
-  assertion now checks semantic order inside `spawn_agent()`, and its isolated
-  suite passes 12/12. A prior PTY run was invalid for the stdin-isolation
-  fixture because its deliberate `cat` read waited on terminal input.
+  exposed when the old final two-second sleep was removed. Explicit run-ID
+  overrides now reject traversal, and zero-byte reservations older than seven
+  days are pruned once daily without weakening same-day atomic uniqueness.
+- Review hardening: cancellation refuses to proceed without its process
+  helpers, never signals the orchestrator PID/group, snapshots reachable legacy
+  descendants before STOP, uses portable `ps -A`, serializes PID-ledger pruning
+  with spawn appends, and ignores dead targeted PIDs. Status checks are
+  SIGPIPE-safe and the integration assertion reads whole Tangle functions.
+- TDD evidence: lifecycle cancellation passes 14/14, missing-marker recovery
+  6/6, run-worktree isolation 14/14, Markdown plan/run-ID resolution 13/13,
+  contextual review wiring 56/56, spawn PID capture 10/10, and the
+  value-proposition integration test passes 19/19.
+- Full-gate evidence: the final non-interactive `make ci-local` after all review
+  fixes passed 16/16 smoke suites, 268/268 unit suites, 7/7 integration suites,
+  and the CI-only verifications. The earlier 267/268 run exposed only a brittle
+  five-line static heartbeat assertion; production ordering was correct, and
+  the replacement semantic-order assertion passes in the final sweep. A prior
+  PTY run was invalid for the stdin-isolation fixture because its deliberate
+  `cat` read waited on terminal input.
 - Tracking blocker: Beads is still unreadable on schema v49 because its reserved
   v65 migration has not been applied. No migration was run; GitHub issues are
   the temporary tracker.

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -11,14 +11,15 @@ open. Review-response commits through `afbaa8cc` are pushed to both remotes.
 The remote Linux integration job exposed a pipefail-only SIGPIPE in two test
 assertions, and a follow-up review found a failed-lock path plus a test lifecycle
 override. All three corrections pass focused coverage and the latest full gate;
-commit and push remain. Release remains explicitly deferred.
+commit `29fa740e` is pushed to both remotes. Review replies and rerun checks
+remain. Release remains explicitly deferred.
 Branch: `fix/900-tangle-lifecycle`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #900](https://github.com/nyldn/claude-octopus/issues/900),
 [issue #902](https://github.com/nyldn/claude-octopus/issues/902)
 PR: [#909](https://github.com/nyldn/claude-octopus/pull/909)
-Next action: commit and push the Linux/review corrections, answer the two new
-review threads, then verify the rerun checks. Merge and release remain deferred.
+Next action: answer the two new review threads, then verify the rerun checks.
+Merge and release remain deferred.
 
 ## Issues #900 and #902: Tangle Lifecycle Ownership
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,20 +1,55 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-13
-Status: Issue #908 is implemented and proposed in PR #911 on
-`fix/908-review-aggregation`. Review
-findings now cross a single-document normalization boundary before persistence,
-counting, event emission, rendering, or publishing; non-object entries are
-rejected and duplicate findings collapse without changing synthesis rank or
-equal-severity input order. Review-response commit `7134d789` is pushed to both
-remotes and its final full gate passes; review-thread responses remain. Release
-is deferred.
-Branch: `fix/908-review-aggregation`
+Status: Issues #900 and #902 are implemented on
+`fix/900-tangle-lifecycle`. Tangle workers now run in dedicated process groups,
+INT/TERM and unexpected orchestrator exits cancel active work, completion
+watchers recover from idle wrappers, and redirected progress changes only when
+the count changes. Commit `9126cf3c` is pushed to both remotes and
+[PR #909](https://github.com/nyldn/claude-octopus/pull/909) is open. Release
+remains explicitly deferred.
+Branch: `fix/900-tangle-lifecycle`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
-Tracking: [issue #908](https://github.com/nyldn/claude-octopus/issues/908)
-PR: [#911](https://github.com/nyldn/claude-octopus/pull/911)
-Next action: answer PR #911's three review threads and verify rerun checks.
-Merge and release remain deferred.
+Tracking: [issue #900](https://github.com/nyldn/claude-octopus/issues/900),
+[issue #902](https://github.com/nyldn/claude-octopus/issues/902)
+PR: [#909](https://github.com/nyldn/claude-octopus/pull/909)
+Next action: review PR #909 checks and feedback, then merge when approved.
+Release remains deferred.
+
+## Issues #900 and #902: Tangle Lifecycle Ownership
+
+- Root causes: the top-level `EXIT INT TERM` cleanup trap removed a temporary
+  directory but swallowed signals without exiting or reaping providers; Tangle
+  had no active-work cancellation registry; tree-only cleanup could lose a
+  child after its shell leader exited; and the completion watcher treated a
+  living but childless wrapper as active forever.
+- Process ownership: legacy workers enter dedicated process groups, so the
+  recorded worker PID is also its PGID. Cancellation first kills that group
+  atomically, with a portable frozen descendant walk for legacy callers and
+  macOS/minimal environments without `pgrep`.
+- Lifecycle ownership: Tangle registers task identity before spawn, reconciles
+  the PID ledger to close the post-spawn handoff race, marks cancelled outputs
+  and completion records, prunes runtime metadata, restores caller traps, and
+  handles both explicit signals and unexpected `set -e` exits.
+- Stalled progress: `OCTOPUS_TANGLE_IDLE_WORKER_GRACE` defaults to 180 seconds.
+  A living wrapper with no active provider descendants becomes
+  `stalled-worker`; non-TTY progress is emitted only when its count changes.
+- Run isolation: default Tangle IDs now use an atomic reservation instead of
+  `date +%s` plus `$$`, preventing same-second worktree and branch collisions
+  exposed when the old final two-second sleep was removed.
+- TDD evidence: lifecycle cancellation passes 8/8, missing-marker recovery 4/4,
+  Markdown plan/run-ID resolution 12/12, run-worktree isolation 13/13, stdin
+  isolation 3/3, Probe cancellation 21/21, spawn PID capture 9/9, and heartbeat
+  ordering 12/12.
+- Full-gate evidence: the final non-interactive `make ci-local` sweep passed
+  16/16 smoke suites and 267/268 unit suites. The sole failure was a brittle
+  five-line static heartbeat assertion; production ordering was correct, the
+  assertion now checks semantic order inside `spawn_agent()`, and its isolated
+  suite passes 12/12. A prior PTY run was invalid for the stdin-isolation
+  fixture because its deliberate `cat` read waited on terminal input.
+- Tracking blocker: Beads is still unreadable on schema v49 because its reserved
+  v65 migration has not been applied. No migration was run; GitHub issues are
+  the temporary tracker.
 
 ## Issue #908: Canonical Review Findings
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -7,16 +7,15 @@ INT/TERM and unexpected orchestrator exits cancel active work, completion
 watchers recover from idle wrappers, and redirected progress changes only when
 the count changes. The implementation commits through `696aafd2` are pushed to
 both remotes and [PR #909](https://github.com/nyldn/claude-octopus/pull/909) is
-open. The review response is complete and passes the final full local gate; its
-commit and push are the remaining branch actions. Release remains explicitly
-deferred.
+open. Review-response commit `1342083a` is pushed to both remotes and passes the
+final full local gate. Release remains explicitly deferred.
 Branch: `fix/900-tangle-lifecycle`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #900](https://github.com/nyldn/claude-octopus/issues/900),
 [issue #902](https://github.com/nyldn/claude-octopus/issues/902)
 PR: [#909](https://github.com/nyldn/claude-octopus/pull/909)
-Next action: commit and push the PR #909 review response, answer its review
-threads, and verify the rerun checks. Merge and release remain deferred.
+Next action: answer the PR #909 review threads and verify the rerun checks.
+Merge and release remain deferred.
 
 ## Issues #900 and #902: Tangle Lifecycle Ownership
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -7,15 +7,18 @@ INT/TERM and unexpected orchestrator exits cancel active work, completion
 watchers recover from idle wrappers, and redirected progress changes only when
 the count changes. The implementation commits through `696aafd2` are pushed to
 both remotes and [PR #909](https://github.com/nyldn/claude-octopus/pull/909) is
-open. Review-response commit `1342083a` is pushed to both remotes and passes the
-final full local gate. Release remains explicitly deferred.
+open. Review-response commits through `afbaa8cc` are pushed to both remotes.
+The remote Linux integration job exposed a pipefail-only SIGPIPE in two test
+assertions, and a follow-up review found a failed-lock path plus a test lifecycle
+override. All three corrections pass focused coverage and the latest full gate;
+commit and push remain. Release remains explicitly deferred.
 Branch: `fix/900-tangle-lifecycle`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #900](https://github.com/nyldn/claude-octopus/issues/900),
 [issue #902](https://github.com/nyldn/claude-octopus/issues/902)
 PR: [#909](https://github.com/nyldn/claude-octopus/pull/909)
-Next action: answer the PR #909 review threads and verify the rerun checks.
-Merge and release remain deferred.
+Next action: commit and push the Linux/review corrections, answer the two new
+review threads, then verify the rerun checks. Merge and release remain deferred.
 
 ## Issues #900 and #902: Tangle Lifecycle Ownership
 
@@ -43,13 +46,20 @@ Merge and release remain deferred.
 - Review hardening: cancellation refuses to proceed without its process
   helpers, never signals the orchestrator PID/group, snapshots reachable legacy
   descendants before STOP, uses portable `ps -A`, serializes PID-ledger pruning
-  with spawn appends, and ignores dead targeted PIDs. Status checks are
-  SIGPIPE-safe and the integration assertion reads whole Tangle functions.
-- TDD evidence: lifecycle cancellation passes 14/14, missing-marker recovery
+  with spawn appends, stops before pruning when `flock` acquisition fails, and
+  ignores dead targeted PIDs. Status checks are SIGPIPE-safe and the integration
+  assertion reads whole Tangle functions. The spawn PID suite again uses the
+  shared test framework's temp-directory cleanup instead of replacing its trap.
+- Linux CI regression: the whole-function assertions still piped a large shell
+  variable through `grep -q`. On Linux, the early reader exit closed the pipe,
+  `echo` received SIGPIPE, and `set -o pipefail` failed the integration job.
+  Here-strings with non-early-closing `grep -c` preserve the semantic assertions
+  without a producer-side broken pipe; the focused suite passes 19/19.
+- TDD evidence: lifecycle cancellation passes 15/15, missing-marker recovery
   6/6, run-worktree isolation 14/14, Markdown plan/run-ID resolution 13/13,
   contextual review wiring 56/56, spawn PID capture 10/10, and the
   value-proposition integration test passes 19/19.
-- Full-gate evidence: the final non-interactive `make ci-local` after all review
+- Full-gate evidence: the latest non-interactive `make ci-local` after all review
   fixes passed 16/16 smoke suites, 268/268 unit suites, 7/7 integration suites,
   and the CI-only verifications. The earlier 267/268 run exposed only a brittle
   five-line static heartbeat assertion; production ordering was correct, and

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -284,15 +284,20 @@ review_progress_fingerprint_since() {
 # Enumerate direct children portably. procps pgrep is preferred, while the ps
 # fallback covers minimal Linux images and macOS without adding a dependency.
 review_child_pids() {
-    local parent_pid="$1" child_pid child_parent
+    local parent_pid="$1" child_pid child_parent process_rows=""
     if command -v pgrep >/dev/null 2>&1; then
-        pgrep -P "$parent_pid" 2>/dev/null || true
-        return 0
+        if pgrep -P "$parent_pid" 2>/dev/null; then
+            return 0
+        fi
     fi
     command -v ps >/dev/null 2>&1 || return 0
+    process_rows=$(ps -A -o pid= -o ppid= 2>/dev/null) \
+        || process_rows=$(ps -ax -o pid= -o ppid= 2>/dev/null) \
+        || process_rows=""
     while read -r child_pid child_parent; do
         [[ "$child_parent" == "$parent_pid" ]] && printf '%s\n' "$child_pid"
-    done < <(ps -ax -o pid= -o ppid= 2>/dev/null)
+    done <<< "$process_rows"
+    return 0
 }
 
 # Snapshot descendants depth-first before signaling. Re-walking after TERM is
@@ -342,8 +347,21 @@ review_terminate_process_tree() {
 # before walking it so a shell cannot advance to another provider attempt while
 # teardown is enumerating descendants, then kill the frozen tree bottom-up.
 review_kill_process_tree_frozen() {
-    local root_pid="$1" child
-    [[ "$root_pid" =~ ^[0-9]+$ ]] || return 0
+    local root_pid="$1" child children current_pgid=""
+    [[ "$root_pid" =~ ^[1-9][0-9]*$ ]] || return 0
+    [[ "$root_pid" != "1" ]] || return 0
+
+    current_pgid=$(ps -o pgid= -p "$$" 2>/dev/null | tr -d '[:space:]') \
+        || current_pgid=""
+    if [[ "$root_pid" == "$$" ]] \
+       || [[ -n "$current_pgid" && "$root_pid" == "$current_pgid" ]]; then
+        return 0
+    fi
+
+    # Snapshot legacy children before signaling. If the wrapper exits during
+    # the group probe or STOP, this preserves every descendant that was still
+    # discoverable while the wrapper was alive.
+    children="$(review_child_pids "$root_pid")"
 
     # spawn_agent places each worker in a dedicated process group whose PGID is
     # the recorded worker PID. Signaling the group is atomic and still works if
@@ -355,11 +373,11 @@ review_kill_process_tree_frozen() {
         return 0
     fi
 
-    kill -STOP "$root_pid" 2>/dev/null || return 0
+    kill -STOP "$root_pid" 2>/dev/null || true
     while IFS= read -r child; do
         [[ "$child" =~ ^[0-9]+$ ]] || continue
         review_kill_process_tree_frozen "$child"
-    done < <(review_child_pids "$root_pid")
+    done <<< "$children"
     kill -KILL "$root_pid" 2>/dev/null || true
 }
 

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -281,6 +281,20 @@ review_progress_fingerprint_since() {
     done | sort | review_hash_stdin
 }
 
+# Enumerate direct children portably. procps pgrep is preferred, while the ps
+# fallback covers minimal Linux images and macOS without adding a dependency.
+review_child_pids() {
+    local parent_pid="$1" child_pid child_parent
+    if command -v pgrep >/dev/null 2>&1; then
+        pgrep -P "$parent_pid" 2>/dev/null || true
+        return 0
+    fi
+    command -v ps >/dev/null 2>&1 || return 0
+    while read -r child_pid child_parent; do
+        [[ "$child_parent" == "$parent_pid" ]] && printf '%s\n' "$child_pid"
+    done < <(ps -ax -o pid= -o ppid= 2>/dev/null)
+}
+
 # Snapshot descendants depth-first before signaling. Re-walking after TERM is
 # unsafe because a TERM-ignoring child can be reparented when its wrapper exits,
 # making it invisible to the later KILL pass.
@@ -290,7 +304,7 @@ review_process_tree_depth_first() {
     while IFS= read -r child; do
         [[ "$child" =~ ^[0-9]+$ ]] || continue
         review_process_tree_depth_first "$child"
-    done < <(pgrep -P "$pid" 2>/dev/null || true)
+    done < <(review_child_pids "$pid")
     printf '%s\n' "$pid"
 }
 
@@ -322,6 +336,56 @@ review_terminate_process_tree() {
         [[ "$target_pid" =~ ^[0-9]+$ ]] || continue
         kill -KILL "$target_pid" 2>/dev/null || true
     done <<< "$process_tree"
+}
+
+# Cancellation is stricter than ordinary timeout cleanup. Freeze each root
+# before walking it so a shell cannot advance to another provider attempt while
+# teardown is enumerating descendants, then kill the frozen tree bottom-up.
+review_kill_process_tree_frozen() {
+    local root_pid="$1" child
+    [[ "$root_pid" =~ ^[0-9]+$ ]] || return 0
+
+    # spawn_agent places each worker in a dedicated process group whose PGID is
+    # the recorded worker PID. Signaling the group is atomic and still works if
+    # the group leader exited after spawning a provider child. Legacy callers
+    # are not group leaders, so a missing -PGID safely falls through to the
+    # portable descendant walk below.
+    if kill -STOP -- "-$root_pid" 2>/dev/null; then
+        kill -KILL -- "-$root_pid" 2>/dev/null || true
+        return 0
+    fi
+
+    kill -STOP "$root_pid" 2>/dev/null || return 0
+    while IFS= read -r child; do
+        [[ "$child" =~ ^[0-9]+$ ]] || continue
+        review_kill_process_tree_frozen "$child"
+    done < <(review_child_pids "$root_pid")
+    kill -KILL "$root_pid" 2>/dev/null || true
+}
+
+review_kill_descendants_frozen() {
+    local root_pid="$1" child children
+    [[ "$root_pid" =~ ^[0-9]+$ ]] || return 0
+    children="$(review_child_pids "$root_pid")"
+    while IFS= read -r child; do
+        [[ "$child" =~ ^[0-9]+$ ]] || continue
+        kill -STOP "$child" 2>/dev/null || true
+    done <<< "$children"
+    while IFS= read -r child; do
+        [[ "$child" =~ ^[0-9]+$ ]] || continue
+        review_kill_process_tree_frozen "$child"
+    done <<< "$children"
+}
+
+review_process_has_active_descendant() {
+    local root_pid="$1" child
+    [[ "$root_pid" =~ ^[0-9]+$ ]] || return 1
+    while IFS= read -r child; do
+        [[ "$child" =~ ^[0-9]+$ ]] || continue
+        review_process_is_running "$child" && return 0
+        review_process_has_active_descendant "$child" && return 0
+    done < <(review_child_pids "$root_pid")
+    return 1
 }
 
 review_run_agent_sync_progress() {

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -703,7 +703,14 @@ ${heuristic_ctx}"
     # LEGACY PATH: Execute an external agent in a Bash subprocess when teams are unavailable.
     # ═══════════════════════════════════════════════════════════════════════════
 
-    # Execute agent in background
+    # Execute each worker in a dedicated process group. The recorded PID is also
+    # its PGID, allowing cancellation to atomically stop every provider
+    # descendant even if the Bash group leader exits during teardown (#900).
+    # Preserve a caller that already enabled monitor mode rather than forcing it
+    # off after the spawn.
+    local _spawn_monitor_was_enabled=false
+    [[ "$-" == *m* ]] && _spawn_monitor_was_enabled=true
+    set -m
     (
         cd "$PROJECT_ROOT" || exit 1
         set -f  # Disable glob expansion
@@ -1190,6 +1197,7 @@ ${heuristic_ctx}"
     ) &
 
     local pid=$!
+    [[ "$_spawn_monitor_was_enabled" == "true" ]] || set +m
 
     _octopus_agent_lifecycle_event "spawned" "$agent_type" "$task_id" "$role" "$phase" "$pid" "$result_file" "" "running"
 

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -136,16 +136,31 @@ _octopus_agent_lifecycle_event() {
 # version at all, so use its generated suffix instead. The reservation file
 # is deliberately kept (not rm'd): deleting it would free that exact name
 # for reuse by a later mktemp call, turning the "genuinely unique" guarantee
-# back into a probabilistic one. Each file is 0 bytes, so the accumulated
-# cost over a session is a handful of empty inodes, not meaningful disk use.
+# back into a probabilistic one. Reservations older than seven days can be
+# deleted safely because the timestamp component makes their full IDs distinct
+# from every current-day allocation.
 # Falls back to the old PID/RANDOM combination only if mktemp itself is
 # unavailable — that path is not a hard uniqueness guarantee, only a
 # best-effort default for environments where mktemp can't run at all.
 # Shared by spawn_agent() and spawn_agent_capture_pid() so both default
 # paths — and their tests — stay in sync from one definition.
+_octopus_prune_task_id_reservations() {
+    local reservation_dir="$1" prune_day marker lock_dir
+    prune_day=$(date +%Y%m%d 2>/dev/null || printf 'unknown')
+    marker="${reservation_dir}/.pruned-${prune_day}"
+    [[ -e "$marker" ]] && return 0
+    lock_dir="${marker}.lock"
+    if mkdir "$lock_dir" 2>/dev/null; then
+        find "$reservation_dir" -type f -mtime +7 -delete 2>/dev/null || true
+        : > "$marker"
+        rmdir "$lock_dir" 2>/dev/null || true
+    fi
+}
+
 _octopus_next_spawn_task_id() {
     local _reservation_dir="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/task-ids"
     mkdir -p "$_reservation_dir" 2>/dev/null || true
+    _octopus_prune_task_id_reservations "$_reservation_dir"
     local _tmp _uniq
     _tmp=$(mktemp "${_reservation_dir}/XXXXXX" 2>/dev/null) && _uniq="${_tmp##*/}"
     printf '%s-%s\n' "$(date +%s)" "${_uniq:-${BASHPID:-$$}${RANDOM}}"

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -241,7 +241,7 @@ ${YELLOW}Environment:${NC}
   OCTOPUS_TANGLE_CODE_REVIEW=false              Skip contextual code review
   OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=unbounded Progress-supervised loop (default)
   OCTOPUS_TANGLE_TIMEOUT=1200                    Minimum positive implementer budget; TIMEOUT=0 stays unlimited
-  OCTOPUS_TANGLE_IDLE_WORKER_GRACE=180           Mark live wrappers with no provider descendants stalled
+  OCTOPUS_TANGLE_IDLE_WORKER_GRACE=180           Seconds to wait before a live wrapper with no provider descendants is marked stalled (0 = immediate)
   OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded   Opt into explicit round cap
   OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=3       Bound count when mode=bounded
   OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW=1800     Stop only after silence/no progress

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -241,6 +241,7 @@ ${YELLOW}Environment:${NC}
   OCTOPUS_TANGLE_CODE_REVIEW=false              Skip contextual code review
   OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=unbounded Progress-supervised loop (default)
   OCTOPUS_TANGLE_TIMEOUT=1200                    Minimum positive implementer budget; TIMEOUT=0 stays unlimited
+  OCTOPUS_TANGLE_IDLE_WORKER_GRACE=180           Mark live wrappers with no provider descendants stalled
   OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded   Opt into explicit round cap
   OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=3       Bound count when mode=bounded
   OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW=1800     Stop only after silence/no progress

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -9,7 +9,13 @@ if ! type probe_result_file_status >/dev/null 2>&1; then
 fi
 if ! type review_kill_process_tree_frozen >/dev/null 2>&1; then
     _octo_review_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/review.sh"
-    [[ -f "$_octo_review_lib" ]] && source "$_octo_review_lib"
+    if [[ -f "$_octo_review_lib" ]]; then
+        # shellcheck source=/dev/null
+        source "$_octo_review_lib" || printf 'ERROR: failed to load Tangle cancellation helpers: %s\n' "$_octo_review_lib" >&2
+    else
+        printf 'ERROR: missing Tangle cancellation helpers: %s\n' "$_octo_review_lib" >&2
+    fi
+    unset _octo_review_lib
 fi
 
 # v8.54.0: Single-agent probe for multi-agentic skill dispatch
@@ -1763,10 +1769,11 @@ _octopus_tangle_restore_traps() {
     if [[ -n "$previous_term_trap" ]]; then eval "$previous_term_trap"; else trap - TERM; fi
 }
 
-_octopus_tangle_prune_pid_ledger() {
+_octopus_tangle_prune_pid_ledger_unlocked() {
     local task_group="$1"
     [[ -n "${PID_FILE:-}" && -f "$PID_FILE" ]] || return 0
-    local tmp_file="${PID_FILE}.cancel.$$"
+    local tmp_file
+    tmp_file=$(mktemp "${PID_FILE}.cancel.XXXXXX") || return 1
     if awk -F: -v prefix="tangle-${task_group}-" \
         'index($3, prefix) != 1 { print }' "$PID_FILE" > "$tmp_file"; then
         mv -f "$tmp_file" "$PID_FILE"
@@ -1775,10 +1782,28 @@ _octopus_tangle_prune_pid_ledger() {
     fi
 }
 
+_octopus_tangle_prune_pid_ledger() {
+    local task_group="$1"
+    [[ -n "${PID_FILE:-}" && -f "$PID_FILE" ]] || return 0
+    if command -v flock >/dev/null 2>&1; then
+        (
+            flock -x 200
+            _octopus_tangle_prune_pid_ledger_unlocked "$task_group"
+        ) 200>"${PID_FILE}.lock"
+    else
+        _octopus_tangle_prune_pid_ledger_unlocked "$task_group"
+    fi
+}
+
 octopus_tangle_cancel_active() {
     local signal_name="${1:-TERM}"
     local task_group="${OCTOPUS_ACTIVE_TANGLE_TASK_GROUP:-}"
     [[ -n "$task_group" ]] || return 0
+    if ! declare -F review_kill_process_tree_frozen >/dev/null 2>&1 \
+       || ! declare -F review_kill_descendants_frozen >/dev/null 2>&1; then
+        log ERROR "Tangle cancellation helpers are unavailable; refusing incomplete cleanup"
+        return 1
+    fi
 
     local exit_code=143
     [[ "$signal_name" == "INT" ]] && exit_code=130
@@ -1829,7 +1854,7 @@ octopus_tangle_cancel_active() {
         fi
         [[ -f "$done_file" ]] || printf '%s\n' "cancelled" > "$done_file" 2>/dev/null || true
         if [[ -f "$result_file" ]] \
-           && ! grep -Eq '^## Status: (SUCCESS|FAILED|TIMEOUT|CANCELLED)' "$result_file" 2>/dev/null; then
+           && ! grep -Ec '^## Status: (SUCCESS|FAILED|TIMEOUT|CANCELLED)' "$result_file" >/dev/null 2>&1; then
             {
                 echo ""
                 echo "## Status: CANCELLED - PARTIAL RESULTS"
@@ -1849,7 +1874,8 @@ octopus_tangle_cancel_active() {
     # race-closing step before clearing lifecycle state.
     review_kill_descendants_frozen "$$"
 
-    _octopus_tangle_prune_pid_ledger "$task_group"
+    _octopus_tangle_prune_pid_ledger "$task_group" \
+        || log ERROR "Failed to prune cancelled Tangle tasks from the PID ledger"
     if [[ "${OCTOPUS_ACTIVE_TANGLE_TMUX:-false}" == "true" ]] \
        && declare -F tmux_cleanup >/dev/null 2>&1; then
         tmux_cleanup 2>/dev/null || true
@@ -2549,8 +2575,16 @@ tangle_next_run_id() {
     fi
 
     local reservation_dir="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/task-ids"
-    local reservation unique_suffix
+    local reservation unique_suffix prune_day marker lock_dir
     mkdir -p "$reservation_dir" 2>/dev/null || true
+    prune_day=$(date +%Y%m%d 2>/dev/null || printf 'unknown')
+    marker="${reservation_dir}/.pruned-${prune_day}"
+    lock_dir="${marker}.lock"
+    if [[ ! -e "$marker" ]] && mkdir "$lock_dir" 2>/dev/null; then
+        find "$reservation_dir" -type f -mtime +7 -delete 2>/dev/null || true
+        : > "$marker"
+        rmdir "$lock_dir" 2>/dev/null || true
+    fi
     reservation=$(mktemp "${reservation_dir}/XXXXXX" 2>/dev/null) && unique_suffix="${reservation##*/}"
     printf '%s-%s\n' "$(date +%s)" "${unique_suffix:-${BASHPID:-$$}${RANDOM}}"
 }
@@ -2709,7 +2743,12 @@ tangle_develop() {
     fi
 
     local task_group="${OCTOPUS_TANGLE_RUN_ID:-}"
-    if [[ -z "$task_group" ]]; then
+    if [[ -n "$task_group" ]]; then
+        if [[ ! "$task_group" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ || "$task_group" == *..* ]]; then
+            log ERROR "Invalid OCTOPUS_TANGLE_RUN_ID: $task_group"
+            return 1
+        fi
+    else
         task_group=$(tangle_next_run_id) || return 1
     fi
     local original_project_root="${PROJECT_ROOT:-$PWD}"
@@ -3184,7 +3223,7 @@ Every [CODING] line must include a same-line Files: clause."
                         local _idle_result_file
                         _idle_result_file=$(find "${RESULTS_DIR:-${HOME}/.claude-octopus/results}" -maxdepth 1 -type f -name "*-${task_ids[$i]}.md" 2>/dev/null | head -1 || true)
                         if [[ -n "$_idle_result_file" ]] \
-                           && ! grep -q '^## Status:' "$_idle_result_file" 2>/dev/null; then
+                           && ! grep -c '^## Status:' "$_idle_result_file" >/dev/null 2>&1; then
                             {
                                 echo ""
                                 echo "## Status: FAILED (Stalled worker without provider descendants)"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -7,6 +7,10 @@ if ! type probe_result_file_status >/dev/null 2>&1; then
     _octo_probe_results_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/probe-results.sh"
     [[ -f "$_octo_probe_results_lib" ]] && source "$_octo_probe_results_lib"
 fi
+if ! type review_kill_process_tree_frozen >/dev/null 2>&1; then
+    _octo_review_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/review.sh"
+    [[ -f "$_octo_review_lib" ]] && source "$_octo_review_lib"
+fi
 
 # v8.54.0: Single-agent probe for multi-agentic skill dispatch
 # Runs one probe perspective synchronously and writes result to RESULTS_DIR.
@@ -1734,6 +1738,135 @@ tangle_process_is_active_non_zombie() {
     return 0
 }
 
+# Active Tangle state is process-global because INT/TERM can arrive while the
+# controller is blocked in spawn PID capture or the completion watcher.
+OCTOPUS_ACTIVE_TANGLE_TASK_GROUP=""
+OCTOPUS_ACTIVE_TANGLE_TMUX="false"
+OCTOPUS_ACTIVE_TANGLE_PIDS=()
+OCTOPUS_ACTIVE_TANGLE_AGENTS=()
+OCTOPUS_ACTIVE_TANGLE_TASK_IDS=()
+
+octopus_tangle_clear_active() {
+    OCTOPUS_ACTIVE_TANGLE_TASK_GROUP=""
+    OCTOPUS_ACTIVE_TANGLE_TMUX="false"
+    OCTOPUS_ACTIVE_TANGLE_PIDS=()
+    OCTOPUS_ACTIVE_TANGLE_AGENTS=()
+    OCTOPUS_ACTIVE_TANGLE_TASK_IDS=()
+}
+
+_octopus_tangle_restore_traps() {
+    local previous_int_trap="${1:-}"
+    local previous_term_trap="${2:-}"
+
+    octopus_tangle_clear_active
+    if [[ -n "$previous_int_trap" ]]; then eval "$previous_int_trap"; else trap - INT; fi
+    if [[ -n "$previous_term_trap" ]]; then eval "$previous_term_trap"; else trap - TERM; fi
+}
+
+_octopus_tangle_prune_pid_ledger() {
+    local task_group="$1"
+    [[ -n "${PID_FILE:-}" && -f "$PID_FILE" ]] || return 0
+    local tmp_file="${PID_FILE}.cancel.$$"
+    if awk -F: -v prefix="tangle-${task_group}-" \
+        'index($3, prefix) != 1 { print }' "$PID_FILE" > "$tmp_file"; then
+        mv -f "$tmp_file" "$PID_FILE"
+    else
+        rm -f "$tmp_file" 2>/dev/null || true
+    fi
+}
+
+octopus_tangle_cancel_active() {
+    local signal_name="${1:-TERM}"
+    local task_group="${OCTOPUS_ACTIVE_TANGLE_TASK_GROUP:-}"
+    [[ -n "$task_group" ]] || return 0
+
+    local exit_code=143
+    [[ "$signal_name" == "INT" ]] && exit_code=130
+    local -a cancel_pids=("${OCTOPUS_ACTIVE_TANGLE_PIDS[@]+"${OCTOPUS_ACTIVE_TANGLE_PIDS[@]}"}")
+    local -a cancel_agents=("${OCTOPUS_ACTIVE_TANGLE_AGENTS[@]+"${OCTOPUS_ACTIVE_TANGLE_AGENTS[@]}"}")
+    local -a cancel_tasks=("${OCTOPUS_ACTIVE_TANGLE_TASK_IDS[@]+"${OCTOPUS_ACTIVE_TANGLE_TASK_IDS[@]}"}")
+    local ledger_pid ledger_agent ledger_task idx found found_idx
+
+    # The ledger closes the race between spawn_agent's append and the caller's
+    # assignment of the returned PID into the active in-memory arrays.
+    if [[ -n "${PID_FILE:-}" && -f "$PID_FILE" ]]; then
+        while IFS=: read -r ledger_pid ledger_agent ledger_task; do
+            [[ "$ledger_task" == "tangle-${task_group}-"* ]] || continue
+            found=false
+            found_idx=""
+            for idx in "${!cancel_tasks[@]}"; do
+                if [[ "${cancel_tasks[$idx]:-}" == "$ledger_task" ]]; then
+                    found=true
+                    found_idx="$idx"
+                    break
+                fi
+            done
+            if [[ "$found" == "true" ]]; then
+                [[ -n "${cancel_pids[$found_idx]:-}" ]] || cancel_pids[$found_idx]="$ledger_pid"
+                [[ -n "${cancel_agents[$found_idx]:-}" ]] || cancel_agents[$found_idx]="$ledger_agent"
+            else
+                cancel_pids+=("$ledger_pid")
+                cancel_agents+=("$ledger_agent")
+                cancel_tasks+=("$ledger_task")
+            fi
+        done < "$PID_FILE"
+    fi
+
+    local pid agent task_id result_file done_dir done_file
+    done_dir="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/agents"
+    mkdir -p "$done_dir" 2>/dev/null || true
+    for idx in "${!cancel_tasks[@]}"; do
+        pid="${cancel_pids[$idx]:-}"
+        agent="${cancel_agents[$idx]:-unknown}"
+        task_id="${cancel_tasks[$idx]:-tangle-${task_group}-${idx}}"
+        result_file="${RESULTS_DIR:-}/$agent-$task_id.md"
+        done_file="$done_dir/${task_id}.done"
+
+        if [[ "$pid" =~ ^[0-9]+$ ]]; then
+            review_kill_process_tree_frozen "$pid"
+            wait "$pid" 2>/dev/null || true
+            rm -f "$done_dir/${pid}.heartbeat" 2>/dev/null || true
+        fi
+        [[ -f "$done_file" ]] || printf '%s\n' "cancelled" > "$done_file" 2>/dev/null || true
+        if [[ -f "$result_file" ]] \
+           && ! grep -Eq '^## Status: (SUCCESS|FAILED|TIMEOUT|CANCELLED)' "$result_file" 2>/dev/null; then
+            {
+                echo ""
+                echo "## Status: CANCELLED - PARTIAL RESULTS"
+                echo ""
+                echo "Tangle interrupted by SIG${signal_name}; partial output above was preserved."
+            } >> "$result_file"
+        fi
+        if declare -F _octopus_agent_lifecycle_event >/dev/null 2>&1; then
+            _octopus_agent_lifecycle_event "cancelled" "$agent" "$task_id" \
+                "implementer" "tangle" "$pid" "$result_file" "$exit_code" "cancelled"
+        fi
+    done
+
+    # A signal can arrive after the provider process exists but before the spawn
+    # helper appends it to the PID ledger. The active orchestrator owns all of
+    # its direct descendants, so sweep any unregistered child trees as the final
+    # race-closing step before clearing lifecycle state.
+    review_kill_descendants_frozen "$$"
+
+    _octopus_tangle_prune_pid_ledger "$task_group"
+    if [[ "${OCTOPUS_ACTIVE_TANGLE_TMUX:-false}" == "true" ]] \
+       && declare -F tmux_cleanup >/dev/null 2>&1; then
+        tmux_cleanup 2>/dev/null || true
+    fi
+    declare -F fleet_dispatch_end >/dev/null 2>&1 && fleet_dispatch_end
+    octopus_tangle_clear_active
+}
+
+octopus_tangle_handle_signal() {
+    local signal_name="${1:-TERM}"
+    local exit_code=143
+    [[ "$signal_name" == "INT" ]] && exit_code=130
+    trap - INT TERM
+    octopus_tangle_cancel_active "$signal_name"
+    exit "$exit_code"
+}
+
 tangle_scope_contamination_summary() {
     local repo_root
     repo_root=$(tangle_resolve_repo_root 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -2404,6 +2537,24 @@ tangle_run_worktree_enabled() {
     [[ "${OCTOPUS_TANGLE_RUN_WORKTREE:-true}" == "true" ]]
 }
 
+# Reserve a collision-free default run ID. Tangle can be invoked repeatedly in
+# the same shell and second (especially in tests and scripted workflows), so a
+# timestamp plus $$ is not unique enough. Reuse the spawn-layer allocator when
+# available; workflows.sh is also sourced directly by tests and integrations,
+# so retain an atomic mktemp-based fallback here.
+tangle_next_run_id() {
+    if declare -F _octopus_next_spawn_task_id >/dev/null 2>&1; then
+        _octopus_next_spawn_task_id
+        return $?
+    fi
+
+    local reservation_dir="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.octo/task-ids"
+    local reservation unique_suffix
+    mkdir -p "$reservation_dir" 2>/dev/null || true
+    reservation=$(mktemp "${reservation_dir}/XXXXXX" 2>/dev/null) && unique_suffix="${reservation##*/}"
+    printf '%s-%s\n' "$(date +%s)" "${unique_suffix:-${BASHPID:-$$}${RANDOM}}"
+}
+
 tangle_extract_plan_file_ref() {
     local prompt="$1"
     local token candidate_ref candidate_basename raw_file_ref
@@ -2557,7 +2708,10 @@ tangle_develop() {
         return $?
     fi
 
-    local task_group="${OCTOPUS_TANGLE_RUN_ID:-$(date +%s)-$$}"
+    local task_group="${OCTOPUS_TANGLE_RUN_ID:-}"
+    if [[ -z "$task_group" ]]; then
+        task_group=$(tangle_next_run_id) || return 1
+    fi
     local original_project_root="${PROJECT_ROOT:-$PWD}"
     local original_pwd="$PWD"
     local resolved_grasp_file="$grasp_file"
@@ -2867,6 +3021,17 @@ Every [CODING] line must include a same-line Files: clause."
         fi
     fi
 
+    local tangle_previous_int_trap tangle_previous_term_trap
+    tangle_previous_int_trap="$(trap -p INT)"
+    tangle_previous_term_trap="$(trap -p TERM)"
+    OCTOPUS_ACTIVE_TANGLE_TASK_GROUP="$task_group"
+    OCTOPUS_ACTIVE_TANGLE_TMUX="$TMUX_MODE"
+    OCTOPUS_ACTIVE_TANGLE_PIDS=()
+    OCTOPUS_ACTIVE_TANGLE_AGENTS=()
+    OCTOPUS_ACTIVE_TANGLE_TASK_IDS=()
+    trap 'octopus_tangle_handle_signal INT' INT
+    trap 'octopus_tangle_handle_signal TERM' TERM
+
     fleet_dispatch_begin
     for line in "${subtask_lines[@]}"; do
         local subtask
@@ -2884,6 +3049,10 @@ Every [CODING] line must include a same-line Files: clause."
         local pane_title="$pane_icon Subtask $((subtask_num+1))"
         local subtask_prompt
         subtask_prompt=$(build_tangle_subtask_prompt "$resolved_prompt" "$subtask")
+        local active_idx="${#OCTOPUS_ACTIVE_TANGLE_TASK_IDS[@]}"
+        OCTOPUS_ACTIVE_TANGLE_PIDS+=("")
+        OCTOPUS_ACTIVE_TANGLE_AGENTS+=("$agent")
+        OCTOPUS_ACTIVE_TANGLE_TASK_IDS+=("$task_id")
 
         # Tangle uses the legacy spawn path in this parallel loop so .done
         # markers are written for the completion watcher. This also allows
@@ -2892,14 +3061,25 @@ Every [CODING] line must include a same-line Files: clause."
         if [[ "$TMUX_MODE" == "true" ]]; then
             # Use async+tmux spawning
             local pid
-            pid=$(spawn_agent_async "$agent" "$subtask_prompt" "$task_id" "$role" "tangle" "$pane_title")
+            if ! pid=$(spawn_agent_async "$agent" "$subtask_prompt" "$task_id" "$role" "tangle" "$pane_title"); then
+                log ERROR "Failed to spawn Tangle task $task_id"
+                octopus_tangle_cancel_active TERM
+                _octopus_tangle_restore_traps "$tangle_previous_int_trap" "$tangle_previous_term_trap"
+                return 1
+            fi
             pids+=("$pid")
         else
             # Standard spawning
             local pid
-            pid=$(spawn_agent_capture_pid "$agent" "$subtask_prompt" "$task_id" "$role" "tangle")
+            if ! pid=$(spawn_agent_capture_pid "$agent" "$subtask_prompt" "$task_id" "$role" "tangle"); then
+                log ERROR "Failed to spawn Tangle task $task_id"
+                octopus_tangle_cancel_active TERM
+                _octopus_tangle_restore_traps "$tangle_previous_int_trap" "$tangle_previous_term_trap"
+                return 1
+            fi
             pids+=("$pid")
         fi
+        OCTOPUS_ACTIVE_TANGLE_PIDS[$active_idx]="$pid"
         task_ids+=("$task_id")
         ((subtask_num++)) || true
     done
@@ -2910,6 +3090,8 @@ Every [CODING] line must include a same-line Files: clause."
     # quality gates can validate a partial dispatch as a complete tangle run.
     if [[ $subtask_num -ne ${#subtask_lines[@]} ]]; then
         log ERROR "Spawned $subtask_num development threads for ${#subtask_lines[@]} parsed subtasks; refusing partial tangle execution"
+        octopus_tangle_cancel_active TERM
+        _octopus_tangle_restore_traps "$tangle_previous_int_trap" "$tangle_previous_term_trap"
         return 1
     fi
 
@@ -2922,6 +3104,8 @@ Every [CODING] line must include a same-line Files: clause."
     [[ "$_tangle_max_wait" =~ ^[0-9]+$ ]] || _tangle_max_wait=0
     local _missing_marker_grace="${OCTOPUS_TANGLE_MISSING_MARKER_GRACE:-180}"
     [[ "$_missing_marker_grace" =~ ^[0-9]+$ ]] || _missing_marker_grace=180
+    local _idle_worker_grace="${OCTOPUS_TANGLE_IDLE_WORKER_GRACE:-180}"
+    [[ "$_idle_worker_grace" =~ ^[0-9]+$ ]] || _idle_worker_grace=180
     local _deadline=0
     if [[ "$_tangle_max_wait" -gt 0 ]]; then
         _deadline=$(( $(date +%s) + _tangle_max_wait ))
@@ -2930,6 +3114,8 @@ Every [CODING] line must include a same-line Files: clause."
     local _failed_tasks=()
     local _terminal_task_ids=""
     local _missing_marker_since=()
+    local _idle_worker_since=()
+    local _last_progress=-1
     while [[ $completed -lt ${#task_ids[@]} ]]; do
         completed=0
         for i in "${!task_ids[@]}"; do
@@ -2939,22 +3125,19 @@ Every [CODING] line must include a same-line Files: clause."
             elif [[ " $_terminal_task_ids " == *" ${task_ids[$i]} "* ]]; then
                 ((completed++)) || true
             else
-                local _wrapper_pid="${pids[$i]:-}"
+                local _worker_pid="${pids[$i]:-}"
                 if [[ "$_tangle_max_wait" -gt 0 ]] && (( $(date +%s) > _deadline )); then
                     log WARN "Thread ${task_ids[$i]} deadline exceeded — killing and marking timeout"
-                    if [[ -n "$_wrapper_pid" ]]; then
-                        pkill -TERM -P "$_wrapper_pid" 2>/dev/null || true
-                        kill -TERM "$_wrapper_pid" 2>/dev/null || true
-                        sleep 1
-                        pkill -KILL -P "$_wrapper_pid" 2>/dev/null || true
-                        kill -KILL "$_wrapper_pid" 2>/dev/null || true
+                    if [[ -n "$_worker_pid" ]]; then
+                        review_kill_process_tree_frozen "$_worker_pid"
+                        wait "$_worker_pid" 2>/dev/null || true
                     fi
                     mkdir -p "$_done_dir" 2>/dev/null || true
                     if [[ ! -f "$_done_file" ]] && ! echo "timeout" > "$_done_file" 2>/dev/null; then
                         log WARN "Failed to write timeout marker for ${task_ids[$i]} at $_done_file"
                     fi
                     [[ " $_terminal_task_ids " == *" ${task_ids[$i]} "* ]] || _terminal_task_ids="${_terminal_task_ids:+$_terminal_task_ids }${task_ids[$i]}"
-                elif [[ -n "$_wrapper_pid" ]] && ! tangle_process_is_active_non_zombie "$_wrapper_pid"; then
+                elif [[ -n "$_worker_pid" ]] && ! tangle_process_is_active_non_zombie "$_worker_pid"; then
                     local _now
                     _now=$(date +%s)
                     if [[ -z "${_missing_marker_since[$i]:-}" ]]; then
@@ -2981,13 +3164,48 @@ Every [CODING] line must include a same-line Files: clause."
                             fi
                         fi
                     fi
+                elif [[ -n "$_worker_pid" ]] \
+                     && ! review_process_has_active_descendant "$_worker_pid"; then
+                    local _idle_now
+                    _idle_now=$(date +%s)
+                    if [[ -z "${_idle_worker_since[$i]:-}" ]]; then
+                        _idle_worker_since[$i]="$_idle_now"
+                        log WARN "Thread ${task_ids[$i]} worker is alive without provider descendants — waiting up to ${_idle_worker_grace}s for completion"
+                    fi
+                    if [[ "$_idle_worker_grace" -eq 0 ]] \
+                       || (( _idle_now - ${_idle_worker_since[$i]} >= _idle_worker_grace )); then
+                        log WARN "Thread ${task_ids[$i]} remained idle without provider descendants for ${_idle_worker_grace}s — killing and marking stalled"
+                        review_kill_process_tree_frozen "$_worker_pid"
+                        wait "$_worker_pid" 2>/dev/null || true
+                        mkdir -p "$_done_dir" 2>/dev/null || true
+                        [[ -f "$_done_file" ]] || printf '%s\n' "stalled-worker" > "$_done_file" 2>/dev/null || true
+                        [[ " $_terminal_task_ids " == *" ${task_ids[$i]} "* ]] \
+                            || _terminal_task_ids="${_terminal_task_ids:+$_terminal_task_ids }${task_ids[$i]}"
+                        local _idle_result_file
+                        _idle_result_file=$(find "${RESULTS_DIR:-${HOME}/.claude-octopus/results}" -maxdepth 1 -type f -name "*-${task_ids[$i]}.md" 2>/dev/null | head -1 || true)
+                        if [[ -n "$_idle_result_file" ]] \
+                           && ! grep -q '^## Status:' "$_idle_result_file" 2>/dev/null; then
+                            {
+                                echo ""
+                                echo "## Status: FAILED (Stalled worker without provider descendants)"
+                                echo "# Completed: $(date)"
+                            } >> "$_idle_result_file" 2>/dev/null || true
+                        fi
+                    fi
+                else
+                    unset "_idle_worker_since[$i]"
                 fi
             fi
         done
-        echo -ne "\r${CYAN}Progress: $completed/${#task_ids[@]} subtasks complete${NC}"
-        sleep 2
+        if [[ -t 1 ]]; then
+            echo -ne "\r${CYAN}Progress: $completed/${#task_ids[@]} subtasks complete${NC}"
+        elif [[ "$completed" -ne "$_last_progress" ]]; then
+            echo "Progress: $completed/${#task_ids[@]} subtasks complete"
+        fi
+        _last_progress="$completed"
+        [[ $completed -ge ${#task_ids[@]} ]] || sleep 2
     done
-    echo ""
+    [[ -t 1 ]] && echo ""
 
     # Final artifact reconciliation: providers can write the result and .done
     # marker after the wrapper PID disappears. Trust a latest SUCCESS status
@@ -3032,6 +3250,7 @@ Every [CODING] line must include a same-line Files: clause."
     if [[ "$TMUX_MODE" == "true" ]]; then
         tmux_cleanup
     fi
+    _octopus_tangle_restore_traps "$tangle_previous_int_trap" "$tangle_previous_term_trap"
 
     # v7.25.0: Record agent completion metrics
     if command -v record_agents_batch_complete &> /dev/null; then

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1787,7 +1787,7 @@ _octopus_tangle_prune_pid_ledger() {
     [[ -n "${PID_FILE:-}" && -f "$PID_FILE" ]] || return 0
     if command -v flock >/dev/null 2>&1; then
         (
-            flock -x 200
+            flock -x 200 || exit $?
             _octopus_tangle_prune_pid_ledger_unlocked "$task_group"
         ) 200>"${PID_FILE}.lock"
     else

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -2213,6 +2213,10 @@ kill_agents() {
     if [[ "$target" == "all" || -z "$target" ]]; then
         log INFO "Killing all tracked agents..."
         while IFS=: read -r pid agent task_id; do
+            if [[ ! "$pid" =~ ^[1-9][0-9]*$ || "$pid" == "1" ]]; then
+                log WARN "Skipping invalid tracked PID: $pid"
+                continue
+            fi
             if kill -0 "$pid" 2>/dev/null; then
                 if declare -F review_kill_process_tree_frozen >/dev/null 2>&1; then
                     review_kill_process_tree_frozen "$pid"
@@ -2228,6 +2232,14 @@ kill_agents() {
         log INFO "Killing agent: $target"
         while IFS=: read -r pid agent task_id; do
             if [[ "$pid" == "$target" || "$task_id" == "$target" ]]; then
+                if [[ ! "$pid" =~ ^[1-9][0-9]*$ || "$pid" == "1" ]]; then
+                    log WARN "Skipping invalid tracked PID: $pid"
+                    continue
+                fi
+                if ! kill -0 "$pid" 2>/dev/null; then
+                    log WARN "Agent $agent ($pid) is no longer running"
+                    continue
+                fi
                 if declare -F review_kill_process_tree_frozen >/dev/null 2>&1; then
                     review_kill_process_tree_frozen "$pid"
                 else

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -549,7 +549,46 @@ mkdir -p "$RESULTS_DIR" "$LOGS_DIR" "$PLANS_DIR" 2>/dev/null || true
 
 # Secure temporary directory (cleaned up on exit)
 OCTOPUS_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/claude-octopus.XXXXXX")
-trap 'rm -rf "$OCTOPUS_TMP_DIR"' EXIT INT TERM
+octopus_cleanup_tmp() {
+    rm -rf "${OCTOPUS_TMP_DIR:?}" 2>/dev/null || true
+}
+
+octopus_orchestrator_cancel_active() {
+    local signal_name="${1:-TERM}"
+    if [[ -n "${OCTOPUS_ACTIVE_TANGLE_TASK_GROUP:-}" ]] \
+       && declare -F octopus_tangle_cancel_active >/dev/null 2>&1; then
+        octopus_tangle_cancel_active "$signal_name" || true
+    elif [[ -n "${OCTOPUS_ACTIVE_PROBE_TASK_GROUP:-}" ]] \
+         && declare -F octopus_probe_cancel_active >/dev/null 2>&1; then
+        octopus_probe_cancel_active "$signal_name" || true
+    fi
+}
+
+octopus_orchestrator_handle_exit() {
+    local exit_code="${1:-0}"
+    trap - EXIT
+    octopus_orchestrator_cancel_active TERM
+    octopus_cleanup_tmp
+    return "$exit_code"
+}
+
+octopus_orchestrator_handle_signal() {
+    local signal_name="${1:-TERM}"
+    local exit_code=143
+    [[ "$signal_name" == "INT" ]] && exit_code=130
+    trap - INT TERM
+
+    octopus_orchestrator_cancel_active "$signal_name"
+    if declare -F review_kill_descendants_frozen >/dev/null 2>&1; then
+        review_kill_descendants_frozen "$$" || true
+    fi
+    octopus_cleanup_tmp
+    exit "$exit_code"
+}
+
+trap 'octopus_orchestrator_handle_exit "$?"' EXIT
+trap 'octopus_orchestrator_handle_signal INT' INT
+trap 'octopus_orchestrator_handle_signal TERM' TERM
 
 # Performance: Preflight check cache (avoids repeated CLI checks)
 PREFLIGHT_CACHE_FILE="${WORKSPACE_DIR}/.preflight-cache"
@@ -2175,7 +2214,13 @@ kill_agents() {
         log INFO "Killing all tracked agents..."
         while IFS=: read -r pid agent task_id; do
             if kill -0 "$pid" 2>/dev/null; then
-                kill "$pid" 2>/dev/null && log INFO "Killed $agent ($pid)"
+                if declare -F review_kill_process_tree_frozen >/dev/null 2>&1; then
+                    review_kill_process_tree_frozen "$pid"
+                else
+                    kill "$pid" 2>/dev/null || true
+                fi
+                wait "$pid" 2>/dev/null || true
+                log INFO "Killed $agent ($pid)"
             fi
         done < "$PID_FILE"
         : > "$PID_FILE"
@@ -2183,7 +2228,13 @@ kill_agents() {
         log INFO "Killing agent: $target"
         while IFS=: read -r pid agent task_id; do
             if [[ "$pid" == "$target" || "$task_id" == "$target" ]]; then
-                kill "$pid" 2>/dev/null && log INFO "Killed $agent ($pid)"
+                if declare -F review_kill_process_tree_frozen >/dev/null 2>&1; then
+                    review_kill_process_tree_frozen "$pid"
+                else
+                    kill "$pid" 2>/dev/null || true
+                fi
+                wait "$pid" 2>/dev/null || true
+                log INFO "Killed $agent ($pid)"
             fi
         done < "$PID_FILE"
     fi

--- a/tests/integration/test-value-proposition.sh
+++ b/tests/integration/test-value-proposition.sh
@@ -131,10 +131,17 @@ test_quality_gates_validation() {
     echo "Validates that tangle phase includes quality validation"
     echo ""
 
-    # Check tangle function code directly
+    # Check both the public wrapper and its workspace implementation. Extract
+    # complete top-level functions so wrapper growth cannot push the actual
+    # decomposition and validation behavior beyond an arbitrary line window.
     local tangle_code=""
     if [[ -f "$ALL_SRC" ]]; then
-        tangle_code=$(grep -A 80 "tangle_develop()" "$ALL_SRC" 2>/dev/null) || tangle_code=""
+        tangle_code=$(
+            sed -n \
+                -e '/^tangle_develop() {/,/^}/p' \
+                -e '/^_tangle_develop_in_workspace() {/,/^}/p' \
+                "$ALL_SRC" 2>/dev/null
+        ) || tangle_code=""
     fi
 
     ((TESTS_RUN++)) || true

--- a/tests/integration/test-value-proposition.sh
+++ b/tests/integration/test-value-proposition.sh
@@ -145,7 +145,7 @@ test_quality_gates_validation() {
     fi
 
     ((TESTS_RUN++)) || true
-    if echo "$tangle_code" | grep -qE "validation|validate"; then
+    if grep -cE "validation|validate" >/dev/null <<< "$tangle_code"; then
         echo -e "${GREEN}✓${NC} Tangle includes validation step"
         ((TESTS_PASSED++)) || true
     else
@@ -154,7 +154,7 @@ test_quality_gates_validation() {
     fi
 
     ((TESTS_RUN++)) || true
-    if echo "$tangle_code" | grep -qE "decompose|subtask"; then
+    if grep -cE "decompose|subtask" >/dev/null <<< "$tangle_code"; then
         echo -e "${GREEN}✓${NC} Tangle decomposes tasks for parallel execution"
         ((TESTS_PASSED++)) || true
     else

--- a/tests/unit/test-develop-md-file-resolution.sh
+++ b/tests/unit/test-develop-md-file-resolution.sh
@@ -85,6 +85,19 @@ else
     test_fail "same-second Tangle run IDs collided: $first_run_id"
 fi
 
+test_case "direct Tangle ID allocation prunes expired reservations"
+tangle_reservation_dir="$WORKSPACE_DIR/.octo/task-ids"
+expired_tangle_reservation="$tangle_reservation_dir/expired-tangle-reservation"
+find "$tangle_reservation_dir" -type f -name '.pruned-*' -delete 2>/dev/null || true
+: > "$expired_tangle_reservation"
+touch -t 202001010000 "$expired_tangle_reservation"
+tangle_next_run_id >/dev/null
+if [[ ! -e "$expired_tangle_reservation" ]]; then
+    test_pass
+else
+    test_fail "expired direct Tangle reservation was not pruned"
+fi
+
 log() { :; }
 octopus_phase_banner() { :; }
 design_review_ceremony() { :; }

--- a/tests/unit/test-develop-md-file-resolution.sh
+++ b/tests/unit/test-develop-md-file-resolution.sh
@@ -66,6 +66,25 @@ mkdir -p "$WORKSPACE_DIR/.octo/agents"
 DECOMPOSE_CAPTURE_FILE="$RESULTS_DIR/decompose.prompt"
 trap 'rm -rf "$RESULTS_DIR"' EXIT
 
+test_case "default Tangle run IDs stay unique within the same second"
+date() {
+    if [[ "${1:-}" == "+%s" ]]; then
+        printf '%s\n' "1234567890"
+        return 0
+    fi
+    command date "$@"
+}
+first_run_id=$(tangle_next_run_id)
+second_run_id=$(tangle_next_run_id)
+unset -f date
+if [[ "$first_run_id" != "$second_run_id" ]] && \
+   [[ "$first_run_id" == 1234567890-* ]] && \
+   [[ "$second_run_id" == 1234567890-* ]]; then
+    test_pass
+else
+    test_fail "same-second Tangle run IDs collided: $first_run_id"
+fi
+
 log() { :; }
 octopus_phase_banner() { :; }
 design_review_ceremony() { :; }

--- a/tests/unit/test-heartbeat-timeout.sh
+++ b/tests/unit/test-heartbeat-timeout.sh
@@ -113,7 +113,14 @@ test_timeout_env_override() {
 test_heartbeat_in_spawn_agent() {
     test_case "Heartbeat monitor started in spawn_agent"
 
-    if grep -B 5 -A 5 'local pid=\$!' "$ALL_SRC" | grep -q "start_heartbeat_monitor"; then
+    local spawn_body pid_line heartbeat_line
+    spawn_body=$(sed -n '/^spawn_agent()/,/^spawn_agent_capture_pid()/p' \
+        "$PROJECT_ROOT/scripts/lib/spawn.sh")
+    pid_line=$(printf '%s\n' "$spawn_body" | awk '/local pid=\$!/{print NR; exit}')
+    heartbeat_line=$(printf '%s\n' "$spawn_body" | \
+        awk '/start_heartbeat_monitor "\$pid" "\$task_id"/{print NR; exit}')
+
+    if [[ -n "$pid_line" && -n "$heartbeat_line" && "$heartbeat_line" -gt "$pid_line" ]]; then
         test_pass
     else
         test_fail "start_heartbeat_monitor not called after PID assignment"

--- a/tests/unit/test-spawn-agent-capture-pid.sh
+++ b/tests/unit/test-spawn-agent-capture-pid.sh
@@ -145,6 +145,7 @@ fi
 # orphaning the descendant. Load review.sh's tree-kill helper the same way
 # spawn.sh's fixed code path resolves it, and prove the descendant is reaped.
 test_case "descendant of a failed spawn is reaped, not left orphaned (#736)"
+eval "$(sed -n '/^review_child_pids() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
 eval "$(sed -n '/^review_process_tree_depth_first() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
 eval "$(sed -n '/^review_terminate_process_tree() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
 eval "$(sed -n '/^review_process_is_running() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/review.sh")"

--- a/tests/unit/test-spawn-agent-capture-pid.sh
+++ b/tests/unit/test-spawn-agent-capture-pid.sh
@@ -7,6 +7,7 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "spawn agent PID capture"
 
 # Load only the helpers under test so the fixture controls spawn_agent and log.
+eval "$(sed -n '/^_octopus_prune_task_id_reservations() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/spawn.sh")"
 eval "$(sed -n '/^_octopus_next_spawn_task_id() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/spawn.sh")"
 eval "$(sed -n '/^spawn_agent_capture_pid() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/spawn.sh")"
 
@@ -14,8 +15,8 @@ TEST_TMP_DIR="/tmp/octopus-tests-$$"
 mkdir -p "$TEST_TMP_DIR"
 trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
 
-# Keep the permanent per-id reservation files (see _octopus_next_spawn_task_id)
-# inside the test sandbox instead of the real ~/.claude-octopus.
+# Keep per-id reservation files inside the test sandbox instead of the real
+# ~/.claude-octopus.
 export WORKSPACE_DIR="$TEST_TMP_DIR"
 
 log() { printf '%s %s\n' "${1:-}" "${2:-}" >> "$TEST_TMP_DIR/log"; }
@@ -107,6 +108,20 @@ if [[ "$unique" == "$total" ]]; then
     test_pass
 else
     test_fail "expected $total distinct task_ids, got only $unique unique"
+fi
+
+test_case "task_id helper prunes expired reservations"
+reservation_dir="$WORKSPACE_DIR/.octo/task-ids"
+expired_reservation="$reservation_dir/expired-reservation"
+mkdir -p "$reservation_dir"
+find "$reservation_dir" -type f -name '.pruned-*' -delete 2>/dev/null || true
+: > "$expired_reservation"
+touch -t 202001010000 "$expired_reservation"
+_octopus_next_spawn_task_id >/dev/null
+if [[ ! -e "$expired_reservation" ]]; then
+    test_pass
+else
+    test_fail "expired task-id reservation was not pruned"
 fi
 
 # The PID/RANDOM fallback only fires when mktemp itself can't run (e.g. no

--- a/tests/unit/test-spawn-agent-capture-pid.sh
+++ b/tests/unit/test-spawn-agent-capture-pid.sh
@@ -11,10 +11,6 @@ eval "$(sed -n '/^_octopus_prune_task_id_reservations() {/,/^}/p' "$PROJECT_ROOT
 eval "$(sed -n '/^_octopus_next_spawn_task_id() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/spawn.sh")"
 eval "$(sed -n '/^spawn_agent_capture_pid() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/spawn.sh")"
 
-TEST_TMP_DIR="/tmp/octopus-tests-$$"
-mkdir -p "$TEST_TMP_DIR"
-trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
-
 # Keep per-id reservation files inside the test sandbox instead of the real
 # ~/.claude-octopus.
 export WORKSPACE_DIR="$TEST_TMP_DIR"

--- a/tests/unit/test-tangle-cancellation-cleanup.sh
+++ b/tests/unit/test-tangle-cancellation-cleanup.sh
@@ -50,6 +50,43 @@ else
     octopus_tangle_cancel_active() { :; }
 fi
 
+test_case "portable child enumeration prefers POSIX ps selection"
+if declare -f review_child_pids | grep -Fq 'ps -A -o pid= -o ppid='; then
+    test_pass
+else
+    test_fail "review_child_pids lacks the POSIX ps -A fallback"
+fi
+
+test_case "frozen cancellation never signals its own worker group"
+self_guard_definition="$(declare -f review_kill_process_tree_frozen)"
+if grep -Fq '^[1-9][0-9]*$' <<< "$self_guard_definition" \
+   && grep -Fq 'root_pid" != "1' <<< "$self_guard_definition" \
+   && grep -Fq 'root_pid" == "$$' <<< "$self_guard_definition" \
+   && grep -Fq 'current_pgid' <<< "$self_guard_definition"; then
+    test_pass
+else
+    test_fail "cancellation helper lacks orchestrator PID/group self-protection"
+fi
+
+test_case "PID ledger pruning uses the spawn ledger lock"
+prune_definition="$(declare -f _octopus_tangle_prune_pid_ledger)"
+if grep -Fq 'flock -x' <<< "$prune_definition" \
+   && grep -Fq '${PID_FILE}.lock' <<< "$prune_definition"; then
+    test_pass
+else
+    test_fail "Tangle PID ledger pruning is not serialized with spawn appends"
+fi
+
+test_case "workflow loader reports missing cancellation helpers and clears its path variable"
+workflow_loader="$(sed -n '1,28p' "$PROJECT_ROOT/scripts/lib/workflows.sh")"
+if grep -Fq 'missing Tangle cancellation helpers' <<< "$workflow_loader" \
+   && grep -Fq 'unset _octo_review_lib' <<< "$workflow_loader" \
+   && grep -Fq 'Tangle cancellation helpers are unavailable' "$PROJECT_ROOT/scripts/lib/workflows.sh"; then
+    test_pass
+else
+    test_fail "workflow cancellation helper loading can still fail silently"
+fi
+
 test_case "TERM reaps ledger-only worker tree and prevents late writes"
 WORKSPACE_DIR="$TEST_TMP_DIR/workspace"
 RESULTS_DIR="$WORKSPACE_DIR/results"
@@ -199,6 +236,47 @@ else
     test_fail "top-level orchestrator still swallows INT/TERM without cancellation and exit"
 fi
 
+test_case "targeted kill ignores a dead or recycled PID"
+if declare -F kill_agents >/dev/null 2>&1; then
+    unset -f kill_agents
+fi
+eval "$(sed -n '/^kill_agents() {/,/^}/p' "$orchestrator_source")"
+dead_target="2147480000"
+printf '%s:%s:%s\n' "$dead_target" "codex" "dead-target" > "$PID_FILE"
+targeted_kill_log="$TEST_TMP_DIR/targeted-kill.log"
+targeted_kill_invoked="$TEST_TMP_DIR/targeted-kill-invoked"
+log() { printf '%s %s\n' "$1" "$2" >> "$targeted_kill_log"; }
+original_frozen_kill_definition="$(declare -f review_kill_process_tree_frozen)"
+review_kill_process_tree_frozen() { : > "$targeted_kill_invoked"; }
+kill_agents "dead-target"
+unset -f review_kill_process_tree_frozen
+eval "$original_frozen_kill_definition"
+log() { :; }
+if [[ ! -e "$targeted_kill_invoked" ]] \
+   && ! grep -Fq "Killed codex ($dead_target)" "$targeted_kill_log" 2>/dev/null; then
+    test_pass
+else
+    test_fail "targeted kill signaled or reported a dead PID"
+fi
+
+test_case "targeted kill rejects PID zero before liveness probing"
+: > "$targeted_kill_log"
+rm "$targeted_kill_invoked" 2>/dev/null || true
+printf '%s:%s:%s\n' "0" "codex" "zero-target" > "$PID_FILE"
+log() { printf '%s %s\n' "$1" "$2" >> "$targeted_kill_log"; }
+review_kill_process_tree_frozen() { : > "$targeted_kill_invoked"; }
+kill_agents "zero-target"
+unset -f review_kill_process_tree_frozen
+eval "$original_frozen_kill_definition"
+log() { :; }
+if [[ ! -e "$targeted_kill_invoked" ]] \
+   && grep -Fq 'invalid tracked PID: 0' "$targeted_kill_log" \
+   && ! grep -Fq 'Killed codex (0)' "$targeted_kill_log"; then
+    test_pass
+else
+    test_fail "targeted kill accepted PID zero"
+fi
+
 test_case "unexpected orchestrator exit cancels registered Tangle work"
 if declare -F octopus_orchestrator_handle_exit >/dev/null 2>&1; then
     unset -f octopus_orchestrator_handle_exit
@@ -208,7 +286,7 @@ exit_cleanup_log="$TEST_TMP_DIR/exit-cleanup.log"
 octopus_orchestrator_cancel_active() { printf 'cancel:%s\n' "$1" >> "$exit_cleanup_log"; }
 octopus_cleanup_tmp() { printf 'tmp\n' >> "$exit_cleanup_log"; }
 if declare -F octopus_orchestrator_handle_exit >/dev/null 2>&1; then
-    if octopus_orchestrator_handle_exit 37; then exit_handler_rc=0; else exit_handler_rc=$?; fi
+    if ( octopus_orchestrator_handle_exit 37 ); then exit_handler_rc=0; else exit_handler_rc=$?; fi
 else
     exit_handler_rc=127
 fi

--- a/tests/unit/test-tangle-cancellation-cleanup.sh
+++ b/tests/unit/test-tangle-cancellation-cleanup.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Regression coverage for #900: cancelling Tangle must terminate every provider
+# descendant, reconcile its runtime ledger, and prevent post-cancel writes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+log() { :; }
+octo_provider_identity_from_agent_type() { printf '%s\n' "${1%%-*}"; }
+get_agent_model() { printf '%s\n' "fixture-model"; }
+
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/events.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/review.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/workflows.sh"
+
+test_suite "Tangle cancellation cleanup (#900)"
+
+worker_pid=""
+worker_child_pid=""
+
+cleanup_tangle_processes() {
+    local pid
+    for pid in "$worker_child_pid" "$worker_pid"; do
+        [[ "$pid" =~ ^[0-9]+$ ]] || continue
+        kill -KILL "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+}
+after_all cleanup_tangle_processes
+
+process_is_running() {
+    local pid="$1" stat
+    kill -0 "$pid" 2>/dev/null || return 1
+    stat=$(ps -o stat= -p "$pid" 2>/dev/null | tr -d '[:space:]') || return 1
+    [[ -n "$stat" && "$stat" != Z* ]]
+}
+
+test_case "tangle cancellation helper is available"
+if declare -F octopus_tangle_cancel_active >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "octopus_tangle_cancel_active is missing"
+    octopus_tangle_cancel_active() { :; }
+fi
+
+test_case "TERM reaps ledger-only worker tree and prevents late writes"
+WORKSPACE_DIR="$TEST_TMP_DIR/workspace"
+RESULTS_DIR="$WORKSPACE_DIR/results"
+PID_FILE="$WORKSPACE_DIR/pids"
+mkdir -p "$RESULTS_DIR" "$WORKSPACE_DIR/.octo/agents"
+
+child_pid_file="$TEST_TMP_DIR/worker-child.pid"
+late_write="$TEST_TMP_DIR/late-write"
+bash -c '
+    trap "" TERM
+    (
+        sleep 1
+        : > "$2"
+    ) &
+    printf "%s\n" "$!" > "$1"
+    wait
+' _ "$child_pid_file" "$late_write" &
+worker_pid=$!
+
+attempt=0
+while [[ ! -s "$child_pid_file" && "$attempt" -lt 100 ]]; do
+    sleep 0.02
+    attempt=$((attempt + 1))
+done
+worker_child_pid="$(cat "$child_pid_file" 2>/dev/null || true)"
+
+task_group="900001"
+task_id="tangle-${task_group}-0"
+result_file="$RESULTS_DIR/codex-${task_id}.md"
+printf '# Agent: codex\n# Task ID: %s\n\n## Output\npartial output\n' "$task_id" > "$result_file"
+printf '%s:%s:%s\n' "$worker_pid" "codex" "$task_id" > "$PID_FILE"
+
+# Exercise the signal handoff window: the worker reached the authoritative PID
+# ledger before spawn_agent_capture_pid returned it to the in-memory array.
+OCTOPUS_ACTIVE_TANGLE_TASK_GROUP="$task_group"
+OCTOPUS_ACTIVE_TANGLE_TMUX="false"
+OCTOPUS_ACTIVE_TANGLE_PIDS=()
+OCTOPUS_ACTIVE_TANGLE_AGENTS=()
+OCTOPUS_ACTIVE_TANGLE_TASK_IDS=()
+
+octopus_tangle_cancel_active TERM
+wait "$worker_pid" 2>/dev/null || true
+sleep 1.1
+
+if ! process_is_running "$worker_pid" \
+   && ! process_is_running "$worker_child_pid" \
+   && [[ ! -e "$late_write" ]]; then
+    test_pass
+else
+    test_fail "worker tree survived cancellation or wrote after cancellation"
+fi
+
+test_case "cancellation records terminal state and prunes runtime metadata"
+done_file="$WORKSPACE_DIR/.octo/agents/${task_id}.done"
+if [[ "$(cat "$done_file" 2>/dev/null || true)" == "cancelled" ]] \
+   && grep -q '^## Status: CANCELLED - PARTIAL RESULTS' "$result_file" \
+   && ! grep -q "$task_id" "$PID_FILE" 2>/dev/null \
+   && [[ -z "${OCTOPUS_ACTIVE_TANGLE_TASK_GROUP:-}" ]]; then
+    test_pass
+else
+    test_fail "cancelled Tangle task lacks terminal marker, result status, ledger cleanup, or state reset"
+fi
+
+test_case "cancellation reaps provider spawned before PID ledger handoff"
+preledger_write="$TEST_TMP_DIR/preledger-late-write"
+bash -c '
+    trap "" TERM
+    (
+        sleep 1
+        : > "$1"
+    ) &
+    wait
+' _ "$preledger_write" &
+preledger_pid=$!
+OCTOPUS_ACTIVE_TANGLE_TASK_GROUP="900002"
+OCTOPUS_ACTIVE_TANGLE_TMUX="false"
+OCTOPUS_ACTIVE_TANGLE_PIDS=("")
+OCTOPUS_ACTIVE_TANGLE_AGENTS=("codex")
+OCTOPUS_ACTIVE_TANGLE_TASK_IDS=("tangle-900002-0")
+: > "$PID_FILE"
+
+octopus_tangle_cancel_active TERM
+wait "$preledger_pid" 2>/dev/null || true
+sleep 1.1
+
+if ! process_is_running "$preledger_pid" && [[ ! -e "$preledger_write" ]]; then
+    test_pass
+else
+    kill -KILL "$preledger_pid" 2>/dev/null || true
+    test_fail "provider survived cancellation before PID ledger handoff"
+fi
+
+test_case "frozen cancellation kills a worker group after its leader exits"
+group_child_pid_file="$TEST_TMP_DIR/group-child.pid"
+group_late_write="$TEST_TMP_DIR/group-late-write"
+monitor_was_enabled=false
+[[ "$-" == *m* ]] && monitor_was_enabled=true
+set -m
+bash -c '
+    (
+        trap "" TERM
+        sleep 1
+        : > "$2"
+    ) &
+    printf "%s\n" "$!" > "$1"
+' _ "$group_child_pid_file" "$group_late_write" &
+group_leader_pid=$!
+[[ "$monitor_was_enabled" == "true" ]] || set +m
+wait "$group_leader_pid" 2>/dev/null || true
+group_child_pid="$(cat "$group_child_pid_file" 2>/dev/null || true)"
+
+review_kill_process_tree_frozen "$group_leader_pid"
+sleep 1.1
+
+if [[ -n "$group_child_pid" ]] \
+   && ! process_is_running "$group_child_pid" \
+   && [[ ! -e "$group_late_write" ]]; then
+    test_pass
+else
+    kill -KILL "$group_child_pid" 2>/dev/null || true
+    test_fail "provider group survived after its recorded leader exited"
+fi
+
+test_case "tangle signal handler maps TERM to exit 143"
+if env "HOME=$TEST_TMP_DIR/signal-home" bash -c '
+    source "'"$PROJECT_ROOT"'/scripts/lib/workflows.sh"
+    OCTOPUS_ACTIVE_TANGLE_TASK_GROUP="signal-term"
+    WORKSPACE_DIR="'"$TEST_TMP_DIR"'/signal-workspace"
+    RESULTS_DIR="$WORKSPACE_DIR/results"
+    PID_FILE="$WORKSPACE_DIR/pids"
+    octopus_tangle_handle_signal TERM
+' >/dev/null 2>&1; then
+    signal_rc=0
+else
+    signal_rc=$?
+fi
+if [[ "$signal_rc" -eq 143 ]]; then test_pass; else test_fail "TERM returned $signal_rc instead of 143"; fi
+
+test_case "orchestrator signal traps cancel work and exit"
+orchestrator_source="$PROJECT_ROOT/scripts/orchestrate.sh"
+if grep -Fq "trap 'octopus_orchestrator_handle_signal TERM' TERM" "$orchestrator_source" \
+   && grep -Fq "trap 'octopus_orchestrator_handle_signal INT' INT" "$orchestrator_source" \
+   && grep -Fq "trap 'octopus_orchestrator_handle_exit \"\$?\"' EXIT" "$orchestrator_source" \
+   && ! grep -Fq "trap 'rm -rf \"\$OCTOPUS_TMP_DIR\"' EXIT INT TERM" "$orchestrator_source"; then
+    test_pass
+else
+    test_fail "top-level orchestrator still swallows INT/TERM without cancellation and exit"
+fi
+
+test_case "unexpected orchestrator exit cancels registered Tangle work"
+if declare -F octopus_orchestrator_handle_exit >/dev/null 2>&1; then
+    unset -f octopus_orchestrator_handle_exit
+fi
+eval "$(sed -n '/^octopus_orchestrator_handle_exit() {/,/^}/p' "$orchestrator_source")"
+exit_cleanup_log="$TEST_TMP_DIR/exit-cleanup.log"
+octopus_orchestrator_cancel_active() { printf 'cancel:%s\n' "$1" >> "$exit_cleanup_log"; }
+octopus_cleanup_tmp() { printf 'tmp\n' >> "$exit_cleanup_log"; }
+if declare -F octopus_orchestrator_handle_exit >/dev/null 2>&1; then
+    if octopus_orchestrator_handle_exit 37; then exit_handler_rc=0; else exit_handler_rc=$?; fi
+else
+    exit_handler_rc=127
+fi
+if [[ "$exit_handler_rc" -eq 37 ]] \
+   && grep -q '^cancel:TERM$' "$exit_cleanup_log" 2>/dev/null \
+   && grep -q '^tmp$' "$exit_cleanup_log" 2>/dev/null; then
+    test_pass
+else
+    test_fail "EXIT handler did not cancel active work, preserve status 37, and clean temp state"
+fi
+
+test_summary

--- a/tests/unit/test-tangle-cancellation-cleanup.sh
+++ b/tests/unit/test-tangle-cancellation-cleanup.sh
@@ -77,6 +77,23 @@ else
     test_fail "Tangle PID ledger pruning is not serialized with spawn appends"
 fi
 
+test_case "PID ledger pruning stops when lock acquisition fails"
+PID_FILE="$TEST_TMP_DIR/lock-failure-pids"
+printf '%s\n' '101:codex:tangle-lock-failure-0' '202:qwen:other-task' > "$PID_FILE"
+flock() { return 1; }
+set +e
+_octopus_tangle_prune_pid_ledger 'lock-failure'
+lock_failure_rc=$?
+set -e
+unset -f flock
+if [[ "$lock_failure_rc" -ne 0 ]] \
+   && grep -q 'tangle-lock-failure-0' "$PID_FILE" \
+   && grep -q 'other-task' "$PID_FILE"; then
+    test_pass
+else
+    test_fail "failed lock returned $lock_failure_rc or allowed PID ledger pruning"
+fi
+
 test_case "workflow loader reports missing cancellation helpers and clears its path variable"
 workflow_loader="$(sed -n '1,28p' "$PROJECT_ROOT/scripts/lib/workflows.sh")"
 if grep -Fq 'missing Tangle cancellation helpers' <<< "$workflow_loader" \

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -56,6 +56,7 @@ assert_contains "$WORKFLOWS" "Skipping ink/deliver because tangle validation gat
 assert_contains "$HELP" "Contextual code review" "develop help documents contextual review"
 assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE" "develop help documents bounded mode"
 assert_contains "$HELP" "OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW" "develop help documents stall window"
+assert_contains "$HELP" "OCTOPUS_TANGLE_IDLE_WORKER_GRACE" "develop help documents idle worker recovery"
 assert_contains "$WORKFLOWS" "OCTOPUS_INK_REVIEW_TIMEOUT:-0" "ink review has no wall timeout by default"
 
 test_case "generated review context stays inside the workspace"

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -57,6 +57,7 @@ assert_contains "$HELP" "Contextual code review" "develop help documents context
 assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE" "develop help documents bounded mode"
 assert_contains "$HELP" "OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW" "develop help documents stall window"
 assert_contains "$HELP" "OCTOPUS_TANGLE_IDLE_WORKER_GRACE" "develop help documents idle worker recovery"
+assert_contains "$HELP" "Seconds to wait before a live wrapper with no provider descendants is marked stalled (0 = immediate)" "develop help explains idle worker grace units and zero behavior"
 assert_contains "$WORKFLOWS" "OCTOPUS_INK_REVIEW_TIMEOUT:-0" "ink review has no wall timeout by default"
 
 test_case "generated review context stays inside the workspace"

--- a/tests/unit/test-tangle-missing-done-marker.sh
+++ b/tests/unit/test-tangle-missing-done-marker.sh
@@ -28,13 +28,17 @@ RED=""
 NC=""
 TMUX_MODE=false
 OCTOPUS_TANGLE_MISSING_MARKER_GRACE=0
+OCTOPUS_TANGLE_IDLE_WORKER_GRACE=0
 DRY_RUN=false
 SUPPORTS_PARALLEL_FILE_SAFETY=false
 RESULTS_DIR="$TEST_TMP_DIR/results"
 WORKSPACE_DIR="$TEST_TMP_DIR/workspace"
+PID_FILE="$WORKSPACE_DIR/pids"
 LOG_CAPTURE_FILE="$TEST_TMP_DIR/tangle.log"
 DATE_COUNTER_FILE="$TEST_TMP_DIR/date-counter"
 SLEEP_COUNTER_FILE="$TEST_TMP_DIR/sleep-counter"
+IDLE_WORKER_PID_FILE="$TEST_TMP_DIR/idle-worker.pid"
+FIXTURE_MODE="dead"
 mkdir -p "$RESULTS_DIR" "$WORKSPACE_DIR/.octo/agents"
 
 log() {
@@ -61,10 +65,18 @@ spawn_agent_capture_pid() {
 
 ## Output
 EOF
-    ( : ) &
-    local dead_pid="$!"
-    wait "$dead_pid" 2>/dev/null || true
-    printf '%s\n' "$dead_pid"
+    if [[ "$FIXTURE_MODE" == "idle" ]]; then
+        tail -f /dev/null >/dev/null 2>&1 &
+        local idle_pid="$!"
+        printf '%s\n' "$idle_pid" > "$IDLE_WORKER_PID_FILE"
+        printf '%s:%s:%s\n' "$idle_pid" "codex" "$task_id" >> "$PID_FILE"
+        printf '%s\n' "$idle_pid"
+        return 0
+    fi
+    # Use a numeric PID outside the platform range. A real reaped PID can be
+    # recycled immediately by the test's own ps/date helpers, making a dead
+    # worker look live and turning cleanup into a signal against the fixture.
+    printf '%s\n' "2147480000"
 }
 sleep() {
     local count
@@ -79,6 +91,9 @@ sleep() {
         rm -f "$WORKSPACE_DIR/.octo/agents" 2>/dev/null || true
         mkdir -p "$WORKSPACE_DIR/.octo/agents"
         printf '0' > "$WORKSPACE_DIR/.octo/agents/tangle-100-0.done"
+        if [[ -s "$IDLE_WORKER_PID_FILE" ]]; then
+            kill -KILL "$(cat "$IDLE_WORKER_PID_FILE")" 2>/dev/null || true
+        fi
     fi
 }
 date() {
@@ -100,6 +115,9 @@ reset_fixture() {
     mkdir -p "$RESULTS_DIR" "$WORKSPACE_DIR/.octo/agents"
     printf '0' > "$DATE_COUNTER_FILE"
     printf '0' > "$SLEEP_COUNTER_FILE"
+    : > "$IDLE_WORKER_PID_FILE"
+    : > "$PID_FILE"
+    FIXTURE_MODE="dead"
 }
 
 test_case "dead wrapper writes missing-done-marker and failed status before deadline"
@@ -129,6 +147,29 @@ if [[ "$(<"$SLEEP_COUNTER_FILE")" -le 6 ]] && \
     test_pass
 else
     test_fail "wait loop did not terminate when marker write failed"
+fi
+
+test_case "living worker without provider descendants becomes terminal"
+reset_fixture
+FIXTURE_MODE="idle"
+idle_output="$TEST_TMP_DIR/idle-worker.out"
+tangle_develop "idle worker task" > "$idle_output" 2>&1 || true
+idle_pid=$(cat "$IDLE_WORKER_PID_FILE" 2>/dev/null || true)
+if grep -q 'finished with status: stalled-worker' "$LOG_CAPTURE_FILE" \
+   && [[ -n "$idle_pid" ]] \
+   && ! kill -0 "$idle_pid" 2>/dev/null; then
+    test_pass
+else
+    kill -KILL "$idle_pid" 2>/dev/null || true
+    test_fail "idle worker was not terminated and recorded as stalled-worker"
+fi
+
+test_case "redirected progress prints only when the count changes"
+progress_count=$(grep -o 'Progress:' "$idle_output" 2>/dev/null | wc -l | tr -d ' ')
+if [[ "${progress_count:-0}" -le 2 ]]; then
+    test_pass
+else
+    test_fail "redirected progress repeated $progress_count unchanged lines"
 fi
 
 unset -f date

--- a/tests/unit/test-tangle-missing-done-marker.sh
+++ b/tests/unit/test-tangle-missing-done-marker.sh
@@ -39,6 +39,7 @@ DATE_COUNTER_FILE="$TEST_TMP_DIR/date-counter"
 SLEEP_COUNTER_FILE="$TEST_TMP_DIR/sleep-counter"
 IDLE_WORKER_PID_FILE="$TEST_TMP_DIR/idle-worker.pid"
 FIXTURE_MODE="dead"
+DATE_MODE="constant"
 mkdir -p "$RESULTS_DIR" "$WORKSPACE_DIR/.octo/agents"
 
 log() {
@@ -104,7 +105,11 @@ date() {
         count=$(<"$DATE_COUNTER_FILE")
         count=$((count + 1))
         printf '%s' "$count" > "$DATE_COUNTER_FILE"
-        printf '%s\n' "100"
+        if [[ "$DATE_MODE" == "advancing" ]]; then
+            printf '%s\n' "$((100 + count))"
+        else
+            printf '%s\n' "100"
+        fi
         return 0
     fi
     command date "$@"
@@ -118,6 +123,8 @@ reset_fixture() {
     : > "$IDLE_WORKER_PID_FILE"
     : > "$PID_FILE"
     FIXTURE_MODE="dead"
+    DATE_MODE="constant"
+    OCTOPUS_TANGLE_IDLE_WORKER_GRACE=0
 }
 
 test_case "dead wrapper writes missing-done-marker and failed status before deadline"
@@ -166,10 +173,36 @@ fi
 
 test_case "redirected progress prints only when the count changes"
 progress_count=$(grep -o 'Progress:' "$idle_output" 2>/dev/null | wc -l | tr -d ' ')
-if [[ "${progress_count:-0}" -le 2 ]]; then
+if [[ "${progress_count:-0}" -eq 2 ]]; then
     test_pass
 else
-    test_fail "redirected progress repeated $progress_count unchanged lines"
+    test_fail "expected exactly 2 redirected progress lines, found $progress_count"
+fi
+
+test_case "nonzero idle grace waits until the exact threshold"
+reset_fixture
+FIXTURE_MODE="idle"
+DATE_MODE="advancing"
+OCTOPUS_TANGLE_IDLE_WORKER_GRACE=2
+tangle_develop "idle worker grace task" >/dev/null 2>&1 || true
+grace_sleep_count="$(<"$SLEEP_COUNTER_FILE")"
+grace_idle_pid="$(cat "$IDLE_WORKER_PID_FILE" 2>/dev/null || true)"
+if [[ "$grace_sleep_count" -eq 3 ]] \
+   && grep -Fq 'remained idle without provider descendants for 2s' "$LOG_CAPTURE_FILE" \
+   && [[ -n "$grace_idle_pid" ]] \
+   && ! kill -0 "$grace_idle_pid" 2>/dev/null; then
+    test_pass
+else
+    kill -KILL "$grace_idle_pid" 2>/dev/null || true
+    test_fail "idle grace boundary was not enforced exactly (sleep_count=$grace_sleep_count)"
+fi
+
+test_case "idle result status check is SIGPIPE-safe"
+if grep -Fq "grep -c '^## Status:'" "$WORKFLOWS" \
+   && ! grep -Fq "grep -q '^## Status:' \"\$_idle_result_file\"" "$WORKFLOWS"; then
+    test_pass
+else
+    test_fail "idle result status check still uses grep -q"
 fi
 
 unset -f date

--- a/tests/unit/test-tangle-run-worktree.sh
+++ b/tests/unit/test-tangle-run-worktree.sh
@@ -69,6 +69,26 @@ else
 fi
 unset OCTOPUS_TANGLE_RUN_WORKTREE
 
+test_case "invalid run ID override is rejected before execution"
+OCTOPUS_TANGLE_RUN_ID="../../escape"
+SEEN_TASK_GROUP=""
+SEEN_PROJECT_ROOT=""
+run_id_log="$TEST_ROOT/invalid-run-id.log"
+log() { printf '%s %s\n' "$1" "$2" >> "$run_id_log"; }
+status=0
+tangle_develop "invalid run id" || status=$?
+log() { :; }
+if [[ "$status" -ne 0 \
+    && -z "$SEEN_PROJECT_ROOT" \
+    && "$(grep -c 'Invalid OCTOPUS_TANGLE_RUN_ID' "$run_id_log" 2>/dev/null || true)" -eq 1 ]]; then
+    test_pass
+else
+    test_fail "invalid run ID reached delegated execution: ${SEEN_PROJECT_ROOT:-none}"
+fi
+OCTOPUS_TANGLE_RUN_ID="run-worktree-test"
+SEEN_PROJECT_ROOT=""
+SEEN_TASK_GROUP=""
+
 test_case "dirty source is rejected before run worktree creation"
 printf 'local-only\n' > "$SOURCE_REPO/untracked.txt"
 OCTOPUS_TANGLE_RUN_ID="dirty-source"


### PR DESCRIPTION
## Summary

- run legacy Tangle workers in dedicated process groups and cancel active work on INT, TERM, spawn failure, and unexpected orchestrator exit
- reconcile in-memory task state with the PID ledger, mark cancellation artifacts, and prevent late provider writes
- recover living wrappers with no provider descendants and avoid repeated non-TTY progress output
- generate collision-free validated Tangle run IDs and prune stale reservations
- harden portable descendant discovery, PID-ledger locking, loader failure handling, and signal self-protection

Fixes #900
Fixes #902

## Verification

- lifecycle cancellation: 14/14
- missing-marker recovery: 6/6
- run-worktree isolation: 14/14
- Markdown plan and run-ID resolution: 13/13
- contextual review wiring: 56/56
- spawn PID capture: 10/10
- value-proposition integration: 19/19
- final non-interactive make ci-local: 16/16 smoke suites, 268/268 unit suites, 7/7 integration suites, and CI-only verifications

Review-response commit: 1342083a

Release is intentionally deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation and cleanup of background tasks and child processes.
  * Added recovery for stalled workers and missing completion signals.
  * Preserved partial results and accurate cancellation status during interrupted runs.
  * Prevented late results and temporary state from persisting after cancellation.
  * Improved progress reporting and safer process handling.
  * Added collision-resistant run tracking and invalid ID validation.
  * Automatically removes expired task reservations.

* **Documentation**
  * Documented the configurable grace period for detecting stalled workers.

* **Tests**
  * Added regression coverage for lifecycle handling, cleanup, stalled workers, progress output, and unique run tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->