### PR TITLE
fix(fleet): keep multiline prompts within records

### DIFF
--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -145,7 +145,10 @@ build_diverse_order() {
 }
 
 emit() {
-    printf '%s|%s|%s\n' "$1" "$2" "$3"
+    local provider="$1" label="$2" perspective="$3"
+    perspective="${perspective//$'\r'/ }"
+    perspective="${perspective//$'\n'/ }"
+    printf '%s|%s|%s\n' "$provider" "$label" "$perspective"
 }
 
 emit_if_allowed() {

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -124,4 +124,15 @@ else
   test_fail "expected provider-local MiniMax researcher model, got '$model'"
 fi
 
+test_case "build-fleet keeps multiline prompts in one record per provider"
+multiline_prompt=$'line one\nPROJECT_DOCUMENTATION_PATH:\n/data/example\nline four'
+fleet_output="$(bash "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" review standard "$multiline_prompt" 2>/dev/null)"
+record_count="$(printf '%s\n' "$fleet_output" | grep -c '|')"
+line_count="$(printf '%s\n' "$fleet_output" | wc -l | tr -d ' ')"
+if [[ "$record_count" -eq 4 && "$line_count" -eq 4 ]] && ! printf '%s\n' "$fleet_output" | grep -q '^PROJECT_DOCUMENTATION_PATH:$'; then
+  test_pass
+else
+  test_fail "multiline prompt escaped fleet record boundaries: records=$record_count lines=$line_count"
+fi
+
 test_summary

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -125,11 +125,11 @@ else
 fi
 
 test_case "build-fleet keeps multiline prompts in one record per provider"
-multiline_prompt=$'line one\nPROJECT_DOCUMENTATION_PATH:\n/data/example\nline four'
+multiline_prompt=$'line one\r\nPROJECT_DOCUMENTATION_PATH:\r/data/example\nline four'
 fleet_output="$(bash "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" review standard "$multiline_prompt" 2>/dev/null)"
 record_count="$(printf '%s\n' "$fleet_output" | grep -c '|')"
 line_count="$(printf '%s\n' "$fleet_output" | wc -l | tr -d ' ')"
-if [[ "$record_count" -eq 4 && "$line_count" -eq 4 ]] && ! printf '%s\n' "$fleet_output" | grep -q '^PROJECT_DOCUMENTATION_PATH:$'; then
+if [[ "$record_count" -eq 4 && "$line_count" -eq 4 ]] && ! printf '%s\n' "$fleet_output" | grep -q '^PROJECT_DOCUMENTATION_PATH:$' && ! printf '%s' "$fleet_output" | grep -q $'\r'; then
   test_pass
 else
   test_fail "multiline prompt escaped fleet record boundaries: records=$record_count lines=$line_count"


### PR DESCRIPTION
## Summary

Keep `build-fleet.sh` output within its documented one-record-per-agent contract when the input prompt contains newlines.

`emit()` now normalizes CR/LF in the perspective prompt to spaces before writing the `provider|label|perspective` record.

## Bug

A multiline workflow prompt was embedded verbatim in the third pipe-delimited field. Downstream consumers such as the design-review ceremony read the fleet line-by-line, so continuation lines from the prompt were parsed as additional provider records. For a Development Cycle handoff this caused values such as `PROJECT_DOCUMENTATION_PATH:` to be treated as provider names and rejected by the provider allowlist.

## Why this fix

`build-fleet.sh` documents its output as one line per agent. Fixing the producer preserves that contract for all consumers rather than adding consumer-specific filtering.

## Validation

- provider-neutral design review: 7/7, including new multiline regression
- provider-neutral council: 6/6
- provider allowlist: 13/13
- fleet diversity: 42/42
- `make test-smoke`: passing
- `git diff --check`: passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multiline prompts so each remains a single record per provider.
  * Removed unintended line breaks and carriage returns from generated fleet output.
  * Ensured generated records remain consistently formatted for downstream processing.

* **Tests**
  * Added regression coverage for record and line counts.
  * Confirmed output does not expose standalone documentation path lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->