### PR TITLE
fix: harden Tangle integrity boundaries

### DIFF
--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,25 +1,17 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-13
-Status: Issues #900 and #902 are implemented on
-`fix/900-tangle-lifecycle`. Tangle workers now run in dedicated process groups,
-INT/TERM and unexpected orchestrator exits cancel active work, completion
-watchers recover from idle wrappers, and redirected progress changes only when
-the count changes. The implementation commits through `696aafd2` are pushed to
-both remotes and [PR #909](https://github.com/nyldn/claude-octopus/pull/909) is
-open. Review-response commits through `afbaa8cc` are pushed to both remotes.
-The remote Linux integration job exposed a pipefail-only SIGPIPE in two test
-assertions, and a follow-up review found a failed-lock path plus a test lifecycle
-override. All three corrections pass focused coverage and the latest full gate;
-commit `29fa740e` is pushed to both remotes. Review replies and rerun checks
-remain. Release remains explicitly deferred.
-Branch: `fix/900-tangle-lifecycle`
+Status: Issues #901, #903, and #905 are implemented on a combined branch and
+pass the complete local gate. PR #914 is open; review, merge, and release are
+the remaining steps.
+Branch: `fix/901-tangle-integrity`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
-Tracking: [issue #900](https://github.com/nyldn/claude-octopus/issues/900),
-[issue #902](https://github.com/nyldn/claude-octopus/issues/902)
-PR: [#909](https://github.com/nyldn/claude-octopus/pull/909)
-Next action: answer the two new review threads, then verify the rerun checks.
-Merge and release remain deferred.
+Tracking: [issue #901](https://github.com/nyldn/claude-octopus/issues/901),
+[issue #903](https://github.com/nyldn/claude-octopus/issues/903), and
+[issue #905](https://github.com/nyldn/claude-octopus/issues/905); implementation
+PR [#914](https://github.com/nyldn/claude-octopus/pull/914)
+Next action: finish the review-response rebase, run matching local and remote
+gates, then merge PR #914. Release remains deferred.
 
 ## Issues #900 and #902: Tangle Lifecycle Ownership
 
@@ -280,6 +272,51 @@ Merge and release remain deferred.
 - Tracking blocker: Beads remains unreadable on schema v49 because its reserved
   v65 migration has not been applied. No migration was run; GitHub issue #915
   is the temporary tracker.
+
+## Issues #901, #903, and #905: Tangle Integrity Boundaries
+
+- **#901:** Tangle subtask prompts now forbid applying, pushing, repairing, or
+  marking migrations against persistent local, linked, remote, or shared
+  databases by default. An explicit apply override retains the invariant that
+  applied versions must match disk. Validation detects changed
+  `supabase/migrations/*.sql` from the actual worktree diff, runs the read-only
+  `supabase migration list --local` comparison, and fails closed on drift,
+  unavailable history, or an empty/non-comparable result. A separate explicit
+  risk override is required when local history cannot be queried.
+- **#903:** Output returned from a disposable consultative workspace is wrapped
+  as unverified, advisory, and non-deliverable before it reaches callers.
+  Design-review synthesis is explicitly forbidden from repeating claimed file
+  changes, test counts, live probes, or completed implementation as facts, and
+  the operator-facing summary is labeled planning-only.
+- **#905:** A clean source checkout may now contain an explicitly referenced,
+  repo-contained untracked `PLAN.md`, `SPEC.md`, or `BRIEF.md` context file.
+  Its contents are injected into the isolated run while unrelated untracked
+  paths, modified tracked inputs, and symlinked context remain blocking. Users
+  no longer need to disable either clean-baseline enforcement or run-worktree
+  isolation for this common workflow.
+- TDD evidence: the migration-drift helper and validation regression initially
+  failed, the consultative provenance regression failed before output wrapping,
+  and the untracked-context regressions failed before the baseline allowlist and
+  pre-worktree resolution. A later spec review added a failing regression proving
+  migration validation incorrectly depended on prompt classification; the gate
+  now derives migration changes independently from the actual diff.
+- Current verification: Bash syntax, diff whitespace, and mode checks pass.
+  All 24 related unit suites pass, including 15/15 migration/worktree evidence,
+  14/14 run-worktree isolation, 13/13 Markdown context resolution, 11/11 clean
+  baseline, 9/9 ceremonies, 8/8 subtask context, 7/7 consultative dispatch, and
+  Council compatibility at 72 passed with one known macOS PTY skip. A fresh
+  complete `make ci-local` exits 0 with 16/16 smoke suites, 267/267 unit suites,
+  and 7/7 integration suites. The first complete sweep exposed three newly
+  documented env vars missing from the accountability manifest; a later sweep
+  exposed a stale integration assertion that inspected only 80 lines after the
+  Tangle wrapper. Both contracts now map to behavioral tests, and the final
+  top-level gate passed without changes to the tested production tree.
+- Tracking blocker: Beads remains unreadable on schema v49 because the `leases`
+  table requires the reserved v65 migration. No migration was run. These GitHub
+  issues are the temporary tracker and this handoff records the blocked `bd`
+  state.
+- Push state: implementation commit `b2ac6790` is pushed to both `origin` and
+  `upstream` on `fix/901-tangle-integrity`; PR #914 targets `upstream/main`.
 
 ## Issue #898: Explicit Activation and Hook Latency
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -2,16 +2,16 @@
 
 Last updated: 2026-08-13
 Status: Issues #901, #903, and #905 are implemented on a combined branch.
-PR #914 review-response regressions pass; matching-head local and remote gates
-and merge are the remaining steps.
+PR #914 review feedback is resolved and CodeRabbit approved the reviewed code;
+matching-head local and remote gates and merge are the remaining steps.
 Branch: `fix/901-tangle-integrity`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #901](https://github.com/nyldn/claude-octopus/issues/901),
 [issue #903](https://github.com/nyldn/claude-octopus/issues/903), and
 [issue #905](https://github.com/nyldn/claude-octopus/issues/905); implementation
 PR [#914](https://github.com/nyldn/claude-octopus/pull/914)
-Next action: commit and push the final review response, run matching local and
-remote gates, then merge PR #914. Release remains deferred.
+Next action: complete the matching local and remote gates, then merge PR #914.
+Release remains deferred.
 
 ## Issues #900 and #902: Tangle Lifecycle Ownership
 
@@ -324,9 +324,9 @@ remote gates, then merge PR #914. Release remains deferred.
   table requires the reserved v65 migration. No migration was run. These GitHub
   issues are the temporary tracker and this handoff records the blocked `bd`
   state.
-- Push state: the rebased implementation head `6b7718bc` is pushed to both
-  `origin` and `upstream` on `fix/901-tangle-integrity`; the final review-response
-  commit is local until the matching gates begin. PR #914 targets `upstream/main`.
+- Push state: the current `fix/901-tangle-integrity` branch head is pushed to
+  both configured remotes, `origin` and `upstream`; PR #914 targets
+  `upstream/main`.
 
 ## Issue #898: Explicit Activation and Hook Latency
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,17 +1,17 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-13
-Status: Issues #901, #903, and #905 are implemented on a combined branch and
-pass the complete local gate. PR #914 is open; review, merge, and release are
-the remaining steps.
+Status: Issues #901, #903, and #905 are implemented on a combined branch.
+PR #914 review-response regressions pass; matching-head local and remote gates
+and merge are the remaining steps.
 Branch: `fix/901-tangle-integrity`
 Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
 Tracking: [issue #901](https://github.com/nyldn/claude-octopus/issues/901),
 [issue #903](https://github.com/nyldn/claude-octopus/issues/903), and
 [issue #905](https://github.com/nyldn/claude-octopus/issues/905); implementation
 PR [#914](https://github.com/nyldn/claude-octopus/pull/914)
-Next action: finish the review-response rebase, run matching local and remote
-gates, then merge PR #914. Release remains deferred.
+Next action: commit and push the final review response, run matching local and
+remote gates, then merge PR #914. Release remains deferred.
 
 ## Issues #900 and #902: Tangle Lifecycle Ownership
 
@@ -28,16 +28,18 @@ gates, then merge PR #914. Release remains deferred.
   the PID ledger to close the post-spawn handoff race, marks cancelled outputs
   and completion records, prunes runtime metadata, restores caller traps, and
   handles both explicit signals and unexpected `set -e` exits.
-- Stalled progress: `OCTOPUS_TANGLE_IDLE_WORKER_GRACE` defaults to 180 seconds.
-  A living wrapper with no active provider descendants becomes
-  `stalled-worker`; non-TTY progress is emitted only when its count changes.
+- Provider liveness: `spawn_agent_capture_pid` returns the provider root, not a
+  wrapper, so a living PID with no descendants remains active until it writes
+  its completion marker. The explicit `OCTOPUS_TANGLE_DEADLINE` remains the
+  operator-controlled bound; dead providers enter missing-marker recovery.
+  Non-TTY progress is emitted only when its count changes.
 - Run isolation: default Tangle IDs now use an atomic reservation instead of
   `date +%s` plus `$$`, preventing same-second worktree and branch collisions
   exposed when the old final two-second sleep was removed. Explicit run-ID
   overrides now reject traversal, and zero-byte reservations older than seven
   days are pruned once daily without weakening same-day atomic uniqueness.
-- Review hardening: cancellation refuses to proceed without its process
-  helpers, never signals the orchestrator PID/group, snapshots reachable legacy
+- Review hardening: Tangle refuses provider dispatch when either cancellation
+  helper is unavailable, never signals the orchestrator PID/group, snapshots reachable legacy
   descendants before STOP, uses portable `ps -A`, serializes PID-ledger pruning
   with spawn appends, stops before pruning when `flock` acquisition fails, and
   ignores dead targeted PIDs. Status checks are SIGPIPE-safe and the integration
@@ -48,9 +50,9 @@ gates, then merge PR #914. Release remains deferred.
   `echo` received SIGPIPE, and `set -o pipefail` failed the integration job.
   Here-strings with non-early-closing `grep -c` preserve the semantic assertions
   without a producer-side broken pipe; the focused suite passes 19/19.
-- TDD evidence: lifecycle cancellation passes 15/15, missing-marker recovery
-  6/6, run-worktree isolation 14/14, Markdown plan/run-ID resolution 13/13,
-  contextual review wiring 56/56, spawn PID capture 10/10, and the
+- TDD evidence: lifecycle cancellation passes 16/16, missing-marker recovery
+  4/4, run-worktree isolation 16/16, Markdown plan/run-ID resolution 15/15,
+  contextual review wiring 54/54, spawn PID capture 10/10, and the
   value-proposition integration test passes 19/19.
 - Full-gate evidence: the latest non-interactive `make ci-local` after all review
   fixes passed 16/16 smoke suites, 268/268 unit suites, 7/7 integration suites,
@@ -293,17 +295,20 @@ gates, then merge PR #914. Release remains deferred.
   Its contents are injected into the isolated run while unrelated untracked
   paths, modified tracked inputs, and symlinked context remain blocking. Users
   no longer need to disable either clean-baseline enforcement or run-worktree
-  isolation for this common workflow.
+  isolation for this common workflow. Exactly one untracked context file is
+  supported per run; additional untracked inputs remain blocking.
 - TDD evidence: the migration-drift helper and validation regression initially
   failed, the consultative provenance regression failed before output wrapping,
   and the untracked-context regressions failed before the baseline allowlist and
   pre-worktree resolution. A later spec review added a failing regression proving
   migration validation incorrectly depended on prompt classification; the gate
   now derives migration changes independently from the actual diff.
-- Current verification: Bash syntax, diff whitespace, and mode checks pass.
-  All 24 related unit suites pass, including 15/15 migration/worktree evidence,
-  14/14 run-worktree isolation, 13/13 Markdown context resolution, 11/11 clean
-  baseline, 9/9 ceremonies, 8/8 subtask context, 7/7 consultative dispatch, and
+- Current verification: the combined review-response regression set passes,
+  including 15/15 migration/worktree evidence, 16/16 run-worktree isolation,
+  15/15 Markdown context resolution, 11/11 clean baseline, 9/9 ceremonies,
+  8/8 subtask context, 8/8 consultative dispatch, 16/16 cancellation cleanup,
+  4/4 live-provider/missing-marker recovery, 27/27 review aggregation, and
+  19/19 value-proposition integration. The prior branch head also passed
   Council compatibility at 72 passed with one known macOS PTY skip. A fresh
   complete `make ci-local` exits 0 with 16/16 smoke suites, 267/267 unit suites,
   and 7/7 integration suites. The first complete sweep exposed three newly
@@ -315,8 +320,9 @@ gates, then merge PR #914. Release remains deferred.
   table requires the reserved v65 migration. No migration was run. These GitHub
   issues are the temporary tracker and this handoff records the blocked `bd`
   state.
-- Push state: implementation commit `b2ac6790` is pushed to both `origin` and
-  `upstream` on `fix/901-tangle-integrity`; PR #914 targets `upstream/main`.
+- Push state: the rebased implementation head `6b7718bc` is pushed to both
+  `origin` and `upstream` on `fix/901-tangle-integrity`; the final review-response
+  commit is local until the matching gates begin. PR #914 targets `upstream/main`.
 
 ## Issue #898: Explicit Activation and Hook Latency
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -54,8 +54,9 @@ remote gates, then merge PR #914. Release remains deferred.
   4/4, run-worktree isolation 16/16, Markdown plan/run-ID resolution 15/15,
   contextual review wiring 54/54, spawn PID capture 10/10, and the
   value-proposition integration test passes 19/19.
-- Full-gate evidence: the latest non-interactive `make ci-local` after all review
-  fixes passed 16/16 smoke suites, 268/268 unit suites, 7/7 integration suites,
+- Historical #900/#902 branch-gate evidence: the final non-interactive
+  `make ci-local` before stacking #901 passed 16/16 smoke suites, 268/268 unit
+  suites, 7/7 integration suites,
   and the CI-only verifications. The earlier 267/268 run exposed only a brittle
   five-line static heartbeat assertion; production ordering was correct, and
   the replacement semantic-order assertion passes in the final sweep. A prior
@@ -310,8 +311,11 @@ remote gates, then merge PR #914. Release remains deferred.
   4/4 live-provider/missing-marker recovery, 27/27 review aggregation, and
   19/19 value-proposition integration. The prior branch head also passed
   Council compatibility at 72 passed with one known macOS PTY skip. A fresh
-  complete `make ci-local` exits 0 with 16/16 smoke suites, 267/267 unit suites,
-  and 7/7 integration suites. The first complete sweep exposed three newly
+  historical branch-only `make ci-local` at `b2ac6790` exited 0 with 16/16
+  smoke suites, 267/267 unit suites, and 7/7 integration suites. Subsequent
+  stacked commits brought the current combined branch to 269 unit suites;
+  matching-head verification is recorded by PR #914 checks and the final
+  session report. The first complete sweep exposed three newly
   documented env vars missing from the accountability manifest; a later sweep
   exposed a stale integration assertion that inspected only 80 lines after the
   Tangle wrapper. Both contracts now map to behavioral tests, and the final

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -120,6 +120,24 @@ new source surface has a proven focused regression set, add its path and suites
 to `tests/changed-scope.tsv`; otherwise leave it unmapped so the full matrix
 remains mandatory.
 
+## Tangle Input and Migration Safety
+
+Keep `OCTOPUS_TANGLE_RUN_WORKTREE=true` (the default). A clean source checkout
+may contain one or more explicit untracked context inputs: reference a bare
+`PLAN.md`, `SPEC.md`, or `BRIEF.md` name, or prefix another Markdown path with
+`plan:`, `spec:`, or `brief:`. Octopus injects that file's contents into the
+isolated run; it does not admit unrelated dirty paths or copy the input into the
+implementation branch. Commit or stash every other source change.
+
+Tangle does not authorize agents to apply, push, or repair migrations on a
+persistent local, linked, remote, or shared database by default. When a run
+changes `supabase/migrations/*.sql` and the Supabase CLI is available, validation
+runs the read-only `supabase migration list --local` check and fails if applied
+versions differ from disk. Use a project-owned disposable reset/test workflow.
+`OCTOPUS_TANGLE_ALLOW_DB_APPLY=true` authorizes application but never permits
+history drift; `OCTOPUS_TANGLE_ALLOW_UNVERIFIED_MIGRATIONS=true` explicitly
+accepts the risk when local history cannot be queried.
+
 ---
 
 ## E2E Testing Infrastructure

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -123,11 +123,12 @@ remains mandatory.
 ## Tangle Input and Migration Safety
 
 Keep `OCTOPUS_TANGLE_RUN_WORKTREE=true` (the default). A clean source checkout
-may contain one or more explicit untracked context inputs: reference a bare
+may contain one explicit untracked context input: reference a bare
 `PLAN.md`, `SPEC.md`, or `BRIEF.md` name, or prefix another Markdown path with
 `plan:`, `spec:`, or `brief:`. Octopus injects that file's contents into the
 isolated run; it does not admit unrelated dirty paths or copy the input into the
-implementation branch. Commit or stash every other source change.
+implementation branch. Additional untracked context files are unsupported;
+commit or stash every other source change.
 
 Tangle does not authorize agents to apply, push, or repair migrations on a
 persistent local, linked, remote, or shared database by default. When a run

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -142,7 +142,7 @@ run_agent_sync_consultative() {
     local old_codex_sandbox="${OCTOPUS_CODEX_SANDBOX:-}"
     local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
     local old_autonomy="${CLAUDE_OCTOPUS_AUTONOMY:-}"
-    local source_root source_root_logical workspace temp_root rc original_prompt isolated_prompt
+    local source_root source_root_logical workspace temp_root rc original_prompt isolated_prompt agent_output
     local -a consultative_args
 
     source_root_logical="$PWD"
@@ -171,7 +171,7 @@ Treat ${workspace} as the working copy for this advisory task. Any relative-path
     unset CLAUDE_OCTOPUS_AUTONOMY
     export OCTOPUS_CODEX_SANDBOX="danger-full-access"
 
-    if (cd "$workspace" && run_agent_sync "${consultative_args[@]}"); then
+    if agent_output=$(cd "$workspace" && run_agent_sync "${consultative_args[@]}"); then
         rc=0
     else
         rc=$?
@@ -192,6 +192,18 @@ Treat ${workspace} as the working copy for this advisory task. Any relative-path
         export OCTOPUS_CODEX_SANDBOX="$old_codex_sandbox"
     else
         unset OCTOPUS_CODEX_SANDBOX
+    fi
+
+    if [[ -n "$agent_output" ]]; then
+        cat <<EOF
+## UNVERIFIED CONSULTATIVE OUTPUT
+
+This output came from a disposable workspace that Octopus deleted before returning. It is advisory and non-deliverable. Claimed file changes, test counts, live probes, or completed implementation are not verified evidence and must not be reported as delivered work.
+
+${agent_output}
+
+## END UNVERIFIED CONSULTATIVE OUTPUT
+EOF
     fi
 
     return "$rc"

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -142,7 +142,7 @@ run_agent_sync_consultative() {
     local old_codex_sandbox="${OCTOPUS_CODEX_SANDBOX:-}"
     local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
     local old_autonomy="${CLAUDE_OCTOPUS_AUTONOMY:-}"
-    local source_root source_root_logical workspace temp_root rc original_prompt isolated_prompt agent_output
+    local source_root source_root_logical workspace temp_root rc original_prompt isolated_prompt agent_output cleanup_note
     local -a consultative_args
 
     source_root_logical="$PWD"
@@ -177,7 +177,9 @@ Treat ${workspace} as the working copy for this advisory task. Any relative-path
         rc=$?
     fi
 
+    cleanup_note="Octopus deleted the workspace before returning."
     if ! rm -rf "$temp_root" 2>/dev/null; then
+        cleanup_note="Octopus attempted cleanup before returning but could not confirm deletion."
         if declare -F log >/dev/null 2>&1; then
             log WARN "Failed to remove consultative workspace: $temp_root"
         else
@@ -198,7 +200,7 @@ Treat ${workspace} as the working copy for this advisory task. Any relative-path
         cat <<EOF
 ## UNVERIFIED CONSULTATIVE OUTPUT
 
-This output came from a disposable workspace that Octopus deleted before returning. It is advisory and non-deliverable. Claimed file changes, test counts, live probes, or completed implementation are not verified evidence and must not be reported as delivered work.
+This output came from a disposable workspace. ${cleanup_note} It is advisory and non-deliverable. Claimed file changes, test counts, live probes, or completed implementation are not verified evidence and must not be reported as delivered work.
 
 ${agent_output}
 

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -443,6 +443,8 @@ Be concise and specific. This is a planning exercise, not implementation."
 
 Three review seats stated their approach to this task. The headings below reflect configured runtime identity rather than historical provider slot names:
 
+Every seat block is UNVERIFIED planning input from a disposable workspace that has already been deleted. Do not repeat claimed file changes, test counts, or live probes as verified facts. If a seat claims completed implementation or verification, mark that claim inadmissible and use only any remaining high-level design reasoning.
+
 SEAT 1 - ${seat_1_label}:
 ${seat_1_approach:-[unavailable]}
 
@@ -471,7 +473,7 @@ Be brief and actionable." "$design_synth_timeout" "synthesizer" "ceremony" 2>/de
     fi
 
     if [[ -n "$synthesis" ]]; then
-        echo -e "${GREEN}Design Review Summary:${NC}"
+        echo -e "${GREEN}Design Review Summary (planning only; no implementation evidence):${NC}"
         echo "$synthesis" | head -20
         echo ""
 

--- a/scripts/lib/testing.sh
+++ b/scripts/lib/testing.sh
@@ -122,6 +122,69 @@ check_tangle_worktree_changes() {
     rm -f "$current_file"
 }
 
+tangle_check_supabase_migration_history() {
+    local changed_paths="$1"
+    local repo_root cli output migration_rows mismatches
+
+    if ! grep -qE '^supabase/migrations/[^/]+\.sql$' <<< "$changed_paths"; then
+        printf '%s\n' "No changed Supabase migrations."
+        return 0
+    fi
+
+    repo_root=$(git -C "${PROJECT_ROOT:-$PWD}" rev-parse --show-toplevel 2>/dev/null \
+        || git -C "$PWD" rev-parse --show-toplevel 2>/dev/null) || {
+        printf '%s\n' "Unable to resolve the repository for Supabase migration validation."
+        return 3
+    }
+    if command -v supabase >/dev/null 2>&1; then
+        cli=$(command -v supabase)
+    elif [[ -x "$repo_root/node_modules/.bin/supabase" ]]; then
+        cli="$repo_root/node_modules/.bin/supabase"
+    else
+        printf '%s\n' "Supabase CLI is unavailable; local migration history was not verified."
+        return 2
+    fi
+
+    if declare -F run_with_timeout >/dev/null 2>&1; then
+        output=$(cd "$repo_root" && run_with_timeout 20 "$cli" migration list --local </dev/null 2>&1) || {
+            printf '%s\n' "Supabase local migration history query failed or timed out."
+            return 3
+        }
+    else
+        output=$(cd "$repo_root" && "$cli" migration list --local </dev/null 2>&1) || {
+            printf '%s\n' "Supabase local migration history query failed."
+            return 3
+        }
+    fi
+
+    migration_rows=$(printf '%s\n' "$output" | sed 's/│/|/g' | awk -F '|' '
+        NF >= 2 {
+            disk = $1
+            database = $2
+            gsub(/[[:space:]]/, "", disk)
+            gsub(/[[:space:]]/, "", database)
+            if (disk ~ /^[0-9]+$/ || database ~ /^[0-9]+$/) {
+                if (disk == "") disk = "missing"
+                if (database == "") database = "missing"
+                print disk "|" database
+            }
+        }
+    ')
+    if [[ -z "$migration_rows" ]]; then
+        printf '%s\n' "Supabase local migration history returned no comparable versions."
+        return 3
+    fi
+    mismatches=$(printf '%s\n' "$migration_rows" | awk -F '|' \
+        '$1 != $2 { print "disk=" $1 ", database=" $2 }')
+    if [[ -n "$mismatches" ]]; then
+        printf '%s\n' "Supabase local migration history does not match files on disk:" "$mismatches"
+        return 1
+    fi
+
+    printf '%s\n' "Supabase local migration history matches files on disk."
+    return 0
+}
+
 tangle_result_latest_status() {
     local result="$1"
     local status_line=""
@@ -222,10 +285,40 @@ validate_tangle_results() {
 
         local worktree_changes=""
         local requires_worktree_changes=false
-        if [[ -n "$worktree_before_file" && -f "$worktree_before_file" ]] && \
-           tangle_prompt_requires_worktree_changes "$original_prompt"; then
-            requires_worktree_changes=true
+        local migration_history_status="NOT REQUIRED"
+        local migration_history_details="No changed Supabase migrations."
+        local migration_history_failed=false
+        if [[ -n "$worktree_before_file" && -f "$worktree_before_file" ]]; then
             worktree_changes=$(check_tangle_worktree_changes "$worktree_before_file")
+            if tangle_prompt_requires_worktree_changes "$original_prompt"; then
+                requires_worktree_changes=true
+            fi
+        fi
+
+        if grep -qE '^supabase/migrations/[^/]+\.sql$' <<< "$worktree_changes"; then
+            local migration_history_rc=0
+            migration_history_details=$(tangle_check_supabase_migration_history "$worktree_changes") || migration_history_rc=$?
+            case "$migration_history_rc" in
+                0)
+                    migration_history_status="PASSED"
+                    ;;
+                1)
+                    migration_history_status="FAILED"
+                    migration_history_failed=true
+                    hard_gate_retry_feedback="${hard_gate_retry_feedback}"$'Hard gate failure: Supabase migration history differs from the files on disk. Reset disposable local state from the current tree before verification; do not repair history to hide a renamed migration.\n'
+                    hard_gate_retry_feedback="${hard_gate_retry_feedback}${migration_history_details}"$'\n\n'
+                    ;;
+                2|3)
+                    if [[ "${OCTOPUS_TANGLE_ALLOW_UNVERIFIED_MIGRATIONS:-false}" == "true" ]]; then
+                        migration_history_status="SKIPPED BY EXPLICIT OVERRIDE"
+                    else
+                        migration_history_status="FAILED"
+                        migration_history_failed=true
+                        hard_gate_retry_feedback="${hard_gate_retry_feedback}"$'Hard gate failure: changed Supabase migrations could not be checked against local applied history. Start the disposable local stack and make the CLI available, or explicitly set OCTOPUS_TANGLE_ALLOW_UNVERIFIED_MIGRATIONS=true to accept this risk.\n'
+                        hard_gate_retry_feedback="${hard_gate_retry_feedback}${migration_history_details}"$'\n\n'
+                    fi
+                    ;;
+            esac
         fi
 
         local correction_result_body=""
@@ -279,6 +372,11 @@ $(<"$correction_file")
         elif [[ $success_rate -lt 90 ]]; then
             gate_status="WARNING"
             gate_color="${YELLOW}"
+        fi
+
+        if [[ "$migration_history_failed" == "true" ]]; then
+            gate_status="FAILED"
+            gate_color="${RED}"
         fi
 
         if [[ -n "$missing_explicit_files" ]]; then
@@ -414,6 +512,9 @@ $(if [[ "$requires_worktree_changes" == "true" ]]; then
 else
     echo "Not required for this prompt."
 fi)
+
+### Migration History: ${migration_history_status}
+${migration_history_details}
 
 ### Subtask Results
 $results

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -241,7 +241,6 @@ ${YELLOW}Environment:${NC}
   OCTOPUS_TANGLE_CODE_REVIEW=false              Skip contextual code review
   OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=unbounded Progress-supervised loop (default)
   OCTOPUS_TANGLE_TIMEOUT=1200                    Minimum positive implementer budget; TIMEOUT=0 stays unlimited
-  OCTOPUS_TANGLE_IDLE_WORKER_GRACE=180           Seconds to wait before a live wrapper with no provider descendants is marked stalled (0 = immediate)
   OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded   Opt into explicit round cap
   OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=3       Bound count when mode=bounded
   OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW=1800     Stop only after silence/no progress

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -2872,6 +2872,12 @@ _tangle_develop_in_workspace() {
         return 0
     fi
 
+    if ! declare -F review_kill_process_tree_frozen >/dev/null 2>&1 \
+       || ! declare -F review_kill_descendants_frozen >/dev/null 2>&1; then
+        log ERROR "Tangle cancellation helpers are unavailable; refusing to start provider work"
+        return 1
+    fi
+
     if tangle_clean_baseline_guard_enabled; then
         tangle_require_clean_git_baseline || return 1
     fi
@@ -3205,8 +3211,6 @@ Every [CODING] line must include a same-line Files: clause."
     [[ "$_tangle_max_wait" =~ ^[0-9]+$ ]] || _tangle_max_wait=0
     local _missing_marker_grace="${OCTOPUS_TANGLE_MISSING_MARKER_GRACE:-180}"
     [[ "$_missing_marker_grace" =~ ^[0-9]+$ ]] || _missing_marker_grace=180
-    local _idle_worker_grace="${OCTOPUS_TANGLE_IDLE_WORKER_GRACE:-180}"
-    [[ "$_idle_worker_grace" =~ ^[0-9]+$ ]] || _idle_worker_grace=180
     local _deadline=0
     if [[ "$_tangle_max_wait" -gt 0 ]]; then
         _deadline=$(( $(date +%s) + _tangle_max_wait ))
@@ -3215,7 +3219,6 @@ Every [CODING] line must include a same-line Files: clause."
     local _failed_tasks=()
     local _terminal_task_ids=""
     local _missing_marker_since=()
-    local _idle_worker_since=()
     local _last_progress=-1
     while [[ $completed -lt ${#task_ids[@]} ]]; do
         completed=0
@@ -3265,36 +3268,6 @@ Every [CODING] line must include a same-line Files: clause."
                             fi
                         fi
                     fi
-                elif [[ -n "$_worker_pid" ]] \
-                     && ! review_process_has_active_descendant "$_worker_pid"; then
-                    local _idle_now
-                    _idle_now=$(date +%s)
-                    if [[ -z "${_idle_worker_since[$i]:-}" ]]; then
-                        _idle_worker_since[$i]="$_idle_now"
-                        log WARN "Thread ${task_ids[$i]} worker is alive without provider descendants — waiting up to ${_idle_worker_grace}s for completion"
-                    fi
-                    if [[ "$_idle_worker_grace" -eq 0 ]] \
-                       || (( _idle_now - ${_idle_worker_since[$i]} >= _idle_worker_grace )); then
-                        log WARN "Thread ${task_ids[$i]} remained idle without provider descendants for ${_idle_worker_grace}s — killing and marking stalled"
-                        review_kill_process_tree_frozen "$_worker_pid"
-                        wait "$_worker_pid" 2>/dev/null || true
-                        mkdir -p "$_done_dir" 2>/dev/null || true
-                        [[ -f "$_done_file" ]] || printf '%s\n' "stalled-worker" > "$_done_file" 2>/dev/null || true
-                        [[ " $_terminal_task_ids " == *" ${task_ids[$i]} "* ]] \
-                            || _terminal_task_ids="${_terminal_task_ids:+$_terminal_task_ids }${task_ids[$i]}"
-                        local _idle_result_file
-                        _idle_result_file=$(find "${RESULTS_DIR:-${HOME}/.claude-octopus/results}" -maxdepth 1 -type f -name "*-${task_ids[$i]}.md" 2>/dev/null | head -1 || true)
-                        if [[ -n "$_idle_result_file" ]] \
-                           && ! grep -c '^## Status:' "$_idle_result_file" >/dev/null 2>&1; then
-                            {
-                                echo ""
-                                echo "## Status: FAILED (Stalled worker without provider descendants)"
-                                echo "# Completed: $(date)"
-                            } >> "$_idle_result_file" 2>/dev/null || true
-                        fi
-                    fi
-                else
-                    unset "_idle_worker_since[$i]"
                 fi
             fi
         done

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1140,8 +1140,13 @@ build_tangle_subtask_prompt() {
         return 64
     fi
 
-    local repo_context
+    local repo_context migration_safety
     repo_context=$(tangle_build_repo_context_block "$assigned_subtask")
+    if [[ "${OCTOPUS_TANGLE_ALLOW_DB_APPLY:-false}" == "true" ]]; then
+        migration_safety="- External migration application is explicitly authorized for this run. Never rename, delete, or rewrite a migration after any database has applied its version, and prove the applied history still matches the files on disk."
+    else
+        migration_safety="- Do not apply, push, repair, or mark database migrations on a persistent local, linked, remote, or shared database. Use only the project's disposable reset/test workflow; if verification requires persistent mutation, report a blocker. Never rename, delete, or rewrite a migration after any database has applied its version."
+    fi
 
     cat <<EOF
 Original task context:
@@ -1159,6 +1164,8 @@ Execution instructions:
 - For [CODING] work, treat file paths/directories named in the assigned subtask as approximate exclusive write scope intent. Use the resolved repository context files above as the concrete targets. Do not edit files clearly owned by another subtask; report a blocker if the required change crosses scopes.
 - If the subtask creates a new exported component, command, event type, route, hook, or helper, wire it into at least one production call site unless the original task explicitly asks for an isolated artifact.
 - Tests alone are not integration evidence. User-facing features must be reachable from the relevant user flow or the subtask must report a blocker.
+Migration safety:
+${migration_safety}
 - In the final output, include "## Worktree Changes", "## Integration Evidence", and "## Verification" sections.
 - If the assigned subtask is incomplete, contradictory, or omits required context, report the blocker instead of inventing scope.
 EOF
@@ -2539,21 +2546,56 @@ tangle_clean_baseline_guard_enabled() {
 }
 
 tangle_require_clean_git_baseline() {
-    local source_root status_output
+    local source_root source_root_physical status_output line path allowed_path allowed_relative_entry
+    local allowed_dir allowed_name allowed_physical allowed_relative
+    local blocking_output=""
+    local -a allowed_untracked=()
     source_root=$(git -C "${PROJECT_ROOT:-$PWD}" rev-parse --show-toplevel 2>/dev/null) || {
         log ERROR "Tangle implementation requires a Git repository when clean-baseline enforcement is enabled"
         return 1
     }
 
+    source_root_physical=$(cd "$source_root" 2>/dev/null && pwd -P) || return 1
+    for allowed_path in "$@"; do
+        [[ -n "$allowed_path" && -f "$allowed_path" && ! -L "$allowed_path" ]] || continue
+        allowed_dir=$(dirname "$allowed_path")
+        allowed_name=$(basename "$allowed_path")
+        allowed_dir=$(cd "$allowed_dir" 2>/dev/null && pwd -P) || continue
+        allowed_physical="${allowed_dir}/${allowed_name}"
+        case "$allowed_physical" in
+            "$source_root_physical"/*)
+                allowed_relative="${allowed_physical#"$source_root_physical"/}"
+                allowed_untracked+=("$allowed_relative")
+                ;;
+        esac
+    done
+
     status_output=$(git -C "$source_root" status --porcelain=v1 --untracked-files=all 2>/dev/null) || {
         log ERROR "Unable to inspect Git baseline at: $source_root"
         return 1
     }
-    if [[ -n "$status_output" ]]; then
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        if [[ "$line" == "?? "* ]]; then
+            path="${line#?? }"
+            local path_is_allowed=false
+            for allowed_relative_entry in ${allowed_untracked[@]+"${allowed_untracked[@]}"}; do
+                [[ "$path" == "$allowed_relative_entry" ]] && path_is_allowed=true && break
+            done
+            if [[ "$path_is_allowed" == "true" ]]; then
+                continue
+            fi
+        fi
+        blocking_output="${blocking_output}${blocking_output:+$'\n'}${line}"
+    done <<< "$status_output"
+
+    if [[ -n "$blocking_output" ]]; then
         log ERROR "Tangle implementation requires a clean Git baseline: $source_root"
         while IFS= read -r line; do
             [[ -n "$line" ]] && log ERROR "  $line"
-        done <<< "$status_output"
+        done <<< "$blocking_output"
+        log ERROR "Commit or stash unrelated changes. To use one untracked brief safely, reference PLAN.md, SPEC.md, or BRIEF.md explicitly (or prefix a path with plan:, spec:, or brief:) while run-worktree isolation remains enabled."
+        log ERROR "Advanced bypass: OCTOPUS_TANGLE_REQUIRE_CLEAN_BASELINE=false keeps isolation enabled, but accepts responsibility for the dirty source state."
         return 1
     fi
     return 0
@@ -2591,18 +2633,31 @@ tangle_next_run_id() {
 
 tangle_extract_plan_file_ref() {
     local prompt="$1"
-    local token candidate_ref candidate_basename raw_file_ref
+    local token token_lower candidate_ref candidate_basename candidate_basename_lower raw_file_ref
     local noglob_was_set=false
     [[ "$-" == *f* ]] && noglob_was_set=true || set -f
     for token in $prompt; do
+        token_lower=$(printf '%s' "$token" | tr '[:upper:]' '[:lower:]')
         candidate_ref="$token"
-        candidate_ref="${candidate_ref#plan:}"
-        candidate_ref="${candidate_ref#plan=}"
+        case "$token_lower" in
+            plan:*|spec:*|brief:*) candidate_ref="${token#*:}" ;;
+            plan=*|spec=*|brief=*) candidate_ref="${token#*=}" ;;
+        esac
         candidate_basename="${candidate_ref##*/}"
-        if [[ "$token" == plan:* || "$token" == plan=* || "$candidate_basename" == "plan.md" || "$candidate_basename" == *.plan.md || "$candidate_basename" == *-plan.md ]]; then
-            raw_file_ref="$token"
-            raw_file_ref="${raw_file_ref#plan:}"
-            raw_file_ref="${raw_file_ref#plan=}"
+        candidate_basename_lower=$(printf '%s' "$candidate_basename" | tr '[:upper:]' '[:lower:]')
+        if [[ "$token_lower" == plan:* || "$token_lower" == plan=* \
+           || "$token_lower" == spec:* || "$token_lower" == spec=* \
+           || "$token_lower" == brief:* || "$token_lower" == brief=* \
+           || "$candidate_basename_lower" == "plan.md" \
+           || "$candidate_basename_lower" == "spec.md" \
+           || "$candidate_basename_lower" == "brief.md" \
+           || "$candidate_basename_lower" == *.plan.md \
+           || "$candidate_basename_lower" == *-plan.md \
+           || "$candidate_basename_lower" == *.spec.md \
+           || "$candidate_basename_lower" == *-spec.md \
+           || "$candidate_basename_lower" == *.brief.md \
+           || "$candidate_basename_lower" == *-brief.md ]]; then
+            raw_file_ref="$candidate_ref"
             [[ "$noglob_was_set" == "false" ]] && set +f
             printf '%s' "$raw_file_ref"
             return 0
@@ -2723,6 +2778,7 @@ tangle_prepare_run_worktree() {
 tangle_develop() {
     local prompt="$1"
     local grasp_file="${2:-}"
+    local task_group original_project_root original_pwd resolved_grasp_file resolved_plan_file rc
 
     # Dry runs retain their historical side-effect-free behavior and do not
     # create an otherwise unused run worktree.
@@ -2731,10 +2787,31 @@ tangle_develop() {
         return $?
     fi
 
+    original_project_root="${PROJECT_ROOT:-$PWD}"
+    original_pwd="$PWD"
+    resolved_grasp_file="$grasp_file"
+    resolved_plan_file=""
+    rc=0
+
+    # Resolve explicit caller context before the clean-baseline gate. A single
+    # repo-contained untracked input can be safely read and injected into the
+    # isolated run without admitting any unrelated dirty path.
+    if tangle_run_worktree_enabled; then
+        if [[ -n "$grasp_file" ]]; then
+            resolved_grasp_file=$(tangle_resolve_context_file_path "$grasp_file" "$original_pwd" 2>/dev/null) \
+                || resolved_grasp_file="$grasp_file"
+        fi
+        resolved_plan_file=$(tangle_resolve_prompt_plan_file_path "$prompt" "$original_pwd" 2>/dev/null) || true
+    fi
+
     # Validate the caller's source checkout before creating an isolated run
     # worktree; checking afterward would only prove that the new worktree is clean.
     if tangle_clean_baseline_guard_enabled; then
-        tangle_require_clean_git_baseline || return 1
+        if tangle_run_worktree_enabled; then
+            tangle_require_clean_git_baseline "$resolved_plan_file" "$resolved_grasp_file" || return 1
+        else
+            tangle_require_clean_git_baseline || return 1
+        fi
     fi
 
     if ! tangle_run_worktree_enabled; then
@@ -2742,7 +2819,7 @@ tangle_develop() {
         return $?
     fi
 
-    local task_group="${OCTOPUS_TANGLE_RUN_ID:-}"
+    task_group="${OCTOPUS_TANGLE_RUN_ID:-}"
     if [[ -n "$task_group" ]]; then
         if [[ ! "$task_group" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ || "$task_group" == *..* ]]; then
             log ERROR "Invalid OCTOPUS_TANGLE_RUN_ID: $task_group"
@@ -2751,21 +2828,6 @@ tangle_develop() {
     else
         task_group=$(tangle_next_run_id) || return 1
     fi
-    local original_project_root="${PROJECT_ROOT:-$PWD}"
-    local original_pwd="$PWD"
-    local resolved_grasp_file="$grasp_file"
-    local resolved_plan_file=""
-    local rc=0
-
-    # Resolve caller-supplied context while still in the source checkout.
-    # Ignored context files are valid inputs but are absent from a new Git
-    # worktree, so delegated execution must retain their canonical source paths.
-    if [[ -n "$grasp_file" ]]; then
-        resolved_grasp_file=$(tangle_resolve_context_file_path "$grasp_file" "$original_pwd" 2>/dev/null) \
-            || resolved_grasp_file="$grasp_file"
-    fi
-    resolved_plan_file=$(tangle_resolve_prompt_plan_file_path "$prompt" "$original_pwd" 2>/dev/null) || true
-
     tangle_prepare_run_worktree "$task_group" || return 1
 
     PROJECT_ROOT="$TANGLE_RUN_WORKTREE"

--- a/tests/integration/test-value-proposition.sh
+++ b/tests/integration/test-value-proposition.sh
@@ -131,21 +131,27 @@ test_quality_gates_validation() {
     echo "Validates that tangle phase includes quality validation"
     echo ""
 
-    # Check both the public wrapper and its workspace implementation. Extract
-    # complete top-level functions so wrapper growth cannot push the actual
-    # decomposition and validation behavior beyond an arbitrary line window.
-    local tangle_code=""
+    # Check the public wrapper and its delegated implementation contract. The
+    # wrapper owns isolation/safety preflight; _tangle_develop_in_workspace owns
+    # decomposition and validation, so line-proximity to tangle_develop() is not
+    # a stable integration boundary.
+    local tangle_entry_code="" tangle_workspace_code=""
     if [[ -f "$ALL_SRC" ]]; then
-        tangle_code=$(
-            sed -n \
-                -e '/^tangle_develop() {/,/^}/p' \
-                -e '/^_tangle_develop_in_workspace() {/,/^}/p' \
-                "$ALL_SRC" 2>/dev/null
-        ) || tangle_code=""
+        tangle_entry_code=$(awk '
+            /^tangle_develop\(\) \{/ { capture=1 }
+            capture { print }
+            capture && /^}$/ { exit }
+        ' "$ALL_SRC")
+        tangle_workspace_code=$(awk '
+            /^_tangle_develop_in_workspace\(\) \{/ { capture=1 }
+            capture { print }
+            capture && /^}$/ { exit }
+        ' "$ALL_SRC")
     fi
 
     ((TESTS_RUN++)) || true
-    if grep -cE "validation|validate" >/dev/null <<< "$tangle_code"; then
+    if grep -c "_tangle_develop_in_workspace" >/dev/null <<< "$tangle_entry_code" && \
+       grep -c 'validate_tangle_results "$task_group"' >/dev/null <<< "$tangle_workspace_code"; then
         echo -e "${GREEN}✓${NC} Tangle includes validation step"
         ((TESTS_PASSED++)) || true
     else
@@ -154,7 +160,8 @@ test_quality_gates_validation() {
     fi
 
     ((TESTS_RUN++)) || true
-    if grep -cE "decompose|subtask" >/dev/null <<< "$tangle_code"; then
+    if grep -c "_tangle_develop_in_workspace" >/dev/null <<< "$tangle_entry_code" && \
+       grep -c 'Decompose this task into subtasks that can be executed in parallel' >/dev/null <<< "$tangle_workspace_code"; then
         echo -e "${GREEN}✓${NC} Tangle decomposes tasks for parallel execution"
         ((TESTS_PASSED++)) || true
     else

--- a/tests/unit/fixtures/env-var-effects.tsv
+++ b/tests/unit/fixtures/env-var-effects.tsv
@@ -54,6 +54,9 @@ OCTOPUS_RESEARCH_BREADTH	skip	changes how many provider seats a research run fan
 OCTOPUS_REVIEWER_FLIP	covered-by	test-fable5-escalation.sh
 OCTOPUS_RUN_ID	covered-by	test-agent-summary.sh
 OCTOPUS_SENTINEL_ENABLED	covered-by	test-sentinel.sh
+OCTOPUS_TANGLE_ALLOW_DB_APPLY	covered-by	test-tangle-subtask-context.sh
+OCTOPUS_TANGLE_ALLOW_UNVERIFIED_MIGRATIONS	covered-by	test-tangle-worktree-evidence.sh
+OCTOPUS_TANGLE_RUN_WORKTREE	covered-by	test-tangle-run-worktree.sh
 OCTOPUS_TRACE_MODELS	skip	emits trace lines to stderr; covered indirectly by model-resolver suites
 OCTOPUS_WORKFLOW_STATE_DIR	covered-by	test-probe-cancellation-cleanup.sh
 OCTOPUS_WORKSPACE	covered-by	test-subagent-stop-gate.sh

--- a/tests/unit/test-ceremonies.sh
+++ b/tests/unit/test-ceremonies.sh
@@ -94,6 +94,57 @@ test_ceremony_called_in_tangle() {
     fi
 }
 
+test_ceremony_rejects_implementation_claims() {
+    test_case "design synthesis treats seat completion claims as unverified"
+
+    if grep -Fq "UNVERIFIED CONSULTATIVE OUTPUT" "$PROJECT_ROOT/scripts/lib/agent-sync.sh" && \
+       grep -Fq "Do not repeat claimed file changes, test counts, or live probes as verified facts" "$PROJECT_ROOT/scripts/lib/quality.sh"; then
+        test_pass
+    else
+        test_fail "ceremony output can still surface disposable-workspace claims as evidence"
+    fi
+}
+
+test_ceremony_synthesis_receives_provenance_boundary() {
+    test_case "design synthesis receives disposable-seat provenance boundary"
+
+    local capture="$TEST_TMP_DIR/ceremony-synthesis.prompt"
+    local counter="$TEST_TMP_DIR/ceremony-seat-count"
+    printf '0\n' > "$counter"
+    if (
+        WORKSPACE_DIR="$TEST_TMP_DIR/ceremony-workspace"
+        # shellcheck source=/dev/null
+        source "$PROJECT_ROOT/scripts/lib/quality.sh"
+        DRY_RUN=false
+        OCTOPUS_CEREMONIES=true
+        CYAN="" GREEN="" NC="" _BOX_TOP="" _BOX_BOT=""
+        log() { :; }
+        octo_provider_identity_label() { printf '%s\n' "$1 / fixture"; }
+        write_structured_decision() { :; }
+        run_agent_sync_consultative() {
+            local count
+            count=$(cat "$counter")
+            count=$((count + 1))
+            printf '%s\n' "$count" > "$counter"
+            if [[ "$count" -le 3 ]]; then
+                printf '%s\n' \
+                    '## UNVERIFIED CONSULTATIVE OUTPUT' \
+                    'Implemented disposable files and verified 417 tests plus live probes.'
+            else
+                printf '%s' "$2" > "$capture"
+                printf '%s\n' 'Planning-only synthesis.'
+            fi
+        }
+        design_review_ceremony "Design the change" >/dev/null
+        grep -Fq "Do not repeat claimed file changes, test counts, or live probes as verified facts" "$capture" && \
+        grep -Fq "UNVERIFIED CONSULTATIVE OUTPUT" "$capture"
+    ); then
+        test_pass
+    else
+        test_fail "synthesis did not receive the unverified-seat boundary"
+    fi
+}
+
 test_retrospective_in_ink() {
     test_case "retrospective_ceremony reference exists"
 
@@ -112,6 +163,8 @@ test_dry_run_skips_ceremony
 test_embrace_dry_run
 test_ceremony_functions_exist
 test_ceremony_called_in_tangle
+test_ceremony_rejects_implementation_claims
+test_ceremony_synthesis_receives_provenance_boundary
 test_retrospective_in_ink
 
 test_summary

--- a/tests/unit/test-consultative-agent-dispatch.sh
+++ b/tests/unit/test-consultative-agent-dispatch.sh
@@ -7,13 +7,10 @@ source "$PROJECT_ROOT/scripts/lib/agent-sync.sh"
 
 test_suite "Consultative Agent Dispatch"
 
-TEST_TMP_DIR="/tmp/octopus-tests-$$"
-SOURCE_ROOT="$TEST_TMP_DIR/source"
+SOURCE_ROOT="$TEST_TMP_DIR/consultative-source"
 OBSERVED_FILE="$TEST_TMP_DIR/observed"
 mkdir -p "$SOURCE_ROOT"
 printf '%s\n' original > "$SOURCE_ROOT/protected.txt"
-cleanup() { rm -rf "$TEST_TMP_DIR"; }
-trap cleanup EXIT INT TERM HUP
 
 _octopus_prepare_consultative_workspace() {
     local source_root="$1" temp_root workspace
@@ -25,9 +22,11 @@ _octopus_prepare_consultative_workspace() {
 }
 
 STUB_RC=0
+STUB_RESPONSE=""
 run_agent_sync() {
     printf '%s\n' "pwd=$PWD;codex=${OCTOPUS_CODEX_SANDBOX-unset};security=${OCTOPUS_SECURITY_V870-unset};agy=${OCTOPUS_AGY_SANDBOX-unset};autonomy=${CLAUDE_OCTOPUS_AUTONOMY-unset};prompt=$2" > "$OBSERVED_FILE"
     printf '%s\n' changed > protected.txt
+    [[ -z "$STUB_RESPONSE" ]] || printf '%s\n' "$STUB_RESPONSE"
     return "$STUB_RC"
 }
 
@@ -60,6 +59,20 @@ if [[ "$output" != *"prompt=inspect $SOURCE_ROOT/protected.txt"* && "$output" !=
     test_pass
 else
     test_fail "source checkout path remained in the agent task: $output"
+fi
+
+test_case "consultative output is marked unverified and non-deliverable"
+STUB_RESPONSE="Implemented files in /tmp/disposable and verified 417 tests plus live probes."
+consultative_output=$(run_agent_sync_consultative codex "design only" 120 implementer ceremony)
+STUB_RESPONSE=""
+if [[ "$consultative_output" == *"Implemented files in /tmp/disposable"* \
+   && "$consultative_output" == *"UNVERIFIED CONSULTATIVE OUTPUT"* \
+   && "$consultative_output" == *"non-deliverable"* \
+   && "$consultative_output" == *"test counts"* \
+   && "$consultative_output" == *"live probes"* ]]; then
+    test_pass
+else
+    test_fail "consultative claims lacked durable provenance: $consultative_output"
 fi
 
 test_case "consultative dispatch restores existing environment after success"

--- a/tests/unit/test-consultative-agent-dispatch.sh
+++ b/tests/unit/test-consultative-agent-dispatch.sh
@@ -75,6 +75,28 @@ else
     test_fail "consultative claims lacked durable provenance: $consultative_output"
 fi
 
+test_case "consultative output does not claim deletion when workspace cleanup fails"
+cleanup_attempt="$TEST_TMP_DIR/cleanup-attempt"
+rm() {
+    if [[ "${1:-}" == "-rf" && "${2:-}" == "$TEST_TMP_DIR"/workspace.* ]]; then
+        printf '%s\n' "$2" > "$cleanup_attempt"
+        return 1
+    fi
+    command rm "$@"
+}
+STUB_RESPONSE="Advisory result from disposable workspace."
+cleanup_failure_output=$(run_agent_sync_consultative codex "design only" 120 implementer ceremony 2>/dev/null)
+STUB_RESPONSE=""
+unset -f rm
+failed_temp_root="$(cat "$cleanup_attempt")"
+command rm -rf "$failed_temp_root"
+if [[ "$cleanup_failure_output" == *"could not confirm deletion"* \
+   && "$cleanup_failure_output" != *"deleted before returning"* ]]; then
+    test_pass
+else
+    test_fail "cleanup failure produced false provenance: $cleanup_failure_output"
+fi
+
 test_case "consultative dispatch restores existing environment after success"
 if [[ "$OCTOPUS_SECURITY_V870" == "enabled" && "$OCTOPUS_AGY_SANDBOX" == "off" && "$OCTOPUS_CODEX_SANDBOX" == "read-only" && "$CLAUDE_OCTOPUS_AUTONOMY" == "autonomous" ]]; then
     test_pass

--- a/tests/unit/test-develop-md-file-resolution.sh
+++ b/tests/unit/test-develop-md-file-resolution.sh
@@ -260,7 +260,8 @@ date() {
 
 CAPTURED_VALIDATE_PROMPT=""
 deadline_override_ok=false
-if OCTOPUS_TANGLE_DEADLINE=1 tangle_develop "deadline override task" >/dev/null 2>&1 && \
+if OCTOPUS_TANGLE_RUN_ID=100 OCTOPUS_TANGLE_DEADLINE=1 \
+   tangle_develop "deadline override task" >/dev/null 2>&1 && \
    grep -q "deadline exceeded" "$LOG_CAPTURE_FILE" && \
    grep -q "finished with status: timeout" "$LOG_CAPTURE_FILE" && \
    [[ "$CAPTURED_VALIDATE_PROMPT" == "deadline override task" ]]; then

--- a/tests/unit/test-develop-md-file-resolution.sh
+++ b/tests/unit/test-develop-md-file-resolution.sh
@@ -59,12 +59,11 @@ NC=""
 TMUX_MODE=false
 DRY_RUN=false
 SUPPORTS_PARALLEL_FILE_SAFETY=false
-RESULTS_DIR="$(mktemp -d)"
+RESULTS_DIR="$TEST_TMP_DIR/develop-md-resolution"
 LOGS_DIR="$RESULTS_DIR/logs"
 WORKSPACE_DIR="$RESULTS_DIR/workspace"
 mkdir -p "$WORKSPACE_DIR/.octo/agents"
 DECOMPOSE_CAPTURE_FILE="$RESULTS_DIR/decompose.prompt"
-trap 'rm -rf "$RESULTS_DIR"' EXIT
 
 test_case "default Tangle run IDs stay unique within the same second"
 date() {
@@ -165,6 +164,26 @@ if [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"Apply the bare plan.md workflow fix."* ]
     test_pass
 else
     test_fail "bare plan.md was not treated as an eligible plan file"
+fi
+
+test_case "bare SPEC.md references inject content case-insensitively"
+spec_file="$RESULTS_DIR/SPEC.md"
+printf '%s\n' "Apply the explicit specification safely." > "$spec_file"
+run_tangle_case "implement $spec_file"
+if [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"Apply the explicit specification safely."* ]]; then
+    test_pass
+else
+    test_fail "bare SPEC.md was not treated as an eligible context file"
+fi
+
+test_case "bare BRIEF.md references inject content case-insensitively"
+brief_file="$RESULTS_DIR/BRIEF.md"
+printf '%s\n' "Apply the explicit brief safely." > "$brief_file"
+run_tangle_case "implement $brief_file"
+if [[ "$CAPTURED_DECOMPOSE_PROMPT" == *"Apply the explicit brief safely."* ]]; then
+    test_pass
+else
+    test_fail "bare BRIEF.md was not treated as an eligible context file"
 fi
 
 test_case "wildcard-looking Markdown tokens are not glob-expanded"

--- a/tests/unit/test-tangle-cancellation-cleanup.sh
+++ b/tests/unit/test-tangle-cancellation-cleanup.sh
@@ -105,11 +105,29 @@ else
 fi
 
 test_case "Tangle refuses dispatch when cancellation helpers are unavailable"
+dispatch_marker="$TEST_TMP_DIR/unexpected-provider-dispatch"
+rm -f "$dispatch_marker"
+behavioral_guarded=false
+if (
+    unset -f review_kill_process_tree_frozen review_kill_descendants_frozen
+    run_agent_sync() {
+        : > "$dispatch_marker"
+        return 0
+    }
+    DRY_RUN=false
+    _tangle_develop_in_workspace "guard test"
+) >/dev/null 2>&1; then
+    behavioral_guarded=false
+elif [[ ! -e "$dispatch_marker" ]]; then
+    behavioral_guarded=true
+fi
+
 workspace_definition="$(declare -f _tangle_develop_in_workspace)"
 helper_guard_line=$(awk '/declare -F review_kill_process_tree_frozen/ { print NR; exit }' <<< "$workspace_definition")
 dispatch_line=$(awk '/run_agent_sync/ { print NR; exit }' <<< "$workspace_definition")
 trap_line=$(awk "/trap 'octopus_tangle_handle_signal/ { print NR; exit }" <<< "$workspace_definition")
-if [[ "$helper_guard_line" =~ ^[0-9]+$ ]] \
+if [[ "$behavioral_guarded" == "true" ]] \
+   && [[ "$helper_guard_line" =~ ^[0-9]+$ ]] \
    && [[ "$dispatch_line" =~ ^[0-9]+$ ]] \
    && [[ "$trap_line" =~ ^[0-9]+$ ]] \
    && (( helper_guard_line < dispatch_line )) \
@@ -118,7 +136,7 @@ if [[ "$helper_guard_line" =~ ^[0-9]+$ ]] \
    && grep -Fq 'refusing to start provider work' <<< "$workspace_definition"; then
     test_pass
 else
-    test_fail "Tangle does not fail closed before provider dispatch and signal-trap installation"
+    test_fail "Tangle does not behaviorally fail closed before provider dispatch and signal-trap installation"
 fi
 
 test_case "TERM reaps ledger-only worker tree and prevents late writes"

--- a/tests/unit/test-tangle-cancellation-cleanup.sh
+++ b/tests/unit/test-tangle-cancellation-cleanup.sh
@@ -104,6 +104,23 @@ else
     test_fail "workflow cancellation helper loading can still fail silently"
 fi
 
+test_case "Tangle refuses dispatch when cancellation helpers are unavailable"
+workspace_definition="$(declare -f _tangle_develop_in_workspace)"
+helper_guard_line=$(awk '/declare -F review_kill_process_tree_frozen/ { print NR; exit }' <<< "$workspace_definition")
+dispatch_line=$(awk '/run_agent_sync/ { print NR; exit }' <<< "$workspace_definition")
+trap_line=$(awk "/trap 'octopus_tangle_handle_signal/ { print NR; exit }" <<< "$workspace_definition")
+if [[ "$helper_guard_line" =~ ^[0-9]+$ ]] \
+   && [[ "$dispatch_line" =~ ^[0-9]+$ ]] \
+   && [[ "$trap_line" =~ ^[0-9]+$ ]] \
+   && (( helper_guard_line < dispatch_line )) \
+   && (( helper_guard_line < trap_line )) \
+   && grep -Fq 'declare -F review_kill_descendants_frozen' <<< "$workspace_definition" \
+   && grep -Fq 'refusing to start provider work' <<< "$workspace_definition"; then
+    test_pass
+else
+    test_fail "Tangle does not fail closed before provider dispatch and signal-trap installation"
+fi
+
 test_case "TERM reaps ledger-only worker tree and prevents late writes"
 WORKSPACE_DIR="$TEST_TMP_DIR/workspace"
 RESULTS_DIR="$WORKSPACE_DIR/results"

--- a/tests/unit/test-tangle-clean-baseline.sh
+++ b/tests/unit/test-tangle-clean-baseline.sh
@@ -10,7 +10,6 @@ source "$PROJECT_ROOT/scripts/lib/workflows.sh"
 TEST_ROOT="$TEST_TMP_DIR/tangle-clean-baseline"
 REPO="$TEST_ROOT/repo"
 mkdir -p "$REPO"
-trap 'rm -rf "$TEST_ROOT"' EXIT INT TERM
 
 git -C "$REPO" init -q
 git -C "$REPO" config user.email octopus-tests@example.invalid
@@ -48,6 +47,42 @@ else
     test_pass
 fi
 rm -f "$REPO/untracked.txt"
+
+test_case "one explicit untracked context file is accepted"
+printf 'implementation brief\n' > "$REPO/SPEC.md"
+if tangle_require_clean_git_baseline "$REPO/SPEC.md"; then
+    test_pass
+else
+    test_fail "explicit untracked context file was rejected"
+fi
+
+test_case "an unrelated untracked file still blocks an allowed context file"
+printf 'unrelated\n' > "$REPO/unrelated.txt"
+if tangle_require_clean_git_baseline "$REPO/SPEC.md" >/dev/null 2>&1; then
+    test_fail "unrelated dirty path was hidden by the context allowlist"
+else
+    test_pass
+fi
+rm -f "$REPO/SPEC.md" "$REPO/unrelated.txt"
+
+test_case "a modified tracked context file is never allowlisted"
+printf 'changed tracked input\n' >> "$REPO/tracked.txt"
+if tangle_require_clean_git_baseline "$REPO/tracked.txt" >/dev/null 2>&1; then
+    test_fail "modified tracked context bypassed the clean baseline"
+else
+    test_pass
+fi
+git -C "$REPO" checkout -- tracked.txt
+
+test_case "an untracked context symlink is never allowlisted"
+printf 'outside context\n' > "$TEST_ROOT/outside.md"
+ln -s "$TEST_ROOT/outside.md" "$REPO/SPEC.md"
+if tangle_require_clean_git_baseline "$REPO/SPEC.md" >/dev/null 2>&1; then
+    test_fail "symlinked context bypassed the clean baseline"
+else
+    test_pass
+fi
+rm -f "$REPO/SPEC.md"
 
 
 test_case "each blocking status entry is reported"

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -56,8 +56,6 @@ assert_contains "$WORKFLOWS" "Skipping ink/deliver because tangle validation gat
 assert_contains "$HELP" "Contextual code review" "develop help documents contextual review"
 assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE" "develop help documents bounded mode"
 assert_contains "$HELP" "OCTOPUS_TANGLE_CORRECTION_STALL_WINDOW" "develop help documents stall window"
-assert_contains "$HELP" "OCTOPUS_TANGLE_IDLE_WORKER_GRACE" "develop help documents idle worker recovery"
-assert_contains "$HELP" "Seconds to wait before a live wrapper with no provider descendants is marked stalled (0 = immediate)" "develop help explains idle worker grace units and zero behavior"
 assert_contains "$WORKFLOWS" "OCTOPUS_INK_REVIEW_TIMEOUT:-0" "ink review has no wall timeout by default"
 
 test_case "generated review context stays inside the workspace"

--- a/tests/unit/test-tangle-missing-done-marker.sh
+++ b/tests/unit/test-tangle-missing-done-marker.sh
@@ -28,7 +28,6 @@ RED=""
 NC=""
 TMUX_MODE=false
 OCTOPUS_TANGLE_MISSING_MARKER_GRACE=0
-OCTOPUS_TANGLE_IDLE_WORKER_GRACE=0
 DRY_RUN=false
 SUPPORTS_PARALLEL_FILE_SAFETY=false
 RESULTS_DIR="$TEST_TMP_DIR/results"
@@ -37,7 +36,9 @@ PID_FILE="$WORKSPACE_DIR/pids"
 LOG_CAPTURE_FILE="$TEST_TMP_DIR/tangle.log"
 DATE_COUNTER_FILE="$TEST_TMP_DIR/date-counter"
 SLEEP_COUNTER_FILE="$TEST_TMP_DIR/sleep-counter"
-IDLE_WORKER_PID_FILE="$TEST_TMP_DIR/idle-worker.pid"
+ACTIVE_ROOT_PID_FILE="$TEST_TMP_DIR/active-root.pid"
+ACTIVE_ROOT_RELEASE_FILE="$TEST_TMP_DIR/active-root.release"
+ACTIVE_ROOT_COMPLETED_FILE="$TEST_TMP_DIR/active-root.completed"
 FIXTURE_MODE="dead"
 DATE_MODE="constant"
 mkdir -p "$RESULTS_DIR" "$WORKSPACE_DIR/.octo/agents"
@@ -66,12 +67,18 @@ spawn_agent_capture_pid() {
 
 ## Output
 EOF
-    if [[ "$FIXTURE_MODE" == "idle" ]]; then
-        tail -f /dev/null >/dev/null 2>&1 &
-        local idle_pid="$!"
-        printf '%s\n' "$idle_pid" > "$IDLE_WORKER_PID_FILE"
-        printf '%s:%s:%s\n' "$idle_pid" "codex" "$task_id" >> "$PID_FILE"
-        printf '%s\n' "$idle_pid"
+    if [[ "$FIXTURE_MODE" == "active-root" ]]; then
+        bash -c '
+            while [[ ! -e "$1" ]]; do :; done
+            printf "0\n" > "$2"
+            : > "$3"
+        ' _ "$ACTIVE_ROOT_RELEASE_FILE" "$WORKSPACE_DIR/.octo/agents/${task_id}.done" \
+            "$ACTIVE_ROOT_COMPLETED_FILE" \
+            >/dev/null 2>&1 &
+        local active_root_pid="$!"
+        printf '%s\n' "$active_root_pid" > "$ACTIVE_ROOT_PID_FILE"
+        printf '%s:%s:%s\n' "$active_root_pid" "codex" "$task_id" >> "$PID_FILE"
+        printf '%s\n' "$active_root_pid"
         return 0
     fi
     # Use a numeric PID outside the platform range. A real reaped PID can be
@@ -86,14 +93,18 @@ sleep() {
     count=$(<"$SLEEP_COUNTER_FILE")
     count=$((count + 1))
     printf '%s' "$count" > "$SLEEP_COUNTER_FILE"
+    if [[ "$FIXTURE_MODE" == "active-root" && $count -eq 1 ]]; then
+        : > "$ACTIVE_ROOT_RELEASE_FILE"
+        command sleep 0.1
+    fi
     if [[ $count -gt 5 ]]; then
         # Do not let a regression hang CI forever. Force a completion marker so
         # tangle_develop can return; the assertions below fail via the counter.
         rm -f "$WORKSPACE_DIR/.octo/agents" 2>/dev/null || true
         mkdir -p "$WORKSPACE_DIR/.octo/agents"
         printf '0' > "$WORKSPACE_DIR/.octo/agents/tangle-100-0.done"
-        if [[ -s "$IDLE_WORKER_PID_FILE" ]]; then
-            kill -KILL "$(cat "$IDLE_WORKER_PID_FILE")" 2>/dev/null || true
+        if [[ -s "$ACTIVE_ROOT_PID_FILE" ]]; then
+            kill -KILL "$(cat "$ACTIVE_ROOT_PID_FILE")" 2>/dev/null || true
         fi
     fi
 }
@@ -120,11 +131,12 @@ reset_fixture() {
     mkdir -p "$RESULTS_DIR" "$WORKSPACE_DIR/.octo/agents"
     printf '0' > "$DATE_COUNTER_FILE"
     printf '0' > "$SLEEP_COUNTER_FILE"
-    : > "$IDLE_WORKER_PID_FILE"
+    : > "$ACTIVE_ROOT_PID_FILE"
+    rm -f "$ACTIVE_ROOT_RELEASE_FILE"
+    rm -f "$ACTIVE_ROOT_COMPLETED_FILE"
     : > "$PID_FILE"
     FIXTURE_MODE="dead"
     DATE_MODE="constant"
-    OCTOPUS_TANGLE_IDLE_WORKER_GRACE=0
 }
 
 test_case "dead wrapper writes missing-done-marker and failed status before deadline"
@@ -156,53 +168,27 @@ else
     test_fail "wait loop did not terminate when marker write failed"
 fi
 
-test_case "living worker without provider descendants becomes terminal"
+test_case "live descendant-free provider root can finish without being killed"
 reset_fixture
-FIXTURE_MODE="idle"
-idle_output="$TEST_TMP_DIR/idle-worker.out"
-tangle_develop "idle worker task" > "$idle_output" 2>&1 || true
-idle_pid=$(cat "$IDLE_WORKER_PID_FILE" 2>/dev/null || true)
-if grep -q 'finished with status: stalled-worker' "$LOG_CAPTURE_FILE" \
-   && [[ -n "$idle_pid" ]] \
-   && ! kill -0 "$idle_pid" 2>/dev/null; then
+FIXTURE_MODE="active-root"
+active_output="$TEST_TMP_DIR/active-root.out"
+tangle_develop "active root task" > "$active_output" 2>&1 || true
+active_root_pid=$(cat "$ACTIVE_ROOT_PID_FILE" 2>/dev/null || true)
+[[ -n "$active_root_pid" ]] && wait "$active_root_pid" 2>/dev/null || true
+if [[ -f "$ACTIVE_ROOT_COMPLETED_FILE" ]] \
+   && ! grep -q 'stalled-worker' "$LOG_CAPTURE_FILE"; then
     test_pass
 else
-    kill -KILL "$idle_pid" 2>/dev/null || true
-    test_fail "idle worker was not terminated and recorded as stalled-worker"
+    kill -KILL "$active_root_pid" 2>/dev/null || true
+    test_fail "descendant-free provider root was killed or marked stalled before completion"
 fi
 
 test_case "redirected progress prints only when the count changes"
-progress_count=$(grep -o 'Progress:' "$idle_output" 2>/dev/null | wc -l | tr -d ' ')
+progress_count=$(grep -o 'Progress:' "$active_output" 2>/dev/null | wc -l | tr -d ' ')
 if [[ "${progress_count:-0}" -eq 2 ]]; then
     test_pass
 else
     test_fail "expected exactly 2 redirected progress lines, found $progress_count"
-fi
-
-test_case "nonzero idle grace waits until the exact threshold"
-reset_fixture
-FIXTURE_MODE="idle"
-DATE_MODE="advancing"
-OCTOPUS_TANGLE_IDLE_WORKER_GRACE=2
-tangle_develop "idle worker grace task" >/dev/null 2>&1 || true
-grace_sleep_count="$(<"$SLEEP_COUNTER_FILE")"
-grace_idle_pid="$(cat "$IDLE_WORKER_PID_FILE" 2>/dev/null || true)"
-if [[ "$grace_sleep_count" -eq 3 ]] \
-   && grep -Fq 'remained idle without provider descendants for 2s' "$LOG_CAPTURE_FILE" \
-   && [[ -n "$grace_idle_pid" ]] \
-   && ! kill -0 "$grace_idle_pid" 2>/dev/null; then
-    test_pass
-else
-    kill -KILL "$grace_idle_pid" 2>/dev/null || true
-    test_fail "idle grace boundary was not enforced exactly (sleep_count=$grace_sleep_count)"
-fi
-
-test_case "idle result status check is SIGPIPE-safe"
-if grep -Fq "grep -c '^## Status:'" "$WORKFLOWS" \
-   && ! grep -Fq "grep -q '^## Status:' \"\$_idle_result_file\"" "$WORKFLOWS"; then
-    test_pass
-else
-    test_fail "idle result status check still uses grep -q"
 fi
 
 unset -f date

--- a/tests/unit/test-tangle-run-worktree.sh
+++ b/tests/unit/test-tangle-run-worktree.sh
@@ -14,7 +14,6 @@ RESULTS_DIR="$TEST_ROOT/results"
 WORKSPACE_DIR="$TEST_ROOT/state"
 TEST_START_PWD="$PWD"
 mkdir -p "$SOURCE_REPO" "$RESULTS_DIR" "$WORKSPACE_DIR"
-trap 'rm -rf "$TEST_ROOT"' EXIT INT TERM
 
 git -C "$SOURCE_REPO" init -q
 git -C "$SOURCE_REPO" config user.email octopus-tests@example.invalid
@@ -103,6 +102,27 @@ else
     test_fail "dirty source reached worktree creation or implementation"
 fi
 rm -f "$SOURCE_REPO/untracked.txt"
+OCTOPUS_TANGLE_RUN_ID="run-worktree-test"
+
+test_case "explicit untracked spec is injected without disabling isolation"
+printf 'untracked spec context\n' > "$SOURCE_REPO/SPEC.md"
+OCTOPUS_TANGLE_RUN_ID="untracked-spec"
+SEEN_PROJECT_ROOT=""
+SEEN_PLAN_FILE=""
+SEEN_PLAN_CONTENT=""
+status=0
+cd "$SOURCE_REPO"
+tangle_develop "Implement SPEC.md" || status=$?
+if [[ "$status" -eq 0 \
+    && "$SEEN_PROJECT_ROOT" == "$RUNTIME_ROOT/untracked-spec/integration" \
+    && "$SEEN_PLAN_FILE" == "$SOURCE_REPO_PHYSICAL/SPEC.md" \
+    && "$SEEN_PLAN_CONTENT" == "untracked spec context" \
+    && -f "$SOURCE_REPO/SPEC.md" ]]; then
+    test_pass
+else
+    test_fail "untracked spec was not safely injected into isolated execution"
+fi
+rm -f "$SOURCE_REPO/SPEC.md"
 OCTOPUS_TANGLE_RUN_ID="run-worktree-test"
 
 status=0

--- a/tests/unit/test-tangle-run-worktree.sh
+++ b/tests/unit/test-tangle-run-worktree.sh
@@ -233,4 +233,13 @@ else
     test_fail "failed run isolation was not preserved"
 fi
 
+test_case "developer docs limit untracked Tangle context to one explicit file"
+developer_docs="$SCRIPT_DIR/../../docs/DEVELOPER.md"
+if grep -Fq 'may contain one explicit untracked context input' "$developer_docs" \
+   && ! grep -Fq 'one or more explicit untracked context inputs' "$developer_docs"; then
+    test_pass
+else
+    test_fail "developer docs overstate the supported untracked context cardinality"
+fi
+
 test_summary

--- a/tests/unit/test-tangle-subtask-context.sh
+++ b/tests/unit/test-tangle-subtask-context.sh
@@ -31,7 +31,6 @@ WORKSPACE_DIR="$RESULTS_DIR/workspace"
 CAPTURE_DIR="$RESULTS_DIR/captured-prompts"
 rm -rf "$RESULTS_DIR"
 mkdir -p "$WORKSPACE_DIR/.octo/agents" "$CAPTURE_DIR"
-trap 'rm -rf "$RESULTS_DIR"' EXIT
 
 log() { :; }
 octopus_phase_banner() { :; }
@@ -121,6 +120,27 @@ if [[ "$captured_prompts" == *"edit the repository files directly"* ]] && \
     test_pass
 else
     test_fail "spawned prompts did not require direct worktree edits and integration evidence"
+fi
+
+test_case "subtask prompts deny persistent migration application by default"
+if [[ "$captured_prompts" == *"Do not apply, push, repair, or mark database migrations"* \
+   && "$captured_prompts" == *"Never rename, delete, or rewrite a migration after any database has applied its version"* ]]; then
+    test_pass
+else
+    test_fail "default subtask prompt omitted migration immutability policy"
+fi
+
+test_case "explicit database-apply authorization preserves the history consistency contract"
+OCTOPUS_TANGLE_ALLOW_DB_APPLY=true
+authorized_prompt=$(build_tangle_subtask_prompt \
+    "Implement supabase/migrations/20260813130000_example.sql" \
+    "1. [CODING] Files: supabase/migrations/20260813130000_example.sql")
+unset OCTOPUS_TANGLE_ALLOW_DB_APPLY
+if [[ "$authorized_prompt" == *"External migration application is explicitly authorized"* \
+   && "$authorized_prompt" == *"prove the applied history still matches the files on disk"* ]]; then
+    test_pass
+else
+    test_fail "authorized migration prompt dropped the consistency requirement"
 fi
 
 test_summary

--- a/tests/unit/test-tangle-worktree-evidence.sh
+++ b/tests/unit/test-tangle-worktree-evidence.sh
@@ -13,7 +13,6 @@ RESULTS_DIR="$TEST_TMP_DIR/tangle-worktree-evidence-results"
 REPO_DIR="$TEST_TMP_DIR/tangle-worktree-evidence-repo"
 rm -rf "$RESULTS_DIR" "$REPO_DIR"
 mkdir -p "$RESULTS_DIR" "$REPO_DIR"
-trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
 
 GREEN=""
 RED=""
@@ -36,6 +35,14 @@ run_agent_sync() { echo "GENUINELY_CLEAN_TEST"; }
 get_gate_threshold() { echo 70; }
 
 source "$PROJECT_ROOT/scripts/lib/testing.sh"
+
+test_case "Supabase migration consistency helper is available"
+if declare -F tangle_check_supabase_migration_history >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "tangle_check_supabase_migration_history is missing"
+    tangle_check_supabase_migration_history() { return 127; }
+fi
 
 write_success_result() {
     local path="$1"
@@ -137,6 +144,8 @@ fi
 test_case "runtime-only .claude-octopus changes do not satisfy implementation evidence"
 if (
     cd "$REPO_DIR"
+    PROJECT_ROOT="$REPO_DIR"
+    export PROJECT_ROOT
     rm -f "$RESULTS_DIR"/codex-tangle-evidence-*.md "$RESULTS_DIR"/tangle-validation-evidence-*.md
     snapshot_tangle_worktree_paths > "$RESULTS_DIR/before-runtime-only.txt"
     mkdir -p .claude-octopus
@@ -187,6 +196,130 @@ if (
     test_pass
 else
     test_fail "validation failed despite a new worktree path"
+fi
+
+test_case "applied Supabase migration missing from disk fails validation"
+if (
+    cd "$REPO_DIR"
+    PROJECT_ROOT="$REPO_DIR"
+    export PROJECT_ROOT
+    rm -f "$RESULTS_DIR"/codex-tangle-evidence-*.md "$RESULTS_DIR"/tangle-validation-evidence-*.md
+    mkdir -p supabase/migrations "$TEST_TMP_DIR/supabase-bin"
+    snapshot_tangle_worktree_paths > "$RESULTS_DIR/before-migration-mismatch.txt"
+    printf '%s\n' '-- replacement migration' > supabase/migrations/20260813130000_replacement.sql
+    cat > "$TEST_TMP_DIR/supabase-bin/supabase" <<'MOCK_SUPABASE'
+#!/usr/bin/env bash
+if [[ "$*" == "migration list --local" ]]; then
+    case "${SUPABASE_LIST_FIXTURE:-mismatch}" in
+        aligned)
+            printf '%s\n' \
+                '        LOCAL      │     REMOTE     │     TIME (UTC)' \
+                '  20260813130000   │ 20260813130000 │ 2026-08-13 13:00:00'
+            ;;
+        empty) : ;;
+        *)
+            printf '%s\n' \
+                '        LOCAL      │     REMOTE     │     TIME (UTC)' \
+                '                   │ 20260813120500 │ 2026-08-13 12:05:00' \
+                '  20260813130000   │                │ 2026-08-13 13:00:00'
+            ;;
+    esac
+fi
+MOCK_SUPABASE
+    chmod +x "$TEST_TMP_DIR/supabase-bin/supabase"
+    write_success_result "$RESULTS_DIR/codex-tangle-evidence-migration.md" \
+        "Added supabase/migrations/20260813130000_replacement.sql and verified the schema."
+    if PATH="$TEST_TMP_DIR/supabase-bin:$PATH" RESULTS_DIR="$RESULTS_DIR" \
+        validate_tangle_results "evidence-migration" \
+        "Implement the database migration" \
+        "$RESULTS_DIR/before-migration-mismatch.txt" >/dev/null 2>&1; then
+        exit 1
+    fi
+    grep -q "Migration History: FAILED" "$RESULTS_DIR/tangle-validation-evidence-migration.md" && \
+    grep -q "20260813120500" "$RESULTS_DIR/tangle-validation-evidence-migration.md"
+); then
+    test_pass
+else
+    test_fail "validation accepted migration history that no longer exists on disk"
+fi
+
+test_case "aligned Supabase migration history passes the read-only gate"
+if (
+    cd "$REPO_DIR"
+    PROJECT_ROOT="$REPO_DIR"
+    export PROJECT_ROOT
+    PATH="$TEST_TMP_DIR/supabase-bin:$PATH"
+    SUPABASE_LIST_FIXTURE=aligned
+    export PATH SUPABASE_LIST_FIXTURE
+    tangle_check_supabase_migration_history \
+        "supabase/migrations/20260813130000_replacement.sql" >/dev/null
+); then
+    test_pass
+else
+    test_fail "matching local migration history was rejected"
+fi
+
+test_case "empty Supabase migration output is not accepted as proof"
+if (
+    cd "$REPO_DIR"
+    PROJECT_ROOT="$REPO_DIR"
+    export PROJECT_ROOT
+    PATH="$TEST_TMP_DIR/supabase-bin:$PATH"
+    SUPABASE_LIST_FIXTURE=empty
+    export PATH SUPABASE_LIST_FIXTURE
+    ! tangle_check_supabase_migration_history \
+        "supabase/migrations/20260813130000_replacement.sql" >/dev/null
+); then
+    test_pass
+else
+    test_fail "empty migration history was treated as consistent"
+fi
+
+test_case "changed migrations are checked regardless of prompt classification"
+if (
+    cd "$REPO_DIR"
+    PROJECT_ROOT="$REPO_DIR"
+    export PROJECT_ROOT
+    rm -f "$RESULTS_DIR"/codex-tangle-evidence-*.md "$RESULTS_DIR"/tangle-validation-evidence-*.md
+    snapshot_tangle_worktree_paths > "$RESULTS_DIR/before-unclassified-migration.txt"
+    printf '%s\n' '-- migration from an unclassified prompt' > supabase/migrations/20260813140000_unclassified.sql
+    write_success_result "$RESULTS_DIR/codex-tangle-evidence-unclassified-migration.md" \
+        "Assessed database integrity and left a migration artifact."
+    if PATH="$TEST_TMP_DIR/supabase-bin:$PATH" RESULTS_DIR="$RESULTS_DIR" \
+        validate_tangle_results "evidence-unclassified-migration" \
+        "Assess database integrity" \
+        "$RESULTS_DIR/before-unclassified-migration.txt" >/dev/null 2>&1; then
+        exit 1
+    fi
+    grep -q "Migration History: FAILED" \
+        "$RESULTS_DIR/tangle-validation-evidence-unclassified-migration.md"
+); then
+    test_pass
+else
+    test_fail "migration history gate depended on prompt classification instead of the diff"
+fi
+
+test_case "explicit unverified-migration override records the skipped gate"
+if (
+    cd "$REPO_DIR"
+    PROJECT_ROOT="$REPO_DIR"
+    export PROJECT_ROOT
+    rm -f "$RESULTS_DIR"/codex-tangle-evidence-*.md "$RESULTS_DIR"/tangle-validation-evidence-*.md
+    snapshot_tangle_worktree_paths > "$RESULTS_DIR/before-unverified-override.txt"
+    printf '%s\n' '-- explicitly unverified migration' > supabase/migrations/20260813150000_unverified.sql
+    write_success_result "$RESULTS_DIR/codex-tangle-evidence-unverified-override.md" \
+        "Added supabase/migrations/20260813150000_unverified.sql."
+    PATH="$TEST_TMP_DIR/supabase-bin:$PATH" SUPABASE_LIST_FIXTURE=empty \
+        OCTOPUS_TANGLE_ALLOW_UNVERIFIED_MIGRATIONS=true RESULTS_DIR="$RESULTS_DIR" \
+        validate_tangle_results "evidence-unverified-override" \
+        "Implement supabase/migrations/20260813150000_unverified.sql" \
+        "$RESULTS_DIR/before-unverified-override.txt" >/dev/null 2>&1
+    grep -q "Migration History: SKIPPED BY EXPLICIT OVERRIDE" \
+        "$RESULTS_DIR/tangle-validation-evidence-unverified-override.md"
+); then
+    test_pass
+else
+    test_fail "explicit unverified migration override did not bypass and record the unavailable history gate"
 fi
 
 test_case "analysis prompt does not require worktree changes"


### PR DESCRIPTION
## Summary

- keep explicitly referenced untracked plan/spec/brief context available while preserving isolated Tangle worktrees and blocking unrelated dirty paths
- mark disposable consultative output as unverified, advisory, and non-deliverable so fabricated implementation/test claims cannot become delivery evidence
- prohibit persistent migration application by default and fail validation when changed Supabase migration files do not match read-only local history
- document the safety controls and add behavioral regression coverage

## Verification

- `make ci-local`
  - smoke: 16/16 suites
  - unit: 267/267 suites
  - integration: 7/7 suites
- focused Tangle/Council compatibility: 24 suites green; Council 72 passed, 1 known macOS PTY skip
- Bash syntax, `git diff --check`, and executable-mode checks pass

Fixes #901
Fixes #903
Fixes #905


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added migration-history validation before quality checks can pass.
  - Added support for explicitly referenced, repository-contained context files in isolated runs.
  - Improved plan, specification, and brief file recognition across naming variations.
  - Added database migration authorization controls and stronger lifecycle monitoring.

- **Bug Fixes**
  - Prevented unverified advisory output from being treated as implementation evidence.
  - Improved handling of migration failures, unavailable tooling, approved overrides, and missing completion markers.

- **Documentation**
  - Documented context-file handling, migration safety, authorization, and verification behavior.

- **Tests**
  - Expanded regression coverage for migration integrity, cleanup, cancellation, context handling, and provenance safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->