### PR TITLE
feat(council): opt-in one-vote-per-vendor seating (default off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
   lab to clear both seats to count as an approver — so an internal split (one seat
   APPROVE, one REVISE) can deadlock an otherwise-decidable gate. The
   distinct-approving-vendor quorum already guards correctness; this addresses the
-  panel *weighting*, which the quorum layer does not. Default (unset) preserves
-  today's roster exactly. Enable with `OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1`.
+  panel *weighting*, which the quorum layer does not. Only the exact value
+  `OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1` enables it; unset or any other value
+  (including `0`) preserves today's roster exactly.
 
 ## [9.65.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+
+- Opt-in one-vote-per-vendor council seating. Set
+  `OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1` to keep at most one non-chair voting
+  seat per provider org: after diversity enforcement the roster drops all but the
+  highest-scoring seat of each vendor (chair/synthesis seats are never touched).
+  With Gemini sunset, a 2-vendor standard council otherwise seats
+  `agy + codex + codex`, weighting the panel 2:1 toward one lab and forcing that
+  lab to clear both seats to count as an approver — so an internal split (one seat
+  APPROVE, one REVISE) can deadlock an otherwise-decidable gate. The
+  distinct-approving-vendor quorum already guards correctness; this addresses the
+  panel *weighting*, which the quorum layer does not. Default (unset) preserves
+  today's roster exactly. Enable with `OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1`.
+
 ## [9.65.0] - 2026-08-16
 
 ### Changed

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1150,6 +1150,33 @@ council_build_roster() {
     done
 
     council_enforce_provider_diversity
+    council_dedup_vendor_seats
+}
+
+council_dedup_vendor_seats() {
+    # OPT-IN (default off): keep at most one non-chair VOTING seat per provider org.
+    #
+    # With Gemini sunset, a 2-vendor standard council can seat agy + codex + codex,
+    # which (a) weights the panel 2:1 toward one lab and (b) forces that lab to clear
+    # BOTH of its seats to count as an approver — so an internal split (one seat
+    # APPROVE, one REVISE) can deadlock an otherwise-decidable gate. The
+    # distinct-approving-vendor quorum already guards correctness (a split vendor
+    # can't pass on one seat); this addresses the panel *weighting*, which the quorum
+    # layer does not. It is a seating-policy preference, so it stays off unless
+    # explicitly enabled with OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1.
+    #
+    # When enabled: keep the highest-scoring non-chair seat per org; chair
+    # (synthesis) seats are never touched. Default (unset/anything but 1) preserves
+    # today's roster exactly.
+    [[ "${OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR:-}" == "1" ]] || return 0
+    COUNCIL_ROSTER_JSON="$(jq -c '
+        [ to_entries[] ] as $e
+        | ( [ $e[] | select(.value.seat == "chair") ] ) as $chairs
+        | ( [ $e[] | select(.value.seat != "chair") ]
+            | group_by(.value.provider_org)
+            | map( max_by( .value.score | tonumber? // 0 ) ) ) as $voters
+        | ( $chairs + $voters ) | sort_by(.key) | map(.value)
+    ' <<< "$COUNCIL_ROSTER_JSON")"
 }
 
 council_required_non_chair() {

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1606,37 +1606,43 @@ test_council_one_vote_per_vendor_opt_in() {
       {"persona":"research-synthesizer","seat":"member","provider":"agy","provider_org":"google","score":"0.7"}
     ]'
 
-    # Default (flag unset): opt-in feature is off, roster is untouched — both openai
-    # seats remain, preserving today's upstream behavior.
-    local default_openai
+    # Compare the WHOLE roster (normalized), not just seat counts, so a regression
+    # that swaps a seat or replaces the chair can't slip through.
+    local roster_norm; roster_norm="$(jq -Sc . <<< "$roster")"
+    # Enabled result: the lower-scored openai seat (security-auditor) is dropped;
+    # chair + higher-scored openai (backend-architect) + agy remain, order preserved.
+    local expected_on; expected_on="$(jq -Sc . <<< '[
+      {"persona":"strategy-analyst","seat":"chair","provider":"claude","provider_org":"anthropic","score":"0.9"},
+      {"persona":"backend-architect","seat":"member","provider":"codex","provider_org":"openai","score":"0.8"},
+      {"persona":"research-synthesizer","seat":"member","provider":"agy","provider_org":"google","score":"0.7"}
+    ]')"
+
+    # Default (flag unset): opt-in feature is off, roster is byte-for-byte untouched.
+    local default_norm
     unset OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR
     COUNCIL_ROSTER_JSON="$roster"
     council_dedup_vendor_seats
-    default_openai="$(jq '[.[] | select(.provider_org=="openai")] | length' <<< "$COUNCIL_ROSTER_JSON")"
+    default_norm="$(jq -Sc . <<< "$COUNCIL_ROSTER_JSON")"
 
     # Explicit disable: ONLY the exact value "1" enables the policy. A non-"1"
-    # value (e.g. "0") must behave exactly like unset — guards against a future
-    # nonempty-value predicate silently enabling it on "0"/"false".
-    local off_openai
+    # value (e.g. "0") must leave the roster identical to unset — guards against a
+    # future nonempty-value predicate silently enabling it on "0"/"false".
+    local off_norm
     COUNCIL_ROSTER_JSON="$roster"
     OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=0 council_dedup_vendor_seats
-    off_openai="$(jq '[.[] | select(.provider_org=="openai")] | length' <<< "$COUNCIL_ROSTER_JSON")"
+    off_norm="$(jq -Sc . <<< "$COUNCIL_ROSTER_JSON")"
 
-    # Enabled: one openai voting seat (the higher-scored backend-architect wins),
-    # chair untouched, agy kept.
-    local on_openai on_persona on_chair on_total
+    # Enabled: roster reduced to exactly the expected one-vote-per-vendor set.
+    local on_norm
     COUNCIL_ROSTER_JSON="$roster"
     OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1 council_dedup_vendor_seats
-    on_openai="$(jq '[.[] | select(.provider_org=="openai")] | length' <<< "$COUNCIL_ROSTER_JSON")"
-    on_persona="$(jq -r '[.[] | select(.provider_org=="openai")][0].persona' <<< "$COUNCIL_ROSTER_JSON")"
-    on_chair="$(jq '[.[] | select(.seat=="chair")] | length' <<< "$COUNCIL_ROSTER_JSON")"
-    on_total="$(jq 'length' <<< "$COUNCIL_ROSTER_JSON")"
+    on_norm="$(jq -Sc . <<< "$COUNCIL_ROSTER_JSON")"
 
-    if [[ "$default_openai" == "2" && "$off_openai" == "2" && "$on_openai" == "1" \
-          && "$on_persona" == "backend-architect" && "$on_chair" == "1" && "$on_total" == "3" ]]; then
+    if [[ "$default_norm" == "$roster_norm" && "$off_norm" == "$roster_norm" \
+          && "$on_norm" == "$expected_on" ]]; then
         test_pass
     else
-        test_fail "dedup wrong: default_openai=$default_openai off_openai=$off_openai on(openai=$on_openai persona=$on_persona chair=$on_chair total=$on_total)"
+        test_fail "dedup roster identity wrong: default==input?$([[ "$default_norm" == "$roster_norm" ]] && echo y || echo n) off==input?$([[ "$off_norm" == "$roster_norm" ]] && echo y || echo n) on=$on_norm"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1596,12 +1596,50 @@ test_council_quorum_met_with_host_native_chair() {
     fi
 }
 
+test_council_one_vote_per_vendor_opt_in() {
+    test_case "OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1 keeps one voting seat per vendor; default leaves the roster intact"
+    load_council_lib || return 1
+    local roster='[
+      {"persona":"strategy-analyst","seat":"chair","provider":"claude","provider_org":"anthropic","score":"0.9"},
+      {"persona":"backend-architect","seat":"member","provider":"codex","provider_org":"openai","score":"0.8"},
+      {"persona":"security-auditor","seat":"member","provider":"codex","provider_org":"openai","score":"0.6"},
+      {"persona":"research-synthesizer","seat":"member","provider":"agy","provider_org":"google","score":"0.7"}
+    ]'
+
+    # Default (flag unset): opt-in feature is off, roster is untouched — both openai
+    # seats remain, preserving today's upstream behavior.
+    local default_openai
+    unset OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR
+    COUNCIL_ROSTER_JSON="$roster"
+    council_dedup_vendor_seats
+    default_openai="$(jq '[.[] | select(.provider_org=="openai")] | length' <<< "$COUNCIL_ROSTER_JSON")"
+
+    # Enabled: one openai voting seat (the higher-scored backend-architect wins),
+    # chair untouched, agy kept.
+    local on_openai on_persona on_chair on_total
+    COUNCIL_ROSTER_JSON="$roster"
+    OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1 council_dedup_vendor_seats
+    on_openai="$(jq '[.[] | select(.provider_org=="openai")] | length' <<< "$COUNCIL_ROSTER_JSON")"
+    on_persona="$(jq -r '[.[] | select(.provider_org=="openai")][0].persona' <<< "$COUNCIL_ROSTER_JSON")"
+    on_chair="$(jq '[.[] | select(.seat=="chair")] | length' <<< "$COUNCIL_ROSTER_JSON")"
+    on_total="$(jq 'length' <<< "$COUNCIL_ROSTER_JSON")"
+
+    if [[ "$default_openai" == "2" && "$on_openai" == "1" && "$on_persona" == "backend-architect" \
+          && "$on_chair" == "1" && "$on_total" == "3" ]]; then
+        test_pass
+    else
+        test_fail "dedup wrong: default_openai=$default_openai on(openai=$on_openai persona=$on_persona chair=$on_chair total=$on_total)"
+        return 1
+    fi
+}
+
 test_council_command_files_are_registered
 test_council_orchestrate_route_exists
 test_council_run_status_beacon_lifecycle
 test_council_benchmark_routing_lib_is_extracted
 test_council_chair_is_host_native_detects_status
 test_council_quorum_met_with_host_native_chair
+test_council_one_vote_per_vendor_opt_in
 test_council_defaults_are_depth_aware
 test_council_rejects_non_usd_budget
 test_council_dry_run_writes_summary_json

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1614,6 +1614,14 @@ test_council_one_vote_per_vendor_opt_in() {
     council_dedup_vendor_seats
     default_openai="$(jq '[.[] | select(.provider_org=="openai")] | length' <<< "$COUNCIL_ROSTER_JSON")"
 
+    # Explicit disable: ONLY the exact value "1" enables the policy. A non-"1"
+    # value (e.g. "0") must behave exactly like unset — guards against a future
+    # nonempty-value predicate silently enabling it on "0"/"false".
+    local off_openai
+    COUNCIL_ROSTER_JSON="$roster"
+    OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=0 council_dedup_vendor_seats
+    off_openai="$(jq '[.[] | select(.provider_org=="openai")] | length' <<< "$COUNCIL_ROSTER_JSON")"
+
     # Enabled: one openai voting seat (the higher-scored backend-architect wins),
     # chair untouched, agy kept.
     local on_openai on_persona on_chair on_total
@@ -1624,11 +1632,11 @@ test_council_one_vote_per_vendor_opt_in() {
     on_chair="$(jq '[.[] | select(.seat=="chair")] | length' <<< "$COUNCIL_ROSTER_JSON")"
     on_total="$(jq 'length' <<< "$COUNCIL_ROSTER_JSON")"
 
-    if [[ "$default_openai" == "2" && "$on_openai" == "1" && "$on_persona" == "backend-architect" \
-          && "$on_chair" == "1" && "$on_total" == "3" ]]; then
+    if [[ "$default_openai" == "2" && "$off_openai" == "2" && "$on_openai" == "1" \
+          && "$on_persona" == "backend-architect" && "$on_chair" == "1" && "$on_total" == "3" ]]; then
         test_pass
     else
-        test_fail "dedup wrong: default_openai=$default_openai on(openai=$on_openai persona=$on_persona chair=$on_chair total=$on_total)"
+        test_fail "dedup wrong: default_openai=$default_openai off_openai=$off_openai on(openai=$on_openai persona=$on_persona chair=$on_chair total=$on_total)"
         return 1
     fi
 }


### PR DESCRIPTION
## What

Add an **opt-in** roster policy: with `OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1`, after diversity enforcement the council keeps at most **one non-chair voting seat per provider org** (highest-scoring seat wins; chair/synthesis seats are never touched).

**Default off** — unset (or anything but `1`) preserves today's roster exactly. Enable with:

```bash
OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1
```

## Why

With Gemini sunset, a 2-vendor standard council seats `agy + codex + codex`, which:
1. Weights the panel **2:1 toward one lab** (OpenAI), and
2. Forces that lab to clear **both** of its seats to count as an approver — so an internal split (one codex seat APPROVE, one REVISE) can **deadlock an otherwise-decidable gate**.

The distinct-approving-vendor quorum (#577/#670 + #926) already guards *correctness* — a split vendor can't pass on a single seat. This addresses the panel *weighting*, which the quorum layer doesn't. Because that's a **seating-policy preference** rather than a bug, it ships as an explicit opt-in and changes nothing for anyone who doesn't set the flag.

## Tests

`council_one_vote_per_vendor_opt_in` — default leaves both same-vendor seats intact; enabled keeps the higher-scored seat per vendor with the chair untouched.

`tests/unit/test-council-command.sh`: **85 passed, 0 failed, 1 skipped** (pre-existing macOS-CI pty flake). No file-mode changes.

## Note

I've been running this locally (as a default-*on* preference) for a while; this PR is the default-*off*, opt-in framing so it's safe to land without affecting other users. Happy to adjust the flag name or default if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in council seating mode that limits voting seats to one per vendor.
  * Enable this mode with `OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1`.
  * Retains the highest-scoring voting seat for each vendor while preserving chair and synthesis seats.
  * Existing council rosters remain unchanged when the setting is unset or disabled.

* **Tests**
  * Added coverage for default, disabled, and one-vote-per-vendor seating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->