### PR TITLE
fix(council): land timeout, agy fail-open, and run-status follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+### Added
+
+- `OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT` bounds the chair-synthesis dispatch
+  independently of the per-seat cap. Synthesis reads every member artifact and
+  writes the final structured document, so it routinely needs more room than a
+  single advice seat — and on a slow chair path (e.g. codex via the
+  chatgpt.com MCP transport) the plain seat cap can expire mid-write. When the
+  override is unset, zero, negative, or non-numeric, synthesis falls back through
+  the chair provider's normal per-seat resolution
+  (`OCTOPUS_COUNCIL_TIMEOUT_<PROVIDER>` → `--seat-timeout` → legacy
+  `OCTOPUS_COUNCIL_AGENT_TIMEOUT` → built-in default), so a malformed value never
+  disables the cap.
+- Council runs now write a `run-status.json` liveness beacon in the run
+  directory, so a backgrounded or detached run is pollable instead of
+  silent-empty. It records `state` (`running` at run-dir creation → `finished`
+  when `summary.json` is written) and the orchestrator `pid`, letting a caller
+  distinguish: no file → died before the run dir existed; `running` with a live
+  pid → in progress; `running` with a dead pid → crashed/killed mid-run;
+  `finished` → done (read `summary.json` for the result). Written atomically so a
+  poller never reads a half-written file.
+
 ### Fixed
 
 - `orchestrate.sh council` now always emits a valid `summary.json`. The runner
@@ -15,6 +36,21 @@
   summary — falling back to a minimal valid `{"status":"incomplete"}` if the rich
   writer also fails — prints the partial-artifact location, and returns nonzero,
   so "runner unhealthy" is a clean signal, never an unbounded wait.
+- `OCTOPUS_AGY_MODEL` validation no longer aborts a run when the agy catalog is
+  unreachable. A restricted sandbox or an offline host makes `agy models` return
+  an empty catalog; the validator treated that "cannot validate" case like a
+  definitively invalid pin and failed model resolution, crashing the council on
+  spawn even when the pin was valid. Validation now fails **open** when the
+  catalog is unreachable (agy still rejects a genuinely bad model at dispatch,
+  with a clear error) and only fails **closed** for a model that is absent from a
+  *reachable* catalog. Set `OCTOPUS_AGY_MODEL_STRICT=1` to require validation and
+  restore the previous fail-closed behavior.
+- Council advice seats killed by their own timeout monitor are now recorded as
+  `timed-out` in `summary.json` instead of a generic `no-response`, and the run
+  prints an actionable warning naming the exact knob to raise
+  (`OCTOPUS_COUNCIL_TIMEOUT_<PROVIDER>`). A codex seat SIGKILLed at the ~5-min cap
+  (exit 137) on the slow chatgpt.com MCP path previously read like an unexplained
+  OOM; it is our own watchdog firing, and the summary/warning now say so.
 
 ## [9.64.0] - 2026-08-13
 

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -53,6 +53,7 @@ COUNCIL_IMPLEMENTATION_HANDOFF_JSON=""
 COUNCIL_ABORTED_FOR_COST=""
 COUNCIL_DIVERSITY_REPLACED=""
 COUNCIL_DIVERSITY_WARNING=""
+COUNCIL_TIMEOUT_WARNINGS=""
 COUNCIL_BENCHMARK_FRESHNESS_WEIGHT=""
 COUNCIL_COST_CHECK_ESTIMATED=""
 COUNCIL_VETO_TRIGGERED=""
@@ -1505,8 +1506,15 @@ EOF
     fi
 
     if declare -f run_agent_sync_consultative >/dev/null 2>&1; then
-        local agent_type="$provider"
-        run_agent_sync_consultative "$agent_type" "$prompt" "$(council_seat_timeout "$agent_type")" "$persona" "council"
+        local agent_type="$provider" _seat_timeout
+        # Synthesis gets its own (usually larger) bound; advice/critique/revision
+        # keep the normal per-seat cap.
+        if [[ "$dispatch_phase" == "chair-synthesis" ]]; then
+            _seat_timeout="$(council_synthesis_timeout "$agent_type")"
+        else
+            _seat_timeout="$(council_seat_timeout "$agent_type")"
+        fi
+        run_agent_sync_consultative "$agent_type" "$prompt" "$_seat_timeout" "$persona" "council"
         return $?
     fi
 
@@ -1831,6 +1839,20 @@ council_seat_timeout() {
     printf '120'
 }
 
+council_synthesis_timeout() {
+    # Chair-synthesis dispatch timeout (seconds). Synthesis reads every member
+    # artifact and writes the final structured document, so it routinely needs
+    # more room than a single advice seat — and on a slow chair path (e.g. codex
+    # via the chatgpt.com MCP transport) the plain seat cap can expire mid-write.
+    # OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT overrides just this phase; otherwise fall
+    # back to the chair provider's normal per-seat resolution so existing tuning
+    # (OCTOPUS_COUNCIL_TIMEOUT_<PROVIDER>, --seat-timeout, ...) still applies.
+    local provider="$1" candidate
+    candidate="${OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT:-}"
+    if [[ "$candidate" =~ ^[1-9][0-9]*$ ]]; then printf '%s' "$candidate"; return 0; fi
+    council_seat_timeout "$provider"
+}
+
 council_compute_approving_providers() {
     # Derive the APPROVING vendor set from the space-separated RESPONDING
     # (substantive responders) and DISSENTING (any seat whose verdict != APPROVE)
@@ -1848,11 +1870,35 @@ council_compute_approving_providers() {
     printf '%s' "$approving"
 }
 
+council_rc_is_timeout() {
+    # True when a seat's dispatch rc came from hitting its own timeout cap rather
+    # than a provider-level error. run_with_timeout kills an over-cap seat with the
+    # coreutils convention (124) or, on the macOS bash fallback, SIGTERM then SIGKILL
+    # — so the seat process exits 143 (128+15) or 137 (128+9). Distinguishing these
+    # keeps a codex seat killed at the ~5-min cap from reading as a mysterious
+    # SIGKILL/OOM: it is our own watchdog firing, and the remedy is a larger cap.
+    case "${1:-}" in
+        124|137|143) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+council_note_seat_timeout() {
+    # Accumulate an actionable end-of-run warning for a seat that hit its cap,
+    # naming the exact env knob that would give that provider more time.
+    local provider="$1" persona="$2" rc="$3" cap="$4" knob line
+    knob="OCTOPUS_COUNCIL_TIMEOUT_$(printf '%s' "$provider" | tr '[:lower:]-' '[:upper:]_')"
+    line="seat ${provider} (${persona}) exceeded its ${cap}s cap (rc=${rc}) — raise ${knob} to give it more time"
+    COUNCIL_TIMEOUT_WARNINGS="${COUNCIL_TIMEOUT_WARNINGS:+${COUNCIL_TIMEOUT_WARNINGS}
+}${line}"
+}
+
 council_run_advice_phase() {
     COUNCIL_RESPONSES_RECEIVED="0"
     COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
     COUNCIL_RESPONDING_PROVIDERS=""
     COUNCIL_SEAT_RECORDS_JSON="[]"
+    COUNCIL_TIMEOUT_WARNINGS=""
     local dissenting_providers=""
 
     local index=0 member persona slug output_path seat mprovider verdict
@@ -1919,6 +1965,16 @@ council_run_advice_phase() {
             else
                 seat_status="no-response"
             fi
+        fi
+        # A seat killed by its own timeout monitor (run_with_timeout: 124, or the
+        # macOS SIGTERM->SIGKILL fallback: 143/137) that left no usable response is a
+        # timeout, not a generic provider shortage. Classify it distinctly so
+        # summary.json and the end-of-run warnings say "hit the cap, raise the knob"
+        # instead of surfacing a bare exit 137 that reads like an OOM. (The salvage
+        # path above already keeps a timed-out-but-complete review as "responded".)
+        if [[ "$seat_status" == "no-response" ]] && council_rc_is_timeout "$dispatch_rc"; then
+            seat_status="timed-out"
+            council_note_seat_timeout "$mprovider" "$persona" "$dispatch_rc" "$(council_seat_timeout "$mprovider")"
         fi
         # Per-seat record for summary.json — makes quorum integrity machine-checkable
         # (a chair or degenerate seat can no longer masquerade as a distinct approving
@@ -2598,6 +2654,44 @@ council_parse_args() {
     council_detect_providers || return $?
 }
 
+council_write_run_status() {
+    # Machine-detectable liveness beacon for a (possibly backgrounded) council
+    # run, so a caller polling the run dir can tell these apart instead of seeing
+    # a silent-empty result:
+    #   - no run dir / no run-status.json    -> died before the run dir existed
+    #   - state "running" AND `kill -0 pid`  -> still running
+    #   - state "running" AND pid gone       -> crashed/killed mid-run
+    #   - state "finished"                   -> done; read summary.json for result
+    # summary.json stays the authoritative RESULT; this is only the liveness/pid
+    # signal, written atomically so a poller never reads a half-written file. It
+    # must never crash the run.
+    local state="$1" status="${2:-}"
+    [[ -n "${COUNCIL_RUN_DIR:-}" && -d "${COUNCIL_RUN_DIR}" ]] || return 0
+    # BASHPID is the *current* process; $$ stays the parent shell PID when a
+    # sourced caller runs council_run in a subshell or background job, so a
+    # poller's `kill -0` would watch the wrong process. Prefer BASHPID, fall back
+    # to $$ on bash 3.2 (macOS default) where BASHPID is unset.
+    local pid="${BASHPID:-$$}"
+    local path="${COUNCIL_RUN_DIR}/run-status.json"
+    local tmp="${COUNCIL_RUN_DIR}/run-status.json.tmp"
+    if jq -n --arg state "$state" --arg status "$status" \
+            --arg run_id "${COUNCIL_RUN_ID:-}" --argjson pid "$pid" \
+            '{state:$state, pid:$pid, run_id:$run_id,
+              status:(if $status == "" then null else $status end)}' \
+            > "$tmp" 2>/dev/null && mv -f "$tmp" "$path" 2>/dev/null; then
+        return 0
+    fi
+    # Fall back to a minimal valid beacon — still written atomically (tmp + mv) so
+    # a poller never reads a half-written file and a prior valid beacon is not
+    # clobbered by a partial direct write.
+    if printf '{"state":"%s","pid":%s}\n' "$state" "$pid" > "$tmp" 2>/dev/null; then
+        mv -f "$tmp" "$path" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+    else
+        rm -f "$tmp" 2>/dev/null || true
+    fi
+    return 0
+}
+
 council_create_run_dir() {
     local parent="$COUNCIL_OUTPUT_DIR"
     if [[ -z "$parent" ]]; then
@@ -2609,7 +2703,7 @@ council_create_run_dir() {
     local timestamp
     timestamp="$(date -u +%Y%m%d-%H%M%S)"
     local suffix
-    suffix="$(printf '%06x' "$$")"
+    suffix="$(printf '%06x' "${BASHPID:-$$}")"
     COUNCIL_RUN_ID="${timestamp}-${suffix}"
     COUNCIL_RUN_DIR="${parent}/${COUNCIL_RUN_ID}"
 
@@ -2620,7 +2714,23 @@ council_create_run_dir() {
         COUNCIL_RUN_DIR="${parent}/${COUNCIL_RUN_ID}"
     done
 
-    mkdir -p "$COUNCIL_RUN_DIR/responses" "$COUNCIL_RUN_DIR/critiques" "$COUNCIL_RUN_DIR/revisions" || return 1
+    # Publish the run directory atomically WITH its "running" beacon: build the
+    # artifact subdirs and write the beacon under a temporary staging dir in the
+    # SAME parent (so the rename is atomic on one filesystem), then rename it into
+    # place. This guarantees the invariant a poller relies on — a visible run
+    # directory always contains run-status.json — even if the process is killed
+    # mid-setup (the half-built staging dir is never named as the run dir).
+    local staging="${parent}/.staging-${COUNCIL_RUN_ID}.${BASHPID:-$$}"
+    rm -rf "$staging" 2>/dev/null
+    mkdir -p "$staging/responses" "$staging/critiques" "$staging/revisions" || { rm -rf "$staging" 2>/dev/null; return 1; }
+    local _final="$COUNCIL_RUN_DIR"
+    COUNCIL_RUN_DIR="$staging"
+    council_write_run_status "running"
+    COUNCIL_RUN_DIR="$_final"
+    if ! mv "$staging" "$COUNCIL_RUN_DIR" 2>/dev/null; then
+        rm -rf "$staging" 2>/dev/null
+        return 1
+    fi
 }
 
 council_write_summary_json() {
@@ -2765,7 +2875,18 @@ council_write_summary_json() {
             handoff: $handoff
           },
           fixture: (if $fixture == "" then null else $fixture end)
-        }' > "$summary_path"
+        }' > "$summary_path" || {
+        # A failed serialization can leave an empty/partial summary.json. Remove it
+        # and fail so the caller's `|| return 1` fires (and #919's safety net writes
+        # a valid fallback) — never mark the run "finished" over a broken summary.
+        rm -f "$summary_path" 2>/dev/null || true
+        return 1
+    }
+
+    # summary.json is the terminal artifact for every intended exit
+    # (dry-run/partial/aborted/completed) and the incomplete-recovery fallback,
+    # so flip the liveness beacon to "finished" here — one hook covers them all.
+    council_write_run_status "finished" "$status"
 }
 
 council_print_run_warnings() {
@@ -2779,6 +2900,13 @@ council_print_run_warnings() {
 
     if [[ "$COUNCIL_CHAIR_FALLBACK_USED" == "true" ]]; then
         echo "Council warning: chair fallback used (${COUNCIL_CHAIR_FALLBACK_PERSONA})."
+    fi
+
+    if [[ -n "${COUNCIL_TIMEOUT_WARNINGS:-}" ]]; then
+        local _tw
+        while IFS= read -r _tw; do
+            [[ -n "$_tw" ]] && echo "Council warning: $_tw"
+        done <<< "$COUNCIL_TIMEOUT_WARNINGS"
     fi
 }
 

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -124,9 +124,22 @@ validate_agy_model_name() {
             ;;
     esac
 
+    # "Cannot validate" (catalog unreachable) is NOT the same as "invalid" (a
+    # model definitively absent from a reachable catalog). Treating them alike
+    # turned a transient/sandboxed `agy models` failure into a spawn-time abort:
+    # OCTOPUS_AGY_MODEL resolution returned 1 and the whole council crashed even
+    # when the pin was perfectly valid. Fail OPEN when the catalog can't be read —
+    # a genuinely bad pin is still caught by agy itself at dispatch, with a clear
+    # error — and keep the strict fail-closed path behind an explicit opt-in.
+    local strict="${OCTOPUS_AGY_MODEL_STRICT:-0}"
+
     if ! command -v agy >/dev/null 2>&1; then
-        log ERROR "Cannot validate OCTOPUS_AGY_MODEL because agy CLI is not installed"
-        return 1
+        if [[ "$strict" == "1" ]]; then
+            log ERROR "Cannot validate OCTOPUS_AGY_MODEL because agy CLI is not installed (OCTOPUS_AGY_MODEL_STRICT=1)"
+            return 1
+        fi
+        log WARN "Skipping OCTOPUS_AGY_MODEL validation: agy CLI not installed; trusting pin '$model' (set OCTOPUS_AGY_MODEL_STRICT=1 to require validation)"
+        return 0
     fi
 
     local available_models=""
@@ -141,8 +154,12 @@ validate_agy_model_name() {
     if ! available_models="$(_octo_run_bare_probe_with_timeout \
         "$catalog_timeout" "$catalog_term_timeout" "$catalog_kill_grace" \
         agy models </dev/null 2>/dev/null)" || [[ -z "$available_models" ]]; then
-        log ERROR "Cannot validate OCTOPUS_AGY_MODEL because 'agy models' returned no models"
-        return 1
+        if [[ "$strict" == "1" ]]; then
+            log ERROR "Cannot validate OCTOPUS_AGY_MODEL because 'agy models' returned no models (OCTOPUS_AGY_MODEL_STRICT=1)"
+            return 1
+        fi
+        log WARN "Skipping OCTOPUS_AGY_MODEL validation: 'agy models' returned no catalog (offline or sandboxed); trusting pin '$model' (set OCTOPUS_AGY_MODEL_STRICT=1 to require validation)"
+        return 0
     fi
 
     local line="" catalog_id="" catalog_label=""

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -710,10 +710,15 @@ MOCK_AGY
     elapsed=$(( $(date +%s) - started ))
     PATH="$old_path"
 
-    if [[ "$lookup_rc" -ne 0 && "$elapsed" -lt 3 ]]; then
+    # The invariant under test is the BOUND: the stalled lookup must be killed by
+    # the 1s timeout and never reach the mock's 3s sleep. A stalled (unreachable)
+    # catalog is a "cannot validate" case, so it now fails OPEN (rc=0) — the pin is
+    # trusted and agy rejects a genuinely bad model at dispatch. (OCTOPUS_AGY_MODEL_STRICT=1
+    # would fail closed; the default path is asserted here.)
+    if [[ "$lookup_rc" -eq 0 && "$elapsed" -lt 3 ]]; then
         test_pass
     else
-        test_fail "stalled agy catalog was not bounded: rc=$lookup_rc elapsed=${elapsed}s"
+        test_fail "stalled agy catalog was not bounded or did not fail open: rc=$lookup_rc elapsed=${elapsed}s"
     fi
 }
 test_agy_command_validation() {

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1479,8 +1479,64 @@ test_council_run_writes_minimal_summary_when_rich_writer_fails() {
     fi
 }
 
+test_council_run_status_beacon_lifecycle() {
+    test_case "council writes a run-status.json beacon: running at run-dir creation, finished at summary"
+    load_council_lib || return 1
+
+    # create_run_dir runs in THIS process, so the staged beacon must record this
+    # shell's own pid — assert the exact value, not merely a positive integer.
+    local expected_pid_running="${BASHPID:-$$}"
+    # Unit: create_run_dir beacons "running" (with run_id + a live pid) BEFORE any
+    # summary.json exists — the signal a poller uses to tell in-progress from
+    # died-on-spawn. Surface a setup failure rather than masking it with `|| true`.
+    local tmp; tmp="$(mktemp -d "$TEST_TMP_DIR/council-runstatus.XXXXXX")"
+    if ! COUNCIL_OUTPUT_DIR="$tmp" council_create_run_dir >/dev/null 2>&1; then
+        test_fail "council_create_run_dir failed"; return 1
+    fi
+    local rs="${COUNCIL_RUN_DIR}/run-status.json" run_id_running="$COUNCIL_RUN_ID"
+    local state_running pid_running rid_running had_summary=no
+    state_running="$(jq -r '.state' "$rs" 2>/dev/null)"
+    pid_running="$(jq -r '.pid' "$rs" 2>/dev/null)"
+    rid_running="$(jq -r '.run_id' "$rs" 2>/dev/null)"
+    [[ -e "${COUNCIL_RUN_DIR}/summary.json" ]] && had_summary=yes
+
+    # #1: a beacon written from a subshell must record the writing process's own
+    # pid (BASHPID), not the parent shell — otherwise a poller watches the wrong
+    # process. Capture the writer's pid and the recorded pid in the SAME subshell
+    # (comparing across two subshells would compare two different pids). On bash
+    # 3.2 (BASHPID unset) both resolve to $$, so this holds on every bash.
+    local sub_result sub_expect sub_pid
+    sub_result="$( ( council_write_run_status "running" >/dev/null 2>&1
+                     printf '%s|%s' "${BASHPID:-$$}" "$(jq -r '.pid' "$rs" 2>/dev/null)" ) )"
+    sub_expect="${sub_result%%|*}"
+    sub_pid="${sub_result##*|}"
+
+    # Integration: a real dry-run flips the beacon to "finished" with the terminal
+    # status, through council_write_summary_json (one hook covers every exit).
+    local tmp2; tmp2="$(mktemp -d "$TEST_TMP_DIR/council-runstatus2.XXXXXX")"
+    if ! council_run --dry-run --goal advice --depth quick --benchmark auto \
+        --output-dir "$tmp2" "Should we cache?" >/dev/null 2>&1; then
+        test_fail "council_run --dry-run failed"; return 1
+    fi
+    local rs2 state_finished status_finished
+    rs2="$(find "$tmp2" -name run-status.json -type f | head -1)"
+    state_finished="$(jq -r '.state' "$rs2" 2>/dev/null)"
+    status_finished="$(jq -r '.status' "$rs2" 2>/dev/null)"
+
+    if [[ "$state_running" == "running" && "$pid_running" == "$expected_pid_running" \
+          && "$rid_running" == "$run_id_running" && "$had_summary" == "no" \
+          && "$sub_pid" == "$sub_expect" \
+          && "$state_finished" == "finished" && "$status_finished" == "dry-run" ]]; then
+        test_pass
+    else
+        test_fail "beacon lifecycle wrong: running(state=$state_running pid=$pid_running run_id=$rid_running/$run_id_running summary=$had_summary subpid=$sub_pid/$sub_expect) finished(state=$state_finished status=$status_finished)"
+        return 1
+    fi
+}
+
 test_council_command_files_are_registered
 test_council_orchestrate_route_exists
+test_council_run_status_beacon_lifecycle
 test_council_benchmark_routing_lib_is_extracted
 test_council_defaults_are_depth_aware
 test_council_rejects_non_usd_budget
@@ -1734,6 +1790,102 @@ test_council_seat_timeout_precedence() {
         test_pass
     else
         test_fail "timeout precedence wrong: default=$d global=$g flag=$f agy=$p codex=$pp invalid=$invalid_provider/$invalid_flag/$invalid_global"
+        return 1
+    fi
+}
+
+test_council_synthesis_timeout_overrides_seat_cap() {
+    test_case "council_synthesis_timeout: env override wins, else falls back to per-seat resolution"
+    load_council_lib || return 1
+    local override fallback per_provider invalid
+    # Explicit synthesis override wins over the seat cap for the chair phase.
+    override="$(OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT=900 COUNCIL_SEAT_TIMEOUT=300 council_synthesis_timeout codex)"
+    # No override -> chair provider's normal per-seat resolution (default 120).
+    fallback="$(OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT='' OCTOPUS_COUNCIL_TIMEOUT_CODEX='' COUNCIL_SEAT_TIMEOUT='' OCTOPUS_COUNCIL_AGENT_TIMEOUT='' council_synthesis_timeout codex)"
+    # No override -> existing per-provider tuning still applies through the fallback.
+    per_provider="$(OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT='' OCTOPUS_COUNCIL_TIMEOUT_CODEX=600 council_synthesis_timeout codex)"
+    # Invalid override falls through to seat resolution rather than disabling the cap.
+    invalid="$(OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT=0 OCTOPUS_COUNCIL_TIMEOUT_CODEX='' COUNCIL_SEAT_TIMEOUT=300 council_synthesis_timeout codex)"
+    if [[ "$override" == "900" ]] && [[ "$fallback" == "120" ]] &&
+       [[ "$per_provider" == "600" ]] && [[ "$invalid" == "300" ]]; then
+        test_pass
+    else
+        test_fail "synthesis timeout wrong: override=$override fallback=$fallback per_provider=$per_provider invalid=$invalid"
+        return 1
+    fi
+}
+
+test_council_live_response_uses_synthesis_timeout_for_chair() {
+    test_case "council_live_response applies the synthesis timeout only to chair-synthesis"
+    load_council_lib || return 1
+    local captured_advice captured_synth
+    # run_agent_sync_consultative receives the resolved timeout as arg 3; capture it.
+    run_agent_sync_consultative() { printf '%s' "$3" > "$TEST_TMP_DIR/council-synth-cap.txt"; printf 'ok\n'; }
+    council_provider_is_available() { return 0; }
+    COUNCIL_PROVIDER_STATUS_JSON='{"codex":"available"}'
+
+    OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT=900 OCTOPUS_COUNCIL_TIMEOUT_CODEX=300 \
+        council_live_response codex strategy-analyst "dummy prompt" chair-synthesis >/dev/null 2>&1
+    captured_synth="$(cat "$TEST_TMP_DIR/council-synth-cap.txt" 2>/dev/null)"
+
+    OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT=900 OCTOPUS_COUNCIL_TIMEOUT_CODEX=300 \
+        council_live_response codex code-reviewer "dummy prompt" independent-advice >/dev/null 2>&1
+    captured_advice="$(cat "$TEST_TMP_DIR/council-synth-cap.txt" 2>/dev/null)"
+
+    unset -f run_agent_sync_consultative council_provider_is_available
+
+    if [[ "$captured_synth" == "900" ]] && [[ "$captured_advice" == "300" ]]; then
+        test_pass
+    else
+        test_fail "expected synthesis=900 advice=300; got synthesis=$captured_synth advice=$captured_advice"
+        return 1
+    fi
+}
+
+test_council_rc_is_timeout_recognizes_cap_kill_codes() {
+    test_case "council_rc_is_timeout matches watchdog kill codes (124/137/143), not other failures"
+    load_council_lib || return 1
+    local ok="" bad=""
+    local c
+    for c in 124 137 143; do council_rc_is_timeout "$c" && ok="${ok}${c} " || bad="${bad}${c}!TIMEOUT "; done
+    for c in 0 1 2 126 127; do council_rc_is_timeout "$c" && bad="${bad}${c}!NONTIMEOUT " || ok="${ok}skip$c "; done
+    if [[ -z "$bad" ]]; then
+        test_pass
+    else
+        test_fail "misclassified: $bad"
+        return 1
+    fi
+}
+
+test_council_advice_marks_timed_out_seat() {
+    test_case "advice phase classifies a seat killed at its cap as timed-out with a knob hint"
+    load_council_lib || return 1
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-timeout.XXXXXX")"; mkdir -p "$d/responses"
+    COUNCIL_RUN_DIR="$d"
+    COUNCIL_ROSTER_JSON='[{"persona":"code-reviewer","seat":"member","provider":"codex","provider_org":"openai","model":"gpt"}]'
+    COUNCIL_FIXTURE=""
+    COUNCIL_TIMEOUT_WARNINGS=""
+    # Simulate the reported codex-137 case: dispatch killed at the cap, no response file.
+    council_dispatch_member_detached() { return 137; }
+    council_run_chair_fallback() { :; }
+
+    OCTOPUS_COUNCIL_TIMEOUT_CODEX=300 council_run_advice_phase >/dev/null 2>&1 || true
+
+    local status warns output
+    status="$(jq -r '.[0].status' <<< "$COUNCIL_SEAT_RECORDS_JSON" 2>/dev/null)"
+    warns="$COUNCIL_TIMEOUT_WARNINGS"
+    # Also assert the end-of-run renderer actually prints it, so a regression in
+    # council_print_run_warnings can't pass while the warning silently disappears.
+    output="$(council_print_run_warnings)"
+
+    unset -f council_dispatch_member_detached council_run_chair_fallback
+
+    if [[ "$status" == "timed-out" ]] &&
+       [[ "$warns" == *"OCTOPUS_COUNCIL_TIMEOUT_CODEX"* ]] && [[ "$warns" == *"300s"* ]] &&
+       [[ "$output" == *"rc=137"* ]] && [[ "$output" == *"OCTOPUS_COUNCIL_TIMEOUT_CODEX"* ]]; then
+        test_pass
+    else
+        test_fail "expected timed-out status + printed knob hint; status='$status' warns=[$warns] output=[$output]"
         return 1
     fi
 }
@@ -2162,6 +2314,10 @@ test_council_fixture_dispatch_uses_inline_transport
 test_council_detached_seat_survives_interrupt
 test_council_detached_seat_timeout_is_cancelled
 test_council_seat_timeout_precedence
+test_council_synthesis_timeout_overrides_seat_cap
+test_council_live_response_uses_synthesis_timeout_for_chair
+test_council_rc_is_timeout_recognizes_cap_kill_codes
+test_council_advice_marks_timed_out_seat
 test_council_seat_timeout_rejects_zero_and_nonnumeric
 test_council_response_has_verdict_salvage
 test_council_chair_only_vendor_excluded_from_quorum

--- a/tests/unit/test-council-model-selection-fixes.sh
+++ b/tests/unit/test-council-model-selection-fixes.sh
@@ -63,6 +63,44 @@ else
     test_pass
 fi
 
+# ── "cannot validate" != "invalid" ─────────────────────────────────────────
+# A restricted sandbox (or an offline host) can make `agy models` return an
+# empty catalog. Treating that like a bad pin turned OCTOPUS_AGY_MODEL resolution
+# into a spawn-time abort even when the pin was valid. Validation must fail OPEN
+# when the catalog is unreachable (agy still rejects a genuinely bad model at
+# dispatch), and only fail closed under an explicit strict opt-in.
+STUB_EMPTY="$TEST_TMP_DIR/bin-empty"
+mkdir -p "$STUB_EMPTY"
+cat > "$STUB_EMPTY/agy" <<'MOCK_AGY_EMPTY'
+#!/usr/bin/env bash
+# Offline/sandboxed: `agy models` yields no catalog.
+[[ "${1:-}" == "models" ]] && exit 0
+exit 0
+MOCK_AGY_EMPTY
+chmod 755 "$STUB_EMPTY/agy"
+
+test_case "agy pin fails open when the catalog is unreachable (sandboxed/offline)"
+if printf 'payload' | env "PATH=$STUB_EMPTY:$PATH" bash -c '
+    log() { :; }
+    source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+    validate_agy_model_name "Gemini 3.5 Flash (Low)"
+' 2>/dev/null; then
+    test_pass
+else
+    test_fail "unreachable catalog hard-failed validation instead of failing open"
+fi
+
+test_case "OCTOPUS_AGY_MODEL_STRICT=1 restores fail-closed on an unreachable catalog"
+if printf 'payload' | env "PATH=$STUB_EMPTY:$PATH" "OCTOPUS_AGY_MODEL_STRICT=1" bash -c '
+    log() { :; }
+    source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+    validate_agy_model_name "Gemini 3.5 Flash (Low)"
+' 2>/dev/null; then
+    test_fail "strict mode accepted a pin it could not validate"
+else
+    test_pass
+fi
+
 # ── council diversity short-circuit ────────────────────────────────────────
 pick_provider() {
     local roster_json="$1" preferred="$2"


### PR DESCRIPTION
## Summary

Lands the reviewed, CI-green council follow-ups onto main after #919. Those PRs all branched from the same SHA and conflicted on `CHANGELOG.md` (and #921 needed a small rebase onto the #919 `council_run` wrapper).

Original work by @klass-723:

- #920 feat(council): configurable chair-synthesis timeout
- #921 fix(council): classify seats killed by their own timeout as timed-out
- #923 fix(agy): fail open when `OCTOPUS_AGY_MODEL` cannot be validated
- #924 feat(council): pollable `run-status.json` beacon

Not included: #922 (macOS unit tests failed) and #925 (still a draft).

## Test plan

- [ ] CI unit/smoke/integration green on this PR
- [ ] Close #920 #921 #923 #924 after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable chair-synthesis timeouts with fallback handling for invalid settings.
  - Added a live run-status beacon showing whether a run is active or finished, including its process and run identifiers.
  - Added clear warnings and reporting when council advice seats time out.

- **Bug Fixes**
  - Runs now reliably produce an incomplete `summary.json` when interrupted.
  - AGY model validation now continues when its catalog is unavailable, with an optional strict mode for fail-closed behavior.
  - Timeout results are classified and reported consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->