### PR TITLE
feat(council): pollable run-status beacon (stop silent-empty background runs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Council runs now write a `run-status.json` liveness beacon in the run
+  directory, so a backgrounded or detached run is pollable instead of
+  silent-empty. It records `state` (`running` at run-dir creation → `finished`
+  when `summary.json` is written) and the orchestrator `pid`, letting a caller
+  distinguish: no file → died before the run dir existed; `running` with a live
+  pid → in progress; `running` with a dead pid → crashed/killed mid-run;
+  `finished` → done (read `summary.json` for the result). Written atomically so a
+  poller never reads a half-written file.
+
 ## [9.64.0] - 2026-08-13
 
 ### Changed

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2611,18 +2611,28 @@ council_write_run_status() {
     # must never crash the run.
     local state="$1" status="${2:-}"
     [[ -n "${COUNCIL_RUN_DIR:-}" && -d "${COUNCIL_RUN_DIR}" ]] || return 0
+    # BASHPID is the *current* process; $$ stays the parent shell PID when a
+    # sourced caller runs council_run in a subshell or background job, so a
+    # poller's `kill -0` would watch the wrong process. Prefer BASHPID, fall back
+    # to $$ on bash 3.2 (macOS default) where BASHPID is unset.
+    local pid="${BASHPID:-$$}"
     local path="${COUNCIL_RUN_DIR}/run-status.json"
     local tmp="${COUNCIL_RUN_DIR}/run-status.json.tmp"
     if jq -n --arg state "$state" --arg status "$status" \
-            --arg run_id "${COUNCIL_RUN_ID:-}" --argjson pid "$$" \
+            --arg run_id "${COUNCIL_RUN_ID:-}" --argjson pid "$pid" \
             '{state:$state, pid:$pid, run_id:$run_id,
               status:(if $status == "" then null else $status end)}' \
             > "$tmp" 2>/dev/null && mv -f "$tmp" "$path" 2>/dev/null; then
         return 0
     fi
-    rm -f "$tmp" 2>/dev/null || true
-    # Fall back to a minimal valid beacon rather than leaving none.
-    printf '{"state":"%s","pid":%s}\n' "$state" "$$" > "$path" 2>/dev/null || true
+    # Fall back to a minimal valid beacon — still written atomically (tmp + mv) so
+    # a poller never reads a half-written file and a prior valid beacon is not
+    # clobbered by a partial direct write.
+    if printf '{"state":"%s","pid":%s}\n' "$state" "$pid" > "$tmp" 2>/dev/null; then
+        mv -f "$tmp" "$path" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+    else
+        rm -f "$tmp" 2>/dev/null || true
+    fi
     return 0
 }
 
@@ -2637,7 +2647,7 @@ council_create_run_dir() {
     local timestamp
     timestamp="$(date -u +%Y%m%d-%H%M%S)"
     local suffix
-    suffix="$(printf '%06x' "$$")"
+    suffix="$(printf '%06x' "${BASHPID:-$$}")"
     COUNCIL_RUN_ID="${timestamp}-${suffix}"
     COUNCIL_RUN_DIR="${parent}/${COUNCIL_RUN_ID}"
 
@@ -2648,12 +2658,23 @@ council_create_run_dir() {
         COUNCIL_RUN_DIR="${parent}/${COUNCIL_RUN_ID}"
     done
 
-    mkdir -p "$COUNCIL_RUN_DIR/responses" "$COUNCIL_RUN_DIR/critiques" "$COUNCIL_RUN_DIR/revisions" || return 1
-
-    # Beacon "running" the moment the run dir exists, so a backgrounded run is
-    # pollable (and a crash-on-spawn is distinguishable from work-in-progress)
-    # long before summary.json is produced.
+    # Publish the run directory atomically WITH its "running" beacon: build the
+    # artifact subdirs and write the beacon under a temporary staging dir in the
+    # SAME parent (so the rename is atomic on one filesystem), then rename it into
+    # place. This guarantees the invariant a poller relies on — a visible run
+    # directory always contains run-status.json — even if the process is killed
+    # mid-setup (the half-built staging dir is never named as the run dir).
+    local staging="${parent}/.staging-${COUNCIL_RUN_ID}.${BASHPID:-$$}"
+    rm -rf "$staging" 2>/dev/null
+    mkdir -p "$staging/responses" "$staging/critiques" "$staging/revisions" || { rm -rf "$staging" 2>/dev/null; return 1; }
+    local _final="$COUNCIL_RUN_DIR"
+    COUNCIL_RUN_DIR="$staging"
     council_write_run_status "running"
+    COUNCIL_RUN_DIR="$_final"
+    if ! mv "$staging" "$COUNCIL_RUN_DIR" 2>/dev/null; then
+        rm -rf "$staging" 2>/dev/null
+        return 1
+    fi
 }
 
 council_write_summary_json() {
@@ -2798,7 +2819,13 @@ council_write_summary_json() {
             handoff: $handoff
           },
           fixture: (if $fixture == "" then null else $fixture end)
-        }' > "$summary_path"
+        }' > "$summary_path" || {
+        # A failed serialization can leave an empty/partial summary.json. Remove it
+        # and fail so the caller's `|| return 1` fires (and #919's safety net writes
+        # a valid fallback) — never mark the run "finished" over a broken summary.
+        rm -f "$summary_path" 2>/dev/null || true
+        return 1
+    }
 
     # summary.json is the terminal artifact for every intended exit
     # (dry-run/partial/aborted/completed) and the incomplete-recovery fallback,

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2598,6 +2598,34 @@ council_parse_args() {
     council_detect_providers || return $?
 }
 
+council_write_run_status() {
+    # Machine-detectable liveness beacon for a (possibly backgrounded) council
+    # run, so a caller polling the run dir can tell these apart instead of seeing
+    # a silent-empty result:
+    #   - no run dir / no run-status.json    -> died before the run dir existed
+    #   - state "running" AND `kill -0 pid`  -> still running
+    #   - state "running" AND pid gone       -> crashed/killed mid-run
+    #   - state "finished"                   -> done; read summary.json for result
+    # summary.json stays the authoritative RESULT; this is only the liveness/pid
+    # signal, written atomically so a poller never reads a half-written file. It
+    # must never crash the run.
+    local state="$1" status="${2:-}"
+    [[ -n "${COUNCIL_RUN_DIR:-}" && -d "${COUNCIL_RUN_DIR}" ]] || return 0
+    local path="${COUNCIL_RUN_DIR}/run-status.json"
+    local tmp="${COUNCIL_RUN_DIR}/run-status.json.tmp"
+    if jq -n --arg state "$state" --arg status "$status" \
+            --arg run_id "${COUNCIL_RUN_ID:-}" --argjson pid "$$" \
+            '{state:$state, pid:$pid, run_id:$run_id,
+              status:(if $status == "" then null else $status end)}' \
+            > "$tmp" 2>/dev/null && mv -f "$tmp" "$path" 2>/dev/null; then
+        return 0
+    fi
+    rm -f "$tmp" 2>/dev/null || true
+    # Fall back to a minimal valid beacon rather than leaving none.
+    printf '{"state":"%s","pid":%s}\n' "$state" "$$" > "$path" 2>/dev/null || true
+    return 0
+}
+
 council_create_run_dir() {
     local parent="$COUNCIL_OUTPUT_DIR"
     if [[ -z "$parent" ]]; then
@@ -2621,6 +2649,11 @@ council_create_run_dir() {
     done
 
     mkdir -p "$COUNCIL_RUN_DIR/responses" "$COUNCIL_RUN_DIR/critiques" "$COUNCIL_RUN_DIR/revisions" || return 1
+
+    # Beacon "running" the moment the run dir exists, so a backgrounded run is
+    # pollable (and a crash-on-spawn is distinguishable from work-in-progress)
+    # long before summary.json is produced.
+    council_write_run_status "running"
 }
 
 council_write_summary_json() {
@@ -2766,6 +2799,11 @@ council_write_summary_json() {
           },
           fixture: (if $fixture == "" then null else $fixture end)
         }' > "$summary_path"
+
+    # summary.json is the terminal artifact for every intended exit
+    # (dry-run/partial/aborted/completed) and the incomplete-recovery fallback,
+    # so flip the liveness beacon to "finished" here — one hook covers them all.
+    council_write_run_status "finished" "$status"
 }
 
 council_print_run_warnings() {

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1360,31 +1360,50 @@ test_council_run_status_beacon_lifecycle() {
     test_case "council writes a run-status.json beacon: running at run-dir creation, finished at summary"
     load_council_lib || return 1
 
-    # Unit: create_run_dir beacons "running" with this process's pid, before any
+    # Unit: create_run_dir beacons "running" (with run_id + a live pid) BEFORE any
     # summary.json exists — the signal a poller uses to tell in-progress from
-    # died-on-spawn.
+    # died-on-spawn. Surface a setup failure rather than masking it with `|| true`.
     local tmp; tmp="$(mktemp -d "$TEST_TMP_DIR/council-runstatus.XXXXXX")"
-    COUNCIL_OUTPUT_DIR="$tmp" council_create_run_dir >/dev/null 2>&1 || true
-    local rs="${COUNCIL_RUN_DIR}/run-status.json"
-    local state_running pid_running
+    if ! COUNCIL_OUTPUT_DIR="$tmp" council_create_run_dir >/dev/null 2>&1; then
+        test_fail "council_create_run_dir failed"; return 1
+    fi
+    local rs="${COUNCIL_RUN_DIR}/run-status.json" run_id_running="$COUNCIL_RUN_ID"
+    local state_running pid_running rid_running had_summary=no
     state_running="$(jq -r '.state' "$rs" 2>/dev/null)"
     pid_running="$(jq -r '.pid' "$rs" 2>/dev/null)"
+    rid_running="$(jq -r '.run_id' "$rs" 2>/dev/null)"
+    [[ -e "${COUNCIL_RUN_DIR}/summary.json" ]] && had_summary=yes
+
+    # #1: a beacon written from a subshell must record the writing process's own
+    # pid (BASHPID), not the parent shell — otherwise a poller watches the wrong
+    # process. Capture the writer's pid and the recorded pid in the SAME subshell
+    # (comparing across two subshells would compare two different pids). On bash
+    # 3.2 (BASHPID unset) both resolve to $$, so this holds on every bash.
+    local sub_result sub_expect sub_pid
+    sub_result="$( ( council_write_run_status "running" >/dev/null 2>&1
+                     printf '%s|%s' "${BASHPID:-$$}" "$(jq -r '.pid' "$rs" 2>/dev/null)" ) )"
+    sub_expect="${sub_result%%|*}"
+    sub_pid="${sub_result##*|}"
 
     # Integration: a real dry-run flips the beacon to "finished" with the terminal
     # status, through council_write_summary_json (one hook covers every exit).
     local tmp2; tmp2="$(mktemp -d "$TEST_TMP_DIR/council-runstatus2.XXXXXX")"
-    council_run --dry-run --goal advice --depth quick --benchmark auto \
-        --output-dir "$tmp2" "Should we cache?" >/dev/null 2>&1 || true
+    if ! council_run --dry-run --goal advice --depth quick --benchmark auto \
+        --output-dir "$tmp2" "Should we cache?" >/dev/null 2>&1; then
+        test_fail "council_run --dry-run failed"; return 1
+    fi
     local rs2 state_finished status_finished
     rs2="$(find "$tmp2" -name run-status.json -type f | head -1)"
     state_finished="$(jq -r '.state' "$rs2" 2>/dev/null)"
     status_finished="$(jq -r '.status' "$rs2" 2>/dev/null)"
 
-    if [[ "$state_running" == "running" && "$pid_running" == "$$" \
+    if [[ "$state_running" == "running" && "$pid_running" =~ ^[1-9][0-9]*$ \
+          && "$rid_running" == "$run_id_running" && "$had_summary" == "no" \
+          && "$sub_pid" == "$sub_expect" \
           && "$state_finished" == "finished" && "$status_finished" == "dry-run" ]]; then
         test_pass
     else
-        test_fail "beacon lifecycle wrong: running(state=$state_running pid=$pid_running/$$) finished(state=$state_finished status=$status_finished)"
+        test_fail "beacon lifecycle wrong: running(state=$state_running pid=$pid_running run_id=$rid_running/$run_id_running summary=$had_summary subpid=$sub_pid/$sub_expect) finished(state=$state_finished status=$status_finished)"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1360,6 +1360,9 @@ test_council_run_status_beacon_lifecycle() {
     test_case "council writes a run-status.json beacon: running at run-dir creation, finished at summary"
     load_council_lib || return 1
 
+    # create_run_dir runs in THIS process, so the staged beacon must record this
+    # shell's own pid — assert the exact value, not merely a positive integer.
+    local expected_pid_running="${BASHPID:-$$}"
     # Unit: create_run_dir beacons "running" (with run_id + a live pid) BEFORE any
     # summary.json exists — the signal a poller uses to tell in-progress from
     # died-on-spawn. Surface a setup failure rather than masking it with `|| true`.
@@ -1397,7 +1400,7 @@ test_council_run_status_beacon_lifecycle() {
     state_finished="$(jq -r '.state' "$rs2" 2>/dev/null)"
     status_finished="$(jq -r '.status' "$rs2" 2>/dev/null)"
 
-    if [[ "$state_running" == "running" && "$pid_running" =~ ^[1-9][0-9]*$ \
+    if [[ "$state_running" == "running" && "$pid_running" == "$expected_pid_running" \
           && "$rid_running" == "$run_id_running" && "$had_summary" == "no" \
           && "$sub_pid" == "$sub_expect" \
           && "$state_finished" == "finished" && "$status_finished" == "dry-run" ]]; then

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1356,8 +1356,42 @@ test_council_dispatch_strips_blocked_env_but_sets_disposable_mode() {
     fi
 }
 
+test_council_run_status_beacon_lifecycle() {
+    test_case "council writes a run-status.json beacon: running at run-dir creation, finished at summary"
+    load_council_lib || return 1
+
+    # Unit: create_run_dir beacons "running" with this process's pid, before any
+    # summary.json exists — the signal a poller uses to tell in-progress from
+    # died-on-spawn.
+    local tmp; tmp="$(mktemp -d "$TEST_TMP_DIR/council-runstatus.XXXXXX")"
+    COUNCIL_OUTPUT_DIR="$tmp" council_create_run_dir >/dev/null 2>&1 || true
+    local rs="${COUNCIL_RUN_DIR}/run-status.json"
+    local state_running pid_running
+    state_running="$(jq -r '.state' "$rs" 2>/dev/null)"
+    pid_running="$(jq -r '.pid' "$rs" 2>/dev/null)"
+
+    # Integration: a real dry-run flips the beacon to "finished" with the terminal
+    # status, through council_write_summary_json (one hook covers every exit).
+    local tmp2; tmp2="$(mktemp -d "$TEST_TMP_DIR/council-runstatus2.XXXXXX")"
+    council_run --dry-run --goal advice --depth quick --benchmark auto \
+        --output-dir "$tmp2" "Should we cache?" >/dev/null 2>&1 || true
+    local rs2 state_finished status_finished
+    rs2="$(find "$tmp2" -name run-status.json -type f | head -1)"
+    state_finished="$(jq -r '.state' "$rs2" 2>/dev/null)"
+    status_finished="$(jq -r '.status' "$rs2" 2>/dev/null)"
+
+    if [[ "$state_running" == "running" && "$pid_running" == "$$" \
+          && "$state_finished" == "finished" && "$status_finished" == "dry-run" ]]; then
+        test_pass
+    else
+        test_fail "beacon lifecycle wrong: running(state=$state_running pid=$pid_running/$$) finished(state=$state_finished status=$status_finished)"
+        return 1
+    fi
+}
+
 test_council_command_files_are_registered
 test_council_orchestrate_route_exists
+test_council_run_status_beacon_lifecycle
 test_council_benchmark_routing_lib_is_extracted
 test_council_defaults_are_depth_aware
 test_council_rejects_non_usd_budget


### PR DESCRIPTION
## Problem (council report, ask #3)

A backgrounded or detached council run — plain `&`, `nohup … & disown`, sandbox-disabled background — returns empty immediately with no error, so a caller can't tell **"still running"** from **"died on spawn."** The report asks for a machine-detectable, pollable status, never silent-empty.

## Change

Write a `run-status.json` liveness beacon in the run dir:

- `state: "running"` (+ orchestrator `pid`, `run_id`) the moment the run dir exists (`council_create_run_dir`).
- `state: "finished"` (+ terminal `status`) when `summary.json` is written — a single hook in `council_write_summary_json` covers every exit (dry-run / partial / aborted / completed, and the incomplete-recovery fallback).

**Poller semantics:**

| Observation | Meaning |
|---|---|
| no run dir / no `run-status.json` | died before the run dir existed |
| `state:"running"` + `kill -0 pid` ok | in progress |
| `state:"running"` + pid gone | crashed/killed mid-run |
| `state:"finished"` | done — read `summary.json` for the result |

`summary.json` stays the authoritative **result**; this is only the liveness/pid signal. Written atomically (`tmp` + `mv`) so a poller never reads a half-written file, and it can never crash the run (falls back to a minimal valid beacon on jq failure).

Composes with #919 (always-emit `summary.json`): #919's fallback also calls `council_write_summary_json`, so the beacon flips to `finished` there too.

## Tests

`council_run_status_beacon_lifecycle` — asserts the beacon is `running` with this process's pid at `create_run_dir`, then `finished` with status `dry-run` after a real dry-run (exercises both hooks through the live path).

`tests/unit/test-council-command.sh`: **74 passed, 0 failed, 1 skipped** (pre-existing macOS-CI pty flake). No file-mode changes.

## Report status

This is ask #3 (pollable background status), the last new item. Full map: quorum (#1) → #922; synthesis/summary (#2) → #919; synthesis timeout (#5-synthesis) → #920; codex 137 (#4/#6) → #921; `OCTOPUS_AGY_MODEL` validation (#5-config) → #923. The `mkstemp … Operation not permitted` piece is largely the agy child's own temp-file creation under sandbox (mitigated by #790's leading-token invocation guidance); our own `mktemp -t` already honors `$TMPDIR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added run-liveness status reporting to show whether a run is active, completed, or interrupted.
  * Run status now includes the process identifier and final outcome.
  * Atomic status updates improve reliability for monitoring and polling tools.
  * Incomplete runs can be distinguished from missing run records.

* **Tests**
  * Added coverage for active and completed run states, process tracking, and final status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->