### PR TITLE
fix(runtime): preserve caller process group for providers

### DIFF
--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -174,10 +174,18 @@ run_with_timeout() {
     # would otherwise outlive the timeout — that is exactly how an expired-token
     # qwen probe hung ~10min instead of dying at the per-agent cap.
     if [[ "$_cmd_is_function" == "false" ]] && command -v gtimeout &>/dev/null; then
-        gtimeout -k 10 "$timeout_secs" "$@"
+        if [[ "${OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP:-false}" == "true" ]]; then
+            gtimeout --foreground -k 10 "$timeout_secs" "$@"
+        else
+            gtimeout -k 10 "$timeout_secs" "$@"
+        fi
         exit_code=$?
     elif [[ "$_cmd_is_function" == "false" ]] && command -v timeout &>/dev/null; then
-        timeout -k 10 "$timeout_secs" "$@"
+        if [[ "${OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP:-false}" == "true" ]]; then
+            timeout --foreground -k 10 "$timeout_secs" "$@"
+        else
+            timeout -k 10 "$timeout_secs" "$@"
+        fi
         exit_code=$?
     else
         # Fallback with proper cleanup (also used for shell functions).

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -143,7 +143,7 @@ _run_with_timeout_preserving_process_group() {
     local timeout_secs="$2"
     shift 2
 
-    "$timeout_bin" --foreground -k 10 "$timeout_secs" bash -c '
+    "$timeout_bin" --foreground "$timeout_secs" bash -c '
         set +e
         _octo_collect_descendants() {
             local parent="$1" child
@@ -159,15 +159,29 @@ _run_with_timeout_preserving_process_group() {
             _octo_collect_descendants "$child_pid"
             if ((${#_octo_descendants[@]})); then
                 kill -TERM "${_octo_descendants[@]}" 2>/dev/null || true
-                sleep 0.2
-                kill -KILL "${_octo_descendants[@]}" 2>/dev/null || true
             fi
-            for _octo_i in 1 2 3 4 5; do
-                kill -0 "$child_pid" 2>/dev/null || break
+            kill -TERM "$child_pid" 2>/dev/null || true
+
+            # Match timeout -k 10 semantics: give the provider subtree the full
+            # 10-second TERM grace period before escalating remaining processes.
+            for _octo_i in $(seq 1 100); do
+                _octo_any_alive=false
+                kill -0 "$child_pid" 2>/dev/null && _octo_any_alive=true
+                for _octo_pid in "${_octo_descendants[@]}"; do
+                    if kill -0 "$_octo_pid" 2>/dev/null; then
+                        _octo_any_alive=true
+                        break
+                    fi
+                done
+                [[ "$_octo_any_alive" == "false" ]] && break
                 sleep 0.1
             done
-            kill -TERM "$child_pid" 2>/dev/null || true
-            sleep 0.1
+
+            _octo_descendants=()
+            _octo_collect_descendants "$child_pid"
+            if ((${#_octo_descendants[@]})); then
+                kill -KILL "${_octo_descendants[@]}" 2>/dev/null || true
+            fi
             kill -KILL "$child_pid" 2>/dev/null || true
             wait "$child_pid" 2>/dev/null || true
         }

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -133,6 +133,59 @@ cleanup_heartbeat() {
     rm -f "${WORKSPACE_DIR}/.octo/agents/${pid}.heartbeat"
 }
 
+
+# Run an external command under GNU timeout while preserving the caller process
+# group. timeout --foreground intentionally stops managing a separate command
+# process group, so this wrapper owns descendant cleanup on TERM/INT/HUP without
+# ever signalling the caller's PGID.
+_run_with_timeout_preserving_process_group() {
+    local timeout_bin="$1"
+    local timeout_secs="$2"
+    shift 2
+
+    "$timeout_bin" --foreground -k 10 "$timeout_secs" bash -c '
+        set +e
+        _octo_collect_descendants() {
+            local parent="$1" child
+            while IFS= read -r child; do
+                child="${child//[[:space:]]/}"
+                [[ -n "$child" ]] || continue
+                _octo_collect_descendants "$child"
+                _octo_descendants+=("$child")
+            done < <(ps -eo pid=,ppid= | while read -r pid ppid; do [[ "$ppid" == "$parent" ]] && echo "$pid"; done)
+        }
+        _octo_cleanup_descendants() {
+            _octo_descendants=()
+            _octo_collect_descendants "$child_pid"
+            if ((${#_octo_descendants[@]})); then
+                kill -TERM "${_octo_descendants[@]}" 2>/dev/null || true
+                sleep 0.2
+                kill -KILL "${_octo_descendants[@]}" 2>/dev/null || true
+            fi
+            for _octo_i in 1 2 3 4 5; do
+                kill -0 "$child_pid" 2>/dev/null || break
+                sleep 0.1
+            done
+            kill -TERM "$child_pid" 2>/dev/null || true
+            sleep 0.1
+            kill -KILL "$child_pid" 2>/dev/null || true
+            wait "$child_pid" 2>/dev/null || true
+        }
+        _octo_on_signal() {
+            trap - TERM INT HUP
+            _octo_cleanup_descendants
+            exit 143
+        }
+        trap _octo_on_signal TERM INT HUP
+        "$@" <&0 &
+        child_pid=$!
+        wait "$child_pid"
+        status=$?
+        trap - TERM INT HUP
+        exit "$status"
+    ' bash "$@"
+}
+
 # Portable timeout function (works on macOS and Linux)
 # Prefers system timeout commands, falls back to manual implementation
 run_with_timeout() {
@@ -175,14 +228,14 @@ run_with_timeout() {
     # qwen probe hung ~10min instead of dying at the per-agent cap.
     if [[ "$_cmd_is_function" == "false" ]] && command -v gtimeout &>/dev/null; then
         if [[ "${OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP:-false}" == "true" ]]; then
-            gtimeout --foreground -k 10 "$timeout_secs" "$@"
+            _run_with_timeout_preserving_process_group gtimeout "$timeout_secs" "$@"
         else
             gtimeout -k 10 "$timeout_secs" "$@"
         fi
         exit_code=$?
     elif [[ "$_cmd_is_function" == "false" ]] && command -v timeout &>/dev/null; then
         if [[ "${OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP:-false}" == "true" ]]; then
-            timeout --foreground -k 10 "$timeout_secs" "$@"
+            _run_with_timeout_preserving_process_group timeout "$timeout_secs" "$@"
         else
             timeout -k 10 "$timeout_secs" "$@"
         fi

--- a/tests/unit/test-preserve-caller-process-group.sh
+++ b/tests/unit/test-preserve-caller-process-group.sh
@@ -6,8 +6,15 @@ test_suite "Caller process-group preservation"
 log() { :; }
 source "$PROJECT_ROOT/scripts/lib/heartbeat.sh"
 
+timeout_bin=""
+if command -v gtimeout >/dev/null 2>&1; then
+    timeout_bin=gtimeout
+elif command -v timeout >/dev/null 2>&1; then
+    timeout_bin=timeout
+fi
+
 test_case "run_with_timeout preserves caller process group when requested"
-if command -v timeout >/dev/null 2>&1; then
+if [[ -n "$timeout_bin" ]]; then
     parent_pgid="$(ps -o pgid= -p $$ | tr -d ' ')"
     child_pgid="$(OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP=true run_with_timeout 5 sh -c 'ps -o pgid= -p $$ | tr -d " "')"
     if [[ "$child_pgid" == "$parent_pgid" ]]; then
@@ -16,15 +23,42 @@ if command -v timeout >/dev/null 2>&1; then
         test_fail "expected child PGID $parent_pgid, got $child_pgid"
     fi
 else
-    test_skip "GNU timeout not available on this platform"
+    test_skip "GNU timeout/gtimeout not available on this platform"
 fi
 
-test_case "heartbeat uses --foreground only for opt-in process-group preservation"
-if grep -q 'OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP' "$PROJECT_ROOT/scripts/lib/heartbeat.sh" \
-   && grep -q 'timeout --foreground -k 10' "$PROJECT_ROOT/scripts/lib/heartbeat.sh"; then
+test_case "preserve mode cleans up timed-out descendants"
+if [[ -n "$timeout_bin" ]]; then
+    tmpdir="$(mktemp -d)"
+    pidfile="$tmpdir/child.pid"
+    set +e
+    OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP=true run_with_timeout 1 sh -c 'sleep 30 & echo "$!" > "$1"; wait' sh "$pidfile" >/dev/null 2>&1
+    status=$?
+    set -e
+    child_pid="$(cat "$pidfile" 2>/dev/null || true)"
+    sleep 0.3
+    if [[ -n "$child_pid" ]] && kill -0 "$child_pid" 2>/dev/null; then
+        kill -KILL "$child_pid" 2>/dev/null || true
+        rm -rf "$tmpdir"
+        test_fail "descendant survived preserve-mode timeout: $child_pid"
+    elif [[ "$status" -eq 124 || "$status" -eq 143 ]]; then
+        rm -rf "$tmpdir"
+        test_pass
+    else
+        rm -rf "$tmpdir"
+        test_fail "unexpected timeout status: $status"
+    fi
+else
+    test_skip "GNU timeout/gtimeout not available on this platform"
+fi
+
+test_case "production and tests prefer gtimeout before timeout"
+if grep -q '_run_with_timeout_preserving_process_group gtimeout' "$PROJECT_ROOT/scripts/lib/heartbeat.sh" \
+   && grep -q '_run_with_timeout_preserving_process_group timeout' "$PROJECT_ROOT/scripts/lib/heartbeat.sh" \
+   && grep -q 'command -v gtimeout' "$0" \
+   && grep -q 'command -v timeout' "$0"; then
     test_pass
 else
-    test_fail "missing opt-in --foreground timeout path"
+    test_fail "gtimeout/timeout preserve-mode paths are not covered"
 fi
 
 test_summary

--- a/tests/unit/test-preserve-caller-process-group.sh
+++ b/tests/unit/test-preserve-caller-process-group.sh
@@ -32,10 +32,14 @@ if [[ -n "$timeout_bin" ]]; then
     tmpdir="$TEST_TMP_DIR/preserve-timeout"
     mkdir -p "$tmpdir"
     pidfile="$tmpdir/child.pid"
-    set +e
-    OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP=true run_with_timeout 1 sh -c 'sleep 30 & echo "$!" > "$1"; wait' sh "$pidfile" >/dev/null 2>&1
-    status=$?
-    set -e
+    if (
+        export "OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP=true"
+        run_with_timeout 1 sh -c 'sleep 30 & echo "$!" > "$1"; wait' sh "$pidfile" >/dev/null 2>&1
+    ); then
+        status=0
+    else
+        status=$?
+    fi
     child_pid="$(cat "$pidfile" 2>/dev/null || true)"
     sleep 0.3
     child_stat="$(ps -o stat= -p "$child_pid" 2>/dev/null | tr -d "[:space:]" || true)"

--- a/tests/unit/test-preserve-caller-process-group.sh
+++ b/tests/unit/test-preserve-caller-process-group.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$PROJECT_ROOT/tests/helpers/test-framework.sh"
+test_suite "Caller process-group preservation"
+log() { :; }
+source "$PROJECT_ROOT/scripts/lib/heartbeat.sh"
+
+test_case "run_with_timeout preserves caller process group when requested"
+if command -v timeout >/dev/null 2>&1; then
+    parent_pgid="$(ps -o pgid= -p $$ | tr -d ' ')"
+    child_pgid="$(OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP=true run_with_timeout 5 sh -c 'ps -o pgid= -p $$ | tr -d " "')"
+    if [[ "$child_pgid" == "$parent_pgid" ]]; then
+        test_pass
+    else
+        test_fail "expected child PGID $parent_pgid, got $child_pgid"
+    fi
+else
+    test_skip "GNU timeout not available on this platform"
+fi
+
+test_case "heartbeat uses --foreground only for opt-in process-group preservation"
+if grep -q 'OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP' "$PROJECT_ROOT/scripts/lib/heartbeat.sh" \
+   && grep -q 'timeout --foreground -k 10' "$PROJECT_ROOT/scripts/lib/heartbeat.sh"; then
+    test_pass
+else
+    test_fail "missing opt-in --foreground timeout path"
+fi
+
+test_summary

--- a/tests/unit/test-preserve-caller-process-group.sh
+++ b/tests/unit/test-preserve-caller-process-group.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-source "$PROJECT_ROOT/tests/helpers/test-framework.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Caller process-group preservation"
 log() { :; }
 source "$PROJECT_ROOT/scripts/lib/heartbeat.sh"
@@ -28,7 +29,8 @@ fi
 
 test_case "preserve mode cleans up timed-out descendants"
 if [[ -n "$timeout_bin" ]]; then
-    tmpdir="$(mktemp -d)"
+    tmpdir="$TEST_TMP_DIR/preserve-timeout"
+    mkdir -p "$tmpdir"
     pidfile="$tmpdir/child.pid"
     set +e
     OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP=true run_with_timeout 1 sh -c 'sleep 30 & echo "$!" > "$1"; wait' sh "$pidfile" >/dev/null 2>&1
@@ -36,15 +38,13 @@ if [[ -n "$timeout_bin" ]]; then
     set -e
     child_pid="$(cat "$pidfile" 2>/dev/null || true)"
     sleep 0.3
-    if [[ -n "$child_pid" ]] && kill -0 "$child_pid" 2>/dev/null; then
+    child_stat="$(ps -o stat= -p "$child_pid" 2>/dev/null | tr -d "[:space:]" || true)"
+    if [[ -n "$child_stat" && "$child_stat" != Z* ]]; then
         kill -KILL "$child_pid" 2>/dev/null || true
-        rm -rf "$tmpdir"
-        test_fail "descendant survived preserve-mode timeout: $child_pid"
-    elif [[ "$status" -eq 124 || "$status" -eq 143 ]]; then
-        rm -rf "$tmpdir"
+        test_fail "descendant survived preserve-mode timeout: $child_pid (stat=$child_stat)"
+    elif [[ "$status" -eq 124 || "$status" -eq 143 || "$status" -eq 137 ]]; then
         test_pass
     else
-        rm -rf "$tmpdir"
         test_fail "unexpected timeout status: $status"
     fi
 else

--- a/tests/unit/test-seteleak-kill-wait-751.sh
+++ b/tests/unit/test-seteleak-kill-wait-751.sh
@@ -105,7 +105,7 @@ test_heartbeat_kill_lines_guarded() {
 
     local file="$PROJECT_ROOT/scripts/lib/heartbeat.sh"
     local snippet
-    snippet=$(sed -n '190,205p' "$file")
+    snippet=$(grep -A12 -B2 'kill -TERM "\$cmd_pid"' "$file")
 
     assert_contains "$snippet" 'kill -TERM "$cmd_pid" 2>/dev/null || true' \
         "kill -TERM on cmd_pid must be guarded" || return

--- a/tests/unit/test-seteleak-kill-wait-751.sh
+++ b/tests/unit/test-seteleak-kill-wait-751.sh
@@ -105,7 +105,10 @@ test_heartbeat_kill_lines_guarded() {
 
     local file="$PROJECT_ROOT/scripts/lib/heartbeat.sh"
     local snippet
-    snippet=$(grep -A12 -B2 'kill -TERM "\$cmd_pid"' "$file")
+    if ! snippet=$(grep -m1 -A12 -B2 'kill -TERM "\$cmd_pid"' "$file"); then
+        test_fail "could not locate the cmd_pid TERM/KILL cleanup block in heartbeat.sh"
+        return
+    fi
 
     assert_contains "$snippet" 'kill -TERM "$cmd_pid" 2>/dev/null || true' \
         "kill -TERM on cmd_pid must be guarded" || return


### PR DESCRIPTION
## Summary

Preserve the caller process group for provider subprocesses when Octopus is running under an external supervisor.

## Root cause

Octopus wraps external provider commands with GNU `timeout`/`gtimeout`. By default, GNU `timeout` starts the command in a separate process group so it can manage signals independently. That is normally useful, but it breaks process-group supervision when Octopus itself is launched by a control plane that expects every provider/retry worker to remain killable through the caller PGID.

Observed on Linux:

`caller PGID 1144088 -> child via timeout PGID 1144097`

This allowed a provider retry to outlive a supervisor stop that correctly killed the Octopus runner process group.

## Fix

Add an opt-in environment variable:

`OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP=true`

When set, `run_with_timeout()` uses `timeout --foreground` / `gtimeout --foreground`. That preserves the caller process group while retaining the configured timeout and kill-after behavior.

When the environment variable is unset, existing Octopus behavior is unchanged.

## Why opt-in

Some callers may rely on the current timeout-created process group for standalone execution. Making this conditional avoids changing default signal/process-group semantics globally while allowing supervised runtimes to opt into a single killable process tree.

## Validation

- new process-group regression test: 2/2 passing;
- event tests: 13/13 passing;
- `make test-smoke`: passing;
- `git diff --check`: passing.

An existing test in `tests/unit/test-provider-auth-validity.sh` remains flaky in its SIGKILL escalation case: it observes exit 137 but can still see the PID as alive immediately afterward. Reproduced with `OCTOPUS_PRESERVE_CALLER_PROCESS_GROUP` unset, so that path does not execute this patch and is not a regression caused by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heartbeat command handling when process-group preservation is enabled.
  * Ensured timed-out descendant processes are properly terminated.
  * Preserved command exit statuses and existing timeout behavior when the option is disabled.
  * Improved compatibility across supported timeout environments and interruption signals.

* **Tests**
  * Added coverage for process-group preservation, descendant cleanup, timeout statuses, and interruption handling.
  * Added compatibility checks for environments without supported timeout commands.
  * Improved reliability of heartbeat cleanup validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->