### PR TITLE
fix: continue tangle corrections after partial review

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -3478,8 +3478,12 @@ tangle_contextual_review_gate() {
         current_signature=$(tangle_findings_signature "$findings_file")
 
         if [[ "$review_rc" -ne 0 ]]; then
-            log WARN "Contextual code review returned non-zero after correction round ${correction_round}; not treating review warning/no-diff as improvement"
-            return "$review_rc"
+            if [[ "${normal_count:-0}" -gt 0 ]]; then
+                log WARN "Contextual code review returned non-zero after correction round ${correction_round}, but ${normal_count} actionable blocking finding(s) remain; continuing correction loop"
+            else
+                log WARN "Contextual code review returned non-zero after correction round ${correction_round} with no actionable blockers"
+                return "$review_rc"
+            fi
         fi
 
         if [[ "${normal_count:-0}" -lt "${previous_normal_count:-0}" ]]; then

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -51,7 +51,7 @@ assert_contains "$WORKFLOWS" 'run_agent_sync "$correction_agent" "$correction_pr
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CODE_REVIEW" "code review gate is toggleable"
 assert_contains "$WORKFLOWS" "Contextual code review warning" "review warnings are blocking"
 assert_contains "$WORKFLOWS" "No changes found to review" "legacy no-diff message is detected"
-assert_contains "$WORKFLOWS" "not treating review warning/no-diff as improvement" "no-diff review is blocking"
+assert_contains "$WORKFLOWS" "with no actionable blockers" "non-zero review without actionable blockers is blocking"
 assert_contains "$WORKFLOWS" "Skipping ink/deliver because tangle validation gate returned non-zero" "ink is skipped when validation fails"
 assert_contains "$HELP" "Contextual code review" "develop help documents contextual review"
 assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE" "develop help documents bounded mode"

--- a/tests/unit/test-tangle-correction-loop-behavior.sh
+++ b/tests/unit/test-tangle-correction-loop-behavior.sh
@@ -33,17 +33,24 @@ run_gate() {
         octopus_agent_override() { echo "codex"; }
 
         COUNTS=($1)
+        REVIEW_RCS=(${REVIEW_RC_SEQUENCE:-})
         IDX_FILE="$RESULTS_DIR/count-idx"
+        REVIEW_IDX_FILE="$RESULTS_DIR/review-idx"
         echo 0 > "$IDX_FILE"
+        echo 0 > "$REVIEW_IDX_FILE"
         CORRECTION_CALLS=0
 
         source "$2/scripts/lib/workflows.sh" 2>/dev/null
 
         tangle_build_develop_review_context() { echo "$RESULTS_DIR/ctx-$7.md"; }
         tangle_run_context_code_review() {
+            local ridx rc
             TANGLE_REVIEW_FINDINGS_FILE="$RESULTS_DIR/findings-$3.json"
             echo "{\"findings\":[]}" > "$TANGLE_REVIEW_FINDINGS_FILE"
-            return 0
+            ridx=$(cat "$REVIEW_IDX_FILE")
+            rc="${REVIEW_RCS[$ridx]:-0}"
+            echo $((ridx + 1)) > "$REVIEW_IDX_FILE"
+            return "$rc"
         }
         # Stub state lives in a file: these stubs run inside command
         # substitutions, so in-shell variable increments would be lost.
@@ -91,6 +98,22 @@ if [[ "$out" == "rounds=3 rc=0" ]]; then
     test_pass
 else
     test_fail "expected rounds=3 rc=0, got '$out'"
+fi
+
+test_case "partial review warning with actionable blockers continues correction loop"
+out=$(REVIEW_RC_SEQUENCE="0 1 0" run_gate "2 1 0")
+if [[ "$out" == "rounds=2 rc=0" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=2 rc=0, got '$out'"
+fi
+
+test_case "partial review warning with zero blockers remains fatal"
+out=$(REVIEW_RC_SEQUENCE="0 1" run_gate "1 0")
+if [[ "$out" == "rounds=1 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=1 rc=1, got '$out'"
 fi
 
 test_case "static blockers trip convergence guard (default 3 no-progress rounds)"


### PR DESCRIPTION
## Summary

Keep the Tangle contextual-review correction loop running when a post-correction review is partial/non-zero but still produced actionable blocking findings.

Previously, any non-zero review result after a correction round aborted the entire loop immediately, even when the findings file contained blockers that the next correction round could fix. That defeats the progressive recovery loop.

## Behavior

- non-zero review + actionable blockers: log the warning and continue correcting
- non-zero review + zero actionable blockers: remain fail-closed
- existing convergence, bounded-mode, stall, and hard-cap guards are unchanged

## Regression coverage

Adds behavioral coverage for:

- `2 blockers / rc=0 -> 1 blocker / rc=1 -> 0 blockers / rc=0` => 2 correction rounds, success
- non-zero review with zero blockers remains fatal

## Validation

- `tests/unit/test-tangle-correction-loop-behavior.sh` — 9/9 pass
- `tests/unit/test-tangle-failed-validation-review-recovery.sh` — 5/5 pass
- `tests/unit/test-tangle-context-review-loop.sh` — 54/54 pass
- `tests/unit/test-tangle-retry-quality-accounting.sh` — 2/2 pass
- `bash -n` on touched workflow/tests — pass
- `git diff --check` — pass
