### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ Run commands with the `--verbose` flag to get detailed debugging output. Logs ar
 
 Join [r/ClaudeOctopus](https://www.reddit.com/r/ClaudeOctopus/) for help, workflow tips, showcases, and updates.
 
-[![Star History Chart](https://api.star-history.com/image?repos=nyldn/claude-octopus&type=date&legend=top-left)](https://www.star-history.com/?repos=nyldn%2Fclaude-octopus&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=nyldn/claude-octopus&type=date&legend=top-left)](https://star-history.dera.page/#nyldn/claude-octopus&type=date&legend=top-left)
 
 ### Contributing
 


### PR DESCRIPTION
The star history chart in the README is currently broken and shows nothing. The service it relied on stopped working after GitHub's stargazer API restrictions, so a fix is necessary to restore the chart.

This updates the chart to a working star history service. Only the chart is affected; any badges are left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Star History Chart image and links to use the new destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->