### PR TITLE
refactor: make review council provider-neutral

### DIFF
--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/../lib/provider-registry.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/../lib/provider-policy.sh" 2>/dev/null || true
 
 WORKFLOW="${1:-research}"
 INTENSITY="${2:-standard}"
@@ -275,32 +277,78 @@ build_research_fleet() {
 }
 
 # ── Review Fleet ──────────────────────────────────────────────────────────────
-build_review_fleet() {
-    local logic_provider
-    logic_provider=$(pick_provider "claude-sonnet" codex opencode copilot)
-    [[ -n "$logic_provider" ]] && emit "$logic_provider" "Logic Reviewer" "Review for correctness and logic bugs, edge cases, regressions in: $PROMPT"
+# Review seats are provider-neutral. Build a deterministic, family-diverse pool
+# from providers that are both admitted by check-providers.sh and declare the
+# registry `council` capability. Claude remains an implicit candidate because it
+# is the host runtime and therefore is not reported by check-providers.sh.
+build_council_order() {
+    local provider family canonical used_families="" first="" rest="" candidates="" preferred=""
 
-    local sec_provider
-    sec_provider=$(pick_provider "claude-sonnet" agy qwen copilot)
-    # Ensure different from logic reviewer
-    if [[ -n "$sec_provider" && "$sec_provider" == "$logic_provider" && "$sec_provider" != "claude-sonnet" ]]; then
-        local alternate_provider
-        alternate_provider=$(pick_provider "" claude-sonnet)
-        if [[ -n "$alternate_provider" && "$alternate_provider" != "$logic_provider" ]]; then
-            sec_provider="$alternate_provider"
+    # Provider policy controls preference order, not eligibility. Any admitted
+    # provider with the registry `council` capability may still fill a seat when
+    # preferred providers are unavailable or denied.
+    preferred="$(octo_council_default_providers 2>/dev/null || true)"
+    for provider in $(printf '%s' "$preferred" | tr ',' ' '); do
+        canonical="$(octo_provider_canonical "$provider" 2>/dev/null || true)"
+        [[ -n "$canonical" ]] || continue
+        octo_provider_has_capability "$canonical" council || continue
+        if [[ "$canonical" == "claude" ]]; then
+            octo_provider_allowed claude-sonnet || continue
+            provider="claude-sonnet"
+        else
+            is_available "$canonical" || continue
+            octo_provider_allowed "$canonical" || continue
+            provider="$canonical"
         fi
-    fi
-    [[ -n "$sec_provider" ]] && emit "$sec_provider" "Security Reviewer" "Review for OWASP vulnerabilities, injection, auth flaws, data exposure in: $PROMPT"
+        _contains "$candidates" "$provider" || candidates="${candidates}${candidates:+ }${provider}"
+    done
 
-    emit_if_allowed "claude-sonnet" "Architecture Reviewer" "Review architecture, integration, API contracts, breaking changes in: $PROMPT"
+    # Append eligible council providers omitted from the preference policy so a
+    # usable backend can naturally replace an unavailable one.
+    for canonical in $(octo_provider_ids council 2>/dev/null); do
+        if [[ "$canonical" == "claude" ]]; then
+            octo_provider_allowed claude-sonnet || continue
+            provider="claude-sonnet"
+        else
+            is_available "$canonical" || continue
+            octo_provider_allowed "$canonical" || continue
+            provider="$canonical"
+        fi
+        _contains "$candidates" "$provider" || candidates="${candidates}${candidates:+ }${provider}"
+    done
 
-    local cve_provider
-    if is_available perplexity; then
-        cve_provider="perplexity"
-    else
-        cve_provider=$(pick_provider "claude-sonnet" agy copilot qwen)
-    fi
-    [[ -n "$cve_provider" ]] && emit "$cve_provider" "CVE Reviewer" "Check for known CVEs, library advisories, and security bulletins related to: $PROMPT"
+    for provider in $candidates; do
+        family=$(get_family "$provider")
+        if ! _contains "$used_families" "$family"; then
+            first="${first}${first:+ }${provider}"
+            used_families="${used_families}${used_families:+ }${family}"
+        else
+            rest="${rest}${rest:+ }${provider}"
+        fi
+    done
+    printf '%s\n' "${first}${rest:+ $rest}"
+}
+
+build_review_fleet() {
+    local order
+    order="$(build_council_order)"
+    # shellcheck disable=SC2206
+    local providers=($order)
+    local count=${#providers[@]}
+    [[ $count -gt 0 ]] || return 0
+
+    local labels=("Logic Reviewer" "Security Reviewer" "Architecture Reviewer" "CVE Reviewer")
+    local prompts=(
+        "Review for correctness and logic bugs, edge cases, regressions in: $PROMPT"
+        "Review for OWASP vulnerabilities, injection, auth flaws, data exposure in: $PROMPT"
+        "Review architecture, integration, API contracts, breaking changes in: $PROMPT"
+        "Check for known CVEs, library advisories, and security bulletins related to: $PROMPT"
+    )
+    local i provider
+    for ((i=0; i<4; i++)); do
+        provider="${providers[$((i % count))]}"
+        emit "$provider" "${labels[$i]}" "${prompts[$i]}"
+    done
     return 0
 }
 

--- a/tests/unit/test-provider-neutral-council.sh
+++ b/tests/unit/test-provider-neutral-council.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Provider-neutral review council with role-based model routing"
+
+TMP_HOME="$(mktemp -d)"
+CHECKER="$TMP_HOME/check-providers.sh"
+trap 'rm -rf "$TMP_HOME"' EXIT
+mkdir -p "$TMP_HOME/.claude-octopus/config"
+cat >"$CHECKER" <<'EOF'
+#!/bin/sh
+cat <<'STATUS'
+PROVIDER_CHECK_START
+codex:available
+commandcode:available
+agy:missing
+perplexity:missing
+openrouter:missing
+PROVIDER_CHECK_END
+STATUS
+EOF
+chmod +x "$CHECKER"
+cat >"$TMP_HOME/.claude-octopus/config/providers.json" <<'EOF'
+{
+  "version":"3.0",
+  "providers": {
+    "codex": {"default":"gpt-5.6-sol"},
+    "commandcode": {"default":"deepseek/deepseek-v4-flash"},
+    "claude": {"default":"claude-sonnet-5"}
+  },
+  "routing":{"phases":{},"roles":{"architecture-reviewer":{"provider":"commandcode","model":"minimaxai/minimax-m3"}}},
+  "tiers":{},
+  "overrides":{}
+}
+EOF
+
+export HOME="$TMP_HOME"
+export OCTOPUS_PROVIDER_CHECKER="$CHECKER"
+export OCTOPUS_ALLOWED_PROVIDERS="codex commandcode claude"
+
+output="$(bash "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" review standard test 2>/dev/null)"
+
+test_case "review council uses admitted council-capable providers without AGY/Perplexity"
+if echo "$output" | cut -d'|' -f1 | grep -Eq '^(agy|perplexity)$'; then
+  test_fail "unusable provider entered council: $output"
+elif echo "$output" | cut -d'|' -f1 | grep -q '^commandcode$'; then
+  test_pass
+else
+  test_fail "CommandCode did not naturally fill a council seat: $output"
+fi
+
+test_case "review seats remain role labels rather than provider identities"
+labels="$(echo "$output" | cut -d'|' -f2 | tr '\n' '|')"
+case "$labels" in
+  *"Logic Reviewer"*"Security Reviewer"*"Architecture Reviewer"*"CVE Reviewer"*) test_pass ;;
+  *) test_fail "review role labels changed: $labels" ;;
+esac
+
+test_case "role routing resolves a role-specific model without changing provider identity"
+log() { :; }
+export PLUGIN_DIR="$PROJECT_ROOT"
+export OCTOPUS_PLATFORM=Linux
+source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+model="$(resolve_octopus_model commandcode commandcode review architecture-reviewer)"
+if [[ "$model" == "minimaxai/minimax-m3" ]]; then
+  test_pass
+else
+  test_fail "expected role-routed MiniMax model, got '$model'"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

Make the review council provider-neutral on top of #933.

The review fleet now:

- builds from providers that are admitted and declare the `council` capability in the provider registry;
- respects `OCTOPUS_COUNCIL_DEFAULT_PROVIDERS` as preference order rather than as a hardcoded role/provider mapping;
- preserves provider-family diversity;
- keeps review roles as roles (`Logic Reviewer`, `Security Reviewer`, `Architecture Reviewer`, `CVE Reviewer`);
- emits provider identity only. Role-specific model selection remains downstream in the existing model resolver via `routing.roles`.

This deliberately does **not** introduce a `council` model/profile. Council is a workflow/event, while model/profile selection belongs to the role/provider routing layer.

## Motivation

After #933 made design-review roles provider-neutral, `build_review_fleet()` still hardcoded provider identities per role (for example Codex for logic, AGY for security, Perplexity for CVE). That means a provider which is usable and registry-capable for council cannot naturally fill a review seat unless it appears in those role-specific lists.

This change completes the separation:

`event/workflow -> role/seat -> usable provider -> role-specific model/profile`

## Validation

- `tests/unit/test-provider-neutral-council.sh` — 3/3 pass
- `tests/unit/test-provider-registry.sh` — 8/8 pass
- `tests/unit/test-model-config-role-routing.sh` — 4/4 pass
- `bash -n` on changed shell/test files — pass
- `git diff --check` — pass

The focused test also verifies that a role-specific model route can resolve MiniMax for CommandCode while the provider identity remains `commandcode`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review councils now select from eligible, available providers based on configured capabilities and policies.
  - Provider assignment is balanced across supported provider families.
  - Review roles remain consistent regardless of the selected provider.
  - Additional providers can fill council seats when others are unavailable.

- **Bug Fixes**
  - Unavailable or disallowed providers are excluded from review councils.
  - Duplicate provider assignments are prevented.

- **Tests**
  - Added coverage for provider availability, fallback routing, role labels, and configured model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->