### PR TITLE
fix(agy): fail open when OCTOPUS_AGY_MODEL cannot be validated (don't crash on an unreachable catalog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `OCTOPUS_AGY_MODEL` validation no longer aborts a run when the agy catalog is
+  unreachable. A restricted sandbox or an offline host makes `agy models` return
+  an empty catalog; the validator treated that "cannot validate" case like a
+  definitively invalid pin and failed model resolution, crashing the council on
+  spawn even when the pin was valid. Validation now fails **open** when the
+  catalog is unreachable (agy still rejects a genuinely bad model at dispatch,
+  with a clear error) and only fails **closed** for a model that is absent from a
+  *reachable* catalog. Set `OCTOPUS_AGY_MODEL_STRICT=1` to require validation and
+  restore the previous fail-closed behavior.
+
 ## [9.64.0] - 2026-08-13
 
 ### Changed

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -124,9 +124,22 @@ validate_agy_model_name() {
             ;;
     esac
 
+    # "Cannot validate" (catalog unreachable) is NOT the same as "invalid" (a
+    # model definitively absent from a reachable catalog). Treating them alike
+    # turned a transient/sandboxed `agy models` failure into a spawn-time abort:
+    # OCTOPUS_AGY_MODEL resolution returned 1 and the whole council crashed even
+    # when the pin was perfectly valid. Fail OPEN when the catalog can't be read —
+    # a genuinely bad pin is still caught by agy itself at dispatch, with a clear
+    # error — and keep the strict fail-closed path behind an explicit opt-in.
+    local strict="${OCTOPUS_AGY_MODEL_STRICT:-0}"
+
     if ! command -v agy >/dev/null 2>&1; then
-        log ERROR "Cannot validate OCTOPUS_AGY_MODEL because agy CLI is not installed"
-        return 1
+        if [[ "$strict" == "1" ]]; then
+            log ERROR "Cannot validate OCTOPUS_AGY_MODEL because agy CLI is not installed (OCTOPUS_AGY_MODEL_STRICT=1)"
+            return 1
+        fi
+        log WARN "Skipping OCTOPUS_AGY_MODEL validation: agy CLI not installed; trusting pin '$model' (set OCTOPUS_AGY_MODEL_STRICT=1 to require validation)"
+        return 0
     fi
 
     local available_models=""
@@ -141,8 +154,12 @@ validate_agy_model_name() {
     if ! available_models="$(_octo_run_bare_probe_with_timeout \
         "$catalog_timeout" "$catalog_term_timeout" "$catalog_kill_grace" \
         agy models </dev/null 2>/dev/null)" || [[ -z "$available_models" ]]; then
-        log ERROR "Cannot validate OCTOPUS_AGY_MODEL because 'agy models' returned no models"
-        return 1
+        if [[ "$strict" == "1" ]]; then
+            log ERROR "Cannot validate OCTOPUS_AGY_MODEL because 'agy models' returned no models (OCTOPUS_AGY_MODEL_STRICT=1)"
+            return 1
+        fi
+        log WARN "Skipping OCTOPUS_AGY_MODEL validation: 'agy models' returned no catalog (offline or sandboxed); trusting pin '$model' (set OCTOPUS_AGY_MODEL_STRICT=1 to require validation)"
+        return 0
     fi
 
     local line="" catalog_id="" catalog_label=""

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -710,10 +710,15 @@ MOCK_AGY
     elapsed=$(( $(date +%s) - started ))
     PATH="$old_path"
 
-    if [[ "$lookup_rc" -ne 0 && "$elapsed" -lt 3 ]]; then
+    # The invariant under test is the BOUND: the stalled lookup must be killed by
+    # the 1s timeout and never reach the mock's 3s sleep. A stalled (unreachable)
+    # catalog is a "cannot validate" case, so it now fails OPEN (rc=0) — the pin is
+    # trusted and agy rejects a genuinely bad model at dispatch. (OCTOPUS_AGY_MODEL_STRICT=1
+    # would fail closed; the default path is asserted here.)
+    if [[ "$lookup_rc" -eq 0 && "$elapsed" -lt 3 ]]; then
         test_pass
     else
-        test_fail "stalled agy catalog was not bounded: rc=$lookup_rc elapsed=${elapsed}s"
+        test_fail "stalled agy catalog was not bounded or did not fail open: rc=$lookup_rc elapsed=${elapsed}s"
     fi
 }
 test_agy_command_validation() {

--- a/tests/unit/test-council-model-selection-fixes.sh
+++ b/tests/unit/test-council-model-selection-fixes.sh
@@ -63,6 +63,44 @@ else
     test_pass
 fi
 
+# ── "cannot validate" != "invalid" ─────────────────────────────────────────
+# A restricted sandbox (or an offline host) can make `agy models` return an
+# empty catalog. Treating that like a bad pin turned OCTOPUS_AGY_MODEL resolution
+# into a spawn-time abort even when the pin was valid. Validation must fail OPEN
+# when the catalog is unreachable (agy still rejects a genuinely bad model at
+# dispatch), and only fail closed under an explicit strict opt-in.
+STUB_EMPTY="$TEST_TMP_DIR/bin-empty"
+mkdir -p "$STUB_EMPTY"
+cat > "$STUB_EMPTY/agy" <<'MOCK_AGY_EMPTY'
+#!/usr/bin/env bash
+# Offline/sandboxed: `agy models` yields no catalog.
+[[ "${1:-}" == "models" ]] && exit 0
+exit 0
+MOCK_AGY_EMPTY
+chmod 755 "$STUB_EMPTY/agy"
+
+test_case "agy pin fails open when the catalog is unreachable (sandboxed/offline)"
+if printf 'payload' | env PATH="$STUB_EMPTY:$PATH" bash -c '
+    log() { :; }
+    source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+    validate_agy_model_name "Gemini 3.5 Flash (Low)"
+' 2>/dev/null; then
+    test_pass
+else
+    test_fail "unreachable catalog hard-failed validation instead of failing open"
+fi
+
+test_case "OCTOPUS_AGY_MODEL_STRICT=1 restores fail-closed on an unreachable catalog"
+if printf 'payload' | env PATH="$STUB_EMPTY:$PATH" OCTOPUS_AGY_MODEL_STRICT=1 bash -c '
+    log() { :; }
+    source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+    validate_agy_model_name "Gemini 3.5 Flash (Low)"
+' 2>/dev/null; then
+    test_fail "strict mode accepted a pin it could not validate"
+else
+    test_pass
+fi
+
 # ── council diversity short-circuit ────────────────────────────────────────
 pick_provider() {
     local roster_json="$1" preferred="$2"

--- a/tests/unit/test-council-model-selection-fixes.sh
+++ b/tests/unit/test-council-model-selection-fixes.sh
@@ -80,7 +80,7 @@ MOCK_AGY_EMPTY
 chmod 755 "$STUB_EMPTY/agy"
 
 test_case "agy pin fails open when the catalog is unreachable (sandboxed/offline)"
-if printf 'payload' | env PATH="$STUB_EMPTY:$PATH" bash -c '
+if printf 'payload' | env "PATH=$STUB_EMPTY:$PATH" bash -c '
     log() { :; }
     source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
     validate_agy_model_name "Gemini 3.5 Flash (Low)"
@@ -91,7 +91,7 @@ else
 fi
 
 test_case "OCTOPUS_AGY_MODEL_STRICT=1 restores fail-closed on an unreachable catalog"
-if printf 'payload' | env PATH="$STUB_EMPTY:$PATH" OCTOPUS_AGY_MODEL_STRICT=1 bash -c '
+if printf 'payload' | env "PATH=$STUB_EMPTY:$PATH" "OCTOPUS_AGY_MODEL_STRICT=1" bash -c '
     log() { :; }
     source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
     validate_agy_model_name "Gemini 3.5 Flash (Low)"


### PR DESCRIPTION
## Problem (from the latest council report, ask #5)

Under a restricted sandbox the runner crashed on spawn with **`Cannot validate OCTOPUS_AGY_MODEL`**. `validate_agy_model_name` conflates two very different situations:

- **Cannot validate** — the agy CLI is missing, or `agy models` returns an empty catalog (offline, or a sandbox blocked the call). We don't *know* whether the pin is valid.
- **Invalid** — the catalog is reachable and the model is definitively absent from it.

Both returned `1`, so an unreachable catalog aborted `OCTOPUS_AGY_MODEL` resolution (`model-resolver.sh:189-191` → `return 1`) and crashed the council even when the pin was perfectly valid.

## Fix

- **Fail open** on "cannot validate": warn and trust the pin. A genuinely bad model is still caught by agy itself at dispatch, with a clear error — far better than a preflight abort.
- **Keep fail-closed** for a model absent from a *reachable* catalog (unchanged, still prints the available list).
- `OCTOPUS_AGY_MODEL_STRICT=1` restores the old strict behavior for anyone who wants a hard preflight failure.

## Tests

- `agy pin fails open when the catalog is unreachable (sandboxed/offline)` — empty-catalog stub → validation returns 0.
- `OCTOPUS_AGY_MODEL_STRICT=1 restores fail-closed on an unreachable catalog` → returns 1.
- Existing `agy model pin still rejects unknown labels` (reachable catalog, absent model) stays fail-closed.
- Updated `agy model validation bounds a stalled catalog lookup`: still asserts the timeout **bound** (lookup killed at 1s, never reaches the mock's 3s sleep), now with fail-open rc — its old `rc≠0` encoded the pre-fix semantics.

`test-council-model-selection-fixes.sh`: **12 passed / 0 failed**. `test-agy-provider.sh`: **50 passed / 0 failed**. No file-mode changes.

## Report follow-ups

This is ask #5 (`OCTOPUS_AGY_MODEL` validation). Quorum (#1) → #922; synthesis/summary (#2) → #919; synthesis timeout (#5) → #920; codex 137 (#4/#6) → #921. Remaining new: background-dispatch pollable status (#3) — separate PR. The `mkstemp … Operation not permitted` is largely the agy child's own temp-file creation under sandbox (mitigated by the leading-token runner-invocation guidance from #790); our own `mktemp -t` already honors `$TMPDIR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AGY model validation now succeeds when the model catalog is unavailable or empty.
  * Models absent from a reachable catalog continue to be rejected.
  * Strict validation mode remains available to enforce fail-closed behavior.
  * Catalog lookups now remain time-bounded, including during timeouts.

* **Tests**
  * Added coverage for unavailable catalogs, timeout handling, and strict validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->