### PR TITLE
feat(council): configurable chair-synthesis timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- `OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT` bounds the chair-synthesis dispatch
+  independently of the per-seat cap. Synthesis reads every member artifact and
+  writes the final structured document, so it routinely needs more room than a
+  single advice seat — and on a slow chair path (e.g. codex via the
+  chatgpt.com MCP transport) the plain seat cap can expire mid-write. When
+  unset, synthesis keeps falling back to the chair provider's normal per-seat
+  resolution, so existing tuning (`OCTOPUS_COUNCIL_TIMEOUT_<PROVIDER>`,
+  `--seat-timeout`) still applies.
+
 ## [9.64.0] - 2026-08-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@
   independently of the per-seat cap. Synthesis reads every member artifact and
   writes the final structured document, so it routinely needs more room than a
   single advice seat — and on a slow chair path (e.g. codex via the
-  chatgpt.com MCP transport) the plain seat cap can expire mid-write. When
-  unset, synthesis keeps falling back to the chair provider's normal per-seat
-  resolution, so existing tuning (`OCTOPUS_COUNCIL_TIMEOUT_<PROVIDER>`,
-  `--seat-timeout`) still applies.
+  chatgpt.com MCP transport) the plain seat cap can expire mid-write. When the
+  override is unset, zero, negative, or non-numeric, synthesis falls back through
+  the chair provider's normal per-seat resolution
+  (`OCTOPUS_COUNCIL_TIMEOUT_<PROVIDER>` → `--seat-timeout` → legacy
+  `OCTOPUS_COUNCIL_AGENT_TIMEOUT` → built-in default), so a malformed value never
+  disables the cap.
 
 ## [9.64.0] - 2026-08-13
 

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1505,8 +1505,15 @@ EOF
     fi
 
     if declare -f run_agent_sync_consultative >/dev/null 2>&1; then
-        local agent_type="$provider"
-        run_agent_sync_consultative "$agent_type" "$prompt" "$(council_seat_timeout "$agent_type")" "$persona" "council"
+        local agent_type="$provider" _seat_timeout
+        # Synthesis gets its own (usually larger) bound; advice/critique/revision
+        # keep the normal per-seat cap.
+        if [[ "$dispatch_phase" == "chair-synthesis" ]]; then
+            _seat_timeout="$(council_synthesis_timeout "$agent_type")"
+        else
+            _seat_timeout="$(council_seat_timeout "$agent_type")"
+        fi
+        run_agent_sync_consultative "$agent_type" "$prompt" "$_seat_timeout" "$persona" "council"
         return $?
     fi
 
@@ -1829,6 +1836,20 @@ council_seat_timeout() {
     candidate="${OCTOPUS_COUNCIL_AGENT_TIMEOUT:-}"
     if [[ "$candidate" =~ ^[1-9][0-9]*$ ]]; then printf '%s' "$candidate"; return 0; fi
     printf '120'
+}
+
+council_synthesis_timeout() {
+    # Chair-synthesis dispatch timeout (seconds). Synthesis reads every member
+    # artifact and writes the final structured document, so it routinely needs
+    # more room than a single advice seat — and on a slow chair path (e.g. codex
+    # via the chatgpt.com MCP transport) the plain seat cap can expire mid-write.
+    # OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT overrides just this phase; otherwise fall
+    # back to the chair provider's normal per-seat resolution so existing tuning
+    # (OCTOPUS_COUNCIL_TIMEOUT_<PROVIDER>, --seat-timeout, ...) still applies.
+    local provider="$1" candidate
+    candidate="${OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT:-}"
+    if [[ "$candidate" =~ ^[1-9][0-9]*$ ]]; then printf '%s' "$candidate"; return 0; fi
+    council_seat_timeout "$provider"
 }
 
 council_compute_approving_providers() {

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1611,6 +1611,54 @@ test_council_seat_timeout_precedence() {
     fi
 }
 
+test_council_synthesis_timeout_overrides_seat_cap() {
+    test_case "council_synthesis_timeout: env override wins, else falls back to per-seat resolution"
+    load_council_lib || return 1
+    local override fallback per_provider invalid
+    # Explicit synthesis override wins over the seat cap for the chair phase.
+    override="$(OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT=900 COUNCIL_SEAT_TIMEOUT=300 council_synthesis_timeout codex)"
+    # No override -> chair provider's normal per-seat resolution (default 120).
+    fallback="$(OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT='' OCTOPUS_COUNCIL_TIMEOUT_CODEX='' COUNCIL_SEAT_TIMEOUT='' OCTOPUS_COUNCIL_AGENT_TIMEOUT='' council_synthesis_timeout codex)"
+    # No override -> existing per-provider tuning still applies through the fallback.
+    per_provider="$(OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT='' OCTOPUS_COUNCIL_TIMEOUT_CODEX=600 council_synthesis_timeout codex)"
+    # Invalid override falls through to seat resolution rather than disabling the cap.
+    invalid="$(OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT=0 OCTOPUS_COUNCIL_TIMEOUT_CODEX='' COUNCIL_SEAT_TIMEOUT=300 council_synthesis_timeout codex)"
+    if [[ "$override" == "900" ]] && [[ "$fallback" == "120" ]] &&
+       [[ "$per_provider" == "600" ]] && [[ "$invalid" == "300" ]]; then
+        test_pass
+    else
+        test_fail "synthesis timeout wrong: override=$override fallback=$fallback per_provider=$per_provider invalid=$invalid"
+        return 1
+    fi
+}
+
+test_council_live_response_uses_synthesis_timeout_for_chair() {
+    test_case "council_live_response applies the synthesis timeout only to chair-synthesis"
+    load_council_lib || return 1
+    local captured_advice captured_synth
+    # run_agent_sync_consultative receives the resolved timeout as arg 3; capture it.
+    run_agent_sync_consultative() { printf '%s' "$3" > "$TEST_TMP_DIR/council-synth-cap.txt"; printf 'ok\n'; }
+    council_provider_is_available() { return 0; }
+    COUNCIL_PROVIDER_STATUS_JSON='{"codex":"available"}'
+
+    OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT=900 OCTOPUS_COUNCIL_TIMEOUT_CODEX=300 \
+        council_live_response codex strategy-analyst "dummy prompt" chair-synthesis >/dev/null 2>&1
+    captured_synth="$(cat "$TEST_TMP_DIR/council-synth-cap.txt" 2>/dev/null)"
+
+    OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT=900 OCTOPUS_COUNCIL_TIMEOUT_CODEX=300 \
+        council_live_response codex code-reviewer "dummy prompt" independent-advice >/dev/null 2>&1
+    captured_advice="$(cat "$TEST_TMP_DIR/council-synth-cap.txt" 2>/dev/null)"
+
+    unset -f run_agent_sync_consultative council_provider_is_available
+
+    if [[ "$captured_synth" == "900" ]] && [[ "$captured_advice" == "300" ]]; then
+        test_pass
+    else
+        test_fail "expected synthesis=900 advice=300; got synthesis=$captured_synth advice=$captured_advice"
+        return 1
+    fi
+}
+
 test_council_detach_escape_hatch_uses_inline() {
     test_case "OCTOPUS_COUNCIL_DETACH=0 falls back to inline dispatch (no sentinel)"
     load_council_lib || return 1
@@ -2035,6 +2083,8 @@ test_council_fixture_dispatch_uses_inline_transport
 test_council_detached_seat_survives_interrupt
 test_council_detached_seat_timeout_is_cancelled
 test_council_seat_timeout_precedence
+test_council_synthesis_timeout_overrides_seat_cap
+test_council_live_response_uses_synthesis_timeout_for_chair
 test_council_seat_timeout_rejects_zero_and_nonnumeric
 test_council_response_has_verdict_salvage
 test_council_chair_only_vendor_excluded_from_quorum


### PR DESCRIPTION
## Context

Follow-up to #919 (always emit `summary.json`). Same report: `orchestrate.sh council` on macOS with a codex seat routed through the chatgpt.com MCP transport. The chair-synthesis step reads every member artifact and writes the final structured document, so it needs more room than a single advice seat — and on that slow chair path the plain per-seat cap can expire mid-write, killing synthesis right at the boundary.

Today the synthesis dispatch just reuses `council_seat_timeout <chair>`, so there is no way to give synthesis more time without also loosening every advice seat.

## Change

- New `council_synthesis_timeout()` resolves `OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT` first, then falls back to the chair provider's normal per-seat resolution (`OCTOPUS_COUNCIL_TIMEOUT_<PROVIDER>` → `--seat-timeout` → legacy global → default).
- `council_live_response` applies it **only** to the `chair-synthesis` phase; advice/critique/revision seats keep the existing per-seat cap.

Backward-compatible: unset ⇒ identical behavior to today.

## Tests

Two unit regressions in `test-council-command.sh`:
- `council_synthesis_timeout_overrides_seat_cap` — override wins; unset falls back to per-seat resolution (incl. per-provider tuning); invalid (`0`) falls through instead of disabling the cap.
- `council_live_response_uses_synthesis_timeout_for_chair` — captures the timeout arg handed to `run_agent_sync_consultative`: `chair-synthesis` gets the synthesis value, `independent-advice` keeps the per-seat value.

`tests/unit/test-council-command.sh`: **75 passed, 0 failed, 1 skipped** (pre-existing macOS-CI pty flake). No file-mode changes.

## Relation to the other follow-ups

- The "auto-retry spawns more stalling run dirs" signature is **not** an internal `orchestrate.sh` retry (the `council)` route just calls `council_run`); it was the caller re-invoking. #919 already makes each run emit a machine-detectable `summary.json`, so the caller stops blind-retrying.
- A separate change will classify a seat killed by its own timeout monitor as `timed-out` (not generic `no-response`) so a codex exit 137 reads as "hit the cap, raise `OCTOPUS_COUNCIL_TIMEOUT_CODEX`" rather than a mysterious SIGKILL/OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated timeout setting for AI council chair synthesis.
  * Synthesis uses the configured override when available, with provider-specific and default timeout fallbacks.

* **Documentation**
  * Documented the new `OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT` setting in the unreleased changelog.

* **Bug Fixes**
  * Improved timeout handling so chair synthesis can be bounded independently from regular council responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->