### PR TITLE
chore: release v9.66.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "9.65.0"
+    "version": "9.66.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v9.65.0 - Setup enables routing suggestions; council and tangle runs stay recoverable. 32 personas, 54 commands, 63 skills. Run /octo:setup.",
-      "version": "9.65.0",
+      "description": "v9.66.0 - Opt-in vendor-balanced councils; reliable persona spawning, workflow synthesis, and review timeouts. 32 personas, 54 commands, 63 skills. Run /octo:setup.",
+      "version": "9.66.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": "2026-06",
   "name": "octo",
   "displayName": "Claude Octopus",
-  "version": "9.65.0",
+  "version": "9.66.0",
   "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
   "author": {
     "name": "nyldn",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.65.0",
-  "description": "v9.65.0 \u2014 Setup enables routing suggestions; council and tangle runs stay recoverable. Run /octo:setup.",
+  "version": "9.66.0",
+  "description": "v9.66.0 \u2014 Opt-in vendor-balanced councils; reliable persona spawning, workflow synthesis, and review timeouts. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Claude Octopus routine manifest (v9.65.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "$comment": "Claude Octopus routine manifest (v9.66.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
   "schemaVersion": 1,
   "routines": [
     {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "9.65.0",
+  "version": "9.66.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Antigravity, Grok, Copilot, Qwen, Perplexity, OpenRouter, OrcaRouter, Ollama, and OpenCode from a single plugin.",
   "author": {
     "name": "nyldn"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "9.65.0",
+  "version": "9.66.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "9.65.0"
+    "version": "9.66.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v9.65.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 54 commands, 63 skills. Run /octo:setup after install.",
-      "version": "9.65.0",
+      "description": "v9.66.0 - Multi-AI orchestration with Double Diamond workflow. 32 personas, 54 commands, 63 skills. Run /octo:setup after install.",
+      "version": "9.66.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "9.65.0",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.65.0. 32 expert personas, 54 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "9.66.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v9.66.0. 32 expert personas, 54 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@
   `OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1` enables it; unset or any other value
   (including `0`) preserves today's roster exactly.
 
+### Changed
+
+- Installation and command docs now state that
+  `disable-model-invocation` is the expected default: Octopus stays dormant
+  until an explicit `/octo:*` command is invoked, while its hooks and statusline
+  remain available.
+
+### Fixed
+
+- Documented personas such as `backend-architect` now resolve through the
+  configured primary/fallback provider while preserving the requested persona
+  as the runtime role. Direct provider names keep their existing dispatch path,
+  so persona names are no longer rejected as unknown backends.
+- Review workflows now fail closed on invalid fleet policy or environment
+  configuration, honor role-specific routing precedence, preserve timeout
+  provenance, emit an incomplete Council liveness beacon when synthesis cannot
+  finish, and use case-sensitive Tangle runtime identities.
+- YAML workflows now wait for same-phase parallel siblings before sequential
+  synthesis, substitute verified sibling output (or an explicit unavailable
+  note), and halt instead of dispatching prompts with unresolved placeholders.
+- The parent PID wait window is now derived from the full summarizer budget,
+  including `OCTOPUS_AGENT_TIMEOUT` overrides, rather than expiring after a
+  fixed 120 seconds while a valid summarizer chain is still running.
+
 ## [9.65.0] - 2026-08-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [9.66.0] - 2026-08-21
+
 ### Added
 
 - Opt-in one-vote-per-vendor council seating. Set

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-08-16
+last_reviewed: 2026-08-21
 ---
 
 # PRODUCT.md
@@ -79,7 +79,7 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 - GitHub stars: 3,889
 - GitHub forks: 365
 - Local CI parity: `make ci-local` runs the same smoke, unit, and integration suites as CI
-- Version: 9.65.0 (active release cadence)
+- Version: 9.66.0 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Antigravity CLI
 
 **Measured Impact:**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 <p align="center">
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/Version-9.65.0-blue" alt="Version 9.65.0">
+  <img src="https://img.shields.io/badge/Version-9.66.0-blue" alt="Version 9.66.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -35,7 +35,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 ## What's New
 
 <!-- BEGIN CURRENT RELEASE -->
-> 🆕 **v9.65.0 — Setup enables routing suggestions; council and tangle runs stay recoverable.**
+> 🆕 **v9.66.0 — Opt-in vendor-balanced councils; reliable persona spawning, workflow synthesis, and review timeouts.**
 >
 > **Default roster:** Claude Opus 5 leads architecture, planning, security reasoning, and final judgment; GPT-5.6 Sol is the independent implementation/review peer; Claude Sonnet 5 is the standard Claude seat; Fable 5 remains an opt-in judgment escalation. Existing model pins and provider configuration still win. See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md).
 <!-- END CURRENT RELEASE -->
@@ -55,7 +55,7 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 
 | Version | Best Features |
 |---------|--------------|
-| **v9.65.0** (new) | Setup enables routing suggestions; council and tangle runs stay recoverable. |
+| **v9.66.0** (new) | Opt-in vendor-balanced councils; reliable persona spawning, workflow synthesis, and review timeouts. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
 | **v9** | Up to 10 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Explicit-only activation by default, with an optional smart router. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Opt-in discipline gates and token compression. Two-stage review. Circuit breakers with automatic provider recovery inside active workflows. Cursor + OpenCode + Codex cross-compatibility. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "9.65.0",
+  "version": "9.66.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {


### PR DESCRIPTION
## Release v9.66.0

Opt-in vendor-balanced councils; reliable persona spawning, workflow synthesis, and review timeouts

---
🤖 Generated with release.sh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in vendor-balanced councils with one vote per vendor.
  * Added reliable persona spawning through configured providers.
  * Added workflow synthesis with improved sibling synchronization and placeholder handling.
  * Added review timeout reporting with preserved timeout details.
  * Added Council liveness reporting and stricter configuration validation.
  * Added case-sensitive Tangle identities and summarizer-budget-based waiting behavior.
* **Documentation**
  * Updated release documentation for version 9.66.0 and its new capabilities.
* **Chores**
  * Updated all plugin and package versions to 9.66.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->