### PR TITLE
refactor: make design review provider-neutral

### DIFF
--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -346,6 +346,19 @@ resolve_octopus_model() {
             [[ -n "$_trace" ]] && echo "[model-trace] Tier 2 (session override): —" >&2
         fi
 
+        # 2a. Provider-local role model. This selects only the model for a
+        # provider that has already been chosen by the workflow/fleet; it must
+        # never change provider identity. Example:
+        #   providers.commandcode.roles.security-reviewer = "minimaxai/minimax-m3"
+        if [[ ( -z "$resolved_model" || "$resolved_model" == "null" ) && -n "$role" ]]; then
+            resolved_model=$(echo "$config_data" | jq -r --arg p "$canonical_provider" --arg role "$role" '.providers[$p].roles[$role] // empty' 2>/dev/null)
+            if [[ -n "$resolved_model" && "$resolved_model" != "null" ]]; then
+                [[ -n "$_trace" ]] && echo "[model-trace] Tier 3a (provider role model): $resolved_model ← SELECTED" >&2
+            else
+                [[ -n "$_trace" ]] && echo "[model-trace] Tier 3a (provider role model): —" >&2
+            fi
+        fi
+
         # 2. Role/Phase Routing
         # Object routes are literal, explicit provider/model selections. Unlike
         # legacy string routes (for example "codex:spark"), their model field

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -341,6 +341,39 @@ DECEOF
 # Before tangle phase, each review role states its approach; conflicts are resolved.
 # After failures, a retrospective fires.
 
+# Resolve the default provider pool through the same provider-neutral council
+# builder used by review. This keeps admission, allowlist, capability and
+# provider-family diversity policy in one place. The design-review role is
+# applied later by run_agent_sync_consultative; provider choice remains separate.
+design_review_default_agents() {
+    local prompt="${1:-design review}"
+    local plugin_root="${PLUGIN_DIR:-}"
+    local helper fleet provider pool=""
+    if [[ -z "$plugin_root" ]]; then
+        plugin_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+    fi
+    helper="$plugin_root/scripts/helpers/build-fleet.sh"
+    if [[ -x "$helper" ]]; then
+        fleet="$(bash "$helper" review standard "$prompt" 2>/dev/null || true)"
+        while IFS='|' read -r provider _; do
+            [[ -n "$provider" ]] || continue
+            pool="${pool}${pool:+ }${provider}"
+        done <<EOF
+$fleet
+EOF
+    fi
+
+    # Claude is the host runtime and remains the safe compatibility fallback if
+    # discovery cannot produce any admitted council provider.
+    [[ -n "$pool" ]] || pool="claude-sonnet"
+    # shellcheck disable=SC2206
+    local providers=($pool)
+    local count=${#providers[@]} i
+    for ((i=0; i<4; i++)); do
+        printf '%s\n' "${providers[$((i % count))]}"
+    done
+}
+
 design_review_ceremony() {
     local prompt="$1"
     local context="${2:-}"
@@ -376,14 +409,20 @@ State your HIGH-LEVEL approach in 3-5 bullet points:
 
 Be concise and specific. This is a planning exercise, not implementation."
 
-    # Gather approaches by semantic review role. Runtime executor/provider/model
-    # selection is separate from seat identity. The provider-named variables are
-    # compatibility aliases only and may be removed in a future major release.
+    # Gather approaches by semantic review role. Runtime provider selection uses
+    # the same admitted, council-capable provider pool as review. Provider-named
+    # env vars remain compatibility aliases only; they no longer define defaults.
     local seat_1_approach="" seat_2_approach="" seat_3_approach=""
-    local design_implementer_agent="${OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-codex-mini}}"
-    local design_researcher_agent="${OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT:-${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-agy}}}"
-    local design_code_reviewer_agent="${OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}}"
-    local design_synthesizer_agent="${OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT:-${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}}"
+    local design_defaults design_implementer_default design_researcher_default design_code_reviewer_default design_synthesizer_default
+    design_defaults="$(design_review_default_agents "$prompt")"
+    design_implementer_default="$(printf '%s\n' "$design_defaults" | sed -n '1p')"
+    design_researcher_default="$(printf '%s\n' "$design_defaults" | sed -n '2p')"
+    design_code_reviewer_default="$(printf '%s\n' "$design_defaults" | sed -n '3p')"
+    design_synthesizer_default="$(printf '%s\n' "$design_defaults" | sed -n '4p')"
+    local design_implementer_agent="${OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-$design_implementer_default}}"
+    local design_researcher_agent="${OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT:-${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-$design_researcher_default}}}"
+    local design_code_reviewer_agent="${OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-$design_code_reviewer_default}}"
+    local design_synthesizer_agent="${OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT:-${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-$design_synthesizer_default}}"
     local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-0}"
     local design_synth_timeout="${OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT:-0}"
     if [[ ! "$design_timeout" =~ ^[0-9]+$ ]]; then

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -341,39 +341,6 @@ DECEOF
 # Before tangle phase, each review role states its approach; conflicts are resolved.
 # After failures, a retrospective fires.
 
-# Resolve the default provider pool through the same provider-neutral council
-# builder used by review. This keeps admission, allowlist, capability and
-# provider-family diversity policy in one place. The design-review role is
-# applied later by run_agent_sync_consultative; provider choice remains separate.
-design_review_default_agents() {
-    local prompt="${1:-design review}"
-    local plugin_root="${PLUGIN_DIR:-}"
-    local helper fleet provider pool=""
-    if [[ -z "$plugin_root" ]]; then
-        plugin_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
-    fi
-    helper="$plugin_root/scripts/helpers/build-fleet.sh"
-    if [[ -x "$helper" ]]; then
-        fleet="$(bash "$helper" review standard "$prompt" 2>/dev/null || true)"
-        while IFS='|' read -r provider _; do
-            [[ -n "$provider" ]] || continue
-            pool="${pool}${pool:+ }${provider}"
-        done <<EOF
-$fleet
-EOF
-    fi
-
-    # Claude is the host runtime and remains the safe compatibility fallback if
-    # discovery cannot produce any admitted council provider.
-    [[ -n "$pool" ]] || pool="claude-sonnet"
-    # shellcheck disable=SC2206
-    local providers=($pool)
-    local count=${#providers[@]} i
-    for ((i=0; i<4; i++)); do
-        printf '%s\n' "${providers[$((i % count))]}"
-    done
-}
-
 design_review_ceremony() {
     local prompt="$1"
     local context="${2:-}"
@@ -409,20 +376,16 @@ State your HIGH-LEVEL approach in 3-5 bullet points:
 
 Be concise and specific. This is a planning exercise, not implementation."
 
-    # Gather approaches by semantic review role. Runtime provider selection uses
-    # the same admitted, council-capable provider pool as review. Provider-named
-    # env vars remain compatibility aliases only; they no longer define defaults.
+    # Gather approaches by semantic review role. Keep the upstream role/provider
+    # shape, replacing only the two providers unavailable in this deployment:
+    # implementer Codex -> CommandCode, researcher AGY -> CommandCode. Model
+    # selection remains role-aware downstream (DeepSeek for implementer, MiniMax
+    # for researcher). Code reviewer and synthesizer retain upstream Claude defaults.
     local seat_1_approach="" seat_2_approach="" seat_3_approach=""
-    local design_defaults design_implementer_default design_researcher_default design_code_reviewer_default design_synthesizer_default
-    design_defaults="$(design_review_default_agents "$prompt")"
-    design_implementer_default="$(printf '%s\n' "$design_defaults" | sed -n '1p')"
-    design_researcher_default="$(printf '%s\n' "$design_defaults" | sed -n '2p')"
-    design_code_reviewer_default="$(printf '%s\n' "$design_defaults" | sed -n '3p')"
-    design_synthesizer_default="$(printf '%s\n' "$design_defaults" | sed -n '4p')"
-    local design_implementer_agent="${OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-$design_implementer_default}}"
-    local design_researcher_agent="${OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT:-${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-$design_researcher_default}}}"
-    local design_code_reviewer_agent="${OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-$design_code_reviewer_default}}"
-    local design_synthesizer_agent="${OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT:-${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-$design_synthesizer_default}}"
+    local design_implementer_agent="${OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-commandcode}}"
+    local design_researcher_agent="${OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT:-${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-commandcode}}}"
+    local design_code_reviewer_agent="${OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}}"
+    local design_synthesizer_agent="${OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT:-${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}}"
     local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-0}"
     local design_synth_timeout="${OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT:-0}"
     if [[ ! "$design_timeout" =~ ^[0-9]+$ ]]; then

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -341,6 +341,39 @@ DECEOF
 # Before tangle phase, each review role states its approach; conflicts are resolved.
 # After failures, a retrospective fires.
 
+# Resolve the default provider pool through the same provider-neutral council
+# builder used by review. This keeps admission, allowlist, capability and
+# provider-family diversity policy in one place. The design-review role is
+# applied later by run_agent_sync_consultative; provider choice remains separate.
+design_review_default_agents() {
+    local prompt="${1:-design review}"
+    local plugin_root="${PLUGIN_DIR:-}"
+    local helper fleet provider pool=""
+    if [[ -z "$plugin_root" ]]; then
+        plugin_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+    fi
+    helper="$plugin_root/scripts/helpers/build-fleet.sh"
+    if [[ -x "$helper" ]]; then
+        fleet="$(bash "$helper" review standard "$prompt" 2>/dev/null || true)"
+        while IFS='|' read -r provider _; do
+            [[ -n "$provider" ]] || continue
+            pool="${pool}${pool:+ }${provider}"
+        done <<EOF
+$fleet
+EOF
+    fi
+
+    # Claude is the host runtime and remains the safe compatibility fallback if
+    # discovery cannot produce any admitted council provider.
+    [[ -n "$pool" ]] || pool="claude-sonnet"
+    # shellcheck disable=SC2206
+    local providers=($pool)
+    local count=${#providers[@]} i
+    for ((i=0; i<4; i++)); do
+        printf '%s\n' "${providers[$((i % count))]}"
+    done
+}
+
 design_review_ceremony() {
     local prompt="$1"
     local context="${2:-}"
@@ -376,16 +409,20 @@ State your HIGH-LEVEL approach in 3-5 bullet points:
 
 Be concise and specific. This is a planning exercise, not implementation."
 
-    # Gather approaches by semantic review role. Keep the upstream role/provider
-    # shape, replacing only the two providers unavailable in this deployment:
-    # implementer Codex -> CommandCode, researcher AGY -> CommandCode. Model
-    # selection remains role-aware downstream (DeepSeek for implementer, MiniMax
-    # for researcher). Code reviewer and synthesizer retain upstream Claude defaults.
+    # Gather approaches by semantic review role. Runtime provider selection uses
+    # the same admitted, council-capable provider pool as review. Provider-named
+    # env vars remain compatibility aliases only; they no longer define defaults.
     local seat_1_approach="" seat_2_approach="" seat_3_approach=""
-    local design_implementer_agent="${OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-commandcode}}"
-    local design_researcher_agent="${OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT:-${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-commandcode}}}"
-    local design_code_reviewer_agent="${OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-claude-sonnet}}"
-    local design_synthesizer_agent="${OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT:-${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-claude-opus}}"
+    local design_defaults design_implementer_default design_researcher_default design_code_reviewer_default design_synthesizer_default
+    design_defaults="$(design_review_default_agents "$prompt")"
+    design_implementer_default="$(printf '%s\n' "$design_defaults" | sed -n '1p')"
+    design_researcher_default="$(printf '%s\n' "$design_defaults" | sed -n '2p')"
+    design_code_reviewer_default="$(printf '%s\n' "$design_defaults" | sed -n '3p')"
+    design_synthesizer_default="$(printf '%s\n' "$design_defaults" | sed -n '4p')"
+    local design_implementer_agent="${OCTOPUS_DESIGN_REVIEW_IMPLEMENTER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CODEX_AGENT:-$design_implementer_default}}"
+    local design_researcher_agent="${OCTOPUS_DESIGN_REVIEW_RESEARCHER_AGENT:-${OCTOPUS_DESIGN_REVIEW_AGY_AGENT:-${OCTOPUS_DESIGN_REVIEW_GEMINI_AGENT:-$design_researcher_default}}}"
+    local design_code_reviewer_agent="${OCTOPUS_DESIGN_REVIEW_CODE_REVIEWER_AGENT:-${OCTOPUS_DESIGN_REVIEW_CLAUDE_AGENT:-$design_code_reviewer_default}}"
+    local design_synthesizer_agent="${OCTOPUS_DESIGN_REVIEW_SYNTHESIZER_AGENT:-${OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT:-$design_synthesizer_default}}"
     local design_timeout="${OCTOPUS_DESIGN_REVIEW_TIMEOUT:-0}"
     local design_synth_timeout="${OCTOPUS_DESIGN_REVIEW_SYNTH_TIMEOUT:-0}"
     if [[ ! "$design_timeout" =~ ^[0-9]+$ ]]; then

--- a/tests/unit/test-provider-neutral-council.sh
+++ b/tests/unit/test-provider-neutral-council.sh
@@ -27,10 +27,13 @@ cat >"$TMP_HOME/.claude-octopus/config/providers.json" <<'EOF'
   "version":"3.0",
   "providers": {
     "codex": {"default":"gpt-5.6-sol"},
-    "commandcode": {"default":"deepseek/deepseek-v4-flash"},
+    "commandcode": {
+      "default":"deepseek/deepseek-v4-flash",
+      "roles":{"architecture-reviewer":"minimaxai/minimax-m3"}
+    },
     "claude": {"default":"claude-sonnet-5"}
   },
-  "routing":{"phases":{},"roles":{"architecture-reviewer":{"provider":"commandcode","model":"minimaxai/minimax-m3"}}},
+  "routing":{"phases":{},"roles":{}},
   "tiers":{},
   "overrides":{}
 }
@@ -58,7 +61,7 @@ case "$labels" in
   *) test_fail "review role labels changed: $labels" ;;
 esac
 
-test_case "role routing resolves a role-specific model without changing provider identity"
+test_case "provider-local role model resolves without changing provider identity"
 log() { :; }
 export PLUGIN_DIR="$PROJECT_ROOT"
 export OCTOPUS_PLATFORM=Linux
@@ -67,7 +70,16 @@ model="$(resolve_octopus_model commandcode commandcode review architecture-revie
 if [[ "$model" == "minimaxai/minimax-m3" ]]; then
   test_pass
 else
-  test_fail "expected role-routed MiniMax model, got '$model'"
+  test_fail "expected provider-local MiniMax role model, got '$model'"
+fi
+
+test_case "provider-local role model does not become a provider route"
+source "$PROJECT_ROOT/scripts/lib/execution-profile.sh"
+provider="$(octopus_execution_profile_provider review review architecture-reviewer commandcode)"
+if [[ "$provider" == "commandcode" ]]; then
+  test_pass
+else
+  test_fail "provider-local role model changed provider selection to '$provider'"
 fi
 
 test_summary

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Provider-neutral design review ceremony"
+
+TMP_HOME="$(mktemp -d)"
+CHECKER="$TMP_HOME/check-providers.sh"
+trap 'rm -rf "$TMP_HOME"' EXIT
+mkdir -p "$TMP_HOME/.claude-octopus/config"
+cat >"$CHECKER" <<'EOF'
+#!/bin/sh
+cat <<'STATUS'
+PROVIDER_CHECK_START
+codex:available
+commandcode:available
+agy:missing
+perplexity:missing
+openrouter:missing
+PROVIDER_CHECK_END
+STATUS
+EOF
+chmod +x "$CHECKER"
+cat >"$TMP_HOME/.claude-octopus/config/providers.json" <<'EOF'
+{
+  "version":"3.0",
+  "providers": {
+    "codex": {"default":"gpt-5.6-sol"},
+    "commandcode": {
+      "default":"deepseek/deepseek-v4-flash",
+      "roles": {
+        "researcher":"minimaxai/minimax-m3",
+        "code-reviewer":"minimaxai/minimax-m3",
+        "synthesizer":"minimaxai/minimax-m3"
+      }
+    },
+    "claude": {"default":"claude-sonnet-5"}
+  },
+  "routing":{"phases":{},"roles":{}},
+  "tiers":{},
+  "overrides":{}
+}
+EOF
+
+export HOME="$TMP_HOME"
+export OCTOPUS_PROVIDER_CHECKER="$CHECKER"
+export OCTOPUS_ALLOWED_PROVIDERS="codex commandcode claude"
+export PLUGIN_DIR="$PROJECT_ROOT"
+export WORKSPACE_DIR="$TMP_HOME/workspace"
+mkdir -p "$WORKSPACE_DIR"
+source "$PROJECT_ROOT/scripts/lib/quality.sh"
+
+test_case "design review defaults use the provider-neutral council pool"
+defaults="$(design_review_default_agents test)"
+if echo "$defaults" | grep -Eq '^(agy|perplexity)$'; then
+  test_fail "ineligible provider entered design review: $defaults"
+elif echo "$defaults" | grep -q '^commandcode$' && echo "$defaults" | grep -q '^codex$' && echo "$defaults" | grep -q '^claude-sonnet$'; then
+  test_pass
+else
+  test_fail "expected Claude, Codex and CommandCode in design review defaults: $defaults"
+fi
+
+test_case "design review assigns providers independently from semantic roles"
+CAPTURE="$TMP_HOME/design-review.calls"
+: > "$CAPTURE"
+DRY_RUN=false
+OCTOPUS_CEREMONIES=true
+CYAN="" GREEN="" NC="" _BOX_TOP="" _BOX_BOT=""
+log() { :; }
+octo_provider_identity_label() { printf '%s / fixture\n' "$1"; }
+write_structured_decision() { :; }
+run_agent_sync_consultative() {
+  printf '%s|%s|%s\n' "$1" "$4" "$5" >> "$CAPTURE"
+  printf '%s\n' 'planning output'
+}
+design_review_ceremony "test" >/dev/null
+roles="$(cut -d'|' -f2 "$CAPTURE" | tr '\n' '|')"
+providers="$(cut -d'|' -f1 "$CAPTURE" | tr '\n' '|')"
+case "$roles" in
+  implementer\|researcher\|code-reviewer\|synthesizer\|) ;;
+  *) test_fail "semantic roles changed: $roles"; roles_bad=1 ;;
+esac
+if [[ "${roles_bad:-0}" == 1 ]]; then :
+elif echo "$providers" | grep -Eq '(^|\|)(agy|perplexity)(\||$)'; then
+  test_fail "legacy provider default leaked into ceremony: $providers"
+else
+  test_pass
+fi
+
+test_case "provider-local model keeps provider identity separate from role model"
+log() { :; }
+export OCTOPUS_PLATFORM=Linux
+source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+model="$(resolve_octopus_model commandcode commandcode ceremony researcher)"
+if [[ "$model" == "minimaxai/minimax-m3" ]]; then
+  test_pass
+else
+  test_fail "expected provider-local MiniMax researcher model, got '$model'"
+fi
+
+test_summary

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -5,9 +5,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Provider-neutral design review ceremony"
 
-TMP_HOME="$(mktemp -d)"
+TMP_HOME="$TEST_TMP_DIR/provider-neutral-design-review"
 CHECKER="$TMP_HOME/check-providers.sh"
-trap 'rm -rf "$TMP_HOME"' EXIT
 mkdir -p "$TMP_HOME/.claude-octopus/config"
 cat >"$CHECKER" <<'EOF'
 #!/bin/sh

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -50,7 +50,17 @@ export WORKSPACE_DIR="$TMP_HOME/workspace"
 mkdir -p "$WORKSPACE_DIR"
 source "$PROJECT_ROOT/scripts/lib/quality.sh"
 
-test_case "design review preserves role-specific provider policy"
+test_case "design review defaults use the provider-neutral council pool"
+defaults="$(design_review_default_agents test)"
+if echo "$defaults" | grep -Eq '^(agy|perplexity)$'; then
+  test_fail "ineligible provider entered design review: $defaults"
+elif echo "$defaults" | grep -q '^commandcode$' && echo "$defaults" | grep -q '^codex$' && echo "$defaults" | grep -q '^claude-sonnet$'; then
+  test_pass
+else
+  test_fail "expected Claude, Codex and CommandCode in design review defaults: $defaults"
+fi
+
+test_case "design review assigns providers independently from semantic roles"
 CAPTURE="$TMP_HOME/design-review.calls"
 : > "$CAPTURE"
 DRY_RUN=false
@@ -64,30 +74,28 @@ run_agent_sync_consultative() {
   printf '%s\n' 'planning output'
 }
 design_review_ceremony "test" >/dev/null
-expected="$(printf '%s\n' \
-  'commandcode|implementer|ceremony' \
-  'commandcode|researcher|ceremony' \
-  'claude-sonnet|code-reviewer|ceremony' \
-  'claude-opus|synthesizer|ceremony')"
-actual="$(cat "$CAPTURE")"
-if [[ "$actual" == "$expected" ]]; then
-  test_pass
+roles="$(cut -d'|' -f2 "$CAPTURE" | tr '\n' '|')"
+providers="$(cut -d'|' -f1 "$CAPTURE" | tr '\n' '|')"
+case "$roles" in
+  implementer\|researcher\|code-reviewer\|synthesizer\|) ;;
+  *) test_fail "semantic roles changed: $roles"; roles_bad=1 ;;
+esac
+if [[ "${roles_bad:-0}" == 1 ]]; then :
+elif echo "$providers" | grep -Eq '(^|\|)(agy|perplexity)(\||$)'; then
+  test_fail "legacy provider default leaked into ceremony: $providers"
 else
-  test_fail "unexpected design-review provider/role mapping: $actual"
+  test_pass
 fi
 
 test_case "provider-local model keeps provider identity separate from role model"
 log() { :; }
 export OCTOPUS_PLATFORM=Linux
 source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
-implementer_model="$(resolve_octopus_model commandcode commandcode ceremony implementer)"
-researcher_model="$(resolve_octopus_model commandcode commandcode ceremony researcher)"
-if [[ "$implementer_model" != "deepseek/deepseek-v4-flash" ]]; then
-  test_fail "expected DeepSeek implementer model, got '$implementer_model'"
-elif [[ "$researcher_model" != "minimaxai/minimax-m3" ]]; then
-  test_fail "expected provider-local MiniMax researcher model, got '$researcher_model'"
-else
+model="$(resolve_octopus_model commandcode commandcode ceremony researcher)"
+if [[ "$model" == "minimaxai/minimax-m3" ]]; then
   test_pass
+else
+  test_fail "expected provider-local MiniMax researcher model, got '$model'"
 fi
 
 test_summary

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -50,17 +50,7 @@ export WORKSPACE_DIR="$TMP_HOME/workspace"
 mkdir -p "$WORKSPACE_DIR"
 source "$PROJECT_ROOT/scripts/lib/quality.sh"
 
-test_case "design review defaults use the provider-neutral council pool"
-defaults="$(design_review_default_agents test)"
-if echo "$defaults" | grep -Eq '^(agy|perplexity)$'; then
-  test_fail "ineligible provider entered design review: $defaults"
-elif echo "$defaults" | grep -q '^commandcode$' && echo "$defaults" | grep -q '^codex$' && echo "$defaults" | grep -q '^claude-sonnet$'; then
-  test_pass
-else
-  test_fail "expected Claude, Codex and CommandCode in design review defaults: $defaults"
-fi
-
-test_case "design review assigns providers independently from semantic roles"
+test_case "design review preserves role-specific provider policy"
 CAPTURE="$TMP_HOME/design-review.calls"
 : > "$CAPTURE"
 DRY_RUN=false
@@ -74,28 +64,30 @@ run_agent_sync_consultative() {
   printf '%s\n' 'planning output'
 }
 design_review_ceremony "test" >/dev/null
-roles="$(cut -d'|' -f2 "$CAPTURE" | tr '\n' '|')"
-providers="$(cut -d'|' -f1 "$CAPTURE" | tr '\n' '|')"
-case "$roles" in
-  implementer\|researcher\|code-reviewer\|synthesizer\|) ;;
-  *) test_fail "semantic roles changed: $roles"; roles_bad=1 ;;
-esac
-if [[ "${roles_bad:-0}" == 1 ]]; then :
-elif echo "$providers" | grep -Eq '(^|\|)(agy|perplexity)(\||$)'; then
-  test_fail "legacy provider default leaked into ceremony: $providers"
-else
+expected="$(printf '%s\n' \
+  'commandcode|implementer|ceremony' \
+  'commandcode|researcher|ceremony' \
+  'claude-sonnet|code-reviewer|ceremony' \
+  'claude-opus|synthesizer|ceremony')"
+actual="$(cat "$CAPTURE")"
+if [[ "$actual" == "$expected" ]]; then
   test_pass
+else
+  test_fail "unexpected design-review provider/role mapping: $actual"
 fi
 
 test_case "provider-local model keeps provider identity separate from role model"
 log() { :; }
 export OCTOPUS_PLATFORM=Linux
 source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
-model="$(resolve_octopus_model commandcode commandcode ceremony researcher)"
-if [[ "$model" == "minimaxai/minimax-m3" ]]; then
-  test_pass
+implementer_model="$(resolve_octopus_model commandcode commandcode ceremony implementer)"
+researcher_model="$(resolve_octopus_model commandcode commandcode ceremony researcher)"
+if [[ "$implementer_model" != "deepseek/deepseek-v4-flash" ]]; then
+  test_fail "expected DeepSeek implementer model, got '$implementer_model'"
+elif [[ "$researcher_model" != "minimaxai/minimax-m3" ]]; then
+  test_fail "expected provider-local MiniMax researcher model, got '$researcher_model'"
 else
-  test_fail "expected provider-local MiniMax researcher model, got '$model'"
+  test_pass
 fi
 
 test_summary


### PR DESCRIPTION
## Summary

Completes the provider-neutral review work from #933 and #934 for the pre-work design review ceremony.

- derive design-review provider defaults from the same admitted, council-capable provider pool used by review
- keep implementer/researcher/code-reviewer/synthesizer as semantic roles rather than provider identities
- preserve legacy provider-named env vars only as explicit compatibility overrides, not defaults
- add provider-local role models so a role can select a model for an already-chosen provider without forcing provider identity

This removes the remaining hardcoded default mapping of Codex / AGY / Claude / Opus in design review while preserving explicit operator overrides.

## Validation

- provider-neutral design review: 3/3 PASS
- pre-work ceremonies: 9/9 PASS
- provider-neutral council: 4/4 PASS
- model-config role routing: 4/4 PASS
- git diff --check: PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-specific model selection for role-based workflows.
  * Design reviews now automatically select suitable default models across available providers.
  * Added fallback model selection when provider discovery is unavailable.
  * Existing environment-based configuration overrides remain supported.

* **Tests**
  * Added coverage for provider-local role model resolution without changing provider selection.
  * Added provider-neutral design-review tests for role routing, model defaults, and provider exclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->