### PR TITLE
refactor: make design review roles provider-neutral

### DIFF
--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -338,7 +338,7 @@ DECEOF
 }
 
 # v8.18.0 Feature: Pre-Work Design Review Ceremony
-# Before tangle phase, each provider states its approach; conflicts are resolved.
+# Before tangle phase, each review role states its approach; conflicts are resolved.
 # After failures, a retrospective fires.
 
 design_review_ceremony() {
@@ -358,7 +358,7 @@ design_review_ceremony() {
     echo ""
     echo -e "${CYAN}${_BOX_TOP}${NC}"
     echo -e "${CYAN}║  📋 DESIGN REVIEW CEREMONY                               ║${NC}"
-    echo -e "${CYAN}║  Each provider states their approach before implementation ║${NC}"
+    echo -e "${CYAN}║  Each review role states its approach before implementation ║${NC}"
     echo -e "${CYAN}${_BOX_BOT}${NC}"
     echo ""
 
@@ -376,13 +376,14 @@ State your HIGH-LEVEL approach in 3-5 bullet points:
 
 Be concise and specific. This is a planning exercise, not implementation."
 
-    # Gather approaches from available providers. Keep these configurable so
-    # operators can pick cheaper/faster review models without patching code.
+    # Gather approaches by semantic review role. Runtime executor/provider/model
+    # selection is separate from seat identity. The provider-named variables are
+    # compatibility aliases only and may be removed in a future major release.
     local seat_1_approach="" seat_2_approach="" seat_3_approach=""
-    local design_codex_agent="${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-codex-mini}"
-    local design_agy_agent="${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-agy}}"
-    local design_claude_agent="${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}"
-    local design_synthesis_agent="${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}"
+    local design_implementer_agent="${OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-codex-mini}}"
+    local design_researcher_agent="${OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT:-${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-agy}}}"
+    local design_code_reviewer_agent="${OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}}"
+    local design_synthesizer_agent="${OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT:-${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}}"
     local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-0}"
     local design_synth_timeout="${OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT:-0}"
     if [[ ! "$design_timeout" =~ ^[0-9]+$ ]]; then
@@ -400,30 +401,30 @@ Be concise and specific. This is a planning exercise, not implementation."
     [[ "$design_synth_timeout" != "0" ]] && _synth_timeout_label="${design_synth_timeout}s"
 
     local seat_1_label seat_2_label seat_3_label synthesis_label
-    seat_1_label="$(octo_provider_identity_label "$design_codex_agent" "implementer")"
-    seat_2_label="$(octo_provider_identity_label "$design_agy_agent" "researcher")"
-    seat_3_label="$(octo_provider_identity_label "$design_claude_agent" "code-reviewer")"
-    synthesis_label="$(octo_provider_identity_label "$design_synthesis_agent" "synthesizer")"
+    seat_1_label="$(octo_provider_identity_label "$design_implementer_agent" "implementer")"
+    seat_2_label="$(octo_provider_identity_label "$design_researcher_agent" "researcher")"
+    seat_3_label="$(octo_provider_identity_label "$design_code_reviewer_agent" "code-reviewer")"
+    synthesis_label="$(octo_provider_identity_label "$design_synthesizer_agent" "synthesizer")"
 
-    log INFO "Design review: gathering provider approaches..."
+    log INFO "Design review: gathering role approaches..."
     log INFO "Design review seats: seat_1=${seat_1_label}, seat_2=${seat_2_label}, seat_3=${seat_3_label}, synthesis=${synthesis_label}, timeout=${_design_timeout_label}, synth_timeout=${_synth_timeout_label}"
 
     seat_1_approach="$(
         (
             export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
-            run_agent_sync_consultative "$design_codex_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony"
+            run_agent_sync_consultative "$design_implementer_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony"
         ) 2>/dev/null
     )" || true
     seat_2_approach="$(
         (
             export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
-            run_agent_sync_consultative "$design_agy_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony"
+            run_agent_sync_consultative "$design_researcher_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony"
         ) 2>/dev/null
     )" || true
     seat_3_approach="$(
         (
             export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
-            run_agent_sync_consultative "$design_claude_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony"
+            run_agent_sync_consultative "$design_code_reviewer_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony"
         ) 2>/dev/null
     )" || true
 
@@ -435,11 +436,11 @@ Be concise and specific. This is a planning exercise, not implementation."
     _synth_started_at=$(date +%s 2>/dev/null || echo 0)
     if declare -f octo_event_emit >/dev/null 2>&1; then
         octo_event_emit "synthesis.start" phase="ceremony" scope="design-review" \
-            provider="$design_synthesis_agent" inputs="3" || true
+            provider="$design_synthesizer_agent" inputs="3" || true
     fi
 
     local synthesis
-    synthesis=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_synthesis_agent" "You are synthesizing a design review ceremony.
+    synthesis=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_synthesizer_agent" "You are synthesizing a design review ceremony.
 
 Three review seats stated their approach to this task. The headings below reflect configured runtime identity rather than historical provider slot names:
 
@@ -467,7 +468,7 @@ Be brief and actionable." "$design_synth_timeout" "synthesizer" "ceremony" 2>/de
         [[ "$_synth_started_at" =~ ^[0-9]+$ && "$_synth_now" =~ ^[0-9]+$ && "$_synth_started_at" -gt 0 ]] \
             && _synth_elapsed=$(( _synth_now - _synth_started_at ))
         octo_event_emit "synthesis.end" phase="ceremony" scope="design-review" \
-            provider="$design_synthesis_agent" \
+            provider="$design_synthesizer_agent" \
             status="$([[ -n "$synthesis" ]] && echo produced || echo empty)" \
             bytes="${#synthesis}" elapsed_s="$_synth_elapsed" || true
     fi

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -436,7 +436,11 @@ Be concise and specific. This is a planning exercise, not implementation."
     _synth_started_at=$(date +%s 2>/dev/null || echo 0)
     if declare -f octo_event_emit >/dev/null 2>&1; then
         octo_event_emit "synthesis.start" phase="ceremony" scope="design-review" \
-            provider="$design_synthesizer_agent" inputs="3" || true
+            provider="$design_synthesizer_agent" provider_label_kind="legacy-alias" \
+            executor_alias="$design_synthesizer_agent" \
+            configured_provider="$(octo_provider_identity_from_agent_type "$design_synthesizer_agent")" \
+            configured_model="$(get_agent_model "$design_synthesizer_agent" "ceremony" "synthesizer" 2>/dev/null || echo unresolved)" \
+            runtime_provider="unknown" runtime_model="unknown" role="synthesizer" inputs="3" || true
     fi
 
     local synthesis
@@ -468,7 +472,11 @@ Be brief and actionable." "$design_synth_timeout" "synthesizer" "ceremony" 2>/de
         [[ "$_synth_started_at" =~ ^[0-9]+$ && "$_synth_now" =~ ^[0-9]+$ && "$_synth_started_at" -gt 0 ]] \
             && _synth_elapsed=$(( _synth_now - _synth_started_at ))
         octo_event_emit "synthesis.end" phase="ceremony" scope="design-review" \
-            provider="$design_synthesizer_agent" \
+            provider="$design_synthesizer_agent" provider_label_kind="legacy-alias" \
+            executor_alias="$design_synthesizer_agent" \
+            configured_provider="$(octo_provider_identity_from_agent_type "$design_synthesizer_agent")" \
+            configured_model="$(get_agent_model "$design_synthesizer_agent" "ceremony" "synthesizer" 2>/dev/null || echo unresolved)" \
+            runtime_provider="unknown" runtime_model="unknown" role="synthesizer" \
             status="$([[ -n "$synthesis" ]] && echo produced || echo empty)" \
             bytes="${#synthesis}" elapsed_s="$_synth_elapsed" || true
     fi

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -90,20 +90,84 @@ else
   test_fail "design review labels did not expose resolved runtime identity: $label | $research_label"
 fi
 
-test_case "design review configuration is role-first and provider-neutral"
-quality="$PROJECT_ROOT/scripts/lib/quality.sh"
-if grep -q 'OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT' "$quality" &&    grep -q 'design_implementer_agent' "$quality" &&    grep -q 'design_researcher_agent' "$quality" &&    grep -q 'design_code_reviewer_agent' "$quality" &&    grep -q 'design_synthesizer_agent' "$quality" &&    ! grep -q 'local design_codex_agent=' "$quality" &&    ! grep -q 'local design_agy_agent=' "$quality" &&    ! grep -q 'local design_claude_agent=' "$quality" &&    ! grep -q 'local design_synthesis_agent=' "$quality"; then
+run_design_review_dispatch_probe() {
+  local mode="$1"
+  local dispatch_log="$2"
+  MODE="$mode" PROJECT_ROOT="$PROJECT_ROOT" DISPATCH_LOG="$dispatch_log" \
+  WORKSPACE_DIR="$TEST_TMP_DIR/workspace-$mode" DRY_RUN=false OCTOPUS_CEREMONIES=true \
+  bash -c '
+    set -e
+    mkdir -p "$WORKSPACE_DIR"
+    source "$PROJECT_ROOT/scripts/lib/quality.sh"
+    if [[ "$MODE" == "role" ]]; then
+      export OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT=role-implementer
+      export OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT=role-researcher
+      export OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT=role-reviewer
+      export OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT=role-synthesizer
+      export OCTOPUS_DESIGN_REVIEW_CODEX_AGENT=legacy-codex
+      export OCTOPUS_DESIGN_REVIEW_AGY_AGENT=legacy-agy
+      export OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT=legacy-claude
+      export OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT=legacy-synth
+    else
+      unset OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT
+      export OCTOPUS_DESIGN_REVIEW_CODEX_AGENT=legacy-codex
+      export OCTOPUS_DESIGN_REVIEW_AGY_AGENT=legacy-agy
+      unset OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT
+      export OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT=legacy-claude
+      export OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT=legacy-synth
+    fi
+    : > "$DISPATCH_LOG"
+    run_agent_sync_consultative() {
+      printf "%s|%s|%s\n" "$1" "$4" "$5" >> "$DISPATCH_LOG"
+      printf "approach\n"
+    }
+    octo_provider_identity_label() { printf "%s\n" "$1"; }
+    octo_provider_identity_from_agent_type() { printf "%s\n" "$1"; }
+    get_agent_model() { printf "test-model\n"; }
+    octo_event_emit() { :; }
+    write_structured_decision() { :; }
+    log() { :; }
+    design_review_ceremony "test task" >/dev/null 2>&1 || true
+  '
+}
+
+test_case "design review role overrides win over legacy provider-named overrides at runtime"
+role_log="$TEST_TMP_DIR/role-precedence.log"
+run_design_review_dispatch_probe role "$role_log"
+if grep -q '^role-implementer|implementer|ceremony$' "$role_log" &&
+   grep -q '^role-researcher|researcher|ceremony$' "$role_log" &&
+   grep -q '^role-reviewer|code-reviewer|ceremony$' "$role_log" &&
+   grep -q '^role-synthesizer|synthesizer|ceremony$' "$role_log" &&
+   ! grep -q 'legacy-' "$role_log"; then
   test_pass
 else
-  test_fail "design review configuration still identifies semantic seats by provider"
+  test_fail "semantic role override did not take precedence over legacy provider override"
 fi
 
-test_case "legacy provider-named design review overrides remain compatibility fallbacks"
-quality="$PROJECT_ROOT/scripts/lib/quality.sh"
-if grep -q 'OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-codex-mini}' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT:-${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-agy}}' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT:-${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}' "$quality"; then
+test_case "legacy provider-named design review overrides remain runtime fallbacks"
+legacy_log="$TEST_TMP_DIR/legacy-fallback.log"
+run_design_review_dispatch_probe legacy "$legacy_log"
+if grep -q '^legacy-codex|implementer|ceremony$' "$legacy_log" &&
+   grep -q '^legacy-agy|researcher|ceremony$' "$legacy_log" &&
+   grep -q '^legacy-claude|code-reviewer|ceremony$' "$legacy_log" &&
+   grep -q '^legacy-synth|synthesizer|ceremony$' "$legacy_log"; then
   test_pass
 else
-  test_fail "legacy design review override compatibility changed unexpectedly"
+  test_fail "legacy provider override did not remain a functional fallback"
+fi
+
+test_case "design review synthesis events carry stable executor and role identity"
+quality="$PROJECT_ROOT/scripts/lib/quality.sh"
+if grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'executor_alias=' &&
+   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'configured_provider=' &&
+   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'configured_model=' &&
+   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'runtime_provider=' &&
+   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'role="synthesizer"' &&
+   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'executor_alias=' &&
+   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'role="synthesizer"'; then
+  test_pass
+else
+  test_fail "design review synthesis events lack stable lifecycle identity fields"
 fi
 
 test_case "design review synthesis prompt no longer uses historical provider headings"

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -111,8 +111,13 @@ run_design_review_dispatch_probe() {
     else
       unset OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT
       export "OCTOPUS_DESIGN_REVIEW_CODEX_AGENT=legacy-codex"
-      export "OCTOPUS_DESIGN_REVIEW_AGY_AGENT=legacy-agy"
-      unset OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT
+      if [[ "$MODE" == "gemini" ]]; then
+        unset OCTOPUS_DESIGN_REVIEW_AGY_AGENT
+        export "OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT=legacy-gemini"
+      else
+        export "OCTOPUS_DESIGN_REVIEW_AGY_AGENT=legacy-agy"
+        unset OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT
+      fi
       export "OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT=legacy-claude"
       export "OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT=legacy-synth"
     fi
@@ -154,6 +159,16 @@ if grep -q '^legacy-codex|implementer|ceremony$' "$legacy_log" &&
   test_pass
 else
   test_fail "legacy provider override did not remain a functional fallback"
+fi
+
+test_case "legacy GEMINI design review override remains secondary researcher fallback"
+gemini_log="$TEST_TMP_DIR/gemini-fallback.log"
+run_design_review_dispatch_probe gemini "$gemini_log"
+if grep -q '^legacy-gemini|researcher|ceremony$' "$gemini_log" &&
+   ! grep -q '^legacy-agy|researcher|ceremony$' "$gemini_log"; then
+  test_pass
+else
+  test_fail "legacy GEMINI override did not remain the secondary researcher fallback"
 fi
 
 test_case "design review synthesis events carry stable executor and role identity"

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -90,6 +90,22 @@ else
   test_fail "design review labels did not expose resolved runtime identity: $label | $research_label"
 fi
 
+test_case "design review configuration is role-first and provider-neutral"
+quality="$PROJECT_ROOT/scripts/lib/quality.sh"
+if grep -q 'OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT' "$quality" &&    grep -q 'design_implementer_agent' "$quality" &&    grep -q 'design_researcher_agent' "$quality" &&    grep -q 'design_code_reviewer_agent' "$quality" &&    grep -q 'design_synthesizer_agent' "$quality" &&    ! grep -q 'local design_codex_agent=' "$quality" &&    ! grep -q 'local design_agy_agent=' "$quality" &&    ! grep -q 'local design_claude_agent=' "$quality" &&    ! grep -q 'local design_synthesis_agent=' "$quality"; then
+  test_pass
+else
+  test_fail "design review configuration still identifies semantic seats by provider"
+fi
+
+test_case "legacy provider-named design review overrides remain compatibility fallbacks"
+quality="$PROJECT_ROOT/scripts/lib/quality.sh"
+if grep -q 'OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-codex-mini}' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT:-${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-agy}}' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}' "$quality" &&    grep -q 'OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT:-${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}' "$quality"; then
+  test_pass
+else
+  test_fail "legacy design review override compatibility changed unexpectedly"
+fi
+
 test_case "design review synthesis prompt no longer uses historical provider headings"
 if ! grep -q '^CODEX APPROACH:' "$PROJECT_ROOT/scripts/lib/quality.sh" && \
    ! grep -q '^GEMINI APPROACH:' "$PROJECT_ROOT/scripts/lib/quality.sh" && \

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -93,28 +93,28 @@ fi
 run_design_review_dispatch_probe() {
   local mode="$1"
   local dispatch_log="$2"
-  MODE="$mode" PROJECT_ROOT="$PROJECT_ROOT" DISPATCH_LOG="$dispatch_log" \
-  WORKSPACE_DIR="$TEST_TMP_DIR/workspace-$mode" DRY_RUN=false OCTOPUS_CEREMONIES=true \
+  env "MODE=${mode}" "PROJECT_ROOT=${PROJECT_ROOT}" "DISPATCH_LOG=${dispatch_log}" \
+    "WORKSPACE_DIR=${TEST_TMP_DIR}/workspace-${mode}" "DRY_RUN=false" "OCTOPUS_CEREMONIES=true" \
   bash -c '
     set -e
     mkdir -p "$WORKSPACE_DIR"
     source "$PROJECT_ROOT/scripts/lib/quality.sh"
     if [[ "$MODE" == "role" ]]; then
-      export OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT=role-implementer
-      export OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT=role-researcher
-      export OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT=role-reviewer
-      export OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT=role-synthesizer
-      export OCTOPUS_DESIGN_REVIEW_CODEX_AGENT=legacy-codex
-      export OCTOPUS_DESIGN_REVIEW_AGY_AGENT=legacy-agy
-      export OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT=legacy-claude
-      export OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT=legacy-synth
+      export "OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT=role-implementer"
+      export "OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT=role-researcher"
+      export "OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT=role-reviewer"
+      export "OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT=role-synthesizer"
+      export "OCTOPUS_DESIGN_REVIEW_CODEX_AGENT=legacy-codex"
+      export "OCTOPUS_DESIGN_REVIEW_AGY_AGENT=legacy-agy"
+      export "OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT=legacy-claude"
+      export "OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT=legacy-synth"
     else
       unset OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT
-      export OCTOPUS_DESIGN_REVIEW_CODEX_AGENT=legacy-codex
-      export OCTOPUS_DESIGN_REVIEW_AGY_AGENT=legacy-agy
+      export "OCTOPUS_DESIGN_REVIEW_CODEX_AGENT=legacy-codex"
+      export "OCTOPUS_DESIGN_REVIEW_AGY_AGENT=legacy-agy"
       unset OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT
-      export OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT=legacy-claude
-      export OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT=legacy-synth
+      export "OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT=legacy-claude"
+      export "OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT=legacy-synth"
     fi
     : > "$DISPATCH_LOG"
     run_agent_sync_consultative() {
@@ -162,8 +162,13 @@ if grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'executor_a
    grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'configured_provider=' &&
    grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'configured_model=' &&
    grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'runtime_provider=' &&
+   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'runtime_model=' &&
    grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'role="synthesizer"' &&
    grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'executor_alias=' &&
+   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'configured_provider=' &&
+   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'configured_model=' &&
+   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'runtime_provider=' &&
+   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'runtime_model=' &&
    grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'role="synthesizer"'; then
   test_pass
 else


### PR DESCRIPTION
## Summary

Make pre-implementation design review configuration role-first instead of provider-slot-first.

The semantic roles are already passed to `run_agent_sync_consultative` (implementer, researcher, code-reviewer, synthesizer), but the configuration surface and local variables still named those seats after historical providers (Codex, AGY, Claude). This becomes misleading as routing changes.

## Changes

Add provider-neutral design review overrides:

- `OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT`
- `OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT`
U- `OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT`
- `OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT`

Rename local design-review variables to the same semantic roles and update log/user-facing wording from "provider approaches" to "role approaches."

## Compatibility

The historical provider-named variables remain accepted as deprecated compatibility fallbacks, with the new role-named variables taking precedence:

- `CODEX_AGENT` -> `MPLEMENTER_AGENT` fallback
- `AGY_AGENT` / `GEMINI_AGENT` → `RESEARCHER_AGENT` fallback
- `CLAUDE_AGENT` → `CODE_REVIEWER_AGENT` fallback
- `SYNTH_AGENT` → `SYNTHESIZER_AGENT` fallback

This avoids breaking existing operator configuration while moving the primary interface to semantic roles.

## Validation

- `tests/unit/test-runtime-provider-labels.sh` — 10/10 pass
- `tests/unit/test-ceremonies.sh` — 9/9 pass
- `tests/unit/test-tangle-context-review-loop.sh` — 54/54 pass
- `bash -n` on touched scripts/tests — pass
- `git diff --check` — pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Design reviews now use clear role-based labels, including implementer, researcher, code reviewer, and synthesizer.
  - Review configuration supports role-specific settings while maintaining compatibility with existing provider-based settings.
  - Role-specific settings take precedence, with legacy configuration retained as a fallback.
  - Review activity now provides clearer execution details, including the assigned role and configured model.

- **Tests**
  - Added coverage for role-based configuration, provider-neutral labels, lifecycle details, and legacy configuration fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->