### PR TITLE
fix(review): include untracked working-tree files

### DIFF
--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -845,6 +845,24 @@ review_local_synthesis_json() {
     fi
 }
 
+# review_collect_working_tree_diff: collects tracked and untracked working-tree changes.
+review_collect_working_tree_diff() {
+    local diff_content=""
+    local path=""
+    local file_diff=""
+    diff_content=$(git diff 2>/dev/null || true)
+
+    while IFS= read -r -d '' path; do
+        file_diff=$(git diff --no-index -- /dev/null "$path" 2>/dev/null || true)
+        if [[ -n "$file_diff" ]]; then
+            [[ -n "$diff_content" ]] && diff_content+=$'\n'
+            diff_content+="$file_diff"
+        fi
+    done < <(git ls-files --others --exclude-standard -z 2>/dev/null)
+
+    printf '%s' "$diff_content"
+}
+
 # review_collect_diff: resolves a review target to unified diff content.
 # Targets can be built-in scopes (staged, working-tree), a PR number, a git
 # pathspec, or an already-generated .diff/.patch file.
@@ -854,7 +872,7 @@ review_collect_diff() {
 
     case "$target" in
         staged)       diff_content=$(git diff --cached 2>/dev/null || true) ;;
-        working-tree) diff_content=$(git diff 2>/dev/null || true) ;;
+        working-tree) diff_content=$(review_collect_working_tree_diff) ;;
         [0-9]*)       diff_content=$(gh pr diff "$target" 2>/dev/null || true) ;;
         *)
             if [[ -f "$target" ]] && [[ -r "$target" ]] && head -n 20 "$target" 2>/dev/null | grep -Ec "^(diff --git|--- |\+\+\+ |@@ )" >/dev/null; then

--- a/tests/unit/test-review-run.sh
+++ b/tests/unit/test-review-run.sh
@@ -211,6 +211,32 @@ else
   pass "review_run: non-OpenAI-compatible Empty output is not retried by adapter policy"
 fi
 
+# ── working-tree diff includes untracked files ───────────────────────────────
+
+WORKTREE_REPO="$TMPDIR_TEST/review-working-tree"
+mkdir -p "$WORKTREE_REPO"
+(
+  cd "$WORKTREE_REPO"
+  git init -q
+  git config user.email test@example.com
+  git config user.name "Octopus Test"
+  printf 'old\n' > tracked.txt
+  printf '*.ignored\n' > .gitignore
+  git add tracked.txt .gitignore
+  git commit -q -m init
+  printf 'changed\n' > tracked.txt
+  printf 'new\n' > 'new file.txt'
+  printf 'ignore me\n' > noise.ignored
+  review_collect_diff working-tree > "$TMPDIR_TEST/working-tree.diff"
+)
+
+assert_contains "$(cat "$TMPDIR_TEST/working-tree.diff")" \
+  "tracked.txt" "review_collect_diff: working-tree includes tracked modifications"
+assert_contains "$(cat "$TMPDIR_TEST/working-tree.diff")" \
+  "new file.txt" "review_collect_diff: working-tree includes untracked files"
+assert_not_contains "$(cat "$TMPDIR_TEST/working-tree.diff")" \
+  "noise.ignored" "review_collect_diff: working-tree excludes ignored untracked files"
+
 # ── MCP schema ───────────────────────────────────────────────────────────────
 
 MCP_INDEX="$PROJECT_ROOT/mcp-server/src/index.ts"

--- a/tests/unit/test-review-run.sh
+++ b/tests/unit/test-review-run.sh
@@ -234,6 +234,10 @@ assert_contains "$(cat "$TMPDIR_TEST/working-tree.diff")" \
   "tracked.txt" "review_collect_diff: working-tree includes tracked modifications"
 assert_contains "$(cat "$TMPDIR_TEST/working-tree.diff")" \
   "new file.txt" "review_collect_diff: working-tree includes untracked files"
+assert_contains "$(cat "$TMPDIR_TEST/working-tree.diff")" \
+  "\+changed" "review_collect_diff: working-tree includes tracked content"
+assert_contains "$(cat "$TMPDIR_TEST/working-tree.diff")" \
+  "\+new" "review_collect_diff: working-tree includes untracked content"
 assert_not_contains "$(cat "$TMPDIR_TEST/working-tree.diff")" \
   "noise.ignored" "review_collect_diff: working-tree excludes ignored untracked files"
 


### PR DESCRIPTION
## Summary

Include untracked files in `working-tree` review targets.

`review_collect_diff working-tree` previously used only `git diff`, which omits new untracked files. This caused contextual review to report `No changes found to review` even when a tangle had successfully created new source files in its integration worktree.

The fix adds `review_collect_working_tree_diff()`, which combines the normal tracked diff with synthetic unified diffs for untracked, non-ignored files discovered via `git ls-files --others --exclude-standard -z`.

## Production reproduction

A supervised tangle created these new files in its integration worktree:

- `src/api-client.ts`
- `src/api-client.test.ts`

Validation detected both files, but contextual review returned `No changes found to review` four times because both files were untracked. With this patch, the same preserved worktree produces a 31,978-byte review diff containing both files.

## Validation

- `tests/unit/test-review-run.sh` — 34/34
- `tests/unit/test-tangle-context-review-loop.sh` — 54/54
- `tests/unit/test-review-context-profile.sh` — 13/13
- `tests/unit/test-command-staged-review.sh` — 9/9
- `make test-smoke` — passing
- `git diff --check` — passing

New regression coverage verifies that `working-tree` review includes tracked modifications and untracked files while excluding ignored untracked files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Working-tree reviews now include untracked, non-ignored files alongside tracked modifications.
  - Ignored files remain excluded from review results.

- **Tests**
  - Added coverage verifying that working-tree reviews correctly include and exclude the appropriate files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->