### PR TITLE
fix: substitute same-phase sibling template vars in ink synthesis

### DIFF
--- a/scripts/lib/yaml-workflow.sh
+++ b/scripts/lib/yaml-workflow.sh
@@ -381,6 +381,15 @@ execute_workflow_phase() {
             log "DEBUG" "Waiting for ${#pids[@]} parallel agents before sequential agent"
             _yaml_wait_for_pids "${TIMEOUT:-600}" "${pids[@]}"
             pids=()
+            # A PID wait alone races the result-file write (see
+            # _yaml_wait_for_done_markers above): the spawn wrapper writes the
+            # file and its .done marker after the provider PID exits. Wait for
+            # the markers too, or _yaml_resolve_sibling_vars below can read a
+            # sibling result file that isn't fully written yet.
+            if [[ ${#spawned_tasks[@]} -gt 0 ]]; then
+                _yaml_wait_for_done_markers "${OCTOPUS_YAML_DONE_WAIT:-30}" "${spawned_tasks[@]}" \
+                    || log "WARN" "Phase $phase_name: sibling completion markers not all seen before sequential agent"
+            fi
         fi
 
         # Resolve prompt template

--- a/scripts/lib/yaml-workflow.sh
+++ b/scripts/lib/yaml-workflow.sh
@@ -213,10 +213,13 @@ resolve_prompt_template() {
 
 # Substitute {{<phase>_<provider>}} variables (e.g. {{ink_codex}}, {{ink_agy}})
 # with that same-phase sibling agent's own result content. Only meaningful for
-# a sequential agent's template, since it runs after its phase's parallel
-# agents have already written their result files; a variable naming a sibling
-# that hasn't produced a result yet (still running, skipped, or unknown
-# provider) is left as-is rather than silently dropped.
+# a sequential agent's template, since it runs after its phase's earlier
+# agents have already written their result files. A variable naming a sibling
+# that hasn't produced a result yet (still running, skipped, or failed
+# integrity verification) is left as-is rather than silently dropped -- but
+# only for the providers this loop knows about (codex, agy, claude,
+# cursor-agent); a variable naming any other provider isn't inspected at all
+# and is left unresolved with no warning.
 _yaml_resolve_sibling_vars() {
     local template="$1"
     local phase_name="$2"
@@ -377,15 +380,20 @@ execute_workflow_phase() {
         # exists once the sibling's result file is written, so wait for the
         # parallel agents here, before resolving this agent's prompt, rather
         # than after (the previous order left those variables unsubstituted).
-        if [[ "$is_parallel" != "true" && ${#pids[@]} -gt 0 ]]; then
-            log "DEBUG" "Waiting for ${#pids[@]} parallel agents before sequential agent"
-            _yaml_wait_for_pids "${TIMEOUT:-600}" "${pids[@]}"
-            pids=()
+        if [[ "$is_parallel" != "true" ]]; then
+            if [[ ${#pids[@]} -gt 0 ]]; then
+                log "DEBUG" "Waiting for ${#pids[@]} parallel agents before sequential agent"
+                _yaml_wait_for_pids "${TIMEOUT:-600}" "${pids[@]}"
+                pids=()
+            fi
             # A PID wait alone races the result-file write (see
             # _yaml_wait_for_done_markers above): the spawn wrapper writes the
             # file and its .done marker after the provider PID exits. Wait for
-            # the markers too, or _yaml_resolve_sibling_vars below can read a
-            # sibling result file that isn't fully written yet.
+            # the markers of every sibling spawned so far in this phase --
+            # not just the just-finished parallel batch -- so a sequential
+            # agent that follows another sequential agent (no intervening
+            # parallel batch, so `pids` alone would look empty) still gets a
+            # fully-written file before _yaml_resolve_sibling_vars reads it.
             if [[ ${#spawned_tasks[@]} -gt 0 ]]; then
                 _yaml_wait_for_done_markers "${OCTOPUS_YAML_DONE_WAIT:-30}" "${spawned_tasks[@]}" \
                     || log "WARN" "Phase $phase_name: sibling completion markers not all seen before sequential agent"

--- a/scripts/lib/yaml-workflow.sh
+++ b/scripts/lib/yaml-workflow.sh
@@ -380,6 +380,7 @@ execute_workflow_phase() {
         # exists once the sibling's result file is written, so wait for the
         # parallel agents here, before resolving this agent's prompt, rather
         # than after (the previous order left those variables unsubstituted).
+        local _sibling_markers_ready=true
         if [[ "$is_parallel" != "true" ]]; then
             if [[ ${#pids[@]} -gt 0 ]]; then
                 log "DEBUG" "Waiting for ${#pids[@]} parallel agents before sequential agent"
@@ -395,8 +396,10 @@ execute_workflow_phase() {
             # parallel batch, so `pids` alone would look empty) still gets a
             # fully-written file before _yaml_resolve_sibling_vars reads it.
             if [[ ${#spawned_tasks[@]} -gt 0 ]]; then
-                _yaml_wait_for_done_markers "${OCTOPUS_YAML_DONE_WAIT:-30}" "${spawned_tasks[@]}" \
-                    || log "WARN" "Phase $phase_name: sibling completion markers not all seen before sequential agent"
+                if ! _yaml_wait_for_done_markers "${OCTOPUS_YAML_DONE_WAIT:-30}" "${spawned_tasks[@]}"; then
+                    _sibling_markers_ready=false
+                    log "WARN" "Phase $phase_name: sibling completion markers not all seen before sequential agent"
+                fi
             fi
         fi
 
@@ -405,7 +408,16 @@ execute_workflow_phase() {
         agent_prompt=$(yaml_get_agent_prompt "$yaml_file" "$phase_name" "$provider")
         if [[ -n "$agent_prompt" ]]; then
             agent_prompt=$(resolve_prompt_template "$agent_prompt" "$prompt" "$previous_output")
-            agent_prompt=$(_yaml_resolve_sibling_vars "$agent_prompt" "$phase_name" "$task_group")
+            if [[ "$_sibling_markers_ready" == "true" ]]; then
+                agent_prompt=$(_yaml_resolve_sibling_vars "$agent_prompt" "$phase_name" "$task_group")
+            else
+                # A result file that exists this early has no recorded hash yet,
+                # so verify_result_integrity would pass it as trivially valid --
+                # it can't tell "not yet hashed" from "tampered". Rather than risk
+                # splicing a partially-written sibling result into this prompt,
+                # skip substitution entirely and leave the placeholders as-is.
+                log "WARN" "Phase $phase_name: skipping sibling-var substitution for $task_id (markers not confirmed)"
+            fi
         else
             # Fallback: construct prompt from role
             agent_prompt="$role: $prompt"

--- a/scripts/lib/yaml-workflow.sh
+++ b/scripts/lib/yaml-workflow.sh
@@ -236,6 +236,10 @@ _yaml_resolve_sibling_vars() {
         local sib_file
         sib_file=$(ls -t "${RESULTS_DIR}"/${sib_agent_type}-${phase_name}-${task_group}-*.md 2>/dev/null | head -1)
         if [[ -n "$sib_file" && -f "$sib_file" ]]; then
+            if ! verify_result_integrity "$sib_file"; then
+                log "WARN" "Sibling result failed integrity verification: $sib_file"
+                continue
+            fi
             local sib_output
             sib_output=$(cat "$sib_file" 2>/dev/null)
             resolved="${resolved//$sib_var/$sib_output}"

--- a/scripts/lib/yaml-workflow.sh
+++ b/scripts/lib/yaml-workflow.sh
@@ -211,6 +211,42 @@ resolve_prompt_template() {
     echo "$resolved"
 }
 
+# Substitute {{<phase>_<provider>}} variables (e.g. {{ink_codex}}, {{ink_agy}})
+# with that same-phase sibling agent's own result content. Only meaningful for
+# a sequential agent's template, since it runs after its phase's parallel
+# agents have already written their result files; a variable naming a sibling
+# that hasn't produced a result yet (still running, skipped, or unknown
+# provider) is left as-is rather than silently dropped.
+_yaml_resolve_sibling_vars() {
+    local template="$1"
+    local phase_name="$2"
+    local task_group="$3"
+
+    [[ "$template" == *"{{${phase_name}_"* ]] || { echo "$template"; return 0; }
+
+    local resolved="$template"
+    local sib_provider
+    for sib_provider in codex agy claude cursor-agent; do
+        local sib_var="{{${phase_name}_${sib_provider}}}"
+        [[ "$resolved" == *"$sib_var"* ]] || continue
+
+        local sib_agent_type="$sib_provider"
+        [[ "$sib_provider" == "claude" ]] && sib_agent_type="claude-sonnet"
+
+        local sib_file
+        sib_file=$(ls -t "${RESULTS_DIR}"/${sib_agent_type}-${phase_name}-${task_group}-*.md 2>/dev/null | head -1)
+        if [[ -n "$sib_file" && -f "$sib_file" ]]; then
+            local sib_output
+            sib_output=$(cat "$sib_file" 2>/dev/null)
+            resolved="${resolved//$sib_var/$sib_output}"
+        else
+            log "WARN" "Template variable $sib_var in phase $phase_name has no sibling result yet; leaving it unsubstituted"
+        fi
+    done
+
+    echo "$resolved"
+}
+
 _yaml_wait_for_pids() {
     local max_wait="${1:-${TIMEOUT:-600}}"
     shift || true
@@ -332,11 +368,23 @@ execute_workflow_phase() {
 
         local task_id="${phase_name}-${task_group}-${agent_idx}"
 
+        # A sequential agent's template may reference a same-phase sibling's
+        # own output (e.g. {{ink_codex}}, {{ink_agy}}). That output only
+        # exists once the sibling's result file is written, so wait for the
+        # parallel agents here, before resolving this agent's prompt, rather
+        # than after (the previous order left those variables unsubstituted).
+        if [[ "$is_parallel" != "true" && ${#pids[@]} -gt 0 ]]; then
+            log "DEBUG" "Waiting for ${#pids[@]} parallel agents before sequential agent"
+            _yaml_wait_for_pids "${TIMEOUT:-600}" "${pids[@]}"
+            pids=()
+        fi
+
         # Resolve prompt template
         local agent_prompt
         agent_prompt=$(yaml_get_agent_prompt "$yaml_file" "$phase_name" "$provider")
         if [[ -n "$agent_prompt" ]]; then
             agent_prompt=$(resolve_prompt_template "$agent_prompt" "$prompt" "$previous_output")
+            agent_prompt=$(_yaml_resolve_sibling_vars "$agent_prompt" "$phase_name" "$task_group")
         else
             # Fallback: construct prompt from role
             agent_prompt="$role: $prompt"
@@ -377,12 +425,6 @@ $previous_output"
             pid=$(spawn_agent_capture_pid "$agent_type" "$agent_prompt" "$task_id" "$role" "$phase_name")
             pids+=("$pid")
         else
-            # Sequential agent - wait for parallel agents first
-            if [[ ${#pids[@]} -gt 0 ]]; then
-                log "DEBUG" "Waiting for ${#pids[@]} parallel agents before sequential agent"
-                _yaml_wait_for_pids "${TIMEOUT:-600}" "${pids[@]}"
-                pids=()
-            fi
             # spawn_agent backgrounds the provider internally, so capture the
             # PID and block until it exits. Without this the phase synthesized
             # and moved on while its sequential agent was still running, losing

--- a/tests/unit/test-yaml-workflow-runtime.sh
+++ b/tests/unit/test-yaml-workflow-runtime.sh
@@ -202,4 +202,73 @@ else
     test_pass
 fi
 
+# ── same-phase sibling template substitution (issue #944) ───────────────────
+# embrace.yaml's ink phase briefs its sequential synthesis agent with
+# {{ink_codex}} / {{ink_agy}} — the parallel siblings' own outputs, not the
+# previous phase's output. Those must reach the sequential agent's prompt.
+OPENAI_API_KEY="test-key"
+ANTIGRAVITY_API_KEY="test-key"
+spawn_agent_capture_pid() {
+    local agent_type="$1" agent_prompt="$2" task_id="$3"
+    echo "spawn:$agent_type:$task_id" >> "$SPAWN_LOG"
+    printf '%s' "$agent_prompt" > "$TEST_TMP_DIR/prompt-${task_id}.txt"
+    (
+        sleep 1
+        echo "output of $agent_type for $task_id" > "$RESULTS_DIR/${agent_type}-${task_id}.md"
+        echo "0" > "$WORKSPACE_DIR/.octo/agents/${task_id}.done"
+    ) &
+    echo $!
+}
+spawn_agent() { spawn_agent_capture_pid "$@" >/dev/null; }
+
+SIB_YAML="$TEST_TMP_DIR/sibling.yaml"
+cat > "$SIB_YAML" <<'EOF'
+name: mini-sibling
+description: "mini sibling workflow"
+version: "1.0.0"
+
+phases:
+  - name: beta
+    alias: beta
+    description: "Beta phase"
+    emoji: "B"
+    agents:
+      - provider: codex
+        role: "Quality"
+        parallel: true
+        prompt_template: |
+          Quality check: {{prompt}}
+      - provider: agy
+        role: "Security"
+        parallel: true
+        prompt_template: |
+          Security check: {{prompt}}
+      - provider: claude
+        role: "Synthesis"
+        parallel: false
+        prompt_template: |
+          Combine:
+          - Quality: {{beta_codex}}
+          - Security: {{beta_agy}}
+    quality_gate:
+      threshold: 1.0
+
+quality_gates:
+  consensus:
+    threshold: 0.75
+EOF
+
+execute_workflow_phase "$SIB_YAML" "beta" "test prompt" "" "tg3" >/dev/null 2>&1
+seq_prompt=$(cat "$TEST_TMP_DIR/prompt-beta-tg3-2.txt" 2>/dev/null || true)
+
+test_case "sequential agent prompt substitutes same-phase sibling vars"
+if [[ "$seq_prompt" == *"output of codex for beta-tg3-0"* \
+      && "$seq_prompt" == *"output of agy for beta-tg3-1"* \
+      && "$seq_prompt" != *'{{beta_codex}}'* \
+      && "$seq_prompt" != *'{{beta_agy}}'* ]]; then
+    test_pass
+else
+    test_fail "sibling vars not substituted: $(printf '%s' "$seq_prompt" | head -c 200)"
+fi
+
 test_summary

--- a/tests/unit/test-yaml-workflow-runtime.sh
+++ b/tests/unit/test-yaml-workflow-runtime.sh
@@ -349,4 +349,51 @@ else
     test_fail "chained sequential sibling not substituted: $(printf '%s' "$seq_chain_prompt" | head -c 200)"
 fi
 
+# A sibling that writes its result file but never writes its .done marker
+# (crash mid-write, killed before completion, etc.) must not have that file
+# spliced into the sequential agent's prompt: verify_result_integrity passes
+# a not-yet-hashed file trivially, so it can't be trusted to catch a partial
+# write. The whole sibling-substitution step must be skipped for this agent
+# when the marker wait times out, not just silently read whatever is on disk.
+OCTOPUS_YAML_DONE_WAIT=1
+LOG_CAPTURE="$TEST_TMP_DIR/log-capture-timeout.txt"
+: > "$LOG_CAPTURE"
+log() { [[ "$1" == "WARN" ]] && echo "$2" >> "$LOG_CAPTURE"; return 0; }
+verify_result_integrity() { return 0; }
+spawn_agent_capture_pid() {
+    local agent_type="$1" agent_prompt="$2" task_id="$3"
+    echo "spawn:$agent_type:$task_id" >> "$SPAWN_LOG"
+    printf '%s' "$agent_prompt" > "$TEST_TMP_DIR/prompt-${task_id}.txt"
+    if [[ "$agent_type" == "codex" ]]; then
+        # Writes its result file but never its .done marker.
+        echo "output of $agent_type for $task_id" > "$RESULTS_DIR/${agent_type}-${task_id}.md"
+        ( sleep 0.2 ) &
+        echo $!
+    else
+        (
+            sleep 0.2
+            echo "output of $agent_type for $task_id" > "$RESULTS_DIR/${agent_type}-${task_id}.md"
+            echo "0" > "$WORKSPACE_DIR/.octo/agents/${task_id}.done"
+        ) &
+        echo $!
+    fi
+}
+spawn_agent() { spawn_agent_capture_pid "$@" >/dev/null; }
+
+phase_status=0
+execute_workflow_phase "$SIB_YAML" "beta" "test prompt" "" "tg6" >/dev/null 2>&1 || phase_status=$?
+seq_prompt_timeout=$(cat "$TEST_TMP_DIR/prompt-beta-tg6-2.txt" 2>/dev/null || true)
+
+test_case "sibling substitution skipped entirely when the marker wait times out"
+if (( phase_status != 0 )); then
+    test_fail "execute_workflow_phase failed with status $phase_status"
+elif [[ "$seq_prompt_timeout" == *'{{beta_codex}}'* \
+      && "$seq_prompt_timeout" == *'{{beta_agy}}'* \
+      && "$seq_prompt_timeout" != *"output of codex for beta-tg6-0"* \
+      && $(grep -c "skipping sibling-var substitution" "$LOG_CAPTURE") -ge 1 ]]; then
+    test_pass
+else
+    test_fail "expected substitution skipped on marker timeout: prompt='$(printf '%s' "$seq_prompt_timeout" | head -c 200)' log='$(cat "$LOG_CAPTURE" 2>/dev/null)'"
+fi
+
 test_summary

--- a/tests/unit/test-yaml-workflow-runtime.sh
+++ b/tests/unit/test-yaml-workflow-runtime.sh
@@ -298,4 +298,55 @@ else
     test_fail "expected unresolved placeholders + integrity warnings: prompt='$(printf '%s' "$seq_prompt_bad" | head -c 200)' log='$(cat "$LOG_CAPTURE" 2>/dev/null)'"
 fi
 
+# A sequential agent that follows another *sequential* agent (no intervening
+# parallel batch) must still see that sibling's output: the marker wait must
+# not be gated on a non-empty `pids` array, since sequential spawns never
+# populate it.
+log() { :; }
+verify_result_integrity() { return 0; }
+
+GAMMA_YAML="$TEST_TMP_DIR/gamma.yaml"
+cat > "$GAMMA_YAML" <<'EOF'
+name: mini-gamma
+description: "mini chained-sequential workflow"
+version: "1.0.0"
+
+phases:
+  - name: gamma
+    alias: gamma
+    description: "Gamma phase"
+    emoji: "G"
+    agents:
+      - provider: codex
+        role: "First"
+        parallel: false
+        prompt_template: |
+          First: {{prompt}}
+      - provider: claude
+        role: "Second"
+        parallel: false
+        prompt_template: |
+          Second combining: {{gamma_codex}}
+    quality_gate:
+      threshold: 1.0
+
+quality_gates:
+  consensus:
+    threshold: 0.75
+EOF
+
+phase_status=0
+execute_workflow_phase "$GAMMA_YAML" "gamma" "test prompt" "" "tg5" >/dev/null 2>&1 || phase_status=$?
+seq_chain_prompt=$(cat "$TEST_TMP_DIR/prompt-gamma-tg5-1.txt" 2>/dev/null || true)
+
+test_case "sequential agent prompt substitutes a preceding sequential sibling's output"
+if (( phase_status != 0 )); then
+    test_fail "execute_workflow_phase failed with status $phase_status"
+elif [[ "$seq_chain_prompt" == *"output of codex for gamma-tg5-0"* \
+      && "$seq_chain_prompt" != *'{{gamma_codex}}'* ]]; then
+    test_pass
+else
+    test_fail "chained sequential sibling not substituted: $(printf '%s' "$seq_chain_prompt" | head -c 200)"
+fi
+
 test_summary

--- a/tests/unit/test-yaml-workflow-runtime.sh
+++ b/tests/unit/test-yaml-workflow-runtime.sh
@@ -279,15 +279,20 @@ LOG_CAPTURE="$TEST_TMP_DIR/log-capture.txt"
 log() { [[ "$1" == "WARN" ]] && echo "$2" >> "$LOG_CAPTURE"; return 0; }
 verify_result_integrity() { return 1; }
 
-execute_workflow_phase "$SIB_YAML" "beta" "test prompt" "" "tg4" >/dev/null 2>&1
+phase_status=0
+execute_workflow_phase "$SIB_YAML" "beta" "test prompt" "" "tg4" >/dev/null 2>&1 || phase_status=$?
 seq_prompt_bad=$(cat "$TEST_TMP_DIR/prompt-beta-tg4-2.txt" 2>/dev/null || true)
 
 test_case "sequential agent prompt leaves sibling var unresolved when integrity check fails"
-if [[ "$seq_prompt_bad" == *'{{beta_codex}}'* \
+if (( phase_status != 0 )); then
+    test_fail "execute_workflow_phase failed with status $phase_status"
+elif [[ "$seq_prompt_bad" == *'{{beta_codex}}'* \
       && "$seq_prompt_bad" == *'{{beta_agy}}'* \
       && "$seq_prompt_bad" != *"output of codex for beta-tg4-0"* \
       && "$seq_prompt_bad" != *"output of agy for beta-tg4-1"* \
-      && $(grep -c "Sibling result failed integrity verification" "$LOG_CAPTURE") -ge 2 ]]; then
+      && $(grep -c "Sibling result failed integrity verification" "$LOG_CAPTURE") -ge 2 \
+      && $(grep -Fc "codex-beta-tg4-0" "$LOG_CAPTURE") -ge 1 \
+      && $(grep -Fc "agy-beta-tg4-1" "$LOG_CAPTURE") -ge 1 ]]; then
     test_pass
 else
     test_fail "expected unresolved placeholders + integrity warnings: prompt='$(printf '%s' "$seq_prompt_bad" | head -c 200)' log='$(cat "$LOG_CAPTURE" 2>/dev/null)'"

--- a/tests/unit/test-yaml-workflow-runtime.sh
+++ b/tests/unit/test-yaml-workflow-runtime.sh
@@ -271,4 +271,26 @@ else
     test_fail "sibling vars not substituted: $(printf '%s' "$seq_prompt" | head -c 200)"
 fi
 
+# A sibling result that fails integrity verification must not reach the
+# synthesis prompt: its placeholder stays unresolved and a warning fires,
+# mirroring the phase-output collection loop's existing tamper handling.
+LOG_CAPTURE="$TEST_TMP_DIR/log-capture.txt"
+: > "$LOG_CAPTURE"
+log() { [[ "$1" == "WARN" ]] && echo "$2" >> "$LOG_CAPTURE"; return 0; }
+verify_result_integrity() { return 1; }
+
+execute_workflow_phase "$SIB_YAML" "beta" "test prompt" "" "tg4" >/dev/null 2>&1
+seq_prompt_bad=$(cat "$TEST_TMP_DIR/prompt-beta-tg4-2.txt" 2>/dev/null || true)
+
+test_case "sequential agent prompt leaves sibling var unresolved when integrity check fails"
+if [[ "$seq_prompt_bad" == *'{{beta_codex}}'* \
+      && "$seq_prompt_bad" == *'{{beta_agy}}'* \
+      && "$seq_prompt_bad" != *"output of codex for beta-tg4-0"* \
+      && "$seq_prompt_bad" != *"output of agy for beta-tg4-1"* \
+      && $(grep -c "Sibling result failed integrity verification" "$LOG_CAPTURE") -ge 2 ]]; then
+    test_pass
+else
+    test_fail "expected unresolved placeholders + integrity warnings: prompt='$(printf '%s' "$seq_prompt_bad" | head -c 200)' log='$(cat "$LOG_CAPTURE" 2>/dev/null)'"
+fi
+
 test_summary


### PR DESCRIPTION
## Description
`config/workflows/embrace.yaml`'s `ink` phase briefs its sequential synthesis agent (`claude`) with `{{ink_codex}}` / `{{ink_agy}}` (`embrace.yaml:204-205`), expecting the parallel siblings' own outputs from the same phase. `resolve_prompt_template()` in `scripts/lib/yaml-workflow.sh` only ever substituted a fixed set of *cross-phase* variables (`{{prompt}}`, `{{probe_synthesis}}`, `{{grasp_consensus}}`, `{{tangle_implementation}}`, `{{previous_phase_output}}`), so those placeholders reached the synthesis prompt unresolved — the final delivery report was written without the quality/security review content it claims to combine.

Root cause was actually two-fold in `execute_workflow_phase` (`scripts/lib/yaml-workflow.sh:330-398` before this change):
1. No substitution logic existed at all for same-phase sibling variables.
2. Even if it had, the sequential agent's prompt was resolved *before* the code waited for its parallel siblings to finish, so their result files wouldn't have existed yet.

## Type of Change
- [x] Bug fix

## Fix
- Moved the "wait for parallel siblings" step to occur before prompt-template resolution for a sequential agent, not after.
- Added `_yaml_resolve_sibling_vars()`, which substitutes `{{<phase>_<provider>}}` with that sibling's own result-file content, matching the naming convention `embrace.yaml` already uses (`{{ink_codex}}`, `{{ink_agy}}`). If a referenced sibling has no result yet (shouldn't happen now that the wait is reordered, but could if a provider was skipped as unavailable), the variable is left as-is and a `WARN` is logged rather than silently producing garbage.

This is intentionally scoped to the substitution bug. The issue's third ask ("fail the phase when a template variable is left unsubstituted") is a separate, larger behavioral change to phase failure semantics and is left for a follow-up rather than folded into this fix.

## Testing
- `bash -n scripts/*.sh scripts/lib/*.sh` — clean.
- `bash tests/unit/test-yaml-workflow-runtime.sh` — 10/10 pass, including a new regression test ("sequential agent prompt substitutes same-phase sibling vars") that spawns a mini phase with two parallel agents (codex, agy) and one sequential claude agent referencing `{{beta_codex}}` / `{{beta_agy}}`, and asserts the sequential agent's captured prompt contains the siblings' actual output rather than the literal placeholders.
- `bash tests/unit/test-openclaw-compat.sh` — 32/32 pass (unaffected surface, run per PR checklist).
- Full `make test-unit` was kicked off but is long-running in this environment; the change is narrowly scoped to one function plus its direct regression test, so this PR isn't blocked on that run finishing.

```bash
bash tests/unit/test-yaml-workflow-runtime.sh
bash tests/unit/test-openclaw-compat.sh
```

## Related Issues
Closes #944


---
_Generated by [Claude Code](https://claude.ai/code/session_018S1p8oNNe3BfTbQCvpukU9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow execution so sequential agents receive available results from parallel agents in the same phase.
  * Ensured synthesis prompts include completed sibling outputs before execution.
  * Preserved unresolved placeholders when corresponding results are unavailable or fail validation, with warnings for invalid results.

* **Tests**
  * Added regression coverage for same-phase result substitution, prompt resolution, completion ordering, and invalid-result handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->