### PR TITLE
docs: clarify project independence

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -6,6 +6,8 @@
 
 **Claude-native first, Octopus for escalation.** Use Claude-native `/init`, `/review`, and `/security-review` when Claude is enough. Use Octopus when you want multiple model opinions, adversarial review, or stricter multi-LLM workflows.
 
+> Claude Octopus is an independent open-source project. It is not affiliated with, endorsed by, or sponsored by Anthropic.
+
 ## What Changes
 
 Without Octopus, you ask one model and trust the answer. With it:

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -4,6 +4,8 @@ last_reviewed: 2026-08-21
 
 # PRODUCT.md
 
+> Claude Octopus is an independent open-source project. It is not affiliated with, endorsed by, or sponsored by Anthropic.
+
 ## Mission
 
 Make up to 10 external AI integrations available for explicit escalation, so blind spots surface on the work that warrants multi-model scrutiny without taxing every ordinary task.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Every AI model has blind spots. Claude Octopus supports ten external provider in
 
 **Claude-native first, Octopus for escalation.** Use Claude-native `/init`, `/review`, and `/security-review` when Claude is enough. Use Octopus when you want multiple model opinions, adversarial review, or stricter multi-LLM workflows.
 
+> Claude Octopus is an independent open-source project. It is not affiliated with, endorsed by, or sponsored by Anthropic.
+
 <p align="center">
   <img src="docs/assets/demo.gif" alt="Claude Octopus Demo — debate and research with multiple AI providers" width="720">
 </p>


### PR DESCRIPTION
Adds a visible README notice that Claude Octopus is an independent open-source project and is not affiliated with, endorsed by, or sponsored by Anthropic.

Verification:
- `git diff --check`
- README-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a disclaimer clarifying that Claude Octopus is an independent open-source project and is not affiliated with, endorsed by, or sponsored by Anthropic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->