### PR TITLE
feat(setup): completing setup opts into suggest-mode routing

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -27,9 +27,13 @@ Octopus is dormant on install. Installing it does not route ordinary prompts or
 delegate to Octopus agents. Every command and skill is manual-only: use
 `/octo:*` when you want escalation. Completing `/octo:setup` turns on
 suggestions (`auto_router_mode=suggest`), which name a matching command without
-dispatching any provider; a profile that never ran setup stays fully dormant,
-and an existing preference is never overwritten. Automatic invocation stays
-opt-in behind `OCTOPUS_AUTO_ROUTER_MODE=invoke`. That opt-in
+dispatching any provider; by default a profile that never ran setup stays fully
+dormant, and an existing preference is never overwritten. Either state can be
+overridden explicitly: `export OCTOPUS_AUTO_ROUTER_MODE=off|suggest|invoke` for
+the current shell, or `"auto_router_mode": "off"` in
+`~/.claude-octopus/preferences.json` to persist it. The environment variable
+wins over the stored preference. Automatic invocation stays opt-in behind
+`OCTOPUS_AUTO_ROUTER_MODE=invoke`. That opt-in
 examines ordinary prompts and can route them into paid external-provider
 workflows; use `suggest` unless you intentionally want automatic invocation and
 are comfortable sending the workflow prompt and any context that workflow

--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -29,10 +29,10 @@ delegate to Octopus agents. Every command and skill is manual-only: use
 suggestions (`auto_router_mode=suggest`), which name a matching command without
 dispatching any provider; by default a profile that never ran setup stays fully
 dormant, and an existing preference is never overwritten. Either state can be
-overridden explicitly: `export OCTOPUS_AUTO_ROUTER_MODE=off|suggest|invoke` for
-the current shell, or `"auto_router_mode": "off"` in
-`~/.claude-octopus/preferences.json` to persist it. The environment variable
-wins over the stored preference. Automatic invocation stays opt-in behind
+overridden explicitly: `export OCTOPUS_AUTO_ROUTER_MODE=off` for the current
+shell (accepted values are `off`, `suggest`, and `invoke`), or
+`"auto_router_mode": "off"` in `~/.claude-octopus/preferences.json` to persist
+it. The environment variable wins over the stored preference. Automatic invocation stays opt-in behind
 `OCTOPUS_AUTO_ROUTER_MODE=invoke`. That opt-in
 examines ordinary prompts and can route them into paid external-provider
 workflows; use `suggest` unless you intentionally want automatic invocation and

--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -23,10 +23,13 @@ You get:    A structured comparison with three independent viewpoints,
 
 This works for research, escalated code review, debugging, TDD, escalated security audits, UI design, PRDs, and full build-to-ship workflows — 54 commands, 63 skills, 32 specialized personas.
 
-Octopus is dormant by default. Installing it does not route ordinary prompts or
+Octopus is dormant on install. Installing it does not route ordinary prompts or
 delegate to Octopus agents. Every command and skill is manual-only: use
-`/octo:*` when you want escalation. Plain-prompt routing is available only after
-you set `OCTOPUS_AUTO_ROUTER_MODE=suggest` or `invoke`. This legacy opt-in
+`/octo:*` when you want escalation. Completing `/octo:setup` turns on
+suggestions (`auto_router_mode=suggest`), which name a matching command without
+dispatching any provider; a profile that never ran setup stays fully dormant,
+and an existing preference is never overwritten. Automatic invocation stays
+opt-in behind `OCTOPUS_AUTO_ROUTER_MODE=invoke`. That opt-in
 examines ordinary prompts and can route them into paid external-provider
 workflows; use `suggest` unless you intentionally want automatic invocation and
 are comfortable sending the workflow prompt and any context that workflow

--- a/.cursor-plugin/commands/octo-setup.md
+++ b/.cursor-plugin/commands/octo-setup.md
@@ -345,9 +345,25 @@ if declare -f octo_config_write >/dev/null 2>&1; then
   octo_config_write "work_mode" "\"${WORK_MODE_VALUE}\""
   octo_config_write "setup_complete" 'true'
 fi
+# Completing setup is an explicit act, so it opts into ROUTING SUGGESTIONS only.
+# This never enables `invoke`: dispatch to a paid provider stays explicit. The
+# write is skipped when the key already exists, so a prior opt-out survives.
+if declare -f octo_pref_write_default >/dev/null 2>&1; then
+  octo_pref_write_default "auto_router_mode" '"suggest"'
+fi
 ```
 
 (Replace `"dev"` with `"knowledge"` or `"both"` based on the user selection.)
+
+Tell the user what that last line changed, in one sentence:
+
+> Octopus now suggests a matching command when your prompt clearly fits one. It
+> never runs a provider on its own. Turn suggestions off with
+> `OCTOPUS_AUTO_ROUTER_MODE=off`, or set `auto_router_mode` in
+> `~/.claude-octopus/preferences.json`.
+
+A user who never runs `/octo:setup` stays fully dormant; that is the #898
+contract and this step is the only thing that relaxes it.
 
 ## STEP 4b: Prompt Cache Optimization (Claude Code v2.1.108+)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Completing `/octo:setup` now persists `auto_router_mode=suggest`, so Octopus
+  names a matching command for a plain prompt instead of staying silent. It
+  still never dispatches a provider on its own; automatic invocation remains
+  opt-in behind `OCTOPUS_AUTO_ROUTER_MODE=invoke`. A profile that never runs
+  setup stays fully dormant, preserving the #898 contract, and an
+  `auto_router_mode` value already present in
+  `~/.claude-octopus/preferences.json` is never overwritten, so a prior opt-out
+  survives. Setup writes the preference file the prompt hooks already read, so
+  no file read is added to the latency-sensitive UserPromptSubmit path. (oco-9yj)
+
 ### Added
 
 - `OCTOPUS_COUNCIL_SYNTHESIS_TIMEOUT` bounds the chair-synthesis dispatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
 - Completing `/octo:setup` now persists `auto_router_mode=suggest`, so Octopus
   names a matching command for a plain prompt instead of staying silent. It
   still never dispatches a provider on its own; automatic invocation remains
-  opt-in behind `OCTOPUS_AUTO_ROUTER_MODE=invoke`. A profile that never runs
-  setup stays fully dormant, preserving the #898 contract, and an
-  `auto_router_mode` value already present in
+  opt-in behind `OCTOPUS_AUTO_ROUTER_MODE=invoke`. Absent an explicit override,
+  a profile that never runs setup stays dormant, preserving the #898 contract;
+  `OCTOPUS_AUTO_ROUTER_MODE` and a stored `auto_router_mode` preference both
+  still apply on their own. An `auto_router_mode` value already present in
   `~/.claude-octopus/preferences.json` is never overwritten, so a prior opt-out
   survives. Setup writes the preference file the prompt hooks already read, so
   no file read is added to the latency-sensitive UserPromptSubmit path. (oco-9yj)

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Not sure which command to use? Pick by goal:
 | Reduce token usage | `/octo:doctor` (includes RTK install + token tips) |
 | Just run something quick | `/octo:quick` |
 
-Or type `/octo:auto <what you want>` and the smart router picks for you. Plain-prompt routing stays off unless you explicitly set `OCTOPUS_AUTO_ROUTER_MODE=suggest|invoke`. 🔍
+Or type `/octo:auto <what you want>` and the smart router picks for you. Plain-prompt routing is off until you run `/octo:setup`, which turns on **suggestions** (Octopus names a matching command; it never dispatches a provider on its own). Set `OCTOPUS_AUTO_ROUTER_MODE=off` to silence them, or `invoke` to let a matched route load automatically. 🔍
 
 <details>
 <summary><strong>How does this compare to Superpowers or plain Claude Code?</strong></summary>

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -348,9 +348,25 @@ if declare -f octo_config_write >/dev/null 2>&1; then
   octo_config_write "work_mode" "\"${WORK_MODE_VALUE}\""
   octo_config_write "setup_complete" 'true'
 fi
+# Completing setup is an explicit act, so it opts into ROUTING SUGGESTIONS only.
+# This never enables `invoke`: dispatch to a paid provider stays explicit. The
+# write is skipped when the key already exists, so a prior opt-out survives.
+if declare -f octo_pref_write_default >/dev/null 2>&1; then
+  octo_pref_write_default "auto_router_mode" '"suggest"'
+fi
 ```
 
 (Replace `"dev"` with `"knowledge"` or `"both"` based on the user selection.)
+
+Tell the user what that last line changed, in one sentence:
+
+> Octopus now suggests a matching command when your prompt clearly fits one. It
+> never runs a provider on its own. Turn suggestions off with
+> `OCTOPUS_AUTO_ROUTER_MODE=off`, or set `auto_router_mode` in
+> `~/.claude-octopus/preferences.json`.
+
+A user who never runs `/octo:setup` stays fully dormant; that is the #898
+contract and this step is the only thing that relaxes it.
 
 ## STEP 4b: Prompt Cache Optimization (Claude Code v2.1.108+)
 

--- a/docs/COMMAND-REFERENCE.md
+++ b/docs/COMMAND-REFERENCE.md
@@ -157,8 +157,13 @@ request supplied to `/octo:auto` and routes to the optimal workflow.
 
 **Default invocation:** `/octo:auto <request>`
 
-Plain-prompt routing is disabled by default. Users who deliberately want it can
-set `OCTOPUS_AUTO_ROUTER_MODE=suggest` or `invoke`.
+Plain-prompt routing is disabled on install. Completing `/octo:setup` persists
+`auto_router_mode=suggest`, so Octopus names a matching command but never
+dispatches a provider on its own; a profile that never ran setup stays fully
+dormant. `OCTOPUS_AUTO_ROUTER_MODE` overrides the stored preference in either
+direction (`off` to silence suggestions, `invoke` to load matched routes), and
+an `auto_router_mode` value already present in
+`~/.claude-octopus/preferences.json` is never overwritten by setup.
 
 **Usage:**
 ```

--- a/scripts/lib/user-config.sh
+++ b/scripts/lib/user-config.sh
@@ -81,26 +81,12 @@ _octo_pref_unlock() {
 # the rename, and this function would silently clobber that opt-out — the exact
 # thing it promises never to do. When the lock cannot be taken, skip the write:
 # leaving the preference unset keeps routing dormant, which is the safe side.
-octo_pref_write_default() {
-  local key="$1"
-  local value="$2"
-  local prefs_file prefs_dir current updated tmp rc=0
-
-  if ! command -v jq &>/dev/null; then
-    echo "⚠️  jq not found — preference '$key' not persisted. Install: brew install jq" >&2
-    return 0
-  fi
-
-  prefs_file="$(octo_prefs_file)"
-  prefs_dir="$(dirname "$prefs_file")"
-  mkdir -p "$prefs_dir" || return 0
-
-  if ! _octo_pref_lock "$prefs_file"; then
-    echo "⚠️  $prefs_file is busy — preference '$key' not persisted." >&2
-    return 0
-  fi
-  # Release the lock on any exit path, including an interrupt mid-write.
-  trap '_octo_pref_unlock "$prefs_file"' RETURN
+# Body of the locked write. Never call this directly: octo_pref_write_default
+# owns the lock around it. Multiple early returns live here so the caller can
+# keep exactly one unlock path.
+_octo_pref_write_locked() {
+  local key="$1" value="$2" prefs_file="$3" prefs_dir="$4"
+  local current updated tmp
 
   current="{}"
   if [[ -f "$prefs_file" ]]; then
@@ -127,11 +113,43 @@ octo_pref_write_default() {
   chmod 600 "$tmp" 2>/dev/null || true
   if printf '%s\n' "$updated" > "$tmp" && mv -f "$tmp" "$prefs_file"; then
     chmod 600 "$prefs_file" 2>/dev/null || true
-  else
-    rm -f "$tmp" 2>/dev/null || true
-    echo "⚠️  Failed to write $prefs_file" >&2
-    rc=1
+    return 0
   fi
+  rm -f "$tmp" 2>/dev/null || true
+  echo "⚠️  Failed to write $prefs_file" >&2
+  return 1
+}
+
+octo_pref_write_default() {
+  local key="$1"
+  local value="$2"
+  local prefs_file prefs_dir rc
+
+  if ! command -v jq &>/dev/null; then
+    echo "⚠️  jq not found — preference '$key' not persisted. Install: brew install jq" >&2
+    return 0
+  fi
+
+  prefs_file="$(octo_prefs_file)"
+  prefs_dir="$(dirname "$prefs_file")"
+  mkdir -p "$prefs_dir" || return 0
+
+  if ! _octo_pref_lock "$prefs_file"; then
+    echo "⚠️  $prefs_file is busy — preference '$key' not persisted." >&2
+    return 0
+  fi
+
+  # No trap here, deliberately. A sourced library must not install EXIT/INT/TERM
+  # traps: they replace the caller's. A RETURN trap is worse — under `set -T`
+  # plus `set -u` it stays armed for later returns and then expands an
+  # out-of-scope path, aborting the caller. Instead the locked body is a
+  # separate function so there is exactly one unlock path here. An interrupt
+  # between lock and unlock leaves a stale lock directory; the bounded spin in
+  # _octo_pref_lock degrades that to "skip the write", matching
+  # scripts/lib/events.sh.
+  _octo_pref_write_locked "$key" "$value" "$prefs_file" "$prefs_dir"
+  rc=$?
+  _octo_pref_unlock "$prefs_file"
   return "$rc"
 }
 

--- a/scripts/lib/user-config.sh
+++ b/scripts/lib/user-config.sh
@@ -48,6 +48,60 @@ octo_config_read() {
   [[ "$val" == "null" ]] && echo "$default" || echo "$val"
 }
 
+# Runtime preferences read by the prompt hooks live in a separate file from the
+# setup choices above. Hooks read preferences.json on the UserPromptSubmit path,
+# so nothing here may add a second file read to that hot path (#898).
+octo_prefs_file() {
+  printf '%s/.claude-octopus/preferences.json' "$HOME"
+}
+
+# Set a preference key ONLY when it is absent. An explicit user choice, including
+# an opt-out, is never overwritten. Value must be valid JSON (e.g. '"suggest"').
+octo_pref_write_default() {
+  local key="$1"
+  local value="$2"
+  local prefs_file prefs_dir current updated tmp
+
+  if ! command -v jq &>/dev/null; then
+    echo "⚠️  jq not found — preference '$key' not persisted. Install: brew install jq" >&2
+    return 0
+  fi
+
+  prefs_file="$(octo_prefs_file)"
+  prefs_dir="$(dirname "$prefs_file")"
+  mkdir -p "$prefs_dir" || return 0
+
+  current="{}"
+  if [[ -f "$prefs_file" ]]; then
+    current=$(cat "$prefs_file" 2>/dev/null) || current="{}"
+    # A corrupt preferences file must not be silently replaced: leaving it alone
+    # keeps the user's other keys recoverable and keeps routing dormant.
+    if ! printf '%s' "$current" | jq empty 2>/dev/null; then
+      echo "⚠️  $prefs_file is not valid JSON — preference '$key' not persisted." >&2
+      return 0
+    fi
+    # Already set (including an explicit opt-out): respect it and stop.
+    if printf '%s' "$current" | jq -e --arg k "$key" 'has($k)' >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+
+  updated=$(printf '%s' "$current" | jq --arg k "$key" --argjson v "$value" '.[$k] = $v' 2>/dev/null) || {
+    echo "⚠️  Failed to set preference '$key'" >&2
+    return 0
+  }
+
+  # Atomic write at 0600 without leaking the caller's umask.
+  tmp=$(mktemp "${prefs_dir}/.preferences.XXXXXX") || return 0
+  chmod 600 "$tmp" 2>/dev/null || true
+  if printf '%s\n' "$updated" > "$tmp" && mv -f "$tmp" "$prefs_file"; then
+    chmod 600 "$prefs_file" 2>/dev/null || true
+  else
+    rm -f "$tmp" 2>/dev/null || true
+    echo "⚠️  Failed to write $prefs_file" >&2
+  fi
+}
+
 octo_config_reset() {
   rm -f "$OCTO_CONFIG_FILE"
   echo "✓ Octopus user config reset."

--- a/scripts/lib/user-config.sh
+++ b/scripts/lib/user-config.sh
@@ -55,12 +55,36 @@ octo_prefs_file() {
   printf '%s/.claude-octopus/preferences.json' "$HOME"
 }
 
+# Portable best-effort exclusive lock, matching scripts/lib/events.sh: flock is
+# Linux-only, while mkdir is atomic on every POSIX filesystem. Bounded spin so a
+# dead holder degrades to "skip the write" rather than hanging setup.
+_octo_pref_lock() {
+  local lockdir="$1.lock"
+  local tries=0
+  while ! mkdir "$lockdir" 2>/dev/null; do
+    tries=$((tries + 1))
+    [[ "$tries" -ge 50 ]] && return 1
+    sleep 0.02 2>/dev/null || return 1
+  done
+  return 0
+}
+
+_octo_pref_unlock() {
+  rmdir "$1.lock" 2>/dev/null || true
+}
+
 # Set a preference key ONLY when it is absent. An explicit user choice, including
 # an opt-out, is never overwritten. Value must be valid JSON (e.g. '"suggest"').
+#
+# The read-check-write sequence holds a lock for its whole duration. Without it,
+# a concurrent writer could set auto_router_mode=off between the has() check and
+# the rename, and this function would silently clobber that opt-out — the exact
+# thing it promises never to do. When the lock cannot be taken, skip the write:
+# leaving the preference unset keeps routing dormant, which is the safe side.
 octo_pref_write_default() {
   local key="$1"
   local value="$2"
-  local prefs_file prefs_dir current updated tmp
+  local prefs_file prefs_dir current updated tmp rc=0
 
   if ! command -v jq &>/dev/null; then
     echo "⚠️  jq not found — preference '$key' not persisted. Install: brew install jq" >&2
@@ -70,6 +94,13 @@ octo_pref_write_default() {
   prefs_file="$(octo_prefs_file)"
   prefs_dir="$(dirname "$prefs_file")"
   mkdir -p "$prefs_dir" || return 0
+
+  if ! _octo_pref_lock "$prefs_file"; then
+    echo "⚠️  $prefs_file is busy — preference '$key' not persisted." >&2
+    return 0
+  fi
+  # Release the lock on any exit path, including an interrupt mid-write.
+  trap '_octo_pref_unlock "$prefs_file"' RETURN
 
   current="{}"
   if [[ -f "$prefs_file" ]]; then
@@ -99,7 +130,9 @@ octo_pref_write_default() {
   else
     rm -f "$tmp" 2>/dev/null || true
     echo "⚠️  Failed to write $prefs_file" >&2
+    rc=1
   fi
+  return "$rc"
 }
 
 octo_config_reset() {

--- a/scripts/lib/user-config.sh
+++ b/scripts/lib/user-config.sh
@@ -90,7 +90,13 @@ _octo_pref_write_locked() {
 
   current="{}"
   if [[ -f "$prefs_file" ]]; then
-    current=$(cat "$prefs_file" 2>/dev/null) || current="{}"
+    # An unreadable existing file must not be treated as empty. Falling back to
+    # "{}" here would let the write below replace the file and discard every key
+    # the user has, which is the opposite of preserving their settings.
+    if ! current=$(cat "$prefs_file" 2>/dev/null); then
+      echo "⚠️  Failed to read $prefs_file — preference '$key' not persisted." >&2
+      return 0
+    fi
     # A corrupt preferences file must not be silently replaced: leaving it alone
     # keeps the user's other keys recoverable and keeps routing dormant.
     if ! printf '%s' "$current" | jq empty 2>/dev/null; then
@@ -116,8 +122,12 @@ _octo_pref_write_locked() {
     return 0
   fi
   rm -f "$tmp" 2>/dev/null || true
-  echo "⚠️  Failed to write $prefs_file" >&2
-  return 1
+  # Warn but succeed, like every other failure path here and like
+  # octo_config_write. Persisting a preference is best-effort: a caller running
+  # under `set -e` must not have its setup run aborted because one optional
+  # write failed. The original file is untouched either way.
+  echo "⚠️  Failed to write $prefs_file — preference '$key' not persisted." >&2
+  return 0
 }
 
 octo_pref_write_default() {
@@ -147,8 +157,14 @@ octo_pref_write_default() {
   # between lock and unlock leaves a stale lock directory; the bounded spin in
   # _octo_pref_lock degrades that to "skip the write", matching
   # scripts/lib/events.sh.
-  _octo_pref_write_locked "$key" "$value" "$prefs_file" "$prefs_dir"
-  rc=$?
+  # The call sits in an `if` condition so a nonzero return cannot trip the
+  # caller's `set -e` before the unlock below. A bare call followed by `rc=$?`
+  # would exit the shell on a failed write and strand the lock directory.
+  if _octo_pref_write_locked "$key" "$value" "$prefs_file" "$prefs_dir"; then
+    rc=0
+  else
+    rc=$?
+  fi
   _octo_pref_unlock "$prefs_file"
   return "$rc"
 }

--- a/tests/unit/test-setup-suggest-routing.sh
+++ b/tests/unit/test-setup-suggest-routing.sh
@@ -136,21 +136,37 @@ else
     pass "lock is released after a successful write"
 fi
 
-# --- 12. invoke is never written automatically ------------------------------
+# --- 12. the helper leaves no trap behind for the caller --------------------
+# A sourced library must not arm a RETURN trap: under `set -T` plus `set -u` it
+# stays live for later returns and then expands an out-of-scope path, killing
+# the caller. Reproduced as exit 127 "prefs_file: unbound variable" before the
+# locked body was split into its own function.
+H7="$TEST_TMP_DIR/home-trap"; mkdir -p "$H7/.claude-octopus"
+trap_out=$(HOME="$H7" bash -c '
+    set -T -u
+    . "$1"
+    octo_pref_write_default "auto_router_mode" "\"suggest\"" >/dev/null 2>&1
+    later() { :; }
+    later
+    echo CALLER_SURVIVED
+' _ "$LIB" 2>&1 | tail -1) || true
+check "no RETURN trap leaks into the caller under set -T -u" "CALLER_SURVIVED" "$trap_out"
+
+# --- 13. invoke is never written automatically ------------------------------
 if grep -nE 'octo_pref_write_default[[:space:]]+"auto_router_mode"[[:space:]]+.?"invoke"' "$SETUP_CMD" >/dev/null 2>&1; then
     fail "setup never auto-enables invoke" "setup writes invoke"
 else
     pass "setup never auto-enables invoke"
 fi
 
-# --- 13. setup persists the preference at its completion point --------------
+# --- 14. setup persists the preference at its completion point --------------
 if grep -q 'octo_pref_write_default "auto_router_mode"' "$SETUP_CMD" 2>/dev/null; then
     pass "setup.md persists auto_router_mode on completion"
 else
     fail "setup.md persists auto_router_mode on completion" "setup.md does not call the helper"
 fi
 
-# --- 14. setup states the consent boundary to the user ----------------------
+# --- 15. setup states the consent boundary to the user ----------------------
 if grep -qi 'suggest' "$SETUP_CMD" 2>/dev/null; then
     pass "setup.md tells the user suggestions were enabled"
 else

--- a/tests/unit/test-setup-suggest-routing.sh
+++ b/tests/unit/test-setup-suggest-routing.sh
@@ -33,7 +33,7 @@ SETUP_CMD="$PROJECT_ROOT/commands/setup.md"
 resolved_mode() {
     local home_dir="$1" out
     out=$(env -u OCTOPUS_AUTO_ROUTER_MODE -u OCTOPUS_AUTO_INVOKE \
-        HOME="$home_dir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+        "HOME=$home_dir" "CLAUDE_PLUGIN_ROOT=$PROJECT_ROOT" \
         "$SESSION_HOOK" 2>/dev/null) || true
     [[ -n "$out" ]] || { echo "off"; return 0; }
     printf '%s' "$out" | python3 -c '
@@ -87,9 +87,19 @@ check "unrelated preference keys survive the write" "off" "$(pref_key "$H3" OCTO
 check "new key is added alongside existing ones" "suggest" "$(pref_key "$H3" auto_router_mode)"
 
 # --- 5. file is owner-only --------------------------------------------------
-fmode=$(stat -f '%Lp' "$H1/.claude-octopus/preferences.json" 2>/dev/null \
-    || stat -c '%a' "$H1/.claude-octopus/preferences.json" 2>/dev/null || echo "?")
-check "preferences.json is written owner-only" "600" "$fmode"
+# GNU stat -f means "filesystem status" and prints a report to stdout, so trying
+# the BSD format flag first pollutes the captured value on Linux. Probe GNU -c
+# first, and accept a result only when it looks like a mode.
+file_mode() {
+    local f="$1" m
+    m=$(stat -c '%a' "$f" 2>/dev/null) || m=""
+    if [[ ! "$m" =~ ^[0-7]{3,4}$ ]]; then
+        m=$(stat -f '%Lp' "$f" 2>/dev/null) || m=""
+    fi
+    [[ "$m" =~ ^[0-7]{3,4}$ ]] || m="?"
+    printf '%s' "$m"
+}
+check "preferences.json is written owner-only" "600" "$(file_mode "$H1/.claude-octopus/preferences.json")"
 
 # --- 6. a profile that never ran setup stays dormant ------------------------
 H4="$TEST_TMP_DIR/home-never-setup"; mkdir -p "$H4/.claude-octopus"
@@ -101,21 +111,46 @@ check "hook resolves suggest from the written preference" "suggest" "$(resolved_
 # --- 8. an explicit opt-out still reaches the hook as off -------------------
 check "hook honors the preserved opt-out" "off" "$(resolved_mode "$H2")"
 
-# --- 9. invoke is never written automatically -------------------------------
+# --- 9. a corrupt preferences file is left untouched ------------------------
+H5="$TEST_TMP_DIR/home-corrupt"; mkdir -p "$H5/.claude-octopus"
+CORRUPT='{"auto_router_mode": "off"'   # truncated: not valid JSON
+printf '%s' "$CORRUPT" > "$H5/.claude-octopus/preferences.json"
+write_default "$H5"
+check "a corrupt preferences file is not replaced" \
+    "$CORRUPT" "$(cat "$H5/.claude-octopus/preferences.json")"
+check "a corrupt preferences file leaves routing dormant" "off" "$(resolved_mode "$H5")"
+
+# --- 10. a held lock skips the write rather than clobbering -----------------
+H6="$TEST_TMP_DIR/home-locked"; mkdir -p "$H6/.claude-octopus"
+mkdir -p "$H6/.claude-octopus/preferences.json.lock"   # simulate a live holder
+write_default "$H6"
+check "a contended write is skipped, not forced" "" "$(pref_key "$H6" auto_router_mode)"
+rmdir "$H6/.claude-octopus/preferences.json.lock" 2>/dev/null || true
+write_default "$H6"
+check "the write succeeds once the lock clears" "suggest" "$(pref_key "$H6" auto_router_mode)"
+
+# --- 11. the lock is released after a normal write --------------------------
+if [[ -d "$H1/.claude-octopus/preferences.json.lock" ]]; then
+    fail "lock is released after a successful write" "lock directory left behind"
+else
+    pass "lock is released after a successful write"
+fi
+
+# --- 12. invoke is never written automatically ------------------------------
 if grep -nE 'octo_pref_write_default[[:space:]]+"auto_router_mode"[[:space:]]+.?"invoke"' "$SETUP_CMD" >/dev/null 2>&1; then
     fail "setup never auto-enables invoke" "setup writes invoke"
 else
     pass "setup never auto-enables invoke"
 fi
 
-# --- 10. setup persists the preference at its completion point --------------
+# --- 13. setup persists the preference at its completion point --------------
 if grep -q 'octo_pref_write_default "auto_router_mode"' "$SETUP_CMD" 2>/dev/null; then
     pass "setup.md persists auto_router_mode on completion"
 else
     fail "setup.md persists auto_router_mode on completion" "setup.md does not call the helper"
 fi
 
-# --- 11. setup states the consent boundary to the user ----------------------
+# --- 14. setup states the consent boundary to the user ----------------------
 if grep -qi 'suggest' "$SETUP_CMD" 2>/dev/null; then
     pass "setup.md tells the user suggestions were enabled"
 else

--- a/tests/unit/test-setup-suggest-routing.sh
+++ b/tests/unit/test-setup-suggest-routing.sh
@@ -152,21 +152,64 @@ trap_out=$(HOME="$H7" bash -c '
 ' _ "$LIB" 2>&1 | tail -1) || true
 check "no RETURN trap leaks into the caller under set -T -u" "CALLER_SURVIVED" "$trap_out"
 
-# --- 13. invoke is never written automatically ------------------------------
+# --- 13. an unreadable existing file is never replaced ----------------------
+# Falling back to "{}" on a failed read would let the write discard every key
+# the user has. Skipping the write is the only safe response.
+H8="$TEST_TMP_DIR/home-unreadable"; mkdir -p "$H8/.claude-octopus"
+UNREADABLE="$H8/.claude-octopus/preferences.json"
+printf '{"OCTO_PROACTIVE_SUGGESTIONS":"off","keep_me":"yes"}\n' > "$UNREADABLE"
+chmod 000 "$UNREADABLE" 2>/dev/null || true
+if [[ -r "$UNREADABLE" ]]; then
+    # Running as root, or a filesystem that ignores the mode bits.
+    test_case "an unreadable preferences file is not replaced"
+    test_skip "cannot make the file unreadable in this environment"
+else
+    write_default "$H8"
+    chmod 600 "$UNREADABLE" 2>/dev/null || true
+    check "an unreadable preferences file is not replaced" \
+        "yes" "$(pref_key "$H8" keep_me)"
+    check "an unreadable file leaves the new key unset" \
+        "" "$(pref_key "$H8" auto_router_mode)"
+fi
+
+# --- 14. a failed write releases the lock under set -e ----------------------
+# A bare call plus `rc=$?` would let errexit kill the caller before the unlock,
+# stranding the lock directory and taking setup down with it.
+H9="$TEST_TMP_DIR/home-failwrite"; mkdir -p "$H9/.claude-octopus"
+FAKEBIN="$TEST_TMP_DIR/failbin"; mkdir -p "$FAKEBIN"
+printf '#!/bin/sh\nexit 1\n' > "$FAKEBIN/mv"
+chmod 755 "$FAKEBIN/mv"
+# The call is bare, exactly as commands/setup.md invokes it. Adding `|| true`
+# here would create the condition context that suppresses errexit and make this
+# assertion vacuous.
+fail_out=$(PATH="$FAKEBIN:$PATH" HOME="$H9" bash -c '
+    set -e
+    . "$1"
+    octo_pref_write_default "auto_router_mode" "\"suggest\"" >/dev/null 2>&1
+    echo CALLER_SURVIVED
+' _ "$LIB" 2>&1 | tail -1) || true
+check "a failed write does not kill the caller under set -e" "CALLER_SURVIVED" "$fail_out"
+if [[ -d "$H9/.claude-octopus/preferences.json.lock" ]]; then
+    fail "a failed write still releases the lock" "lock directory stranded"
+else
+    pass "a failed write still releases the lock"
+fi
+
+# --- 15. invoke is never written automatically ------------------------------
 if grep -nE 'octo_pref_write_default[[:space:]]+"auto_router_mode"[[:space:]]+.?"invoke"' "$SETUP_CMD" >/dev/null 2>&1; then
     fail "setup never auto-enables invoke" "setup writes invoke"
 else
     pass "setup never auto-enables invoke"
 fi
 
-# --- 14. setup persists the preference at its completion point --------------
+# --- 16. setup persists the preference at its completion point --------------
 if grep -q 'octo_pref_write_default "auto_router_mode"' "$SETUP_CMD" 2>/dev/null; then
     pass "setup.md persists auto_router_mode on completion"
 else
     fail "setup.md persists auto_router_mode on completion" "setup.md does not call the helper"
 fi
 
-# --- 15. setup states the consent boundary to the user ----------------------
+# --- 17. setup states the consent boundary to the user ----------------------
 if grep -qi 'suggest' "$SETUP_CMD" 2>/dev/null; then
     pass "setup.md tells the user suggestions were enabled"
 else

--- a/tests/unit/test-setup-suggest-routing.sh
+++ b/tests/unit/test-setup-suggest-routing.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Tests that a completed /octo:setup opts the user into suggest-mode routing.
+#
+# Contract (oco-9yj): Octopus stays dormant on install (#898). Completing
+# /octo:setup is an explicit act that implies consent to SUGGESTIONS only.
+# Execution (invoke) is never enabled automatically, and an explicit user
+# preference is never overwritten.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Setup opts into suggest-mode routing"
+
+pass() { test_case "$1"; test_pass; }
+fail() { test_case "$1"; test_fail "${2:-$1}"; }
+check() {
+    local name="$1" expected="$2" actual="$3"
+    test_case "$name"
+    if [[ "$expected" == "$actual" ]]; then
+        test_pass
+    else
+        test_fail "Expected: $expected | Actual: $actual"
+    fi
+}
+
+LIB="$PROJECT_ROOT/scripts/lib/user-config.sh"
+SESSION_HOOK="$PROJECT_ROOT/hooks/auto-router-inject.sh"
+SETUP_CMD="$PROJECT_ROOT/commands/setup.md"
+
+# Effective router mode the session hook resolves for a given HOME.
+resolved_mode() {
+    local home_dir="$1" out
+    out=$(env -u OCTOPUS_AUTO_ROUTER_MODE -u OCTOPUS_AUTO_INVOKE \
+        HOME="$home_dir" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+        "$SESSION_HOOK" 2>/dev/null) || true
+    [[ -n "$out" ]] || { echo "off"; return 0; }
+    printf '%s' "$out" | python3 -c '
+import re,sys
+raw=sys.stdin.read()
+m=re.search(r"mode=\\?\"([a-z]+)\\?\"", raw)
+print(m.group(1) if m else "off")
+'
+}
+
+pref_key() {
+    python3 -c '
+import json,sys
+try:
+    with open(sys.argv[1]) as f: d=json.load(f)
+except Exception: sys.exit(0)
+v=d.get(sys.argv[2])
+if v is not None: print(v)
+' "$1/.claude-octopus/preferences.json" "$2" 2>/dev/null
+}
+
+write_default() {
+    local home_dir="$1"
+    ( HOME="$home_dir"; . "$LIB"; octo_pref_write_default "auto_router_mode" '"suggest"' ) \
+        >/dev/null 2>&1 || true
+}
+
+# --- 1. helper exists -------------------------------------------------------
+if grep -q 'octo_pref_write_default()' "$LIB" 2>/dev/null; then
+    pass "user-config.sh exposes octo_pref_write_default"
+else
+    fail "user-config.sh exposes octo_pref_write_default" "helper missing"
+fi
+
+# --- 2. writes suggest on a fresh profile -----------------------------------
+H1="$TEST_TMP_DIR/home-fresh"; mkdir -p "$H1/.claude-octopus"
+write_default "$H1"
+check "setup completion writes auto_router_mode=suggest" "suggest" "$(pref_key "$H1" auto_router_mode)"
+
+# --- 3. never clobbers an explicit user preference --------------------------
+H2="$TEST_TMP_DIR/home-optout"; mkdir -p "$H2/.claude-octopus"
+printf '{"auto_router_mode":"off"}\n' > "$H2/.claude-octopus/preferences.json"
+write_default "$H2"
+check "an explicit opt-out is never overwritten" "off" "$(pref_key "$H2" auto_router_mode)"
+
+# --- 4. preserves unrelated keys --------------------------------------------
+H3="$TEST_TMP_DIR/home-merge"; mkdir -p "$H3/.claude-octopus"
+printf '{"OCTO_PROACTIVE_SUGGESTIONS":"off"}\n' > "$H3/.claude-octopus/preferences.json"
+write_default "$H3"
+check "unrelated preference keys survive the write" "off" "$(pref_key "$H3" OCTO_PROACTIVE_SUGGESTIONS)"
+check "new key is added alongside existing ones" "suggest" "$(pref_key "$H3" auto_router_mode)"
+
+# --- 5. file is owner-only --------------------------------------------------
+fmode=$(stat -f '%Lp' "$H1/.claude-octopus/preferences.json" 2>/dev/null \
+    || stat -c '%a' "$H1/.claude-octopus/preferences.json" 2>/dev/null || echo "?")
+check "preferences.json is written owner-only" "600" "$fmode"
+
+# --- 6. a profile that never ran setup stays dormant ------------------------
+H4="$TEST_TMP_DIR/home-never-setup"; mkdir -p "$H4/.claude-octopus"
+check "no setup, no preferences file: router stays off" "off" "$(resolved_mode "$H4")"
+
+# --- 7. the written preference actually reaches the hook --------------------
+check "hook resolves suggest from the written preference" "suggest" "$(resolved_mode "$H1")"
+
+# --- 8. an explicit opt-out still reaches the hook as off -------------------
+check "hook honors the preserved opt-out" "off" "$(resolved_mode "$H2")"
+
+# --- 9. invoke is never written automatically -------------------------------
+if grep -nE 'octo_pref_write_default[[:space:]]+"auto_router_mode"[[:space:]]+.?"invoke"' "$SETUP_CMD" >/dev/null 2>&1; then
+    fail "setup never auto-enables invoke" "setup writes invoke"
+else
+    pass "setup never auto-enables invoke"
+fi
+
+# --- 10. setup persists the preference at its completion point --------------
+if grep -q 'octo_pref_write_default "auto_router_mode"' "$SETUP_CMD" 2>/dev/null; then
+    pass "setup.md persists auto_router_mode on completion"
+else
+    fail "setup.md persists auto_router_mode on completion" "setup.md does not call the helper"
+fi
+
+# --- 11. setup states the consent boundary to the user ----------------------
+if grep -qi 'suggest' "$SETUP_CMD" 2>/dev/null; then
+    pass "setup.md tells the user suggestions were enabled"
+else
+    fail "setup.md tells the user suggestions were enabled" "no user-facing mention of suggest mode"
+fi
+
+test_summary


### PR DESCRIPTION
## Why

Octopus is dormant on install (#898). That correctly stops unrequested paid dispatch, but `/octo:setup` and dormancy were orthogonal: a user who ran setup and authenticated providers still got nothing until they memorized command names. Setup completion is an explicit act and should count as consent to *suggestions*.

## What

Completing `/octo:setup` persists `auto_router_mode=suggest`.

- Octopus names a matching command for a plain prompt. It never dispatches a provider on its own.
- `invoke` is never written automatically; it stays opt-in behind `OCTOPUS_AUTO_ROUTER_MODE=invoke`.
- A profile that never runs setup stays fully dormant. The #898 contract is unchanged for anyone who does not opt in.
- An existing `auto_router_mode` value is never overwritten, so a prior opt-out survives a re-run of setup.

## Design note

Setup writes `~/.claude-octopus/preferences.json`, the file the prompt hooks already read, rather than `user-config.json` which setup uses for its other choices. Splitting it this way avoids adding a second file read to the `UserPromptSubmit` path that #898 measured at 38-41 ms per inactive hook. The write is atomic at `0600`, preserves unrelated keys, and leaves a corrupt preferences file untouched rather than replacing it.

## Evidence

New regression `tests/unit/test-setup-suggest-routing.sh` went red first at 6/12 failing, with the 6 passing cases being the guard conditions (dormant default, opt-out preserved, invoke never written) that prove the suite can distinguish. It now passes 12/12.

Adjacent contracts re-run green: explicit activation 20/20, auto-router hooks 14/14, proactive suggestions 12/12.

Full local gate `make ci-changed` failed closed to the complete matrix (shared orchestrator plus generator changes) and passed: 16/16 smoke, 274/274 unit, 7/7 integration, plus the CI-only verifications. `make sync-check` clean, ShellCheck error-level clean, `git diff --check` clean, no file mode changes.

Refs: oco-9yj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now enables routing suggestions by default without automatically invoking providers.
  * Existing preferences and explicit opt-outs are preserved.
  * Users can disable suggestions or opt in to automatic invocation through configuration.
  * Profiles that have never completed setup remain dormant.

* **Bug Fixes**
  * Improved preference handling for invalid or inaccessible configuration files while preserving settings and secure file permissions.

* **Documentation**
  * Updated setup guidance, command references, README instructions, and changelog to explain routing modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->