### PR TITLE
fix: retry no-progress corrections under convergence guard

### DIFF
--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -3470,9 +3470,22 @@ tangle_contextual_review_gate() {
             return 1
         fi
 
-        if ! tangle_apply_review_corrections "$resolved_prompt" "$review_context_file" "$findings_file" "$correction_round" "$tangle_coding_agent" "$correction_strategy"; then
-            log WARN "Correction round ${correction_round} made no observable progress; escalating without starting a hot loop"
-            return 1
+        local correction_rc=0
+        tangle_apply_review_corrections "$resolved_prompt" "$review_context_file" "$findings_file" "$correction_round" "$tangle_coding_agent" "$correction_strategy" || correction_rc=$?
+        if [[ "$correction_rc" -ne 0 ]]; then
+            if [[ "${TANGLE_CORRECTION_STATUS:-}" == "failed-no-progress" && "${TANGLE_CORRECTION_CHANGED:-0}" != "1" ]]; then
+                no_progress_rounds=$((no_progress_rounds + 1))
+                correction_strategy="single-finding"
+                log WARN "Correction round ${correction_round} made no observable worktree progress (${no_progress_rounds}/${convergence_round_limit}); retrying under convergence policy"
+                if [[ "${convergence_round_limit:-0}" -gt 0 && "$no_progress_rounds" -ge "$convergence_round_limit" ]]; then
+                    log ERROR "Stopping tangle correction loop after ${no_progress_rounds} consecutive failed-no-progress rounds"
+                    return 1
+                fi
+                ((correction_round++)) || true
+                continue
+            fi
+            log WARN "Correction round ${correction_round} failed with terminal status=${TANGLE_CORRECTION_STATUS:-unknown}; stopping correction loop"
+            return "$correction_rc"
         fi
 
         if [[ -n "${TANGLE_CORRECTION_CONTAMINATION:-}" ]]; then

--- a/tests/unit/test-tangle-correction-loop-behavior.sh
+++ b/tests/unit/test-tangle-correction-loop-behavior.sh
@@ -34,6 +34,7 @@ run_gate() {
 
         COUNTS=($1)
         REVIEW_RCS=(${REVIEW_RC_SEQUENCE:-})
+        CORRECTION_STATUSES=(${CORRECTION_STATUS_SEQUENCE:-})
         KEY_SEQ="${FINDING_KEY_SEQUENCE:-}"
         IDX_FILE="$RESULTS_DIR/count-idx"
         REVIEW_IDX_FILE="$RESULTS_DIR/review-idx"
@@ -80,12 +81,25 @@ run_gate() {
         }
         tangle_validation_signature() { echo "vsig"; }
         tangle_apply_review_corrections() {
+            local status="${CORRECTION_STATUSES[$((CORRECTION_CALLS))]:-done}"
             CORRECTION_CALLS=$((CORRECTION_CALLS + 1))
-            TANGLE_CORRECTION_STATUS="done"
-            TANGLE_CORRECTION_CHANGED=1
+            TANGLE_CORRECTION_STATUS="$status"
             TANGLE_CORRECTION_CONTAMINATION=""
             TANGLE_CORRECTION_FILE="$RESULTS_DIR/corr-$CORRECTION_CALLS.md"
-            return 0
+            case "$status" in
+                failed-no-progress)
+                    TANGLE_CORRECTION_CHANGED=0
+                    return 1
+                    ;;
+                interrupted-partial)
+                    TANGLE_CORRECTION_CHANGED=0
+                    return 1
+                    ;;
+                *)
+                    TANGLE_CORRECTION_CHANGED=1
+                    return 0
+                    ;;
+            esac
         }
         validate_tangle_results() { return 0; }
 
@@ -128,6 +142,30 @@ if [[ "$out" == "rounds=1 rc=1" ]]; then
     test_pass
 else
     test_fail "expected rounds=1 rc=1, got '$out'"
+fi
+
+test_case "single failed-no-progress round consumes convergence budget and retries"
+out=$(CORRECTION_STATUS_SEQUENCE="failed-no-progress done" OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 run_gate "2 1 0")
+if [[ "$out" == "rounds=3 rc=0" ]]; then
+    test_pass
+else
+    test_fail "expected failed-no-progress retry to recover, got '$out'"
+fi
+
+test_case "three consecutive failed-no-progress rounds stop at convergence limit"
+out=$(CORRECTION_STATUS_SEQUENCE="failed-no-progress failed-no-progress failed-no-progress done" OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 run_gate "2 1 0")
+if [[ "$out" == "rounds=3 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected three failed-no-progress rounds to stop, got '$out'"
+fi
+
+test_case "interrupted correction remains terminal"
+out=$(CORRECTION_STATUS_SEQUENCE="interrupted-partial done" OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 run_gate "2 1 0")
+if [[ "$out" == "rounds=1 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected interrupted correction to remain terminal, got '$out'"
 fi
 
 test_case "static blockers trip convergence guard (default 3 no-progress rounds)"

--- a/tests/unit/test-tangle-correction-loop-behavior.sh
+++ b/tests/unit/test-tangle-correction-loop-behavior.sh
@@ -43,6 +43,7 @@ run_gate() {
         echo 0 > "$REVIEW_IDX_FILE"
         echo 0 > "$KEY_IDX_FILE"
         CORRECTION_CALLS=0
+        CORRECTION_STRATEGIES=()
 
         source "$2/scripts/lib/workflows.sh" 2>/dev/null
 
@@ -81,6 +82,7 @@ run_gate() {
         }
         tangle_validation_signature() { echo "vsig"; }
         tangle_apply_review_corrections() {
+            CORRECTION_STRATEGIES+=("${6:-}")
             local status="${CORRECTION_STATUSES[$((CORRECTION_CALLS))]:-done}"
             CORRECTION_CALLS=$((CORRECTION_CALLS + 1))
             TANGLE_CORRECTION_STATUS="$status"
@@ -106,7 +108,11 @@ run_gate() {
         rc=0
         tangle_contextual_review_gate tg "prompt" "ctx" "subtasks" \
             "$RESULTS_DIR/validation.md" "$RESULTS_DIR/wt.txt" 0 codex || rc=$?
-        echo "rounds=$CORRECTION_CALLS rc=$rc"
+        if [[ "${ASSERT_STRATEGIES:-0}" == "1" ]]; then
+            echo "rounds=$CORRECTION_CALLS rc=$rc strategies=${CORRECTION_STRATEGIES[*]}"
+        else
+            echo "rounds=$CORRECTION_CALLS rc=$rc"
+        fi
     ' _ "$seq" "$PROJECT_ROOT"
 }
 
@@ -145,24 +151,24 @@ else
 fi
 
 test_case "single failed-no-progress round consumes convergence budget and retries"
-out=$(CORRECTION_STATUS_SEQUENCE="failed-no-progress done" OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 run_gate "2 1 0")
-if [[ "$out" == "rounds=3 rc=0" ]]; then
+out=$(ASSERT_STRATEGIES=1 CORRECTION_STATUS_SEQUENCE="failed-no-progress done" OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 run_gate "2 1 0")
+if [[ "$out" == "rounds=3 rc=0 strategies=delta single-finding delta" ]]; then
     test_pass
 else
     test_fail "expected failed-no-progress retry to recover, got '$out'"
 fi
 
 test_case "three consecutive failed-no-progress rounds stop at convergence limit"
-out=$(CORRECTION_STATUS_SEQUENCE="failed-no-progress failed-no-progress failed-no-progress done" OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 run_gate "2 1 0")
-if [[ "$out" == "rounds=3 rc=1" ]]; then
+out=$(ASSERT_STRATEGIES=1 CORRECTION_STATUS_SEQUENCE="failed-no-progress failed-no-progress failed-no-progress done" OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 run_gate "2 1 0")
+if [[ "$out" == "rounds=3 rc=1 strategies=delta single-finding single-finding" ]]; then
     test_pass
 else
     test_fail "expected three failed-no-progress rounds to stop, got '$out'"
 fi
 
 test_case "interrupted correction remains terminal"
-out=$(CORRECTION_STATUS_SEQUENCE="interrupted-partial done" OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 run_gate "2 1 0")
-if [[ "$out" == "rounds=1 rc=1" ]]; then
+out=$(ASSERT_STRATEGIES=1 CORRECTION_STATUS_SEQUENCE="interrupted-partial done" OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS=3 run_gate "2 1 0")
+if [[ "$out" == "rounds=1 rc=1 strategies=delta" ]]; then
     test_pass
 else
     test_fail "expected interrupted correction to remain terminal, got '$out'"


### PR DESCRIPTION
## Summary

Follow-up to #935 for Tangle correction convergence.

A single correction attempt that returns non-zero with no observable worktree change currently bypasses the existing convergence policy and aborts the entire correction loop immediately. This makes the `OCTOPUS_TANGLE_CONVERGENCE_NO_PROGRESS_ROUNDS` guard inconsistent: static reviews get the configured no-progress budget, while one `failed-no-progress` implementer attempt gets none.

This change routes only `failed-no-progress` / zero-diff correction failures through the existing convergence budget:

- count the failed attempt as one no-progress round
- switch the next attempt to `single-finding`
- retry until the existing convergence threshold is reached
- keep the absolute correction hard cap unchanged
- keep interrupted correction statuses terminal
- skip redundant validation/review when the worktree did not change

## Validation

- tangle correction loop behavior: 14/14 PASS
- tangle contextual review loop: 54/54 PASS
- failed validation review recovery: 5/5 PASS
- review aggregation robustness: 32/32 PASS
- `git diff --check`: PASS

Follow-up to #935.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved correction handling when an attempt makes no progress.
  - Automatically retries recoverable no-progress results using a focused correction strategy.
  - Stops after the configured convergence limit to prevent endless retries.
  - Preserves and reports terminal failures, including interrupted or partially completed corrections, without unnecessary additional attempts.
  - Correction attempts now recover more reliably while avoiding repeated work when progress cannot be made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->