### PR TITLE
feat(council): support model-aware seats and review recovery

### DIFF
--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,16 +1,18 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-23
-Status: The live GitHub queue audit is complete after PR #962 reaches `main`.
+Status: PR #959 has been reconciled with current `main` in an isolated
+worktree. Its two reproduced blockers and an additional fail-open dependency
+path are fixed locally; publication and exact-head hosted validation remain.
 PRs #956, #957, #958, #960, and #962 are resolved; PR #940 was closed without
-merge; PR #959 remains open and blocked on two reproduced defects. Issue #943
-is fixed by PR #962 and closes with that squash merge.
-Branch: `main` (this state is delivered through PR #962)
+merge. Issue #943 is fixed by PR #962 and closed with that squash merge.
+Branch: `repair/pr959-current-main` at `c5a31997` (not yet pushed)
 Current release: [v9.66.1](https://github.com/nyldn/claude-octopus/releases/tag/v9.66.1)
-Tracking: Beads `oco-j08`; PRs #940, #956 through #962; issue #943
-Next action: Do not merge PR #959 until its history append propagates failure
-and it preserves the newline/CR sanitization already on `main`; then require a
-fresh exact-head full matrix, approval, and zero unresolved review threads.
+Tracking: Beads `oco-c0v` (discovered from `oco-j08`); PR #959
+Next action: Confirm the contributor head has not advanced, push
+`repair/pr959-current-main` normally to `Jhacarreiro:feat/model-aware-seats`,
+then require a fresh exact-head hosted matrix, current approval, mergeability,
+and zero unresolved non-outdated review threads before squash-merging.
 
 ## GitHub Queue Audit (2026-08-23)
 
@@ -34,11 +36,21 @@ fresh exact-head full matrix, approval, and zero unresolved review threads.
   caller-`errexit` and non-enforcing fixture gaps. Each finding was reproduced
   before editing. The focused signal suite passes 8/8 and timeout-budget suite
   passes 7/7 after the response.
-- PR #959 remains held. `provider_history_append` reports success when its
-  append fails because it captures the status of `!`, and the branch restores
-  raw fleet record emission, undoing merged multiline/CR sanitization. Both
-  defects were reproduced against its exact head and posted through the safe
-  GitHub text helper.
+- PR #959 was reconciled from contributor head `21ca124e` with current `main`
+  `849ec887` without rewriting contributor history. The merge keeps `main`'s
+  newline/CR fleet-record sanitization and AGY retry contracts while preserving
+  model-aware seat routing. `provider_history_append` now propagates append
+  failures instead of capturing the status of `!`; provider-history helpers
+  fail closed with status 127 when `agent-spec.sh` cannot load; and design
+  recovery uses the namespaced design roles rather than legacy generic roles.
+  RED/GREEN regressions cover each path. A full fail-closed `make ci-changed`
+  run at local head `c5a31997` exited 0 with 282/282 unit suites and 7/7
+  integration suites passing; the Council suite's one documented macOS PTY
+  case remains skipped. `make sync` is current, `git diff --check` is clean,
+  and the branch has no unintended executable-mode changes. Spec-compliance
+  and code-quality review found no remaining blocker. Hosted exact-head checks,
+  current approval, mergeability, and review-thread state remain unverified
+  until the repaired branch is published.
 - PR #940 was closed without merge: the chart break was real, but ownership and
   security of the unaffiliated replacement endpoint were not established.
   PR #961 was independently observed after its owner merge; its disclaimer was

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -23,6 +23,7 @@ source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/../lib/provider-registry.sh"
 source "${SCRIPT_DIR}/../lib/provider-policy.sh"
+source "${SCRIPT_DIR}/../lib/agent-spec.sh"
 
 WORKFLOW="${1:-research}"
 INTENSITY="${2:-standard}"
@@ -36,27 +37,8 @@ log() {
 
 # ── Provider → Model Family Mapping ──────────────────────────────────────────
 get_family() {
-    case "$1" in
-        codex|codex-*)       echo "openai" ;;
-        gemini|gemini-*|agy|agy-*|antigravity) echo "google-antigravity" ;;
-        claude-sdk|claude-sdk-*) echo "anthropic" ;;
-        claude-sonnet|claude-opus|claude|claude-*) echo "anthropic" ;;
-        perplexity|perplexity-*) echo "perplexity" ;;
-        copilot|copilot-*)   echo "microsoft" ;;
-        qwen|qwen-*)         echo "alibaba" ;;
-        opencode|opencode-*) echo "multi" ;;
-        ollama|ollama-*)     echo "local" ;;
-        cursor-agent|cursor-agent-*) echo "xai" ;;
-        grok|grok-*)         echo "xai" ;;   # grok-provider (xAI Grok CLI)
-        openrouter|openrouter-*) echo "multi" ;;
-        commandcode|commandcode-*) echo "multi" ;;
-        openai-compatible|openai-compatible-*) echo "multi" ;;
-        atlascloud|atlascloud-*) echo "multi" ;;
-        vibe|vibe-*)         echo "mistral" ;;
-        *)                   echo "unknown" ;;
-    esac
+    octo_model_family "$1"
 }
-
 # ── Provider Detection ────────────────────────────────────────────────────────
 # check-providers.sh is the single admission gate for both the activation banner
 # and fleet construction. Do not duplicate binary/auth probes here: that was the
@@ -102,6 +84,7 @@ _contains() { [[ " $1 " == *" $2 "* ]]; }
 # Check if provider is available
 is_available() {
     local p="$1"
+    p="${p%%:*}"
     _contains "${AVAILABLE_CLI[*]:-}" "$p"
 }
 
@@ -289,16 +272,21 @@ build_council_order() {
     # preferred providers are unavailable or denied.
     preferred="$(octo_council_default_providers)" || return $?
     for provider in $(printf '%s' "$preferred" | tr ',' ' '); do
-        canonical="$(octo_provider_canonical "$provider" 2>/dev/null || true)"
+        local requested_model="" requested_provider="$provider"
+        if [[ "$requested_provider" == *:* ]]; then
+            requested_model="${requested_provider#*:}"
+            requested_provider="${requested_provider%%:*}"
+        fi
+        canonical="$(octo_provider_canonical "$requested_provider" 2>/dev/null || true)"
         [[ -n "$canonical" ]] || continue
         octo_provider_has_capability "$canonical" council || continue
         if [[ "$canonical" == "claude" ]]; then
             octo_provider_allowed claude-sonnet || continue
-            provider="claude-sonnet"
+            provider="claude-sonnet${requested_model:+:$requested_model}"
         else
             is_available "$canonical" || continue
             octo_provider_allowed "$canonical" || continue
-            provider="$canonical"
+            provider="$canonical${requested_model:+:$requested_model}"
         fi
         _contains "$candidates" "$provider" || candidates="${candidates}${candidates:+ }${provider}"
     done
@@ -350,6 +338,15 @@ build_review_fleet() {
         emit "$provider" "${labels[$i]}" "${prompts[$i]}"
     done
     return 0
+}
+
+build_review_order() {
+    local order
+    order="$(build_council_order)" || return $?
+    local provider
+    for provider in $order; do
+        printf '%s\n' "$provider"
+    done
 }
 
 # ── Debate Fleet ──────────────────────────────────────────────────────────────
@@ -422,6 +419,7 @@ build_architecture_fleet() {
 case "$WORKFLOW" in
     research|discover)     build_research_fleet ;;
     review|security)       build_review_fleet ;;
+    review-order)          build_review_order ;;
     debate)                build_debate_fleet ;;
     architecture)          build_architecture_fleet ;;
     *)                     build_research_fleet ;;

--- a/scripts/lib/agent-spec.sh
+++ b/scripts/lib/agent-spec.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -eo pipefail
 # Agent spec helpers. A spec may be a legacy executor alias (e.g. codex-review)
 # or a model-qualified seat (e.g. commandcode:minimaxai/minimax-m3).
 # Source-safe: defines functions only.

--- a/scripts/lib/agent-spec.sh
+++ b/scripts/lib/agent-spec.sh
@@ -8,6 +8,34 @@ octo_agent_spec_executor() {
     printf '%s\n' "${spec%%:*}"
 }
 
+octo_agent_spec_provider() {
+    local executor
+    executor="$(octo_agent_spec_executor "${1:-}")"
+    if declare -f octo_provider_canonical >/dev/null 2>&1; then
+        octo_provider_canonical "$executor" 2>/dev/null && return 0
+    fi
+    case "$executor" in
+        codex|codex-*) echo codex ;;
+        commandcode|commandcode-*) echo commandcode ;;
+        claude-sdk|claude-sdk-*) echo claude-sdk ;;
+        claude|claude-*) echo claude ;;
+        gemini|gemini-*) echo gemini ;;
+        agy|agy-*|antigravity) echo agy ;;
+        perplexity|perplexity-*) echo perplexity ;;
+        openrouter|openrouter-*) echo openrouter ;;
+        opencode|opencode-*) echo opencode ;;
+        openai-compatible|openai-compatible-*) echo openai-compatible ;;
+        atlascloud|atlascloud-*) echo atlascloud ;;
+        qwen|qwen-*) echo qwen ;;
+        grok|grok-*) echo grok ;;
+        cursor-agent|cursor-agent-*) echo cursor-agent ;;
+        copilot|copilot-*) echo copilot ;;
+        vibe|vibe-*) echo vibe ;;
+        ollama|ollama-*) echo ollama ;;
+        *) echo "$executor" ;;
+    esac
+}
+
 octo_agent_spec_explicit_model() {
     local spec="${1:-}"
     [[ "$spec" == *:* ]] || return 1

--- a/scripts/lib/agent-spec.sh
+++ b/scripts/lib/agent-spec.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 # Agent spec helpers. A spec may be a legacy executor alias (e.g. codex-review)
 # or a model-qualified seat (e.g. commandcode:minimaxai/minimax-m3).
 # Source-safe: defines functions only.

--- a/scripts/lib/agent-spec.sh
+++ b/scripts/lib/agent-spec.sh
@@ -50,7 +50,7 @@ octo_model_family() {
 
     case "$executor" in
         codex|codex-*) echo openai ;;
-        claude|claude-*|claude-sdk|claude-sdk-*) echo anthropic ;;
+        claude|claude-*) echo anthropic ;;
         gemini|gemini-*|agy|agy-*|antigravity) echo google ;;
         qwen|qwen-*) echo alibaba ;;
         grok|grok-*|cursor-agent|cursor-agent-*) echo xai ;;

--- a/scripts/lib/agent-spec.sh
+++ b/scripts/lib/agent-spec.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Agent spec helpers. A spec may be a legacy executor alias (e.g. codex-review)
+# or a model-qualified seat (e.g. commandcode:minimaxai/minimax-m3).
+# Source-safe: defines functions only.
+
+octo_agent_spec_executor() {
+    local spec="${1:-}"
+    printf '%s\n' "${spec%%:*}"
+}
+
+octo_agent_spec_explicit_model() {
+    local spec="${1:-}"
+    [[ "$spec" == *:* ]] || return 1
+    local model="${spec#*:}"
+    [[ -n "$model" ]] || return 1
+    printf '%s\n' "$model"
+}
+
+octo_agent_spec_slug() {
+    local spec="${1:-unknown}"
+    # Keep the full seat identity while making it safe for filenames and
+    # colon-delimited ledgers. Repeated separators collapse deterministically.
+    printf '%s' "$spec" | sed -E 's/[^A-Za-z0-9._-]+/_/g; s/^_+//; s/_+$//'
+}
+
+octo_model_family() {
+    local spec="${1:-}" effective_model="${2:-}"
+    local executor model prefix
+    executor="$(octo_agent_spec_executor "$spec")"
+    model="$effective_model"
+    if [[ -z "$model" ]]; then
+        model="$(octo_agent_spec_explicit_model "$spec" 2>/dev/null || true)"
+    fi
+
+    case "$model" in
+        anthropic/*|*claude*) echo anthropic; return ;;
+        minimaxai/*|minimax/*|*minimax*) echo minimax; return ;;
+        deepseek/*|*deepseek*) echo deepseek; return ;;
+        openai/*|gpt-*|o[0-9]*|*chatgpt*) echo openai; return ;;
+        google/*|*gemini*) echo google; return ;;
+        qwen/*|alibaba/*|*qwen*) echo alibaba; return ;;
+        x-ai/*|xai/*|*grok*) echo xai; return ;;
+        mistralai/*|*mistral*) echo mistral; return ;;
+        stealth/*) echo stealth; return ;;
+        */*)
+            prefix="${model%%/*}"
+            [[ -n "$prefix" ]] && { printf '%s\n' "$prefix"; return; }
+            ;;
+    esac
+
+    case "$executor" in
+        codex|codex-*) echo openai ;;
+        claude|claude-*|claude-sdk|claude-sdk-*) echo anthropic ;;
+        gemini|gemini-*|agy|agy-*|antigravity) echo google ;;
+        qwen|qwen-*) echo alibaba ;;
+        grok|grok-*|cursor-agent|cursor-agent-*) echo xai ;;
+        vibe|vibe-*) echo mistral ;;
+        perplexity|perplexity-*) echo perplexity ;;
+        copilot|copilot-*) echo microsoft ;;
+        commandcode|commandcode-*|openrouter|openrouter-*|opencode|opencode-*|openai-compatible|openai-compatible-*|atlascloud|atlascloud-*) echo multi ;;
+        ollama|ollama-*) echo local ;;
+        *) echo unknown ;;
+    esac
+}

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+_agent_sync_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_agent_sync_lib_dir}/agent-spec.sh" 2>/dev/null || true
 # ═══════════════════════════════════════════════════════════════════════════════
 # agent-sync.sh — Agent synchronous dispatch & Agent Teams routing
 # Extracted from orchestrate.sh (v9.7.4)
@@ -323,7 +325,7 @@ ${provider_ctx}"
     else
         _progress_unique="$(date +%s)-$$-${RANDOM:-0}"
     fi
-    local _progress_task_id="sync-${phase:-unknown}-${agent_type}-${_progress_unique}"
+    local _progress_task_id="sync-${phase:-unknown}-$(octo_agent_spec_slug "$agent_type")-${_progress_unique}"
     local _estimated_cost="0.000000"
     if type estimate_agent_call_cost >/dev/null 2>&1; then
         _estimated_cost=$(estimate_agent_call_cost "$agent_type" "$model" "$enhanced_prompt")

--- a/scripts/lib/auto-route.sh
+++ b/scripts/lib/auto-route.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+_agent_spec_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_agent_spec_lib_dir}/agent-spec.sh" 2>/dev/null || true
 # lib/auto-route.sh — Auto-routing and routing rule matching
 # Extracted from orchestrate.sh
 
@@ -475,7 +477,7 @@ Focus on:
                 local domain_file="$audit_dir/$domain.md"
                 local agent_type="agy"
                 local task_id="audit-${domain}-${audit_group}"
-                local agent_result_file="${RESULTS_DIR}/${agent_type}-${task_id}.md"
+                local agent_result_file="${RESULTS_DIR}/$(octo_agent_spec_slug "$agent_type")-${task_id}.md"
                 domain_files+=("$domain_file")
                 agent_result_files+=("$agent_result_file")
 
@@ -515,7 +517,8 @@ Output a structured report with findings and recommendations." ;;
                 # Quota fast-fail: skip this provider if marked dead this session.
                 # The quota watcher marks the bare provider, so normalize any
                 # agent suffix before checking the session-level dead set.
-                local _bare_provider="${agent_type%%-*}"
+                local _bare_provider
+                _bare_provider="$(octo_agent_spec_executor "$agent_type")"
                 if declare -f octo_quota_is_dead >/dev/null 2>&1 && octo_quota_is_dead "$_bare_provider"; then
                     echo -e "    ├─ skipping ${domain} (${agent_type}): quota/auth dead this session"
                     pids+=("")

--- a/scripts/lib/auto-route.sh
+++ b/scripts/lib/auto-route.sh
@@ -518,7 +518,7 @@ Output a structured report with findings and recommendations." ;;
                 # The quota watcher marks the bare provider, so normalize any
                 # agent suffix before checking the session-level dead set.
                 local _bare_provider
-                _bare_provider="$(octo_agent_spec_executor "$agent_type")"
+                _bare_provider="$(octo_agent_spec_provider "$agent_type")"
                 if declare -f octo_quota_is_dead >/dev/null 2>&1 && octo_quota_is_dead "$_bare_provider"; then
                     echo -e "    ├─ skipping ${domain} (${agent_type}): quota/auth dead this session"
                     pids+=("")

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -535,13 +535,13 @@ council_check_cost_cap() {
 
 council_provider_command() {
     local provider
-    provider="$(octo_agent_spec_executor "$1")"
+    provider="$(octo_agent_spec_provider "$1")"
     octo_provider_command "$provider" 2>/dev/null || echo "$provider"
 }
 
 council_provider_org() {
     local provider
-    provider="$(octo_agent_spec_executor "$1")"
+    provider="$(octo_agent_spec_provider "$1")"
     octo_provider_org "$provider" 2>/dev/null || echo "$provider"
 }
 
@@ -816,8 +816,19 @@ council_roster_has_provider_org() {
 }
 
 council_roster_has_model_family() {
-    local model_family="$1"
-    jq -e --arg family "$model_family" 'any(.[]; .model_family == $family)' <<< "$COUNCIL_ROSTER_JSON" >/dev/null
+    local model_family="$1" member explicit_family spec model
+    if jq -e --arg family "$model_family" 'any(.[]; (.model_family // "") == $family)' <<< "$COUNCIL_ROSTER_JSON" >/dev/null; then
+        return 0
+    fi
+    while IFS= read -r member; do
+        [[ -n "$member" ]] || continue
+        explicit_family="$(jq -r '.model_family // ""' <<< "$member")"
+        [[ -n "$explicit_family" ]] && continue
+        spec="$(jq -r '.agent_spec // .provider // ""' <<< "$member")"
+        model="$(jq -r '.model // ""' <<< "$member")"
+        [[ "$(council_model_family "$spec" "$model")" == "$model_family" ]] && return 0
+    done < <(jq -c '.[]' <<< "$COUNCIL_ROSTER_JSON")
+    return 1
 }
 
 council_score_roster_entry() {
@@ -884,7 +895,7 @@ council_persona_seat() {
 
 council_provider_is_available() {
     local provider
-    provider="$(octo_agent_spec_executor "$1")"
+    provider="$(octo_agent_spec_provider "$1")"
     local status
     status="$(jq -r --arg provider "$provider" '.[$provider] // "missing"' <<< "$COUNCIL_PROVIDER_STATUS_JSON")"
     [[ "$status" == "available" || "$status" == "host-native" ]]
@@ -931,7 +942,7 @@ council_roster_entry_json() {
 
     preferred_provider="$(council_persona_default_provider "$persona")"
     [[ -n "$provider_spec" ]] || provider_spec="$(council_pick_provider "$preferred_provider")"
-    provider="$(octo_agent_spec_executor "$provider_spec")"
+    provider="$(octo_agent_spec_provider "$provider_spec")"
     explicit_model="$(octo_agent_spec_explicit_model "$provider_spec" 2>/dev/null || true)"
     provider_org="$(council_provider_org "$provider")"
     model="$(council_persona_model "$persona")"
@@ -1570,7 +1581,7 @@ council_live_response() {
     local prompt="$3"
     local dispatch_phase="${4:-}"
     local status_provider
-    status_provider="$(octo_agent_spec_executor "$provider")"
+    status_provider="$(octo_agent_spec_provider "$provider")"
 
     # v9.43: Host-native path — provider IS the active host runtime (e.g. Codex CLI
     # running council from within Codex). Spawning an external subprocess of the same
@@ -1936,7 +1947,7 @@ council_seat_timeout() {
     #   3. OCTOPUS_COUNCIL_AGENT_TIMEOUT        (legacy global env)
     #   4. built-in default
     local provider pvar candidate
-    provider="$(octo_agent_spec_executor "$1")"
+    provider="$(octo_agent_spec_provider "$1")"
     pvar="OCTOPUS_COUNCIL_TIMEOUT_$(printf '%s' "$provider" | tr '[:lower:]-' '[:upper:]_')"
     candidate="${!pvar:-}"
     if [[ "$candidate" =~ ^[1-9][0-9]*$ ]]; then printf '%s' "$candidate"; return 0; fi
@@ -2032,7 +2043,7 @@ council_run_advice_phase() {
         persona="$(jq -r '.persona' <<< "$member")"
         seat="$(jq -r '.seat' <<< "$member")"
         mprovider_spec="$(jq -r '.agent_spec // .provider' <<< "$member")"
-        mprovider="$(octo_agent_spec_executor "$mprovider_spec")"
+        mprovider="$(octo_agent_spec_provider "$mprovider_spec")"
         seat_org="$(jq -r '.provider_org // ""' <<< "$member")"
         seat_model="$(jq -r '.model // ""' <<< "$member")"
         seat_model_family="$(jq -r '.model_family // ""' <<< "$member")"
@@ -2267,7 +2278,7 @@ council_run_chair_fallback() {
             verdict="$(council_response_verdict "$output_path")"
             seat_status="responded"
             seat_rec="$(jq -cn --argjson idx "$index" --arg persona "$persona" \
-                --arg agent_spec "$seat_agent_spec" --arg provider "$(octo_agent_spec_executor "$provider")" --arg org "$seat_org" --arg model "$seat_model" --arg model_family "$seat_model_family" \
+                --arg agent_spec "$seat_agent_spec" --arg provider "$(octo_agent_spec_provider "$provider")" --arg org "$seat_org" --arg model "$seat_model" --arg model_family "$seat_model_family" \
                 --argjson bytes "${resp_bytes:-0}" --arg verdict "$verdict" --arg status "$seat_status" \
                 --arg timeout_provenance "$dispatch_timeout_provenance" \
                 '{index:$idx, persona:$persona, seat:"chair", agent_spec:$agent_spec, provider:$provider,

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -14,6 +14,7 @@ COUNCIL_WORKTREE=""
 COUNCIL_BENCHMARK=""
 COUNCIL_PROVIDERS=""
 _council_registry_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_council_registry_dir}/agent-spec.sh" 2>/dev/null || true
 source "${_council_registry_dir}/provider-registry.sh" 2>/dev/null || true
 source "${_council_registry_dir}/provider-policy.sh" 2>/dev/null || true
 COUNCIL_PROVIDER_POLICY_VALID="true"
@@ -533,11 +534,19 @@ council_check_cost_cap() {
 }
 
 council_provider_command() {
-    octo_provider_command "$1" 2>/dev/null || echo "$1"
+    local provider
+    provider="$(octo_agent_spec_executor "$1")"
+    octo_provider_command "$provider" 2>/dev/null || echo "$provider"
 }
 
 council_provider_org() {
-    octo_provider_org "$1" 2>/dev/null || echo "$1"
+    local provider
+    provider="$(octo_agent_spec_executor "$1")"
+    octo_provider_org "$provider" 2>/dev/null || echo "$provider"
+}
+
+council_model_family() {
+    octo_model_family "$1" "${2:-}"
 }
 
 council_agent_config_value() {
@@ -806,6 +815,11 @@ council_roster_has_provider_org() {
     jq -e --arg org "$provider_org" 'any(.[]; .provider_org == $org)' <<< "$COUNCIL_ROSTER_JSON" >/dev/null
 }
 
+council_roster_has_model_family() {
+    local model_family="$1"
+    jq -e --arg family "$model_family" 'any(.[]; .model_family == $family)' <<< "$COUNCIL_ROSTER_JSON" >/dev/null
+}
+
 council_score_roster_entry() {
     local persona="$1"
     local provider="$2"
@@ -818,7 +832,9 @@ council_score_roster_entry() {
     availability="0.00"
     council_provider_is_available "$provider" && availability="1.00"
     diversity="1.00"
-    council_roster_has_provider_org "$provider_org" && diversity="0.40"
+    local model_family
+    model_family="$(council_model_family "$provider_spec" "$model")"
+    council_roster_has_model_family "$model_family" && diversity="0.40"
     cost_budget="1.00"
     benchmark="$(council_benchmark_signal "$provider_org" "$model")"
     preference="0.50"
@@ -866,7 +882,8 @@ council_persona_seat() {
 }
 
 council_provider_is_available() {
-    local provider="$1"
+    local provider
+    provider="$(octo_agent_spec_executor "$1")"
     local status
     status="$(jq -r --arg provider "$provider" '.[$provider] // "missing"' <<< "$COUNCIL_PROVIDER_STATUS_JSON")"
     [[ "$status" == "available" || "$status" == "host-native" ]]
@@ -874,7 +891,7 @@ council_provider_is_available() {
 
 council_pick_provider() {
     local preferred="$1"
-    if council_provider_is_available "$preferred" && ! council_roster_has_provider_org "$(council_provider_org "$preferred")"; then
+    if council_provider_is_available "$preferred" && ! council_roster_has_model_family "$(council_model_family "$preferred")"; then
         echo "$preferred"
         return 0
     fi
@@ -884,7 +901,7 @@ council_pick_provider() {
     IFS=',' read -r -a provider_list <<< "$providers"
     for provider in "${provider_list[@]}"; do
         provider="${provider// /}"
-        if council_provider_is_available "$provider" && ! council_roster_has_provider_org "$(council_provider_org "$provider")"; then
+        if council_provider_is_available "$provider" && ! council_roster_has_model_family "$(council_model_family "$provider")"; then
             echo "$provider"
             return 0
         fi
@@ -908,17 +925,22 @@ council_roster_contains() {
 
 council_roster_entry_json() {
     local persona="$1"
-    local provider="${2:-}"
-    local preferred_provider provider_org model seat benchmark_signal score permission_mode family dispatch_model
+    local provider_spec="${2:-}" provider=""
+    local preferred_provider provider_org model model_family seat benchmark_signal score permission_mode family dispatch_model explicit_model
 
     preferred_provider="$(council_persona_default_provider "$persona")"
-    [[ -n "$provider" ]] || provider="$(council_pick_provider "$preferred_provider")"
+    [[ -n "$provider_spec" ]] || provider_spec="$(council_pick_provider "$preferred_provider")"
+    provider="$(octo_agent_spec_executor "$provider_spec")"
+    explicit_model="$(octo_agent_spec_explicit_model "$provider_spec" 2>/dev/null || true)"
     provider_org="$(council_provider_org "$provider")"
     model="$(council_persona_model "$persona")"
+    [[ -n "$explicit_model" ]] && model="$explicit_model"
     # agy ignores the per-persona model (agy-exec runs `--model default`), so record
     # the model agy will ACTUALLY use — resolved from its own settings — instead of
     # the placeholder, so the seat's cross-lab lineage is verifiable from the artifact.
-    if [[ "$provider" == "agy" ]] && declare -f agy_current_model >/dev/null 2>&1; then
+    if [[ -n "$explicit_model" ]]; then
+        : # model is pinned by agent_spec
+    elif [[ "$provider" == "agy" ]] && declare -f agy_current_model >/dev/null 2>&1; then
         model="$(agy_current_model)"
     elif declare -f get_agent_model >/dev/null 2>&1; then
         # The same lineage principle applies to every other provider: the council
@@ -937,6 +959,7 @@ council_roster_entry_json() {
             model="$dispatch_model"
         fi
     fi
+    model_family="$(council_model_family "$provider" "$model")"
     seat="$(council_persona_seat "$persona")"
     family="$(council_persona_family "$persona")"
     permission_mode="$(council_agent_config_value "$persona" "permissionMode" | tr -d '"')"
@@ -947,9 +970,11 @@ council_roster_entry_json() {
     jq -nc \
         --arg seat "$seat" \
         --arg persona "$persona" \
+        --arg agent_spec "$provider_spec" \
         --arg provider "$provider" \
         --arg model "$model" \
         --arg provider_org "$provider_org" \
+        --arg model_family "$model_family" \
         --arg permission_mode "$permission_mode" \
         --arg family "$family" \
         --arg score "$score" \
@@ -957,9 +982,11 @@ council_roster_entry_json() {
         '{
             seat: $seat,
             persona: $persona,
+            agent_spec: $agent_spec,
             provider: $provider,
             model: $model,
             provider_org: $provider_org,
+            model_family: $model_family,
             permission_mode: $permission_mode,
             family: $family,
             score: ($score | tonumber),
@@ -1032,6 +1059,48 @@ council_provider_for_org() {
     return 1
 }
 
+council_available_model_families_json() {
+    local providers="$COUNCIL_PROVIDERS"
+    [[ "$providers" == "auto" ]] && providers="$COUNCIL_DEFAULT_PROVIDERS"
+    local json='[]' provider family
+    IFS=',' read -r -a provider_list <<< "$providers"
+    for provider in "${provider_list[@]}"; do
+        provider="${provider// /}"
+        council_provider_is_available "$provider" || continue
+        family="$(council_model_family "$provider")"
+        json="$(jq -c --arg family "$family" 'if index($family) then . else . + [$family] end' <<< "$json")"
+    done
+    echo "$json"
+}
+
+council_provider_for_model_family() {
+    local wanted_family="$1"
+    local providers="$COUNCIL_PROVIDERS" provider
+    [[ "$providers" == "auto" ]] && providers="$COUNCIL_DEFAULT_PROVIDERS"
+    IFS=',' read -r -a provider_list <<< "$providers"
+    for provider in "${provider_list[@]}"; do
+        provider="${provider// /}"
+        if council_provider_is_available "$provider" && [[ "$(council_model_family "$provider")" == "$wanted_family" ]]; then
+            echo "$provider"
+            return 0
+        fi
+    done
+    return 1
+}
+
+council_candidate_for_model_family() {
+    local wanted_family="$1" provider candidate
+    provider="$(council_provider_for_model_family "$wanted_family")" || return 1
+    while IFS= read -r candidate; do
+        [[ -n "$candidate" ]] || continue
+        council_roster_contains "$candidate" && continue
+        council_persona_is_pinned "$candidate" && continue
+        echo "$candidate|$provider"
+        return 0
+    done < <(council_candidate_personas)
+    return 1
+}
+
 council_candidate_for_provider_org() {
     local wanted_org="$1"
     local provider candidate preferred org
@@ -1052,33 +1121,33 @@ council_candidate_for_provider_org() {
 }
 
 council_enforce_provider_diversity() {
-    # Represent every AVAILABLE provider org on the council (the requested provider
+    # Represent every AVAILABLE model family on the council (the requested provider
     # list, or the auto list, filtered by availability), bounded by the number of
     # non-chair seats. The previous implementation only guaranteed >=2 orgs and
     # bailed at quick depth, so a low-scoring-but-available provider (e.g. agy,
     # whose personas score below codex's) could be seated 0 times even when the
     # user explicitly passed `--providers claude,codex,agy` — chair(claude)+codex
-    # already satisfied the 2-org floor. Only duplicate-org seats are replaced
+    # already satisfied the 2-org floor. Only duplicate-family seats are replaced
     # (never displace a seat that is the sole representative of a needed org, so the
     # loop can't thrash when more orgs are available than seats), the chair seat is
     # never touched, and the replaced seat keeps its label.
-    local available_orgs available_count
-    available_orgs="$(council_available_provider_orgs_json)"
-    available_count="$(jq 'length' <<< "$available_orgs")"
+    local available_families available_count
+    available_families="$(council_available_model_families_json)"
+    available_count="$(jq 'length' <<< "$available_families")"
     (( available_count >= 2 )) || return 0
 
     local guard=0
     while (( guard++ < 12 )); do
         local roster_count
-        roster_count="$(jq '[.[].provider_org] | unique | length' <<< "$COUNCIL_ROSTER_JSON")"
+        roster_count="$(jq '[.[].model_family] | unique | length' <<< "$COUNCIL_ROSTER_JSON")"
         (( roster_count >= available_count )) && break
 
-        local missing_org
-        missing_org="$(jq -r --argjson roster "$COUNCIL_ROSTER_JSON" '.[] as $org | select(($roster | map(.provider_org) | index($org)) | not) | $org' <<< "$available_orgs" | head -1)"
-        [[ -z "$missing_org" ]] && break
+        local missing_family
+        missing_family="$(jq -r --argjson roster "$COUNCIL_ROSTER_JSON" '.[] as $family | select(($roster | map(.model_family) | index($family)) | not) | $family' <<< "$available_families" | head -1)"
+        [[ -z "$missing_family" ]] && break
 
         local replacement
-        replacement="$(council_candidate_for_provider_org "$missing_org" || true)"
+        replacement="$(council_candidate_for_model_family "$missing_family" || true)"
         if [[ -z "$replacement" ]]; then
             COUNCIL_DIVERSITY_WARNING="available provider diversity could not be represented by configured personas"
             break
@@ -1088,11 +1157,11 @@ council_enforce_provider_diversity() {
 
         # Replace the lowest-scoring non-chair seat whose org is duplicated (safe to
         # drop without losing coverage). If none exists, stop — never displace a
-        # unique-org seat.
+        # unique-family seat.
         local replace_index
         replace_index="$(jq -r '
-            ([.[].provider_org] | group_by(.) | map(select(length>1)[0])) as $dups
-            | [ to_entries[] | select(.value.seat != "chair") | select(.value.provider_org as $o | $dups | index($o)) ]
+            ([.[].model_family] | group_by(.) | map(select(length>1)[0])) as $dups
+            | [ to_entries[] | select(.value.seat != "chair") | select(.value.model_family as $f | $dups | index($f)) ]
             | if length == 0 then empty else (min_by(.value.score) | .key) end
         ' <<< "$COUNCIL_ROSTER_JSON")"
         [[ -z "$replace_index" ]] && break
@@ -1556,7 +1625,7 @@ council_dispatch_member() {
     local persona provider prompt
 
     persona="$(jq -r '.persona' <<< "$member_json")"
-    provider="$(jq -r '.provider' <<< "$member_json")"
+    provider="$(jq -r '.agent_spec // .provider' <<< "$member_json")"
     prompt="$(council_prompt_for_member "$persona" "$phase")"
 
     if council_persona_should_fail "$persona"; then
@@ -1863,7 +1932,8 @@ council_seat_timeout() {
     #   2. COUNCIL_SEAT_TIMEOUT                 (the --seat-timeout flag, run-wide)
     #   3. OCTOPUS_COUNCIL_AGENT_TIMEOUT        (legacy global env)
     #   4. built-in default
-    local provider="$1" pvar candidate
+    local provider pvar candidate
+    provider="$(octo_agent_spec_executor "$1")"
     pvar="OCTOPUS_COUNCIL_TIMEOUT_$(printf '%s' "$provider" | tr '[:lower:]-' '[:upper:]_')"
     candidate="${!pvar:-}"
     if [[ "$candidate" =~ ^[1-9][0-9]*$ ]]; then printf '%s' "$candidate"; return 0; fi
@@ -1948,18 +2018,22 @@ council_run_advice_phase() {
     COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
     COUNCIL_CHAIR_HOST_NATIVE="false"
     COUNCIL_RESPONDING_PROVIDERS=""
+    COUNCIL_RESPONDING_MODEL_FAMILIES=""
     COUNCIL_SEAT_RECORDS_JSON="[]"
     COUNCIL_TIMEOUT_WARNINGS=""
-    local dissenting_providers=""
+    local dissenting_providers="" dissenting_model_families=""
 
-    local index=0 member persona slug output_path seat mprovider verdict
-    local seat_org seat_model resp_bytes seat_status seat_rec dispatch_timeout_provenance
+    local index=0 member persona slug output_path seat mprovider mprovider_spec verdict
+    local seat_org seat_model seat_model_family resp_bytes seat_status seat_rec dispatch_timeout_provenance
     while IFS= read -r member; do
         persona="$(jq -r '.persona' <<< "$member")"
         seat="$(jq -r '.seat' <<< "$member")"
-        mprovider="$(jq -r '.provider' <<< "$member")"
+        mprovider_spec="$(jq -r '.agent_spec // .provider' <<< "$member")"
+        mprovider="$(octo_agent_spec_executor "$mprovider_spec")"
         seat_org="$(jq -r '.provider_org // ""' <<< "$member")"
         seat_model="$(jq -r '.model // ""' <<< "$member")"
+        seat_model_family="$(jq -r '.model_family // ""' <<< "$member")"
+        [[ -n "$seat_model_family" ]] || seat_model_family="$(council_model_family "$mprovider" "$seat_model")"
         slug="$(council_slug "$persona")"
         output_path="${COUNCIL_RUN_DIR}/responses/$(printf '%02d' "$index")-${slug}.md"
         verdict=""; seat_status="no-response"; resp_bytes=0
@@ -1998,8 +2072,10 @@ council_run_advice_phase() {
             seat_status="responded"
             if [[ "$seat" != "chair" ]]; then
                 COUNCIL_RESPONDING_PROVIDERS="${COUNCIL_RESPONDING_PROVIDERS} ${mprovider}"
+                COUNCIL_RESPONDING_MODEL_FAMILIES="${COUNCIL_RESPONDING_MODEL_FAMILIES} ${seat_model_family}"
                 if [[ "$verdict" != "APPROVE" ]]; then
                     dissenting_providers="${dissenting_providers} ${mprovider}"
+                    dissenting_model_families="${dissenting_model_families} ${seat_model_family}"
                 fi
             fi
         elif council_response_nonempty "$output_path"; then
@@ -2034,11 +2110,11 @@ council_run_advice_phase() {
         # vendor). payload_kind is "full" here; #2 (agy chunking) populates delta/chunk,
         # and #2/#3 extend `status` with degraded/timed_out. RATIONALE: sail-cruisey #2077.
         seat_rec="$(jq -cn --argjson idx "$index" --arg persona "$persona" --arg seat "$seat" \
-            --arg provider "$mprovider" --arg org "$seat_org" --arg model "$seat_model" \
+            --arg agent_spec "$mprovider_spec" --arg provider "$mprovider" --arg org "$seat_org" --arg model "$seat_model" --arg model_family "$seat_model_family" \
             --argjson bytes "${resp_bytes:-0}" --arg verdict "$verdict" --arg status "$seat_status" \
             --arg timeout_provenance "$dispatch_timeout_provenance" \
-            '{index:$idx, persona:$persona, seat:$seat, provider:$provider, provider_org:$org,
-              model:$model, response_bytes:$bytes, payload_kind:"full",
+            '{index:$idx, persona:$persona, seat:$seat, agent_spec:$agent_spec, provider:$provider, provider_org:$org,
+              model:$model, model_family:$model_family, response_bytes:$bytes, payload_kind:"full",
               verdict:(if $verdict=="" then null else $verdict end),
               status:$status,
               timeout_provenance:(if $timeout_provenance=="" then null else $timeout_provenance end),
@@ -2055,11 +2131,10 @@ council_run_advice_phase() {
     required="$(council_required_non_chair)"
     received_non_chair="$(council_received_non_chair)"
 
-    # Distinct-vendor quorum, in two layers:
-    #   distinct_providers  — vendors that returned a SUBSTANTIVE response.
-    #   approving_providers — vendors ALL of whose substantive seats cleanly
-    #                         APPROVED (any dissent drops the whole vendor).
-    # A cross-lab consensus requires >= `required` DISTINCT APPROVING vendors
+    # Quorum is evaluated by model family, while legacy provider metrics remain
+    # in summary.json for compatibility and runtime diagnostics. Multiple seats
+    # using the same model family do not create independent consensus.
+    # A cross-lab consensus requires >= `required` DISTINCT APPROVING families
     # (2 for standard/deep, 1 for quick). Counting responders alone let a split
     # double-seated vendor pass on its approving seat (#1992/#1994/#1983) and a
     # single vendor stand in for consensus (#1993); gating on approvers closes both.
@@ -2068,21 +2143,27 @@ council_run_advice_phase() {
     COUNCIL_APPROVING_PROVIDERS="$(council_compute_approving_providers "$COUNCIL_RESPONDING_PROVIDERS" "$dissenting_providers")"
     COUNCIL_DISTINCT_APPROVING_PROVIDERS="$(printf '%s' "$COUNCIL_APPROVING_PROVIDERS" | tr ' ' '\n' | sed '/^$/d' | sort -u | wc -l | tr -d '[:space:]')"
     [[ -z "$COUNCIL_DISTINCT_APPROVING_PROVIDERS" ]] && COUNCIL_DISTINCT_APPROVING_PROVIDERS=0
+    COUNCIL_DISTINCT_MODEL_FAMILIES="$(printf '%s' "$COUNCIL_RESPONDING_MODEL_FAMILIES" | tr ' ' '
+' | sed '/^$/d' | sort -u | wc -l | tr -d '[:space:]')"
+    [[ -z "$COUNCIL_DISTINCT_MODEL_FAMILIES" ]] && COUNCIL_DISTINCT_MODEL_FAMILIES=0
+    COUNCIL_APPROVING_MODEL_FAMILIES="$(council_compute_approving_providers "$COUNCIL_RESPONDING_MODEL_FAMILIES" "$dissenting_model_families")"
+    COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES="$(printf '%s' "$COUNCIL_APPROVING_MODEL_FAMILIES" | tr ' ' '
+' | sed '/^$/d' | sort -u | wc -l | tr -d '[:space:]')"
+    [[ -z "$COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES" ]] && COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES=0
 
-    # Flag which seats' providers made the approving set so distinct_approving_providers
-    # is recomputable from the seats array alone: distinct providers among seats where
-    # counted_as_approver == true equals distinct_approving_providers.
-    COUNCIL_SEAT_RECORDS_JSON="$(jq -c --arg approving " ${COUNCIL_APPROVING_PROVIDERS} " '
-        map(.provider as $p
+    # Flag seats whose model family made the approving set, so the family-based
+    # quorum is recomputable directly from the seat records.
+    COUNCIL_SEAT_RECORDS_JSON="$(jq -c --arg approving_families " ${COUNCIL_APPROVING_MODEL_FAMILIES} " '
+        map(.model_family as $f
             | .counted_as_approver = (.seat != "chair"
                 and .status == "responded" and .verdict == "APPROVE"
-                and ($approving | contains(" " + $p + " "))))' <<< "${COUNCIL_SEAT_RECORDS_JSON:-[]}")"
+                and ($approving_families | contains(" " + $f + " "))))' <<< "${COUNCIL_SEAT_RECORDS_JSON:-[]}")"
 
     # Chair presence: a dispatched chair response OR a host-native chair (which
     # synthesizes in-context and cannot self-dispatch). Gating met on the response
     # file alone falsely fails a run whose chair IS the host — the reported
-    # quorum.met=false with distinct_approving_providers=2. met now reflects vendor
-    # approvals plus a present (synthesis-capable) chair, not chair receipt.
+    # quorum.met=false despite sufficient independent model families. met now
+    # reflects family approvals plus a present synthesis-capable chair.
     COUNCIL_CHAIR_HOST_NATIVE="false"
     if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" != "true" ]] && council_chair_is_host_native; then
         COUNCIL_CHAIR_HOST_NATIVE="true"
@@ -2093,15 +2174,15 @@ council_run_advice_phase() {
     fi
 
     if [[ "$chair_present" == "true" ]] && (( received_non_chair >= required )) \
-        && { (( required < 2 )) || (( COUNCIL_DISTINCT_APPROVING_PROVIDERS >= required )); }; then
+        && { (( required < 2 )) || (( COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES >= required )); }; then
         COUNCIL_QUORUM_MET="true"
     else
         COUNCIL_QUORUM_MET="false"
-        if (( required >= 2 )) && (( COUNCIL_DISTINCT_APPROVING_PROVIDERS < required )) && (( received_non_chair >= required )); then
+        if (( required >= 2 )) && (( COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES < required )) && (( received_non_chair >= required )); then
             # council.sh has no log() of its own (it lives in orchestrate.sh); emit
             # via the same stderr convention the rest of this file uses so the guard
             # never crashes when council is sourced standalone.
-            echo "Council warning: Quorum FAILED the distinct-approving-vendor guard: ${received_non_chair} responses, ${COUNCIL_DISTINCT_PROVIDERS} distinct provider(s) (${COUNCIL_RESPONDING_PROVIDERS# }), but only ${COUNCIL_DISTINCT_APPROVING_PROVIDERS} cleanly APPROVED (${COUNCIL_APPROVING_PROVIDERS:-none}). A single approving vendor — or a split double-seated vendor — is not a valid cross-lab consensus. Restore/await a 2nd approving provider (§4) or surface the provider-shortage gate to the human." >&2
+            echo "Council warning: Quorum FAILED the distinct-approving-model-family guard: ${received_non_chair} responses, ${COUNCIL_DISTINCT_MODEL_FAMILIES} distinct model family/families (${COUNCIL_RESPONDING_MODEL_FAMILIES# }), but only ${COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES} cleanly APPROVED (${COUNCIL_APPROVING_MODEL_FAMILIES:-none}). Multiple executors or seats from the same model family do not create independent consensus. Restore/await another approving model family or surface the shortage to the human." >&2
         fi
     fi
 }
@@ -2858,6 +2939,10 @@ council_write_summary_json() {
         --arg responding_providers "${COUNCIL_RESPONDING_PROVIDERS:+${COUNCIL_RESPONDING_PROVIDERS# }}" \
         --arg distinct_approving_providers "${COUNCIL_DISTINCT_APPROVING_PROVIDERS:-0}" \
         --arg approving_providers "${COUNCIL_APPROVING_PROVIDERS:-}" \
+        --arg distinct_model_families "${COUNCIL_DISTINCT_MODEL_FAMILIES:-0}" \
+        --arg responding_model_families "${COUNCIL_RESPONDING_MODEL_FAMILIES:+${COUNCIL_RESPONDING_MODEL_FAMILIES# }}" \
+        --arg distinct_approving_model_families "${COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES:-0}" \
+        --arg approving_model_families "${COUNCIL_APPROVING_MODEL_FAMILIES:-}" \
         --arg chair_received "$COUNCIL_CHAIR_RESPONSE_RECEIVED" \
         --arg chair_host_native "${COUNCIL_CHAIR_HOST_NATIVE:-false}" \
         --arg chair_fallback_used "$COUNCIL_CHAIR_FALLBACK_USED" \
@@ -2903,6 +2988,10 @@ council_write_summary_json() {
             responding_providers: $responding_providers,
             distinct_approving_providers: ($distinct_approving_providers | tonumber),
             approving_providers: $approving_providers,
+            distinct_model_families: ($distinct_model_families | tonumber),
+            responding_model_families: $responding_model_families,
+            distinct_approving_model_families: ($distinct_approving_model_families | tonumber),
+            approving_model_families: $approving_model_families,
             met: ($quorum_met == "true")
           },
           providers: $providers,

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1569,6 +1569,8 @@ council_live_response() {
     local persona="$2"
     local prompt="$3"
     local dispatch_phase="${4:-}"
+    local status_provider
+    status_provider="$(octo_agent_spec_executor "$provider")"
 
     # v9.43: Host-native path — provider IS the active host runtime (e.g. Codex CLI
     # running council from within Codex). Spawning an external subprocess of the same
@@ -1579,7 +1581,7 @@ council_live_response() {
     # falls through to its built-in fallback — a placeholder note is not shaped like
     # a valid synthesis and would break downstream gates.
     local _provider_status
-    _provider_status="$(jq -r --arg p "$provider" '.[$p] // "missing"' <<< "$COUNCIL_PROVIDER_STATUS_JSON")"
+    _provider_status="$(jq -r --arg p "$status_provider" '.[$p] // "missing"' <<< "$COUNCIL_PROVIDER_STATUS_JSON")"
     if [[ "$_provider_status" == "host-native" ]]; then
         if [[ "$dispatch_phase" == "chair-synthesis" ]]; then
             return 1
@@ -1600,7 +1602,7 @@ EOF
         return 0
     fi
 
-    if ! council_provider_is_available "$provider"; then
+    if ! council_provider_is_available "$status_provider"; then
         return 1
     fi
 

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2626,29 +2626,32 @@ council_detect_providers() {
     local json='{}'
 
     if [[ -n "${OCTOPUS_COUNCIL_PROVIDER_FIXTURE:-}" ]]; then
-        local entry name status
+        local entry name status status_key
         IFS=',' read -r -a fixture_entries <<< "$OCTOPUS_COUNCIL_PROVIDER_FIXTURE"
         for entry in "${fixture_entries[@]}"; do
-            name="${entry%%:*}"
-            status="${entry#*:}"
+            name="${entry%:*}"
+            status="${entry##*:}"
             [[ -n "$name" && -n "$status" && "$name" != "$status" ]] || continue
-            json="$(jq -c --arg name "$name" --arg status "$status" '. + {($name): $status}' <<< "$json")"
+            status_key="$(octo_agent_spec_provider "$name")"
+            json="$(jq -c --arg name "$status_key" --arg status "$status" '. + {($name): $status}' <<< "$json")"
         done
         COUNCIL_PROVIDER_STATUS_JSON="$json"
         return 0
     fi
 
-    local provider cmd status
+    local provider cmd status status_key host_provider
+    host_provider="$(octo_agent_spec_provider "${OCTOPUS_HOST:-}")"
     IFS=',' read -r -a provider_list <<< "$providers"
     for provider in "${provider_list[@]}"; do
+        status_key="$(octo_agent_spec_provider "$provider")"
         # v9.43: When this provider IS the host runtime, spawning it as a subprocess
         # fails (recursive invocation — e.g. codex-within-codex on Windows/Git Bash).
         # Mark as host-native so council_live_response emits an in-context response
         # instead of a broken subprocess call.
-        if [[ "${OCTOPUS_HOST:-}" == "$provider" ]]; then
+        if [[ -n "${OCTOPUS_HOST:-}" && "$host_provider" == "$status_key" ]]; then
             status="host-native"
         else
-            case "$provider" in
+            case "$status_key" in
                 openai-compatible|openai-tools|openai-compatible-agent)
                     if declare -f openai_compatible_is_available >/dev/null 2>&1 && openai_compatible_is_available; then
                         status="available"
@@ -2687,7 +2690,7 @@ council_detect_providers() {
                     ;;
             esac
         fi
-        json="$(jq -c --arg name "$provider" --arg status "$status" '. + {($name): $status}' <<< "$json")"
+        json="$(jq -c --arg name "$status_key" --arg status "$status" '. + {($name): $status}' <<< "$json")"
     done
 
     COUNCIL_PROVIDER_STATUS_JSON="$json"

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -826,6 +826,7 @@ council_score_roster_entry() {
     local provider_org="$3"
     local model="$4"
     local seat="$5"
+    local provider_spec="${6:-$2}"
 
     local role_fit availability diversity cost_budget benchmark preference
     role_fit="$(council_role_fit_signal "$persona" "$seat")"
@@ -965,7 +966,7 @@ council_roster_entry_json() {
     permission_mode="$(council_agent_config_value "$persona" "permissionMode" | tr -d '"')"
     [[ -n "$permission_mode" ]] || permission_mode="plan"
     benchmark_signal="$(council_benchmark_signal "$provider_org" "$model")"
-    score="$(council_score_roster_entry "$persona" "$provider" "$provider_org" "$model" "$seat")"
+    score="$(council_score_roster_entry "$persona" "$provider" "$provider_org" "$model" "$seat" "$provider_spec")"
 
     jq -nc \
         --arg seat "$seat" \
@@ -1224,18 +1225,18 @@ council_build_roster() {
 }
 
 council_dedup_vendor_seats() {
-    # OPT-IN (default off): keep at most one non-chair VOTING seat per provider org.
+    # OPT-IN (default off): keep at most one non-chair VOTING seat per model family.
     #
-    # With Gemini sunset, a 2-vendor standard council can seat agy + codex + codex,
-    # which (a) weights the panel 2:1 toward one lab and (b) forces that lab to clear
-    # BOTH of its seats to count as an approver — so an internal split (one seat
+    # A standard council can seat multiple execution providers backed by the same model family,
+    # which (a) overweights one model family and (b) forces that family to clear
+    # all of its seats to count as an approver — so an internal split (one seat
     # APPROVE, one REVISE) can deadlock an otherwise-decidable gate. The
-    # distinct-approving-vendor quorum already guards correctness (a split vendor
+    # distinct-approving-model-family quorum already guards correctness (a split family
     # can't pass on one seat); this addresses the panel *weighting*, which the quorum
     # layer does not. It is a seating-policy preference, so it stays off unless
     # explicitly enabled with OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1.
     #
-    # When enabled: keep the highest-scoring non-chair seat per org; chair
+    # When enabled: keep the highest-scoring non-chair seat per model family; chair
     # (synthesis) seats are never touched. Default (unset/anything but 1) preserves
     # today's roster exactly.
     [[ "${OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR:-}" == "1" ]] || return 0
@@ -1243,7 +1244,7 @@ council_dedup_vendor_seats() {
         [ to_entries[] ] as $e
         | ( [ $e[] | select(.value.seat == "chair") ] ) as $chairs
         | ( [ $e[] | select(.value.seat != "chair") ]
-            | group_by(.value.provider_org)
+            | group_by(.value.model_family)
             | map( max_by( .value.score | tonumber? // 0 ) ) ) as $voters
         | ( $chairs + $voters ) | sort_by(.key) | map(.value)
     ' <<< "$COUNCIL_ROSTER_JSON")"
@@ -2207,7 +2208,7 @@ council_synthesis_capable_persona() {
 
 council_run_chair_fallback() {
     local persona provider member_json slug output_path index
-    local seat_org seat_model resp_bytes verdict seat_status seat_rec existing_response dispatch_rc
+    local seat_agent_spec seat_org seat_model seat_model_family resp_bytes verdict seat_status seat_rec existing_response dispatch_rc
     local dispatch_timeout_provenance
 
     while IFS= read -r persona; do
@@ -2254,18 +2255,21 @@ council_run_chair_fallback() {
             # roster, so persist it as an additional seat execution record. Without
             # this, summary.json claims to expose every seat while silently omitting
             # the chair response that actually made synthesis possible.
+            seat_agent_spec="$(jq -r '.agent_spec // .provider // ""' <<< "$member_json")"
             seat_org="$(jq -r '.provider_org // ""' <<< "$member_json")"
             seat_model="$(jq -r '.model // ""' <<< "$member_json")"
+            seat_model_family="$(jq -r '.model_family // ""' <<< "$member_json")"
+            [[ -n "$seat_model_family" ]] || seat_model_family="$(council_model_family "$seat_agent_spec" "$seat_model")"
             resp_bytes="$(wc -c < "$output_path" 2>/dev/null | tr -d '[:space:]')"
             [[ -z "$resp_bytes" ]] && resp_bytes=0
             verdict="$(council_response_verdict "$output_path")"
             seat_status="responded"
             seat_rec="$(jq -cn --argjson idx "$index" --arg persona "$persona" \
-                --arg provider "$provider" --arg org "$seat_org" --arg model "$seat_model" \
+                --arg agent_spec "$seat_agent_spec" --arg provider "$(octo_agent_spec_executor "$provider")" --arg org "$seat_org" --arg model "$seat_model" --arg model_family "$seat_model_family" \
                 --argjson bytes "${resp_bytes:-0}" --arg verdict "$verdict" --arg status "$seat_status" \
                 --arg timeout_provenance "$dispatch_timeout_provenance" \
-                '{index:$idx, persona:$persona, seat:"chair", provider:$provider,
-                  provider_org:$org, model:$model, response_bytes:$bytes,
+                '{index:$idx, persona:$persona, seat:"chair", agent_spec:$agent_spec, provider:$provider,
+                  provider_org:$org, model:$model, model_family:$model_family, response_bytes:$bytes,
                   payload_kind:"full",
                   verdict:(if $verdict=="" then null else $verdict end),
                   status:$status,

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -508,11 +508,12 @@ get_role_budget_proportion() {
 # opt in without inflating smaller providers.
 get_provider_context_limit() {
     local agent_type="${1:-}"
-    local provider
+    local provider executor
     provider="$(octo_agent_spec_provider "$agent_type")"
+    executor="$(octo_agent_spec_executor "$agent_type")"
     local default_budget="${OCTOPUS_CONTEXT_BUDGET:-12000}"
 
-    case "$agent_type" in
+    case "$executor" in
         codex-large-context) echo "${OCTOPUS_CODEX_LARGE_CONTEXT_BUDGET:-${default_budget}}" ; return 0 ;;
         claude-sdk*) echo "${OCTOPUS_CLAUDE_SDK_CONTEXT_BUDGET:-1000000}" ; return 0 ;;  # v9.50.0: Agent SDK 1M window
         claude-opus*|claude-sonnet|claude) echo "${OCTOPUS_CLAUDE_CONTEXT_BUDGET:-${default_budget}}" ; return 0 ;;

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -509,7 +509,7 @@ get_role_budget_proportion() {
 get_provider_context_limit() {
     local agent_type="${1:-}"
     local provider
-    provider="$(octo_agent_spec_executor "$agent_type")"
+    provider="$(octo_agent_spec_provider "$agent_type")"
     local default_budget="${OCTOPUS_CONTEXT_BUDGET:-12000}"
 
     case "$agent_type" in

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 _profile_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_profile_lib_dir}/agent-spec.sh" 2>/dev/null || true
 if ! declare -f octopus_resolve_reasoning_level >/dev/null 2>&1; then
     source "${_profile_lib_dir}/execution-profile.sh" 2>/dev/null || true
 fi
@@ -137,6 +138,8 @@ get_agent_command() {
     local phase="${2:-}"
     local role="${3:-}"
     local model=""
+    local agent_executor
+    agent_executor="$(octo_agent_spec_executor "$agent_type")"
     # Allow swapping the claude binary (e.g. clarp = subscription-billed drop-in
     # for `claude -p`, instead of metered API). Default unchanged. May include
     # args (word-split downstream by read -ra), e.g. "clarp --strict-mcp-config".
@@ -180,7 +183,7 @@ get_agent_command() {
             ;;
     esac
 
-    case "$agent_type" in
+    case "$agent_executor" in
         # v8.9.0: Spark, reasoning, and large-context variants share the
         # same command shape; only model resolution differs by agent type.
         codex|codex-standard|codex-max|codex-mini|codex-general|codex-spark|codex-reasoning|codex-large-context)
@@ -505,7 +508,8 @@ get_role_budget_proportion() {
 # opt in without inflating smaller providers.
 get_provider_context_limit() {
     local agent_type="${1:-}"
-    local provider="${agent_type%%-*}"
+    local provider
+    provider="$(octo_agent_spec_executor "$agent_type")"
     local default_budget="${OCTOPUS_CONTEXT_BUDGET:-12000}"
 
     case "$agent_type" in
@@ -687,6 +691,8 @@ get_agent_model() {
     local agent_type="$1"
     local phase="${2:-}"
     local role="${3:-}"
+    local agent_executor
+    agent_executor="$(octo_agent_spec_executor "$agent_type")"
     
     # Auto-migrate stale model names on first call when the routing helper is
     # part of the current harness. dispatch.sh is also sourced independently by
@@ -697,7 +703,7 @@ get_agent_model() {
 
     # Determine base provider type
     local provider=""
-    case "$agent_type" in
+    case "$agent_executor" in
         codex*)      provider="codex" ;;
         gemini*)     provider="agy" ;;  # legacy Google-seat IDs migrate to AGY
         agy*|antigravity) provider="agy" ;;
@@ -719,7 +725,16 @@ get_agent_model() {
     esac
 
     local resolved_model
-    if ! resolved_model=$(resolve_octopus_model "$provider" "$agent_type" "$phase" "$role"); then
+    # A model-qualified agent spec (provider:model) is an explicit seat identity.
+    # Preserve the literal model instead of collapsing back to the provider default.
+    if [[ "$agent_type" == *:* ]]; then
+        resolved_model="${agent_type#*:}"
+        [[ -n "$resolved_model" ]] || { log ERROR "Empty model in agent spec: $agent_type"; return 1; }
+        if ! validate_model_name_for_provider "$provider" "$resolved_model"; then
+            log ERROR "Invalid explicit model '$resolved_model' for provider '$provider'"
+            return 1
+        fi
+    elif ! resolved_model=$(resolve_octopus_model "$provider" "$agent_type" "$phase" "$role"); then
         return 1
     fi
 

--- a/scripts/lib/provider-allowlist.sh
+++ b/scripts/lib/provider-allowlist.sh
@@ -90,8 +90,10 @@ octo_provider_allowlist_value() {
 }
 
 octo_provider_allowed() {
-    local provider requested_canonical
-    provider="$(octo_normalize_provider_name "${1:-}")"
+    local provider requested_canonical raw_provider
+    raw_provider="${1:-}"
+    raw_provider="${raw_provider%%:*}"
+    provider="$(octo_normalize_provider_name "$raw_provider")"
     [[ -n "$provider" ]] || return 1
     requested_canonical="$(octo_provider_canonical "$provider" 2>/dev/null || printf '%s' "$provider")"
 

--- a/scripts/lib/provider-lockout.sh
+++ b/scripts/lib/provider-lockout.sh
@@ -103,6 +103,20 @@ provider_history_file_key() {
     printf '%s\n' "$key"
 }
 
+provider_history_lock() {
+    local history_file="$1" lock_dir="${1}.lock" tries=0
+    while ! mkdir "$lock_dir" 2>/dev/null; do
+        tries=$((tries + 1))
+        [[ "$tries" -ge 50 ]] && return 1
+        sleep 0.02 2>/dev/null || return 1
+    done
+    return 0
+}
+
+provider_history_unlock() {
+    rmdir "${1}.lock" 2>/dev/null || true
+}
+
 # v8.18.0 Feature: Per-Provider History Files
 # Each provider accumulates project-specific knowledge in .octo/providers/{name}-history.md
 
@@ -125,25 +139,45 @@ append_provider_history() {
     local timestamp
     timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-    # Append structured entry
-    cat >> "$history_file" << HISTEOF
+    # Model-qualified seats for one provider share this file. Serialize the full
+    # append+trim transaction so one seat's trim cannot clobber another's append.
+    # History is best-effort: if the lock cannot be acquired promptly, skip the
+    # diagnostic write rather than falling back to an unsafe concurrent update.
+    if ! provider_history_lock "$history_file"; then
+        log WARN "Provider history lock busy for $provider; skipping history append"
+        return 0
+    fi
+
+    local history_rc=0 tmp_file=""
+    {
+        cat >> "$history_file" << HISTEOF
 ### ${phase} | ${timestamp}
 **Task:** ${task_brief:0:100}
 **Learned:** ${learned:0:200}
 ---
 HISTEOF
 
-    # Cap at 50 entries: count entries and trim oldest if exceeded
-    local entry_count
-    entry_count=$(grep -c "^### " "$history_file" 2>/dev/null) || entry_count=0
-    if [[ "$entry_count" -gt 50 ]]; then
-        local excess=$((entry_count - 50))
-        # Remove oldest entries (from top of file)
-        local trim_line
-        trim_line=$(grep -n "^### " "$history_file" | sed -n "$((excess + 1))p" | cut -d: -f1)
-        if [[ -n "$trim_line" && "$trim_line" -gt 1 ]]; then
-            tail -n "+$trim_line" "$history_file" > "$history_file.tmp" && mv "$history_file.tmp" "$history_file"
+        # Cap at 50 entries: count entries and trim oldest if exceeded.
+        local entry_count
+        entry_count=$(grep -c "^### " "$history_file" 2>/dev/null) || entry_count=0
+        if [[ "$entry_count" -gt 50 ]]; then
+            local excess=$((entry_count - 50)) trim_line
+            trim_line=$(grep -n "^### " "$history_file" | sed -n "$((excess + 1))p" | cut -d: -f1)
+            if [[ -n "$trim_line" && "$trim_line" -gt 1 ]]; then
+                tmp_file=$(mktemp "${history_file}.tmp.XXXXXX") || history_rc=1
+                if [[ "$history_rc" -eq 0 ]]; then
+                    tail -n "+$trim_line" "$history_file" > "$tmp_file" && mv "$tmp_file" "$history_file" || history_rc=1
+                fi
+            fi
         fi
+    } || history_rc=$?
+
+    [[ -z "$tmp_file" || ! -e "$tmp_file" ]] || rm -f "$tmp_file" 2>/dev/null || true
+    provider_history_unlock "$history_file"
+
+    if [[ "$history_rc" -ne 0 ]]; then
+        log WARN "Provider history update failed for $provider"
+        return "$history_rc"
     fi
 
     log DEBUG "Appended provider history for $provider (phase: $phase)"

--- a/scripts/lib/provider-lockout.sh
+++ b/scripts/lib/provider-lockout.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+_provider_lockout_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_provider_lockout_dir}/agent-spec.sh" 2>/dev/null || true
 # ═══════════════════════════════════════════════════════════════════════════════
 # lib/provider-lockout.sh — single owner of the provider lockout + history protocol
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -150,7 +152,8 @@ read_provider_history() {
 
 build_provider_context() {
     local agent_type="$1"
-    local base_provider="${agent_type%%-*}"  # codex-fast -> codex
+    local base_provider
+    base_provider="$(octo_agent_spec_executor "$agent_type")"  # codex-fast -> codex; provider:model -> provider
     local history
     history=$(read_provider_history "$base_provider")
 

--- a/scripts/lib/provider-lockout.sh
+++ b/scripts/lib/provider-lockout.sh
@@ -93,6 +93,16 @@ reset_provider_lockouts() {
     LOCKED_PROVIDERS=""
 }
 
+provider_history_file_key() {
+    local provider key
+    provider="$(octo_agent_spec_provider "${1:-unknown}")"
+    key="$(octo_agent_spec_slug "$provider")"
+    case "$key" in
+        ""|.|..) key="unknown" ;;
+    esac
+    printf '%s\n' "$key"
+}
+
 # v8.18.0 Feature: Per-Provider History Files
 # Each provider accumulates project-specific knowledge in .octo/providers/{name}-history.md
 
@@ -101,14 +111,15 @@ append_provider_history() {
         off|false|0|no) return 0 ;;
     esac
 
-    local provider
+    local provider history_key
     provider="$(octo_agent_spec_provider "$1")"
+    history_key="$(provider_history_file_key "$provider")"
     local phase="$2"
     local task_brief="$3"
     local learned="$4"
 
     local history_dir="${WORKSPACE_DIR}/.octo/providers"
-    local history_file="$history_dir/${provider}-history.md"
+    local history_file="$history_dir/${history_key}-history.md"
     mkdir -p "$history_dir"
 
     local timestamp
@@ -143,8 +154,10 @@ read_provider_history() {
         off|false|0|no) return 0 ;;
     esac
 
-    local provider="$1"
-    local history_file="${WORKSPACE_DIR}/.octo/providers/${provider}-history.md"
+    local provider history_key
+    provider="$(octo_agent_spec_provider "$1")"
+    history_key="$(provider_history_file_key "$provider")"
+    local history_file="${WORKSPACE_DIR}/.octo/providers/${history_key}-history.md"
 
     if [[ -f "$history_file" ]]; then
         cat "$history_file"

--- a/scripts/lib/provider-lockout.sh
+++ b/scripts/lib/provider-lockout.sh
@@ -149,14 +149,17 @@ append_provider_history() {
     fi
 
     local history_rc=0 tmp_file=""
-    {
-        cat >> "$history_file" << HISTEOF
+    if ! cat >> "$history_file" << HISTEOF
 ### ${phase} | ${timestamp}
 **Task:** ${task_brief:0:100}
 **Learned:** ${learned:0:200}
 ---
 HISTEOF
+    then
+        history_rc=$?
+    fi
 
+    if [[ "$history_rc" -eq 0 ]]; then
         # Cap at 50 entries: count entries and trim oldest if exceeded.
         local entry_count
         entry_count=$(grep -c "^### " "$history_file" 2>/dev/null) || entry_count=0
@@ -170,7 +173,7 @@ HISTEOF
                 fi
             fi
         fi
-    } || history_rc=$?
+    fi
 
     [[ -z "$tmp_file" || ! -e "$tmp_file" ]] || rm -f "$tmp_file" 2>/dev/null || true
     provider_history_unlock "$history_file"

--- a/scripts/lib/provider-lockout.sh
+++ b/scripts/lib/provider-lockout.sh
@@ -101,7 +101,8 @@ append_provider_history() {
         off|false|0|no) return 0 ;;
     esac
 
-    local provider="$1"
+    local provider
+    provider="$(octo_agent_spec_executor "$1")"
     local phase="$2"
     local task_brief="$3"
     local learned="$4"

--- a/scripts/lib/provider-lockout.sh
+++ b/scripts/lib/provider-lockout.sh
@@ -102,7 +102,7 @@ append_provider_history() {
     esac
 
     local provider
-    provider="$(octo_agent_spec_executor "$1")"
+    provider="$(octo_agent_spec_provider "$1")"
     local phase="$2"
     local task_brief="$3"
     local learned="$4"
@@ -154,7 +154,7 @@ read_provider_history() {
 build_provider_context() {
     local agent_type="$1"
     local base_provider
-    base_provider="$(octo_agent_spec_executor "$agent_type")"  # codex-fast -> codex; provider:model -> provider
+    base_provider="$(octo_agent_spec_provider "$agent_type")"  # codex-fast -> codex; provider:model -> provider
     local history
     history=$(read_provider_history "$base_provider")
 

--- a/scripts/lib/provider-policy.sh
+++ b/scripts/lib/provider-policy.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+_provider_policy_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_provider_policy_dir}/agent-spec.sh" 2>/dev/null || true
 # Shared provider-selection policy defaults.
 # Identity and capabilities live in provider-registry.sh; these ordered lists
 # are workflow policy and remain independently configurable.
@@ -13,7 +15,7 @@ OCTOPUS_SMOKE_ROUTING_PROVIDERS_DEFAULT="codex agy claude opencode openrouter or
 
 octo_validate_provider_policy_list() {
     local raw="$1" capability="$2" label="$3"
-    local provider canonical seen=""
+    local provider canonical seat model seen=""
     [[ -n "$raw" ]] || {
         echo "$label must not be empty" >&2
         return 2
@@ -28,6 +30,12 @@ octo_validate_provider_policy_list() {
     esac
 
     for provider in $(printf '%s' "$raw" | tr ',' ' '); do
+        model=""
+        if [[ "$provider" == *:* ]]; then
+            model="${provider#*:}"
+            provider="${provider%%:*}"
+            [[ -n "$model" ]] || { echo "$label contains empty model for provider '$provider'" >&2; return 2; }
+        fi
         canonical="$(octo_provider_canonical "$provider" 2>/dev/null || true)"
         [[ -n "$canonical" ]] || {
             echo "$label references unknown provider '$provider'" >&2
@@ -38,13 +46,14 @@ octo_validate_provider_policy_list() {
             echo "$label provider '$canonical' does not support '$capability'${reason:+ ($reason)}" >&2
             return 2
         }
+        seat="$canonical${model:+:$model}"
         case " $seen " in
-            *" $canonical "*)
-                echo "$label contains duplicate provider '$canonical'" >&2
+            *" $seat "*)
+                echo "$label contains duplicate seat '$seat'" >&2
                 return 2
                 ;;
         esac
-        seen="${seen}${seen:+ }${canonical}"
+        seen="${seen}${seen:+ }${seat}"
     done
     return 0
 }

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -391,7 +391,9 @@ design_review_candidate_agents() {
 
 design_review_unwrap_consultative_output() {
     local payload="${1:-}"
-    if [[ "$payload" == *'## UNVERIFIED CONSULTATIVE OUTPUT'* ]]; then
+    local first_line="${payload%%$'\n'*}"
+    first_line="${first_line%$'\r'}"
+    if [[ "$first_line" == '## UNVERIFIED CONSULTATIVE OUTPUT' ]]; then
         printf '%s\n' "$payload" | awk '
             /^## UNVERIFIED CONSULTATIVE OUTPUT$/ { inside=1; blank_count=0; next }
             /^## END UNVERIFIED CONSULTATIVE OUTPUT$/ { exit }
@@ -568,7 +570,12 @@ design_review_run_synthesis_with_recovery() {
     local output="" candidate="" attempt rc=0 candidates="" tried=" $initial_agent " pass reason
 
     for attempt in 1 2; do
-        output="$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$initial_agent" "$synthesis_prompt" "$timeout" "synthesizer" "ceremony" 2>/dev/null)" || rc=$?
+        output="$(
+            (
+                export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
+                run_agent_sync_consultative "$initial_agent" "$synthesis_prompt" "$timeout" "synthesizer" "ceremony"
+            ) 2>/dev/null
+        )" || rc=$?
         if design_review_synthesis_valid "$output"; then
             printf -v "$synthesis_var" '%s' "$output"
             printf -v "$agent_var" '%s' "$initial_agent"
@@ -594,7 +601,12 @@ design_review_run_synthesis_with_recovery() {
             fi
             tried="${tried}${candidate} "
             log WARN "Design review synthesis falling back from $initial_agent to $candidate"
-            output="$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$candidate" "$synthesis_prompt" "$timeout" "synthesizer" "ceremony" 2>/dev/null)" || rc=$?
+            output="$(
+                (
+                    export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
+                    run_agent_sync_consultative "$candidate" "$synthesis_prompt" "$timeout" "synthesizer" "ceremony"
+                ) 2>/dev/null
+            )" || rc=$?
             if design_review_synthesis_valid "$output"; then
                 printf -v "$synthesis_var" '%s' "$output"
                 printf -v "$agent_var" '%s' "$candidate"

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -390,9 +390,23 @@ design_review_candidate_agents() {
 }
 
 design_review_approach_valid() {
-    local approach="${1:-}"
+    local approach="${1:-}" payload
     local compact chars words
-    compact="$(printf '%s' "$approach" | tr '\r\n\t' '   ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+    payload="$approach"
+    if printf '%s\n' "$payload" | grep -Fq '## UNVERIFIED CONSULTATIVE OUTPUT'; then
+        payload="$(printf '%s\n' "$payload" | awk '
+            /^## UNVERIFIED CONSULTATIVE OUTPUT$/ { inside=1; blank_count=0; next }
+            /^## END UNVERIFIED CONSULTATIVE OUTPUT$/ { exit }
+            inside {
+                if (blank_count < 2) {
+                    if ($0 == "") blank_count++
+                    next
+                }
+                print
+            }
+        ')"
+    fi
+    compact="$(printf '%s' "$payload" | tr '\r\n\t' '   ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
     chars=${#compact}
     words="$(printf '%s\n' "$compact" | awk '{print NF}')"
     [[ "$chars" -ge 80 && "$words" -ge 12 ]] || return 1

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -407,14 +407,17 @@ design_review_approach_valid() {
         ')"
     fi
     compact="$(printf '%s' "$payload" | tr '\r\n\t' '   ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+    # Reject metadata/path fragments before the general substance gates. Normalize
+    # case in Bash so lowercase keys work, and recognize POSIX, relative, Windows,
+    # and file:// paths without treating ordinary prose containing ':' as metadata.
+    local compact_lc
+    compact_lc="${compact,,}"
+    if [[ "$compact_lc" =~ ^[[:space:]]*[a-z0-9_\ -]*(path|file|dir|root)[a-z0-9_\ -]*:[[:space:]]*(/|\./|\.\./|[a-z]:[\/]|file://).*$ ]]; then
+        return 1
+    fi
     chars=${#compact}
     words="$(printf '%s\n' "$compact" | awk '{print NF}')"
     [[ "$chars" -ge 80 && "$words" -ge 12 ]] || return 1
-    # Reject path/metadata fragments that technically contain text but do not form
-    # a substantive review contribution (the production incident was one of these).
-    if printf '%s\n' "$compact" | grep -Eq '^[A-Z0-9_ -]*(PATH|FILE|DIR|ROOT)[A-Z0-9_ -]*:[[:space:]]*[^.!?]*$'; then
-        return 1
-    fi
     return 0
 }
 

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -389,12 +389,10 @@ design_review_candidate_agents() {
     bash "$helper" review-order standard "$prompt" 2>/dev/null
 }
 
-design_review_approach_valid() {
-    local approach="${1:-}" payload
-    local compact chars words
-    payload="$approach"
+design_review_unwrap_consultative_output() {
+    local payload="${1:-}"
     if [[ "$payload" == *'## UNVERIFIED CONSULTATIVE OUTPUT'* ]]; then
-        payload="$(printf '%s\n' "$payload" | awk '
+        printf '%s\n' "$payload" | awk '
             /^## UNVERIFIED CONSULTATIVE OUTPUT$/ { inside=1; blank_count=0; next }
             /^## END UNVERIFIED CONSULTATIVE OUTPUT$/ { exit }
             inside {
@@ -404,23 +402,95 @@ design_review_approach_valid() {
                 }
                 print
             }
-        ')"
+        '
+    else
+        printf '%s\n' "$payload"
     fi
+}
+
+design_review_validation_reason() {
+    local payload compact compact_lc chars words
+    payload="$(design_review_unwrap_consultative_output "${1:-}")"
     compact="$(printf '%s' "$payload" | tr '\r\n\t' '   ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
-    # Reject metadata/path fragments before the general substance gates. Normalize
-    # case in Bash so lowercase keys work, and recognize POSIX, relative, Windows,
-    # and file:// paths without treating ordinary prose containing ':' as metadata.
-    local compact_lc
     compact_lc="$(printf '%s' "$compact" | tr '[:upper:]' '[:lower:]')"
+    if [[ -z "$compact" ]]; then
+        echo empty
+        return 0
+    fi
     if [[ "$compact_lc" =~ ^[[:space:]]*[a-z0-9_\ -]*(path|file|dir|root)[a-z0-9_\ -]*:[[:space:]]*(/|\./|\.\./|[a-z]:[\/]|file://).*$ ]]; then
-        return 1
+        echo metadata_path_only
+        return 0
     fi
     chars=${#compact}
     words="$(printf '%s\n' "$compact" | awk '{print NF}')"
-    [[ "$chars" -ge 80 && "$words" -ge 12 ]] || return 1
-    return 0
+    if [[ "$chars" -lt 80 ]]; then
+        echo too_short_chars
+        return 0
+    fi
+    if [[ "$words" -lt 12 ]]; then
+        echo too_few_words
+        return 0
+    fi
+    echo valid
 }
 
+design_review_synthesis_validation_reason() {
+    local payload compact chars words base_reason
+    base_reason="$(design_review_validation_reason "${1:-}")"
+    [[ "$base_reason" == valid ]] || { echo "$base_reason"; return 0; }
+    payload="$(design_review_unwrap_consultative_output "${1:-}")"
+    compact="$(printf '%s' "$payload" | tr '\r\n\t' '   ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+    chars=${#compact}
+    words="$(printf '%s\n' "$compact" | awk '{print NF}')"
+    if [[ "$chars" -lt 120 ]]; then
+        echo synthesis_too_short_chars
+        return 0
+    fi
+    if [[ "$words" -lt 18 ]]; then
+        echo synthesis_too_few_words
+        return 0
+    fi
+    echo valid
+}
+
+design_review_write_invalid_diagnostic() {
+    local kind="$1" role="$2" agent_spec="$3" attempt="$4" rc="$5" reason="$6" output="${7:-}"
+    local base_dir diag_dir safe_role safe_agent stamp file excerpt limit=16384
+    base_dir="${RESULTS_DIR:-${HOME:-/tmp}/.claude-octopus/results}"
+    diag_dir="$base_dir/design-review-diagnostics"
+    mkdir -p "$diag_dir" 2>/dev/null || return 0
+    safe_role="$(printf '%s' "$role" | sed -E 's/[^A-Za-z0-9._-]+/_/g')"
+    if declare -f octo_agent_spec_slug >/dev/null 2>&1; then
+        safe_agent="$(octo_agent_spec_slug "$agent_spec")"
+    else
+        safe_agent="$(printf '%s' "$agent_spec" | sed -E 's/[^A-Za-z0-9._-]+/_/g')"
+    fi
+    stamp="$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || date +%s)"
+    file="$diag_dir/${kind}-${safe_role}-${safe_agent}-attempt-${attempt}-${stamp}-$$.json"
+    excerpt="${output:0:16384}"
+    jq -n \
+        --arg kind "$kind" \
+        --arg role "$role" \
+        --arg agent_spec "$agent_spec" \
+        --arg attempt "$attempt" \
+        --arg rc "$rc" \
+        --arg reason "$reason" \
+        --arg bytes "${#output}" \
+        --arg excerpt "$excerpt" \
+        --argjson truncated "$([[ ${#output} -gt $limit ]] && echo true || echo false)" \
+        --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" \
+        '{kind:$kind, role:$role, agent_spec:$agent_spec, attempt:($attempt|tonumber? // $attempt), rc:($rc|tonumber? // $rc), validation_failure:$reason, bytes:($bytes|tonumber? // $bytes), raw_excerpt:$excerpt, raw_truncated:$truncated, timestamp:$timestamp}' \
+        > "$file" 2>/dev/null || { rm -f "$file" 2>/dev/null || true; return 0; }
+    log DEBUG "Design review invalid-output diagnostic: $file"
+}
+
+design_review_approach_valid() {
+    [[ "$(design_review_validation_reason "${1:-}")" == valid ]]
+}
+
+design_review_synthesis_valid() {
+    [[ "$(design_review_synthesis_validation_reason "${1:-}")" == valid ]]
+}
 design_review_run_seat_with_recovery() {
     local initial_agent="$1" role="$2" ceremony_prompt="$3" timeout="$4"
     local reserved="$5" approach_var="$6" agent_var="$7"
@@ -441,7 +511,10 @@ design_review_run_seat_with_recovery() {
             [[ "$attempt" -gt 1 ]] && log INFO "Design review seat '$role' recovered on retry with $initial_agent"
             return 0
         fi
-        log WARN "Design review seat '$role' returned invalid output from $initial_agent (attempt $attempt/2, rc=$rc, bytes=${#approach})"
+        local invalid_reason
+        invalid_reason="$(design_review_validation_reason "$approach")"
+        design_review_write_invalid_diagnostic "seat" "$role" "$initial_agent" "$attempt" "$rc" "$invalid_reason" "$approach"
+        log WARN "Design review seat '$role' returned invalid output from $initial_agent (attempt $attempt/2, rc=$rc, bytes=${#approach}, reason=$invalid_reason)"
         rc=0
     done
 
@@ -472,7 +545,10 @@ design_review_run_seat_with_recovery() {
                 log INFO "Design review seat '$role' recovered with fallback $candidate"
                 return 0
             fi
-            log WARN "Design review fallback '$candidate' for seat '$role' returned invalid output (rc=$rc, bytes=${#approach})"
+            local fallback_reason
+            fallback_reason="$(design_review_validation_reason "$approach")"
+            design_review_write_invalid_diagnostic "seat-fallback" "$role" "$candidate" "fallback" "$rc" "$fallback_reason" "$approach"
+            log WARN "Design review fallback '$candidate' for seat '$role' returned invalid output (rc=$rc, bytes=${#approach}, reason=$fallback_reason)"
             rc=0
         done <<EOF
 $candidates
@@ -484,6 +560,59 @@ EOF
     printf -v "$approach_var" '%s' ""
     printf -v "$agent_var" '%s' "$initial_agent"
     log WARN "Design review seat '$role' exhausted the admitted review pool; ceremony will continue DEGRADED"
+    return 0
+}
+
+design_review_run_synthesis_with_recovery() {
+    local initial_agent="$1" synthesis_prompt="$2" timeout="$3" reserved="$4" synthesis_var="$5" agent_var="$6"
+    local output="" candidate="" attempt rc=0 candidates="" tried=" $initial_agent " pass reason
+
+    for attempt in 1 2; do
+        output="$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$initial_agent" "$synthesis_prompt" "$timeout" "synthesizer" "ceremony" 2>/dev/null)" || rc=$?
+        if design_review_synthesis_valid "$output"; then
+            printf -v "$synthesis_var" '%s' "$output"
+            printf -v "$agent_var" '%s' "$initial_agent"
+            [[ "$attempt" -gt 1 ]] && log INFO "Design review synthesis recovered on retry with $initial_agent"
+            return 0
+        fi
+        reason="$(design_review_synthesis_validation_reason "$output")"
+        design_review_write_invalid_diagnostic "synthesis" "synthesizer" "$initial_agent" "$attempt" "$rc" "$reason" "$output"
+        log WARN "Design review synthesis returned invalid output from $initial_agent (attempt $attempt/2, rc=$rc, bytes=${#output}, reason=$reason)"
+        rc=0
+    done
+
+    candidates="$(design_review_candidate_agents "$synthesis_prompt" 2>/dev/null || true)"
+    for pass in unique reuse; do
+        while IFS= read -r candidate; do
+            [[ -n "$candidate" ]] || continue
+            [[ " $tried " == *" $candidate "* ]] && continue
+            if [[ "$pass" == "unique" && " $reserved " == *" $candidate "* ]]; then
+                continue
+            fi
+            if [[ "$pass" == "reuse" && " $reserved " != *" $candidate "* ]]; then
+                continue
+            fi
+            tried="${tried}${candidate} "
+            log WARN "Design review synthesis falling back from $initial_agent to $candidate"
+            output="$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$candidate" "$synthesis_prompt" "$timeout" "synthesizer" "ceremony" 2>/dev/null)" || rc=$?
+            if design_review_synthesis_valid "$output"; then
+                printf -v "$synthesis_var" '%s' "$output"
+                printf -v "$agent_var" '%s' "$candidate"
+                log INFO "Design review synthesis recovered with fallback $candidate"
+                return 0
+            fi
+            reason="$(design_review_synthesis_validation_reason "$output")"
+            design_review_write_invalid_diagnostic "synthesis-fallback" "synthesizer" "$candidate" "fallback" "$rc" "$reason" "$output"
+            log WARN "Design review synthesis fallback '$candidate' returned invalid output (rc=$rc, bytes=${#output}, reason=$reason)"
+            rc=0
+        done <<EOF
+$candidates
+EOF
+    done
+
+    printf -v "$synthesis_var" '%s' ""
+    printf -v "$agent_var" '%s' "$initial_agent"
+    log WARN "Design review synthesis exhausted the admitted review pool; ceremony will continue DEGRADED without synthesis"
     return 0
 }
 
@@ -605,8 +734,8 @@ Be concise and specific. This is a planning exercise, not implementation."
             runtime_provider="unknown" runtime_model="unknown" role="synthesizer" inputs="3" || true
     fi
 
-    local synthesis
-    synthesis=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="design-review-ceremony" run_agent_sync_consultative "$design_synthesizer_agent" "You are synthesizing a design review ceremony.
+    local synthesis="" synthesis_prompt
+    synthesis_prompt="You are synthesizing a design review ceremony.
 
 Three review seats stated their approach to this task. The headings below reflect configured runtime identity rather than historical provider slot names:
 
@@ -626,7 +755,12 @@ Identify:
 2. GAPS: What did everyone miss?
 3. RESOLUTION: The recommended unified approach (2-3 sentences)
 
-Be brief and actionable." "$design_synth_timeout" "synthesizer" "ceremony" 2>/dev/null) || true
+Be brief and actionable."
+    design_reserved="$design_implementer_agent $design_researcher_agent $design_code_reviewer_agent $design_synthesizer_agent"
+    design_review_run_synthesis_with_recovery "$design_synthesizer_agent" "$synthesis_prompt" "$design_synth_timeout" \
+        "$design_reserved" synthesis design_synthesizer_agent
+    synthesis_label="$(octo_provider_identity_label "$design_synthesizer_agent" "synthesizer")"
+
 
     if declare -f octo_event_emit >/dev/null 2>&1; then
         local _synth_now _synth_elapsed="unknown"
@@ -639,7 +773,7 @@ Be brief and actionable." "$design_synth_timeout" "synthesizer" "ceremony" 2>/de
             configured_provider="$(octo_provider_identity_from_agent_type "$design_synthesizer_agent")" \
             configured_model="$(get_agent_model "$design_synthesizer_agent" "ceremony" "synthesizer" 2>/dev/null || echo unresolved)" \
             runtime_provider="unknown" runtime_model="unknown" role="synthesizer" \
-            status="$([[ -n "$synthesis" ]] && echo produced || echo empty)" \
+            status="$([[ -n "$synthesis" ]] && echo produced || echo degraded)" \
             bytes="${#synthesis}" elapsed_s="$_synth_elapsed" || true
     fi
 

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -393,7 +393,7 @@ design_review_approach_valid() {
     local approach="${1:-}" payload
     local compact chars words
     payload="$approach"
-    if printf '%s\n' "$payload" | grep -Fq '## UNVERIFIED CONSULTATIVE OUTPUT'; then
+    if [[ "$payload" == *'## UNVERIFIED CONSULTATIVE OUTPUT'* ]]; then
         payload="$(printf '%s\n' "$payload" | awk '
             /^## UNVERIFIED CONSULTATIVE OUTPUT$/ { inside=1; blank_count=0; next }
             /^## END UNVERIFIED CONSULTATIVE OUTPUT$/ { exit }

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -377,6 +377,99 @@ EOF
     done
 }
 
+design_review_candidate_agents() {
+    local prompt="${1:-design review}"
+    local plugin_root="${PLUGIN_DIR:-}"
+    local helper
+    if [[ -z "$plugin_root" ]]; then
+        plugin_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+    fi
+    helper="$plugin_root/scripts/helpers/build-fleet.sh"
+    [[ -x "$helper" ]] || return 1
+    bash "$helper" review-order standard "$prompt" 2>/dev/null
+}
+
+design_review_approach_valid() {
+    local approach="${1:-}"
+    local compact chars words
+    compact="$(printf '%s' "$approach" | tr '\r\n\t' '   ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+    chars=${#compact}
+    words="$(printf '%s\n' "$compact" | awk '{print NF}')"
+    [[ "$chars" -ge 80 && "$words" -ge 12 ]] || return 1
+    # Reject path/metadata fragments that technically contain text but do not form
+    # a substantive review contribution (the production incident was one of these).
+    if printf '%s\n' "$compact" | grep -Eq '^[A-Z0-9_ -]*(PATH|FILE|DIR|ROOT)[A-Z0-9_ -]*:[[:space:]]*[^.!?]*$'; then
+        return 1
+    fi
+    return 0
+}
+
+design_review_run_seat_with_recovery() {
+    local initial_agent="$1" role="$2" ceremony_prompt="$3" timeout="$4"
+    local reserved="$5" approach_var="$6" agent_var="$7"
+    local approach="" candidate="" attempt rc=0 candidates="" tried=" $initial_agent " pass
+
+    # First recover the same seat/model. One retry after the initial attempt keeps
+    # transient/provider anomalies from silently reducing a three-seat ceremony.
+    for attempt in 1 2; do
+        approach="$(
+            (
+                export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
+                run_agent_sync_consultative "$initial_agent" "$ceremony_prompt" "$timeout" "$role" "ceremony"
+            ) 2>/dev/null
+        )" || rc=$?
+        if design_review_approach_valid "$approach"; then
+            printf -v "$approach_var" '%s' "$approach"
+            printf -v "$agent_var" '%s' "$initial_agent"
+            [[ "$attempt" -gt 1 ]] && log INFO "Design review seat '$role' recovered on retry with $initial_agent"
+            return 0
+        fi
+        log WARN "Design review seat '$role' returned invalid output from $initial_agent (attempt $attempt/2, rc=$rc, bytes=${#approach})"
+        rc=0
+    done
+
+    candidates="$(design_review_candidate_agents "$ceremony_prompt" 2>/dev/null || true)"
+    # Prefer an unused seat identity first; if the pool has no unused candidate,
+    # reuse another admitted candidate rather than giving up without trying.
+    for pass in unique reuse; do
+        while IFS= read -r candidate; do
+            [[ -n "$candidate" ]] || continue
+            [[ " $tried " == *" $candidate "* ]] && continue
+            if [[ "$pass" == "unique" && " $reserved " == *" $candidate "* ]]; then
+                continue
+            fi
+            if [[ "$pass" == "reuse" && " $reserved " != *" $candidate "* ]]; then
+                continue
+            fi
+            tried="${tried}${candidate} "
+            log WARN "Design review seat '$role' falling back from $initial_agent to $candidate"
+            approach="$(
+                (
+                    export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
+                    run_agent_sync_consultative "$candidate" "$ceremony_prompt" "$timeout" "$role" "ceremony"
+                ) 2>/dev/null
+            )" || rc=$?
+            if design_review_approach_valid "$approach"; then
+                printf -v "$approach_var" '%s' "$approach"
+                printf -v "$agent_var" '%s' "$candidate"
+                log INFO "Design review seat '$role' recovered with fallback $candidate"
+                return 0
+            fi
+            log WARN "Design review fallback '$candidate' for seat '$role' returned invalid output (rc=$rc, bytes=${#approach})"
+            rc=0
+        done <<EOF
+$candidates
+EOF
+    done
+
+    # Best effort is deliberate: preserve the useful seats and make degradation
+    # explicit rather than failing the whole implementation workflow.
+    printf -v "$approach_var" '%s' ""
+    printf -v "$agent_var" '%s' "$initial_agent"
+    log WARN "Design review seat '$role' exhausted the admitted review pool; ceremony will continue DEGRADED"
+    return 0
+}
+
 design_review_ceremony() {
     local prompt="$1"
     local context="${2:-}"
@@ -463,24 +556,22 @@ Be concise and specific. This is a planning exercise, not implementation."
     log INFO "Design review: gathering role approaches..."
     log INFO "Design review seats: seat_1=${seat_1_label}, seat_2=${seat_2_label}, seat_3=${seat_3_label}, synthesis=${synthesis_label}, timeout=${_design_timeout_label}, synth_timeout=${_synth_timeout_label}"
 
-    seat_1_approach="$(
-        (
-            export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
-            run_agent_sync_consultative "$design_implementer_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony"
-        ) 2>/dev/null
-    )" || true
-    seat_2_approach="$(
-        (
-            export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
-            run_agent_sync_consultative "$design_researcher_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony"
-        ) 2>/dev/null
-    )" || true
-    seat_3_approach="$(
-        (
-            export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
-            run_agent_sync_consultative "$design_code_reviewer_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony"
-        ) 2>/dev/null
-    )" || true
+    local design_reserved
+    design_reserved="$design_implementer_agent $design_researcher_agent $design_code_reviewer_agent $design_synthesizer_agent"
+    design_review_run_seat_with_recovery "$design_implementer_agent" "implementer" "$ceremony_prompt" "$design_timeout" \
+        "$design_reserved" seat_1_approach design_implementer_agent
+    design_reserved="$design_implementer_agent $design_researcher_agent $design_code_reviewer_agent $design_synthesizer_agent"
+    design_review_run_seat_with_recovery "$design_researcher_agent" "researcher" "$ceremony_prompt" "$design_timeout" \
+        "$design_reserved" seat_2_approach design_researcher_agent
+    design_reserved="$design_implementer_agent $design_researcher_agent $design_code_reviewer_agent $design_synthesizer_agent"
+    design_review_run_seat_with_recovery "$design_code_reviewer_agent" "code-reviewer" "$ceremony_prompt" "$design_timeout" \
+        "$design_reserved" seat_3_approach design_code_reviewer_agent
+
+    # Labels must reflect the effective seat after any recovery/fallback.
+    seat_1_label="$(octo_provider_identity_label "$design_implementer_agent" "implementer")"
+    seat_2_label="$(octo_provider_identity_label "$design_researcher_agent" "researcher")"
+    seat_3_label="$(octo_provider_identity_label "$design_code_reviewer_agent" "code-reviewer")"
+    log INFO "Design review effective seats: seat_1=${seat_1_label}, seat_2=${seat_2_label}, seat_3=${seat_3_label}"
 
     # Synthesize conflicts and resolution.
     # synthesis.start/end bracket the call so the event stream shows how long the

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -411,7 +411,7 @@ design_review_approach_valid() {
     # case in Bash so lowercase keys work, and recognize POSIX, relative, Windows,
     # and file:// paths without treating ordinary prose containing ':' as metadata.
     local compact_lc
-    compact_lc="${compact,,}"
+    compact_lc="$(printf '%s' "$compact" | tr '[:upper:]' '[:lower:]')"
     if [[ "$compact_lc" =~ ^[[:space:]]*[a-z0-9_\ -]*(path|file|dir|root)[a-z0-9_\ -]*:[[:space:]]*(/|\./|\.\./|[a-z]:[\/]|file://).*$ ]]; then
         return 1
     fi

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+_agent_spec_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_agent_spec_lib_dir}/agent-spec.sh" 2>/dev/null || true
 # Claude Octopus — Code Review Pipeline
 # Extracted from orchestrate.sh
 # Source-safe: no main execution block.
@@ -1298,8 +1300,8 @@ CRITICAL OUTPUT FORMAT: Return ONLY a valid JSON object. No markdown, no prose, 
     while IFS=: read -r agent_type role specialty; do
         [[ -z "$agent_type" ]] && continue
         local task_id="review-r1-${role}-${timestamp}"
-        # Use spawn_agent's actual output path convention: ${RESULTS_DIR}/${agent_type}-${task_id}.md
-        local result_file="${RESULTS_DIR}/${agent_type}-${task_id}.md"
+        # Use spawn_agent's actual output path convention: ${RESULTS_DIR}/$(octo_agent_spec_slug "$agent_type")-${task_id}.md
+        local result_file="${RESULTS_DIR}/$(octo_agent_spec_slug "$agent_type")-${task_id}.md"
         round1_files+=("$result_file")
         round1_agent_types+=("$agent_type")
         round1_roles+=("$role")
@@ -1353,7 +1355,7 @@ ${agent_prompt_base}"
                 reconnect_count=${reconnect_count%%$'\n'*}
                 retry_role="${round1_roles[$retry_idx]}"
                 retry_task_id="${round1_task_ids[$retry_idx]}-retry1"
-                retry_result_file="${RESULTS_DIR}/${retry_agent_type}-${retry_task_id}.md"
+                retry_result_file="${RESULTS_DIR}/$(octo_agent_spec_slug "$retry_agent_type")-${retry_task_id}.md"
                 archived_file="${retry_file}.attempt1"
                 mv "$retry_file" "$archived_file" 2>/dev/null || true
                 log WARN "review_run: ${retry_agent_type}/${retry_role} ended Empty output after ${reconnect_count} reconnect(s); retrying once after ${openai_compat_empty_retry_backoff}s (artifact=$(basename "$archived_file"))"

--- a/scripts/lib/session.sh
+++ b/scripts/lib/session.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+_agent_spec_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_agent_spec_lib_dir}/agent-spec.sh" 2>/dev/null || true
 # session.sh — Session management and progress tracking
 # Contains: init_progress_tracking, display_progress_summary, cleanup_old_progress_files,
 #           display_rich_progress, generate_session_name, init_session,
@@ -245,7 +247,7 @@ display_rich_progress() {
             local task_id="probe-${task_group}-${i}"
             local agent_type="${agent_types[$i]}"
             local agent_name="${agent_names[$i]}"
-            local result_file="${RESULTS_DIR}/${agent_type}-${task_id}.md"
+            local result_file="${RESULTS_DIR}/$(octo_agent_spec_slug "$agent_type")-${task_id}.md"
             local pid="${pids[$i]}"
 
             # Check if agent is still running

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -1017,7 +1017,7 @@ ${heuristic_ctx}"
                 # v8.18.0: Record provider learning
                 local result_summary
                 result_summary=$(head -c 200 "$result_file" 2>/dev/null | tr '\n' ' ')
-                append_provider_history "$agent_type" "${phase:-unknown}" "${enhanced_prompt:0:100}" "$result_summary" 2>/dev/null || true
+                append_provider_history "$provider_prefix" "${phase:-unknown}" "${enhanced_prompt:0:100}" "$result_summary" 2>/dev/null || true
                 # v8.20.0: Record outcome for provider intelligence
                 record_outcome "$agent_type" "$agent_type" "${task_type:-unknown}" "${phase:-unknown}" "success" "$elapsed_ms" 2>/dev/null || true
                 # v9.13: Reset circuit breaker on success

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -3,6 +3,7 @@
 # Agent spawning and lifecycle management
 
 _octopus_spawn_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_octopus_spawn_lib_dir}/agent-spec.sh" 2>/dev/null || true
 if ! type start_quota_watcher >/dev/null 2>&1; then
     source "${_octopus_spawn_lib_dir}/quota-watcher.sh" 2>/dev/null || true
 fi
@@ -34,7 +35,8 @@ _octopus_agent_lifecycle_event() {
     local exit_code="${8:-}"
     local status="${9:-}"
 
-    local provider="${agent_type%%-*}"
+    local provider
+    provider="$(octo_agent_spec_executor "$agent_type")"
     local event_name="agent.${event}"
 
     if declare -f octo_event_emit >/dev/null 2>&1; then
@@ -229,6 +231,8 @@ spawn_agent() {
     local agent_type="$1"
     local prompt="$2"
     local task_id="${3:-$(_octopus_next_spawn_task_id)}"
+    local agent_slug
+    agent_slug="$(octo_agent_spec_slug "$agent_type")"
     local role="${4:-}"         # Optional role override
     local phase="${5:-}"        # Optional phase context
     local use_fork="${6:-false}" # Optional fork context (v2.1.12+)
@@ -505,7 +509,8 @@ ${heuristic_ctx}"
     fi
 
     # v9.13: Circuit breaker check — skip provider if circuit is open
-    local provider_prefix="${agent_type%%-*}"  # codex-standard → codex
+    local provider_prefix
+    provider_prefix="$(octo_agent_spec_executor "$agent_type")"  # codex-standard → codex; provider:model → provider
     if type is_provider_available &>/dev/null && ! is_provider_available "$provider_prefix"; then
         log "WARN" "Circuit open for $provider_prefix — skipping $agent_type (use fallback)"
         record_outcome "$provider_prefix" "$agent_type" "skipped" "${phase:-unknown}" "circuit_open" "0" 2>/dev/null || true
@@ -554,8 +559,8 @@ ${heuristic_ctx}"
         return $?
     fi
 
-    local log_file="${LOGS_DIR}/${agent_type}-${task_id}.log"
-    local result_file="${RESULTS_DIR}/${agent_type}-${task_id}.md"
+    local log_file="${LOGS_DIR}/${agent_slug}-${task_id}.log"
+    local result_file="${RESULTS_DIR}/${agent_slug}-${task_id}.md"
 
     # v8.52: Warn if spawning Claude agent on enterprise without subagent model fix (CC < v2.1.73)
     # Prior to v2.1.73, model: opus/sonnet/haiku in agent frontmatter was silently downgraded on Bedrock/Vertex/Foundry
@@ -810,7 +815,8 @@ ${heuristic_ctx}"
             local _quota_watcher_pid=""
             local _spawn_pid=$BASHPID
             local _provider_prefix
-            _provider_prefix="$(octo_provider_canonical "$agent_type" 2>/dev/null || printf '%s' "${agent_type%%-*}")"
+            _provider_prefix="$(octo_agent_spec_executor "$agent_type")"
+            _provider_prefix="$(octo_provider_canonical "$_provider_prefix" 2>/dev/null || printf '%s' "$_provider_prefix")"
             _quota_watcher_pid=$(start_quota_watcher \
                 "$_spawn_pid" \
                 "$temp_errors" \
@@ -1224,11 +1230,11 @@ ${heuristic_ctx}"
     if command -v flock &>/dev/null; then
         (
             flock -x 200
-            echo "$pid:$agent_type:$task_id" >> "$PID_FILE"
+            echo "$pid:$agent_slug:$task_id" >> "$PID_FILE"
         ) 200>"${PID_FILE}.lock"
     else
         # macOS fallback: simple append (race condition risk is low for our use case)
-        echo "$pid:$agent_type:$task_id" >> "$PID_FILE"
+        echo "$pid:$agent_slug:$task_id" >> "$PID_FILE"
     fi
 
     log INFO "Agent spawned with PID: $pid"

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -36,7 +36,7 @@ _octopus_agent_lifecycle_event() {
     local status="${9:-}"
 
     local provider
-    provider="$(octo_agent_spec_executor "$agent_type")"
+    provider="$(octo_agent_spec_provider "$agent_type")"
     local event_name="agent.${event}"
 
     if declare -f octo_event_emit >/dev/null 2>&1; then
@@ -510,7 +510,7 @@ ${heuristic_ctx}"
 
     # v9.13: Circuit breaker check — skip provider if circuit is open
     local provider_prefix
-    provider_prefix="$(octo_agent_spec_executor "$agent_type")"  # codex-standard → codex; provider:model → provider
+    provider_prefix="$(octo_agent_spec_provider "$agent_type")"  # codex-standard → codex; provider:model → provider
     if type is_provider_available &>/dev/null && ! is_provider_available "$provider_prefix"; then
         log "WARN" "Circuit open for $provider_prefix — skipping $agent_type (use fallback)"
         record_outcome "$provider_prefix" "$agent_type" "skipped" "${phase:-unknown}" "circuit_open" "0" 2>/dev/null || true
@@ -815,7 +815,7 @@ ${heuristic_ctx}"
             local _quota_watcher_pid=""
             local _spawn_pid=$BASHPID
             local _provider_prefix
-            _provider_prefix="$(octo_agent_spec_executor "$agent_type")"
+            _provider_prefix="$(octo_agent_spec_provider "$agent_type")"
             _provider_prefix="$(octo_provider_canonical "$_provider_prefix" 2>/dev/null || printf '%s' "$_provider_prefix")"
             _quota_watcher_pid=$(start_quota_watcher \
                 "$_spawn_pid" \

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -619,14 +619,10 @@ ${heuristic_ctx}"
         _estimated_cost=$(estimate_agent_call_cost "$agent_type" "$model" "$enhanced_prompt")
     fi
 
-    # v8.14.0: Track provider usage in persistent state
-    local provider_name
-    case "$agent_type" in
-        codex*) provider_name="codex" ;;
-        gemini*) provider_name="agy" ;;
-        claude*) provider_name="claude" ;;
-        *) provider_name="$agent_type" ;;
-    esac
+    # v8.14.0: Track provider usage in persistent state. provider_prefix is the
+    # canonical provider identity used by circuit-breaker/history/accounting; do
+    # not split metrics by model-qualified agent_spec.
+    local provider_name="$provider_prefix"
     update_metrics "provider" "$provider_name" 2>/dev/null || true
 
     # v8.7.0: Register task in bridge ledger (non-fatal if ledger missing)

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -213,6 +213,7 @@ EOF
 # ═══════════════════════════════════════════════════════════════════════════════
 octo_provider_identity_from_agent_type() {
     local agent_type="$1"
+    agent_type="${agent_type%%:*}"
     case "$agent_type" in
         openai-compatible|openai-tools|openai-compatible-agent) echo "openai-compatible" ;;
         atlascloud-agent|atlascloud) echo "atlascloud" ;;

--- a/tests/unit/test-ceremonies.sh
+++ b/tests/unit/test-ceremonies.sh
@@ -129,7 +129,11 @@ test_ceremony_synthesis_receives_provenance_boundary() {
             if [[ "$count" -le 3 ]]; then
                 printf '%s\n' \
                     '## UNVERIFIED CONSULTATIVE OUTPUT' \
-                    'Implemented disposable files and verified 417 tests plus live probes.'
+                    '' \
+                    'This output came from a disposable workspace. It is advisory and non-deliverable. Claimed file changes, test counts, live probes, or completed implementation are not verified evidence and must not be reported as delivered work.' \
+                    '' \
+                    'Architecture recommendation: preserve the existing orchestration contract and treat disposable-seat completion claims as unverified evidence until the main workflow validates them independently.' \
+                    '## END UNVERIFIED CONSULTATIVE OUTPUT'
             else
                 printf '%s' "$2" > "$capture"
                 printf '%s\n' 'Planning-only synthesis.'

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1003,8 +1003,8 @@ test_council_chair_fallback_preserves_quorum() {
              | $fallback.index == (.council | length)
              and $fallback.persona == .warnings.chair_fallback_persona
              and $fallback.seat == "chair"
-             and ([$fallback.provider, $fallback.provider_org, $fallback.model,
-                   $fallback.payload_kind, $fallback.status]
+             and ([$fallback.agent_spec, $fallback.provider, $fallback.provider_org, $fallback.model,
+                   $fallback.model_family, $fallback.payload_kind, $fallback.status]
                   | all(type == "string" and length > 0))
              and $fallback.response_bytes > 0
              and $fallback.verdict == "APPROVE"
@@ -1620,24 +1620,24 @@ test_council_quorum_met_with_host_native_chair() {
 }
 
 test_council_one_vote_per_vendor_opt_in() {
-    test_case "OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1 keeps one voting seat per vendor; default leaves the roster intact"
+    test_case "OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1 keeps one voting seat per model family; default leaves the roster intact"
     load_council_lib || return 1
     local roster='[
-      {"persona":"strategy-analyst","seat":"chair","provider":"claude","provider_org":"anthropic","score":"0.9"},
-      {"persona":"backend-architect","seat":"member","provider":"codex","provider_org":"openai","score":"0.8"},
-      {"persona":"security-auditor","seat":"member","provider":"codex","provider_org":"openai","score":"0.6"},
-      {"persona":"research-synthesizer","seat":"member","provider":"agy","provider_org":"google","score":"0.7"}
+      {"persona":"strategy-analyst","seat":"chair","provider":"claude","provider_org":"anthropic","model_family":"anthropic","score":"0.9"},
+      {"persona":"backend-architect","seat":"member","provider":"codex","provider_org":"openai","model_family":"openai","score":"0.8"},
+      {"persona":"security-auditor","seat":"member","provider":"codex","provider_org":"openai","model_family":"openai","score":"0.6"},
+      {"persona":"research-synthesizer","seat":"member","provider":"agy","provider_org":"google","model_family":"google","score":"0.7"}
     ]'
 
     # Compare the WHOLE roster (normalized), not just seat counts, so a regression
     # that swaps a seat or replaces the chair can't slip through.
     local roster_norm; roster_norm="$(jq -Sc . <<< "$roster")"
-    # Enabled result: the lower-scored openai seat (security-auditor) is dropped;
-    # chair + higher-scored openai (backend-architect) + agy remain, order preserved.
+    # Enabled result: the lower-scored OpenAI-family seat (security-auditor) is dropped;
+    # chair + higher-scored OpenAI-family seat (backend-architect) + agy remain.
     local expected_on; expected_on="$(jq -Sc . <<< '[
-      {"persona":"strategy-analyst","seat":"chair","provider":"claude","provider_org":"anthropic","score":"0.9"},
-      {"persona":"backend-architect","seat":"member","provider":"codex","provider_org":"openai","score":"0.8"},
-      {"persona":"research-synthesizer","seat":"member","provider":"agy","provider_org":"google","score":"0.7"}
+      {"persona":"strategy-analyst","seat":"chair","provider":"claude","provider_org":"anthropic","model_family":"anthropic","score":"0.9"},
+      {"persona":"backend-architect","seat":"member","provider":"codex","provider_org":"openai","model_family":"openai","score":"0.8"},
+      {"persona":"research-synthesizer","seat":"member","provider":"agy","provider_org":"google","model_family":"google","score":"0.7"}
     ]')"
 
     # Default (flag unset): opt-in feature is off, roster is byte-for-byte untouched.
@@ -1655,7 +1655,7 @@ test_council_one_vote_per_vendor_opt_in() {
     OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=0 council_dedup_vendor_seats
     off_norm="$(jq -Sc . <<< "$COUNCIL_ROSTER_JSON")"
 
-    # Enabled: roster reduced to exactly the expected one-vote-per-vendor set.
+    # Enabled: roster reduced to exactly the expected one-vote-per-model-family set.
     local on_norm
     COUNCIL_ROSTER_JSON="$roster"
     OCTOPUS_COUNCIL_ONE_VOTE_PER_VENDOR=1 council_dedup_vendor_seats

--- a/tests/unit/test-council-model-selection-fixes.sh
+++ b/tests/unit/test-council-model-selection-fixes.sh
@@ -114,15 +114,15 @@ pick_provider() {
     ' _ "$roster_json" "$preferred"
 }
 
-test_case "preferred provider passed over when its org already holds a seat"
+test_case "preferred provider passed over when its model family already holds a seat"
 out=$(pick_provider '[{"persona":"strategy-analyst","provider":"claude","provider_org":"anthropic"}]' claude)
 if [[ "$out" == "opencode" ]]; then
     test_pass
 else
-    test_fail "expected opencode (anthropic already seated), got '$out'"
+    test_fail "expected opencode (anthropic model family already seated), got '$out'"
 fi
 
-test_case "preferred provider kept when its org is not yet seated"
+test_case "preferred provider kept when its model family is not yet seated"
 out=$(pick_provider '[]' claude)
 if [[ "$out" == "claude" ]]; then
     test_pass
@@ -130,7 +130,7 @@ else
     test_fail "expected claude on empty roster, got '$out'"
 fi
 
-test_case "falls back to preferred when every org is already seated"
+test_case "falls back to an available provider when every model family is already seated"
 out=$(bash -c '
     log() { :; }
     source "'"$PROJECT_ROOT"'/scripts/lib/council.sh" 2>/dev/null

--- a/tests/unit/test-model-aware-seats.sh
+++ b/tests/unit/test-model-aware-seats.sh
@@ -88,4 +88,28 @@ case_b='[{"persona":"strategy-analyst","seat":"chair","agent_spec":"claude-sonne
 run_quorum_case "$case_b"
 if [[ "$COUNCIL_QUORUM_MET" == false && "$COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES" == 1 && "$COUNCIL_DISTINCT_APPROVING_PROVIDERS" == 2 ]]; then test_pass; else test_fail "same-family quorum mismatch"; fi
 
+
+test_case "model-qualified large-context Codex keeps the large context budget"
+OCTOPUS_CONTEXT_BUDGET=12000
+OCTOPUS_CODEX_CONTEXT_BUDGET=24000
+OCTOPUS_CODEX_LARGE_CONTEXT_BUDGET=77777
+if [[ "$(get_provider_context_limit 'codex-large-context:gpt-5')" == 77777 ]]; then
+  test_pass
+else
+  test_fail "qualified codex-large-context lost its special budget"
+fi
+
+test_case "Council provider status canonicalizes model-qualified provider keys"
+COUNCIL_PROVIDERS='commandcode:stealth/ox-alpha'
+OCTOPUS_COUNCIL_PROVIDER_FIXTURE='commandcode:stealth/ox-alpha:available'
+council_detect_providers
+if [[ "$(jq -r '.commandcode // "missing"' <<< "$COUNCIL_PROVIDER_STATUS_JSON")" == available ]] && \
+   [[ "$(jq -r 'has("commandcode:stealth/ox-alpha")' <<< "$COUNCIL_PROVIDER_STATUS_JSON")" == false ]] && \
+   council_provider_is_available 'commandcode:stealth/ox-alpha'; then
+  test_pass
+else
+  test_fail "provider status map was not canonicalized: $COUNCIL_PROVIDER_STATUS_JSON"
+fi
+unset OCTOPUS_COUNCIL_PROVIDER_FIXTURE
+
 test_summary

--- a/tests/unit/test-model-aware-seats.sh
+++ b/tests/unit/test-model-aware-seats.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "PASS: $1"; }
+bad(){ FAIL=$((FAIL+1)); echo "FAIL: $1" >&2; }
+
+source scripts/lib/agent-spec.sh
+[[ "$(octo_agent_spec_executor 'commandcode:stealth/ox-alpha')" == commandcode ]] && ok executor || bad executor
+[[ "$(octo_agent_spec_explicit_model 'commandcode:stealth/ox-alpha')" == stealth/ox-alpha ]] && ok model || bad model
+[[ "$(octo_agent_spec_slug 'commandcode:stealth/ox-alpha')" == commandcode_stealth_ox-alpha ]] && ok slug || bad slug
+[[ "$(octo_model_family 'commandcode:minimaxai/minimax-m3')" == minimax ]] && ok minimax-family || bad minimax-family
+[[ "$(octo_model_family 'codex:gpt-5.6-luna')" == openai ]] && ok openai-family || bad openai-family
+
+log(){ :; }
+PLUGIN_DIR="$ROOT"
+source scripts/lib/validation.sh
+source scripts/lib/model-resolver.sh
+source scripts/lib/dispatch.sh
+[[ "$(get_agent_model 'commandcode:stealth/ox-alpha' ceremony code-reviewer)" == stealth/ox-alpha ]] && ok commandcode-model-pin || bad commandcode-model-pin
+[[ "$(get_agent_model 'codex:gpt-5.6-luna' ceremony code-reviewer)" == gpt-5.6-luna ]] && ok codex-model-pin || bad codex-model-pin
+get_agent_command 'commandcode:stealth/ox-alpha' ceremony code-reviewer | grep -q 'commandcode-exec.sh stealth/ox-alpha' && ok commandcode-dispatch || bad commandcode-dispatch
+get_agent_command 'codex:gpt-5.6-luna' ceremony code-reviewer | grep -q -- '--model gpt-5.6-luna' && ok codex-dispatch || bad codex-dispatch
+
+fake=$(mktemp)
+cat > "$fake" <<'CHECK'
+#!/usr/bin/env bash
+echo commandcode:available
+echo codex:available
+echo claude:available
+CHECK
+chmod +x "$fake"
+order="$(OCTOPUS_PROVIDER_CHECKER="$fake" OCTOPUS_COUNCIL_DEFAULT_PROVIDERS='commandcode:stealth/ox-alpha,commandcode:minimaxai/minimax-m3,commandcode:deepseek/deepseek-v4-flash,codex:gpt-5.6-luna,codex:gpt-5.6-sol' bash scripts/helpers/build-fleet.sh review-order standard test)"
+ox_line="$(printf '%s\n' "$order" | grep -n -F 'commandcode:stealth/ox-alpha' | head -1 | cut -d: -f1)"
+luna_line="$(printf '%s\n' "$order" | grep -n -F 'codex:gpt-5.6-luna' | head -1 | cut -d: -f1)"
+all_present=true
+for spec in \
+  'commandcode:stealth/ox-alpha' \
+  'commandcode:minimaxai/minimax-m3' \
+  'commandcode:deepseek/deepseek-v4-flash' \
+  'codex:gpt-5.6-luna' \
+  'codex:gpt-5.6-sol'; do
+  printf '%s\n' "$order" | grep -Fxq "$spec" || all_present=false
+done
+[[ "$all_present" == true && -n "$ox_line" && -n "$luna_line" && "$ox_line" -lt "$luna_line" ]] && ok review-order || bad review-order
+rm -f "$fake"
+
+source scripts/lib/council.sh
+council_prompt_for_member(){ echo prompt; }
+council_persona_should_fail(){ return 1; }
+run_quorum_case(){
+  local roster="$1" d
+  d=$(mktemp -d); mkdir -p "$d/responses"
+  COUNCIL_RUN_DIR="$d" COUNCIL_DEPTH=standard COUNCIL_FIXTURE=full-success COUNCIL_EXECUTION_MODE="" \
+  COUNCIL_TASK=x COUNCIL_GOAL=advice COUNCIL_DOMAIN=auto COUNCIL_STYLE=balanced COUNCIL_ROSTER_JSON="$roster"
+  council_run_advice_phase >/dev/null 2>&1 || true
+  rm -rf "$d"
+}
+case_a='[{"persona":"strategy-analyst","seat":"chair","agent_spec":"claude-sonnet","provider":"claude-sonnet","provider_org":"anthropic","model":"claude-sonnet-5","model_family":"anthropic"},{"persona":"code-reviewer","seat":"member","agent_spec":"commandcode:minimaxai/minimax-m3","provider":"commandcode","provider_org":"commandcode","model":"minimaxai/minimax-m3","model_family":"minimax"},{"persona":"backend-architect","seat":"member","agent_spec":"commandcode:deepseek/deepseek-v4-flash","provider":"commandcode","provider_org":"commandcode","model":"deepseek/deepseek-v4-flash","model_family":"deepseek"}]'
+run_quorum_case "$case_a"
+[[ "$COUNCIL_QUORUM_MET" == true && "$COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES" == 2 && "$COUNCIL_DISTINCT_APPROVING_PROVIDERS" == 1 ]] && ok same-provider-different-families || bad same-provider-different-families
+case_b='[{"persona":"strategy-analyst","seat":"chair","agent_spec":"claude-sonnet","provider":"claude-sonnet","provider_org":"anthropic","model":"claude-sonnet-5","model_family":"anthropic"},{"persona":"code-reviewer","seat":"member","agent_spec":"commandcode:openai/gpt-5","provider":"commandcode","provider_org":"commandcode","model":"openai/gpt-5","model_family":"openai"},{"persona":"backend-architect","seat":"member","agent_spec":"codex:gpt-5.6-luna","provider":"codex","provider_org":"openai","model":"gpt-5.6-luna","model_family":"openai"}]'
+run_quorum_case "$case_b"
+[[ "$COUNCIL_QUORUM_MET" == false && "$COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES" == 1 && "$COUNCIL_DISTINCT_APPROVING_PROVIDERS" == 2 ]] && ok different-provider-same-family || bad different-provider-same-family
+
+echo "Passed: $PASS  Failed: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/unit/test-model-aware-seats.sh
+++ b/tests/unit/test-model-aware-seats.sh
@@ -1,29 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
-ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-cd "$ROOT"
-PASS=0; FAIL=0
-ok(){ PASS=$((PASS+1)); echo "PASS: $1"; }
-bad(){ FAIL=$((FAIL+1)); echo "FAIL: $1" >&2; }
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Model-aware seats"
+cd "$PROJECT_ROOT"
 
 source scripts/lib/agent-spec.sh
-[[ "$(octo_agent_spec_executor 'commandcode:stealth/ox-alpha')" == commandcode ]] && ok executor || bad executor
-[[ "$(octo_agent_spec_explicit_model 'commandcode:stealth/ox-alpha')" == stealth/ox-alpha ]] && ok model || bad model
-[[ "$(octo_agent_spec_slug 'commandcode:stealth/ox-alpha')" == commandcode_stealth_ox-alpha ]] && ok slug || bad slug
-[[ "$(octo_model_family 'commandcode:minimaxai/minimax-m3')" == minimax ]] && ok minimax-family || bad minimax-family
-[[ "$(octo_model_family 'codex:gpt-5.6-luna')" == openai ]] && ok openai-family || bad openai-family
+
+test_case "agent spec separates executor and explicit model"
+if [[ "$(octo_agent_spec_executor 'commandcode:stealth/ox-alpha')" == commandcode ]] && \
+   [[ "$(octo_agent_spec_explicit_model 'commandcode:stealth/ox-alpha')" == stealth/ox-alpha ]]; then test_pass; else test_fail "agent spec parsing mismatch"; fi
+
+test_case "agent spec slug is path-safe"
+[[ "$(octo_agent_spec_slug 'commandcode:stealth/ox-alpha')" == commandcode_stealth_ox-alpha ]] && test_pass || test_fail "unexpected slug"
+
+test_case "model family distinguishes MiniMax and OpenAI"
+if [[ "$(octo_model_family 'commandcode:minimaxai/minimax-m3')" == minimax ]] && \
+   [[ "$(octo_model_family 'codex:gpt-5.6-luna')" == openai ]]; then test_pass; else test_fail "model family mismatch"; fi
 
 log(){ :; }
-PLUGIN_DIR="$ROOT"
+PLUGIN_DIR="$PROJECT_ROOT"
 source scripts/lib/validation.sh
 source scripts/lib/model-resolver.sh
 source scripts/lib/dispatch.sh
-[[ "$(get_agent_model 'commandcode:stealth/ox-alpha' ceremony code-reviewer)" == stealth/ox-alpha ]] && ok commandcode-model-pin || bad commandcode-model-pin
-[[ "$(get_agent_model 'codex:gpt-5.6-luna' ceremony code-reviewer)" == gpt-5.6-luna ]] && ok codex-model-pin || bad codex-model-pin
-get_agent_command 'commandcode:stealth/ox-alpha' ceremony code-reviewer | grep -q 'commandcode-exec.sh stealth/ox-alpha' && ok commandcode-dispatch || bad commandcode-dispatch
-get_agent_command 'codex:gpt-5.6-luna' ceremony code-reviewer | grep -q -- '--model gpt-5.6-luna' && ok codex-dispatch || bad codex-dispatch
 
-fake=$(mktemp)
+test_case "model-qualified dispatch preserves CommandCode and Codex pins"
+cc_model="$(get_agent_model 'commandcode:stealth/ox-alpha' ceremony code-reviewer)"
+codex_model="$(get_agent_model 'codex:gpt-5.6-luna' ceremony code-reviewer)"
+cc_cmd="$(get_agent_command 'commandcode:stealth/ox-alpha' ceremony code-reviewer)"
+codex_cmd="$(get_agent_command 'codex:gpt-5.6-luna' ceremony code-reviewer)"
+if [[ "$cc_model" == stealth/ox-alpha && "$codex_model" == gpt-5.6-luna && "$cc_cmd" == *'commandcode-exec.sh stealth/ox-alpha'* && "$codex_cmd" == *'--model gpt-5.6-luna'* ]]; then test_pass; else test_fail "model-qualified dispatch mismatch"; fi
+
+test_case "review order keeps same-provider model variants and Ox Alpha before Luna"
+fake="$TEST_TMP_DIR/provider-check.sh"
 cat > "$fake" <<'CHECK'
 #!/usr/bin/env bash
 echo commandcode:available
@@ -35,34 +45,38 @@ order="$(OCTOPUS_PROVIDER_CHECKER="$fake" OCTOPUS_COUNCIL_DEFAULT_PROVIDERS='com
 ox_line="$(printf '%s\n' "$order" | grep -n -F 'commandcode:stealth/ox-alpha' | head -1 | cut -d: -f1)"
 luna_line="$(printf '%s\n' "$order" | grep -n -F 'codex:gpt-5.6-luna' | head -1 | cut -d: -f1)"
 all_present=true
-for spec in \
-  'commandcode:stealth/ox-alpha' \
-  'commandcode:minimaxai/minimax-m3' \
-  'commandcode:deepseek/deepseek-v4-flash' \
-  'codex:gpt-5.6-luna' \
-  'codex:gpt-5.6-sol'; do
+for spec in 'commandcode:stealth/ox-alpha' 'commandcode:minimaxai/minimax-m3' 'commandcode:deepseek/deepseek-v4-flash' 'codex:gpt-5.6-luna' 'codex:gpt-5.6-sol'; do
   printf '%s\n' "$order" | grep -Fxq "$spec" || all_present=false
 done
-[[ "$all_present" == true && -n "$ox_line" && -n "$luna_line" && "$ox_line" -lt "$luna_line" ]] && ok review-order || bad review-order
-rm -f "$fake"
+if [[ "$all_present" == true && -n "$ox_line" && -n "$luna_line" && "$ox_line" -lt "$luna_line" ]]; then test_pass; else test_fail "review order mismatch"; fi
 
 source scripts/lib/council.sh
 council_prompt_for_member(){ echo prompt; }
 council_persona_should_fail(){ return 1; }
 run_quorum_case(){
   local roster="$1" d
-  d=$(mktemp -d); mkdir -p "$d/responses"
-  COUNCIL_RUN_DIR="$d" COUNCIL_DEPTH=standard COUNCIL_FIXTURE=full-success COUNCIL_EXECUTION_MODE="" \
-  COUNCIL_TASK=x COUNCIL_GOAL=advice COUNCIL_DOMAIN=auto COUNCIL_STYLE=balanced COUNCIL_ROSTER_JSON="$roster"
+  d="$TEST_TMP_DIR/quorum-$RANDOM"
+  mkdir -p "$d/responses"
+  COUNCIL_RUN_DIR="$d"
+  COUNCIL_DEPTH=standard
+  COUNCIL_FIXTURE=full-success
+  COUNCIL_EXECUTION_MODE=""
+  COUNCIL_TASK=x
+  COUNCIL_GOAL=advice
+  COUNCIL_DOMAIN=auto
+  COUNCIL_STYLE=balanced
+  COUNCIL_ROSTER_JSON="$roster"
   council_run_advice_phase >/dev/null 2>&1 || true
-  rm -rf "$d"
 }
+
+test_case "same provider with different model families contributes independent quorum"
 case_a='[{"persona":"strategy-analyst","seat":"chair","agent_spec":"claude-sonnet","provider":"claude-sonnet","provider_org":"anthropic","model":"claude-sonnet-5","model_family":"anthropic"},{"persona":"code-reviewer","seat":"member","agent_spec":"commandcode:minimaxai/minimax-m3","provider":"commandcode","provider_org":"commandcode","model":"minimaxai/minimax-m3","model_family":"minimax"},{"persona":"backend-architect","seat":"member","agent_spec":"commandcode:deepseek/deepseek-v4-flash","provider":"commandcode","provider_org":"commandcode","model":"deepseek/deepseek-v4-flash","model_family":"deepseek"}]'
 run_quorum_case "$case_a"
-[[ "$COUNCIL_QUORUM_MET" == true && "$COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES" == 2 && "$COUNCIL_DISTINCT_APPROVING_PROVIDERS" == 1 ]] && ok same-provider-different-families || bad same-provider-different-families
+if [[ "$COUNCIL_QUORUM_MET" == true && "$COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES" == 2 && "$COUNCIL_DISTINCT_APPROVING_PROVIDERS" == 1 ]]; then test_pass; else test_fail "same-provider family quorum mismatch"; fi
+
+test_case "different providers with one model family do not create false independence"
 case_b='[{"persona":"strategy-analyst","seat":"chair","agent_spec":"claude-sonnet","provider":"claude-sonnet","provider_org":"anthropic","model":"claude-sonnet-5","model_family":"anthropic"},{"persona":"code-reviewer","seat":"member","agent_spec":"commandcode:openai/gpt-5","provider":"commandcode","provider_org":"commandcode","model":"openai/gpt-5","model_family":"openai"},{"persona":"backend-architect","seat":"member","agent_spec":"codex:gpt-5.6-luna","provider":"codex","provider_org":"openai","model":"gpt-5.6-luna","model_family":"openai"}]'
 run_quorum_case "$case_b"
-[[ "$COUNCIL_QUORUM_MET" == false && "$COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES" == 1 && "$COUNCIL_DISTINCT_APPROVING_PROVIDERS" == 2 ]] && ok different-provider-same-family || bad different-provider-same-family
+if [[ "$COUNCIL_QUORUM_MET" == false && "$COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES" == 1 && "$COUNCIL_DISTINCT_APPROVING_PROVIDERS" == 2 ]]; then test_pass; else test_fail "same-family quorum mismatch"; fi
 
-echo "Passed: $PASS  Failed: $FAIL"
-[[ $FAIL -eq 0 ]]
+test_summary

--- a/tests/unit/test-model-aware-seats.sh
+++ b/tests/unit/test-model-aware-seats.sh
@@ -15,6 +15,15 @@ if [[ "$(octo_agent_spec_executor 'commandcode:stealth/ox-alpha')" == commandcod
 test_case "agent spec slug is path-safe"
 [[ "$(octo_agent_spec_slug 'commandcode:stealth/ox-alpha')" == commandcode_stealth_ox-alpha ]] && test_pass || test_fail "unexpected slug"
 
+test_case "legacy executor aliases stay intact while provider identity is canonicalized"
+if [[ "$(octo_agent_spec_executor 'codex-standard')" == codex-standard ]] && \
+   [[ "$(octo_agent_spec_provider 'codex-standard')" == codex ]] && \
+   [[ "$(octo_agent_spec_provider 'commandcode:stealth/ox-alpha')" == commandcode ]]; then
+  test_pass
+else
+  test_fail "executor alias and provider identity were conflated"
+fi
+
 test_case "model family distinguishes MiniMax and OpenAI"
 if [[ "$(octo_model_family 'commandcode:minimaxai/minimax-m3')" == minimax ]] && \
    [[ "$(octo_model_family 'codex:gpt-5.6-luna')" == openai ]]; then test_pass; else test_fail "model family mismatch"; fi

--- a/tests/unit/test-provider-history-toggle.sh
+++ b/tests/unit/test-provider-history-toggle.sh
@@ -73,4 +73,21 @@ else
     test_fail "model-qualified provider history was not normalized to commandcode-history.md"
 fi
 
+
+test_case "provider history filename key cannot escape the providers directory"
+rm -rf "$WORKSPACE_DIR"
+mkdir -p "$WORKSPACE_DIR" "$RESULTS_DIR"
+source "$PROJECT_ROOT/scripts/lib/provider-lockout.sh"
+unset OCTOPUS_PROVIDER_HISTORY || true
+append_provider_history '../../escaped' tangle "task" "safe history"
+safe_file="$(find "$WORKSPACE_DIR/.octo/providers" -maxdepth 1 -type f -name '*escaped*-history.md' | head -1)"
+if [[ -n "$safe_file" ]] && \
+   [[ "$safe_file" == "$WORKSPACE_DIR/.octo/providers/"* ]] && \
+   [[ ! -e "$WORKSPACE_DIR/escaped-history.md" ]] && \
+   [[ ! -e "$WORKSPACE_DIR/.octo/escaped-history.md" ]]; then
+    test_pass
+else
+    test_fail "provider history path escaped or safe file missing: ${safe_file:-none}"
+fi
+
 test_summary

--- a/tests/unit/test-provider-history-toggle.sh
+++ b/tests/unit/test-provider-history-toggle.sh
@@ -108,10 +108,14 @@ for pid in $pids; do wait "$pid"; done
 history_file="$WORKSPACE_DIR/.octo/providers/commandcode-history.md"
 entry_count="$(grep -c '^### ' "$history_file" 2>/dev/null || true)"
 leftovers="$(find "$WORKSPACE_DIR/.octo/providers" -maxdepth 1 \( -name 'commandcode-history.md.tmp.*' -o -name 'commandcode-history.md.lock' \) -print)"
-if [[ "$entry_count" == '50' ]] && [[ -z "$leftovers" ]]; then
+missing=""
+for i in $(seq 49 56); do
+    grep -Fq "**Task:** concurrent-$i" "$history_file" || missing="$missing $i"
+done
+if [[ "$entry_count" == '50' ]] && [[ -z "$leftovers" ]] && [[ -z "$missing" ]]; then
     test_pass
 else
-    test_fail "concurrent history transaction was not serialized: entries=$entry_count leftovers=${leftovers:-none}"
+    test_fail "concurrent history transaction was not serialized: entries=$entry_count leftovers=${leftovers:-none} missing=${missing:-none}"
 fi
 
 test_summary

--- a/tests/unit/test-provider-history-toggle.sh
+++ b/tests/unit/test-provider-history-toggle.sh
@@ -59,4 +59,18 @@ else
     test_fail "quality.sh provider history toggle behavior regressed"
 fi
 
+test_case "model-qualified provider history writes to the normalized executor file"
+rm -rf "$WORKSPACE_DIR"
+mkdir -p "$WORKSPACE_DIR" "$RESULTS_DIR"
+source "$PROJECT_ROOT/scripts/lib/provider-lockout.sh"
+unset OCTOPUS_PROVIDER_HISTORY || true
+append_provider_history 'commandcode:stealth/ox-alpha' tangle "task" "model-aware history"
+if [[ -f "$WORKSPACE_DIR/.octo/providers/commandcode-history.md" ]] && \
+   [[ ! -e "$WORKSPACE_DIR/.octo/providers/commandcode:stealth/ox-alpha-history.md" ]] && \
+   grep -Fq 'model-aware history' "$WORKSPACE_DIR/.octo/providers/commandcode-history.md"; then
+    test_pass
+else
+    test_fail "model-qualified provider history was not normalized to commandcode-history.md"
+fi
+
 test_summary

--- a/tests/unit/test-provider-history-toggle.sh
+++ b/tests/unit/test-provider-history-toggle.sh
@@ -90,4 +90,28 @@ else
     test_fail "provider history path escaped or safe file missing: ${safe_file:-none}"
 fi
 
+
+test_case "concurrent model-qualified seats serialize shared provider history append and trim"
+rm -rf "$WORKSPACE_DIR"
+mkdir -p "$WORKSPACE_DIR" "$RESULTS_DIR"
+source "$PROJECT_ROOT/scripts/lib/provider-lockout.sh"
+unset OCTOPUS_PROVIDER_HISTORY || true
+for i in $(seq 1 48); do
+    append_provider_history 'commandcode:stealth/ox-alpha' tangle "seed-$i" "seed history $i"
+done
+pids=""
+for i in $(seq 49 56); do
+    append_provider_history "commandcode:model-$i" tangle "concurrent-$i" "concurrent history $i" &
+    pids="$pids $!"
+done
+for pid in $pids; do wait "$pid"; done
+history_file="$WORKSPACE_DIR/.octo/providers/commandcode-history.md"
+entry_count="$(grep -c '^### ' "$history_file" 2>/dev/null || true)"
+leftovers="$(find "$WORKSPACE_DIR/.octo/providers" -maxdepth 1 \( -name 'commandcode-history.md.tmp.*' -o -name 'commandcode-history.md.lock' \) -print)"
+if [[ "$entry_count" == '50' ]] && [[ -z "$leftovers" ]]; then
+    test_pass
+else
+    test_fail "concurrent history transaction was not serialized: entries=$entry_count leftovers=${leftovers:-none}"
+fi
+
 test_summary

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -169,12 +169,20 @@ else
 fi
 
 test_case "review order supports multiple models from one provider with Ox Alpha before Luna"
-order="$(OCTOPUS_COUNCIL_DEFAULT_PROVIDERS='commandcode:stealth/ox-alpha,commandcode:minimaxai/minimax-m3,commandcode:deepseek/deepseek-v4-flash,codex:gpt-5.6-luna,codex:gpt-5.6-sol' bash "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" review-order standard test 2>/dev/null)"
+order="$(OCTOPUS_PROVIDER_CHECKER="$CHECKER" OCTOPUS_COUNCIL_DEFAULT_PROVIDERS='commandcode:stealth/ox-alpha,commandcode:minimaxai/minimax-m3,commandcode:deepseek/deepseek-v4-flash,codex:gpt-5.6-luna,codex:gpt-5.6-sol' bash "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" review-order standard test 2>/dev/null)"
 first_four="$(printf '%s\n' "$order" | sed -n '1,4p')"
 if [[ "$first_four" == $'commandcode:stealth/ox-alpha\ncommandcode:minimaxai/minimax-m3\ncommandcode:deepseek/deepseek-v4-flash\ncodex:gpt-5.6-luna' ]]; then
   test_pass
 else
   test_fail "model-qualified council order mismatch: $(tr '\n' '|' <<< "$order")"
+fi
+
+test_case "wrapped degenerate consultative output is rejected"
+wrapped_bad=$'## UNVERIFIED CONSULTATIVE OUTPUT\n\nThis output came from a disposable workspace. It is advisory and non-deliverable. Claimed file changes, test counts, live probes, or completed implementation are not verified evidence and must not be reported as delivered work.\n\nPROJECT_DOCUMENTATION_PATH: /tmp/repo\n\n## END UNVERIFIED CONSULTATIVE OUTPUT'
+if design_review_approach_valid "$wrapped_bad"; then
+  test_fail "wrapper/disclaimer masked degenerate inner payload"
+else
+  test_pass
 fi
 
 test_summary

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -89,7 +89,7 @@ octo_provider_identity_label() { printf '%s / fixture\n' "$1"; }
 write_structured_decision() { :; }
 run_agent_sync_consultative() {
   printf '%s|%s|%s\n' "$1" "$4" "$5" >> "$CAPTURE"
-  printf '%s\n' 'planning output'
+  printf '%s\n' '- Architecture: keep boundaries explicit and preserve existing contracts.' '- Risks: validate edge cases, dependency failures, and integration behavior.' '- Testing: run focused unit coverage plus end-to-end verification before delivery.'
 }
 design_review_ceremony "test" >/dev/null
 roles="$(cut -d'|' -f2 "$CAPTURE" | tr '\n' '|')"
@@ -122,6 +122,59 @@ if [[ "$model" == "minimaxai/minimax-m3" ]]; then
   test_pass
 else
   test_fail "expected provider-local MiniMax researcher model, got '$model'"
+fi
+
+test_case "design review retries the same model before falling back"
+CALLS="$TMP_HOME/retry.calls"
+: > "$CALLS"
+log() { :; }
+design_review_candidate_agents() { printf '%s\n' 'commandcode:stealth/ox-alpha' 'codex:gpt-5.6-luna'; }
+run_agent_sync_consultative() {
+  printf '%s\n' "$1" >> "$CALLS"
+  if [[ "$(wc -l < "$CALLS" | tr -d ' ')" == "1" ]]; then
+    printf '%s\n' 'PROJECT_DOCUMENTATION_PATH: /tmp/repo'
+  else
+    printf '%s\n' '- Architecture: preserve current contracts and isolate the change behind a narrow interface.' '- Risks: validate provider failures and malformed outputs without reducing review coverage.' '- Testing: exercise retry, fallback, and successful synthesis paths with deterministic fixtures.'
+  fi
+}
+retry_out=""; retry_agent=""
+design_review_run_seat_with_recovery 'commandcode:minimaxai/minimax-m3' 'code-reviewer' 'prompt' 0   'commandcode:minimaxai/minimax-m3 codex:gpt-5.6-luna' retry_out retry_agent
+if [[ "$retry_agent" == 'commandcode:minimaxai/minimax-m3' ]] && [[ "$(wc -l < "$CALLS" | tr -d ' ')" == "2" ]]; then
+  test_pass
+else
+  test_fail "same-seat retry did not recover: agent=$retry_agent calls=$(tr '\n' '|' < "$CALLS")"
+fi
+
+test_case "design review falls back through the shared council order after retry exhaustion"
+CALLS="$TMP_HOME/fallback.calls"
+: > "$CALLS"
+design_review_candidate_agents() {
+  printf '%s\n'     'commandcode:minimaxai/minimax-m3'     'commandcode:stealth/ox-alpha'     'codex:gpt-5.6-luna'
+}
+run_agent_sync_consultative() {
+  printf '%s\n' "$1" >> "$CALLS"
+  case "$1" in
+    commandcode:minimaxai/minimax-m3) printf '%s\n' 'PROJECT_DOCUMENTATION_PATH: /tmp/repo' ;;
+    commandcode:stealth/ox-alpha)
+      printf '%s\n' '- Architecture: use the existing orchestration path and preserve seat semantics.' '- Risks: recover invalid provider output without silently dropping an independent perspective.' '- Testing: verify model-qualified fallback order and best-effort degradation behavior.' ;;
+    *) printf '%s\n' 'unexpected fallback' ;;
+  esac
+}
+fallback_out=""; fallback_agent=""
+design_review_run_seat_with_recovery 'commandcode:minimaxai/minimax-m3' 'code-reviewer' 'prompt' 0   'commandcode:minimaxai/minimax-m3 codex:gpt-5.6-luna' fallback_out fallback_agent
+if [[ "$fallback_agent" == 'commandcode:stealth/ox-alpha' ]] &&    [[ "$(sed -n '3p' "$CALLS")" == 'commandcode:stealth/ox-alpha' ]]; then
+  test_pass
+else
+  test_fail "fallback order wrong: agent=$fallback_agent calls=$(tr '\n' '|' < "$CALLS")"
+fi
+
+test_case "review order supports multiple models from one provider with Ox Alpha before Luna"
+order="$(OCTOPUS_COUNCIL_DEFAULT_PROVIDERS='commandcode:stealth/ox-alpha,commandcode:minimaxai/minimax-m3,commandcode:deepseek/deepseek-v4-flash,codex:gpt-5.6-luna,codex:gpt-5.6-sol' bash "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" review-order standard test 2>/dev/null)"
+first_four="$(printf '%s\n' "$order" | sed -n '1,4p')"
+if [[ "$first_four" == $'commandcode:stealth/ox-alpha\ncommandcode:minimaxai/minimax-m3\ncommandcode:deepseek/deepseek-v4-flash\ncodex:gpt-5.6-luna' ]]; then
+  test_pass
+else
+  test_fail "model-qualified council order mismatch: $(tr '\n' '|' <<< "$order")"
 fi
 
 test_summary

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -185,4 +185,13 @@ else
   test_pass
 fi
 
+test_case "large wrapped degenerate consultative output is rejected"
+large_meta="$(printf 'X%.0s' {1..131072})"
+wrapped_large=$'## UNVERIFIED CONSULTATIVE OUTPUT\n\nThis output came from a disposable workspace. It is advisory and non-deliverable. Claimed file changes, test counts, live probes, or completed implementation are not verified evidence and must not be reported as delivered work.\n\nPROJECT_DOCUMENTATION_PATH: /tmp/repo-'"$large_meta"$'\n\n## END UNVERIFIED CONSULTATIVE OUTPUT'
+if design_review_approach_valid "$wrapped_large"; then
+  test_fail "large wrapper payload bypassed inner-content validation"
+else
+  test_pass
+fi
+
 test_summary

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -210,4 +210,105 @@ else
   test_fail "substantive prose with colon was rejected as metadata"
 fi
 
+
+test_case "invalid outputs are persisted as bounded diagnostic artifacts"
+RESULTS_DIR="$TMP_HOME/diagnostic-results"
+export RESULTS_DIR
+rm -rf "$RESULTS_DIR"
+mkdir -p "$RESULTS_DIR"
+large_invalid="$(printf 'X%.0s' {1..20000})"
+design_review_write_invalid_diagnostic "seat" "code-reviewer" "commandcode:stealth/ox-alpha" "1" "0" "too_few_words" "$large_invalid"
+diag_file="$(find "$RESULTS_DIR/design-review-diagnostics" -type f -name 'seat-code-reviewer-*.json' | head -1)"
+if [[ -n "$diag_file" ]] && \
+   [[ "$(jq -r '.agent_spec' "$diag_file")" == 'commandcode:stealth/ox-alpha' ]] && \
+   [[ "$(jq -r '.validation_failure' "$diag_file")" == 'too_few_words' ]] && \
+   [[ "$(jq -r '.bytes' "$diag_file")" == '20000' ]] && \
+   [[ "$(jq -r '.raw_truncated' "$diag_file")" == 'true' ]] && \
+   [[ "$(jq -r '.raw_excerpt | length' "$diag_file")" == '16384' ]]; then
+  test_pass
+else
+  test_fail "bounded diagnostic artifact missing or malformed: file=$diag_file"
+fi
+
+test_case "design review synthesis retries the same model before fallback"
+RESULTS_DIR="$TMP_HOME/synthesis-retry-results"
+export RESULTS_DIR
+rm -rf "$RESULTS_DIR"
+mkdir -p "$RESULTS_DIR"
+CALLS="$TMP_HOME/synthesis-retry.calls"
+: > "$CALLS"
+design_review_candidate_agents() { printf '%s\n' 'commandcode:stealth/ox-alpha' 'codex:gpt-5.6-luna'; }
+run_agent_sync_consultative() {
+  printf '%s\n' "$1" >> "$CALLS"
+  if [[ "$(wc -l < "$CALLS" | tr -d ' ')" == "1" ]]; then
+    printf '%s\n' 'PROJECT_DOCUMENTATION_PATH: /tmp/repo'
+  else
+    printf '%s\n' 'CONFLICTS: The reviewers differ on sequencing but agree on preserving the existing orchestration boundary.' 'GAPS: Failure diagnostics and retry semantics need explicit validation before implementation continues.' 'RESOLUTION: Keep the current architecture, retry the same synthesizer once, then use the shared review pool only if the second response is still invalid.'
+  fi
+}
+synth_out=""; synth_agent=""
+design_review_run_synthesis_with_recovery 'commandcode:minimaxai/minimax-m3' 'synthesis prompt' 0 \
+  'commandcode:minimaxai/minimax-m3 codex:gpt-5.6-luna' synth_out synth_agent
+if [[ "$synth_agent" == 'commandcode:minimaxai/minimax-m3' ]] && \
+   [[ "$(wc -l < "$CALLS" | tr -d ' ')" == '2' ]] && \
+   [[ "$synth_out" == *'RESOLUTION:'* ]] && \
+   find "$RESULTS_DIR/design-review-diagnostics" -type f -name 'synthesis-synthesizer-*.json' | grep -q .; then
+  test_pass
+else
+  test_fail "same-model synthesis retry did not recover: agent=$synth_agent calls=$(tr '\n' '|' < "$CALLS")"
+fi
+
+test_case "design review synthesis falls back through the shared review order"
+RESULTS_DIR="$TMP_HOME/synthesis-fallback-results"
+export RESULTS_DIR
+rm -rf "$RESULTS_DIR"
+mkdir -p "$RESULTS_DIR"
+CALLS="$TMP_HOME/synthesis-fallback.calls"
+: > "$CALLS"
+design_review_candidate_agents() {
+  printf '%s\n' 'commandcode:minimaxai/minimax-m3' 'commandcode:stealth/ox-alpha' 'codex:gpt-5.6-luna'
+}
+run_agent_sync_consultative() {
+  printf '%s\n' "$1" >> "$CALLS"
+  case "$1" in
+    commandcode:minimaxai/minimax-m3) printf '%s\n' 'PROJECT_DOCUMENTATION_PATH: /tmp/repo' ;;
+    commandcode:stealth/ox-alpha)
+      printf '%s\n' 'CONFLICTS: The seats disagree on implementation ordering, but not on the desired contract.' 'GAPS: The review needs explicit failure diagnostics and bounded fallback behavior.' 'RESOLUTION: Preserve the admitted review pool, record the failed synthesizer output, and continue with this alternate synthesizer for the final planning summary.' ;;
+    *) printf '%s\n' 'unexpected synthesis candidate' ;;
+  esac
+}
+synth_out=""; synth_agent=""
+design_review_run_synthesis_with_recovery 'commandcode:minimaxai/minimax-m3' 'synthesis prompt' 0 \
+  'commandcode:minimaxai/minimax-m3 codex:gpt-5.6-luna' synth_out synth_agent
+if [[ "$synth_agent" == 'commandcode:stealth/ox-alpha' ]] && \
+   [[ "$(sed -n '3p' "$CALLS")" == 'commandcode:stealth/ox-alpha' ]] && \
+   [[ "$synth_out" == *'RESOLUTION:'* ]]; then
+  test_pass
+else
+  test_fail "synthesis fallback order wrong: agent=$synth_agent calls=$(tr '\n' '|' < "$CALLS")"
+fi
+
+test_case "design review synthesis degrades explicitly after exhausting the pool"
+RESULTS_DIR="$TMP_HOME/synthesis-degraded-results"
+export RESULTS_DIR
+rm -rf "$RESULTS_DIR"
+mkdir -p "$RESULTS_DIR"
+CALLS="$TMP_HOME/synthesis-degraded.calls"
+: > "$CALLS"
+design_review_candidate_agents() { printf '%s\n' 'commandcode:minimaxai/minimax-m3'; }
+run_agent_sync_consultative() {
+  printf '%s\n' "$1" >> "$CALLS"
+  printf '%s\n' 'PROJECT_DOCUMENTATION_PATH: /tmp/repo'
+}
+synth_out="sentinel"; synth_agent=""
+design_review_run_synthesis_with_recovery 'commandcode:minimaxai/minimax-m3' 'synthesis prompt' 0 \
+  'commandcode:minimaxai/minimax-m3' synth_out synth_agent
+if [[ -z "$synth_out" ]] && \
+   [[ "$synth_agent" == 'commandcode:minimaxai/minimax-m3' ]] && \
+   [[ "$(wc -l < "$CALLS" | tr -d ' ')" == '2' ]]; then
+  test_pass
+else
+  test_fail "synthesis did not degrade cleanly after pool exhaustion: agent=$synth_agent output=$synth_out calls=$(tr '\n' '|' < "$CALLS")"
+fi
+
 test_summary

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -311,4 +311,37 @@ else
   test_fail "synthesis did not degrade cleanly after pool exhaustion: agent=$synth_agent output=$synth_out calls=$(tr '\n' '|' < "$CALLS")"
 fi
 
+
+test_case "wrapper marker quoted in substantive prose is not unwrapped"
+quoted_marker='Recommendation: document the literal marker ## UNVERIFIED CONSULTATIVE OUTPUT as part of the trust-boundary protocol, but preserve this substantive review response and continue validating architecture, retries, diagnostics, and fallback behavior normally.'
+if [[ "$(design_review_unwrap_consultative_output "$quoted_marker")" == "$quoted_marker" ]] && design_review_approach_valid "$quoted_marker"; then
+  test_pass
+else
+  test_fail "marker quoted in prose was misclassified as a wrapper header"
+fi
+
+test_case "synthesis dispatch scopes supervised execution env without leaking to caller"
+RESULTS_DIR="$TMP_HOME/synthesis-env-results"
+export RESULTS_DIR
+mkdir -p "$RESULTS_DIR"
+export OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED='caller-value'
+CALL_ENV="$TMP_HOME/synthesis-env.calls"
+: > "$CALL_ENV"
+design_review_candidate_agents() { printf '%s\n' 'commandcode:stealth/ox-alpha'; }
+run_agent_sync_consultative() {
+  printf '%s\n' "${OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED:-unset}" >> "$CALL_ENV"
+  printf '%s\n' 'CONFLICTS: The approaches differ only in sequencing and all preserve the established runtime boundaries.' 'GAPS: Diagnostics and retry behavior need explicit regression coverage across provider failures.' 'RESOLUTION: Keep the existing architecture, validate the bounded diagnostic artifacts, and use the shared fallback pool only after retrying the same synthesizer.'
+}
+synth_out=""; synth_agent=""
+design_review_run_synthesis_with_recovery 'commandcode:stealth/ox-alpha' 'synthesis prompt' 0 \
+  'commandcode:stealth/ox-alpha' synth_out synth_agent
+if [[ "$(head -1 "$CALL_ENV")" == 'design-review-ceremony' ]] && \
+   [[ "$OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED" == 'caller-value' ]] && \
+   [[ -n "$synth_out" ]]; then
+  test_pass
+else
+  test_fail "synthesis env scope leaked or was not applied"
+fi
+unset OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED
+
 test_summary

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -194,4 +194,20 @@ else
   test_pass
 fi
 
+test_case "lowercase metadata key with dotted path is rejected"
+lowercase_path='project_documentation_path: /tmp/repo/README.md with additional metadata words that should never count as substantive review content for this seat'
+if design_review_approach_valid "$lowercase_path"; then
+  test_fail "lowercase dotted path metadata passed validation"
+else
+  test_pass
+fi
+
+test_case "ordinary prose containing a colon is not treated as path metadata"
+prose='Recommendation: preserve the existing orchestration contract, validate fallback behavior carefully, and add regression coverage for provider failures before merging the implementation.'
+if design_review_approach_valid "$prose"; then
+  test_pass
+else
+  test_fail "substantive prose with colon was rejected as metadata"
+fi
+
 test_summary

--- a/tests/unit/test-provider-router-canonical-ids.sh
+++ b/tests/unit/test-provider-router-canonical-ids.sh
@@ -51,4 +51,14 @@ status=$(get_circuit_breaker_status)
 rm -f "$_PROVIDER_STATE_DIR/agy.cooldown"
 if [[ "$status" == *"agy: OPEN"* || "$status" == *"agy: half-open"* ]] && [[ -n "$(octo_provider_ids dispatch)" ]]; then test_pass; else test_fail "runtime circuit breaker omitted Antigravity: $status"; fi
 
+
+test_case "spawn provider metrics aggregate by canonical provider prefix"
+spawn_file="$PROJECT_ROOT/scripts/lib/spawn.sh"
+if grep -Fq 'local provider_name="$provider_prefix"' "$spawn_file" && \
+   ! grep -Fq '*) provider_name="$agent_type" ;;' "$spawn_file"; then
+    test_pass
+else
+    test_fail "spawn provider metrics can still split model-qualified specs"
+fi
+
 test_summary

--- a/tests/unit/test-review-round1-spawn-failure.sh
+++ b/tests/unit/test-review-round1-spawn-failure.sh
@@ -50,6 +50,7 @@ else
     {
         echo '#!/usr/bin/env bash'
         echo 'set -eo pipefail'  # mirrors orchestrate.sh exactly
+        printf 'source %q\n' "$PROJECT_ROOT/scripts/lib/agent-spec.sh"
         echo 'RESULTS_DIR="'"$TEST_TMP_DIR"'"'
         echo 'timestamp="ts1"'
         echo 'fleet="codex:reviewer1:logic


### PR DESCRIPTION
## Summary
- support model-qualified seat identities (`provider:model`) across Octopus dispatch/fleet/council paths
- separate execution provider, explicit model, and model family so multi-model routers such as CommandCode can contribute independent model families
- evaluate council diversity/quorum by `model_family` while preserving legacy provider metrics for runtime diagnostics
- add Design Review recovery: retry the same seat/model first, then fall back through the existing council review order, then continue explicitly degraded only after the admitted pool is exhausted
- reject semantically empty/path-fragment review outputs and report the effective fallback seat labels

## Model-aware behavior
- `commandcode:stealth/ox-alpha`, `commandcode:minimaxai/minimax-m3`, and `commandcode:deepseek/deepseek-v4-flash` can coexist in the same pool
- `codex:gpt-5.6-luna` and `codex:gpt-5.6-sol` can coexist in the same pool
- Ox Alpha is kept ahead of Luna in the tested review order
- same provider + different model families can satisfy independent-family quorum
- different providers + the same model family do not create false independence

## Validation
- `tests/unit/test-model-aware-seats.sh`: 12/12
- `tests/unit/test-provider-neutral-design-review.sh`: 9/9
- `tests/unit/test-dispatch-round-trip.sh`: 6/6
- `tests/unit/test-provider-allowlist.sh`: 13/13
- `tests/unit/test-provider-neutral-council.sh`: 6/6
- `tests/unit/test-consultative-agent-dispatch.sh`: 8/8
- `tests/unit/test-spawn-agent-capture-pid.sh`: 10/10
- `tests/unit/test-provider-health-fleet.sh`: 13/13
- `make test-smoke`: exit 0
- `git diff --check`: clean
- touched shell files pass `bash -n`

## Baseline note
`make sync-check` currently fails on clean `upstream/main` (`6a1fd2b2`) with `CHECK: skills/ is out of date — run scripts/build-codex-skills.sh`. The same failure reproduces unchanged on this branch, so this PR intentionally does not mix unrelated generated-skill churn into the model-aware seating change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for model-qualified agent selections and model-family-aware routing.
  * Council reviews now measure quorum across distinct model families, with optional one-vote-per-family handling.
  * Added recovery and fallback options for failed or low-quality design-review responses.
  * Added a way to view eligible review providers without running review prompts.

* **Bug Fixes**
  * Improved provider normalization, model validation, quota handling, and result-file naming.
  * Improved review ordering and reliability across multiple providers and models.
  * Improved concurrent provider history handling and degraded-mode reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->