### PR TITLE
fix: normalize review findings artifacts

### DIFF
--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -4,15 +4,16 @@ Last updated: 2026-08-13
 Status: Issue #908 is implemented and proposed in PR #911 on
 `fix/908-review-aggregation`. Review
 findings now cross a single-document normalization boundary before persistence,
-counting, event emission, rendering, or publishing; duplicate findings collapse
-without changing synthesis rank. PR, merge, and release are the remaining
-steps, and release remains explicitly deferred.
+counting, event emission, rendering, or publishing; non-object entries are
+rejected and duplicate findings collapse without changing synthesis rank or
+equal-severity input order. Review-response commit `878d41d8` and its final full
+gate are complete; push and review-thread responses remain. Release is deferred.
 Branch: `fix/908-review-aggregation`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #908](https://github.com/nyldn/claude-octopus/issues/908)
 PR: [#911](https://github.com/nyldn/claude-octopus/pull/911)
-Next action: review PR #911 checks and feedback, then merge when approved.
-Release remains deferred.
+Next action: push the latest PR #911 review response and answer its three
+threads, then verify rerun checks. Merge and release remain deferred.
 
 ## Issue #908: Canonical Review Findings
 
@@ -33,12 +34,12 @@ Release remains deferred.
   or duplicate output. The missing-repository inline-comment fallback renders
   once.
 - TDD evidence: aggregation coverage failed on the missing normalizer, scalar
-  count, multi-document renderer, and initially on rank preservation. It now
-  passes 25/25; the broader review-focused bundle passes all 166 existing
-  assertions plus the new cases.
-- Full-gate evidence: the fresh final `make ci-local` after the stable-order and
-  single-render refinements passed 16/16 smoke, 267/267 unit, and 7/7
-  integration suites, plus all CI-only verifications.
+  count, multi-document renderer, rank preservation, non-object entry, and
+  equal-severity order cases. It now passes 27/27; review-run passes 31/31 and
+  PR-review workflow passes 16/16.
+- Full-gate evidence: the final `make ci-local` after the non-object and stable
+  order review changes passed 16/16 smoke, 267/267 unit, and 7/7 integration
+  suites, plus all CI-only verifications.
 - Throughput follow-up: [issue #910](https://github.com/nyldn/claude-octopus/issues/910)
   proposes a fail-closed changed-files local gate while retaining the full CI
   and release matrix.

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,31 +1,47 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-13
-Status: Issues #904 and #915 are implemented on `fix/904-agy-model`. AGY model
-validation accepts the exact machine ID or display label from the live catalog,
-preflight excludes invalid configured models, review-sized prompts no longer
-stall in Bash before the CLI launches, and an opt-in live doctor verifies the
-installed CLI, catalog/keyring auth, configured model, and real print dispatch.
-[PR #912](https://github.com/nyldn/claude-octopus/pull/912) carries both fixes.
-It is rebased onto merged PR #913, the first matching changed-scope gate selected
-and passed the full matrix, and the real authenticated AGY health probe passed
-all four stages. A matching-head three-round AGY review completed; its two
-findings were reproduced against the supported entrypoints and rejected as false.
-CodeRabbit then exposed valid live-doctor consistency and timeout gaps; their TDD
-fixes pass the expanded 50-case AGY suite. The final changed-scope gate selected
-and passed the full matrix, and the real authenticated AGY probe passed again on
-that exact implementation. Commit `7f3b1567` is pushed to both remotes;
-CodeRabbit passed that head, while the separate provider-review job is quota
-blocked and reported no code finding. Matching remote checks and merge remain.
-Release is deferred.
-Branch: `fix/904-agy-model`
+Status: Issue #908 is implemented and proposed in PR #911 on
+`fix/908-review-aggregation`. Review
+findings now cross a single-document normalization boundary before persistence,
+counting, event emission, rendering, or publishing; duplicate findings collapse
+without changing synthesis rank. PR, merge, and release are the remaining
+steps, and release remains explicitly deferred.
+Branch: `fix/908-review-aggregation`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
-Tracking: [issue #904](https://github.com/nyldn/claude-octopus/issues/904),
-[issue #915](https://github.com/nyldn/claude-octopus/issues/915)
-PR: [#912](https://github.com/nyldn/claude-octopus/pull/912)
-Next action: push the final handoff-only review cleanup, verify its matching
-remote checks, dismiss only obsolete resolved review requests, and merge PR #912.
-Release is deferred.
+Tracking: [issue #908](https://github.com/nyldn/claude-octopus/issues/908)
+PR: [#911](https://github.com/nyldn/claude-octopus/pull/911)
+Next action: review PR #911 checks and feedback, then merge when approved.
+Release remains deferred.
+
+## Issue #908: Canonical Review Findings
+
+- Root cause: several consumers ran `jq '.findings | length'` directly on an
+  artifact that could contain more than one top-level JSON document. `jq`
+  emitted one scalar per document (`0\\n0` or `1\\n1`), breaking Bash arithmetic
+  and rendering the same finding once per document.
+- Trust boundary: verifier and synthesis output must normalize to exactly one
+  object containing a findings array. Invalid and multi-document output falls
+  back locally before the final artifact is written.
+- Consumers: debate, synthesis events, proof packets, terminal reports, PR
+  summaries, and inline comments now use a scalar count helper that either
+  returns one non-negative integer or fails with no output.
+- Deduplication: exact duplicates use file, line, category, and title/message as
+  identity. Stable first-occurrence reduction preserves the synthesizer's
+  severity/rank ordering.
+- Rendering: invalid artifacts fail closed without findings, arithmetic errors,
+  or duplicate output. The missing-repository inline-comment fallback renders
+  once.
+- TDD evidence: aggregation coverage failed on the missing normalizer, scalar
+  count, multi-document renderer, and initially on rank preservation. It now
+  passes 25/25; the broader review-focused bundle passes all 166 existing
+  assertions plus the new cases.
+- Full-gate evidence: the fresh final `make ci-local` after the stable-order and
+  single-render refinements passed 16/16 smoke, 267/267 unit, and 7/7
+  integration suites, plus all CI-only verifications.
+- Throughput follow-up: [issue #910](https://github.com/nyldn/claude-octopus/issues/910)
+  proposes a fail-closed changed-files local gate while retaining the full CI
+  and release matrix.
 
 ## Issue #910: Fail-Closed Changed-Scope Local Gate
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -6,14 +6,15 @@ Status: Issue #908 is implemented and proposed in PR #911 on
 findings now cross a single-document normalization boundary before persistence,
 counting, event emission, rendering, or publishing; non-object entries are
 rejected and duplicate findings collapse without changing synthesis rank or
-equal-severity input order. Review-response commit `878d41d8` and its final full
-gate are complete; push and review-thread responses remain. Release is deferred.
+equal-severity input order. Review-response commit `7134d789` is pushed to both
+remotes and its final full gate passes; review-thread responses remain. Release
+is deferred.
 Branch: `fix/908-review-aggregation`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #908](https://github.com/nyldn/claude-octopus/issues/908)
 PR: [#911](https://github.com/nyldn/claude-octopus/pull/911)
-Next action: push the latest PR #911 review response and answer its three
-threads, then verify rerun checks. Merge and release remain deferred.
+Next action: answer PR #911's three review threads and verify rerun checks.
+Merge and release remain deferred.
 
 ## Issue #908: Canonical Review Findings
 

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -667,6 +667,7 @@ review_normalize_findings_json() {
         if length == 1
            and (.[0] | type == "object")
            and (.[0].findings | type == "array")
+           and all(.[0].findings[]; type == "object")
         then .[0]
              | .findings |= (
                  reduce .[] as $finding
@@ -697,6 +698,7 @@ review_findings_count() {
         if length == 1
            and (.[0] | type == "object")
            and (.[0].findings | type == "array")
+           and all(.[0].findings[]; type == "object")
         then (.[0].findings | length)
         else error("invalid findings document")
         end
@@ -706,7 +708,7 @@ review_findings_count() {
 review_local_synthesis_json() {
     local findings_json="$1"
     local warning="${2:-}"
-    local sort_filter='def severity_rank: if .severity == "normal" then 0 elif .severity == "nit" then 1 elif .severity == "pre-existing" then 2 else 3 end; unique_by([(.file // ""), ((.line // 0) | tostring), (.category // ""), (.title // .message // "")]) | sort_by(severity_rank)'
+    local sort_filter='def severity_rank: if .severity == "normal" then 0 elif .severity == "nit" then 1 elif .severity == "pre-existing" then 2 else 3 end; if all(.[]; type == "object") then to_entries | reduce .[] as $entry ({seen:{}, ordered:[]}; ($entry.value | [(.file // ""), ((.line // 0) | tostring), (.category // ""), (.title // .message // "")] | @json) as $key | if .seen[$key] then . else .seen[$key] = true | .ordered += [$entry] end) | .ordered | sort_by([(.value | severity_rank), .key]) | map(.value) else error("expected object findings entries") end'
     if [[ -n "$warning" ]]; then
         printf '%s' "$findings_json" | jq -c --arg warning "$warning" "{findings:(. // [] | ${sort_filter}), warning:\$warning}" 2>/dev/null \
             || printf '{"findings":[],"warning":%s}\n' "$(printf '%s' "$warning" | jq -R .)"

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -658,10 +658,55 @@ PYEXTRACT
     return 1
 }
 
+# Provider output is untrusted and may contain multiple top-level JSON values.
+# Canonicalize exactly one findings document before any arithmetic, rendering,
+# or persistence. Multiple documents are rejected rather than concatenated,
+# and exact duplicate findings collapse to one deterministic entry.
+review_normalize_findings_json() {
+    jq -cse '
+        if length == 1
+           and (.[0] | type == "object")
+           and (.[0].findings | type == "array")
+        then .[0]
+             | .findings |= (
+                 reduce .[] as $finding
+                   ({seen:{}, ordered:[]};
+                    ($finding | [
+                      (.file // ""),
+                      ((.line // 0) | tostring),
+                      (.category // ""),
+                      (.title // .message // "")
+                    ] | @json) as $key
+                    | if .seen[$key]
+                      then .
+                      else .seen[$key] = true | .ordered += [$finding]
+                      end)
+                 | .ordered
+               )
+        else error("expected exactly one object with a findings array")
+        end
+    '
+}
+
+# Print exactly one validated non-negative integer for a canonical findings
+# document. Invalid or multi-document input fails with no stdout so callers can
+# choose an explicit fail-closed behavior without creating a `0\n0` scalar.
+review_findings_count() {
+    local findings_json="$1"
+    printf '%s' "$findings_json" | jq -er -s '
+        if length == 1
+           and (.[0] | type == "object")
+           and (.[0].findings | type == "array")
+        then (.[0].findings | length)
+        else error("invalid findings document")
+        end
+    ' 2>/dev/null
+}
+
 review_local_synthesis_json() {
     local findings_json="$1"
     local warning="${2:-}"
-    local sort_filter='def severity_rank: if .severity == "normal" then 0 elif .severity == "nit" then 1 elif .severity == "pre-existing" then 2 else 3 end; sort_by(severity_rank)'
+    local sort_filter='def severity_rank: if .severity == "normal" then 0 elif .severity == "nit" then 1 elif .severity == "pre-existing" then 2 else 3 end; unique_by([(.file // ""), ((.line // 0) | tostring), (.category // ""), (.title // .message // "")]) | sort_by(severity_rank)'
     if [[ -n "$warning" ]]; then
         printf '%s' "$findings_json" | jq -c --arg warning "$warning" "{findings:(. // [] | ${sort_filter}), warning:\$warning}" 2>/dev/null \
             || printf '{"findings":[],"warning":%s}\n' "$(printf '%s' "$warning" | jq -R .)"
@@ -1349,6 +1394,15 @@ Return ONLY valid JSON with 'findings' array including verdict field."
     fi
     # v9.3.1: Strip markdown fences that LLMs wrap around JSON responses (#188)
     verified_findings=$(echo "$verified_findings" | sed '/^```json$/d; /^```JSON$/d; /^```$/d')
+    local normalized_verified_findings
+    if normalized_verified_findings=$(printf '%s' "$verified_findings" | review_normalize_findings_json 2>/dev/null); then
+        verified_findings="$normalized_verified_findings"
+    else
+        log WARN "review_run: verification returned invalid or multi-document findings JSON; preserving Round 1 findings"
+        verified_findings=$(printf '{"findings":%s}' "$(
+            echo "$all_findings" | jq 'map(. + {"verdict":"confirmed"})' 2>/dev/null || echo "[]"
+        )")
+    fi
 
     # Filter false positives
     local confirmed_findings
@@ -1362,7 +1416,10 @@ Return ONLY valid JSON with 'findings' array including verdict field."
         debate_candidates=$(echo "$confirmed_findings" | \
             jq '[.[] | select(.verdict == "needs-debate")]' 2>/dev/null || echo "[]")
         local debate_count
-        debate_count=$(echo "$debate_candidates" | jq 'length' 2>/dev/null || echo "0")
+        if ! debate_count=$(printf '{"findings":%s}' "$debate_candidates" | review_findings_count); then
+            log WARN "review_run: invalid debate candidates; skipping debate gate and preserving confirmed findings"
+            debate_count=0
+        fi
         if [[ "$debate_count" -gt 0 ]]; then
             log INFO "review_run: debating $debate_count contested findings"
             local debate_prompt="Challenge these $debate_count contested code review findings. For each, state whether it is a real bug (include) or false positive (exclude). Be adversarial.
@@ -1414,17 +1471,27 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
 
     # v9.3.1: Strip markdown fences from synthesis result (#188)
     final_json=$(echo "$final_json" | sed '/^```json$/d; /^```JSON$/d; /^```$/d')
-    if ! printf '%s' "$final_json" | jq -e '.findings | type == "array"' >/dev/null 2>&1; then
-        log WARN "review_run: synthesis returned invalid findings JSON, using local fallback"
+    local normalized_final_json
+    if ! normalized_final_json=$(printf '%s' "$final_json" | review_normalize_findings_json 2>/dev/null); then
+        log WARN "review_run: synthesis returned invalid or multi-document findings JSON, using local fallback"
         final_json=$(review_local_synthesis_json "$confirmed_findings" "$round1_warning")
         synth_ok="false"
-    elif [[ -n "$round1_warning" ]]; then
-        final_json=$(printf '%s' "$final_json" | jq -c --arg warning "$round1_warning" '. + {warning:$warning}' 2>/dev/null \
-            || review_local_synthesis_json "$confirmed_findings" "$round1_warning")
+    else
+        final_json="$normalized_final_json"
+    fi
+    if [[ -n "$round1_warning" ]]; then
+        local warned_final_json
+        if warned_final_json=$(printf '%s' "$final_json" | \
+            jq -c --arg warning "$round1_warning" '. + {warning:$warning}' 2>/dev/null); then
+            final_json="$warned_final_json"
+        else
+            final_json=$(review_local_synthesis_json "$confirmed_findings" "$round1_warning")
+            synth_ok="false"
+        fi
     fi
 
     # Write findings file
-    echo "$final_json" > "$findings_file"
+    printf '%s\n' "$final_json" > "$findings_file"
     log INFO "review_run: findings saved to $findings_file"
 
     # #498: emit a synthesis lifecycle event when Round 3 synthesis succeeds.
@@ -1432,7 +1499,9 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
     # attribution would be wrong there (per design-review verification).
     if [[ "$synth_ok" == "true" ]] && declare -f octo_event_emit >/dev/null 2>&1; then
         local _synth_count
-        _synth_count=$(printf '%s' "$final_json" | jq '.findings | length' 2>/dev/null || echo 0)
+        if ! _synth_count=$(review_findings_count "$final_json"); then
+            _synth_count=0
+        fi
         octo_event_emit "synthesis" phase="review" provider="$synthesis_provider" provider_label_kind="legacy-alias" executor_alias="$synthesis_provider" configured_provider="$(octo_provider_identity_from_agent_type "$synthesis_provider")" configured_model="$(get_agent_model "$synthesis_provider" "review" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="review" count="${_synth_count:-0}" || true
     fi
 
@@ -1491,7 +1560,9 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
 
     if [[ -n "$proof_dir" ]]; then
         local proof_finding_count proof_warning proof_verdict proof_summary
-        proof_finding_count=$(jq '.findings | length' "$findings_file" 2>/dev/null || echo "0")
+        if ! proof_finding_count=$(review_findings_count "$(<"$findings_file")"); then
+            proof_finding_count=0
+        fi
         proof_warning=$(jq -r '.warning // empty' "$findings_file" 2>/dev/null || true)
         if [[ -n "$proof_warning" ]]; then
             proof_verdict="fail"
@@ -1517,12 +1588,16 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
 post_inline_comments() {
     local pr_number="$1"
     local findings_file="$2"
+    local findings_json
+    if ! findings_json=$(review_normalize_findings_json < "$findings_file" 2>/dev/null); then
+        log ERROR "post_inline_comments: invalid findings artifact: $findings_file"
+        return 1
+    fi
 
     local repo=""
     repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
     if [[ -z "$repo" ]]; then
         log ERROR "post_inline_comments: could not determine repo (is gh auth configured?)"
-        render_terminal_report "$findings_file"
         return 1
     fi
 
@@ -1542,10 +1617,13 @@ post_inline_comments() {
     gh pr review "$pr_number" --comment --body "$summary" 2>/dev/null || true
 
     local finding_count
-    finding_count=$(jq '.findings | length' "$findings_file" 2>/dev/null || echo "0")
+    if ! finding_count=$(review_findings_count "$findings_json"); then
+        log ERROR "post_inline_comments: invalid findings count: $findings_file"
+        return 1
+    fi
     log INFO "post_inline_comments: posting $finding_count inline comments to PR #$pr_number"
 
-    jq -c '.findings[]' "$findings_file" 2>/dev/null | while IFS= read -r finding; do
+    printf '%s' "$findings_json" | jq -c '.findings[]' 2>/dev/null | while IFS= read -r finding; do
         local file line severity title detail
         file=$(echo "$finding"     | jq -r '.file')
         line=$(echo "$finding"     | jq -r '.line')
@@ -1589,12 +1667,14 @@ review_emit_finding_events() {
     local findings_file="$1"
     declare -f octo_event_emit >/dev/null 2>&1 || return 0
     [[ -f "$findings_file" ]] || return 0
+    local findings_json
+    findings_json=$(review_normalize_findings_json < "$findings_file" 2>/dev/null) || return 1
 
     local sentinel="${findings_file}.events-emitted"
     [[ -e "$sentinel" ]] && return 0
     : > "$sentinel" 2>/dev/null || true
 
-    jq -c '.findings[]?' "$findings_file" 2>/dev/null | while IFS= read -r _rf; do
+    printf '%s' "$findings_json" | jq -c '.findings[]?' 2>/dev/null | while IFS= read -r _rf; do
         octo_event_emit "review.finding" \
             severity="$(printf '%s' "$_rf" | jq -r '.severity // "unknown"')" \
             file="$(printf '%s' "$_rf" | jq -r '.file // "unknown"')" \
@@ -1607,11 +1687,14 @@ review_emit_finding_events() {
 
 render_terminal_report() {
     local findings_file="$1"
-
-    review_emit_finding_events "$findings_file"
-
-    local finding_count
-    finding_count=$(jq '.findings | length' "$findings_file" 2>/dev/null || echo "0")
+    local findings_json="" finding_count="0"
+    local findings_valid=true
+    if ! findings_json=$(review_normalize_findings_json < "$findings_file" 2>/dev/null); then
+        findings_valid=false
+    elif ! finding_count=$(review_findings_count "$findings_json"); then
+        findings_valid=false
+        finding_count=0
+    fi
 
     echo ""
     echo "+-----------------------------------------------------------------+"
@@ -1619,10 +1702,18 @@ render_terminal_report() {
     echo "+-----------------------------------------------------------------+"
     echo ""
 
+    if [[ "$findings_valid" != "true" ]]; then
+        echo "WARNING: invalid findings artifact; expected exactly one JSON document."
+        echo "Review output was not rendered."
+        return 1
+    fi
+
+    review_emit_finding_events "$findings_file" || true
+
     if [[ "$finding_count" -eq 0 ]]; then
         # v9.20.1: Distinguish "clean review" from "all providers failed" (#255)
         local warning_msg
-        warning_msg=$(jq -r '.warning // empty' "$findings_file" 2>/dev/null)
+        warning_msg=$(printf '%s' "$findings_json" | jq -r '.warning // empty' 2>/dev/null)
         if [[ -n "$warning_msg" ]]; then
             echo "⚠️  WARNING: $warning_msg"
             echo ""
@@ -1637,7 +1728,7 @@ render_terminal_report() {
     echo "Found $finding_count issue(s):"
     echo ""
 
-    jq -c '.findings[]' "$findings_file" 2>/dev/null | while IFS= read -r finding; do
+    printf '%s' "$findings_json" | jq -c '.findings[]' 2>/dev/null | while IFS= read -r finding; do
         local severity title file line detail
         severity=$(echo "$finding" | jq -r '.severity')
         title=$(echo "$finding"    | jq -r '.title')
@@ -1663,10 +1754,17 @@ render_terminal_report() {
 # render_review_summary: short markdown summary for PR-level comment
 render_review_summary() {
     local findings_file="$1"
+    local findings_json
+    if ! findings_json=$(review_normalize_findings_json < "$findings_file" 2>/dev/null); then
+        echo "## /octo:review - Invalid findings artifact"
+        echo ""
+        echo "Review output was not published because it was not exactly one valid JSON document."
+        return 1
+    fi
     local normal_count nit_count preexisting_count
-    normal_count=$(jq '[.findings[] | select(.severity=="normal")] | length' "$findings_file" 2>/dev/null || echo "0")
-    nit_count=$(jq '[.findings[] | select(.severity=="nit")] | length' "$findings_file" 2>/dev/null || echo "0")
-    preexisting_count=$(jq '[.findings[] | select(.severity=="pre-existing")] | length' "$findings_file" 2>/dev/null || echo "0")
+    normal_count=$(printf '%s' "$findings_json" | jq '[.findings[] | select(.severity=="normal")] | length')
+    nit_count=$(printf '%s' "$findings_json" | jq '[.findings[] | select(.severity=="nit")] | length')
+    preexisting_count=$(printf '%s' "$findings_json" | jq '[.findings[] | select(.severity=="pre-existing")] | length')
 
     echo "## /octo:review - Multi-LLM Code Review"
     echo ""

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -93,6 +93,14 @@ else
     test_fail "single-document findings were not normalized and deduplicated: $single_normalized"
 fi
 
+test_case "findings normalizer rejects non-object entries"
+non_object_document='{"findings":[null]}'
+if printf '%s' "$non_object_document" | review_normalize_findings_json >/dev/null 2>&1; then
+    test_fail "non-object finding was accepted"
+else
+    test_pass
+fi
+
 test_case "findings normalizer preserves synthesis ranking while deduplicating"
 ranked_document='{"findings":[{"file":"z-last-path.js","line":9,"severity":"normal","title":"Highest-ranked"},{"file":"a-first-path.js","line":1,"severity":"nit","title":"Lower-ranked"},{"file":"z-last-path.js","line":9,"severity":"normal","title":"Highest-ranked"}]}'
 ranked_normalized="$(printf '%s' "$ranked_document" | review_normalize_findings_json 2>/dev/null || true)"
@@ -101,6 +109,15 @@ if [[ "$ranked_titles" == $'Highest-ranked\nLower-ranked' ]]; then
     test_pass
 else
     test_fail "normalization reordered synthesized findings: $ranked_titles"
+fi
+
+test_case "local synthesis preserves first occurrence order within a severity"
+same_severity='[{"file":"z-last-path.js","line":9,"severity":"normal","title":"First-seen"},{"file":"a-first-path.js","line":1,"severity":"normal","title":"Second-seen"},{"file":"z-last-path.js","line":9,"severity":"normal","title":"First-seen"}]'
+same_severity_titles="$(review_local_synthesis_json "$same_severity" | jq -r '.findings[].title' 2>/dev/null || true)"
+if [[ "$same_severity_titles" == $'First-seen\nSecond-seen' ]]; then
+    test_pass
+else
+    test_fail "local synthesis reordered equal-severity findings: $same_severity_titles"
 fi
 
 test_case "findings normalizer rejects multiple JSON documents"
@@ -114,7 +131,7 @@ else
     test_pass
 fi
 
-test_case "findings count returns one integer or fails without output"
+test_case "findings count returns one integer or rejects malformed input without output"
 valid_count="$(review_findings_count "$single_normalized" 2>/dev/null || true)"
 invalid_count_file="$TEST_TMP_DIR/invalid-count.out"
 if review_findings_count "$(cat "$multi_document_file")" > "$invalid_count_file" 2>/dev/null; then
@@ -122,10 +139,17 @@ if review_findings_count "$(cat "$multi_document_file")" > "$invalid_count_file"
 else
     invalid_count_rc=$?
 fi
-if [[ "$valid_count" == "1" && "$invalid_count_rc" -ne 0 && ! -s "$invalid_count_file" ]]; then
+non_object_count_file="$TEST_TMP_DIR/non-object-count.out"
+if review_findings_count "$non_object_document" > "$non_object_count_file" 2>/dev/null; then
+    non_object_count_rc=0
+else
+    non_object_count_rc=$?
+fi
+if [[ "$valid_count" == "1" && "$invalid_count_rc" -ne 0 && ! -s "$invalid_count_file" &&
+      "$non_object_count_rc" -ne 0 && ! -s "$non_object_count_file" ]]; then
     test_pass
 else
-    test_fail "count helper returned valid='$valid_count' invalid_rc='$invalid_count_rc' invalid_output='$(cat "$invalid_count_file")'"
+    test_fail "count helper returned valid='$valid_count' multi_rc='$invalid_count_rc' non_object_rc='$non_object_count_rc'"
 fi
 
 test_case "terminal rendering fails closed on multi-document findings"

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -84,6 +84,82 @@ else
     test_fail "non-array findings escaped extraction: $non_array_out"
 fi
 
+test_case "findings normalizer accepts one document and deduplicates findings"
+single_document='{"findings":[{"file":"CHANGELOG.md","line":1,"category":"docs","title":"Duplicate"},{"file":"CHANGELOG.md","line":1,"category":"docs","title":"Duplicate"}]}'
+single_normalized="$(printf '%s' "$single_document" | review_normalize_findings_json 2>/dev/null || true)"
+if [[ "$(printf '%s' "$single_normalized" | jq -r '.findings | length' 2>/dev/null || true)" == "1" ]]; then
+    test_pass
+else
+    test_fail "single-document findings were not normalized and deduplicated: $single_normalized"
+fi
+
+test_case "findings normalizer preserves synthesis ranking while deduplicating"
+ranked_document='{"findings":[{"file":"z-last-path.js","line":9,"severity":"normal","title":"Highest-ranked"},{"file":"a-first-path.js","line":1,"severity":"nit","title":"Lower-ranked"},{"file":"z-last-path.js","line":9,"severity":"normal","title":"Highest-ranked"}]}'
+ranked_normalized="$(printf '%s' "$ranked_document" | review_normalize_findings_json 2>/dev/null || true)"
+ranked_titles="$(printf '%s' "$ranked_normalized" | jq -r '.findings[].title' 2>/dev/null || true)"
+if [[ "$ranked_titles" == $'Highest-ranked\nLower-ranked' ]]; then
+    test_pass
+else
+    test_fail "normalization reordered synthesized findings: $ranked_titles"
+fi
+
+test_case "findings normalizer rejects multiple JSON documents"
+multi_document_file="$TEST_TMP_DIR/multi-document-findings.json"
+printf '%s\n%s\n' \
+    '{"findings":[{"title":"Duplicate"}]}' \
+    '{"findings":[{"title":"Duplicate"}]}' > "$multi_document_file"
+if review_normalize_findings_json < "$multi_document_file" >/dev/null 2>&1; then
+    test_fail "multi-document findings were accepted"
+else
+    test_pass
+fi
+
+test_case "findings count returns one integer or fails without output"
+valid_count="$(review_findings_count "$single_normalized" 2>/dev/null || true)"
+invalid_count_file="$TEST_TMP_DIR/invalid-count.out"
+if review_findings_count "$(cat "$multi_document_file")" > "$invalid_count_file" 2>/dev/null; then
+    invalid_count_rc=0
+else
+    invalid_count_rc=$?
+fi
+if [[ "$valid_count" == "1" && "$invalid_count_rc" -ne 0 && ! -s "$invalid_count_file" ]]; then
+    test_pass
+else
+    test_fail "count helper returned valid='$valid_count' invalid_rc='$invalid_count_rc' invalid_output='$(cat "$invalid_count_file")'"
+fi
+
+test_case "terminal rendering fails closed on multi-document findings"
+multi_render_output="$TEST_TMP_DIR/multi-render.out"
+if render_terminal_report "$multi_document_file" > "$multi_render_output" 2>&1; then
+    multi_render_rc=0
+else
+    multi_render_rc=$?
+fi
+if [[ "$multi_render_rc" -ne 0 ]] &&
+   grep -q 'invalid findings artifact' "$multi_render_output" &&
+   [[ "$(grep -c 'Duplicate' "$multi_render_output" 2>/dev/null || true)" == "0" ]] &&
+   ! grep -q 'syntax error in expression' "$multi_render_output"; then
+    test_pass
+else
+    test_fail "multi-document rendering did not fail closed: $(tr '\n' ' ' < "$multi_render_output")"
+fi
+
+test_case "missing repository fallback renders the terminal report once"
+original_render_terminal_report="$(declare -f render_terminal_report)"
+gh() { return 1; }
+render_terminal_report() { printf '%s\n' "rendered-once"; }
+missing_repo_file="$TEST_TMP_DIR/missing-repo.json"
+printf '%s\n' "$single_normalized" > "$missing_repo_file"
+missing_repo_output="$(post_inline_comments 123 "$missing_repo_file" 2>/dev/null || render_terminal_report "$missing_repo_file")"
+unset -f gh
+unset -f render_terminal_report
+eval "$original_render_terminal_report"
+if [[ "$(grep -c '^rendered-once$' <<< "$missing_repo_output" 2>/dev/null || true)" == "1" ]]; then
+    test_pass
+else
+    test_fail "missing-repository fallback rendered more than once: $missing_repo_output"
+fi
+
 test_case "progress fingerprint ignores unrelated result artifacts"
 progress_dir="$TEST_TMP_DIR/progress"
 mkdir -p "$progress_dir"
@@ -341,6 +417,6 @@ test_case "review uses stall watchdog"
 if grep -q "OCTOPUS_REVIEW_STALL_WINDOW" "$REVIEW_SH"; then test_pass; else test_fail "missing review stall window"; fi
 
 test_case "invalid synthesis has local fallback"
-if grep -q "synthesis returned invalid findings JSON" "$REVIEW_SH"; then test_pass; else test_fail "missing local fallback"; fi
+if grep -q "synthesis returned invalid.*findings JSON" "$REVIEW_SH"; then test_pass; else test_fail "missing local fallback"; fi
 
 test_summary


### PR DESCRIPTION
## Summary

- normalize provider findings at one JSON-document trust boundary
- reject malformed or multi-document output before counting, persistence, rendering, or publishing
- deduplicate findings without changing synthesis ranking and render terminal fallbacks once

## Verification

- `bash tests/unit/test-review-aggregation-robustness.sh` (25/25)
- `bash tests/unit/test-review-run.sh` (31/31)
- `bash tests/unit/test-pr-review-workflow.sh` (16/16)
- `make ci-local` (16/16 smoke, 267/267 unit, 7/7 integration; CI-only checks passed)

Fixes #908

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review-result handling by validating and normalizing findings before display or publication.
  * Removed duplicate findings while preserving ranking and order.
  * Invalid or ambiguous review data now fails safely instead of producing misleading output.
  * Added reliable fallback behavior when verification or synthesis results are unavailable.
  * Prevented invalid findings from being published or rendered.

* **Tests**
  * Expanded coverage for validation, deduplication, counting, fallback behavior, and safe rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->