### PR TITLE
fix(agy): retry synchronous SIGSEGV seats

### DIFF
--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,16 +1,48 @@
 # AI Agent Handoff
 
-Last updated: 2026-08-22
-Status: v9.66.1 is released from exact tested `main`. PR #950's OpenClaw tool
-contracts and PR #953's deterministic benchmark-gated council tests are merged
-and shipped. The shared marketplace, development-wrapper submodule, and
-user-scoped installation are current. The installed plugin still resolves
-`backend-architect` through AGY while preserving the persona role.
-Branch: `main` (this handoff update is delivered through a docs-only PR)
+Last updated: 2026-08-23
+Status: The live GitHub queue audit is complete after PR #962 reaches `main`.
+PRs #956, #957, #958, #960, and #962 are resolved; PR #940 was closed without
+merge; PR #959 remains open and blocked on two reproduced defects. Issue #943
+is fixed by PR #962 and closes with that squash merge.
+Branch: `main` (this state is delivered through PR #962)
 Current release: [v9.66.1](https://github.com/nyldn/claude-octopus/releases/tag/v9.66.1)
-Tracking: Beads `oco-8ws`; release commit `28d3de9c`; Test Suite `32549434980`
-Next action: keep PR #940 excluded until its third-party chart dependency has
-proportional repository evidence. Investigate issue #943 independently.
+Tracking: Beads `oco-j08`; PRs #940, #956 through #962; issue #943
+Next action: Do not merge PR #959 until its history append propagates failure
+and it preserves the newline/CR sanitization already on `main`; then require a
+fresh exact-head full matrix, approval, and zero unresolved review threads.
+
+## GitHub Queue Audit (2026-08-23)
+
+- Canonical source of truth: `nyldn/claude-octopus`, protected `main`. The dirty
+  `claude-octopus-dev` coordination checkout, its `.beads` state, gate lock,
+  stash, and unrelated worktrees were preserved.
+- Verified and squash-merged: #956 as `3d25f8ba`, #958 as `ac57d513`, #957 as
+  `5043528b`, and #960 as `5c663f68`. Each merge used the exact approved head
+  after the required local/hosted checks and review-thread audit. PR #960's
+  final hosted run passed macOS/Ubuntu smoke and unit suites, symlink-path,
+  portability, full integration, and Test Summary; all five threads were
+  resolved.
+- PR #962 fixes issue #943: synchronous AGY dispatch retries one exit-139
+  failure inside the original timeout, retains mode-0600 crash evidence, uses
+  collision-safe temporary paths, and preserves degraded reasons and caller
+  shell options. Its focused regressions cover recovery, terminal retry,
+  non-AGY behavior, classification failure, timeout exhaustion, real timeout
+  interruption, and caller `errexit` preservation.
+- PR #962 review response: independent Codex and Claude review identified the
+  fractional timeout risk before publication; CodeRabbit later found the
+  caller-`errexit` and non-enforcing fixture gaps. Each finding was reproduced
+  before editing. The focused signal suite passes 8/8 and timeout-budget suite
+  passes 7/7 after the response.
+- PR #959 remains held. `provider_history_append` reports success when its
+  append fails because it captures the status of `!`, and the branch restores
+  raw fleet record emission, undoing merged multiline/CR sanitization. Both
+  defects were reproduced against its exact head and posted through the safe
+  GitHub text helper.
+- PR #940 was closed without merge: the chart break was real, but ownership and
+  security of the unaffiliated replacement endpoint were not established.
+  PR #961 was independently observed after its owner merge; its disclaimer was
+  propagated across the three product docs and its exact hosted matrix passed.
 
 ## Production Release v9.66.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Synchronous Antigravity seats now retry once after an intermittent exit 139
+  (SIGSEGV) without extending the original timeout budget. Signal-terminated
+  seats retain private stderr artifacts linked from run status, including when
+  the retry succeeds, so orchestration failures remain diagnosable.
+
 ## [9.66.1] - 2026-08-21
 
 ### Changed

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -458,10 +458,11 @@ ${provider_ctx}"
             fi
         fi
 
-        set +e
-        printf '%s' "$enhanced_prompt" | run_with_timeout "$_attempt_timeout" "${cmd_array[@]}" 2>"$temp_err" >"$temp_out"
-        exit_code=$?
-        set -e
+        if printf '%s' "$enhanced_prompt" | run_with_timeout "$_attempt_timeout" "${cmd_array[@]}" 2>"$temp_err" >"$temp_out"; then
+            exit_code=0
+        else
+            exit_code=$?
+        fi
 
         if [[ "$exit_code" -ge 128 && "$exit_code" -le 192 ]]; then
             local _signal_attempt=$((_sync_retry_count + 1))

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -46,6 +46,25 @@ octopus_agent_teams_can_honor_timeout() {
     [[ "$effective_timeout" -eq 0 ]]
 }
 
+# Return the integer timeout for one synchronous attempt within a fixed
+# wall-clock deadline. Retried attempts reserve one second because date(1) and
+# run_with_timeout both operate at whole-second precision; without that margin,
+# differing fractional start times can extend the original budget by <1s.
+octopus_sync_attempt_timeout() {
+    local deadline="$1"
+    local now="$2"
+    local retry_count="${3:-0}"
+    local remaining
+
+    [[ "$deadline" =~ ^[0-9]+$ && "$now" =~ ^[0-9]+$ && "$retry_count" =~ ^[0-9]+$ ]] || return 1
+    remaining=$((deadline - now))
+    if [[ "$retry_count" -gt 0 ]]; then
+        remaining=$((remaining - 1))
+    fi
+    [[ "$remaining" -gt 0 ]] || return 1
+    printf '%s\n' "$remaining"
+}
+
 # Check if an agent should use Agent Teams dispatch
 # Returns 0 (true) if agent should use native teams, 1 (false) for legacy bash
 should_use_agent_teams() {
@@ -385,8 +404,8 @@ ${provider_ctx}"
     # Capture output and exit code separately
     local output
     local exit_code
-    local temp_err="${RESULTS_DIR}/.tmp-agent-error-$$.err"
-    local temp_out="${RESULTS_DIR}/.tmp-agent-out-$$.out"
+    local temp_err="${RESULTS_DIR}/.tmp-agent-error-${_progress_unique}.err"
+    local temp_out="${RESULTS_DIR}/.tmp-agent-out-${_progress_unique}.out"
 
     # -p "" triggers headless mode for CLIs that require it while prompt content
     # comes via stdin to avoid OS argument limits. Qwen and Cursor Agent follow
@@ -398,9 +417,12 @@ ${provider_ctx}"
 
     # v9.2.2: All agents use stdin to avoid ARG_MAX "Argument list too long" on large diffs (Issue #173)
     # Captured for partial-writes detection on timeout.
-    local _dispatch_start _dispatch_cwd
+    local _dispatch_start _dispatch_cwd _sync_timeout_deadline=0
     _dispatch_start=$(date +%s)
     _dispatch_cwd=$(pwd)
+    if [[ "$timeout_secs" =~ ^[0-9]+$ ]] && [[ "$timeout_secs" -gt 0 ]]; then
+        _sync_timeout_deadline=$((_dispatch_start + timeout_secs))
+    fi
 
     local _quota_watcher_pid=""
 
@@ -412,10 +434,55 @@ ${provider_ctx}"
         "$agent_type" "running" 0 "$_estimated_cost" "$timeout_secs" \
         "$_progress_task_id" "${phase:-unknown}" "" || true
 
-    set +e
-    printf '%s' "$enhanced_prompt" | run_with_timeout "$timeout_secs" "${cmd_array[@]}" 2>"$temp_err" >"$temp_out"
-    exit_code=$?
-    set -e
+    # AGY has an intermittent native SIGSEGV under heterogeneous orchestration
+    # (#943). Retry that provider exactly once, while keeping both attempts
+    # inside the caller's original wall-clock budget. Signal stderr is retained
+    # for every provider so terminal crashes remain diagnosable from run data.
+    local _sync_retry_count=0
+    local _sync_sigsegv_retries=0
+    local _sync_recovered_sigsegv=false
+    local _sync_signal_artifact=""
+    case "$agent_type" in
+        agy*|antigravity) _sync_sigsegv_retries=1 ;;
+    esac
+
+    while true; do
+        local _attempt_timeout="$timeout_secs"
+        if [[ "$_sync_timeout_deadline" -gt 0 ]]; then
+            local _attempt_now
+            _attempt_now=$(date +%s)
+            if ! _attempt_timeout=$(octopus_sync_attempt_timeout \
+                "$_sync_timeout_deadline" "$_attempt_now" "$_sync_retry_count"); then
+                exit_code=124
+                break
+            fi
+        fi
+
+        set +e
+        printf '%s' "$enhanced_prompt" | run_with_timeout "$_attempt_timeout" "${cmd_array[@]}" 2>"$temp_err" >"$temp_out"
+        exit_code=$?
+        set -e
+
+        if [[ "$exit_code" -ge 128 && "$exit_code" -le 192 ]]; then
+            local _signal_attempt=$((_sync_retry_count + 1))
+            _sync_signal_artifact="${RESULTS_DIR}/sync-failure-${_progress_unique}-attempt-${_signal_attempt}.stderr.log"
+            if (umask 077; cp "$temp_err" "$_sync_signal_artifact") 2>/dev/null; then
+                chmod 600 "$_sync_signal_artifact" 2>/dev/null || true
+            else
+                _sync_signal_artifact=""
+            fi
+        fi
+
+        if [[ "$exit_code" -eq 139 && "$_sync_retry_count" -lt "$_sync_sigsegv_retries" ]]; then
+            _sync_retry_count=$((_sync_retry_count + 1))
+            log WARN "Agent $agent_type exited 139 (SIGSEGV); retrying once within the original ${timeout_secs}s budget (stderr: ${_sync_signal_artifact:-unavailable})"
+            : > "$temp_err"
+            : > "$temp_out"
+            continue
+        fi
+        [[ "$exit_code" -eq 0 && "$_sync_retry_count" -gt 0 ]] && _sync_recovered_sigsegv=true
+        break
+    done
     output=$(cat "$temp_out")
 
     stop_quota_watcher "$_quota_watcher_pid"
@@ -494,8 +561,8 @@ ${provider_ctx}"
         fi
         type update_agent_status >/dev/null 2>&1 && update_agent_status \
             "$agent_type" "$_sync_status" "$_elapsed_ms" "$_estimated_cost" "$timeout_secs" \
-            "$_progress_task_id" "${phase:-unknown}" "" || true
-        type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "$_sync_status" "$tokens_in" "$(octo_estimate_tokens_for_file "$temp_out" 2>/dev/null || echo 0)" "$_sync_reason" "$_elapsed_ms" "" "$role" || true
+            "$_progress_task_id" "${phase:-unknown}" "$_sync_signal_artifact" || true
+        type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "$_sync_status" "$tokens_in" "$(octo_estimate_tokens_for_file "$temp_out" 2>/dev/null || echo 0)" "$_sync_reason" "$_elapsed_ms" "$_sync_signal_artifact" "$role" || true
         rm -f "$temp_err" "$temp_out"
         return $exit_code
     fi
@@ -513,8 +580,8 @@ ${provider_ctx}"
                 log WARN "Agent $agent_type prompt rejected as oversized — skipping provider (reduce session context or lower OCTOPUS_CONTEXT_BUDGET)"
                 type update_agent_status >/dev/null 2>&1 && update_agent_status \
                     "$agent_type" "skipped" "$_elapsed_ms" 0 "$timeout_secs" \
-                    "$_progress_task_id" "${phase:-unknown}" "" || true
-                type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "skipped" "$tokens_in" 0 "Prompt rejected by provider (oversize)" "$_elapsed_ms" "" "$role" || true
+                    "$_progress_task_id" "${phase:-unknown}" "$_sync_signal_artifact" || true
+                type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "skipped" "$tokens_in" 0 "Prompt rejected by provider (oversize)" "$_elapsed_ms" "$_sync_signal_artifact" "$role" || true
                 rm -f "$temp_err" "$temp_out"
                 echo ""
                 return 0
@@ -522,23 +589,42 @@ ${provider_ctx}"
             log ERROR "Agent $agent_type returned unusable output: $_sync_reason"
             type update_agent_status >/dev/null 2>&1 && update_agent_status \
                 "$agent_type" "failed" "$_elapsed_ms" "$_estimated_cost" "$timeout_secs" \
-                "$_progress_task_id" "${phase:-unknown}" "" || true
-            type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "failed" "$tokens_in" "$(octo_estimate_tokens_for_file "$temp_out" 2>/dev/null || echo 0)" "$_sync_reason" "$_elapsed_ms" "" "$role" || true
+                "$_progress_task_id" "${phase:-unknown}" "$_sync_signal_artifact" || true
+            type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "failed" "$tokens_in" "$(octo_estimate_tokens_for_file "$temp_out" 2>/dev/null || echo 0)" "$_sync_reason" "$_elapsed_ms" "$_sync_signal_artifact" "$role" || true
             rm -f "$temp_err" "$temp_out"
             return 1
         fi
+        if [[ "$_sync_recovered_sigsegv" == "true" ]]; then
+            _sync_status="degraded"
+            if [[ -n "$_sync_reason" ]]; then
+                _sync_reason="Recovered after AGY exit 139; ${_sync_reason}"
+            else
+                _sync_reason="Recovered after AGY exit 139"
+            fi
+        fi
         if [[ "$_sync_output_truncated" == "true" ]]; then
             _sync_status="degraded"
-            _sync_reason="Output truncated"
+            if [[ -n "$_sync_reason" ]]; then
+                _sync_reason="${_sync_reason}; output truncated"
+            else
+                _sync_reason="Output truncated"
+            fi
         fi
-        type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "$_sync_status" "$tokens_in" "$(octo_estimate_tokens_for_file "$temp_out" 2>/dev/null || echo 0)" "$_sync_reason" "$_elapsed_ms" "" "$role" || true
+        type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "$_sync_status" "$tokens_in" "$(octo_estimate_tokens_for_file "$temp_out" 2>/dev/null || echo 0)" "$_sync_reason" "$_elapsed_ms" "$_sync_signal_artifact" "$role" || true
         type update_agent_status >/dev/null 2>&1 && update_agent_status \
             "$agent_type" "$_sync_status" "$_elapsed_ms" "$_estimated_cost" "$timeout_secs" \
-            "$_progress_task_id" "${phase:-unknown}" "" || true
+            "$_progress_task_id" "${phase:-unknown}" "$_sync_signal_artifact" || true
     else
+        local _unclassified_status="completed"
+        local _unclassified_reason=""
+        if [[ "$_sync_recovered_sigsegv" == "true" ]]; then
+            _unclassified_status="degraded"
+            _unclassified_reason="Recovered after AGY exit 139"
+        fi
+        type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "$_unclassified_status" "$tokens_in" "$(octo_estimate_tokens_for_file "$temp_out" 2>/dev/null || echo 0)" "$_unclassified_reason" "$_elapsed_ms" "$_sync_signal_artifact" "$role" || true
         type update_agent_status >/dev/null 2>&1 && update_agent_status \
-            "$agent_type" "completed" "$_elapsed_ms" "$_estimated_cost" "$timeout_secs" \
-            "$_progress_task_id" "${phase:-unknown}" "" || true
+            "$agent_type" "$_unclassified_status" "$_elapsed_ms" "$_estimated_cost" "$timeout_secs" \
+            "$_progress_task_id" "${phase:-unknown}" "$_sync_signal_artifact" || true
     fi
 
     # v8.7.0: Wrap external CLI output with trust markers

--- a/tests/unit/test-agent-sync-signal-retry.sh
+++ b/tests/unit/test-agent-sync-signal-retry.sh
@@ -104,7 +104,7 @@ test_case "AGY exit 139 retries once and records the recovered crash artifact"
 agy_output="$(run_sync_fixture agy 1)" && agy_rc=0 || agy_rc=$?
 agy_root="$TEST_TMP_DIR/agy-1"
 agy_artifact="$(find "$agy_root/results" -maxdepth 1 -name 'sync-failure-*.stderr.log' -print -quit)"
-agy_mode="$(stat -f '%Lp' "$agy_artifact" 2>/dev/null || stat -c '%a' "$agy_artifact" 2>/dev/null || true)"
+agy_mode="$(stat -c '%a' "$agy_artifact" 2>/dev/null || stat -f '%Lp' "$agy_artifact" 2>/dev/null || true)"
 first_timeout="$(sed -n '1p' "$agy_root/timeouts")"
 retry_timeout="$(sed -n '2p' "$agy_root/timeouts")"
 if [[ "$agy_rc" -eq 0 ]] && [[ "$(cat "$agy_root/attempts")" == "2" ]] && \

--- a/tests/unit/test-agent-sync-signal-retry.sh
+++ b/tests/unit/test-agent-sync-signal-retry.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #943: intermittent AGY SIGSEGV failures must
+# receive one bounded retry, and signal stderr must remain inspectable.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "synchronous provider signal retry"
+
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/agent-sync.sh"
+
+test_case "retry attempts use a conservative remainder of the original timeout"
+if declare -F octopus_sync_attempt_timeout >/dev/null 2>&1 && \
+   [[ "$(octopus_sync_attempt_timeout 130 100 0)" == "30" ]] && \
+   [[ "$(octopus_sync_attempt_timeout 130 100 1)" == "29" ]] && \
+   ! octopus_sync_attempt_timeout 130 129 1 >/dev/null 2>&1 && \
+   ! octopus_sync_attempt_timeout 130 130 0 >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "retry timeout helper can extend or revive an exhausted wall-clock budget"
+fi
+
+run_sync_fixture() (
+    local provider="$1"
+    local fail_count="$2"
+    local scenario="${3:-${provider}-${fail_count}}"
+    local fixture_root="$TEST_TMP_DIR/$scenario"
+    local fake_provider="$fixture_root/provider.sh"
+
+    mkdir -p "$fixture_root/results"
+    export RESULTS_DIR="$fixture_root/results"
+    export ATTEMPT_FILE="$fixture_root/attempts"
+    export FAIL_COUNT="$fail_count"
+
+    cat > "$fake_provider" <<'EOF'
+#!/usr/bin/env bash
+attempt=0
+[[ -f "$ATTEMPT_FILE" ]] && attempt="$(cat "$ATTEMPT_FILE")"
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" > "$ATTEMPT_FILE"
+if [[ "$attempt" -le "$FAIL_COUNT" ]]; then
+    printf 'synthetic provider crash attempt %s\n' "$attempt" >&2
+    exit 139
+fi
+printf 'recovered provider output\n'
+EOF
+    chmod 755 "$fake_provider"
+
+    log() { :; }
+    classify_task() { printf 'standard\n'; }
+    get_role_for_context() { printf 'reviewer\n'; }
+    apply_persona() { printf '%s\n' "$2"; }
+    load_earned_skills() { :; }
+    build_provider_context() { :; }
+    enforce_context_budget() { printf '%s\n' "$1"; }
+    get_agent_model() { printf 'fixture-model\n'; }
+    estimate_agent_call_cost() { printf '0.000000\n'; }
+    check_provider_health() { return 0; }
+    record_agent_call() { :; }
+    get_agent_command() { printf '%s\n' "$fake_provider"; }
+    build_provider_env() { PROVIDER_ENV_ARRAY=(); }
+    run_with_timeout() {
+        printf '%s\n' "$1" >> "$fixture_root/timeouts"
+        shift
+        "$@"
+    }
+    stop_quota_watcher() { :; }
+    update_agent_status() { :; }
+    octo_estimate_tokens_for_file() { printf '0\n'; }
+    classify_agent_output() { printf '%s\n' "${CLASSIFICATION_RESULT:-ok:}"; }
+    wrap_cli_output() { printf '%s\n' "$2"; }
+    write_agent_status() {
+        printf '%s|%s|%s|%s\n' "$1" "$2" "$5" "$7" >> "$fixture_root/statuses"
+    }
+
+    OCTOPUS_PERSISTENCE_AVAILABLE=true \
+        run_agent_sync "$provider" 'review this change' 30 reviewer council
+)
+
+test_case "AGY exit 139 retries once and records the recovered crash artifact"
+agy_output="$(run_sync_fixture agy 1)" && agy_rc=0 || agy_rc=$?
+agy_root="$TEST_TMP_DIR/agy-1"
+agy_artifact="$(find "$agy_root/results" -maxdepth 1 -name 'sync-failure-*.stderr.log' -print -quit)"
+agy_mode="$(stat -f '%Lp' "$agy_artifact" 2>/dev/null || stat -c '%a' "$agy_artifact" 2>/dev/null || true)"
+first_timeout="$(sed -n '1p' "$agy_root/timeouts")"
+retry_timeout="$(sed -n '2p' "$agy_root/timeouts")"
+if [[ "$agy_rc" -eq 0 ]] && [[ "$(cat "$agy_root/attempts")" == "2" ]] && \
+   [[ "$agy_output" == *"recovered provider output"* ]] && \
+   [[ "$first_timeout" =~ ^[0-9]+$ ]] && [[ "$retry_timeout" =~ ^[0-9]+$ ]] && \
+   [[ "$retry_timeout" -lt "$first_timeout" ]] && \
+   [[ -f "$agy_artifact" ]] && grep -q 'synthetic provider crash attempt 1' "$agy_artifact" && \
+   [[ "$agy_mode" == "600" ]] && \
+   grep -Fq "agy|degraded|Recovered after AGY exit 139|$agy_artifact" "$agy_root/statuses"; then
+    test_pass
+else
+    test_fail "AGY retry/artifact contract failed (rc=$agy_rc attempts=$(cat "$agy_root/attempts" 2>/dev/null || echo 0) timeouts=${first_timeout:-missing}/${retry_timeout:-missing} artifact=${agy_artifact:-missing} mode=${agy_mode:-unknown})"
+fi
+
+test_case "a second AGY exit 139 fails without a third attempt and retains stderr"
+set +e
+run_sync_fixture agy 2 >/dev/null 2>&1
+terminal_rc=$?
+set -e
+terminal_root="$TEST_TMP_DIR/agy-2"
+terminal_artifact="$(find "$terminal_root/results" -maxdepth 1 -name 'sync-failure-*-attempt-2.stderr.log' -print -quit)"
+if [[ "$terminal_rc" -eq 139 ]] && [[ "$(cat "$terminal_root/attempts")" == "2" ]] && \
+   [[ -f "$terminal_artifact" ]] && grep -q 'synthetic provider crash attempt 2' "$terminal_artifact" && \
+   grep -Fq "agy|failed|Exit code 139|$terminal_artifact" "$terminal_root/statuses"; then
+    test_pass
+else
+    test_fail "terminal AGY crash did not stop after one retry with evidence (rc=$terminal_rc attempts=$(cat "$terminal_root/attempts" 2>/dev/null || echo 0))"
+fi
+
+test_case "non-AGY exit 139 is not retried but still preserves signal stderr"
+set +e
+run_sync_fixture openrouter 1 >/dev/null 2>&1
+other_rc=$?
+set -e
+other_root="$TEST_TMP_DIR/openrouter-1"
+other_artifact="$(find "$other_root/results" -maxdepth 1 -name 'sync-failure-*.stderr.log' -print -quit)"
+if [[ "$other_rc" -eq 139 ]] && [[ "$(cat "$other_root/attempts")" == "1" ]] && \
+   [[ -f "$other_artifact" ]] && grep -q 'synthetic provider crash attempt 1' "$other_artifact"; then
+    test_pass
+else
+    test_fail "non-AGY signal policy regressed (rc=$other_rc attempts=$(cat "$other_root/attempts" 2>/dev/null || echo 0))"
+fi
+
+test_case "a recovered crash keeps its artifact when output classification fails"
+set +e
+CLASSIFICATION_RESULT='failed:Empty output' run_sync_fixture agy 1 classified >/dev/null 2>&1
+classified_rc=$?
+set -e
+classified_root="$TEST_TMP_DIR/classified"
+classified_artifact="$(find "$classified_root/results" -maxdepth 1 -name 'sync-failure-*-attempt-1.stderr.log' -print -quit)"
+if [[ "$classified_rc" -eq 1 ]] && [[ -f "$classified_artifact" ]] && \
+   grep -Fq "agy|failed|Empty output|$classified_artifact" "$classified_root/statuses"; then
+    test_pass
+else
+    test_fail "post-retry classification failure dropped its crash artifact (rc=$classified_rc artifact=${classified_artifact:-missing})"
+fi
+
+test_case "recovered crashes preserve an existing degraded classifier reason"
+CLASSIFICATION_RESULT='degraded:Partial output' run_sync_fixture agy 1 degraded >/dev/null
+degraded_root="$TEST_TMP_DIR/degraded"
+degraded_artifact="$(find "$degraded_root/results" -maxdepth 1 -name 'sync-failure-*-attempt-1.stderr.log' -print -quit)"
+if grep -Fq "agy|degraded|Recovered after AGY exit 139; Partial output|$degraded_artifact" "$degraded_root/statuses"; then
+    test_pass
+else
+    test_fail "recovery status overwrote the classifier's degraded reason"
+fi
+
+test_summary

--- a/tests/unit/test-agent-sync-signal-retry.sh
+++ b/tests/unit/test-agent-sync-signal-retry.sh
@@ -13,6 +13,9 @@ test_suite "synchronous provider signal retry"
 
 # shellcheck source=/dev/null
 source "$PROJECT_ROOT/scripts/lib/agent-sync.sh"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/lib/heartbeat.sh"
+eval "$(declare -f run_with_timeout | sed '1s/^run_with_timeout/octopus_test_real_run_with_timeout/')"
 
 test_case "retry attempts use a conservative remainder of the original timeout"
 if declare -F octopus_sync_attempt_timeout >/dev/null 2>&1 && \
@@ -29,6 +32,7 @@ run_sync_fixture() (
     local provider="$1"
     local fail_count="$2"
     local scenario="${3:-${provider}-${fail_count}}"
+    local sync_timeout="${4:-30}"
     local fixture_root="$TEST_TMP_DIR/$scenario"
     local fake_provider="$fixture_root/provider.sh"
 
@@ -44,6 +48,9 @@ attempt=0
 attempt=$((attempt + 1))
 printf '%s\n' "$attempt" > "$ATTEMPT_FILE"
 if [[ "$attempt" -le "$FAIL_COUNT" ]]; then
+    if [[ "${OVERLONG_FIRST_ATTEMPT:-false}" == "true" ]] && [[ "$attempt" -eq 1 ]]; then
+        sleep "${OVERLONG_SLEEP:-3}"
+    fi
     printf 'synthetic provider crash attempt %s\n' "$attempt" >&2
     exit 139
 fi
@@ -66,6 +73,10 @@ EOF
     build_provider_env() { PROVIDER_ENV_ARRAY=(); }
     run_with_timeout() {
         printf '%s\n' "$1" >> "$fixture_root/timeouts"
+        if [[ "${ENFORCE_TIMEOUT:-false}" == "true" ]]; then
+            octopus_test_real_run_with_timeout "$@"
+            return $?
+        fi
         shift
         "$@"
     }
@@ -78,8 +89,15 @@ EOF
         printf '%s|%s|%s|%s\n' "$1" "$2" "$5" "$7" >> "$fixture_root/statuses"
     }
 
+    if [[ "${CALLER_ERREXIT:-on}" == "off" ]]; then
+        set +e
+    fi
+
     OCTOPUS_PERSISTENCE_AVAILABLE=true \
-        run_agent_sync "$provider" 'review this change' 30 reviewer council
+        run_agent_sync "$provider" 'review this change' "$sync_timeout" reviewer council
+    local sync_rc=$?
+    printf '%s\n' "$-" > "$fixture_root/caller-options-after"
+    return "$sync_rc"
 )
 
 test_case "AGY exit 139 retries once and records the recovered crash artifact"
@@ -152,6 +170,31 @@ if grep -Fq "agy|degraded|Recovered after AGY exit 139; Partial output|$degraded
     test_pass
 else
     test_fail "recovery status overwrote the classifier's degraded reason"
+fi
+
+test_case "successful sync dispatch preserves a caller with errexit disabled"
+CALLER_ERREXIT=off run_sync_fixture agy 0 caller-errexit-off >/dev/null
+caller_options="$(cat "$TEST_TMP_DIR/caller-errexit-off/caller-options-after")"
+if [[ "$caller_options" != *e* ]]; then
+    test_pass
+else
+    test_fail "run_agent_sync enabled errexit in a caller that had it disabled (options=$caller_options)"
+fi
+
+test_case "an overlong attempt is interrupted before an AGY retry can exceed the deadline"
+overlong_start=$SECONDS
+set +e
+ENFORCE_TIMEOUT=true OVERLONG_FIRST_ATTEMPT=true OVERLONG_SLEEP=4 \
+    run_sync_fixture agy 1 overlong-deadline 2 >/dev/null 2>&1
+overlong_rc=$?
+set -e
+overlong_elapsed=$((SECONDS - overlong_start))
+overlong_root="$TEST_TMP_DIR/overlong-deadline"
+if [[ "$overlong_rc" -eq 124 ]] && [[ "$(cat "$overlong_root/attempts")" == "1" ]] && \
+   [[ "$(cat "$overlong_root/timeouts")" == "2" ]] && [[ "$overlong_elapsed" -lt 4 ]]; then
+    test_pass
+else
+    test_fail "overlong attempt escaped its deadline (rc=$overlong_rc attempts=$(cat "$overlong_root/attempts" 2>/dev/null || echo 0) elapsed=${overlong_elapsed}s)"
 fi
 
 test_summary


### PR DESCRIPTION
## Summary

- Retry synchronous Antigravity (`agy`) dispatch exactly once after exit 139 (SIGSEGV).
- Keep both attempts inside the caller's original wall-clock timeout, with a conservative whole-second precision margin.
- Preserve signal stderr as mode-0600 diagnostic artifacts and link them from agent status, including recovered calls.
- Use unique temporary files so concurrent synchronous dispatches do not collide.
- Preserve existing degraded-classification reasons when a retry recovers.

## Verification

- `tests/unit/test-agent-sync-signal-retry.sh`: 6/6
- `tests/unit/test-agent-timeout-budget.sh`: 7/7
- `tests/unit/test-consultative-agent-dispatch.sh`: 8/8
- `tests/unit/test-agent-output-cap.sh`: 14/14
- `tests/unit/test-agy-provider.sh`: 50/50
- `CI=true GITHUB_ACTIONS=true make ci-changed`: full local matrix passed on the implementation commit before the docs-only `main` update; rerun on the reconciled exact head is recorded below before push.

## Independent review

- Antigravity review returned no findings.
- Codex and Claude independently identified missing no-timeout-extension coverage and a fractional-second overrun risk; both were reproduced, fixed, and covered by regression tests.
- Retaining the private crash artifacts is intentional: they are durable diagnostic evidence, not temporary transport files.

Closes #943


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Synchronous Antigravity runs now retry once after intermittent segmentation faults without extending the original timeout.
  * Repeated crashes stop after one retry, while other provider failures remain non-retriable.
  * Error output and diagnostic links are preserved for signal-terminated runs, including successful retries.
  * Recovered runs are reported as degraded when applicable, with clearer status details when output is truncated or unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->