### PR TITLE
test(council): remove benchmark freshness clock dependency

### DIFF
--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -71,6 +71,18 @@ load_council_lib() {
     source "$lib"
 }
 
+council_run_with_snapshot_age() {
+    local snapshot_age_days="$1"
+    shift
+
+    local run_status=0
+    council_snapshot_age_days() { printf '%s\n' "$snapshot_age_days"; }
+    council_run "$@" || run_status=$?
+    # shellcheck disable=SC1090
+    source "$PROJECT_ROOT/scripts/lib/benchmark-routing.sh"
+    return "$run_status"
+}
+
 prepare_cached_quick_dry_run() {
     [[ -f "$CACHED_COUNCIL_QUICK_DRY_RUN_SUMMARY" ]] && return 0
     local tmp_dir
@@ -238,7 +250,8 @@ test_council_dry_run_loads_fresh_benchmark_snapshot() {
     local tmp_dir
     tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-benchmark.XXXXXX")"
 
-    council_run --dry-run --benchmark auto --output-dir "$tmp_dir" "Should we use Redis?"
+    council_run_with_snapshot_age 30 --dry-run --benchmark auto \
+        --output-dir "$tmp_dir" "Should we use Redis?"
 
     local summary
     summary="$(find "$tmp_dir" -name summary.json -type f | head -1)"
@@ -367,7 +380,8 @@ test_council_scores_roster_with_benchmark_signal() {
     tmp_dir="$(mktemp -d "$TEST_TMP_DIR/council-score.XXXXXX")"
 
     OCTOPUS_COUNCIL_PROVIDER_FIXTURE='claude:available,codex:available,agy:available' \
-        council_run --dry-run --depth quick --output-dir "$tmp_dir" "Review auth"
+        council_run_with_snapshot_age 30 --dry-run --depth quick \
+            --output-dir "$tmp_dir" "Review auth"
 
     local summary
     summary="$(find "$tmp_dir" -name summary.json -type f | head -1)"


### PR DESCRIPTION
## Summary

- pin benchmark snapshot age to 30 days only while the two freshness-dependent council tests run
- restore the production freshness implementation immediately afterward
- keep production benchmark routing and assertions unchanged

## Root cause

The repository snapshot reached age 90 at the UTC date rollover. Production correctly calculated a zero freshness weight at that boundary, while the score test still required a positive signal. The load test would also become clock-dependent after age 90.

## Verification

- Before fix: `make ci-changed` failed `Council roster has normalized scores and benchmark signals` with all three providers at `benchmark_signal: 0.0000` and `benchmark_source: null`.
- Helper check: both affected assertions pass with age 30, and the real age function is restored afterward.
- `CI=true GITHUB_ACTIONS=true make ci-changed`: focused mode passed smoke checks plus 2/2 selected unit suites; council suite 86 passed, 0 failed, 1 documented skip.
- `git diff --check`: clean; executable mode preserved.

Tracks `oco-016`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved benchmark-related test coverage by simulating snapshots with a 30-day age.
  * Added test support for verifying run status preservation under aged snapshot conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->