### PR TITLE
test(ci): make deadline proof scheduler-independent

### DIFF
--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,18 +1,18 @@
 # AI Agent Handoff
 
 Last updated: 2026-08-26
-Status: The v10.0.0 reliability release candidate implements the six approved
-modernization additions plus hermetic end-to-end failure injection. The final
-review-response tree passes the complete local CI, plugin assembly, strict
-plugin validation, ShellCheck, and staged-review gates. Commit/push, protected
-PR verification, merge, tag, publication, and installed-release checks remain.
-Branch: `release/v10.0.0`; protected release PR #965 is under review.
+Status: PR #965 merged the six approved v10 modernization additions and
+hermetic end-to-end failure injection to `main` as `dd4cb943`. Exact-main Test
+Suite run `32961618258` correctly blocked tagging after one macOS-only timing
+oracle failure; no `v10.0.0` tag or release exists yet. A deterministic oracle
+fix is in progress on `fix/v10-macos-deadline`.
+Branch: `fix/v10-macos-deadline`, based on exact merged `main` `dd4cb943`.
 Current release: [v9.66.1](https://github.com/nyldn/claude-octopus/releases/tag/v9.66.1)
 Tracking: Beads epic `oco-de9`; children `oco-de9.1` through `oco-de9.8`
-Next action: commit and push the verified third-round PR #965 review response,
-reply to and resolve its one remaining inline thread, then wait for exact-head
-approval and hosted CI. Tag only the squash-merge commit on `main`, then rerun
-`bash scripts/validate-release.sh` against v10.
+Next action: verify the deterministic macOS deadline oracle, run the complete
+local gate, open and merge its protected hotfix PR, then require exact-main CI
+before tagging that squash-merge commit. After tagging, publish v10, sync both
+marketplaces, and rerun `bash scripts/validate-release.sh` plus fresh installs.
 
 ## V10 Reliability Release Candidate
 
@@ -70,6 +70,21 @@ approval and hosted CI. Tag only the squash-merge commit on `main`, then rerun
   accepts only the valid one-to-two-second range while preserving the timeout
   status, single-attempt, and elapsed-deadline assertions; five consecutive
   focused runs pass 8/8.
+- PR #965 exact-head Test Suite run `32960005405` passed Ubuntu and macOS unit,
+  symlink-path, smoke, full integration, and summary jobs at `66104bab`; GitHub
+  reported approval and zero unresolved threads before the normal squash merge.
+  Its non-required native review rerun failed only because Claude organization
+  spend and Copilot monthly quota were both exhausted; CodeRabbit's exact-head
+  check passed, so degraded provider capacity was not treated as approval.
+- Exact-main Test Suite run `32961618258` passed Ubuntu unit and symlink-path but
+  exposed the remaining macOS-only timing assumption: production returned 124
+  after one two-second attempt, while coarse `SECONDS` advanced by four under
+  runner load. The replacement oracle uses a ten-second provider completion
+  marker to prove the timeout interrupted natural execution, with a broad
+  fifteen-second hang bound that is not sensitive to scheduler jitter. Five
+  consecutive focused runs pass 8/8, and `make ci-local` passes 16 smoke,
+  289/289 unit, and 8/8 integration suites with failure injection 15/15 and
+  zero skips.
 - Focused evidence after the final response includes synchronous contract
   19/19, persistence degradation 6/6, semantic cache alignment 36/36, output
   cap 14/14, agent summary 11/11, version consistency 20/20 and 30/30, and

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -79,7 +79,7 @@ marketplaces, and rerun `bash scripts/validate-release.sh` plus fresh installs.
 - Exact-main Test Suite run `32961618258` passed Ubuntu unit and symlink-path but
   exposed the remaining macOS-only timing assumption: production returned 124
   after one two-second attempt, while coarse `SECONDS` advanced by four under
-  runner load. The replacement oracle uses a ten-second provider completion
+  runner load. The replacement oracle uses a thirty-second provider completion
   marker to prove the timeout interrupted natural execution, with a broad
   fifteen-second hang bound that is not sensitive to scheduler jitter. Five
   consecutive focused runs pass 8/8, and `make ci-local` passes 16 smoke,

--- a/tests/unit/test-agent-sync-signal-retry.sh
+++ b/tests/unit/test-agent-sync-signal-retry.sh
@@ -49,7 +49,18 @@ attempt=$((attempt + 1))
 printf '%s\n' "$attempt" > "$ATTEMPT_FILE"
 if [[ "$attempt" -le "$FAIL_COUNT" ]]; then
     if [[ "${OVERLONG_FIRST_ATTEMPT:-false}" == "true" ]] && [[ "$attempt" -eq 1 ]]; then
-        sleep "${OVERLONG_SLEEP:-3}"
+        if [[ -n "${OVERLONG_COMPLETION_FILE:-}" ]]; then
+            python3 -c '
+import pathlib
+import sys
+import time
+
+time.sleep(float(sys.argv[2]))
+pathlib.Path(sys.argv[1]).write_text("completed\\n")
+' "$OVERLONG_COMPLETION_FILE" "${OVERLONG_SLEEP:-3}"
+        else
+            sleep "${OVERLONG_SLEEP:-3}"
+        fi
     fi
     printf 'synthetic provider crash attempt %s\n' "$attempt" >&2
     exit 139
@@ -187,8 +198,10 @@ fi
 
 test_case "an overlong attempt is interrupted before an AGY retry can exceed the deadline"
 overlong_start=$SECONDS
+overlong_completion="$TEST_TMP_DIR/overlong-completed"
 set +e
-ENFORCE_TIMEOUT=true OVERLONG_FIRST_ATTEMPT=true OVERLONG_SLEEP=4 \
+ENFORCE_TIMEOUT=true OVERLONG_FIRST_ATTEMPT=true OVERLONG_SLEEP=10 \
+    OVERLONG_COMPLETION_FILE="$overlong_completion" \
     run_sync_fixture agy 1 overlong-deadline 2 >/dev/null 2>&1
 overlong_rc=$?
 set -e
@@ -196,10 +209,11 @@ overlong_elapsed=$((SECONDS - overlong_start))
 overlong_root="$TEST_TMP_DIR/overlong-deadline"
 overlong_attempt_timeout="$(cat "$overlong_root/timeouts" 2>/dev/null || true)"
 if [[ "$overlong_rc" -eq 124 ]] && [[ "$(cat "$overlong_root/attempts")" == "1" ]] && \
-   [[ "$overlong_attempt_timeout" =~ ^[12]$ ]] && [[ "$overlong_elapsed" -lt 4 ]]; then
+   [[ "$overlong_attempt_timeout" =~ ^[12]$ ]] && [[ ! -e "$overlong_completion" ]] && \
+   [[ "$overlong_elapsed" -lt 15 ]]; then
     test_pass
 else
-    test_fail "overlong attempt escaped its deadline (rc=$overlong_rc attempts=$(cat "$overlong_root/attempts" 2>/dev/null || echo 0) timeout=${overlong_attempt_timeout:-missing} elapsed=${overlong_elapsed}s)"
+    test_fail "overlong attempt escaped its deadline (rc=$overlong_rc attempts=$(cat "$overlong_root/attempts" 2>/dev/null || echo 0) timeout=${overlong_attempt_timeout:-missing} completed=$([[ -e "$overlong_completion" ]] && echo yes || echo no) elapsed=${overlong_elapsed}s)"
 fi
 
 test_summary

--- a/tests/unit/test-agent-sync-signal-retry.sh
+++ b/tests/unit/test-agent-sync-signal-retry.sh
@@ -200,9 +200,13 @@ test_case "an overlong attempt is interrupted before an AGY retry can exceed the
 overlong_start=$SECONDS
 overlong_completion="$TEST_TMP_DIR/overlong-completed"
 set +e
-ENFORCE_TIMEOUT=true OVERLONG_FIRST_ATTEMPT=true OVERLONG_SLEEP=10 \
-    OVERLONG_COMPLETION_FILE="$overlong_completion" \
+(
+    export "ENFORCE_TIMEOUT=true"
+    export "OVERLONG_FIRST_ATTEMPT=true"
+    export "OVERLONG_SLEEP=30"
+    export "OVERLONG_COMPLETION_FILE=$overlong_completion"
     run_sync_fixture agy 1 overlong-deadline 2 >/dev/null 2>&1
+)
 overlong_rc=$?
 set -e
 overlong_elapsed=$((SECONDS - overlong_start))


### PR DESCRIPTION
## Summary

- replace the coarse macOS wall-clock deadline assertion with a direct provider-completion marker
- keep timeout status, single-attempt, assigned-budget, and broad hang-bound checks
- record the blocked v10 release and recovery evidence in the durable handoff

## Root cause

Exact-main Test Suite run 32961618258 returned status 124 after one two-second attempt, but macOS runner scheduling advanced Bash `SECONDS` by exactly four and failed the strict `< 4` assertion. The runtime contract succeeded; the test inferred interruption from a coarse clock.

The marker is written by the same long-running Python child after its ten-second sleep. Killing that child prevents the marker, so the test directly proves interruption without depending on scheduler timing.

## Verification

- five consecutive focused runs: 8/8 each
- `CI=true GITHUB_ACTIONS=true make ci-changed`: 16 smoke + 3 selected suites passed
- `make ci-local`: 16 smoke, 289/289 unit, 8/8 integration
- v10 failure injection: 15/15, zero skips
- ShellCheck, Bash syntax, sync check, handoff 13/13, and diff checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout regression testing to reliably detect interrupted operations on macOS.
  * Added clearer failure reporting for incomplete timed-out attempts.
* **Documentation**
  * Updated release handoff records with merge status, validation results, remaining release blockers, and next steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->