### PR TITLE
fix: track blocker identity in correction convergence

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1717,6 +1717,26 @@ tangle_findings_signature() {
     jq -r '[.findings[]? | select((.severity // "") == "normal") | (.title // .message // "untitled")] | sort | join(" | ")' "$findings_file" 2>/dev/null || echo "unparseable"
 }
 
+# Stable blocker identities for convergence tracking. File + normalized title is
+# intentionally stronger than count-only progress while remaining resilient to
+# line movement and detail/confidence rewrites between review rounds.
+tangle_normal_finding_keys() {
+    local findings_file="$1"
+    [[ -f "$findings_file" ]] || return 0
+    jq -r '''
+        .findings[]?
+        | select((.severity // "") == "normal")
+        | ((.file // "unknown") | ascii_downcase) + "|" +
+          (((.title // .message // "untitled") | ascii_downcase | gsub("[[:space:]]+"; " ") | sub("^ "; "") | sub(" $"; "")))
+    ''' "$findings_file" 2>/dev/null | sort -u || true
+}
+
+tangle_resolved_finding_count() {
+    local previous_keys="$1"
+    local current_keys="$2"
+    comm -23         <(printf '%s\n' "$previous_keys" | sed '/^$/d' | sort -u)         <(printf '%s\n' "$current_keys" | sed '/^$/d' | sort -u)         | awk 'NF { n++ } END { print n + 0 }'
+}
+
 # Fingerprint only the actionable validation-gate decision. This lets the
 # correction loop distinguish useful validation movement from a static gate that
 # is being recomputed from immutable initial subtask result files.
@@ -3420,6 +3440,8 @@ tangle_contextual_review_gate() {
     local previous_normal_count="$normal_count"
     local previous_signature
     previous_signature=$(tangle_findings_signature "$findings_file")
+    local previous_finding_keys
+    previous_finding_keys=$(tangle_normal_finding_keys "$findings_file")
     local previous_validation_signature
     previous_validation_signature=$(tangle_validation_signature "$validation_file")
     local best_normal_count="$normal_count"
@@ -3476,6 +3498,8 @@ tangle_contextual_review_gate() {
         normal_count=$(tangle_review_blocking_count "$findings_file")
         local current_signature
         current_signature=$(tangle_findings_signature "$findings_file")
+        local current_finding_keys
+        current_finding_keys=$(tangle_normal_finding_keys "$findings_file")
 
         if [[ "$review_rc" -ne 0 ]]; then
             if [[ "${normal_count:-0}" -gt 0 ]]; then
@@ -3504,9 +3528,15 @@ tangle_contextual_review_gate() {
         local current_validation_signature
         current_validation_signature=$(tangle_validation_signature "$validation_file")
         local made_progress=0
+        local resolved_finding_count=0
+        resolved_finding_count=$(tangle_resolved_finding_count "$previous_finding_keys" "$current_finding_keys")
         if [[ "${normal_count:-0}" -lt "${best_normal_count:-0}" ]]; then
             best_normal_count="$normal_count"
             made_progress=1
+        fi
+        if [[ "${resolved_finding_count:-0}" -gt 0 ]]; then
+            made_progress=1
+            log INFO "Correction round ${correction_round} resolved ${resolved_finding_count} blocker identity/identities from the previous review; resetting convergence guard"
         fi
         if [[ "$current_validation_signature" != "$previous_validation_signature" ]]; then
             if octo_bool_enabled "$validation_progress_resets_convergence"; then
@@ -3535,6 +3565,7 @@ tangle_contextual_review_gate() {
 
         previous_normal_count="$normal_count"
         previous_signature="$current_signature"
+        previous_finding_keys="$current_finding_keys"
         previous_validation_signature="$current_validation_signature"
         ((correction_round++)) || true
     done

--- a/tests/unit/test-tangle-correction-loop-behavior.sh
+++ b/tests/unit/test-tangle-correction-loop-behavior.sh
@@ -34,10 +34,13 @@ run_gate() {
 
         COUNTS=($1)
         REVIEW_RCS=(${REVIEW_RC_SEQUENCE:-})
+        KEY_SEQ="${FINDING_KEY_SEQUENCE:-}"
         IDX_FILE="$RESULTS_DIR/count-idx"
         REVIEW_IDX_FILE="$RESULTS_DIR/review-idx"
+        KEY_IDX_FILE="$RESULTS_DIR/key-idx"
         echo 0 > "$IDX_FILE"
         echo 0 > "$REVIEW_IDX_FILE"
+        echo 0 > "$KEY_IDX_FILE"
         CORRECTION_CALLS=0
 
         source "$2/scripts/lib/workflows.sh" 2>/dev/null
@@ -64,6 +67,17 @@ run_gate() {
             echo "$c"
         }
         tangle_findings_signature() { echo "sig-$(cat "$IDX_FILE")"; }
+        tangle_normal_finding_keys() {
+            local idx c i
+            idx=$(cat "$KEY_IDX_FILE")
+            echo $((idx + 1)) > "$KEY_IDX_FILE"
+            if [[ -n "$KEY_SEQ" ]]; then
+                printf "%s\n" "$KEY_SEQ" | sed -n "$((idx + 1))p" | tr "," "\n"
+            else
+                c="${COUNTS[$idx]:-0}"
+                for ((i=1; i<=c; i++)); do echo "same-$i"; done
+            fi
+        }
         tangle_validation_signature() { echo "vsig"; }
         tangle_apply_review_corrections() {
             CORRECTION_CALLS=$((CORRECTION_CALLS + 1))
@@ -122,6 +136,25 @@ if [[ "$out" == "rounds=3 rc=1" ]]; then
     test_pass
 else
     test_fail "expected rounds=3 rc=1, got '$out'"
+fi
+
+test_case "resolved blocker identities reset convergence even without a new best count"
+# Best count reaches 3, then later reviews expose different blockers. Each round
+# resolves at least one blocker from the immediately previous review, so the
+# no-progress watchdog must not stop before the hard cap / eventual convergence.
+out=$(FINDING_KEY_SEQUENCE=$'a,b,c,d,e,f,g\na,b,c\nd,e,f,g,h,i,j\nd,e,f,g,h,i,j\ne,f,g,h,i' OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 OCTOPUS_TANGLE_CORRECTION_HARD_CAP=5 run_gate "7 3 7 7 5 0")
+if [[ "$out" == "rounds=5 rc=0" ]]; then
+    test_pass
+else
+    test_fail "expected identity-aware progress to continue to zero, got '$out'"
+fi
+
+test_case "rewritten count without resolved identities still trips convergence guard"
+out=$(FINDING_KEY_SEQUENCE=$'a,b,c,d,e\na,b,c,d,e\na,b,c,d,e\na,b,c,d,e' OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 run_gate "5 5 5 5 5")
+if [[ "$out" == "rounds=3 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected unchanged blocker identities to stop at 3 rounds, got '$out'"
 fi
 
 test_case "hard cap stops improving-but-never-zero loop"


### PR DESCRIPTION
## Summary

Make the Tangle correction-loop convergence guard blocker-identity aware instead of count-only.

The loop now fingerprints actionable `normal` findings by normalized `file + title` and treats resolution of any blocker from the immediately previous review as real progress. This resets the no-progress watchdog even when newly discovered blockers keep the total count above the historical minimum.

## Problem

The current guard only resets when `normal_count` reaches a new historical best. That can stop a legitimately progressing correction loop:

- round N reaches 3 blockers;
- those 3 blockers are fully resolved;
- the next review discovers a different set of 7 blockers;
- subsequent rounds reduce 7 -> 5;
- the guard still reports "no new best" because 5 > historical best 3 and can terminate after three rounds.

This conflates blocker cardinality with blocker identity.

## Behavior after this change

For each review transition the loop compares stable blocker identities:

- persistent: present in both previous and current review;
- resolved: present previously, absent now;
- new: absent previously, present now.

If at least one previous blocker is resolved, the convergence watchdog resets. Static blocker sets still trip the existing guard, and the absolute correction-round ceiling remains unchanged.

The fingerprint deliberately uses normalized `file + title`, ignoring line movement, detail text, and confidence changes.

## Validation

- `tests/unit/test-tangle-correction-loop-behavior.sh` — 11/11 pass
- `tests/unit/test-tangle-context-review-loop.sh` — 54/54 pass
- `tests/unit/test-tangle-retry-quality-accounting.sh` — 2/2 pass
- `tests/unit/test-review-aggregation-robustness.sh` — 32/32 pass
- `bash -n` — pass
- `git diff --check` — pass

New behavioral coverage includes:

1. old blockers are resolved while a different/new blocker set appears, so convergence continues;
2. unchanged blocker identities still hit the 3-round no-progress guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review correction loops by recognizing when previously reported blockers have been resolved.
  * Convergence tracking now resets after blocker resolution, while unchanged blockers still trigger safeguards.

* **Tests**
  * Added coverage for resolved and unchanged blocker scenarios to ensure correction loops behave consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->