### PR TITLE
fix(council): host-native chair satisfies quorum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@
 
 ### Fixed
 
+- Council quorum now treats a host-native chair as present even when it cannot
+  self-dispatch a chair response file. `met` reflects vendor approvals plus a
+  present, synthesis-capable chair (`chair_received` or `chair_host_native`),
+  so a Claude Code-hosted council with two approving vendors is no longer
+  reported as `quorum.met: false`. An unavailable non-host-native chair still
+  fails quorum.
+
 - `orchestrate.sh council` now always emits a valid `summary.json`. The runner
   wrote one only on its four intended exit paths (dry-run, no-quorum, veto-abort,
   completed); if the chair-synthesis seat was SIGKILLed at the timeout cap, a

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -44,6 +44,7 @@ COUNCIL_ROSTER_JSON=""
 COUNCIL_RESPONSES_RECEIVED=""
 COUNCIL_QUORUM_MET=""
 COUNCIL_CHAIR_RESPONSE_RECEIVED=""
+COUNCIL_CHAIR_HOST_NATIVE=""
 COUNCIL_CHAIR_FALLBACK_USED=""
 COUNCIL_CHAIR_FALLBACK_PERSONA=""
 COUNCIL_IMPLEMENTATION_PLAN_WRITTEN=""
@@ -1893,9 +1894,26 @@ council_note_seat_timeout() {
 }${line}"
 }
 
+council_chair_is_host_native() {
+    # The chair can be the active host runtime (e.g. Claude Code running the
+    # council). A host-native chair cannot self-dispatch, so it never produces a
+    # substantive chair response file — but it IS present and synthesizes the
+    # council in-context. Quorum must treat it as a satisfied chair, otherwise a
+    # run with two cleanly-approving vendors is falsely reported quorum.met=false
+    # purely because chair_received never flipped true.
+    local chair_json chair_provider status
+    chair_json="$(council_chair_member_json 2>/dev/null || true)"
+    [[ -n "$chair_json" ]] || return 1
+    chair_provider="$(jq -r '.provider // ""' <<< "$chair_json" 2>/dev/null)"
+    [[ -n "$chair_provider" ]] || return 1
+    status="$(jq -r --arg p "$chair_provider" '.[$p] // "missing"' <<< "${COUNCIL_PROVIDER_STATUS_JSON:-{}}" 2>/dev/null)"
+    [[ "$status" == "host-native" ]]
+}
+
 council_run_advice_phase() {
     COUNCIL_RESPONSES_RECEIVED="0"
     COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
+    COUNCIL_CHAIR_HOST_NATIVE="false"
     COUNCIL_RESPONDING_PROVIDERS=""
     COUNCIL_SEAT_RECORDS_JSON="[]"
     COUNCIL_TIMEOUT_WARNINGS=""
@@ -2022,7 +2040,21 @@ council_run_advice_phase() {
                 and .status == "responded" and .verdict == "APPROVE"
                 and ($approving | contains(" " + $p + " "))))' <<< "${COUNCIL_SEAT_RECORDS_JSON:-[]}")"
 
-    if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" == "true" ]] && (( received_non_chair >= required )) \
+    # Chair presence: a dispatched chair response OR a host-native chair (which
+    # synthesizes in-context and cannot self-dispatch). Gating met on the response
+    # file alone falsely fails a run whose chair IS the host — the reported
+    # quorum.met=false with distinct_approving_providers=2. met now reflects vendor
+    # approvals plus a present (synthesis-capable) chair, not chair receipt.
+    COUNCIL_CHAIR_HOST_NATIVE="false"
+    if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" != "true" ]] && council_chair_is_host_native; then
+        COUNCIL_CHAIR_HOST_NATIVE="true"
+    fi
+    local chair_present="false"
+    if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" == "true" || "$COUNCIL_CHAIR_HOST_NATIVE" == "true" ]]; then
+        chair_present="true"
+    fi
+
+    if [[ "$chair_present" == "true" ]] && (( received_non_chair >= required )) \
         && { (( required < 2 )) || (( COUNCIL_DISTINCT_APPROVING_PROVIDERS >= required )); }; then
         COUNCIL_QUORUM_MET="true"
     else
@@ -2783,6 +2815,7 @@ council_write_summary_json() {
         --arg distinct_approving_providers "${COUNCIL_DISTINCT_APPROVING_PROVIDERS:-0}" \
         --arg approving_providers "${COUNCIL_APPROVING_PROVIDERS:-}" \
         --arg chair_received "$COUNCIL_CHAIR_RESPONSE_RECEIVED" \
+        --arg chair_host_native "${COUNCIL_CHAIR_HOST_NATIVE:-false}" \
         --arg chair_fallback_used "$COUNCIL_CHAIR_FALLBACK_USED" \
         --arg chair_fallback_persona "$COUNCIL_CHAIR_FALLBACK_PERSONA" \
         --arg implementation_plan_written "$COUNCIL_IMPLEMENTATION_PLAN_WRITTEN" \
@@ -2821,6 +2854,7 @@ council_write_summary_json() {
             required_non_chair: (if $depth == "quick" then 1 else 2 end),
             received_non_chair: ($received_non_chair | tonumber),
             chair_received: ($chair_received == "true"),
+            chair_host_native: ($chair_host_native == "true"),
             distinct_providers: ($distinct_providers | tonumber),
             responding_providers: $responding_providers,
             distinct_approving_providers: ($distinct_approving_providers | tonumber),

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1419,6 +1419,22 @@ test_council_run_does_not_clobber_healthy_summary() {
     fi
 }
 
+test_council_chair_is_host_native_detects_status() {
+    test_case "council_chair_is_host_native reflects the chair provider's host-native status"
+    load_council_lib || return 1
+    COUNCIL_ROSTER_JSON='[{"persona":"strategy-analyst","seat":"chair","provider":"claude","provider_org":"anthropic","model":"opus"}]'
+    COUNCIL_CHAIR_FALLBACK_USED="false"; COUNCIL_CHAIR_FALLBACK_PERSONA=""
+    local hostnative available
+    COUNCIL_PROVIDER_STATUS_JSON='{"claude":"host-native"}' council_chair_is_host_native && hostnative=yes || hostnative=no
+    COUNCIL_PROVIDER_STATUS_JSON='{"claude":"available"}' council_chair_is_host_native && available=yes || available=no
+    if [[ "$hostnative" == "yes" && "$available" == "no" ]]; then
+        test_pass
+    else
+        test_fail "expected host-native=yes available=no; got host-native=$hostnative available=$available"
+        return 1
+    fi
+}
+
 test_council_run_replaces_malformed_body_summary() {
     test_case "council_run treats an empty/malformed body summary.json as missing and repairs it"
     load_council_lib || return 1
@@ -1534,10 +1550,58 @@ test_council_run_status_beacon_lifecycle() {
     fi
 }
 
+test_council_quorum_met_with_host_native_chair() {
+    test_case "quorum.met is true when a host-native chair + two vendors approve (chair_received stays false)"
+    load_council_lib || return 1
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-hnchair.XXXXXX")"; mkdir -p "$d/responses"
+    COUNCIL_RUN_DIR="$d"
+    COUNCIL_DEPTH="standard"   # required_non_chair = 2
+    COUNCIL_FIXTURE=""
+    COUNCIL_CHAIR_FALLBACK_USED="false"; COUNCIL_CHAIR_FALLBACK_PERSONA=""
+    COUNCIL_ROSTER_JSON='[
+      {"persona":"strategy-analyst","seat":"chair","provider":"claude","provider_org":"anthropic","model":"opus"},
+      {"persona":"backend-architect","seat":"member","provider":"codex","provider_org":"openai","model":"gpt"},
+      {"persona":"security-auditor","seat":"member","provider":"agy","provider_org":"google","model":"gemini"}
+    ]'
+    # Non-chair vendors approve; the host-native chair (claude) cannot self-dispatch
+    # (return 1, no substantive file) — mirrors the real host-agent path.
+    council_dispatch_member_detached() {
+        local mj="$1" out="$3" prov
+        prov="$(jq -r '.provider' <<< "$mj")"
+        case "$prov" in
+            codex|agy) printf '## Review by %s\n\nThe change is sound and well tested. No blocking concerns.\n\nVERDICT: APPROVE\n' "$prov" > "$out"; return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+    council_run_chair_fallback() { :; }   # no dispatched fallback available
+
+    COUNCIL_PROVIDER_STATUS_JSON='{"claude":"host-native","codex":"available","agy":"available"}' \
+        council_run_advice_phase >/dev/null 2>&1 || true
+    local met_hn chair_recv_hn hostnative_hn
+    met_hn="$COUNCIL_QUORUM_MET"; chair_recv_hn="$COUNCIL_CHAIR_RESPONSE_RECEIVED"; hostnative_hn="$COUNCIL_CHAIR_HOST_NATIVE"
+
+    # Negative control: same two approvals but the chair provider is merely
+    # "available" and never responded — chair is genuinely absent, met must be false.
+    COUNCIL_PROVIDER_STATUS_JSON='{"claude":"available","codex":"available","agy":"available"}' \
+        council_run_advice_phase >/dev/null 2>&1 || true
+    local met_absent="$COUNCIL_QUORUM_MET"
+
+    unset -f council_dispatch_member_detached council_run_chair_fallback
+
+    if [[ "$met_hn" == "true" && "$chair_recv_hn" == "false" && "$hostnative_hn" == "true" && "$met_absent" == "false" ]]; then
+        test_pass
+    else
+        test_fail "host-native chair quorum wrong: met=$met_hn chair_received=$chair_recv_hn host_native=$hostnative_hn ; absent-chair met=$met_absent"
+        return 1
+    fi
+}
+
 test_council_command_files_are_registered
 test_council_orchestrate_route_exists
 test_council_run_status_beacon_lifecycle
 test_council_benchmark_routing_lib_is_extracted
+test_council_chair_is_host_native_detects_status
+test_council_quorum_met_with_host_native_chair
 test_council_defaults_are_depth_aware
 test_council_rejects_non_usd_budget
 test_council_dry_run_writes_summary_json


### PR DESCRIPTION
## Summary
- Rebases [@klass-723](https://github.com/klass-723)'s #922 onto current `main` (after #926).
- A host-native chair cannot self-dispatch a chair response file. Quorum now treats that chair as present when vendor approvals already meet the non-chair bar (`chair_host_native` plus `chair_received`).
- An unavailable non-host-native chair still fails quorum. `chair_received` stays false on the host-native path.
- CHANGELOG Unreleased Fixed bullet added.

## Test plan
- [x] `bash -n` on `scripts/lib/council.sh` and the council unit tests
- [ ] CI: Ubuntu + macOS unit tests (watch the OpenCode banner flake that failed original #922)
- [ ] After merge, close #922 with a pointer

Closes nothing until this lands; original PR is #922.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Host-native chairs now count toward council quorum when they can synthesize a response, even without submitting a response file.
  * Councils still require an available response from non-host-native chairs.
  * Quorum status now accurately records host-native chair presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->