### PR TITLE
ci: add changed-scope local gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ agents directly.
 
 Mirror of the "Repo Orientation for Agents" section in `CLAUDE.md` (keep both in sync). Essentials:
 
-- **Derived artifacts, never hand-edit**: `.claude-plugin/marketplace.json` (regen: `./scripts/sync-marketplace.sh`) and `openclaw/src/tools/index.ts` (regen: `./scripts/build-openclaw.sh`). `scripts/sync-readme.py` owns current facts across both READMEs and `PRODUCT.md`. Run `make sync` after component, metadata, release, model, or provider changes; `make ci-local` before pushing code.
+- **Derived artifacts, never hand-edit**: `.claude-plugin/marketplace.json` (regen: `./scripts/sync-marketplace.sh`) and `openclaw/src/tools/index.ts` (regen: `./scripts/build-openclaw.sh`). `scripts/sync-readme.py` owns current facts across both READMEs and `PRODUCT.md`. Run `make sync` after component, metadata, release, model, or provider changes. During development use focused suites; before an ordinary branch push run `make ci-changed`, which fails closed to the full matrix for shared or unmapped changes. Run `make ci-local` before merge and release.
 - **Exec bits**: scripts stay `100755`; `git diff origin/main...HEAD --summary | grep "mode change"` must be empty (CI-enforced; `allow-mode-change` label bypasses). Local test runs chmod test fixtures as a side effect — recheck modes after every local test run.
 - **Provider wiring**: 7-point checklist across 5 files, documented in `docs/PROVIDERS.md`. Case globs are order-sensitive (`claude-sdk*` before `claude*`).
 - **Releases**: follow `RELEASING.md`; tag the squash-merge commit on `main`, never the branch head.

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,19 +1,22 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-13
-Status: Issue #910 is implemented on `fix/910-ci-changed`. The new
-`make ci-changed` gate selects audited focused suites for mapped surfaces and
-fails closed to the complete local matrix for shared, generated, manifest, or
-unknown changes. Focused selection and execution pass; the final full gate
-also passes.
-Implementation commit `63fa6ef8` is pushed to both remotes and
+Status: Issue #910 and its full-gate optimization follow-up are implemented on
+`fix/910-ci-changed`. The new `make ci-changed` gate selects audited focused
+suites for mapped surfaces and fails closed to the complete local matrix for
+shared, generated, manifest, or unknown changes. Full-matrix runs now report
+their slowest suites, Council fixtures reuse identical artifacts and skip only
+the separately tested detached transport, and ordinary unit tests cannot leave
+production-style Tangle worktrees in the real repository.
+Implementation commits `63fa6ef8` and `9d9e6bed` are pushed to both remotes and
 [PR #913](https://github.com/nyldn/claude-octopus/pull/913) is open. Release is
 deferred.
 Branch: `fix/910-ci-changed`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #910](https://github.com/nyldn/claude-octopus/issues/910)
 PR: [#913](https://github.com/nyldn/claude-octopus/pull/913)
-Next action: review PR #913 checks and feedback. Merge and release are deferred.
+Next action: review the new PR #913 checks and feedback for commit `9d9e6bed`.
+Merge and release are deferred.
 
 ## Issue #910: Fail-Closed Changed-Scope Local Gate
 
@@ -60,6 +63,44 @@ Next action: review PR #913 checks and feedback. Merge and release are deferred.
 - Tracking blocker: Beads remains unreadable on schema v49 because its reserved
   v65 migration has not been applied. No migration was run; GitHub issue #910
   is the temporary tracker.
+
+### Full-gate optimization follow-up
+
+- Root cause measurement: a fresh standalone Council baseline passed but took
+  220.65 seconds. Repeated fixture scenarios each paid detached-seat polling
+  and several test cases rebuilt byte-for-byte-equivalent dry-run, standard,
+  chair-fallback, or all-approve artifacts for separate assertions.
+- Optimization boundary: production Council seats remain detached. Internal
+  fixture dispatch uses the existing inline path, while the dedicated atomic
+  rename, signal survival, timeout, descendant cancellation, exit propagation,
+  and escape-hatch tests still exercise the real detached transport. Identical
+  fixture artifacts are cached only within the Council suite; every assertion
+  and unique failure scenario remains.
+- Test isolation: `tests/helpers/test-framework.sh` now defaults
+  `OCTOPUS_TANGLE_RUN_WORKTREE=false` while preserving an explicit caller
+  setting. `test-tangle-run-worktree.sh` explicitly unsets the flag and still
+  proves production-default isolation. Eleven Tangle suites passed without
+  changing repository worktree or `octopus/run/*` ref counts.
+- Profiling: `tests/run-all-tests.sh` records wall time around every suite and
+  prints a deterministic top-ten `Slowest suites` table. The fresh full unit
+  run identified Council (166s), knowledge routing (38s), lifecycle events
+  (24s), Octopus events (23s), and provider auth validity (22s) as the leading
+  remaining costs.
+- Performance evidence: the standalone Council suite fell from 220.65s to
+  150.35s, a 31.9% reduction, while passing 73/74 cases with the same one known
+  macOS PTY skip. No suite or assertion was deleted.
+- TDD/review evidence: the new harness/timing regressions failed 2 cases before
+  implementation and pass 19/19 after it. The fixture parent-context
+  reproduction failed before the inline path and passed afterward. An AGY
+  adversarial test review led to coverage for inherited `true`, failing fixture
+  dispatch, and stale sentinel cleanup. Spec review rejected sharing the
+  standard-depth benchmark fixture with a quick-depth run before delivery.
+- Final verification: fresh `make ci-local` completed in 695.40s and passed
+  smoke 16/16, unit 268/268, integration 7/7, and the CI-only verifications.
+  Repository state remained exactly 15 worktrees and 1,251 `octopus/run/*`
+  refs before and after the complete gate; the prior full run had left 94 stale
+  worktree registrations. Source commit `9d9e6bed` is pushed to origin and
+  upstream.
 
 ## Issue #898: Explicit Activation and Hook Latency
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -9,16 +9,18 @@ their slowest suites, Council fixtures reuse identical artifacts and skip only
 the separately tested detached transport, and ordinary unit tests cannot leave
 production-style Tangle worktrees in the real repository.
 Implementation commits `63fa6ef8` and `9d9e6bed` are pushed to both remotes and
-[PR #913](https://github.com/nyldn/claude-octopus/pull/913) is open, mergeable,
-and approved by CodeRabbit. Release is deferred.
+[PR #913](https://github.com/nyldn/claude-octopus/pull/913) is open. The code
+commit has prior full-matrix and CodeRabbit evidence, but merge remains deferred
+until required checks and review complete for the eventual branch head. Release
+is deferred.
 Branch: `fix/910-ci-changed`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #910](https://github.com/nyldn/claude-octopus/issues/910)
 PR: [#913](https://github.com/nyldn/claude-octopus/pull/913)
-Next action: merge PR #913 when desired. The complete GitHub test matrix is
-green; the separate multi-provider review workflow failed only because Claude
-and Copilot exhausted their weekly and monthly quotas. Merge and release are
-deferred.
+Next action: wait for matching-head PR #913 checks and review, then merge only
+if they permit it. The separate multi-provider review workflow is currently
+limited because Claude and Copilot exhausted their weekly and monthly quotas.
+Merge and release are deferred.
 
 ## Issue #910: Fail-Closed Changed-Scope Local Gate
 
@@ -103,11 +105,13 @@ deferred.
   refs before and after the complete gate; the prior full run had left 94 stale
   worktree registrations. Source commit `9d9e6bed` is pushed to origin and
   upstream.
-- Remote verification: GitHub Test Suite run `31738318645` passed portability,
-  both smoke platforms, the symlinked-path run, both full unit platforms, and
-  full integration. CodeRabbit approved head `4136fa87` without inline findings.
-  The separate `pr-review` job is red because Claude hit its weekly limit and
-  the Copilot fallback hit its monthly quota; it reported no code finding.
+- Commit-bound remote verification: GitHub Test Suite run `31738318645` passed
+  portability, both smoke platforms, the symlinked-path run, both full unit
+  platforms, and full integration for head `4136fa87`; CodeRabbit approved that
+  head without inline findings. Later handoff-only commits require their own
+  matching-head checks and review before merge. The separate `pr-review` job is
+  red because Claude hit its weekly limit and the Copilot fallback hit its
+  monthly quota; it reported no code finding.
 
 ## Issue #898: Explicit Activation and Hook Latency
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -4,12 +4,16 @@ Last updated: 2026-08-13
 Status: Issue #910 is implemented on `fix/910-ci-changed`. The new
 `make ci-changed` gate selects audited focused suites for mapped surfaces and
 fails closed to the complete local matrix for shared, generated, manifest, or
-unknown changes. Focused selection and execution pass; the final full gate,
-also passes. Commit, push, and PR remain. Release is deferred.
+unknown changes. Focused selection and execution pass; the final full gate
+also passes.
+Implementation commit `63fa6ef8` is pushed to both remotes and
+[PR #913](https://github.com/nyldn/claude-octopus/pull/913) is open. Release is
+deferred.
 Branch: `fix/910-ci-changed`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #910](https://github.com/nyldn/claude-octopus/issues/910)
-Next action: commit, push, open the upstream PR, and record its URL here.
+PR: [#913](https://github.com/nyldn/claude-octopus/pull/913)
+Next action: review PR #913 checks and feedback. Merge and release are deferred.
 
 ## Issue #910: Fail-Closed Changed-Scope Local Gate
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,16 +1,61 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-13
-Status: Issue #898 is implemented and passes the complete local gate on branch
-`fix/898-explicit-activation`; PR, merge, and release are the remaining steps.
-Octopus is now dormant until explicit invocation. Native command/skill gates,
-session-affine workflow hooks, passive startup notices, host-filtered tool
-hooks, and opt-in automation replace the previous install-wide engagement.
-The stable plugin entrypoint also advances to the host-loaded version so an old
-but still-present cache cannot strand explicit commands on stale hooks.
-Branch: `fix/898-explicit-activation`
-Current release: [v9.63.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.63.0)
-Tracking: [issue #898](https://github.com/nyldn/claude-octopus/issues/898)
+Status: Issue #910 is implemented on `fix/910-ci-changed`. The new
+`make ci-changed` gate selects audited focused suites for mapped surfaces and
+fails closed to the complete local matrix for shared, generated, manifest, or
+unknown changes. Focused selection and execution pass; the final full gate,
+also passes. Commit, push, and PR remain. Release is deferred.
+Branch: `fix/910-ci-changed`
+Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
+Tracking: [issue #910](https://github.com/nyldn/claude-octopus/issues/910)
+Next action: commit, push, open the upstream PR, and record its URL here.
+
+## Issue #910: Fail-Closed Changed-Scope Local Gate
+
+- Root cause: repository instructions required all unit and integration suites
+  before every code push. The complete unit sweep reached 267-268 suites, and
+  the unrelated Council suite alone took 188-218 seconds during recent focused
+  fixes.
+- Selector contract: `tests/changed-scope.tsv` maps known changed-path globs to
+  required suite globs. The selector includes committed branch changes plus
+  staged, unstaged, and untracked paths, prints the changed files, matching
+  rules, and selected suites, and accepts deterministic explicit paths for
+  regression testing.
+- Fail-closed boundary: shared orchestration, workflow, spawn, dispatch,
+  generators, plugin manifests, CI, the Makefile, the test runner, the selector
+  and manifest themselves, and every unmapped path select `make ci-local`.
+  Missing comparison bases, missing mapped suites, and malformed empty mapping
+  policies also select the full matrix. Known user-owned harness artifacts such
+  as `.beads.gate.lock` and `.octo-continue.md` are explicitly ignored.
+- Focused boundary: every focused run still executes `make sync-check`, all 16
+  smoke suites (including syntax and packaging), and the suite-reachability
+  guard. Explicit test-runner suite paths are confined to existing
+  `test-*.sh` or `validate-*.sh` files under `tests/`.
+- CI and release: GitHub Actions continues to run the authoritative complete
+  unit and integration jobs. `make ci-local` remains mandatory before merge and
+  release; agent instructions now distinguish iterative, ordinary-push, and
+  final gates.
+- TDD evidence: the first regression passed only 1/10 cases before the command,
+  manifest, and explicit-suite support existed. It now passes 17/17, including
+  deterministic review/model plans and full-matrix fallback for shared,
+  generator, unknown, selector, manifest, and missing-base changes. Automatic
+  base discovery never narrows to `HEAD~1`, which could omit earlier commits.
+- Runtime evidence: a model-resolver-only plan selected seven model/provider
+  suites plus suite reachability, excluded Council, and passed all 16 smoke
+  suites and all 8 selected suites in roughly one minute. The current #910
+  branch selects the full matrix because it changes the selector, manifest,
+  Makefile, and test runner.
+- Final-gate evidence: `make ci-local` passes 16/16 smoke suites, 268/268 unit
+  suites, 7/7 integration suites, and the CI-only verifications.
+- Review evidence: the implementation matches the requested proportional
+  edit/push/final contract. Code-quality review found one unsafe automatic
+  `HEAD~1` comparison fallback that could omit earlier branch commits; it was
+  removed, covered by the 17/17 selector regression suite, and no blocking
+  review finding remains.
+- Tracking blocker: Beads remains unreadable on schema v49 because its reserved
+  v65 migration has not been applied. No migration was run; GitHub issue #910
+  is the temporary tracker.
 
 ## Issue #898: Explicit Activation and Hook Latency
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -9,14 +9,16 @@ their slowest suites, Council fixtures reuse identical artifacts and skip only
 the separately tested detached transport, and ordinary unit tests cannot leave
 production-style Tangle worktrees in the real repository.
 Implementation commits `63fa6ef8` and `9d9e6bed` are pushed to both remotes and
-[PR #913](https://github.com/nyldn/claude-octopus/pull/913) is open. Release is
-deferred.
+[PR #913](https://github.com/nyldn/claude-octopus/pull/913) is open, mergeable,
+and approved by CodeRabbit. Release is deferred.
 Branch: `fix/910-ci-changed`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #910](https://github.com/nyldn/claude-octopus/issues/910)
 PR: [#913](https://github.com/nyldn/claude-octopus/pull/913)
-Next action: review the new PR #913 checks and feedback for commit `9d9e6bed`.
-Merge and release are deferred.
+Next action: merge PR #913 when desired. The complete GitHub test matrix is
+green; the separate multi-provider review workflow failed only because Claude
+and Copilot exhausted their weekly and monthly quotas. Merge and release are
+deferred.
 
 ## Issue #910: Fail-Closed Changed-Scope Local Gate
 
@@ -101,6 +103,11 @@ Merge and release are deferred.
   refs before and after the complete gate; the prior full run had left 94 stale
   worktree registrations. Source commit `9d9e6bed` is pushed to origin and
   upstream.
+- Remote verification: GitHub Test Suite run `31738318645` passed portability,
+  both smoke platforms, the symlinked-path run, both full unit platforms, and
+  full integration. CodeRabbit approved head `4136fa87` without inline findings.
+  The separate `pr-review` job is red because Claude hit its weekly limit and
+  the Copilot fallback hit its monthly quota; it reported no code finding.
 
 ## Issue #898: Explicit Activation and Hook Latency
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,9 +323,11 @@ The rules below encode failures that have already cost real CI rounds. Every one
 | `README.md`, `.claude-plugin/README.md`, and `PRODUCT.md` current facts | `./scripts/sync-readme.py` (included in `make sync`) | `tests/unit/test-readme-release-sync.sh` |
 
 After changing commands, skills, agents, plugin metadata, release notes, models,
-providers, or public facts: run `make sync`. Before pushing code: run
-`make ci-local` (mirrors the required checks plus CI-only verifications;
-targeted test suites alone do NOT predict CI green).
+providers, or public facts: run `make sync`. During development, run focused
+suites. Before an ordinary branch push, run `make ci-changed`; its checked-in
+manifest always runs sync, smoke, packaging, and reachability checks and fails
+closed to the full matrix for shared or unmapped changes. Before merge and
+release, run `make ci-local` (the complete required-check and CI-only matrix).
 
 ### Hard rules (each one has broken a real PR)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-smoke test-unit test-integration test-live test-root test-coverage test-all test-plugin-name validate-plugin-assembly clean-tests help sync sync-check ci-local
+.PHONY: test test-smoke test-unit test-integration test-live test-root test-coverage test-all test-plugin-name validate-plugin-assembly clean-tests help sync sync-check ci-changed ci-local
 
 # Default: smoke + unit (fast feedback)
 test: test-smoke test-unit
@@ -22,6 +22,11 @@ sync-check:
 # Local green here predicts remote green; targeted suites alone do not.
 ci-local: sync-check test-smoke test-unit test-integration
 	@echo "ci-local complete: matches required checks (Smoke/Unit/Integration) + CI-only verifications"
+
+# Proportional pre-push gate. The selector always runs sync/smoke coverage and
+# fails closed to ci-local for shared, generated, manifest, or unmapped changes.
+ci-changed:
+	@./scripts/ci-changed.sh
 
 # Validate plugin name (critical - prevents command prefix breakage)
 test-plugin-name:
@@ -88,6 +93,8 @@ help:
 	@echo "  make test-smoke        - Run smoke tests (<30s)"
 	@echo "  make test-unit         - Run unit tests (1-2min)"
 	@echo "  make test-integration  - Run integration tests (5-10min)"
+	@echo "  make ci-changed        - Run fail-closed tests selected from changed files"
+	@echo "  make ci-local          - Run the complete pre-merge/release matrix"
 	@echo "  make          - Run E2E tests (15-30min)"
 	@echo "  make test-live         - Run live tests (real Claude sessions, real API cost)"
 	@echo "  make test-root         - Run tests/ root suites (not in CI, see #741)"

--- a/RTK.md
+++ b/RTK.md
@@ -35,7 +35,10 @@ the blockage and work in `AI_AGENT_HANDOFF.md`, then flag it to the maintainer.
   commit rather than the branch head.
 - Scripts remain executable. Recheck for mode changes after local tests because
   test fixtures can change modes as a side effect.
-- Run targeted tests while developing and `make ci-local` before pushing code.
+- Run targeted tests while developing and `make ci-changed` before an ordinary
+  branch push. Its checked-in manifest always runs sync, smoke, packaging, and
+  reachability checks and fails closed to `make ci-local` for shared or unmapped
+  changes. Run the complete `make ci-local` matrix before merge and release.
   At minimum, documentation-only changes run `make sync-check` and
   `git diff --check`.
 - Preserve untracked harness-local files such as `.octo-continue.md` unless the

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -103,6 +103,25 @@ claude --add-dir=config/workflows          # Double Diamond
 
 ---
 
+## Local CI Gates
+
+Use the smallest gate that matches the delivery stage:
+
+| Stage | Command | Contract |
+|-------|---------|----------|
+| Edit loop | affected test files | Fast feedback while the change is still moving |
+| Ordinary branch push | `make ci-changed` | Always runs sync and all smoke checks, then audited suites from `tests/changed-scope.tsv` |
+| Merge or release | `make ci-local` | Complete smoke, unit, integration, and CI-only matrix |
+
+Inspect a selection without executing it with `scripts/ci-changed.sh --list`.
+The selector fails closed to `make ci-local` for shared orchestration,
+generators, manifests, unknown paths, missing bases, or stale mappings. When a
+new source surface has a proven focused regression set, add its path and suites
+to `tests/changed-scope.tsv`; otherwise leave it unmapped so the full matrix
+remains mandatory.
+
+---
+
 ## E2E Testing Infrastructure
 
 Automated smoke testing runs on a remote VPS, checking for new releases every 2 hours.

--- a/scripts/ci-changed.sh
+++ b/scripts/ci-changed.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# Select a proportional local gate from changed paths, failing closed to ci-local.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST="$PROJECT_ROOT/tests/changed-scope.tsv"
+
+LIST_ONLY=false
+BASE_REF="${OCTOPUS_CHANGED_BASE:-}"
+declare -a EXPLICIT_CHANGED=()
+declare -a CHANGED_FILES=()
+declare -a SELECTED_SUITES=()
+declare -a MAPPING_LINES=()
+declare -a FULL_REASONS=()
+FULL_MATRIX=false
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/ci-changed.sh [--list] [--base REF] [--changed PATH ...]
+
+Select and run a fail-closed local test gate from the changed files.
+  --list          Print the deterministic plan without running it
+  --base REF      Compare committed changes against REF
+  --changed PATH  Test an explicit changed path instead of reading Git (repeatable)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --list)
+            LIST_ONLY=true
+            shift
+            ;;
+        --base)
+            [[ $# -ge 2 ]] || { echo "ERROR: --base requires a ref" >&2; exit 2; }
+            BASE_REF="$2"
+            shift 2
+            ;;
+        --changed)
+            [[ $# -ge 2 ]] || { echo "ERROR: --changed requires a path" >&2; exit 2; }
+            EXPLICIT_CHANGED+=("$2")
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+array_contains() {
+    local needle="$1"
+    shift
+    local item=""
+    for item in "$@"; do
+        [[ "$item" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+append_unique_changed() {
+    local path="$1"
+    [[ -n "$path" ]] || return 0
+    if ! array_contains "$path" ${CHANGED_FILES[@]+"${CHANGED_FILES[@]}"}; then
+        CHANGED_FILES+=("$path")
+    fi
+}
+
+append_selected_suite() {
+    local suite="$1"
+    local changed="$2"
+    local pattern="$3"
+    if [[ ! -f "$suite" ]]; then
+        FULL_MATRIX=true
+        FULL_REASONS+=("mapping '$pattern' for '$changed' names missing suite '$suite'")
+        return 0
+    fi
+    if ! array_contains "$suite" ${SELECTED_SUITES[@]+"${SELECTED_SUITES[@]}"}; then
+        SELECTED_SUITES+=("$suite")
+    fi
+}
+
+if [[ ${#EXPLICIT_CHANGED[@]} -gt 0 ]]; then
+    for changed in "${EXPLICIT_CHANGED[@]}"; do
+        append_unique_changed "$changed"
+    done
+else
+    if [[ -z "$BASE_REF" ]]; then
+        if git rev-parse --verify --quiet upstream/main >/dev/null; then
+            BASE_REF="upstream/main"
+        elif git rev-parse --verify --quiet origin/main >/dev/null; then
+            BASE_REF="origin/main"
+        fi
+    fi
+
+    committed_changed=""
+    unstaged_changed=""
+    staged_changed=""
+    untracked_changed=""
+    if [[ -z "$BASE_REF" ]] || ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+        FULL_MATRIX=true
+        FULL_REASONS+=("no valid comparison base is available")
+    elif ! git merge-base "$BASE_REF" HEAD >/dev/null 2>&1; then
+        FULL_MATRIX=true
+        FULL_REASONS+=("comparison base '$BASE_REF' has no merge base with HEAD")
+    else
+        if ! committed_changed="$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null)"; then
+            FULL_MATRIX=true
+            FULL_REASONS+=("failed to diff committed changes from '$BASE_REF'")
+        fi
+    fi
+    if ! unstaged_changed="$(git diff --name-only 2>/dev/null)"; then
+        FULL_MATRIX=true
+        FULL_REASONS+=("failed to inspect unstaged changes")
+    fi
+    if ! staged_changed="$(git diff --cached --name-only 2>/dev/null)"; then
+        FULL_MATRIX=true
+        FULL_REASONS+=("failed to inspect staged changes")
+    fi
+    if ! untracked_changed="$(git ls-files --others --exclude-standard 2>/dev/null)"; then
+        FULL_MATRIX=true
+        FULL_REASONS+=("failed to inspect untracked changes")
+    fi
+    while IFS= read -r changed; do append_unique_changed "$changed"; done < <(
+        printf '%s\n' "$committed_changed" "$unstaged_changed" "$staged_changed" "$untracked_changed" |
+            sed '/^$/d' | LC_ALL=C sort -u
+    )
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+    FULL_MATRIX=true
+    FULL_REASONS+=("changed-scope manifest is missing")
+fi
+
+if [[ ${#CHANGED_FILES[@]} -gt 1 ]]; then
+    declare -a SORTED_CHANGED=()
+    while IFS= read -r changed; do SORTED_CHANGED+=("$changed"); done < <(
+        printf '%s\n' "${CHANGED_FILES[@]}" | LC_ALL=C sort -u
+    )
+    CHANGED_FILES=("${SORTED_CHANGED[@]}")
+fi
+
+if [[ "$FULL_MATRIX" == "false" ]]; then
+    for changed in ${CHANGED_FILES[@]+"${CHANGED_FILES[@]}"}; do
+        matched=false
+        while IFS=$'\t' read -r pattern suite_spec; do
+            pattern="${pattern%$'\r'}"
+            suite_spec="${suite_spec%$'\r'}"
+            [[ -n "$pattern" && "$pattern" != \#* ]] || continue
+            # Manifest entries are intentional globs, not literal strings.
+            # shellcheck disable=SC2053
+            if [[ "$changed" == $pattern ]]; then
+                matched=true
+                MAPPING_LINES+=("$changed <= $pattern => $suite_spec")
+                if [[ -z "$suite_spec" ]]; then
+                    FULL_MATRIX=true
+                    FULL_REASONS+=("mapping '$pattern' for '$changed' has no suite policy")
+                    continue
+                fi
+                case "$suite_spec" in
+                    @full)
+                        FULL_MATRIX=true
+                        FULL_REASONS+=("'$changed' matches full-matrix rule '$pattern'")
+                        ;;
+                    @ignore)
+                        ;;
+                    @self)
+                        append_selected_suite "$changed" "$changed" "$pattern"
+                        ;;
+                    *)
+                        for suite_glob in $suite_spec; do
+                            found_suite=false
+                            while IFS= read -r suite; do
+                                [[ -n "$suite" ]] || continue
+                                found_suite=true
+                                append_selected_suite "$suite" "$changed" "$pattern"
+                            done < <(compgen -G "$suite_glob" | LC_ALL=C sort || true)
+                            if [[ "$found_suite" == "false" ]]; then
+                                FULL_MATRIX=true
+                                FULL_REASONS+=("mapping '$pattern' for '$changed' matched no suite for '$suite_glob'")
+                            fi
+                        done
+                        ;;
+                esac
+            fi
+        done < "$MANIFEST"
+        if [[ "$matched" == "false" ]]; then
+            FULL_MATRIX=true
+            FULL_REASONS+=("unmapped changed path '$changed'")
+        fi
+    done
+fi
+
+if [[ "$FULL_MATRIX" == "false" ]]; then
+    append_selected_suite "tests/unit/test-suite-reachability.sh" "always" "always"
+fi
+
+if [[ "$FULL_MATRIX" == "false" && ${#SELECTED_SUITES[@]} -gt 1 ]]; then
+    declare -a SORTED_SUITES=()
+    while IFS= read -r suite; do SORTED_SUITES+=("$suite"); done < <(
+        printf '%s\n' "${SELECTED_SUITES[@]}" | LC_ALL=C sort -u
+    )
+    SELECTED_SUITES=("${SORTED_SUITES[@]}")
+fi
+
+if [[ "$FULL_MATRIX" == "true" ]]; then
+    echo "Mode: full"
+else
+    echo "Mode: focused"
+fi
+echo "Changed files:"
+if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
+    echo "  - (none)"
+else
+    for changed in "${CHANGED_FILES[@]}"; do echo "  - $changed"; done
+fi
+
+if [[ ${#MAPPING_LINES[@]} -gt 0 ]]; then
+    echo "Mappings:"
+    for mapping in "${MAPPING_LINES[@]}"; do echo "  - $mapping"; done
+fi
+
+if [[ "$FULL_MATRIX" == "true" ]]; then
+    echo "Reasons:"
+    for reason in ${FULL_REASONS[@]+"${FULL_REASONS[@]}"}; do echo "  - $reason"; done
+    echo "Command: make ci-local"
+    [[ "$LIST_ONLY" == "true" ]] && exit 0
+    exec make ci-local
+fi
+
+echo "Always: make sync-check, make test-smoke"
+echo "Selected suites:"
+for suite in "${SELECTED_SUITES[@]}"; do echo "  - $suite"; done
+[[ "$LIST_ONLY" == "true" ]] && exit 0
+
+make sync-check
+make test-smoke
+
+declare -a SUITE_ARGS=()
+for suite in "${SELECTED_SUITES[@]}"; do
+    SUITE_ARGS+=("--suite=$suite")
+done
+bash tests/run-all-tests.sh "${SUITE_ARGS[@]}"

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1606,7 +1606,17 @@ council_dispatch_member_detached() {
     # to fall back to the legacy inline dispatch.
     local member_json="$1" phase="$2" output_path="$3"
     local partial="${output_path}.partial" done_file="${output_path}.done"
-    rm -f "$partial" "$done_file" "$output_path"
+    rm -f "$partial" "$done_file" "${done_file}.tmp" "$output_path"
+
+    # Fixture runs already replace provider dispatch with deterministic in-process
+    # responses. Paying the detached seat's polling/reaping protocol for every
+    # fixture seat duplicates the dedicated transport tests below and makes the
+    # Council unit suite take minutes. Keep production dispatch detached, while
+    # fixture scenarios exercise Council behavior through the existing inline path.
+    if [[ -n "$COUNCIL_FIXTURE" ]]; then
+        council_dispatch_member "$member_json" "$phase" > "$output_path"
+        return $?
+    fi
 
     if [[ "${OCTOPUS_COUNCIL_DETACH:-1}" != "1" ]]; then
         council_dispatch_member "$member_json" "$phase" > "$output_path"

--- a/tests/changed-scope.tsv
+++ b/tests/changed-scope.tsv
@@ -1,0 +1,46 @@
+# Changed-path glob<TAB>required suite globs or @full/@self/@ignore.
+#
+# A changed path may match more than one row; all selected suites are unioned.
+# Any path with no matching row fails closed to the complete ci-local matrix.
+
+scripts/lib/review.sh	tests/unit/test-review-*.sh tests/unit/test-pr-review-*.sh tests/integration/test-plugin-expert-review.sh
+scripts/lib/model-resolver.sh	tests/unit/test-resolve-model.sh tests/unit/test-agy-provider.sh tests/unit/test-current-provider-model-defaults.sh tests/unit/test-model-config-role-routing.sh tests/unit/test-model-metadata-parity.sh tests/unit/test-bare-auth-probe-timeout.sh tests/unit/test-provider-auth-validity.sh
+scripts/lib/preflight.sh	tests/unit/test-agy-provider.sh tests/unit/test-provider-availability-parity.sh tests/unit/test-provider-banner-auth.sh tests/unit/test-provider-registry*.sh tests/test-version-check.sh
+
+AI_AGENT_HANDOFF.md	tests/unit/test-handoff.sh
+RTK.md	tests/unit/test-rtk-detection.sh tests/unit/test-handoff.sh
+AGENTS.md	tests/unit/test-v8.2.0-agent-fields.sh tests/integration/test-native-first-docs.sh
+CLAUDE.md	tests/unit/test-v8.2.0-agent-fields.sh tests/integration/test-native-first-docs.sh
+README.md	tests/unit/test-readme-release-sync.sh tests/integration/test-readme-compliance.sh
+PRODUCT.md	tests/unit/test-readme-release-sync.sh tests/integration/test-readme-compliance.sh
+docs/*	tests/integration/test-native-first-docs.sh tests/integration/test-readme-compliance.sh
+CHANGELOG.md	tests/unit/test-readme-release-sync.sh
+.beads.gate.lock	@ignore
+.octo-continue.md	@ignore
+
+tests/unit/test-*.sh	@self
+tests/integration/test-*.sh	@self
+tests/smoke/test-*.sh	@self
+tests/test-*.sh	@self
+tests/validate-*.sh	@self
+
+scripts/orchestrate.sh	@full
+scripts/lib/workflows.sh	@full
+scripts/lib/spawn.sh	@full
+scripts/lib/agents.sh	@full
+scripts/lib/dispatch.sh	@full
+scripts/build-*	@full
+scripts/sync-*	@full
+scripts/gen-*	@full
+scripts/validate-*	@full
+scripts/ci-changed.sh	@full
+tests/changed-scope.tsv	@full
+tests/run-all*.sh	@full
+Makefile	@full
+.github/workflows/*	@full
+.claude-plugin/*	@full
+.codex-plugin/*	@full
+.cursor-plugin/*	@full
+.factory-plugin/*	@full
+openclaw/*	@full
+config/*	@full

--- a/tests/helpers/test-framework.sh
+++ b/tests/helpers/test-framework.sh
@@ -22,6 +22,14 @@ TESTS_SKIPPED=0
 TEST_START_TIME=0
 TEST_SUITE_START_TIME=0
 
+# Production Tangle writes are isolated in persistent Git worktrees. Unit tests
+# default to in-place execution inside their disposable TEST_TMP_DIR instead, so
+# ordinary behavior suites cannot leave registrations or octopus/run/* refs in the
+# developer's real repository. The dedicated run-worktree suite explicitly unsets
+# this variable to verify the production default.
+OCTOPUS_TANGLE_RUN_WORKTREE="${OCTOPUS_TANGLE_RUN_WORKTREE:-false}"
+export OCTOPUS_TANGLE_RUN_WORKTREE
+
 # Arrays for tracking
 FAILED_TESTS=()
 SKIPPED_TESTS=()

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -17,6 +17,7 @@
 # Options:
 #   --fail-fast     Stop on first suite failure
 #   --list          List discovered tests without running them
+#   --suite=PATH    Run one explicit suite path relative to tests/ (repeatable)
 
 set -euo pipefail
 
@@ -122,6 +123,7 @@ print_summary() {
 
 # Parse flags
 declare -a CATEGORIES=()
+declare -a EXPLICIT_SUITE_ARGS=()
 for arg in "$@"; do
     case "$arg" in
         --smoke)       CATEGORIES+=("smoke") ;;
@@ -138,19 +140,27 @@ for arg in "$@"; do
         --everything)  CATEGORIES=("smoke" "unit" "integration" "root" "live") ;;
         --fail-fast)   FAIL_FAST=true ;;
         --list)        LIST_ONLY=true ;;
+        --suite=*)
+            suite_arg="${arg#--suite=}"
+            if [[ -z "$suite_arg" ]]; then
+                echo -e "${RED}--suite requires a path relative to tests/${NC}" >&2
+                exit 2
+            fi
+            EXPLICIT_SUITE_ARGS+=("$suite_arg")
+            ;;
         *)
             echo -e "${YELLOW}Unknown flag '$arg', ignoring${NC}" ;;
     esac
 done
 
-# Default to --all if no categories specified
-if [[ ${#CATEGORIES[@]} -eq 0 ]]; then
+# Default to --all only when no category or explicit suite was requested.
+if [[ ${#CATEGORIES[@]} -eq 0 && ${#EXPLICIT_SUITE_ARGS[@]} -eq 0 ]]; then
     CATEGORIES=("smoke" "unit" "integration" "root")
 fi
 
 # Deduplicate categories while preserving order
 declare -a UNIQUE_CATS=()
-for cat in "${CATEGORIES[@]}"; do
+for cat in ${CATEGORIES[@]+"${CATEGORIES[@]}"}; do
     local_dup=false
     for seen in "${UNIQUE_CATS[@]+"${UNIQUE_CATS[@]}"}"; do
         if [[ "$seen" == "$cat" ]]; then
@@ -162,11 +172,14 @@ for cat in "${CATEGORIES[@]}"; do
         UNIQUE_CATS+=("$cat")
     fi
 done
-CATEGORIES=("${UNIQUE_CATS[@]}")
+CATEGORIES=()
+for seen in ${UNIQUE_CATS[@]+"${UNIQUE_CATS[@]}"}; do
+    CATEGORIES+=("$seen")
+done
 
 # Build test list from categories via auto-discovery
 declare -a TEST_SUITES=()
-for cat in "${CATEGORIES[@]}"; do
+for cat in ${CATEGORIES[@]+"${CATEGORIES[@]}"}; do
     case "$cat" in
         smoke)
             while IFS= read -r f; do
@@ -196,8 +209,54 @@ for cat in "${CATEGORIES[@]}"; do
     esac
 done
 
-if [[ ${#TEST_SUITES[@]} -eq 0 ]]; then
-    echo -e "${YELLOW}No test files discovered for categories: ${CATEGORIES[*]}${NC}"
+# Add explicitly requested suites after category discovery. Paths are confined
+# to tests/ and must name existing files; invalid input fails instead of
+# silently expanding to the default matrix.
+for suite_arg in ${EXPLICIT_SUITE_ARGS[@]+"${EXPLICIT_SUITE_ARGS[@]}"}; do
+    case "$suite_arg" in
+        /*|../*|*/../*|*/..)
+            echo -e "${RED}Invalid --suite path outside tests/: $suite_arg${NC}" >&2
+            exit 2
+            ;;
+        tests/*) suite_path="$SCRIPT_DIR/${suite_arg#tests/}" ;;
+        *)       suite_path="$SCRIPT_DIR/$suite_arg" ;;
+    esac
+    suite_name="${suite_path##*/}"
+    case "$suite_name" in
+        test-*.sh|validate-*.sh) ;;
+        *)
+            echo -e "${RED}Explicit suite must be test-*.sh or validate-*.sh: $suite_arg${NC}" >&2
+            exit 2
+            ;;
+    esac
+    if [[ ! -f "$suite_path" ]]; then
+        echo -e "${RED}Explicit suite not found: $suite_arg${NC}" >&2
+        exit 2
+    fi
+    TEST_SUITES+=("$suite_path")
+done
+
+# Deduplicate explicit/category overlap while preserving deterministic order.
+declare -a UNIQUE_SUITES=()
+for suite in "${TEST_SUITES[@]}"; do
+    suite_seen=false
+    for seen in ${UNIQUE_SUITES[@]+"${UNIQUE_SUITES[@]}"}; do
+        if [[ "$seen" == "$suite" ]]; then
+            suite_seen=true
+            break
+        fi
+    done
+    if ! $suite_seen; then
+        UNIQUE_SUITES+=("$suite")
+    fi
+done
+TEST_SUITES=()
+for suite in ${UNIQUE_SUITES[@]+"${UNIQUE_SUITES[@]}"}; do
+    TEST_SUITES+=("$suite")
+done
+
+if [[ -z "${TEST_SUITES[*]-}" ]]; then
+    echo -e "${YELLOW}No test files discovered for categories: ${CATEGORIES[*]-}${NC}"
     exit 0
 fi
 
@@ -206,7 +265,11 @@ echo -e "${CYAN}╔════════════════════�
 echo -e "${CYAN}║          Claude Octopus Test Suite                       ║${NC}"
 echo -e "${CYAN}╚══════════════════════════════════════════════════════════╝${NC}"
 echo ""
-echo -e "${BLUE}Categories:${NC} ${CATEGORIES[*]}"
+if [[ -n "${CATEGORIES[*]-}" ]]; then
+    echo -e "${BLUE}Categories:${NC} ${CATEGORIES[*]}"
+else
+    echo -e "${BLUE}Categories:${NC} explicit suites"
+fi
 echo -e "${BLUE}Discovered:${NC} ${#TEST_SUITES[@]} test suites"
 if $FAIL_FAST; then
     echo -e "${BLUE}Fail-fast:${NC} enabled"

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -38,11 +38,13 @@ FAILED_SUITES=0
 SKIPPED_SUITES=0
 FAIL_FAST=false
 LIST_ONLY=false
+SUITE_TIMINGS=()
 
 # Function to run a test suite
 run_test_suite() {
     local test_file="$1"
     local test_name
+    local suite_start suite_end suite_duration
     # Show relative path from tests/ for clarity
     test_name="${test_file#"$SCRIPT_DIR"/}"
 
@@ -53,6 +55,7 @@ run_test_suite() {
     echo ""
 
     TOTAL_SUITES=$((TOTAL_SUITES + 1))
+    suite_start="$(date +%s)"
 
     # Non-live suites must never launch real provider/auth probes. Besides
     # spending API quota, a CLI blocked on Keychain can stall the entire gate.
@@ -62,6 +65,9 @@ run_test_suite() {
     else
         OCTOPUS_SKIP_PROVIDER_PROBES=true bash "$test_file" || test_rc=$?
     fi
+    suite_end="$(date +%s)"
+    suite_duration=$((suite_end - suite_start))
+    SUITE_TIMINGS+=("${suite_duration}"$'\t'"${test_name}")
 
     if [[ "$test_rc" -eq 0 ]]; then
         PASSED_SUITES=$((PASSED_SUITES + 1))
@@ -111,6 +117,15 @@ print_summary() {
     if [[ $SKIPPED_SUITES -gt 0 ]]; then
         echo -e "Skipped:           ${YELLOW}$SKIPPED_SUITES${NC}"
     fi
+    echo ""
+
+    echo "Slowest suites:"
+    printf '%s\n' "${SUITE_TIMINGS[@]}" |
+        LC_ALL=C sort -t $'\t' -k1,1nr -k2,2 |
+        awk 'NR <= 10' |
+        while IFS=$'\t' read -r duration suite; do
+            printf '  %ss %s\n' "$duration" "$suite"
+        done
     echo ""
 
     if [[ $FAILED_SUITES -eq 0 ]]; then

--- a/tests/unit/test-ci-changed.sh
+++ b/tests/unit/test-ci-changed.sh
@@ -142,6 +142,25 @@ else
     test_fail "explicit suite selection expanded to the default matrix: $runner_list"
 fi
 
+test_case "test harness disables production Tangle worktree isolation by default"
+preserved_tangle_setting="$(OCTOPUS_TANGLE_RUN_WORKTREE=true bash -c 'source "$1"; printf "%s" "$OCTOPUS_TANGLE_RUN_WORKTREE"' _ "$PROJECT_ROOT/tests/helpers/test-framework.sh")"
+if [[ "${OCTOPUS_TANGLE_RUN_WORKTREE:-}" == "false" ]] &&
+   [[ "$preserved_tangle_setting" == "true" ]] &&
+   grep -q '^unset OCTOPUS_TANGLE_RUN_WORKTREE' "$PROJECT_ROOT/tests/unit/test-tangle-run-worktree.sh"; then
+    test_pass
+else
+    test_fail "ordinary unit suites can still create production-style Tangle worktrees"
+fi
+
+test_case "test runner reports its slowest suites"
+timing_output="$(bash "$RUN_ALL" --suite=unit/test-suite-reachability.sh 2>&1 || true)"
+if grep -q '^Slowest suites:' <<< "$timing_output" &&
+   grep -Eq '^[[:space:]]+[0-9]+s[[:space:]]+unit/test-suite-reachability\.sh$' <<< "$timing_output"; then
+    test_pass
+else
+    test_fail "runner did not emit actionable per-suite timing: $timing_output"
+fi
+
 test_case "test runner rejects non-suite explicit paths"
 invalid_runner_output="$TEST_TMP_DIR/invalid-runner.out"
 if bash "$RUN_ALL" --list --suite=changed-scope.tsv > "$invalid_runner_output" 2>&1; then

--- a/tests/unit/test-ci-changed.sh
+++ b/tests/unit/test-ci-changed.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Regression coverage for the fail-closed changed-scope local CI gate.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "changed-scope local CI selection"
+
+CI_CHANGED="$PROJECT_ROOT/scripts/ci-changed.sh"
+RUN_ALL="$PROJECT_ROOT/tests/run-all-tests.sh"
+
+plan_for() {
+    bash "$CI_CHANGED" --list --changed "$1" 2>&1 || true
+}
+
+test_case "changed-scope entrypoint and manifest exist"
+if [[ -x "$CI_CHANGED" && -f "$PROJECT_ROOT/tests/changed-scope.tsv" ]]; then
+    test_pass
+else
+    test_fail "missing executable scripts/ci-changed.sh or tests/changed-scope.tsv"
+fi
+
+test_case "review-only changes select review suites without Council"
+review_plan="$(plan_for 'scripts/lib/review.sh')"
+if grep -q '^Mode: focused$' <<< "$review_plan" &&
+   grep -q 'tests/unit/test-review-aggregation-robustness.sh' <<< "$review_plan" &&
+   ! grep -q 'test-council-command.sh' <<< "$review_plan"; then
+    test_pass
+else
+    test_fail "review selection was not focused and auditable: $review_plan"
+fi
+
+test_case "shared orchestrator changes select the full matrix"
+orchestrator_plan="$(plan_for 'scripts/orchestrate.sh')"
+if grep -q '^Mode: full$' <<< "$orchestrator_plan" &&
+   grep -q 'scripts/orchestrate.sh' <<< "$orchestrator_plan"; then
+    test_pass
+else
+    test_fail "orchestrator change did not fail closed: $orchestrator_plan"
+fi
+
+test_case "generator changes select the full matrix"
+generator_plan="$(plan_for 'scripts/sync-readme.py')"
+if grep -q '^Mode: full$' <<< "$generator_plan" &&
+   grep -q 'scripts/sync-readme.py' <<< "$generator_plan"; then
+    test_pass
+else
+    test_fail "generator change did not fail closed: $generator_plan"
+fi
+
+test_case "selector and manifest changes select the full matrix"
+selector_plan="$(plan_for 'scripts/ci-changed.sh')"
+manifest_plan="$(plan_for 'tests/changed-scope.tsv')"
+if grep -q '^Mode: full$' <<< "$selector_plan" &&
+   grep -q '^Mode: full$' <<< "$manifest_plan"; then
+    test_pass
+else
+    test_fail "gate implementation changes did not fail closed"
+fi
+
+test_case "unknown paths select the full matrix"
+unknown_plan="$(plan_for 'scripts/lib/new-unmapped-surface.sh')"
+if grep -q '^Mode: full$' <<< "$unknown_plan" &&
+   grep -q 'unmapped' <<< "$unknown_plan"; then
+    test_pass
+else
+    test_fail "unknown change did not fail closed: $unknown_plan"
+fi
+
+test_case "missing comparison bases select the full matrix"
+missing_base_plan="$(bash "$CI_CHANGED" --list --base 'refs/heads/does-not-exist' 2>&1 || true)"
+if grep -q '^Mode: full$' <<< "$missing_base_plan" &&
+   grep -q 'no valid comparison base' <<< "$missing_base_plan"; then
+    test_pass
+else
+    test_fail "missing comparison base did not fail closed: $missing_base_plan"
+fi
+
+test_case "automatic base selection never narrows to the previous commit"
+if ! grep -q 'BASE_REF="HEAD~1"' "$CI_CHANGED"; then
+    test_pass
+else
+    test_fail "automatic HEAD~1 fallback can omit earlier branch commits"
+fi
+
+test_case "known harness-local artifacts do not force the full matrix"
+harness_plan="$(plan_for '.beads.gate.lock')"
+if grep -q '^Mode: focused$' <<< "$harness_plan" &&
+   grep -q 'tests/unit/test-suite-reachability.sh' <<< "$harness_plan" &&
+   ! grep -q 'unmapped changed path' <<< "$harness_plan"; then
+    test_pass
+else
+    test_fail "known harness-local artifact changed the source-test scope: $harness_plan"
+fi
+
+test_case "changed test suites select themselves"
+self_plan="$(plan_for 'tests/unit/test-ci-changed.sh')"
+if grep -q '^Mode: focused$' <<< "$self_plan" &&
+   grep -q 'tests/unit/test-ci-changed.sh' <<< "$self_plan"; then
+    test_pass
+else
+    test_fail "changed unit suite was not selected: $self_plan"
+fi
+
+test_case "model-resolution changes select provider suites without Council"
+model_plan="$(plan_for 'scripts/lib/model-resolver.sh')"
+if grep -q '^Mode: focused$' <<< "$model_plan" &&
+   grep -q 'tests/unit/test-resolve-model.sh' <<< "$model_plan" &&
+   grep -q 'tests/unit/test-agy-provider.sh' <<< "$model_plan" &&
+   ! grep -q 'test-council-command.sh' <<< "$model_plan"; then
+    test_pass
+else
+    test_fail "model-resolution selection was not proportional: $model_plan"
+fi
+
+test_case "selection output is deterministic"
+first_plan="$(bash "$CI_CHANGED" --list --changed 'scripts/lib/review.sh' --changed 'scripts/lib/model-resolver.sh' 2>&1 || true)"
+second_plan="$(bash "$CI_CHANGED" --list --changed 'scripts/lib/model-resolver.sh' --changed 'scripts/lib/review.sh' 2>&1 || true)"
+if [[ "$first_plan" == "$second_plan" ]]; then
+    test_pass
+else
+    test_fail "identical changed files produced different plans"
+fi
+
+test_case "one unsafe file makes a mixed change set full"
+mixed_plan="$(bash "$CI_CHANGED" --list --changed 'scripts/lib/review.sh' --changed 'scripts/orchestrate.sh' 2>&1 || true)"
+if grep -q '^Mode: full$' <<< "$mixed_plan"; then
+    test_pass
+else
+    test_fail "mixed safe and unsafe changes did not fail closed: $mixed_plan"
+fi
+
+test_case "test runner accepts one explicit suite without defaulting to all"
+runner_list="$(bash "$RUN_ALL" --list --suite=unit/test-ci-changed.sh 2>&1 || true)"
+if grep -q 'Discovered:.*1 test suites' <<< "$runner_list" &&
+   grep -q 'unit/test-ci-changed.sh' <<< "$runner_list" &&
+   ! grep -q 'unit/test-council-command.sh' <<< "$runner_list"; then
+    test_pass
+else
+    test_fail "explicit suite selection expanded to the default matrix: $runner_list"
+fi
+
+test_case "test runner rejects non-suite explicit paths"
+invalid_runner_output="$TEST_TMP_DIR/invalid-runner.out"
+if bash "$RUN_ALL" --list --suite=changed-scope.tsv > "$invalid_runner_output" 2>&1; then
+    invalid_runner_rc=0
+else
+    invalid_runner_rc=$?
+fi
+if [[ "$invalid_runner_rc" -eq 2 ]] &&
+   grep -q 'Explicit suite must be' "$invalid_runner_output" &&
+   ! grep -q 'test-council-command.sh' "$invalid_runner_output"; then
+    test_pass
+else
+    test_fail "invalid explicit path did not fail safely: rc=$invalid_runner_rc"
+fi
+
+test_case "Makefile and agent instructions expose proportional gates"
+if grep -q '^ci-changed:' "$PROJECT_ROOT/Makefile" &&
+   grep -q 'make ci-changed' "$PROJECT_ROOT/RTK.md" &&
+   grep -q 'make ci-changed' "$PROJECT_ROOT/AGENTS.md" &&
+   grep -q 'make ci-changed' "$PROJECT_ROOT/CLAUDE.md" &&
+   grep -q 'tests/changed-scope.tsv' "$PROJECT_ROOT/docs/DEVELOPER.md"; then
+    test_pass
+else
+    test_fail "changed-scope command or iterative versus final guidance is missing"
+fi
+
+test_case "GitHub CI retains the authoritative full matrix"
+if grep -q 'run: make test-unit' "$PROJECT_ROOT/.github/workflows/test.yml" &&
+   grep -q 'run: make test-integration' "$PROJECT_ROOT/.github/workflows/test.yml" &&
+   ! grep -q 'make ci-changed' "$PROJECT_ROOT/.github/workflows/test.yml"; then
+    test_pass
+else
+    test_fail "GitHub CI no longer runs the complete unit and integration jobs"
+fi
+
+test_summary

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -8,6 +8,12 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 
 test_suite "Council Command"
 
+CACHED_COUNCIL_QUICK_DRY_RUN_SUMMARY=""
+CACHED_COUNCIL_STANDARD_RUN_DIR=""
+CACHED_COUNCIL_CHAIR_FALLBACK_RUN_DIR=""
+CACHED_COUNCIL_CHAIR_FALLBACK_OUTPUT=""
+CACHED_COUNCIL_ALL_APPROVE_RUN_DIR=""
+
 test_council_command_files_are_registered() {
     test_case "Council command and skill are registered"
 
@@ -65,6 +71,52 @@ load_council_lib() {
     source "$lib"
 }
 
+prepare_cached_quick_dry_run() {
+    [[ -f "$CACHED_COUNCIL_QUICK_DRY_RUN_SUMMARY" ]] && return 0
+    local tmp_dir
+    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-quick-cache.XXXXXX")"
+    council_run --dry-run --goal advice --depth quick --benchmark auto \
+        --output-dir "$tmp_dir" "Should we use Redis?"
+    CACHED_COUNCIL_QUICK_DRY_RUN_SUMMARY="$(find "$tmp_dir" -name summary.json -type f | head -1)"
+    [[ -f "$CACHED_COUNCIL_QUICK_DRY_RUN_SUMMARY" ]]
+}
+
+prepare_cached_standard_fixture_run() {
+    [[ -f "$CACHED_COUNCIL_STANDARD_RUN_DIR/summary.json" ]] && return 0
+    local tmp_dir
+    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-standard-cache.XXXXXX")"
+    OCTOPUS_COUNCIL_FIXTURE=full-success \
+    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='claude:available,codex:available,agy:available' \
+        council_run --goal advice --depth standard --output-dir "$tmp_dir" "Should we use Redis?"
+    CACHED_COUNCIL_STANDARD_RUN_DIR="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    [[ -f "$CACHED_COUNCIL_STANDARD_RUN_DIR/summary.json" ]]
+}
+
+prepare_cached_chair_fallback_run() {
+    [[ -f "$CACHED_COUNCIL_CHAIR_FALLBACK_RUN_DIR/summary.json" ]] && return 0
+    local tmp_dir
+    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-chair-cache.XXXXXX")"
+    CACHED_COUNCIL_CHAIR_FALLBACK_OUTPUT="$TEST_TMP_DIR/council-chair-cache.out"
+    OCTOPUS_COUNCIL_FIXTURE=full-success \
+    OCTOPUS_COUNCIL_FAIL_PERSONAS='strategy-analyst' \
+    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='claude:available,codex:available,agy:available' \
+        council_run --depth quick --output-dir "$tmp_dir" "Review auth" \
+        >"$CACHED_COUNCIL_CHAIR_FALLBACK_OUTPUT" 2>&1
+    CACHED_COUNCIL_CHAIR_FALLBACK_RUN_DIR="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    [[ -f "$CACHED_COUNCIL_CHAIR_FALLBACK_RUN_DIR/summary.json" ]]
+}
+
+prepare_cached_all_approve_run() {
+    [[ -f "$CACHED_COUNCIL_ALL_APPROVE_RUN_DIR/summary.json" ]] && return 0
+    local tmp_dir
+    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-approve-cache.XXXXXX")"
+    OCTOPUS_COUNCIL_FIXTURE=full-success \
+    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='codex:available,agy:available' \
+        council_run --depth standard --output-dir "$tmp_dir" "Review X" >/dev/null 2>&1 || true
+    CACHED_COUNCIL_ALL_APPROVE_RUN_DIR="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    [[ -f "$CACHED_COUNCIL_ALL_APPROVE_RUN_DIR/summary.json" ]]
+}
+
 test_council_defaults_are_depth_aware() {
     test_case "Council defaults are depth aware"
     load_council_lib || return 1
@@ -96,14 +148,9 @@ test_council_rejects_non_usd_budget() {
 test_council_dry_run_writes_summary_json() {
     test_case "Council dry-run writes summary JSON"
     load_council_lib || return 1
+    prepare_cached_quick_dry_run || { test_fail "cached quick dry-run failed"; return 1; }
 
-    local tmp_dir
-    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council.XXXXXX")"
-
-    council_run --dry-run --goal advice --depth quick --output-dir "$tmp_dir" "Should we use Redis?"
-
-    local summary
-    summary="$(find "$tmp_dir" -name summary.json -type f | head -1)"
+    local summary="$CACHED_COUNCIL_QUICK_DRY_RUN_SUMMARY"
     [[ -n "$summary" ]] || { test_fail "summary.json not written"; return 1; }
 
     if jq -e '.command == "council" and .status == "dry-run" and .implementation.worktree == "auto"' "$summary" >/dev/null; then
@@ -149,14 +196,9 @@ test_council_dry_run_maps_implementation_and_worktree() {
 test_council_dry_run_has_multi_seat_recommendation_and_cost() {
     test_case "Council dry-run has multiple seats and positive cost estimate"
     load_council_lib || return 1
+    prepare_cached_quick_dry_run || { test_fail "cached quick dry-run failed"; return 1; }
 
-    local tmp_dir
-    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-cost.XXXXXX")"
-
-    council_run --dry-run --depth quick --output-dir "$tmp_dir" "Should we use Redis?"
-
-    local summary
-    summary="$(find "$tmp_dir" -name summary.json -type f | head -1)"
+    local summary="$CACHED_COUNCIL_QUICK_DRY_RUN_SUMMARY"
     [[ -n "$summary" ]] || { test_fail "summary.json not written"; return 1; }
 
     if jq -e '(.council | length) >= 2 and .budget.estimated_cost_usd > 0' "$summary" >/dev/null; then
@@ -592,16 +634,9 @@ test_council_pass_parser_accepts_variants() {
 test_council_fixture_run_writes_phase_artifacts() {
     test_case "Council fixture run writes phase artifacts"
     load_council_lib || return 1
+    prepare_cached_standard_fixture_run || { test_fail "cached standard fixture run failed"; return 1; }
 
-    local tmp_dir
-    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-full.XXXXXX")"
-
-    OCTOPUS_COUNCIL_FIXTURE=full-success \
-    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='claude:available,codex:available,agy:available' \
-        council_run --goal advice --depth standard --output-dir "$tmp_dir" "Should we use Redis?"
-
-    local run_dir summary
-    run_dir="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    local run_dir="$CACHED_COUNCIL_STANDARD_RUN_DIR" summary
     summary="$run_dir/summary.json"
 
     [[ -f "$run_dir/config.json" ]] || { test_fail "config.json not written"; return 1; }
@@ -630,16 +665,9 @@ test_council_fixture_run_writes_phase_artifacts() {
 test_council_synthesis_is_chair_generated() {
     test_case "Council synthesis is generated by chair dispatch"
     load_council_lib || return 1
+    prepare_cached_standard_fixture_run || { test_fail "cached standard fixture run failed"; return 1; }
 
-    local tmp_dir
-    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-synthesis.XXXXXX")"
-
-    OCTOPUS_COUNCIL_FIXTURE=full-success \
-    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='claude:available,codex:available,agy:available' \
-        council_run --goal advice --depth standard --output-dir "$tmp_dir" "Should we use Redis?"
-
-    local synthesis
-    synthesis="$(find "$tmp_dir" -name synthesis.md -type f | head -1)"
+    local synthesis="$CACHED_COUNCIL_STANDARD_RUN_DIR/synthesis.md"
     [[ -n "$synthesis" ]] || { test_fail "synthesis.md not written"; return 1; }
 
     if grep -q "Fixture response for chair-synthesis" "$synthesis" &&
@@ -943,16 +971,9 @@ test_council_chair_fallback_preserves_quorum() {
     test_case "Council retries failed chair with synthesis-capable fallback"
     load_council_lib || return 1
 
-    local tmp_dir
-    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-chair-fallback.XXXXXX")"
+    prepare_cached_chair_fallback_run || { test_fail "cached chair fallback run failed"; return 1; }
 
-    OCTOPUS_COUNCIL_FIXTURE=full-success \
-    OCTOPUS_COUNCIL_FAIL_PERSONAS='strategy-analyst' \
-    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='claude:available,codex:available,agy:available' \
-        council_run --depth quick --output-dir "$tmp_dir" "Review auth"
-
-    local summary
-    summary="$(find "$tmp_dir" -name summary.json -type f | head -1)"
+    local summary="$CACHED_COUNCIL_CHAIR_FALLBACK_RUN_DIR/summary.json"
     [[ -n "$summary" ]] || { test_fail "summary.json not written"; return 1; }
 
     if jq -e '
@@ -986,14 +1007,8 @@ test_council_chair_fallback_warning_prints_to_cli() {
     test_case "Council prints chair fallback warning to CLI"
     load_council_lib || return 1
 
-    local tmp_dir out_file
-    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-chair-output.XXXXXX")"
-    out_file="$TEST_TMP_DIR/council-chair-output.out"
-
-    OCTOPUS_COUNCIL_FIXTURE=full-success \
-    OCTOPUS_COUNCIL_FAIL_PERSONAS='strategy-analyst' \
-    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='claude:available,codex:available,agy:available' \
-        council_run --depth quick --output-dir "$tmp_dir" "Review auth" >"$out_file" 2>&1
+    prepare_cached_chair_fallback_run || { test_fail "cached chair fallback run failed"; return 1; }
+    local out_file="$CACHED_COUNCIL_CHAIR_FALLBACK_OUTPUT"
 
     if grep -q "Council warning: chair fallback used" "$out_file"; then
         test_pass
@@ -1507,12 +1522,8 @@ test_council_split_double_seat_fails_quorum() {
 test_council_all_approve_meets_quorum() {
     test_case "Council quorum meets when >=2 distinct vendors cleanly APPROVE"
     load_council_lib || return 1
-    local tmp_dir rd
-    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-approve.XXXXXX")"
-    OCTOPUS_COUNCIL_FIXTURE=full-success \
-    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='codex:available,agy:available' \
-        council_run --depth standard --output-dir "$tmp_dir" "Review X" >/dev/null 2>&1 || true
-    rd="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    prepare_cached_all_approve_run || { test_fail "cached all-approve run failed"; return 1; }
+    local rd="$CACHED_COUNCIL_ALL_APPROVE_RUN_DIR"
     if jq -e '.quorum.met == true and .quorum.distinct_approving_providers >= 2' "$rd/summary.json" >/dev/null; then
         test_pass
     else
@@ -1604,6 +1615,52 @@ test_council_detach_escape_hatch_uses_inline() {
         test_pass
     else
         test_fail "escape hatch wrong: rc=$rc content=[$(tr '\n' '|' < "$d/x.md" 2>/dev/null)]"
+        return 1
+    fi
+}
+
+test_council_fixture_dispatch_uses_inline_transport() {
+    test_case "Council fixtures bypass detached transport already covered separately"
+    load_council_lib || return 1
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/fixture-inline.XXXXXX")"
+    local member='{"provider":"codex","persona":"code-reviewer","seat":"member"}'
+    local dispatch_context="parent"
+
+    COUNCIL_FIXTURE="full-success"
+    : > "$d/x.md.partial"
+    : > "$d/x.md.done"
+    : > "$d/x.md.done.tmp"
+    council_dispatch_member() {
+        dispatch_context="inline"
+        printf 'fixture response\nVERDICT: APPROVE\n'
+        return 0
+    }
+
+    local rc=0
+    council_dispatch_member_detached "$member" "independent-advice" "$d/x.md" || rc=$?
+    local success_ok="false"
+    if [[ $rc -eq 0 ]] && [[ "$dispatch_context" == "inline" ]] &&
+       grep -q 'VERDICT: APPROVE' "$d/x.md" &&
+       [[ ! -e "$d/x.md.partial" && ! -e "$d/x.md.done" && ! -e "$d/x.md.done.tmp" ]]; then
+        success_ok="true"
+    fi
+
+    dispatch_context="parent"
+    council_dispatch_member() {
+        dispatch_context="inline"
+        printf 'fixture failure body\n'
+        return 3
+    }
+    rc=0
+    council_dispatch_member_detached "$member" "independent-advice" "$d/fail.md" || rc=$?
+
+    if [[ "$success_ok" == "true" ]] && [[ $rc -eq 3 ]] &&
+       [[ "$dispatch_context" == "inline" ]] &&
+       grep -q 'fixture failure body' "$d/fail.md" &&
+       [[ ! -e "$d/fail.md.partial" && ! -e "$d/fail.md.done" && ! -e "$d/fail.md.done.tmp" ]]; then
+        test_pass
+    else
+        test_fail "fixture dispatch still paid detached transport overhead: success=$success_ok rc=$rc context=$dispatch_context"
         return 1
     fi
 }
@@ -1897,12 +1954,8 @@ test_council_response_has_verdict_salvage() {
 test_council_seats_array_makes_quorum_inspectable() {
     test_case "summary.json seats[] records per-seat state and quorum is recomputable from it"
     load_council_lib || return 1
-    local tmp_dir rd s
-    tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-seats.XXXXXX")"
-    OCTOPUS_COUNCIL_FIXTURE=full-success \
-    OCTOPUS_COUNCIL_PROVIDER_FIXTURE='codex:available,agy:available' \
-        council_run --depth standard --output-dir "$tmp_dir" "Review X" >/dev/null 2>&1 || true
-    rd="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    prepare_cached_all_approve_run || { test_fail "cached all-approve run failed"; return 1; }
+    local rd="$CACHED_COUNCIL_ALL_APPROVE_RUN_DIR" s
     s="$rd/summary.json"
     # Every seat carries the FULL documented contract (incl. provider_org, model,
     # verdict), the fields are well-typed, the counted_as_approver invariant holds,
@@ -1969,6 +2022,7 @@ test_council_split_double_seat_fails_quorum
 test_council_all_approve_meets_quorum
 test_council_detached_dispatch_atomic_and_propagates_rc
 test_council_detach_escape_hatch_uses_inline
+test_council_fixture_dispatch_uses_inline_transport
 test_council_detached_seat_survives_interrupt
 test_council_detached_seat_timeout_is_cancelled
 test_council_seat_timeout_precedence


### PR DESCRIPTION
## Summary

- add a fail-closed `make ci-changed` gate driven by an audited changed-path manifest
- always run sync, smoke/packaging, and suite reachability; select focused review/model/provider suites where mappings are proven
- retain the complete GitHub and `make ci-local` matrix for shared, unknown, merge, and release changes
- document the edit, ordinary-push, and final-gate contract for maintainers and coding agents

## Verification

- selector regression: 17/17
- focused model-resolver exercise: 16/16 smoke + 8/8 selected suites, Council excluded
- final `make ci-local`: 16/16 smoke, 268/268 unit, 7/7 integration, CI-only checks
- Bash 3.2 syntax, ShellCheck, and `git diff --check`

Fixes #910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added proportional pre-push validation that selects checks based on changed files.
  - Added support for explicitly selected test suites, validation, timing summaries, and check inspection.

- **Bug Fixes**
  - Improved fail-closed behavior when changes cannot be safely mapped to focused checks.
  - Improved test isolation and fixture execution reliability.

- **Documentation**
  - Updated guidance for pre-push, merge, and release validation workflows.
  - Documented local CI gates and focused-suite registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->