### PR TITLE
fix(council): classify seats killed by their own timeout as timed-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Council advice seats killed by their own timeout monitor are now recorded as
+  `timed-out` in `summary.json` instead of a generic `no-response`, and the run
+  prints an actionable warning naming the exact knob to raise
+  (`OCTOPUS_COUNCIL_TIMEOUT_<PROVIDER>`). A codex seat SIGKILLed at the ~5-min cap
+  (exit 137) on the slow chatgpt.com MCP path previously read like an unexplained
+  OOM; it is our own watchdog firing, and the summary/warning now say so.
+
 ## [9.64.0] - 2026-08-13
 
 ### Changed

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -53,6 +53,7 @@ COUNCIL_IMPLEMENTATION_HANDOFF_JSON=""
 COUNCIL_ABORTED_FOR_COST=""
 COUNCIL_DIVERSITY_REPLACED=""
 COUNCIL_DIVERSITY_WARNING=""
+COUNCIL_TIMEOUT_WARNINGS=""
 COUNCIL_BENCHMARK_FRESHNESS_WEIGHT=""
 COUNCIL_COST_CHECK_ESTIMATED=""
 COUNCIL_VETO_TRIGGERED=""
@@ -1848,11 +1849,35 @@ council_compute_approving_providers() {
     printf '%s' "$approving"
 }
 
+council_rc_is_timeout() {
+    # True when a seat's dispatch rc came from hitting its own timeout cap rather
+    # than a provider-level error. run_with_timeout kills an over-cap seat with the
+    # coreutils convention (124) or, on the macOS bash fallback, SIGTERM then SIGKILL
+    # — so the seat process exits 143 (128+15) or 137 (128+9). Distinguishing these
+    # keeps a codex seat killed at the ~5-min cap from reading as a mysterious
+    # SIGKILL/OOM: it is our own watchdog firing, and the remedy is a larger cap.
+    case "${1:-}" in
+        124|137|143) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+council_note_seat_timeout() {
+    # Accumulate an actionable end-of-run warning for a seat that hit its cap,
+    # naming the exact env knob that would give that provider more time.
+    local provider="$1" persona="$2" rc="$3" cap="$4" knob line
+    knob="OCTOPUS_COUNCIL_TIMEOUT_$(printf '%s' "$provider" | tr '[:lower:]-' '[:upper:]_')"
+    line="seat ${provider} (${persona}) exceeded its ${cap}s cap (rc=${rc}) — raise ${knob} to give it more time"
+    COUNCIL_TIMEOUT_WARNINGS="${COUNCIL_TIMEOUT_WARNINGS:+${COUNCIL_TIMEOUT_WARNINGS}
+}${line}"
+}
+
 council_run_advice_phase() {
     COUNCIL_RESPONSES_RECEIVED="0"
     COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
     COUNCIL_RESPONDING_PROVIDERS=""
     COUNCIL_SEAT_RECORDS_JSON="[]"
+    COUNCIL_TIMEOUT_WARNINGS=""
     local dissenting_providers=""
 
     local index=0 member persona slug output_path seat mprovider verdict
@@ -1919,6 +1944,16 @@ council_run_advice_phase() {
             else
                 seat_status="no-response"
             fi
+        fi
+        # A seat killed by its own timeout monitor (run_with_timeout: 124, or the
+        # macOS SIGTERM->SIGKILL fallback: 143/137) that left no usable response is a
+        # timeout, not a generic provider shortage. Classify it distinctly so
+        # summary.json and the end-of-run warnings say "hit the cap, raise the knob"
+        # instead of surfacing a bare exit 137 that reads like an OOM. (The salvage
+        # path above already keeps a timed-out-but-complete review as "responded".)
+        if [[ "$seat_status" == "no-response" ]] && council_rc_is_timeout "$dispatch_rc"; then
+            seat_status="timed-out"
+            council_note_seat_timeout "$mprovider" "$persona" "$dispatch_rc" "$(council_seat_timeout "$mprovider")"
         fi
         # Per-seat record for summary.json — makes quorum integrity machine-checkable
         # (a chair or degenerate seat can no longer masquerade as a distinct approving
@@ -2779,6 +2814,13 @@ council_print_run_warnings() {
 
     if [[ "$COUNCIL_CHAIR_FALLBACK_USED" == "true" ]]; then
         echo "Council warning: chair fallback used (${COUNCIL_CHAIR_FALLBACK_PERSONA})."
+    fi
+
+    if [[ -n "${COUNCIL_TIMEOUT_WARNINGS:-}" ]]; then
+        local _tw
+        while IFS= read -r _tw; do
+            [[ -n "$_tw" ]] && echo "Council warning: $_tw"
+        done <<< "$COUNCIL_TIMEOUT_WARNINGS"
     fi
 }
 

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1640,16 +1640,21 @@ test_council_advice_marks_timed_out_seat() {
 
     OCTOPUS_COUNCIL_TIMEOUT_CODEX=300 council_run_advice_phase >/dev/null 2>&1 || true
 
-    local status warns
+    local status warns output
     status="$(jq -r '.[0].status' <<< "$COUNCIL_SEAT_RECORDS_JSON" 2>/dev/null)"
     warns="$COUNCIL_TIMEOUT_WARNINGS"
+    # Also assert the end-of-run renderer actually prints it, so a regression in
+    # council_print_run_warnings can't pass while the warning silently disappears.
+    output="$(council_print_run_warnings)"
 
     unset -f council_dispatch_member_detached council_run_chair_fallback
 
-    if [[ "$status" == "timed-out" ]] && [[ "$warns" == *"OCTOPUS_COUNCIL_TIMEOUT_CODEX"* ]] && [[ "$warns" == *"300s"* ]]; then
+    if [[ "$status" == "timed-out" ]] &&
+       [[ "$warns" == *"OCTOPUS_COUNCIL_TIMEOUT_CODEX"* ]] && [[ "$warns" == *"300s"* ]] &&
+       [[ "$output" == *"rc=137"* ]] && [[ "$output" == *"OCTOPUS_COUNCIL_TIMEOUT_CODEX"* ]]; then
         test_pass
     else
-        test_fail "expected timed-out status + knob hint; status='$status' warns=[$warns]"
+        test_fail "expected timed-out status + printed knob hint; status='$status' warns=[$warns] output=[$output]"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1611,6 +1611,49 @@ test_council_seat_timeout_precedence() {
     fi
 }
 
+test_council_rc_is_timeout_recognizes_cap_kill_codes() {
+    test_case "council_rc_is_timeout matches watchdog kill codes (124/137/143), not other failures"
+    load_council_lib || return 1
+    local ok="" bad=""
+    local c
+    for c in 124 137 143; do council_rc_is_timeout "$c" && ok="${ok}${c} " || bad="${bad}${c}!TIMEOUT "; done
+    for c in 0 1 2 126 127; do council_rc_is_timeout "$c" && bad="${bad}${c}!NONTIMEOUT " || ok="${ok}skip$c "; done
+    if [[ -z "$bad" ]]; then
+        test_pass
+    else
+        test_fail "misclassified: $bad"
+        return 1
+    fi
+}
+
+test_council_advice_marks_timed_out_seat() {
+    test_case "advice phase classifies a seat killed at its cap as timed-out with a knob hint"
+    load_council_lib || return 1
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-timeout.XXXXXX")"; mkdir -p "$d/responses"
+    COUNCIL_RUN_DIR="$d"
+    COUNCIL_ROSTER_JSON='[{"persona":"code-reviewer","seat":"member","provider":"codex","provider_org":"openai","model":"gpt"}]'
+    COUNCIL_FIXTURE=""
+    COUNCIL_TIMEOUT_WARNINGS=""
+    # Simulate the reported codex-137 case: dispatch killed at the cap, no response file.
+    council_dispatch_member_detached() { return 137; }
+    council_run_chair_fallback() { :; }
+
+    OCTOPUS_COUNCIL_TIMEOUT_CODEX=300 council_run_advice_phase >/dev/null 2>&1 || true
+
+    local status warns
+    status="$(jq -r '.[0].status' <<< "$COUNCIL_SEAT_RECORDS_JSON" 2>/dev/null)"
+    warns="$COUNCIL_TIMEOUT_WARNINGS"
+
+    unset -f council_dispatch_member_detached council_run_chair_fallback
+
+    if [[ "$status" == "timed-out" ]] && [[ "$warns" == *"OCTOPUS_COUNCIL_TIMEOUT_CODEX"* ]] && [[ "$warns" == *"300s"* ]]; then
+        test_pass
+    else
+        test_fail "expected timed-out status + knob hint; status='$status' warns=[$warns]"
+        return 1
+    fi
+}
+
 test_council_detach_escape_hatch_uses_inline() {
     test_case "OCTOPUS_COUNCIL_DETACH=0 falls back to inline dispatch (no sentinel)"
     load_council_lib || return 1
@@ -2035,6 +2078,8 @@ test_council_fixture_dispatch_uses_inline_transport
 test_council_detached_seat_survives_interrupt
 test_council_detached_seat_timeout_is_cancelled
 test_council_seat_timeout_precedence
+test_council_rc_is_timeout_recognizes_cap_kill_codes
+test_council_advice_marks_timed_out_seat
 test_council_seat_timeout_rejects_zero_and_nonnumeric
 test_council_response_has_verdict_salvage
 test_council_chair_only_vendor_excluded_from_quorum


### PR DESCRIPTION
## Context

Follow-up to #919 / #920. Same report: on macOS a council codex seat routed through the chatgpt.com MCP transport dies with **exit 137** at the ~5-min per-seat cap. The reporter read that as a SIGKILL/OOM ("codex seat SIGKILLed on MCP timeout"). It isn't the OS — it's **our own watchdog**: `run_with_timeout` kills an over-cap seat with the coreutils convention (124) or, on the macOS bash fallback, SIGTERM→SIGKILL (143/137). That code reaches the advice phase via the detached `.done` sentinel, but a timed-out seat with no usable response was lumped into a generic `no-response`, so nothing distinguished "hit the cap" from "provider returned nothing."

## Change

- `council_rc_is_timeout()` — recognizes the watchdog kill codes (124/137/143).
- In the advice phase, a seat with no usable response whose dispatch rc is a timeout is recorded as **`timed-out`** in `summary.json` (instead of `no-response`).
- `council_note_seat_timeout()` accumulates an actionable end-of-run warning naming the exact knob to raise: `Council warning: seat codex (code-reviewer) exceeded its 300s cap (rc=137) — raise OCTOPUS_COUNCIL_TIMEOUT_CODEX to give it more time`.

Quorum is untouched: `timed-out` is not `responded`, so it still can't count as an approver, and the existing salvage path still keeps a timed-out-**but-complete** review as a real response.

## Tests

- `council_rc_is_timeout_recognizes_cap_kill_codes` — 124/137/143 match; 0/1/2/126/127 don't.
- `council_advice_marks_timed_out_seat` — a stubbed 137 dispatch with no output yields seat status `timed-out` plus the `OCTOPUS_COUNCIL_TIMEOUT_CODEX` / `300s` hint.

`tests/unit/test-council-command.sh`: **75 passed, 0 failed, 1 skipped** (pre-existing macOS-CI pty flake). No file-mode changes.

## Report follow-up status

This is the last of the report's asks that needs code. For the record:
- **#1 synthesis hang / no summary** → #919 (merged path: always emit `summary.json`).
- **#5 synthesis timeout config** → #920 (`OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT`).
- **#3 auto-retry spawns stalling run dirs** → not a code change: `orchestrate.sh` has no internal council retry (the `council)` route just calls `council_run`); the repeated run dirs were the caller re-invoking, and #919 gives it a machine-detectable failure to stop on.
- **#4 codex 137 / MCP timeout** → this PR (reframed + surfaced). A blind auto-retry of a seat that just burned its full cap was deliberately not added (doubles latency/cost, may re-hang); raising the now-named per-provider knob is the intended remedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Council seats terminated by the timeout watchdog are now recorded as **timed-out** instead of **no-response**.
  * Complete responses produced at the timeout boundary are preserved.
  * Watchdog terminations are correctly distinguished from out-of-memory failures.

* **Improvements**
  * Added provider-specific timeout warnings with guidance on adjusting timeout settings.
  * Timeout messages now provide clearer details to help diagnose and resolve interrupted council runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->