### PR TITLE
fix: harden provider-neutral council policy

### DIFF
--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -21,8 +21,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
-source "${SCRIPT_DIR}/../lib/provider-registry.sh" 2>/dev/null || true
-source "${SCRIPT_DIR}/../lib/provider-policy.sh" 2>/dev/null || true
+source "${SCRIPT_DIR}/../lib/provider-registry.sh"
+source "${SCRIPT_DIR}/../lib/provider-policy.sh"
 
 WORKFLOW="${1:-research}"
 INTENSITY="${2:-standard}"
@@ -287,7 +287,7 @@ build_council_order() {
     # Provider policy controls preference order, not eligibility. Any admitted
     # provider with the registry `council` capability may still fill a seat when
     # preferred providers are unavailable or denied.
-    preferred="$(octo_council_default_providers 2>/dev/null || true)"
+    preferred="$(octo_council_default_providers)" || return $?
     for provider in $(printf '%s' "$preferred" | tr ',' ' '); do
         canonical="$(octo_provider_canonical "$provider" 2>/dev/null || true)"
         [[ -n "$canonical" ]] || continue
@@ -331,7 +331,7 @@ build_council_order() {
 
 build_review_fleet() {
     local order
-    order="$(build_council_order)"
+    order="$(build_council_order)" || return $?
     # shellcheck disable=SC2206
     local providers=($order)
     local count=${#providers[@]}

--- a/tests/unit/test-provider-neutral-council.sh
+++ b/tests/unit/test-provider-neutral-council.sh
@@ -5,9 +5,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Provider-neutral review council with role-based model routing"
 
-TMP_HOME="$(mktemp -d)"
+TMP_HOME="$TEST_TMP_DIR/provider-neutral-council"
 CHECKER="$TMP_HOME/check-providers.sh"
-trap 'rm -rf "$TMP_HOME"' EXIT
 mkdir -p "$TMP_HOME/.claude-octopus/config"
 cat >"$CHECKER" <<'EOF'
 #!/bin/sh
@@ -41,14 +40,47 @@ export OCTOPUS_PROVIDER_CHECKER="$CHECKER"
 export OCTOPUS_ALLOWED_PROVIDERS="codex commandcode claude"
 
 output="$(bash "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" review standard test 2>/dev/null)"
+provider_ids="$(printf '%s\n' "$output" | cut -d'|' -f1)"
 
 test_case "review council uses admitted council-capable providers without AGY/Perplexity"
-if echo "$output" | cut -d'|' -f1 | grep -Eq '^(agy|perplexity)$'; then
-  test_fail "unusable provider entered council: $output"
-elif echo "$output" | cut -d'|' -f1 | grep -q '^commandcode$'; then
-  test_pass
+case "$provider_ids" in
+  *$'\nagy'$'\n'*|agy$'\n'*|*$'\nperplexity'$'\n'*|perplexity$'\n'*)
+    test_fail "unusable provider entered council: $output"
+    ;;
+  *)
+    case $'\n'"$provider_ids"$'\n' in
+      *$'\ncommandcode\n'*) test_pass ;;
+      *) test_fail "CommandCode did not naturally fill a council seat: $output" ;;
+    esac
+    ;;
+esac
+
+test_case "review council emits four seats and wraps provider order deterministically"
+seat_count="$(printf '%s\n' "$provider_ids" | sed '/^$/d' | wc -l | tr -d ' ')"
+first_provider="$(printf '%s\n' "$provider_ids" | sed -n '1p')"
+fourth_provider="$(printf '%s\n' "$provider_ids" | sed -n '4p')"
+missing=""
+for expected in claude-sonnet codex commandcode; do
+  case $'\n'"$provider_ids"$'\n' in
+    *$'\n'"$expected"$'\n'*) ;;
+    *) missing="${missing}${missing:+ }${expected}" ;;
+  esac
+done
+if [[ "$seat_count" != "4" ]]; then
+  test_fail "expected four review seats, got $seat_count: $output"
+elif [[ -n "$missing" ]]; then
+  test_fail "missing admitted providers from council: $missing; output: $output"
+elif [[ "$fourth_provider" != "$first_provider" ]]; then
+  test_fail "expected fourth seat to wrap to first provider ($first_provider), got $fourth_provider"
 else
-  test_fail "CommandCode did not naturally fill a council seat: $output"
+  test_pass
+fi
+
+test_case "invalid council provider policy fails closed"
+if OCTOPUS_COUNCIL_DEFAULT_PROVIDERS="codex,codex" bash "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" review standard test >/dev/null 2>&1; then
+  test_fail "duplicate council provider policy unexpectedly succeeded"
+else
+  test_pass
 fi
 
 test_case "review seats remain role labels rather than provider identities"

--- a/tests/unit/test-provider-neutral-council.sh
+++ b/tests/unit/test-provider-neutral-council.sh
@@ -55,23 +55,13 @@ case "$provider_ids" in
     ;;
 esac
 
-test_case "review council emits four seats and wraps provider order deterministically"
+test_case "review council emits four seats in deterministic policy order"
 seat_count="$(printf '%s\n' "$provider_ids" | sed '/^$/d' | wc -l | tr -d ' ')"
-first_provider="$(printf '%s\n' "$provider_ids" | sed -n '1p')"
-fourth_provider="$(printf '%s\n' "$provider_ids" | sed -n '4p')"
-missing=""
-for expected in claude-sonnet codex commandcode; do
-  case $'\n'"$provider_ids"$'\n' in
-    *$'\n'"$expected"$'\n'*) ;;
-    *) missing="${missing}${missing:+ }${expected}" ;;
-  esac
-done
+expected_provider_ids="$(printf '%s\n' claude-sonnet codex commandcode claude-sonnet)"
 if [[ "$seat_count" != "4" ]]; then
   test_fail "expected four review seats, got $seat_count: $output"
-elif [[ -n "$missing" ]]; then
-  test_fail "missing admitted providers from council: $missing; output: $output"
-elif [[ "$fourth_provider" != "$first_provider" ]]; then
-  test_fail "expected fourth seat to wrap to first provider ($first_provider), got $fourth_provider"
+elif [[ "$provider_ids" != "$expected_provider_ids" ]]; then
+  test_fail "expected provider order [claude-sonnet,codex,commandcode,claude-sonnet], got [$(printf '%s' "$provider_ids" | paste -sd, -)]"
 else
   test_pass
 fi


### PR DESCRIPTION
## Summary

Follow-up hardening for #934 after merge, addressing the remaining review findings against the provider-neutral council implementation.

- fail closed when required provider registry/policy libraries cannot be sourced
- propagate invalid `OCTOPUS_COUNCIL_DEFAULT_PROVIDERS` configuration instead of silently falling back
- preserve the shared test framework cleanup lifecycle
- assert the complete four-seat round-robin sequence and provider coverage
- avoid `grep -q` / `pipefail` false negatives in council test pipelines
- add an explicit regression that invalid duplicate council policy fails closed

## Validation

- provider-neutral council: 5/5 PASS
- provider registry contracts: 14/14 PASS
- provider registry governance: 11/11 PASS
- provider registry parity: 9/9 PASS
- canonical provider registry: 8/8 PASS
- provider allowlist: 13/13 PASS
- `git diff --check`: PASS

Follow-up to #934.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when building review councils by ensuring provider configuration and command failures are reported instead of silently ignored.
  * Strengthened council validation to reject unsupported providers, require the designated command provider, preserve deterministic seat assignments, and fail safely when duplicate policies are detected.

* **Tests**
  * Expanded coverage for provider-neutral council validation and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->