### PR TITLE
fix: route persona spawn targets through providers

### DIFF
--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -37,7 +37,7 @@ authorization.
   PR #948's code-focused test passes 13/13 and its normal Test Suite is green,
   but the required PR-review job failed because both the Claude spend limit and
   Copilot monthly quota were exhausted. Do not treat #940 or #948 as merge-ready.
-- Installed-runtime boundary: `/Users/chris/.claude-octopus/plugin` still points
+- Installed-runtime boundary: `~/.claude-octopus/plugin` still points
   at the installed v9.65.0 source and therefore still contains the persona-spawn
   defect. Do not claim the installation is fixed until this branch is merged,
   released or otherwise installed, and the documented architecture command is

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,14 +1,46 @@
 # AI Agent Handoff
 
-Last updated: 2026-08-14
-Status: all pull requests open at session start are merged; GitHub reports an
-empty open-PR queue. v9.64.0 is published to production from `upstream/main`,
-and the shared `nyldn/plugins` marketplace now serves v9.64.0.
-Branch: `main`
-Current release: [v9.64.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.64.0)
-Tracking: [PR #877](https://github.com/nyldn/claude-octopus/pull/877)
-Next action: paused at the user's request; do not start new work until the user
-provides the next task.
+Last updated: 2026-08-21
+Status: persona-name spawn routing is fixed and locally verified on an isolated
+branch. The branch still needs its draft PR and remote CI; do not merge without
+the user's explicit authorization.
+Branch: `fix/persona-spawn-routing`
+Current release: [v9.65.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.65.0)
+Tracking: Beads `oco-mpm`
+Next action: push the branch, open a draft PR, inspect its checks and review
+threads, and leave it unmerged pending explicit authorization.
+
+## Persona Spawn Routing and Recent Queue Audit
+
+- Incident: the shipped architecture skill invoked `orchestrate.sh spawn
+  backend-architect`, but the spawn command passed that curated persona name
+  directly to provider validation. The runtime rejected it as an unknown agent
+  even though help and the skill documented persona-name spawning.
+- Fix: `resolve_persona_spawn_target()` resolves curated persona names through
+  `agents/config.yaml`, prefers an available configured primary provider, uses
+  `fallback_cli` only when needed, and leaves direct provider targets on their
+  existing path. The persona name is retained as the runtime role. AGY remains
+  synchronous in live runs and genuinely dry in `--dry-run` mode.
+- Regression evidence: the new persona suite passes 9/9; AGY provider coverage
+  passes 50/50; agent predicates pass 13/13; Bash syntax, ShellCheck error-level
+  analysis, and `git diff --check` pass. A fresh non-PTY `CI=true
+  GITHUB_ACTIONS=true make ci-changed` selected the full `make ci-local` matrix
+  and exited 0 with all smoke, unit, integration, and CI-only checks passing.
+- Live queue correction: PRs #945 and #946 both claimed issue #944. PR #945 was
+  closed as superseded after a credential-gated explanation; #946 is the more
+  complete fail-closed implementation and its focused YAML runtime suite passes
+  18/18 at head `52e0aeee`.
+- Other live queue findings: #940's one-line chart change serves a valid SVG and
+  destination but GitHub still reports it blocked with no Actions checks; #941,
+  #942, and #946 are clean, approved, and have no unresolved review threads.
+  PR #948's code-focused test passes 13/13 and its normal Test Suite is green,
+  but the required PR-review job failed because both the Claude spend limit and
+  Copilot monthly quota were exhausted. Do not treat #940 or #948 as merge-ready.
+- Installed-runtime boundary: `/Users/chris/.claude-octopus/plugin` still points
+  at the installed v9.65.0 source and therefore still contains the persona-spawn
+  defect. Do not claim the installation is fixed until this branch is merged,
+  released or otherwise installed, and the documented architecture command is
+  re-run from the installed path.
 
 ## Release Currency Audit (post-v9.64.0)
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,14 +1,15 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-21
-Status: persona-name spawn routing is fixed and locally verified on an isolated
-branch. The branch still needs its draft PR and remote CI; do not merge without
-the user's explicit authorization.
+Status: persona-name spawn routing is fixed, locally verified, pushed, and open
+as draft PR #949. Remote CI and review are pending; do not merge without the
+user's explicit authorization.
 Branch: `fix/persona-spawn-routing`
 Current release: [v9.65.0](https://github.com/nyldn/claude-octopus/releases/tag/v9.65.0)
-Tracking: Beads `oco-mpm`
-Next action: push the branch, open a draft PR, inspect its checks and review
-threads, and leave it unmerged pending explicit authorization.
+Tracking: Beads `oco-mpm`; [PR #949](https://github.com/nyldn/claude-octopus/pull/949)
+Next action: inspect PR #949's checks and review threads after they complete,
+address only reproduced findings, and leave it unmerged pending explicit
+authorization.
 
 ## Persona Spawn Routing and Recent Queue Audit
 

--- a/scripts/lib/agents.sh
+++ b/scripts/lib/agents.sh
@@ -384,6 +384,38 @@ get_agent_config() {
     ' "$AGENTS_CONFIG"
 }
 
+# Resolve a curated persona name to the provider used by `orchestrate.sh spawn`.
+# Direct provider names return non-zero so the caller preserves its existing path.
+resolve_persona_spawn_target() {
+    local persona="$1"
+    local primary fallback
+
+    case "$persona" in
+        ''|*[!a-zA-Z0-9_-]*) return 1 ;;
+    esac
+    if [[ -n "${AVAILABLE_AGENTS:-}" && " $AVAILABLE_AGENTS " == *" $persona "* ]]; then
+        return 1
+    fi
+
+    primary="$(get_agent_config "$persona" "cli" 2>/dev/null | sed 's/[[:space:]]*#.*$//; s/[[:space:]]*$//' || true)"
+    [[ -n "$primary" ]] || return 1
+
+    if ! declare -f is_agent_available_v2 >/dev/null 2>&1 || is_agent_available_v2 "$primary"; then
+        printf '%s\n' "$primary"
+        return 0
+    fi
+
+    fallback="$(get_agent_config "$persona" "fallback_cli" 2>/dev/null | sed 's/[[:space:]]*#.*$//; s/[[:space:]]*$//' || true)"
+    if [[ -n "$fallback" ]] && is_agent_available_v2 "$fallback"; then
+        printf '%s\n' "$fallback"
+        return 0
+    fi
+
+    # Preserve the configured primary so normal dispatch reports its concrete
+    # availability/authentication failure when no configured fallback can run.
+    printf '%s\n' "$primary"
+}
+
 # v8.2.0: Get agent memory scope from config (project/none)
 get_agent_memory() {
     local agent_name="$1"

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -2932,15 +2932,31 @@ case "$COMMAND" in
         ;;
     spawn)
         [[ $# -lt 2 ]] && { log ERROR "Usage: spawn <agent> <prompt>"; exit 1; }
-        case "$1" in
+        _spawn_target="$1"
+        _spawn_role=""
+        _spawn_provider="$(resolve_persona_spawn_target "$_spawn_target" 2>/dev/null || true)"
+        if [[ -n "$_spawn_provider" ]]; then
+            _spawn_role="$_spawn_target"
+            _spawn_target="$_spawn_provider"
+        fi
+        case "$_spawn_target" in
             agy|agy-*|antigravity)
-                log INFO "Running $1 synchronously because Antigravity CLI print mode does not emit output from background jobs"
-                run_agent_sync "$1" "$2" "$TIMEOUT" "none" "spawn"
+                if [[ "$DRY_RUN" == "true" ]]; then
+                    spawn_agent "$_spawn_target" "$2" "" "${_spawn_role:-none}" "spawn"
+                else
+                    log INFO "Running $_spawn_target synchronously because Antigravity CLI print mode does not emit output from background jobs"
+                    run_agent_sync "$_spawn_target" "$2" "$TIMEOUT" "${_spawn_role:-none}" "spawn"
+                fi
                 ;;
             *)
-                spawn_agent "$1" "$2"
+                if [[ -n "$_spawn_role" ]]; then
+                    spawn_agent "$_spawn_target" "$2" "" "$_spawn_role" "spawn"
+                else
+                    spawn_agent "$1" "$2"
+                fi
                 ;;
         esac
+        unset _spawn_target _spawn_role _spawn_provider
         ;;
     auto)
         source "${SCRIPT_DIR}/lib/auto-route.sh" 2>/dev/null || true

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -799,10 +799,10 @@ test_agy_sync_bypasses_timeout_wrapper() {
 }
 
 test_agy_spawn_cli_uses_sync_dispatch() {
-    test_case "orchestrate spawn routes agy through sync dispatch"
+    test_case "orchestrate spawn routes direct and persona-resolved agy through sync dispatch"
 
     if grep -q 'Antigravity CLI print mode does not emit output from background jobs' "$PROJECT_ROOT/scripts/orchestrate.sh" && \
-       grep -q 'run_agent_sync "$1" "$2" "$TIMEOUT" "none" "spawn"' "$PROJECT_ROOT/scripts/orchestrate.sh"; then
+       grep -q 'run_agent_sync "\$_spawn_target" "\$2" "\$TIMEOUT" "\${_spawn_role:-none}" "spawn"' "$PROJECT_ROOT/scripts/orchestrate.sh"; then
         test_pass
     else
         test_fail "orchestrate.sh spawn should run agy synchronously"

--- a/tests/unit/test-persona-spawn-routing.sh
+++ b/tests/unit/test-persona-spawn-routing.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Regression coverage for persona names accepted by `orchestrate.sh spawn`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+AGENTS_LIB="$PROJECT_ROOT/scripts/lib/agents.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+# shellcheck source=/dev/null
+source "$AGENTS_LIB"
+
+test_suite "persona spawn routing"
+
+run_orchestrate() {
+    (cd "$PROJECT_ROOT" && bash scripts/orchestrate.sh --dry-run "$@" 2>&1)
+}
+
+test_case "spawn resolves backend-architect to its configured provider and preserves the persona role"
+agy_bin="$TEST_TMP_DIR/persona-primary-bin"
+mkdir -p "$agy_bin"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$agy_bin/agy"
+chmod +x "$agy_bin/agy"
+out="$(PATH="$agy_bin:$PATH" run_orchestrate spawn backend-architect "Design a durable coordinator")" && rc=0 || rc=$?
+if [[ "$rc" -eq 0 ]] && \
+   [[ "$out" == *"[DRY-RUN] Would execute:"* ]] && \
+   [[ "$out" == *"agy-exec.sh"* ]] && \
+   [[ "$out" == *"role=backend-architect"* ]] && \
+   [[ "$out" != *"Unknown agent type: backend-architect"* ]]; then
+    test_pass
+else
+    test_fail "expected persona dispatch dry-run; got exit=$rc, output: $out"
+fi
+
+test_case "persona resolver keeps an available configured primary provider"
+get_agent_config() {
+    case "$2" in
+        cli) printf '%s\n' 'agy # configured primary' ;;
+        fallback_cli) printf '%s\n' 'codex' ;;
+    esac
+}
+is_agent_available_v2() { [[ "$1" == "agy" ]]; }
+out="$(resolve_persona_spawn_target backend-architect)" && rc=0 || rc=$?
+if [[ "$rc" -eq 0 && "$out" == "agy" ]]; then
+    test_pass
+else
+    test_fail "expected available primary agy; got exit=$rc, output: $out"
+fi
+
+test_case "persona resolver uses configured fallback only when primary is unavailable"
+is_agent_available_v2() { [[ "$1" == "codex" ]]; }
+out="$(resolve_persona_spawn_target backend-architect)" && rc=0 || rc=$?
+if [[ "$rc" -eq 0 && "$out" == "codex" ]]; then
+    test_pass
+else
+    test_fail "expected fallback codex; got exit=$rc, output: $out"
+fi
+
+test_case "persona resolver preserves the primary when no configured provider is available"
+is_agent_available_v2() { return 1; }
+out="$(resolve_persona_spawn_target backend-architect)" && rc=0 || rc=$?
+if [[ "$rc" -eq 0 && "$out" == "agy" ]]; then
+    test_pass
+else
+    test_fail "expected unavailable primary agy for concrete dispatch diagnostics; got exit=$rc, output: $out"
+fi
+
+test_case "persona resolver never reinterprets a direct provider listed in AVAILABLE_AGENTS"
+AVAILABLE_AGENTS="codex agy"
+config_marker="$TEST_TMP_DIR/direct-provider-config-called"
+rm -f "$config_marker"
+get_agent_config() { touch "$config_marker"; printf '%s\n' 'agy'; }
+resolve_persona_spawn_target codex >/dev/null 2>&1 && rc=0 || rc=$?
+unset AVAILABLE_AGENTS
+if [[ "$rc" -ne 0 && ! -e "$config_marker" ]]; then
+    test_pass
+else
+    test_fail "direct provider was reinterpreted through persona config"
+fi
+
+test_case "persona resolver rejects unsafe target names before config lookup"
+config_marker="$TEST_TMP_DIR/persona-config-called"
+rm -f "$config_marker"
+get_agent_config() { touch "$config_marker"; printf '%s\n' 'agy'; }
+resolve_persona_spawn_target 'backend.*' >/dev/null 2>&1 && rc=0 || rc=$?
+if [[ "$rc" -ne 0 && ! -e "$config_marker" ]]; then
+    test_pass
+else
+    test_fail "unsafe target reached config lookup or resolved successfully"
+fi
+
+test_case "direct provider spawn remains provider-oriented"
+out="$(run_orchestrate spawn codex "Review a durable coordinator")" && rc=0 || rc=$?
+if [[ "$rc" -eq 0 ]] && \
+   [[ "$out" == *"[DRY-RUN] Would execute: codex"* ]] && \
+   [[ "$out" != *"role=backend-architect"* ]]; then
+    test_pass
+else
+    test_fail "expected unchanged direct provider dry-run; got exit=$rc, output: $out"
+fi
+
+test_case "unknown persona target still fails closed"
+out="$(run_orchestrate spawn not-a-persona "Review a durable coordinator")" && rc=0 || rc=$?
+if [[ "$rc" -ne 0 && "$out" == *"Unknown agent type: not-a-persona"* ]]; then
+    test_pass
+else
+    test_fail "expected unknown target rejection; got exit=$rc, output: $out"
+fi
+
+test_case "direct agy dry-run preserves the legacy none role without live dispatch"
+out="$(PATH="$agy_bin:$PATH" run_orchestrate spawn agy "Review a durable coordinator")" && rc=0 || rc=$?
+if [[ "$rc" -eq 0 ]] && \
+   [[ "$out" == *"[DRY-RUN] Would execute:"* ]] && \
+   [[ "$out" == *"agy-exec.sh"* ]] && \
+   [[ "$out" == *"role=none"* ]] && \
+   [[ "$out" != *"Running agy synchronously"* ]]; then
+    test_pass
+else
+    test_fail "expected safe legacy-role AGY dry-run; got exit=$rc, output: $out"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

- Restore the documented orchestrate spawn persona contract by resolving curated persona names through agents/config.yaml.
- Preserve direct provider spawning, provider validation, and the configured persona as the runtime role.
- Use fallback_cli only when the configured primary provider is unavailable, while keeping AGY live execution synchronous and dry runs non-executing.
- Add focused regression coverage for persona resolution, provider collisions, fallbacks, unsafe and unknown targets, and direct AGY behavior.

## Root cause

The architecture, code-review, and security skills invoke spawn with curated persona names such as backend-architect. The spawn command forwarded that name directly to provider command resolution, which accepts provider identifiers rather than persona identifiers. The documented architecture command therefore failed with Unknown agent type: backend-architect.

## Verification

- Reproduced the exact failure before the implementation.
- Persona spawn routing: 9/9.
- AGY provider suite: 50/50.
- Agent predicate suite: 13/13.
- Bash syntax, ShellCheck at error severity, and git diff check passed.
- Fresh CI=true GITHUB_ACTIONS=true make ci-changed selected the full make ci-local matrix and exited 0 with all smoke, unit, integration, and CI-only checks passing.
- The documented dry-run now reports the AGY adapter with role=backend-architect.

## Operational boundary

The installed v9.65.0 plugin still contains the defect until this change is merged and installed. This pull request is intentionally draft and must not be merged without explicit authorization.

Tracking: Beads oco-mpm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed persona-based spawn routing to select an available provider or configured fallback.
  * Preserved persona roles during dispatch for improved task handling.
  * Improved validation for invalid, unknown, and unavailable spawn targets.
  * Maintained Antigravity support for dry-run and synchronous execution.

* **Tests**
  * Added regression coverage for provider selection, fallback behavior, validation, and direct-provider launches.

* **Documentation**
  * Updated release handoff notes with fix status, verification results, and deployment requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->