### PR TITLE
fix(council): host-native chair satisfies quorum (met from vendor approvals, not chair receipt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Council `quorum.met` no longer reports `false` when the chair is the host
+  runtime. A host-native chair (e.g. Claude Code running the council) cannot
+  self-dispatch, so it never produces a substantive chair response file — but it
+  is present and synthesizes the council in-context. `met` was gated on the chair
+  response, so a run with two cleanly-approving vendors was falsely reported
+  `quorum.met=false` (`distinct_approving_providers: 2`, `chair_received: false`).
+  `met` now treats a host-native chair as a present, synthesis-capable chair, and
+  `summary.json` exposes `quorum.chair_host_native` so the decision is
+  recomputable. A chair that is merely unavailable (not host-native) still fails
+  quorum.
+
 ## [9.64.0] - 2026-08-13
 
 ### Changed

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -44,6 +44,7 @@ COUNCIL_ROSTER_JSON=""
 COUNCIL_RESPONSES_RECEIVED=""
 COUNCIL_QUORUM_MET=""
 COUNCIL_CHAIR_RESPONSE_RECEIVED=""
+COUNCIL_CHAIR_HOST_NATIVE=""
 COUNCIL_CHAIR_FALLBACK_USED=""
 COUNCIL_CHAIR_FALLBACK_PERSONA=""
 COUNCIL_IMPLEMENTATION_PLAN_WRITTEN=""
@@ -1848,9 +1849,26 @@ council_compute_approving_providers() {
     printf '%s' "$approving"
 }
 
+council_chair_is_host_native() {
+    # The chair can be the active host runtime (e.g. Claude Code running the
+    # council). A host-native chair cannot self-dispatch, so it never produces a
+    # substantive chair response file — but it IS present and synthesizes the
+    # council in-context. Quorum must treat it as a satisfied chair, otherwise a
+    # run with two cleanly-approving vendors is falsely reported quorum.met=false
+    # purely because chair_received never flipped true.
+    local chair_json chair_provider status
+    chair_json="$(council_chair_member_json 2>/dev/null || true)"
+    [[ -n "$chair_json" ]] || return 1
+    chair_provider="$(jq -r '.provider // ""' <<< "$chair_json" 2>/dev/null)"
+    [[ -n "$chair_provider" ]] || return 1
+    status="$(jq -r --arg p "$chair_provider" '.[$p] // "missing"' <<< "${COUNCIL_PROVIDER_STATUS_JSON:-{}}" 2>/dev/null)"
+    [[ "$status" == "host-native" ]]
+}
+
 council_run_advice_phase() {
     COUNCIL_RESPONSES_RECEIVED="0"
     COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
+    COUNCIL_CHAIR_HOST_NATIVE="false"
     COUNCIL_RESPONDING_PROVIDERS=""
     COUNCIL_SEAT_RECORDS_JSON="[]"
     local dissenting_providers=""
@@ -1966,7 +1984,21 @@ council_run_advice_phase() {
                 and .status == "responded" and .verdict == "APPROVE"
                 and ($approving | contains(" " + $p + " "))))' <<< "${COUNCIL_SEAT_RECORDS_JSON:-[]}")"
 
-    if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" == "true" ]] && (( received_non_chair >= required )) \
+    # Chair presence: a dispatched chair response OR a host-native chair (which
+    # synthesizes in-context and cannot self-dispatch). Gating met on the response
+    # file alone falsely fails a run whose chair IS the host — the reported
+    # quorum.met=false with distinct_approving_providers=2. met now reflects vendor
+    # approvals plus a present (synthesis-capable) chair, not chair receipt.
+    COUNCIL_CHAIR_HOST_NATIVE="false"
+    if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" != "true" ]] && council_chair_is_host_native; then
+        COUNCIL_CHAIR_HOST_NATIVE="true"
+    fi
+    local chair_present="false"
+    if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" == "true" || "$COUNCIL_CHAIR_HOST_NATIVE" == "true" ]]; then
+        chair_present="true"
+    fi
+
+    if [[ "$chair_present" == "true" ]] && (( received_non_chair >= required )) \
         && { (( required < 2 )) || (( COUNCIL_DISTINCT_APPROVING_PROVIDERS >= required )); }; then
         COUNCIL_QUORUM_MET="true"
     else
@@ -2673,6 +2705,7 @@ council_write_summary_json() {
         --arg distinct_approving_providers "${COUNCIL_DISTINCT_APPROVING_PROVIDERS:-0}" \
         --arg approving_providers "${COUNCIL_APPROVING_PROVIDERS:-}" \
         --arg chair_received "$COUNCIL_CHAIR_RESPONSE_RECEIVED" \
+        --arg chair_host_native "${COUNCIL_CHAIR_HOST_NATIVE:-false}" \
         --arg chair_fallback_used "$COUNCIL_CHAIR_FALLBACK_USED" \
         --arg chair_fallback_persona "$COUNCIL_CHAIR_FALLBACK_PERSONA" \
         --arg implementation_plan_written "$COUNCIL_IMPLEMENTATION_PLAN_WRITTEN" \
@@ -2711,6 +2744,7 @@ council_write_summary_json() {
             required_non_chair: (if $depth == "quick" then 1 else 2 end),
             received_non_chair: ($received_non_chair | tonumber),
             chair_received: ($chair_received == "true"),
+            chair_host_native: ($chair_host_native == "true"),
             distinct_providers: ($distinct_providers | tonumber),
             responding_providers: $responding_providers,
             distinct_approving_providers: ($distinct_approving_providers | tonumber),

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1356,9 +1356,73 @@ test_council_dispatch_strips_blocked_env_but_sets_disposable_mode() {
     fi
 }
 
+test_council_chair_is_host_native_detects_status() {
+    test_case "council_chair_is_host_native reflects the chair provider's host-native status"
+    load_council_lib || return 1
+    COUNCIL_ROSTER_JSON='[{"persona":"strategy-analyst","seat":"chair","provider":"claude","provider_org":"anthropic","model":"opus"}]'
+    COUNCIL_CHAIR_FALLBACK_USED="false"; COUNCIL_CHAIR_FALLBACK_PERSONA=""
+    local hostnative available
+    COUNCIL_PROVIDER_STATUS_JSON='{"claude":"host-native"}' council_chair_is_host_native && hostnative=yes || hostnative=no
+    COUNCIL_PROVIDER_STATUS_JSON='{"claude":"available"}' council_chair_is_host_native && available=yes || available=no
+    if [[ "$hostnative" == "yes" && "$available" == "no" ]]; then
+        test_pass
+    else
+        test_fail "expected host-native=yes available=no; got host-native=$hostnative available=$available"
+        return 1
+    fi
+}
+
+test_council_quorum_met_with_host_native_chair() {
+    test_case "quorum.met is true when a host-native chair + two vendors approve (chair_received stays false)"
+    load_council_lib || return 1
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-hnchair.XXXXXX")"; mkdir -p "$d/responses"
+    COUNCIL_RUN_DIR="$d"
+    COUNCIL_DEPTH="standard"   # required_non_chair = 2
+    COUNCIL_FIXTURE=""
+    COUNCIL_CHAIR_FALLBACK_USED="false"; COUNCIL_CHAIR_FALLBACK_PERSONA=""
+    COUNCIL_ROSTER_JSON='[
+      {"persona":"strategy-analyst","seat":"chair","provider":"claude","provider_org":"anthropic","model":"opus"},
+      {"persona":"backend-architect","seat":"member","provider":"codex","provider_org":"openai","model":"gpt"},
+      {"persona":"security-auditor","seat":"member","provider":"agy","provider_org":"google","model":"gemini"}
+    ]'
+    # Non-chair vendors approve; the host-native chair (claude) cannot self-dispatch
+    # (return 1, no substantive file) — mirrors the real host-agent path.
+    council_dispatch_member_detached() {
+        local mj="$1" out="$3" prov
+        prov="$(jq -r '.provider' <<< "$mj")"
+        case "$prov" in
+            codex|agy) printf '## Review by %s\n\nThe change is sound and well tested. No blocking concerns.\n\nVERDICT: APPROVE\n' "$prov" > "$out"; return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+    council_run_chair_fallback() { :; }   # no dispatched fallback available
+
+    COUNCIL_PROVIDER_STATUS_JSON='{"claude":"host-native","codex":"available","agy":"available"}' \
+        council_run_advice_phase >/dev/null 2>&1 || true
+    local met_hn chair_recv_hn hostnative_hn
+    met_hn="$COUNCIL_QUORUM_MET"; chair_recv_hn="$COUNCIL_CHAIR_RESPONSE_RECEIVED"; hostnative_hn="$COUNCIL_CHAIR_HOST_NATIVE"
+
+    # Negative control: same two approvals but the chair provider is merely
+    # "available" and never responded — chair is genuinely absent, met must be false.
+    COUNCIL_PROVIDER_STATUS_JSON='{"claude":"available","codex":"available","agy":"available"}' \
+        council_run_advice_phase >/dev/null 2>&1 || true
+    local met_absent="$COUNCIL_QUORUM_MET"
+
+    unset -f council_dispatch_member_detached council_run_chair_fallback
+
+    if [[ "$met_hn" == "true" && "$chair_recv_hn" == "false" && "$hostnative_hn" == "true" && "$met_absent" == "false" ]]; then
+        test_pass
+    else
+        test_fail "host-native chair quorum wrong: met=$met_hn chair_received=$chair_recv_hn host_native=$hostnative_hn ; absent-chair met=$met_absent"
+        return 1
+    fi
+}
+
 test_council_command_files_are_registered
 test_council_orchestrate_route_exists
 test_council_benchmark_routing_lib_is_extracted
+test_council_chair_is_host_native_detects_status
+test_council_quorum_met_with_host_native_chair
 test_council_defaults_are_depth_aware
 test_council_rejects_non_usd_budget
 test_council_dry_run_writes_summary_json


### PR DESCRIPTION
## Problem (highest-value ask from the latest council report)

`summary.json` reports `quorum.met: false` while `distinct_approving_providers: 2` and both non-chair vendor bodies are real APPROVEs. Isolated by diffing a `met:true` run against a `met:false` one: the difference is `chair_received: false`. When the chair **is** the host runtime (Claude Code running the council), it cannot self-dispatch, so it never produces a substantive chair response file — yet it is present and synthesizes the council in-context. `met` was gated on the chair response, so every such run had to be overridden manually per "per-seat read is authoritative."

## Fix

Chair presence = **a dispatched chair response OR a host-native chair**:

- `council_chair_is_host_native()` resolves the chair seat's provider and checks its status in `COUNCIL_PROVIDER_STATUS_JSON` (`host-native`).
- The `met` computation uses `chair_present` instead of `chair_received` directly. `met` now reflects vendor approvals + a present, synthesis-capable chair.
- `summary.json` gains `quorum.chair_host_native` so `met` is recomputable from the artifact: `met = received_non_chair >= required AND (required < 2 OR distinct_approving_providers >= required) AND (chair_received OR chair_host_native)`.

No loosening of the real shortage gate: a chair that is merely **unavailable** (not host-native) still fails quorum, and the distinct-approving-vendor guard (#1992/#1993/#670) is untouched.

## Tests

- `council_chair_is_host_native_detects_status` — helper returns true for a `host-native` chair provider, false for `available`.
- `council_quorum_met_with_host_native_chair` — advice-phase run: host-native chair + two approving vendors → `met=true` with `chair_received=false` and `chair_host_native=true`; **negative control**: same approvals but an available-but-absent chair → `met=false`.

`tests/unit/test-council-command.sh`: **75 passed, 0 failed, 1 skipped** (pre-existing macOS-CI pty flake). No file-mode changes.

## Relation to the report's other asks

- **#2 synthesis watchdog / no summary.json** → #919 (always emit a valid `summary.json`).
- **#4/#6 codex 137 at the cap** → #921 (classify `timed-out`, name the knob) + #920 (`OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT`).
- **#3 auto-retry spawning run dirs** → not an internal `orchestrate.sh` retry; #919 gives the caller a machine-detectable failure to stop on.
- **#3 background silent-empty status / #5 tempfile+`OCTOPUS_AGY_MODEL` validation** → genuinely new; can follow up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed quorum evaluation when the council chair is provided by the active host runtime.
  - Prevented false quorum failures when independent providers approve but the host-native chair cannot submit a separate response.
  - Clarified that an unavailable, non-host-native chair still prevents quorum.

- **Documentation**
  - Added an Unreleased changelog entry describing the updated quorum behavior and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->