### PR TITLE
fix: continue tangle corrections after partial review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 ### Fixed
 
+- Tangle contextual-review correction now continues when a post-correction
+  review returns non-zero but still produced actionable blockers. A non-zero
+  review with zero blockers stays fail-closed.
+
 - Council quorum now treats a host-native chair as present even when it cannot
   self-dispatch a chair response file. `met` reflects vendor approvals plus a
   present, synthesis-capable chair (`chair_received` or `chair_host_native`),

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -3478,8 +3478,12 @@ tangle_contextual_review_gate() {
         current_signature=$(tangle_findings_signature "$findings_file")
 
         if [[ "$review_rc" -ne 0 ]]; then
-            log WARN "Contextual code review returned non-zero after correction round ${correction_round}; not treating review warning/no-diff as improvement"
-            return "$review_rc"
+            if [[ "${normal_count:-0}" -gt 0 ]]; then
+                log WARN "Contextual code review returned non-zero after correction round ${correction_round}, but ${normal_count} actionable blocking finding(s) remain; continuing correction loop"
+            else
+                log WARN "Contextual code review returned non-zero after correction round ${correction_round} with no actionable blockers"
+                return "$review_rc"
+            fi
         fi
 
         if [[ "${normal_count:-0}" -lt "${previous_normal_count:-0}" ]]; then

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -51,7 +51,7 @@ assert_contains "$WORKFLOWS" 'run_agent_sync "$correction_agent" "$correction_pr
 assert_contains "$WORKFLOWS" "OCTOPUS_TANGLE_CODE_REVIEW" "code review gate is toggleable"
 assert_contains "$WORKFLOWS" "Contextual code review warning" "review warnings are blocking"
 assert_contains "$WORKFLOWS" "No changes found to review" "legacy no-diff message is detected"
-assert_contains "$WORKFLOWS" "not treating review warning/no-diff as improvement" "no-diff review is blocking"
+assert_contains "$WORKFLOWS" "with no actionable blockers" "non-zero review without actionable blockers is blocking"
 assert_contains "$WORKFLOWS" "Skipping ink/deliver because tangle validation gate returned non-zero" "ink is skipped when validation fails"
 assert_contains "$HELP" "Contextual code review" "develop help documents contextual review"
 assert_contains "$HELP" "OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE" "develop help documents bounded mode"

--- a/tests/unit/test-tangle-correction-loop-behavior.sh
+++ b/tests/unit/test-tangle-correction-loop-behavior.sh
@@ -33,17 +33,24 @@ run_gate() {
         octopus_agent_override() { echo "codex"; }
 
         COUNTS=($1)
+        REVIEW_RCS=(${REVIEW_RC_SEQUENCE:-})
         IDX_FILE="$RESULTS_DIR/count-idx"
+        REVIEW_IDX_FILE="$RESULTS_DIR/review-idx"
         echo 0 > "$IDX_FILE"
+        echo 0 > "$REVIEW_IDX_FILE"
         CORRECTION_CALLS=0
 
         source "$2/scripts/lib/workflows.sh" 2>/dev/null
 
         tangle_build_develop_review_context() { echo "$RESULTS_DIR/ctx-$7.md"; }
         tangle_run_context_code_review() {
+            local ridx rc
             TANGLE_REVIEW_FINDINGS_FILE="$RESULTS_DIR/findings-$3.json"
             echo "{\"findings\":[]}" > "$TANGLE_REVIEW_FINDINGS_FILE"
-            return 0
+            ridx=$(cat "$REVIEW_IDX_FILE")
+            rc="${REVIEW_RCS[$ridx]:-0}"
+            echo $((ridx + 1)) > "$REVIEW_IDX_FILE"
+            return "$rc"
         }
         # Stub state lives in a file: these stubs run inside command
         # substitutions, so in-shell variable increments would be lost.
@@ -91,6 +98,22 @@ if [[ "$out" == "rounds=3 rc=0" ]]; then
     test_pass
 else
     test_fail "expected rounds=3 rc=0, got '$out'"
+fi
+
+test_case "partial review warning with actionable blockers continues correction loop"
+out=$(REVIEW_RC_SEQUENCE="0 1 0" run_gate "2 1 0")
+if [[ "$out" == "rounds=2 rc=0" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=2 rc=0, got '$out'"
+fi
+
+test_case "partial review warning with zero blockers remains fatal"
+out=$(REVIEW_RC_SEQUENCE="0 1" run_gate "1 0")
+if [[ "$out" == "rounds=1 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=1 rc=1, got '$out'"
 fi
 
 test_case "static blockers trip convergence guard (default 3 no-progress rounds)"


### PR DESCRIPTION
## Summary
- Rebases [@Jhacarreiro](https://github.com/Jhacarreiro)'s #925 onto current `main` (after #927).
- Tangle contextual-review correction continues when a post-correction review is non-zero but still has actionable blockers.
- A non-zero review with zero blockers stays fail-closed. Convergence, bounded-mode, stall, and hard-cap guards are unchanged.
- CHANGELOG Unreleased Fixed bullet added.

## Test plan
- [ ] CI: Ubuntu + macOS unit tests (original #925 was already green)
- [ ] After merge, close #925 with a pointer

Original PR is #925.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contextual review correction now continues when a review reports actionable blockers alongside a non-zero status.
  * Reviews that return non-zero without actionable blockers still stop the correction process safely.

* **Tests**
  * Added coverage for continuing correction when blockers remain.
  * Added coverage ensuring correction stops when no actionable blockers are reported.

* **Documentation**
  * Updated the changelog to describe the revised correction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->