### PR TITLE
fix(council): namespace review roles from execution routing

### DIFF
--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -855,6 +855,25 @@ ${prompt}"
     fi
 }
 
+# Map namespaced council roles to their legacy persona/tool-policy semantics.
+# Model/provider routing must keep the original namespaced role so council seats
+# cannot inherit unrelated execution-role routes from routing.roles.
+octo_persona_role() {
+    case "${1:-}" in
+        design-feasibility-reviewer) echo "implementer" ;;
+        design-research-reviewer) echo "researcher" ;;
+        design-code-reviewer) echo "code-reviewer" ;;
+        design-synthesizer) echo "synthesizer" ;;
+        implementation-logic-reviewer) echo "logic-reviewer" ;;
+        implementation-security-reviewer) echo "security-reviewer" ;;
+        implementation-architecture-reviewer) echo "arch-reviewer" ;;
+        implementation-cve-reviewer) echo "cve-reviewer" ;;
+        implementation-diversity-reviewer) echo "reviewer" ;;
+        implementation-verifier|implementation-debater|implementation-synthesizer) echo "code-reviewer" ;;
+        *) printf '%s\n' "${1:-}" ;;
+    esac
+}
+
 # Apply persona instruction to a prompt
 # Usage: apply_persona <role> <prompt>
 # Returns: Enhanced prompt with persona prefix
@@ -870,8 +889,9 @@ apply_persona() {
         return
     fi
 
-    local persona
-    persona=$(get_persona_instruction "$role")
+    local persona_role persona
+    persona_role="$(octo_persona_role "$role")"
+    persona=$(get_persona_instruction "$persona_role")
 
     if [[ -z "$persona" ]]; then
         echo "$prompt"
@@ -891,7 +911,7 @@ EOF
 )
 
     # v8.19.0: Apply tool policy RBAC (v8.53.0: pass agent_name for readonly check)
-    combined=$(apply_tool_policy "$role" "$combined" "$agent_name")
+    combined=$(apply_tool_policy "$persona_role" "$combined" "$agent_name")
 
     echo "$combined"
 }

--- a/scripts/lib/quality.sh
+++ b/scripts/lib/quality.sh
@@ -455,10 +455,10 @@ Be concise and specific. This is a planning exercise, not implementation."
     [[ "$design_synth_timeout" != "0" ]] && _synth_timeout_label="${design_synth_timeout}s"
 
     local seat_1_label seat_2_label seat_3_label synthesis_label
-    seat_1_label="$(octo_provider_identity_label "$design_implementer_agent" "implementer")"
-    seat_2_label="$(octo_provider_identity_label "$design_researcher_agent" "researcher")"
-    seat_3_label="$(octo_provider_identity_label "$design_code_reviewer_agent" "code-reviewer")"
-    synthesis_label="$(octo_provider_identity_label "$design_synthesizer_agent" "synthesizer")"
+    seat_1_label="$(octo_provider_identity_label "$design_implementer_agent" "design-feasibility-reviewer")"
+    seat_2_label="$(octo_provider_identity_label "$design_researcher_agent" "design-research-reviewer")"
+    seat_3_label="$(octo_provider_identity_label "$design_code_reviewer_agent" "design-code-reviewer")"
+    synthesis_label="$(octo_provider_identity_label "$design_synthesizer_agent" "design-synthesizer")"
 
     log INFO "Design review: gathering role approaches..."
     log INFO "Design review seats: seat_1=${seat_1_label}, seat_2=${seat_2_label}, seat_3=${seat_3_label}, synthesis=${synthesis_label}, timeout=${_design_timeout_label}, synth_timeout=${_synth_timeout_label}"
@@ -466,19 +466,19 @@ Be concise and specific. This is a planning exercise, not implementation."
     seat_1_approach="$(
         (
             export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
-            run_agent_sync_consultative "$design_implementer_agent" "$ceremony_prompt" "$design_timeout" "implementer" "ceremony"
+            run_agent_sync_consultative "$design_implementer_agent" "$ceremony_prompt" "$design_timeout" "design-feasibility-reviewer" "ceremony"
         ) 2>/dev/null
     )" || true
     seat_2_approach="$(
         (
             export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
-            run_agent_sync_consultative "$design_researcher_agent" "$ceremony_prompt" "$design_timeout" "researcher" "ceremony"
+            run_agent_sync_consultative "$design_researcher_agent" "$ceremony_prompt" "$design_timeout" "design-research-reviewer" "ceremony"
         ) 2>/dev/null
     )" || true
     seat_3_approach="$(
         (
             export "OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED=design-review-ceremony"
-            run_agent_sync_consultative "$design_code_reviewer_agent" "$ceremony_prompt" "$design_timeout" "code-reviewer" "ceremony"
+            run_agent_sync_consultative "$design_code_reviewer_agent" "$ceremony_prompt" "$design_timeout" "design-code-reviewer" "ceremony"
         ) 2>/dev/null
     )" || true
 
@@ -493,8 +493,8 @@ Be concise and specific. This is a planning exercise, not implementation."
             provider="$design_synthesizer_agent" provider_label_kind="legacy-alias" \
             executor_alias="$design_synthesizer_agent" \
             configured_provider="$(octo_provider_identity_from_agent_type "$design_synthesizer_agent")" \
-            configured_model="$(get_agent_model "$design_synthesizer_agent" "ceremony" "synthesizer" 2>/dev/null || echo unresolved)" \
-            runtime_provider="unknown" runtime_model="unknown" role="synthesizer" inputs="3" || true
+            configured_model="$(get_agent_model "$design_synthesizer_agent" "ceremony" "design-synthesizer" 2>/dev/null || echo unresolved)" \
+            runtime_provider="unknown" runtime_model="unknown" role="design-synthesizer" inputs="3" || true
     fi
 
     local synthesis
@@ -518,7 +518,7 @@ Identify:
 2. GAPS: What did everyone miss?
 3. RESOLUTION: The recommended unified approach (2-3 sentences)
 
-Be brief and actionable." "$design_synth_timeout" "synthesizer" "ceremony" 2>/dev/null) || true
+Be brief and actionable." "$design_synth_timeout" "design-synthesizer" "ceremony" 2>/dev/null) || true
 
     if declare -f octo_event_emit >/dev/null 2>&1; then
         local _synth_now _synth_elapsed="unknown"
@@ -529,8 +529,8 @@ Be brief and actionable." "$design_synth_timeout" "synthesizer" "ceremony" 2>/de
             provider="$design_synthesizer_agent" provider_label_kind="legacy-alias" \
             executor_alias="$design_synthesizer_agent" \
             configured_provider="$(octo_provider_identity_from_agent_type "$design_synthesizer_agent")" \
-            configured_model="$(get_agent_model "$design_synthesizer_agent" "ceremony" "synthesizer" 2>/dev/null || echo unresolved)" \
-            runtime_provider="unknown" runtime_model="unknown" role="synthesizer" \
+            configured_model="$(get_agent_model "$design_synthesizer_agent" "ceremony" "design-synthesizer" 2>/dev/null || echo unresolved)" \
+            runtime_provider="unknown" runtime_model="unknown" role="design-synthesizer" \
             status="$([[ -n "$synthesis" ]] && echo produced || echo empty)" \
             bytes="${#synthesis}" elapsed_s="$_synth_elapsed" || true
     fi

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -1432,7 +1432,7 @@ ${round1_prompts[$retry_idx]}"
         if [[ "$agent_findings" != "[]" ]] && declare -f octo_event_emit >/dev/null 2>&1; then
             while IFS=$'\t' read -r _rf_sev _rf_title; do
                 [[ -z "${_rf_sev}${_rf_title}" ]] && continue
-                octo_event_emit "review.finding" provider="$provider_key" provider_label_kind="legacy-alias" executor_alias="$atype" configured_provider="$(octo_provider_identity_from_agent_type "${atype:-unknown}")" configured_model="$(get_agent_model "$atype" "review" "reviewer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" role="reviewer" severity="${_rf_sev:-unknown}" message="${_rf_title:-}" round="1" || true
+                octo_event_emit "review.finding" provider="$provider_key" provider_label_kind="legacy-alias" executor_alias="$atype" configured_provider="$(octo_provider_identity_from_agent_type "${atype:-unknown}")" configured_model="$(get_agent_model "$atype" "review" "${round1_roles[$idx]}" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" role="${round1_roles[$idx]}" severity="${_rf_sev:-unknown}" message="${_rf_title:-}" round="1" || true
             done < <(printf '%s' "$agent_findings" | jq -r '.[]? | [(.severity // "unknown"), (.title // .message // "")] | @tsv' 2>/dev/null)
         fi
         if ! review_result_completed_successfully "$f"; then

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -70,19 +70,19 @@ _review_fleet_from_config() {
         case "$provider" in
             codex|codex-*)
                 if [[ "$has_logic" == "false" ]]; then
-                    fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+                    fleet+="${provider}:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
                     has_logic=true
                 fi
                 ;;
             opencode|opencode-*)
                 if [[ "$has_logic" == "false" ]]; then
-                    fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+                    fleet+="${provider}:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
                     has_logic=true
                 fi
                 ;;
             agy|agy-*|antigravity|gemini|gemini-*)
                 if [[ "$has_security" == "false" ]]; then
-                    fleet+="agy:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+                    fleet+="agy:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
                     has_security=true
                 fi
                 ;;
@@ -90,46 +90,46 @@ _review_fleet_from_config() {
                 if [[ "$has_arch" == "false" ]]; then
                     local agent="${provider}"
                     [[ "$provider" == "claude" ]] && agent="claude-sonnet"
-                    fleet+="${agent}:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
+                    fleet+="${agent}:implementation-architecture-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
                     has_arch=true
                 fi
                 ;;
             perplexity|perplexity-*)
                 if [[ "$has_cve" == "false" ]]; then
-                    fleet+="${provider}:cve-reviewer:known CVEs, library advisories, live web search"$'\n'
+                    fleet+="${provider}:implementation-cve-reviewer:known CVEs, library advisories, live web search"$'\n'
                     has_cve=true
                 fi
                 ;;
             openrouter|openrouter-*)
                 if [[ "$has_diversity" == "false" ]]; then
-                    fleet+="${provider}:diversity-reviewer:cross-family perspective on logic, missed assumptions, training-data divergence from primary providers"$'\n'
+                    fleet+="${provider}:implementation-diversity-reviewer:cross-family perspective on logic, missed assumptions, training-data divergence from primary providers"$'\n'
                     has_diversity=true
                 fi
                 ;;
             openai-compatible|openai-tools|openai-compatible-agent)
                 if [[ "$has_logic" == "false" ]]; then
-                    fleet+="${provider}:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+                    fleet+="${provider}:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
                     has_logic=true
                 elif [[ "$has_diversity" == "false" ]]; then
-                    fleet+="${provider}:diversity-reviewer:OpenAI-compatible independent review path"$'\n'
+                    fleet+="${provider}:implementation-diversity-reviewer:OpenAI-compatible independent review path"$'\n'
                     has_diversity=true
                 fi
                 ;;
             qwen|qwen-*)
                 if [[ "$has_security" == "false" ]]; then
-                    fleet+="${provider}:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+                    fleet+="${provider}:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
                     has_security=true
                 elif [[ "$has_diversity" == "false" ]]; then
-                    fleet+="${provider}:diversity-reviewer:cross-family perspective on logic and assumptions"$'\n'
+                    fleet+="${provider}:implementation-diversity-reviewer:cross-family perspective on logic and assumptions"$'\n'
                     has_diversity=true
                 fi
                 ;;
             copilot|copilot-*)
                 if [[ "$has_cve" == "false" ]]; then
-                    fleet+="${provider}:cve-reviewer:known CVEs via web search, library advisories"$'\n'
+                    fleet+="${provider}:implementation-cve-reviewer:known CVEs via web search, library advisories"$'\n'
                     has_cve=true
                 elif [[ "$has_diversity" == "false" ]]; then
-                    fleet+="${provider}:diversity-reviewer:cross-perspective review"$'\n'
+                    fleet+="${provider}:implementation-diversity-reviewer:cross-perspective review"$'\n'
                     has_diversity=true
                 fi
                 ;;
@@ -141,7 +141,7 @@ _review_fleet_from_config() {
     # Anchor: always include arch-reviewer (claude-sonnet) if config didn't supply one.
     # Architecture context bridges per-finding noise from the specialist agents.
     if [[ "$has_arch" == "false" ]]; then
-        fleet+="claude-sonnet:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
+        fleet+="claude-sonnet:implementation-architecture-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
     fi
 
     log INFO "review fleet: config-driven (.routing.features.review)"
@@ -203,44 +203,44 @@ build_review_fleet() {
 
     # logic-reviewer: Codex (OpenAI) → OpenCode → Copilot → claude-sonnet fallback
     if command -v codex >/dev/null 2>&1; then
-        fleet+="codex:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+        fleet+="codex:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
     elif command -v opencode >/dev/null 2>&1; then
-        fleet+="opencode:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+        fleet+="opencode:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
     elif command -v copilot >/dev/null 2>&1; then
-        fleet+="copilot:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+        fleet+="copilot:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
     else
-        fleet+="claude-sonnet:logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+        fleet+="claude-sonnet:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
     fi
 
     # security-reviewer: AGY (Google) → Qwen → Copilot → claude-sonnet fallback
     # Prefer different family from logic-reviewer for diversity
     if command -v agy >/dev/null 2>&1; then
-        fleet+="agy:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+        fleet+="agy:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
     elif command -v qwen >/dev/null 2>&1; then
-        fleet+="qwen:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+        fleet+="qwen:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
     elif command -v copilot >/dev/null 2>&1; then
-        fleet+="copilot:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+        fleet+="copilot:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
     else
-        fleet+="claude-sonnet:security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+        fleet+="claude-sonnet:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
     fi
 
     # arch-reviewer: claude-sonnet (always available — best at holistic analysis)
-    fleet+="claude-sonnet:arch-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
+    fleet+="claude-sonnet:implementation-architecture-reviewer:architecture, integration, API contracts, breaking changes"$'\n'
 
     # cve-reviewer: Perplexity → AGY → Copilot → Qwen → claude WebSearch
     if command -v perplexity >/dev/null 2>&1 || [[ -n "${PERPLEXITY_API_KEY:-}" ]]; then
-        fleet+="perplexity:cve-reviewer:known CVEs, library advisories, live web search"$'\n'
+        fleet+="perplexity:implementation-cve-reviewer:known CVEs, library advisories, live web search"$'\n'
     elif command -v agy >/dev/null 2>&1; then
-        fleet+="agy:cve-reviewer:known CVEs and library advisories"$'\n'
+        fleet+="agy:implementation-cve-reviewer:known CVEs and library advisories"$'\n'
         log INFO "CVE lookup: Perplexity unavailable, using AGY"
     elif command -v copilot >/dev/null 2>&1; then
-        fleet+="copilot:cve-reviewer:known CVEs via web search, library advisories"$'\n'
+        fleet+="copilot:implementation-cve-reviewer:known CVEs via web search, library advisories"$'\n'
         log INFO "CVE lookup: Perplexity+AGY unavailable, using Copilot"
     elif command -v qwen >/dev/null 2>&1; then
-        fleet+="qwen:cve-reviewer:known CVEs via web search, library advisories"$'\n'
+        fleet+="qwen:implementation-cve-reviewer:known CVEs via web search, library advisories"$'\n'
         log INFO "CVE lookup: Perplexity+AGY unavailable, using Qwen"
     else
-        fleet+="claude-sonnet:cve-reviewer:known CVEs via WebSearch tool, library advisories"$'\n'
+        fleet+="claude-sonnet:implementation-cve-reviewer:known CVEs via WebSearch tool, library advisories"$'\n'
         log WARN "CVE lookup: no dedicated web-search provider, using Claude WebSearch (degraded)"
     fi
 
@@ -1511,7 +1511,7 @@ Return ONLY valid JSON with 'findings' array including verdict field."
     verifier_provider="$(review_phase_provider "codex")" || return 1
     verifier_provider_key="$(review_provider_key_from_agent_type "$verifier_provider")"
     if [[ -n "${OCTOPUS_REVIEW_SINGLE_PROVIDER:-}" ]]; then
-        verified_findings=$(review_run_agent_sync_progress "$verifier_provider" "$verifier_prompt" "code-reviewer" "review" "verifier-${verifier_provider}") && {
+        verified_findings=$(review_run_agent_sync_progress "$verifier_provider" "$verifier_prompt" "implementation-verifier" "review" "verifier-${verifier_provider}") && {
             echo "${verifier_provider_key}|ok|Round 2 verification" >> "$provider_status_file"
         } || {
             log WARN "review_run: ${verifier_provider} verification failed, using all findings as confirmed"
@@ -1521,13 +1521,13 @@ Return ONLY valid JSON with 'findings' array including verdict field."
             )")
         }
     else
-        verified_findings=$(review_run_agent_sync_progress "codex" "$verifier_prompt" "code-reviewer" "review" "verifier-codex") && {
+        verified_findings=$(review_run_agent_sync_progress "codex" "$verifier_prompt" "implementation-verifier" "review" "verifier-codex") && {
             echo "codex|ok|Round 2 verification" >> "$provider_status_file"
         } || {
             log WARN "review_run: codex verifier failed, falling back to claude-sonnet"
             log "USER" "⚠ Round 2: Codex unavailable → claude-sonnet (fallback). Codex API usage will NOT change."
             echo "codex|fallback|Round 2 → claude-sonnet" >> "$provider_status_file"
-            verified_findings=$(review_run_agent_sync_progress "claude-sonnet" "$verifier_prompt" "code-reviewer" "review" "verifier-claude-sonnet") || {
+            verified_findings=$(review_run_agent_sync_progress "claude-sonnet" "$verifier_prompt" "implementation-verifier" "review" "verifier-claude-sonnet") || {
                 log WARN "review_run: verification failed entirely, using all findings as confirmed"
                 verified_findings=$(printf '{"findings":%s}' "$(
                     echo "$all_findings" | jq 'map(. + {"verdict":"confirmed"})' 2>/dev/null || echo "[]"
@@ -1571,7 +1571,7 @@ Return JSON: {\"include\": [...finding titles...], \"exclude\": [...finding titl
             local debate_result debate_provider debate_provider_key
             debate_provider="$(review_phase_provider "codex")" || return 1
             debate_provider_key="$(review_provider_key_from_agent_type "$debate_provider")"
-            debate_result=$(review_run_agent_sync_progress "$debate_provider" "$debate_prompt" "code-reviewer" "review" "debate-${debate_provider}") && {
+            debate_result=$(review_run_agent_sync_progress "$debate_provider" "$debate_prompt" "implementation-debater" "review" "debate-${debate_provider}") && {
                 echo "${debate_provider_key}|ok|Round 3 debate" >> "$provider_status_file"
             } || {
                 log WARN "review_run: ${debate_provider} debate agent failed, including all contested findings"
@@ -1605,7 +1605,7 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
     local final_json synth_ok="true" synthesis_provider synthesis_provider_key
     synthesis_provider="$(review_phase_provider "claude-sonnet")" || return 1
     synthesis_provider_key="$(review_provider_key_from_agent_type "$synthesis_provider")"
-    final_json=$(review_run_agent_sync_progress "$synthesis_provider" "$synthesis_prompt" "code-reviewer" "review" "synthesis-${synthesis_provider}") || {
+    final_json=$(review_run_agent_sync_progress "$synthesis_provider" "$synthesis_prompt" "implementation-synthesizer" "review" "synthesis-${synthesis_provider}") || {
         synth_ok="false"
         log WARN "review_run: ${synthesis_provider} synthesis failed, using confirmed findings sorted as-is"
         echo "${synthesis_provider_key}|fallback|Round 3 synthesis failed; using local deterministic fallback" >> "$provider_status_file"
@@ -1645,7 +1645,7 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
         if ! _synth_count=$(review_findings_count "$final_json"); then
             _synth_count=0
         fi
-        octo_event_emit "synthesis" phase="review" provider="$synthesis_provider" provider_label_kind="legacy-alias" executor_alias="$synthesis_provider" configured_provider="$(octo_provider_identity_from_agent_type "$synthesis_provider")" configured_model="$(get_agent_model "$synthesis_provider" "review" "synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="synthesizer" synthesis_strategy="review" count="${_synth_count:-0}" || true
+        octo_event_emit "synthesis" phase="review" provider="$synthesis_provider" provider_label_kind="legacy-alias" executor_alias="$synthesis_provider" configured_provider="$(octo_provider_identity_from_agent_type "$synthesis_provider")" configured_model="$(get_agent_model "$synthesis_provider" "review" "implementation-synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="implementation-synthesizer" synthesis_strategy="review" count="${_synth_count:-0}" || true
     fi
 
     if [[ -n "$proof_dir" ]]; then

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -106,7 +106,7 @@ _review_fleet_from_config() {
                     has_diversity=true
                 fi
                 ;;
-            openai-compatible|openai-tools|openai-compatible-agent)
+            openai-compatible|openai-tools|openai-compatible-agent*)
                 if [[ "$has_logic" == "false" ]]; then
                     fleet+="${provider}:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
                     has_logic=true

--- a/tests/unit/test-council-role-names.sh
+++ b/tests/unit/test-council-role-names.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Council role namespacing"
+
+source "$PROJECT_ROOT/scripts/lib/dispatch.sh"
+
+test_case "design council roles keep legacy persona semantics"
+if [[ "$(octo_persona_role design-feasibility-reviewer)" == implementer ]] && \
+   [[ "$(octo_persona_role design-research-reviewer)" == researcher ]] && \
+   [[ "$(octo_persona_role design-code-reviewer)" == code-reviewer ]] && \
+   [[ "$(octo_persona_role design-synthesizer)" == synthesizer ]]; then
+    test_pass
+else
+    test_fail "design council persona aliases changed behavior"
+fi
+
+test_case "implementation council roles keep legacy persona semantics"
+if [[ "$(octo_persona_role implementation-logic-reviewer)" == logic-reviewer ]] && \
+   [[ "$(octo_persona_role implementation-security-reviewer)" == security-reviewer ]] && \
+   [[ "$(octo_persona_role implementation-architecture-reviewer)" == arch-reviewer ]] && \
+   [[ "$(octo_persona_role implementation-cve-reviewer)" == cve-reviewer ]] && \
+   [[ "$(octo_persona_role implementation-diversity-reviewer)" == reviewer ]] && \
+   [[ "$(octo_persona_role implementation-verifier)" == code-reviewer ]] && \
+   [[ "$(octo_persona_role implementation-debater)" == code-reviewer ]] && \
+   [[ "$(octo_persona_role implementation-synthesizer)" == code-reviewer ]]; then
+    test_pass
+else
+    test_fail "implementation council persona aliases changed behavior"
+fi
+
+test_case "implementation review fleet uses namespaced roles"
+review_file="$PROJECT_ROOT/scripts/lib/review.sh"
+if grep -Fq ':implementation-logic-reviewer:' "$review_file" && \
+   grep -Fq ':implementation-security-reviewer:' "$review_file" && \
+   grep -Fq ':implementation-architecture-reviewer:' "$review_file" && \
+   grep -Fq ':implementation-cve-reviewer:' "$review_file" && \
+   grep -Fq ':implementation-diversity-reviewer:' "$review_file" && \
+   grep -Fq '"implementation-verifier" "review"' "$review_file" && \
+   grep -Fq '"implementation-debater" "review"' "$review_file" && \
+   grep -Fq '"implementation-synthesizer" "review"' "$review_file"; then
+    test_pass
+else
+    test_fail "implementation review still reuses execution-role names"
+fi
+
+test_summary

--- a/tests/unit/test-council-role-names.sh
+++ b/tests/unit/test-council-role-names.sh
@@ -5,7 +5,9 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Council role namespacing"
 
+log() { :; }
 source "$PROJECT_ROOT/scripts/lib/dispatch.sh"
+source "$PROJECT_ROOT/scripts/lib/review.sh"
 
 test_case "design council roles keep legacy persona semantics"
 if [[ "$(octo_persona_role design-feasibility-reviewer)" == implementer ]] && \
@@ -54,6 +56,25 @@ if grep -Fq 'get_agent_model "$atype" "review" "${round1_roles[$idx]}"' "$review
     test_pass
 else
     test_fail "Round 1 finding event still collapses role to generic reviewer"
+fi
+
+test_case "suffixed OpenAI-compatible participants stay in the configured review fleet"
+fleet_home="$TEST_TMP_DIR/openai-compatible-agent-prefix"
+mkdir -p "$fleet_home/.claude-octopus/config"
+cat > "$fleet_home/.claude-octopus/config/providers.json" <<'EOF'
+{
+  "routing": {
+    "features": {
+      "review": ["openai-compatible-agent-custom"]
+    }
+  }
+}
+EOF
+configured_fleet="$(HOME="$fleet_home" _review_fleet_from_config)"
+if grep -Fq 'openai-compatible-agent-custom:implementation-logic-reviewer:' <<< "$configured_fleet"; then
+    test_pass
+else
+    test_fail "suffixed OpenAI-compatible participant was dropped: $configured_fleet"
 fi
 
 test_summary

--- a/tests/unit/test-council-role-names.sh
+++ b/tests/unit/test-council-role-names.sh
@@ -46,4 +46,14 @@ else
     test_fail "implementation review still reuses execution-role names"
 fi
 
+
+test_case "Round 1 finding events preserve namespaced council role"
+review_file="$PROJECT_ROOT/scripts/lib/review.sh"
+if grep -Fq 'get_agent_model "$atype" "review" "${round1_roles[$idx]}"' "$review_file" && \
+   grep -Fq 'role="${round1_roles[$idx]}" severity=' "$review_file"; then
+    test_pass
+else
+    test_fail "Round 1 finding event still collapses role to generic reviewer"
+fi
+
 test_summary

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -94,7 +94,7 @@ run_agent_sync_consultative() {
 design_review_ceremony "test" >/dev/null
 roles="$(cut -d'|' -f2 "$CAPTURE" | tr '\n' '|')"
 providers="$(cut -d'|' -f1 "$CAPTURE" | tr '\n' '|')"
-expected_calls=$'claude-sonnet|implementer|ceremony\ncodex|researcher|ceremony\ncommandcode|code-reviewer|ceremony\nclaude-sonnet|synthesizer|ceremony'
+expected_calls=$'claude-sonnet|design-feasibility-reviewer|ceremony\ncodex|design-research-reviewer|ceremony\ncommandcode|design-code-reviewer|ceremony\nclaude-sonnet|design-synthesizer|ceremony'
 if [[ "$(<"$CAPTURE")" == "$expected_calls" ]]; then
   test_pass
 else
@@ -122,6 +122,38 @@ if [[ "$model" == "minimaxai/minimax-m3" ]]; then
   test_pass
 else
   test_fail "expected provider-local MiniMax researcher model, got '$model'"
+fi
+
+
+test_case "design council roles do not inherit execution-role model routes"
+cat >"$TMP_HOME/.claude-octopus/config/providers.json" <<'EOF'
+{
+  "version":"3.0",
+  "providers": {
+    "codex": {"default":"gpt-5.6-sol"},
+    "commandcode": {"default":"deepseek/deepseek-v4-flash"},
+    "claude": {"default":"claude-sonnet-5"}
+  },
+  "routing": {
+    "phases": {},
+    "roles": {
+      "implementer": {"provider":"commandcode","model":"deepseek/deepseek-v4-flash"},
+      "researcher": {"provider":"commandcode","model":"minimaxai/minimax-m3"},
+      "code-reviewer": {"provider":"commandcode","model":"deepseek/deepseek-v4-pro"},
+      "synthesizer": {"provider":"commandcode","model":"deepseek/deepseek-v4-pro"}
+    }
+  },
+  "tiers":{},
+  "overrides":{}
+}
+EOF
+source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+if [[ "$(resolve_octopus_model commandcode commandcode ceremony design-feasibility-reviewer)" == "deepseek/deepseek-v4-flash" ]] && \
+   [[ "$(resolve_octopus_model commandcode commandcode ceremony design-research-reviewer)" == "deepseek/deepseek-v4-flash" ]] && \
+   [[ "$(resolve_octopus_model commandcode commandcode ceremony design-code-reviewer)" == "deepseek/deepseek-v4-flash" ]]; then
+  test_pass
+else
+  test_fail "namespaced design roles inherited execution-role routing"
 fi
 
 test_summary

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -122,6 +122,8 @@ run_design_review_dispatch_probe() {
       export "OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT=legacy-synth"
     fi
     : > "$DISPATCH_LOG"
+    # Probe fake seat aliases without inheriting repository/user allowlist policy.
+    octo_provider_allowed() { return 0; }
     run_agent_sync_consultative() {
       printf "%s|%s|%s\n" "$1" "$4" "$5" >> "$DISPATCH_LOG"
       printf "approach\n"
@@ -139,10 +141,10 @@ run_design_review_dispatch_probe() {
 test_case "design review role overrides win over legacy provider-named overrides at runtime"
 role_log="$TEST_TMP_DIR/role-precedence.log"
 run_design_review_dispatch_probe role "$role_log"
-if grep -q '^role-implementer|implementer|ceremony$' "$role_log" &&
-   grep -q '^role-researcher|researcher|ceremony$' "$role_log" &&
-   grep -q '^role-reviewer|code-reviewer|ceremony$' "$role_log" &&
-   grep -q '^role-synthesizer|synthesizer|ceremony$' "$role_log" &&
+if grep -q '^role-implementer|design-feasibility-reviewer|ceremony$' "$role_log" &&
+   grep -q '^role-researcher|design-research-reviewer|ceremony$' "$role_log" &&
+   grep -q '^role-reviewer|design-code-reviewer|ceremony$' "$role_log" &&
+   grep -q '^role-synthesizer|design-synthesizer|ceremony$' "$role_log" &&
    ! grep -q 'legacy-' "$role_log"; then
   test_pass
 else
@@ -152,10 +154,10 @@ fi
 test_case "legacy provider-named design review overrides remain runtime fallbacks"
 legacy_log="$TEST_TMP_DIR/legacy-fallback.log"
 run_design_review_dispatch_probe legacy "$legacy_log"
-if grep -q '^legacy-codex|implementer|ceremony$' "$legacy_log" &&
-   grep -q '^legacy-agy|researcher|ceremony$' "$legacy_log" &&
-   grep -q '^legacy-claude|code-reviewer|ceremony$' "$legacy_log" &&
-   grep -q '^legacy-synth|synthesizer|ceremony$' "$legacy_log"; then
+if grep -q '^legacy-codex|design-feasibility-reviewer|ceremony$' "$legacy_log" &&
+   grep -q '^legacy-agy|design-research-reviewer|ceremony$' "$legacy_log" &&
+   grep -q '^legacy-claude|design-code-reviewer|ceremony$' "$legacy_log" &&
+   grep -q '^legacy-synth|design-synthesizer|ceremony$' "$legacy_log"; then
   test_pass
 else
   test_fail "legacy provider override did not remain a functional fallback"
@@ -164,8 +166,8 @@ fi
 test_case "legacy GEMINI design review override remains secondary researcher fallback"
 gemini_log="$TEST_TMP_DIR/gemini-fallback.log"
 run_design_review_dispatch_probe gemini "$gemini_log"
-if grep -q '^legacy-gemini|researcher|ceremony$' "$gemini_log" &&
-   ! grep -q '^legacy-agy|researcher|ceremony$' "$gemini_log"; then
+if grep -q '^legacy-gemini|design-research-reviewer|ceremony$' "$gemini_log" &&
+   ! grep -q '^legacy-agy|design-research-reviewer|ceremony$' "$gemini_log"; then
   test_pass
 else
   test_fail "legacy GEMINI override did not remain the secondary researcher fallback"
@@ -178,13 +180,13 @@ if grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'executor_a
    grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'configured_model=' &&
    grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'runtime_provider=' &&
    grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'runtime_model=' &&
-   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'role="synthesizer"' &&
+   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'role="design-synthesizer"' &&
    grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'executor_alias=' &&
    grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'configured_provider=' &&
    grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'configured_model=' &&
    grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'runtime_provider=' &&
    grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'runtime_model=' &&
-   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'role="synthesizer"'; then
+   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'role="design-synthesizer"'; then
   test_pass
 else
   test_fail "design review synthesis events lack stable lifecycle identity fields"

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -182,24 +182,32 @@ else
   test_fail "legacy GEMINI override did not remain the secondary researcher fallback"
 fi
 
+event_has_field() {
+  local event="$1" expected="$2"
+  case "|${event}|" in
+    *"|${expected}|"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 test_case "design review synthesis events carry stable executor and role identity"
 synthesis_dispatch_log="$TEST_TMP_DIR/synthesis-events-dispatch.log"
 synthesis_event_log="$TEST_TMP_DIR/synthesis-events.log"
 run_design_review_dispatch_probe role "$synthesis_dispatch_log" "$synthesis_event_log"
 start_event="$(grep '^synthesis.start|' "$synthesis_event_log" | head -1)"
 end_event="$(grep '^synthesis.end|' "$synthesis_event_log" | head -1)"
-if [[ "$start_event" == *"executor_alias=role-synthesizer"* ]] &&
-   [[ "$start_event" == *"configured_provider=role-synthesizer"* ]] &&
-   [[ "$start_event" == *"configured_model=test-model"* ]] &&
-   [[ "$start_event" == *"runtime_provider=unknown"* ]] &&
-   [[ "$start_event" == *"runtime_model=unknown"* ]] &&
-   [[ "$start_event" == *"role=design-synthesizer"* ]] &&
-   [[ "$end_event" == *"executor_alias=role-synthesizer"* ]] &&
-   [[ "$end_event" == *"configured_provider=role-synthesizer"* ]] &&
-   [[ "$end_event" == *"configured_model=test-model"* ]] &&
-   [[ "$end_event" == *"runtime_provider=unknown"* ]] &&
-   [[ "$end_event" == *"runtime_model=unknown"* ]] &&
-   [[ "$end_event" == *"role=design-synthesizer"* ]]; then
+if event_has_field "$start_event" "executor_alias=role-synthesizer" &&
+   event_has_field "$start_event" "configured_provider=role-synthesizer" &&
+   event_has_field "$start_event" "configured_model=test-model" &&
+   event_has_field "$start_event" "runtime_provider=unknown" &&
+   event_has_field "$start_event" "runtime_model=unknown" &&
+   event_has_field "$start_event" "role=design-synthesizer" &&
+   event_has_field "$end_event" "executor_alias=role-synthesizer" &&
+   event_has_field "$end_event" "configured_provider=role-synthesizer" &&
+   event_has_field "$end_event" "configured_model=test-model" &&
+   event_has_field "$end_event" "runtime_provider=unknown" &&
+   event_has_field "$end_event" "runtime_model=unknown" &&
+   event_has_field "$end_event" "role=design-synthesizer"; then
   test_pass
 else
   test_fail "design review synthesis events lack stable lifecycle identity fields: start=$start_event end=$end_event"

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -194,12 +194,12 @@ test_case "design review synthesis events carry stable executor and role identit
 synthesis_dispatch_log="$TEST_TMP_DIR/synthesis-events-dispatch.log"
 synthesis_event_log="$TEST_TMP_DIR/synthesis-events.log"
 run_design_review_dispatch_probe role "$synthesis_dispatch_log" "$synthesis_event_log"
-start_count="$(grep -c '^synthesis.start|' "$synthesis_event_log" || true)"
-end_count="$(grep -c '^synthesis.end|' "$synthesis_event_log" || true)"
-start_line="$(grep -n '^synthesis.start|' "$synthesis_event_log" | cut -d: -f1)"
-end_line="$(grep -n '^synthesis.end|' "$synthesis_event_log" | cut -d: -f1)"
-start_event="$(grep '^synthesis.start|' "$synthesis_event_log")"
-end_event="$(grep '^synthesis.end|' "$synthesis_event_log")"
+start_count="$(grep -Fc 'synthesis.start|' "$synthesis_event_log" || true)"
+end_count="$(grep -Fc 'synthesis.end|' "$synthesis_event_log" || true)"
+start_line="$(grep -Fn 'synthesis.start|' "$synthesis_event_log" | cut -d: -f1)"
+end_line="$(grep -Fn 'synthesis.end|' "$synthesis_event_log" | cut -d: -f1)"
+start_event="$(grep -F 'synthesis.start|' "$synthesis_event_log")"
+end_event="$(grep -F 'synthesis.end|' "$synthesis_event_log")"
 if [[ "$start_count" == 1 ]] &&
    [[ "$end_count" == 1 ]] &&
    [[ "$start_line" =~ ^[0-9]+$ ]] && [[ "$end_line" =~ ^[0-9]+$ ]] &&

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -194,9 +194,17 @@ test_case "design review synthesis events carry stable executor and role identit
 synthesis_dispatch_log="$TEST_TMP_DIR/synthesis-events-dispatch.log"
 synthesis_event_log="$TEST_TMP_DIR/synthesis-events.log"
 run_design_review_dispatch_probe role "$synthesis_dispatch_log" "$synthesis_event_log"
-start_event="$(grep '^synthesis.start|' "$synthesis_event_log" | head -1)"
-end_event="$(grep '^synthesis.end|' "$synthesis_event_log" | head -1)"
-if event_has_field "$start_event" "executor_alias=role-synthesizer" &&
+start_count="$(grep -c '^synthesis.start|' "$synthesis_event_log" || true)"
+end_count="$(grep -c '^synthesis.end|' "$synthesis_event_log" || true)"
+start_line="$(grep -n '^synthesis.start|' "$synthesis_event_log" | cut -d: -f1)"
+end_line="$(grep -n '^synthesis.end|' "$synthesis_event_log" | cut -d: -f1)"
+start_event="$(grep '^synthesis.start|' "$synthesis_event_log")"
+end_event="$(grep '^synthesis.end|' "$synthesis_event_log")"
+if [[ "$start_count" == 1 ]] &&
+   [[ "$end_count" == 1 ]] &&
+   [[ "$start_line" =~ ^[0-9]+$ ]] && [[ "$end_line" =~ ^[0-9]+$ ]] &&
+   [[ "$start_line" -lt "$end_line" ]] &&
+   event_has_field "$start_event" "executor_alias=role-synthesizer" &&
    event_has_field "$start_event" "configured_provider=role-synthesizer" &&
    event_has_field "$start_event" "configured_model=test-model" &&
    event_has_field "$start_event" "runtime_provider=unknown" &&

--- a/tests/unit/test-runtime-provider-labels.sh
+++ b/tests/unit/test-runtime-provider-labels.sh
@@ -93,7 +93,8 @@ fi
 run_design_review_dispatch_probe() {
   local mode="$1"
   local dispatch_log="$2"
-  env "MODE=${mode}" "PROJECT_ROOT=${PROJECT_ROOT}" "DISPATCH_LOG=${dispatch_log}" \
+  local event_log="${3:-${dispatch_log}.events}"
+  env "MODE=${mode}" "PROJECT_ROOT=${PROJECT_ROOT}" "DISPATCH_LOG=${dispatch_log}" "EVENT_LOG=${event_log}" \
     "WORKSPACE_DIR=${TEST_TMP_DIR}/workspace-${mode}" "DRY_RUN=false" "OCTOPUS_CEREMONIES=true" \
   bash -c '
     set -e
@@ -122,6 +123,7 @@ run_design_review_dispatch_probe() {
       export "OCTOPUS_DESIGN_REVIEW_SYNTH_AGENT=legacy-synth"
     fi
     : > "$DISPATCH_LOG"
+    : > "$EVENT_LOG"
     # Probe fake seat aliases without inheriting repository/user allowlist policy.
     octo_provider_allowed() { return 0; }
     run_agent_sync_consultative() {
@@ -131,7 +133,14 @@ run_design_review_dispatch_probe() {
     octo_provider_identity_label() { printf "%s\n" "$1"; }
     octo_provider_identity_from_agent_type() { printf "%s\n" "$1"; }
     get_agent_model() { printf "test-model\n"; }
-    octo_event_emit() { :; }
+    octo_event_emit() {
+      local event="$1"
+      shift
+      printf "%s" "$event" >> "$EVENT_LOG"
+      local arg
+      for arg in "$@"; do printf "|%s" "$arg" >> "$EVENT_LOG"; done
+      printf "\n" >> "$EVENT_LOG"
+    }
     write_structured_decision() { :; }
     log() { :; }
     design_review_ceremony "test task" >/dev/null 2>&1 || true
@@ -174,22 +183,26 @@ else
 fi
 
 test_case "design review synthesis events carry stable executor and role identity"
-quality="$PROJECT_ROOT/scripts/lib/quality.sh"
-if grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'executor_alias=' &&
-   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'configured_provider=' &&
-   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'configured_model=' &&
-   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'runtime_provider=' &&
-   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'runtime_model=' &&
-   grep -A9 'octo_event_emit "synthesis.start"' "$quality" | grep -q 'role="design-synthesizer"' &&
-   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'executor_alias=' &&
-   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'configured_provider=' &&
-   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'configured_model=' &&
-   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'runtime_provider=' &&
-   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'runtime_model=' &&
-   grep -A10 'octo_event_emit "synthesis.end"' "$quality" | grep -q 'role="design-synthesizer"'; then
+synthesis_dispatch_log="$TEST_TMP_DIR/synthesis-events-dispatch.log"
+synthesis_event_log="$TEST_TMP_DIR/synthesis-events.log"
+run_design_review_dispatch_probe role "$synthesis_dispatch_log" "$synthesis_event_log"
+start_event="$(grep '^synthesis.start|' "$synthesis_event_log" | head -1)"
+end_event="$(grep '^synthesis.end|' "$synthesis_event_log" | head -1)"
+if [[ "$start_event" == *"executor_alias=role-synthesizer"* ]] &&
+   [[ "$start_event" == *"configured_provider=role-synthesizer"* ]] &&
+   [[ "$start_event" == *"configured_model=test-model"* ]] &&
+   [[ "$start_event" == *"runtime_provider=unknown"* ]] &&
+   [[ "$start_event" == *"runtime_model=unknown"* ]] &&
+   [[ "$start_event" == *"role=design-synthesizer"* ]] &&
+   [[ "$end_event" == *"executor_alias=role-synthesizer"* ]] &&
+   [[ "$end_event" == *"configured_provider=role-synthesizer"* ]] &&
+   [[ "$end_event" == *"configured_model=test-model"* ]] &&
+   [[ "$end_event" == *"runtime_provider=unknown"* ]] &&
+   [[ "$end_event" == *"runtime_model=unknown"* ]] &&
+   [[ "$end_event" == *"role=design-synthesizer"* ]]; then
   test_pass
 else
-  test_fail "design review synthesis events lack stable lifecycle identity fields"
+  test_fail "design review synthesis events lack stable lifecycle identity fields: start=$start_event end=$end_event"
 fi
 
 test_case "design review synthesis prompt no longer uses historical provider headings"


### PR DESCRIPTION
## Summary

Namespace internal Design Review and Implementation Review council roles so they no longer collide with pipeline execution roles such as `implementer`, `researcher`, `code-reviewer`, `security-reviewer`, and `synthesizer`.

This keeps council persona semantics intact while preventing `routing.roles.<execution-role>` from accidentally influencing model/provider resolution for a council seat that merely shares the same role name.

## Problem

The same literal role names are currently used for two different concepts:

- pipeline execution routing (`implementer`, `researcher`, etc.)
- internal review/council perspectives

Because model resolution consults `routing.roles[$role]`, an execution route can unintentionally affect a Design Review or Implementation Review seat with the same role label.

Example: an `implementer` execution route pinned to a coding model can leak into the Design Review seat that is only meant to provide an implementability perspective.

## Changes

Design Review roles become:

- `design-feasibility-reviewer`
- `design-research-reviewer`
- `design-code-reviewer`
- `design-synthesizer`

Implementation Review roles become:

- `implementation-logic-reviewer`
- `implementation-security-reviewer`
- `implementation-architecture-reviewer`
- `implementation-cve-reviewer`
- `implementation-diversity-reviewer`
- `implementation-verifier`
- `implementation-debater`
- `implementation-synthesizer`

A small `octo_persona_role()` compatibility layer maps these namespaced council roles back to the existing persona/tool-policy semantics. Routing/model resolution continues to see the namespaced role.

## Compatibility

This intentionally preserves existing persona and tool-policy behavior. The change only separates council role identity from execution-role routing identity.

## Validation

Focused tests:

- `test-council-role-names.sh` 3/3
- `test-provider-neutral-design-review.sh` 7/7
- `test-ceremonies.sh` 9/9
- `test-provider-neutral-council.sh` 6/6
- `test-agent-lifecycle-events.sh` 10/10
- `test-review-run.sh` 31/31
- `test-council-model-selection-fixes.sh` 12/12
- `test-consultative-agent-dispatch.sh` 8/8
- smoke: 16/16

Also passes `bash -n` and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added clearer, role-specific labels across design and implementation review workflows.
  * Improved model selection so design reviews use their designated review model independently from execution workflows.
  * Standardized role identification across verification, debate, synthesis, and review status reporting.
  * Preserved compatibility with existing role-based behavior.

* **Quality Improvements**
  * Expanded automated coverage for role naming, model selection, provider routing, compatibility, and review lifecycle reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->