### PR TITLE
fix(council): always emit summary.json so a stalled runner can't hang the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `orchestrate.sh council` now always emits a `summary.json`. The runner wrote
+  one only on its four intended exit paths (dry-run, no-quorum, veto-abort,
+  completed); if the chair-synthesis seat was SIGKILLed at the timeout cap, or a
+  late helper returned nonzero after synthesis but before the completed-summary
+  write, the run directory was left with no `summary.json` at all and a caller
+  polling for it waited indefinitely. `council_run` now wraps its body and, on
+  any exit that leaves no summary, writes a machine-detectable
+  `status: "incomplete"` summary, prints the partial-artifact location, and
+  returns nonzero — so "runner unhealthy" is a clean signal, never an unbounded
+  wait.
+
 ## [9.64.0] - 2026-08-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,17 @@
 
 ### Fixed
 
-- `orchestrate.sh council` now always emits a `summary.json`. The runner wrote
-  one only on its four intended exit paths (dry-run, no-quorum, veto-abort,
-  completed); if the chair-synthesis seat was SIGKILLed at the timeout cap, or a
+- `orchestrate.sh council` now always emits a valid `summary.json`. The runner
+  wrote one only on its four intended exit paths (dry-run, no-quorum, veto-abort,
+  completed); if the chair-synthesis seat was SIGKILLed at the timeout cap, a
   late helper returned nonzero after synthesis but before the completed-summary
-  write, the run directory was left with no `summary.json` at all and a caller
-  polling for it waited indefinitely. `council_run` now wraps its body and, on
-  any exit that leaves no summary, writes a machine-detectable
-  `status: "incomplete"` summary, prints the partial-artifact location, and
-  returns nonzero — so "runner unhealthy" is a clean signal, never an unbounded
-  wait.
+  write, or the summary write itself failed and left an empty/garbage file, the
+  run directory was left with no usable `summary.json` and a caller polling for
+  it waited indefinitely. `council_run` now wraps its body and, on any exit that
+  leaves no parseable summary, writes a machine-detectable `status: "incomplete"`
+  summary — falling back to a minimal valid `{"status":"incomplete"}` if the rich
+  writer also fails — prints the partial-artifact location, and returns nonzero,
+  so "runner unhealthy" is a clean signal, never an unbounded wait.
 
 ## [9.64.0] - 2026-08-13
 

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2889,6 +2889,17 @@ council_summary_is_valid() {
     jq -e . "$f" >/dev/null 2>&1
 }
 
+_council_warn() {
+    # Route diagnostics through the project logger when it is available (the
+    # runner sources it), falling back to stderr when council.sh is sourced
+    # standalone (e.g. the unit suite). Mirrors the guarded pattern in agent-sync.sh.
+    if declare -F log >/dev/null 2>&1; then
+        log WARN "$1"
+    else
+        printf 'WARN: %s\n' "$1" >&2
+    fi
+}
+
 # Public entrypoint. The runner writes summary.json on every intended exit path
 # (dry-run, partial/no-quorum, veto-aborted, completed). But a real run can leave
 # the run directory with NO usable summary.json when:
@@ -2926,9 +2937,9 @@ council_run() {
         fi
         council_print_run_warnings 2>/dev/null || true
         if council_summary_is_valid "$_summary"; then
-            echo "Council ended before writing a summary (status=incomplete); review partial artifacts under ${COUNCIL_RUN_DIR}" >&2
+            _council_warn "Council ended before writing a summary (status=incomplete); review partial artifacts under ${COUNCIL_RUN_DIR}"
         else
-            echo "Council ended before writing a summary and a fallback summary could not be created under ${COUNCIL_RUN_DIR}" >&2
+            _council_warn "Council ended before writing a summary and a fallback summary could not be created under ${COUNCIL_RUN_DIR}"
         fi
         # Preserve a genuine failure code; surface one if the body somehow
         # returned success while skipping its own summary write.

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2782,7 +2782,9 @@ council_print_run_warnings() {
     fi
 }
 
-council_run() {
+# Body of the council run. Wrapped by council_run() below so that a summary.json
+# is ALWAYS emitted for a real run. Do not call this directly.
+_council_run_impl() {
     if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
         council_usage
         return 0
@@ -2875,4 +2877,42 @@ council_run() {
     council_write_summary_json "completed" || return 1
     council_print_run_warnings
     echo "Council complete: ${COUNCIL_RUN_DIR}/summary.json"
+}
+
+# Public entrypoint. The runner writes summary.json on every intended exit path
+# (dry-run, partial/no-quorum, veto-aborted, completed). But a real run can leave
+# the run directory with NO summary.json at all when:
+#   - the chair-synthesis dispatch is SIGKILLed at the seat timeout cap and the
+#     nonzero return trips an early exit before the final write, or
+#   - a late helper returns nonzero (council_process_implementation_gates /
+#     council_append_corpus_artifacts both `|| return 1` AFTER synthesis but
+#     BEFORE the "completed" summary write).
+# In those cases a caller that polls for summary.json waits indefinitely — the
+# runner is dead but nothing signals it. This wrapper guarantees a
+# machine-detectable summary.json ("incomplete") so "runner unhealthy" is never
+# an unbounded wait, and points the caller at whatever partial artifacts exist.
+council_run() {
+    if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+        council_usage
+        return 0
+    fi
+
+    local _council_rc=0
+    _council_run_impl "$@" || _council_rc=$?
+
+    # Safety net: only fires when the body exited without leaving a summary.json.
+    # All normal paths already wrote one, so this is a no-op on healthy runs and
+    # never clobbers a real summary. Guarded on COUNCIL_RUN_DIR because arg-parse
+    # / missing-task / dry-run-help failures never create a run directory.
+    if [[ -n "${COUNCIL_RUN_DIR:-}" && -d "${COUNCIL_RUN_DIR}" \
+          && ! -f "${COUNCIL_RUN_DIR}/summary.json" ]]; then
+        council_write_summary_json "incomplete" 2>/dev/null || true
+        council_print_run_warnings 2>/dev/null || true
+        echo "Council ended before writing a summary (status=incomplete); review partial artifacts under ${COUNCIL_RUN_DIR}" >&2
+        # Preserve a genuine failure code; surface one if the body somehow
+        # returned success while skipping its own summary write.
+        [[ "$_council_rc" -eq 0 ]] && _council_rc=1
+    fi
+
+    return "$_council_rc"
 }

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2879,16 +2879,27 @@ _council_run_impl() {
     echo "Council complete: ${COUNCIL_RUN_DIR}/summary.json"
 }
 
+council_summary_is_valid() {
+    # A summary.json is only useful to a polling caller if it is present,
+    # non-empty, and parseable JSON. A jq failure mid-write can truncate the file
+    # to empty or garbage, which is exactly as unreadable as a missing one — treat
+    # all three as "no usable summary" so the safety net below recovers them.
+    local f="$1"
+    [[ -s "$f" ]] || return 1
+    jq -e . "$f" >/dev/null 2>&1
+}
+
 # Public entrypoint. The runner writes summary.json on every intended exit path
 # (dry-run, partial/no-quorum, veto-aborted, completed). But a real run can leave
-# the run directory with NO summary.json at all when:
+# the run directory with NO usable summary.json when:
 #   - the chair-synthesis dispatch is SIGKILLed at the seat timeout cap and the
-#     nonzero return trips an early exit before the final write, or
+#     nonzero return trips an early exit before the final write,
 #   - a late helper returns nonzero (council_process_implementation_gates /
 #     council_append_corpus_artifacts both `|| return 1` AFTER synthesis but
-#     BEFORE the "completed" summary write).
+#     BEFORE the "completed" summary write), or
+#   - the completed-summary write itself fails and leaves an empty/garbage file.
 # In those cases a caller that polls for summary.json waits indefinitely — the
-# runner is dead but nothing signals it. This wrapper guarantees a
+# runner is dead but nothing signals it. This wrapper guarantees a valid,
 # machine-detectable summary.json ("incomplete") so "runner unhealthy" is never
 # an unbounded wait, and points the caller at whatever partial artifacts exist.
 council_run() {
@@ -2900,15 +2911,25 @@ council_run() {
     local _council_rc=0
     _council_run_impl "$@" || _council_rc=$?
 
-    # Safety net: only fires when the body exited without leaving a summary.json.
-    # All normal paths already wrote one, so this is a no-op on healthy runs and
-    # never clobbers a real summary. Guarded on COUNCIL_RUN_DIR because arg-parse
-    # / missing-task / dry-run-help failures never create a run directory.
-    if [[ -n "${COUNCIL_RUN_DIR:-}" && -d "${COUNCIL_RUN_DIR}" \
-          && ! -f "${COUNCIL_RUN_DIR}/summary.json" ]]; then
+    # Safety net: fires when the body left NO usable summary.json (absent, empty,
+    # or unparseable). Healthy paths write a valid summary, so this is a no-op
+    # there and never clobbers a real one. Guarded on COUNCIL_RUN_DIR because
+    # arg-parse / missing-task / dry-run-help failures never create a run dir.
+    local _summary="${COUNCIL_RUN_DIR:-}/summary.json"
+    if [[ -n "${COUNCIL_RUN_DIR:-}" && -d "${COUNCIL_RUN_DIR}" ]] \
+          && ! council_summary_is_valid "$_summary"; then
+        # Prefer the rich summary; if it fails or still yields invalid JSON, drop a
+        # minimal valid one so the caller ALWAYS has a machine-detectable status.
         council_write_summary_json "incomplete" 2>/dev/null || true
+        if ! council_summary_is_valid "$_summary"; then
+            printf '{"status":"incomplete"}\n' > "$_summary" 2>/dev/null || true
+        fi
         council_print_run_warnings 2>/dev/null || true
-        echo "Council ended before writing a summary (status=incomplete); review partial artifacts under ${COUNCIL_RUN_DIR}" >&2
+        if council_summary_is_valid "$_summary"; then
+            echo "Council ended before writing a summary (status=incomplete); review partial artifacts under ${COUNCIL_RUN_DIR}" >&2
+        else
+            echo "Council ended before writing a summary and a fallback summary could not be created under ${COUNCIL_RUN_DIR}" >&2
+        fi
         # Preserve a genuine failure code; surface one if the body somehow
         # returned success while skipping its own summary write.
         [[ "$_council_rc" -eq 0 ]] && _council_rc=1

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1356,6 +1356,69 @@ test_council_dispatch_strips_blocked_env_but_sets_disposable_mode() {
     fi
 }
 
+test_council_run_emits_summary_when_body_leaves_none() {
+    test_case "council_run emits a fallback summary.json when the run body exits without one"
+    load_council_lib || return 1
+
+    # Simulate the killer signature: the run body reaches a real run directory
+    # (synthesis dispatched) then exits nonzero WITHOUT writing summary.json —
+    # e.g. the chair-synthesis seat is SIGKILLed at the timeout cap, or a late
+    # `|| return 1` fires after synthesis but before the completed-summary write.
+    # A caller polling for summary.json would otherwise wait forever.
+    local d
+    d="$(mktemp -d "$TEST_TMP_DIR/council-incomplete.XXXXXX")"
+
+    _council_run_impl() { COUNCIL_RUN_DIR="$d"; return 1; }
+    # Keep the writer/warnings deterministic and independent of the full summary
+    # generator (already covered by the dry-run / full-success tests).
+    council_write_summary_json() { printf '{"status":"%s"}\n' "$1" > "${COUNCIL_RUN_DIR}/summary.json"; }
+    council_print_run_warnings() { :; }
+
+    local rc=0
+    council_run "dummy task" >/dev/null 2>&1 || rc=$?
+
+    local status=""
+    [[ -f "$d/summary.json" ]] && status="$(jq -r '.status' "$d/summary.json" 2>/dev/null)"
+
+    unset -f _council_run_impl council_write_summary_json council_print_run_warnings
+
+    if [[ "$status" == "incomplete" && "$rc" -ne 0 ]]; then
+        test_pass
+    else
+        test_fail "expected fallback summary status=incomplete and nonzero rc; got status='$status' rc=$rc"
+        return 1
+    fi
+}
+
+test_council_run_does_not_clobber_healthy_summary() {
+    test_case "council_run leaves a body-written summary.json untouched on a healthy run"
+    load_council_lib || return 1
+
+    local d
+    d="$(mktemp -d "$TEST_TMP_DIR/council-healthy.XXXXXX")"
+
+    # Healthy body: writes its own summary and returns success. The wrapper must
+    # NOT re-invoke the writer or overwrite the status.
+    _council_run_impl() { COUNCIL_RUN_DIR="$d"; printf '{"status":"completed"}\n' > "$d/summary.json"; return 0; }
+    council_write_summary_json() { printf '{"status":"WRAPPER_CLOBBERED"}\n' > "${COUNCIL_RUN_DIR}/summary.json"; }
+    council_print_run_warnings() { :; }
+
+    local rc=0
+    council_run "dummy task" >/dev/null 2>&1 || rc=$?
+
+    local status
+    status="$(jq -r '.status' "$d/summary.json" 2>/dev/null)"
+
+    unset -f _council_run_impl council_write_summary_json council_print_run_warnings
+
+    if [[ "$status" == "completed" && "$rc" -eq 0 ]]; then
+        test_pass
+    else
+        test_fail "wrapper clobbered a healthy summary or changed rc; status='$status' rc=$rc"
+        return 1
+    fi
+}
+
 test_council_command_files_are_registered
 test_council_orchestrate_route_exists
 test_council_benchmark_routing_lib_is_extracted
@@ -1411,6 +1474,8 @@ test_council_scans_artifact_critical_veto
 test_council_structured_veto_requires_veto_role
 test_council_veto_scan_ignores_discussed_token
 test_council_dispatch_strips_blocked_env_but_sets_disposable_mode
+test_council_run_emits_summary_when_body_leaves_none
+test_council_run_does_not_clobber_healthy_summary
 
 test_council_host_native_detection() {
     test_case "council_detect_providers marks host provider as host-native (issue #444)"

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1419,6 +1419,66 @@ test_council_run_does_not_clobber_healthy_summary() {
     fi
 }
 
+test_council_run_replaces_malformed_body_summary() {
+    test_case "council_run treats an empty/malformed body summary.json as missing and repairs it"
+    load_council_lib || return 1
+
+    local d
+    d="$(mktemp -d "$TEST_TMP_DIR/council-malformed.XXXXXX")"
+
+    # A jq failure mid-write can leave garbage that -f would accept. The wrapper
+    # must treat unparseable JSON as no summary and replace it with a valid one.
+    _council_run_impl() { COUNCIL_RUN_DIR="$d"; printf 'not json{' > "$d/summary.json"; return 0; }
+    council_write_summary_json() { printf '{"status":"%s"}\n' "$1" > "${COUNCIL_RUN_DIR}/summary.json"; }
+    council_print_run_warnings() { :; }
+
+    local rc=0
+    council_run "dummy task" >/dev/null 2>&1 || rc=$?
+
+    local status valid=1
+    jq -e . "$d/summary.json" >/dev/null 2>&1 || valid=0
+    status="$(jq -r '.status' "$d/summary.json" 2>/dev/null)"
+
+    unset -f _council_run_impl council_write_summary_json council_print_run_warnings
+
+    if [[ "$valid" -eq 1 && "$status" == "incomplete" && "$rc" -ne 0 ]]; then
+        test_pass
+    else
+        test_fail "expected repaired valid incomplete summary + nonzero rc; valid=$valid status='$status' rc=$rc"
+        return 1
+    fi
+}
+
+test_council_run_writes_minimal_summary_when_rich_writer_fails() {
+    test_case "council_run drops a minimal valid summary.json when the rich writer fails"
+    load_council_lib || return 1
+
+    local d
+    d="$(mktemp -d "$TEST_TMP_DIR/council-writerfail.XXXXXX")"
+
+    # Body leaves no summary AND the rich writer itself fails (e.g. jq errors) —
+    # the wrapper must still guarantee a parseable, machine-detectable artifact.
+    _council_run_impl() { COUNCIL_RUN_DIR="$d"; return 1; }
+    council_write_summary_json() { return 1; }
+    council_print_run_warnings() { :; }
+
+    local rc=0
+    council_run "dummy task" >/dev/null 2>&1 || rc=$?
+
+    local status valid=1
+    jq -e . "$d/summary.json" >/dev/null 2>&1 || valid=0
+    status="$(jq -r '.status' "$d/summary.json" 2>/dev/null)"
+
+    unset -f _council_run_impl council_write_summary_json council_print_run_warnings
+
+    if [[ "$valid" -eq 1 && "$status" == "incomplete" && "$rc" -ne 0 ]]; then
+        test_pass
+    else
+        test_fail "expected minimal valid incomplete summary + nonzero rc; valid=$valid status='$status' rc=$rc"
+        return 1
+    fi
+}
+
 test_council_command_files_are_registered
 test_council_orchestrate_route_exists
 test_council_benchmark_routing_lib_is_extracted
@@ -1476,6 +1536,8 @@ test_council_veto_scan_ignores_discussed_token
 test_council_dispatch_strips_blocked_env_but_sets_disposable_mode
 test_council_run_emits_summary_when_body_leaves_none
 test_council_run_does_not_clobber_healthy_summary
+test_council_run_replaces_malformed_body_summary
+test_council_run_writes_minimal_summary_when_rich_writer_fails
 
 test_council_host_native_detection() {
     test_case "council_detect_providers marks host provider as host-native (issue #444)"


### PR DESCRIPTION
## Problem

Reported against `orchestrate.sh council` (macOS, codex+agy seats): the synthesis phase hangs with **no `summary.json`**, the orchestrator process exits, and the caller waits 11+ minutes for a completion event that never comes. Preflight was healthy; every gate fell back to manual dispatch. No error, no nonzero exit surfaced — nothing signals "dead."

## Root cause

`council_run` writes `summary.json` on its four intended exit paths only — dry-run, no-quorum (`partial`), veto (`aborted`), and `completed`. A real run can leave the run directory with **no `summary.json` at all** when:

- the chair-synthesis seat is SIGKILLed at the per-seat timeout cap (its nonzero trips an early exit), or
- a late helper returns nonzero — `council_process_implementation_gates` and `council_append_corpus_artifacts` are both `|| return 1` **after** synthesis but **before** the `completed` summary write.

A caller polling for `summary.json` then waits indefinitely. That is the reporter's "idle 11+ min" — the *caller* waiting, not synthesis running (the seat was already killed at the cap by `run_with_timeout`).

## Fix

Wrap `council_run` around the existing body (`_council_run_impl`). On any exit that leaves no `summary.json`, emit a machine-detectable fallback (`status: "incomplete"`), print the partial-artifact location, and return nonzero. Healthy runs already write their own summary, so the wrapper is a no-op there and never clobbers a real summary. This delivers the report's "Expected": a clean, machine-detectable *runner unhealthy* signal instead of an unbounded wait.

Minimal and low-risk: the body is unchanged; only an always-on safety net is added around it.

## Tests

Two unit regressions in `test-council-command.sh`:
- `council_run_emits_summary_when_body_leaves_none` — body reaches a run dir then exits nonzero without a summary → fallback `incomplete` summary written + nonzero rc.
- `council_run_does_not_clobber_healthy_summary` — healthy body's summary left untouched, rc preserved.

`tests/unit/test-council-command.sh`: **75 passed, 0 failed, 1 skipped** (the skip is the pre-existing macOS-CI `script(1)` pty flake). `make sync` clean; no file-mode changes.

## Scope / follow-ups (not in this PR)

This targets the primary "hang forever" signature. Deliberately deferred, happy to do as follow-ups:
- **Auto-retry backoff + cap** so a stall doesn't spawn N more stalling run dirs.
- **codex exit 137 is *our own* timeout monitor**, not OOM — `run_with_timeout`'s bash fallback sends SIGTERM at the cap then `kill -KILL` 10s later; codex stuck in the chatgpt.com MCP transport doesn't die on SIGTERM in time and gets SIGKILLed. Worth treating an MCP transport timeout as a clean retriable error and revisiting whether the ~5-min cap is too tight for the MCP path (already tunable via `OCTOPUS_COUNCIL_TIMEOUT_CODEX`).
- A dedicated synthesis-phase watchdog timeout exposed as config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Council runs that stop before generating a summary now create a machine-readable `incomplete` summary when possible.
  * Malformed or missing summaries are repaired with a valid fallback artifact.
  * Incomplete runs report the summary location and return a failure status, preventing callers from waiting indefinitely.
  * Successful runs continue to preserve their completed summaries.
* **Tests**
  * Added coverage for incomplete runs, malformed summaries, fallback handling, and successful results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->