### PR TITLE
fix: complete v10 post-release UAT follow-ups

### DIFF
--- a/.claude/skills/skill-copilot-provider/SKILL.md
+++ b/.claude/skills/skill-copilot-provider/SKILL.md
@@ -115,7 +115,7 @@ Indicator legend:
 
 ## Doctor Integration
 
-The `/octo:doctor` providers check reports Copilot availability and auth method:
+The `octopus doctor providers` check reports Copilot availability and auth method:
 
 ```
 Providers:

--- a/.claude/skills/skill-doctor/SKILL.md
+++ b/.claude/skills/skill-doctor/SKILL.md
@@ -388,14 +388,17 @@ Without a `RUNTIME.md`, orchestration prompts lack project-specific details — 
 ## Quick Reference
 
 `/octo:doctor` was removed in v9.41.0 to preserve Claude Code's native `/doctor` command.
-Invoke this skill by asking Claude naturally, or run the orchestrator directly:
+Invoke this manual skill explicitly, or run the CLI directly:
 
 | What to say / run | Action |
 |-------------------|--------|
-| "run Octopus doctor diagnostics" | Run all 14 categories |
-| "check Octopus providers" | Check provider installation only |
-| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor auth --verbose` | Detailed auth status |
-| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --json` | Machine-readable output |
+| `/octo:skill-doctor` | Run all 14 categories inside Claude Code |
+| `octopus doctor providers` | Check provider installation only |
+| `octopus doctor auth --verbose` | Detailed auth status |
+| `octopus doctor --json` | Machine-readable output |
+| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor auth --verbose` | Detailed auth status when the CLI is unavailable |
+| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --json` | Machine-readable output when the CLI is unavailable |
 
-Resolve and export `OCTO_PLUGIN_ROOT` with the Step 1 resolver before using either
-direct command.
+If the `octopus` CLI is not on `PATH`, resolve and export `OCTO_PLUGIN_ROOT`
+with the Step 1 resolver, then run the equivalent `scripts/orchestrate.sh`
+command directly.

--- a/.cursor-plugin/commands/octo-doctor.md
+++ b/.cursor-plugin/commands/octo-doctor.md
@@ -375,14 +375,17 @@ Without a `RUNTIME.md`, orchestration prompts lack project-specific details — 
 ## Quick Reference
 
 `/octo:doctor` was removed in v9.41.0 to preserve Claude Code's native `/doctor` command.
-Invoke this skill by asking Claude naturally, or run the orchestrator directly:
+Invoke this manual skill explicitly, or run the CLI directly:
 
 | What to say / run | Action |
 |-------------------|--------|
-| "run Octopus doctor diagnostics" | Run all 14 categories |
-| "check Octopus providers" | Check provider installation only |
-| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor auth --verbose` | Detailed auth status |
-| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --json` | Machine-readable output |
+| `/octo:skill-doctor` | Run all 14 categories inside Claude Code |
+| `octopus doctor providers` | Check provider installation only |
+| `octopus doctor auth --verbose` | Detailed auth status |
+| `octopus doctor --json` | Machine-readable output |
+| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor auth --verbose` | Detailed auth status when the CLI is unavailable |
+| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --json` | Machine-readable output when the CLI is unavailable |
 
-Resolve and export `OCTO_PLUGIN_ROOT` with the Step 1 resolver before using either
-direct command.
+If the `octopus` CLI is not on `PATH`, resolve and export `OCTO_PLUGIN_ROOT`
+with the Step 1 resolver, then run the equivalent `scripts/orchestrate.sh`
+command directly.

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -32,6 +32,10 @@ checkout.
   health-handler path used by synchronous dispatch instead of requiring the
   removed hard-coded call. Release validation reports successful skill
   registration independently of unrelated earlier validation errors.
+- Follow-up review hardened the release checks with pipefail-safe exact
+  membership tests, an ordering assertion for health preflight before dispatch,
+  framework-based Doctor assertions, packaged-skill coverage, and exact
+  occurrence counting for the retired Doctor command.
 - `make sync` and the final non-interactive `make ci-changed` full rule pass:
   16/16 smoke suites, 289/289 unit suites, and 8/8 integration suites. The one
   documented macOS Council PTY case and the optional uninitialized debate

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,18 +1,46 @@
 # AI Agent Handoff
 
-Last updated: 2026-08-26
-Status: v10 reliability modernization is released. PR #965 merged additions
-1-6 and hermetic end-to-end failure injection as `dd4cb943`; PR #966 merged the
-deterministic macOS deadline oracle as `6265807f`. Exact-main Test Suite run
-`32969018355` passed before the annotated `v10.0.0` tag and GitHub release were
-published from that exact commit.
-Branch: `docs/v10-release-handoff`, based on tagged `main` `6265807f`.
-Handoff publication: evidence commit `c714303b` is pushed as PR #967; every
-review-response commit is pushed and checked for local/remote parity before merge.
+Last updated: 2026-08-27
+Status: v10.0.0 is released and post-release installed-package UAT is complete.
+The UAT follow-ups are ready for review with no private environment, network,
+authentication, or operational details included in the public diff.
+Branch: `codex/v10-release-audit`, based on `upstream/main` `745b4bca`.
 Current release: [v10.0.0](https://github.com/nyldn/claude-octopus/releases/tag/v10.0.0)
-Tracking: Beads epic `oco-de9` and children `oco-de9.1` through `oco-de9.8` are closed.
-Next action: no v10 release action remains. Start from current protected `main`,
-run `bd ready`, and preserve unrelated dirty state in the coordination checkout.
+Tracking: `bd` is unavailable in this checkout, so no Beads issue was created or
+updated for the post-release follow-ups.
+Next action: review and publish the public-safe follow-up branch. Keep private UAT
+records out of commits and preserve unrelated dirty state in the coordination
+checkout.
+
+## V10 Post-Release UAT Follow-ups
+
+- The tagged v10.0.0 checkout passes release validation, and the released
+  marketplace package resolves, installs, enables, authenticates, and loads in
+  an isolated installed-package test. Whats-new, Doctor 2.0, the explicit
+  `skill-doctor` entrypoint, and a real quick Codex dispatch all completed.
+- Installed-package UAT exposed one upgrade-only routing defect: an existing
+  generated schema-v3 `providers.codex.mini` value could retain
+  `gpt-5-codex-mini`, which current ChatGPT-authenticated Codex rejects. The
+  migration now maps only the known legacy generated mini values to
+  `gpt-5.6-luna`; fresh defaults were already correct. Regression coverage
+  passes 15/15.
+- Current public guidance now uses `/octo:skill-doctor` in Claude Code and
+  `octopus doctor` in a shell. The retired `/octo:doctor` remains unregistered
+  so Claude Code's native `/doctor` command is not shadowed. Generated Factory
+  command output and Codex skill packaging are synchronized.
+- The legacy model-config assertion now verifies the Provider Registry 2.0
+  health-handler path used by synchronous dispatch instead of requiring the
+  removed hard-coded call. Release validation reports successful skill
+  registration independently of unrelated earlier validation errors.
+- `make sync` and the final non-interactive `make ci-changed` full rule pass:
+  16/16 smoke suites, 289/289 unit suites, and 8/8 integration suites. The one
+  documented macOS Council PTY case and the optional uninitialized debate
+  submodule case remain skips, not failures. `git diff --check` passes and no
+  executable-mode changes are present.
+- Doctor's only diagnostic failure in the installed-package run was the known
+  `claude --bare` authentication-probe compatibility issue tracked as #288;
+  runtime fallback disables that probe automatically. It did not block direct
+  Claude authentication or the real workflow checks.
 
 ## V10 Reliability Release
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -34,8 +34,9 @@ checkout.
   registration independently of unrelated earlier validation errors.
 - Follow-up review hardened the release checks with pipefail-safe exact
   membership tests, an ordering assertion for health preflight before dispatch,
-  framework-based Doctor assertions, packaged-skill coverage, and exact
-  occurrence counting for the retired Doctor command.
+  consistent error logging, framework-based Doctor assertions, packaged-skill
+  coverage, and exact occurrence counting that rejects missing or unreadable
+  Doctor guidance surfaces.
 - `make sync` and the final non-interactive `make ci-changed` full rule pass:
   16/16 smoke suites, 289/289 unit suites, and 8/8 integration suites. The one
   documented macOS Council PTY case and the optional uninitialized debate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Migrate legacy generated `codex-mini` pins such as `gpt-5-codex-mini` to
+  `gpt-5.6-luna`, preventing quick workflows from selecting a model that is
+  unsupported for ChatGPT-authenticated Codex CLI sessions. Agent help now
+  reports the GPT-5.6 Sol/Terra/Luna tiers used by v10 routing.
+- Correct current documentation and runtime guidance to use
+  `/octo:skill-doctor` in Claude Code or `octopus doctor` in a shell.
+  `/octo:doctor` remains intentionally unregistered so Claude Code's native
+  `/doctor` command is not shadowed.
+
 ## [10.0.0] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Code's native manual-invocation gate. Start it with `/octo:*`.
 
 > **Seeing `cannot be used with Skill tool due to disable-model-invocation`?**
 > That is the gate working as intended — the model tried to auto-invoke an
-> Octopus skill. Run the command explicitly instead: type `/octo:doctor` (the
-> command), not a model call to the `skill-doctor` skill. Slash commands are
+> Octopus skill. Invoke it explicitly instead: type `/octo:skill-doctor` (the
+> manually invokable skill), not a model call to the `skill-doctor` skill. Slash skills are
 > user-invoked, so they bypass this invocation gate; the model will not call
 > Octopus skills on its own unless you opt into the router below. Rule of thumb:
 > **invoke Octopus with
@@ -391,7 +391,7 @@ Not sure which command to use? Pick by goal:
 | Write a product spec | `/octo:prd` |
 | Go from spec to shipping code | `/octo:factory` |
 | Debug a tricky issue | `/octo:debug` |
-| Reduce token usage | `/octo:doctor` (includes RTK install + token tips) |
+| Reduce token usage | `/octo:skill-doctor` or `octopus doctor` (includes RTK install + token tips) |
 | Just run something quick | `/octo:quick` |
 
 Or type `/octo:auto <what you want>` and the smart router picks for you. Plain-prompt routing is off until you run `/octo:setup`, which turns on **suggestions** (Octopus names a matching command; it never dispatches a provider on its own). Set `OCTOPUS_AUTO_ROUTER_MODE=off` to silence them, or `invoke` to let a matched route load automatically. 🔍
@@ -681,7 +681,7 @@ The workflow continues with available providers. You'll see the status in the vi
 🐙 *Fun fact: a real octopus has three hearts, blue blood, and 500 million neurons — two-thirds of which live in its eight arms.* Each arm can taste, touch, and act independently. Claude Octopus works the same way: each tentacle (command) operates autonomously with its own squeeze of logic, then ink flows back as the final deliverable. The crossfire review? That's the squeeze — adversarial pressure that untangles everything before it ships.
 
 **How do I debug when something goes wrong?**
-Run commands with the `--verbose` flag to get detailed debugging output. Logs are stored in `~/.claude-octopus/logs/` for inspection. You can also use `/octo:doctor` to run diagnostics and identify potential issues.
+Run commands with the `--verbose` flag to get detailed debugging output. Logs are stored in `~/.claude-octopus/logs/` for inspection. You can also invoke `/octo:skill-doctor` in Claude Code or run `octopus doctor` in a shell to identify potential issues.
 
 ---
 

--- a/docs/COMMAND-REFERENCE.md
+++ b/docs/COMMAND-REFERENCE.md
@@ -1,6 +1,6 @@
 # Command and Usage Reference
 
-Complete reference for all 49 Claude Octopus slash commands, CLI tools (`octopus` + `octo-compress`), plus activation rules, provider indicators, and manual-only project-lifecycle skills.
+Complete reference for all 54 Claude Octopus slash commands, CLI tools (`octopus` + `octo-compress`), plus activation rules, provider indicators, and manual-only project-lifecycle skills.
 
 ---
 
@@ -19,7 +19,7 @@ All slash commands use the `/octo:` namespace. The smart router command is `/oct
 | Command | Description |
 |---------|-------------|
 | `/octo:setup` | Check setup status and configure providers (aliases: `/octo:configure`, `/octo:config`, `/octo:init`, `/octo:wizard`, `/octo:sys-setup`) |
-| `/octo:doctor` | Fail-closed diagnostics across 14 categories with human or JSON output |
+| `/octo:skill-doctor` | Manually invoke fail-closed diagnostics without shadowing Claude Code's native `/doctor` |
 | `/octo:model-config` | Configure provider model selection per workflow phase |
 | `/octo:km` | Toggle Knowledge Work mode |
 | `/octo:dev` | Switch to Dev Work mode |
@@ -197,7 +197,7 @@ an `auto_router_mode` value already present in
 
 **Alias and fuzzy matching:**
 - Setup aliases such as `/octo:configure`, `/octo:config`, `/octo:init`, `/octo:install`, `/octo:settings`, and `/octo:wizard` resolve to `/octo:setup`.
-- Common shortcut aliases resolve before routing: `/octo:cost` -> `/octo:costs`, `/octo:usage` -> `/octo:costs`, `/octo:optimize` -> `/octo:auto`, `/octo:sys-update` -> `/octo:doctor`.
+- Common shortcut aliases resolve before routing: `/octo:cost` -> `/octo:costs`, `/octo:usage` -> `/octo:costs`, and `/octo:optimize` -> `/octo:auto`.
 - Mistyped explicit `/octo:*` commands return close matches and write the event to `~/.claude-octopus/alias-log.tsv`.
 
 **Router promotion:** Prompts that name multiple concrete options, such as "Redis or DynamoDB" or "Option A vs Option B", are promoted to `/octo:debate` so the answer gets structured multi-model scoring instead of a single-model response.
@@ -238,19 +238,24 @@ You're all set! Try: /octo:auto research OAuth patterns
 
 ---
 
-### `/octo:doctor`
+### Doctor diagnostics
 
 Run fail-closed environment diagnostics across 14 check categories.
 
+Octopus intentionally leaves `/octo:doctor` unregistered so Claude Code's
+native `/doctor` remains available. Invoke `/octo:skill-doctor` inside Claude
+Code, or use the exact CLI commands below when you need arguments or JSON.
+
 **Usage:**
 ```
-/octo:doctor                    # Run all checks
-/octo:doctor providers          # Check provider installation only
-/octo:doctor providers --live   # Run a bounded live AGY catalog/model/dispatch probe
-/octo:doctor auth --verbose     # Detailed auth status
-/octo:doctor config             # Plugin install/version plus Claude Code feature flags
-/octo:doctor skills             # Skill loading plus modern plugin capability notes
-/octo:doctor --json             # Machine-readable Doctor 2.0 output
+/octo:skill-doctor              # Run all checks inside Claude Code
+octopus doctor                  # Run all checks from a shell
+octopus doctor providers        # Check provider installation only
+octopus doctor providers --live # Run a bounded live AGY catalog/model/dispatch probe
+octopus doctor auth --verbose   # Detailed auth status
+octopus doctor config           # Plugin install/version plus Claude Code feature flags
+octopus doctor skills           # Skill loading plus modern plugin capability notes
+octopus doctor --json           # Machine-readable Doctor 2.0 output
 ```
 
 **Check categories:**
@@ -278,13 +283,13 @@ arguments. With `--json`, a diagnostic failure still leaves a valid
 `schema_version: "10.0"` report on stdout; capture the exit status separately
 instead of discarding the report under shell `errexit`.
 
-`/octo:doctor providers --live` is opt-in because it sends one small real AGY
+`octopus doctor providers --live` is opt-in because it sends one small real AGY
 request. It checks the installed version, live `agy models` catalog and keyring
 authentication, the configured model against that catalog, and a bounded
 print-mode response. Normal doctor and startup checks do not spend provider
 quota or trigger interactive authentication.
 
-**Modern Claude Code checks:** On Claude Code v2.1.126+, `/octo:doctor` reports which newer runtime capabilities Octopus can safely use. Current checks cover gateway model discovery opt-in, reserved MCP server names, experimental manifest key placement, `skillOverrides`, plugin zip archives, `--plugin-url`, stream-json plugin load errors, force-synchronized output, and package-manager auto-update prompts.
+**Modern Claude Code checks:** On Claude Code v2.1.126+, Doctor reports which newer runtime capabilities Octopus can safely use. Current checks cover gateway model discovery opt-in, reserved MCP server names, experimental manifest key placement, `skillOverrides`, plugin zip archives, `--plugin-url`, stream-json plugin load errors, force-synchronized output, and package-manager auto-update prompts.
 
 These are advisory unless they identify a concrete misconfiguration. For example, `gateway-model-discovery` warns only when `ANTHROPIC_BASE_URL` is set without `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, and `mcp-workspace-reserved` warns only when a settings file defines `mcpServers.workspace`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,4 +27,5 @@ Provider-specific configuration is in `config/providers/`:
 
 ## Quick Start
 
-Run `/octo:setup` in Claude Code for guided setup, or `/octo:doctor` to diagnose issues.
+Run `/octo:setup` in Claude Code for guided setup. For diagnostics, invoke
+`/octo:skill-doctor` in Claude Code or run `octopus doctor` in a shell.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -3,10 +3,13 @@
 The most common failure is a provider that will not authenticate or is silently skipped. Start with the two built-in diagnostics, then use the per-provider table.
 
 ```bash
-/octo:doctor                    # local install, auth signals, versions, and configuration
-/octo:doctor providers --live   # bounded live AGY catalog/model/dispatch check
-octopus <cmd> --verbose   # per-dispatch detail: which provider, which model, why skipped
+octopus doctor                  # local install, auth signals, versions, and configuration
+octopus doctor providers --live # bounded live AGY catalog/model/dispatch check
+octopus <cmd> --verbose         # per-dispatch detail: which provider, which model, why skipped
 ```
+
+Inside Claude Code, invoke the same diagnostics with `/octo:skill-doctor`.
+That namespaced skill preserves Claude Code's native `/doctor` command.
 
 For model-selection questions specifically, `OCTOPUS_TRACE_MODELS=1` prints the resolution tier (env pin, session override, phase route, capability map, default) for every dispatch.
 
@@ -17,7 +20,7 @@ A provider is used only when its CLI is installed AND its auth check passes. If 
 | Provider | Availability check | Fix |
 |----------|-------------------|-----|
 | 🔴 Codex | `codex` on PATH, auth configured | `codex login` (ChatGPT subscription) or set `OPENAI_API_KEY` |
-| 🧭 Antigravity | `agy` on PATH; opt-in live check verifies catalog, model, and dispatch | Launch plain `agy` and finish its browser sign-in, then run `/octo:doctor providers --live`. There is no separate login shell subcommand. On macOS keyring errors, open Keychain Access, find the Antigravity CLI item, and allow `agy` under Access Control. See the official [install/auth](https://antigravity.google/docs/cli/install) and [troubleshooting](https://antigravity.google/docs/cli/troubleshooting) guides. |
+| 🧭 Antigravity | `agy` on PATH; opt-in live check verifies catalog, model, and dispatch | Launch plain `agy` and finish its browser sign-in, then run `octopus doctor providers --live`. There is no separate login shell subcommand. On macOS keyring errors, open Keychain Access, find the Antigravity CLI item, and allow `agy` under Access Control. See the official [install/auth](https://antigravity.google/docs/cli/install) and [troubleshooting](https://antigravity.google/docs/cli/troubleshooting) guides. |
 | 🟢 Copilot | `copilot` on PATH plus one of: `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`, `~/.copilot/config.json`, or `gh auth status` passing | `gh auth login` is the simplest path |
 | 🟤 Qwen | `qwen` on PATH plus `~/.qwen/oauth_creds.json` or `QWEN_API_KEY` | Free OAuth ended 2026-04-15; set `QWEN_API_KEY` or Coding-Plan auth (`OPENAI_API_KEY` + `OPENAI_BASE_URL`) |
 | ⚫ Ollama | `ollama` on PATH AND server responding at `http://localhost:11434` | `ollama serve`; a missing model is NOT auto-pulled (see below) |
@@ -45,4 +48,4 @@ A provider is used only when its CLI is installed AND its auth check passes. If 
 
 ## Escalation
 
-If `/octo:doctor` is green and a workflow still fails, capture `--verbose` output plus the session log and open an issue: https://github.com/nyldn/claude-octopus/issues
+If `octopus doctor` is green and a workflow still fails, capture `--verbose` output plus the session log and open an issue: https://github.com/nyldn/claude-octopus/issues

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Claude Octopus Dependency Installer
 # ═══════════════════════════════════════════════════════════════════════════════
-# Called by /octo:setup and /octo:doctor to detect and install dependencies.
+# Called by /octo:setup and Doctor diagnostics to detect and install dependencies.
 # Usage: install-deps.sh [check|install|install-statusline|install-plugins]
 #   check             — Report missing deps as structured output
 #   install           — Install all missing deps (npm, brew, statusline, plugins)
@@ -120,7 +120,7 @@ check_deps() {
         if declare -f octo_is_windows_git_bash >/dev/null 2>&1 && octo_is_windows_git_bash; then
             warnings+=("rtk:RTK not installed (optional) — saves tokens on bash output. On Windows Git Bash, install RTK and use its CLAUDE.md injection mode instead of rtk init -g.")
         else
-            warnings+=("rtk:RTK not installed (optional) — saves 60-90% tokens on bash output. Install: brew install rtk && rtk init -g. Run /octo:doctor for guided setup.")
+            warnings+=("rtk:RTK not installed (optional) — saves 60-90% tokens on bash output. Install: brew install rtk && rtk init -g. Run octopus doctor for guided setup.")
         fi
     fi
 

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -523,6 +523,7 @@ EOF
     local -a stale_paths=(
         '.providers.codex.default'
         '.providers.codex.fallback'
+        '.providers.codex.mini'
         '.overrides.codex'
     )
 
@@ -533,6 +534,8 @@ EOF
 
         local replacement=""
         case "$current_val" in
+            gpt-5-codex-mini|gpt-5.1-codex-mini)
+                if [[ "$path" == '.providers.codex.mini' ]]; then replacement="gpt-5.6-luna"; fi ;;
             claude-sonnet-4-5|claude-sonnet-4-5-20250514|claude-3-5-sonnet*|claude-sonnet-4*)
                 if [[ "$path" == *codex* ]]; then replacement="gpt-5.6-sol"; fi ;;
             gpt-4o*|gpt-4-turbo*|gpt-4-*|o1-*|chatgpt-*)

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -1047,7 +1047,7 @@ print_provider_report() {
     [[ -n "$copilot_detail" ]] && printf "│    → %-38.38s│\n" "$copilot_detail"
     if [[ "$had_fallback" == "true" ]]; then
         echo "│                                             │"
-        echo "│ ⚠ Some providers failed — run /octo:doctor  │"
+        echo "│ ⚠ Some providers failed — run octopus doctor│"
     fi
     echo "└─────────────────────────────────────────────┘"
 
@@ -1061,7 +1061,7 @@ print_provider_report() {
         done < "$status_file"
     fi
 
-    # Persist failures for /octo:doctor
+    # Persist failures for Doctor diagnostics.
     if [[ "$had_fallback" == "true" ]]; then
         mkdir -p "$(dirname "$fallback_log")"
         local ts
@@ -1121,7 +1121,7 @@ review_run() {
     elif command -v codex >/dev/null 2>&1; then
         if ! check_codex_auth_freshness 2>/dev/null; then
             log "WARN" "review_run: Codex auth may be stale — review fleet may fall back to claude-sonnet"
-            log "USER" "⚠ Codex auth check failed. Run 'codex auth' or /octo:doctor to fix. Falling back to claude-sonnet for Codex roles."
+            log "USER" "⚠ Codex auth check failed. Run 'codex auth' or 'octopus doctor' to fix. Falling back to claude-sonnet for Codex roles."
             echo "codex|auth-failed|Run: codex auth" >> "$provider_status_file"
         fi
     else
@@ -1541,7 +1541,7 @@ ${round1_prompts[$retry_idx]}"
     done
     if [[ $_r1_failed -ge $_r1_total ]] && [[ $_r1_total -gt 0 ]]; then
         log ERROR "review_run: ALL Round 1 providers failed ($_r1_failed/$_r1_total). Review output is unreliable."
-        echo "{\"findings\":[],\"warning\":\"All $_r1_total review providers failed. No code was actually reviewed. Run /octo:doctor to diagnose provider issues.\"}" > "$findings_file"
+        echo "{\"findings\":[],\"warning\":\"All $_r1_total review providers failed. No code was actually reviewed. Run octopus doctor to diagnose provider issues.\"}" > "$findings_file"
         if [[ -n "$proof_dir" ]]; then
             octo_proof_artifact "$proof_dir" "review-findings" "$findings_file" "all providers failed"
             octo_proof_claim "$proof_dir" "Code was reviewed by at least one provider" "contradicted" "$findings_file"

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -53,11 +53,11 @@ _claude_octopus() {
     )
 
     agents=(
-        'codex:GPT-5.3-Codex (premium, high-capability)'
-        'codex-standard:GPT-5.2-Codex'
-        'codex-max:GPT-5.3-Codex'
-        'codex-mini:GPT-5.1-Codex-Mini (fast)'
-        'codex-general:GPT-5.2'
+        'codex:GPT-5.6 Sol (frontier)'
+        'codex-standard:GPT-5.6 Terra (balanced)'
+        'codex-max:GPT-5.6 Sol (frontier)'
+        'codex-mini:GPT-5.6 Luna (fast)'
+        'codex-general:GPT-5.6 Terra (balanced)'
         'agy:Antigravity (Google seat)'
         'agy-research:Antigravity research mode'
         'codex-review:Code review mode'
@@ -694,9 +694,9 @@ ${RED}════════════════════════�
   audit [count] [filter]  View audit trail (decisions log)
 
 ${YELLOW}Available Agents:${NC}
-  codex           GPT-5.3-Codex       ${GREEN}Premium${NC} (high-capability coding)
-  codex-standard  GPT-5.2-Codex       Standard tier
-  codex-mini      GPT-5.1-Codex-Mini  Quick/cheap tasks
+  codex           GPT-5.6 Sol          ${GREEN}Premium${NC} (frontier coding)
+  codex-standard  GPT-5.6 Terra        Standard tier
+  codex-mini      GPT-5.6 Luna         Quick/cheap tasks
   agy             Antigravity         Google research and design seat
   agy-research    Antigravity         Research-focused routing
 

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -383,10 +383,12 @@ else
     REGISTERED_SKILLS=$(grep -o '\.claude/skills/[^"]*\.md' "$ROOT_DIR/.claude-plugin/plugin.json" | sed 's|.*\.claude/skills/||' | sort)
 fi
 
+skill_registration_errors=0
 for skill_file in $SKILL_FILES; do
     if ! echo "$REGISTERED_SKILLS" | grep -q "^${skill_file}$"; then
         echo -e "  ${RED}ERROR: Skill file '$skill_file' not registered in plugin.json${NC}"
         ((errors++)) || true
+        ((skill_registration_errors++)) || true
     fi
 done
 
@@ -394,13 +396,14 @@ for reg_skill in $REGISTERED_SKILLS; do
     if ! echo "$SKILL_FILES" | grep -q "^${reg_skill}$"; then
         echo -e "  ${RED}ERROR: Registered skill '$reg_skill' does not exist${NC}"
         ((errors++)) || true
+        ((skill_registration_errors++)) || true
     fi
 done
 
 skill_count=$(echo "$SKILL_FILES" | wc -l | tr -d ' ')
 reg_skill_count=$(echo "$REGISTERED_SKILLS" | wc -l | tr -d ' ')
 
-if [[ "$skill_count" == "$reg_skill_count" ]] && [[ $errors -eq 0 ]]; then
+if [[ "$skill_count" == "$reg_skill_count" ]] && [[ $skill_registration_errors -eq 0 ]]; then
     echo -e "  ${GREEN}✓ All $skill_count skills properly registered${NC}"
 fi
 

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -386,7 +386,7 @@ fi
 skill_registration_errors=0
 for skill_file in $SKILL_FILES; do
     if ! grep -Fxc -- "$skill_file" <<< "$REGISTERED_SKILLS" >/dev/null; then
-        echo -e "  ${RED}ERROR: Skill file '$skill_file' not registered in plugin.json${NC}"
+        log ERROR "Skill file '$skill_file' not registered in plugin.json"
         ((errors++)) || true
         ((skill_registration_errors++)) || true
     fi
@@ -394,7 +394,7 @@ done
 
 for reg_skill in $REGISTERED_SKILLS; do
     if ! grep -Fxc -- "$reg_skill" <<< "$SKILL_FILES" >/dev/null; then
-        echo -e "  ${RED}ERROR: Registered skill '$reg_skill' does not exist${NC}"
+        log ERROR "Registered skill '$reg_skill' does not exist"
         ((errors++)) || true
         ((skill_registration_errors++)) || true
     fi

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -385,7 +385,7 @@ fi
 
 skill_registration_errors=0
 for skill_file in $SKILL_FILES; do
-    if ! echo "$REGISTERED_SKILLS" | grep -q "^${skill_file}$"; then
+    if ! grep -Fxc -- "$skill_file" <<< "$REGISTERED_SKILLS" >/dev/null; then
         echo -e "  ${RED}ERROR: Skill file '$skill_file' not registered in plugin.json${NC}"
         ((errors++)) || true
         ((skill_registration_errors++)) || true
@@ -393,7 +393,7 @@ for skill_file in $SKILL_FILES; do
 done
 
 for reg_skill in $REGISTERED_SKILLS; do
-    if ! echo "$SKILL_FILES" | grep -q "^${reg_skill}$"; then
+    if ! grep -Fxc -- "$reg_skill" <<< "$SKILL_FILES" >/dev/null; then
         echo -e "  ${RED}ERROR: Registered skill '$reg_skill' does not exist${NC}"
         ((errors++)) || true
         ((skill_registration_errors++)) || true

--- a/skills/skill-copilot-provider/SKILL.md
+++ b/skills/skill-copilot-provider/SKILL.md
@@ -107,7 +107,7 @@ Indicator legend:
 
 ## Doctor Integration
 
-The `/octo:doctor` providers check reports Copilot availability and auth method:
+The `octopus doctor providers` check reports Copilot availability and auth method:
 
 ```
 Providers:

--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -370,14 +370,17 @@ Without a `RUNTIME.md`, orchestration prompts lack project-specific details — 
 ## Quick Reference
 
 `/octo:doctor` was removed in v9.41.0 to preserve Claude Code's native `/doctor` command.
-Invoke this skill by asking Claude naturally, or run the orchestrator directly:
+Invoke this manual skill explicitly, or run the CLI directly:
 
 | What to say / run | Action |
 |-------------------|--------|
-| "run Octopus doctor diagnostics" | Run all 14 categories |
-| "check Octopus providers" | Check provider installation only |
-| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor auth --verbose` | Detailed auth status |
-| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --json` | Machine-readable output |
+| `/octo:skill-doctor` | Run all 14 categories inside Claude Code |
+| `octopus doctor providers` | Check provider installation only |
+| `octopus doctor auth --verbose` | Detailed auth status |
+| `octopus doctor --json` | Machine-readable output |
+| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor auth --verbose` | Detailed auth status when the CLI is unavailable |
+| `bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --json` | Machine-readable output when the CLI is unavailable |
 
-Resolve and export `OCTO_PLUGIN_ROOT` with the Step 1 resolver before using either
-direct command.
+If the `octopus` CLI is not on `PATH`, resolve and export `OCTO_PLUGIN_ROOT`
+with the Step 1 resolver, then run the equivalent `scripts/orchestrate.sh`
+command directly.

--- a/tests/test-model-config-v849.sh
+++ b/tests/test-model-config-v849.sh
@@ -375,11 +375,15 @@ else
     fail "check_all_providers() function missing"
 fi
 
-# Verify health check is wired into run_agent_sync
-if grep -A 160 'run_agent_sync()' "$_ORCH_ALL_TMP" | grep -q 'check_provider_health'; then
-    pass "run_agent_sync() calls check_provider_health() before dispatch"
+# Verify health check is wired into run_agent_sync through Provider Registry 2.0.
+# The resolved handler is normally check_provider_health, but keeping dispatch
+# indirect prevents this legacy contract from fighting the registry metadata.
+run_agent_sync_body=$(sed -n '/^run_agent_sync()/,/^}/p' "$_ORCH_ALL_TMP")
+if grep -q 'octo_provider_health_handler' <<< "$run_agent_sync_body" &&
+   grep -q '"\$_health_handler" "\$_provider_for_health"' <<< "$run_agent_sync_body"; then
+    pass "run_agent_sync() invokes the registry health handler before dispatch"
 else
-    fail "run_agent_sync() not wired to health check"
+    fail "run_agent_sync() not wired to the registry health handler"
 fi
 
 echo ""

--- a/tests/test-model-config-v849.sh
+++ b/tests/test-model-config-v849.sh
@@ -379,11 +379,15 @@ fi
 # The resolved handler is normally check_provider_health, but keeping dispatch
 # indirect prevents this legacy contract from fighting the registry metadata.
 run_agent_sync_body=$(sed -n '/^run_agent_sync()/,/^}/p' "$_ORCH_ALL_TMP")
+health_handler_line=$(awk 'index($0, "\"$_health_handler\" \"$_provider_for_health\"") { print NR; exit }' <<< "$run_agent_sync_body")
+dispatch_line=$(awk 'index($0, "get_agent_command \"$agent_type\"") { print NR; exit }' <<< "$run_agent_sync_body")
 if grep -q 'octo_provider_health_handler' <<< "$run_agent_sync_body" &&
-   grep -q '"\$_health_handler" "\$_provider_for_health"' <<< "$run_agent_sync_body"; then
+   [[ "$health_handler_line" =~ ^[0-9]+$ ]] &&
+   [[ "$dispatch_line" =~ ^[0-9]+$ ]] &&
+   (( health_handler_line < dispatch_line )); then
     pass "run_agent_sync() invokes the registry health handler before dispatch"
 else
-    fail "run_agent_sync() not wired to the registry health handler"
+    fail "run_agent_sync() does not invoke the registry health handler before dispatch"
 fi
 
 echo ""

--- a/tests/unit/test-command-frontmatter.sh
+++ b/tests/unit/test-command-frontmatter.sh
@@ -57,8 +57,17 @@ else
 fi
 
 count_doctor_references() {
-    { grep -oF -- '/octo:doctor' "$1" 2>/dev/null || true; } | awk 'END { print NR + 0 }'
+    local path="$1"
+    [[ -f "$path" && -r "$path" ]] || return 1
+    { grep -oF -- '/octo:doctor' "$path" || [[ $? -eq 1 ]]; } | awk 'END { print NR + 0 }'
 }
+
+test_case "Doctor reference counter rejects unavailable files"
+if count_doctor_references "$TEST_TMP_DIR/missing-doctor-surface" >/dev/null; then
+    test_fail "missing Doctor guidance surfaces must not count as zero references"
+else
+    test_pass
+fi
 
 PUBLIC_DOCTOR_SURFACES=(
     "README.md|0"
@@ -76,9 +85,10 @@ PUBLIC_DOCTOR_SURFACES=(
 for surface in "${PUBLIC_DOCTOR_SURFACES[@]}"; do
     relative_path="${surface%%|*}"
     expected_count="${surface##*|}"
-    actual_count=$(count_doctor_references "$PROJECT_ROOT/$relative_path")
     test_case "$relative_path uses only supported Doctor guidance"
-    if [[ "$actual_count" -eq "$expected_count" ]] &&
+    if ! actual_count=$(count_doctor_references "$PROJECT_ROOT/$relative_path"); then
+        test_fail "$relative_path is missing or unreadable"
+    elif [[ "$actual_count" -eq "$expected_count" ]] &&
        { [[ "$expected_count" -eq 0 ]] || grep -Fq '`/octo:doctor` was removed in v9.41.0' "$PROJECT_ROOT/$relative_path"; }; then
         test_pass
     else
@@ -87,8 +97,9 @@ for surface in "${PUBLIC_DOCTOR_SURFACES[@]}"; do
 done
 
 test_case "COMMAND-REFERENCE.md explains the retired Doctor command exactly once"
-doctor_reference_count=$(count_doctor_references "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md")
-if [[ "$doctor_reference_count" -eq 1 ]] &&
+if ! doctor_reference_count=$(count_doctor_references "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md"); then
+    test_fail "docs/COMMAND-REFERENCE.md is missing or unreadable"
+elif [[ "$doctor_reference_count" -eq 1 ]] &&
    grep -Fq 'intentionally leaves `/octo:doctor` unregistered' "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md"; then
     test_pass
 else

--- a/tests/unit/test-command-frontmatter.sh
+++ b/tests/unit/test-command-frontmatter.sh
@@ -56,33 +56,43 @@ else
     PASSED=$((PASSED + 1))
 fi
 
-echo "Testing: Current public guidance does not advertise retired /octo:doctor..."
-PUBLIC_DOCTOR_SURFACES="
-README.md
-docs/README.md
-docs/TROUBLESHOOTING.md
-.claude/skills/skill-copilot-provider/SKILL.md
-scripts/lib/review.sh
-scripts/install-deps.sh
-"
-for relative_path in $PUBLIC_DOCTOR_SURFACES; do
-    if grep -q '/octo:doctor' "$PROJECT_ROOT/$relative_path"; then
-        echo -e "${RED}✗${NC} $relative_path advertises retired /octo:doctor"
-        FAILED=$((FAILED + 1))
+count_doctor_references() {
+    { grep -oF -- '/octo:doctor' "$1" 2>/dev/null || true; } | awk 'END { print NR + 0 }'
+}
+
+PUBLIC_DOCTOR_SURFACES=(
+    "README.md|0"
+    "docs/README.md|0"
+    "docs/TROUBLESHOOTING.md|0"
+    ".claude/skills/skill-copilot-provider/SKILL.md|0"
+    ".claude/skills/skill-doctor/SKILL.md|1"
+    ".cursor-plugin/commands/octo-doctor.md|1"
+    "scripts/lib/review.sh|0"
+    "scripts/install-deps.sh|0"
+    "skills/skill-copilot-provider/SKILL.md|0"
+    "skills/skill-doctor/SKILL.md|1"
+)
+
+for surface in "${PUBLIC_DOCTOR_SURFACES[@]}"; do
+    relative_path="${surface%%|*}"
+    expected_count="${surface##*|}"
+    actual_count=$(count_doctor_references "$PROJECT_ROOT/$relative_path")
+    test_case "$relative_path uses only supported Doctor guidance"
+    if [[ "$actual_count" -eq "$expected_count" ]] &&
+       { [[ "$expected_count" -eq 0 ]] || grep -Fq '`/octo:doctor` was removed in v9.41.0' "$PROJECT_ROOT/$relative_path"; }; then
+        test_pass
     else
-        echo -e "${GREEN}✓${NC} $relative_path uses a supported Doctor entrypoint"
-        PASSED=$((PASSED + 1))
+        test_fail "$relative_path has $actual_count retired /octo:doctor references; expected $expected_count intentional reference(s)"
     fi
 done
 
-doctor_reference_count=$(grep -c '/octo:doctor' "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md" 2>/dev/null || true)
+test_case "COMMAND-REFERENCE.md explains the retired Doctor command exactly once"
+doctor_reference_count=$(count_doctor_references "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md")
 if [[ "$doctor_reference_count" -eq 1 ]] &&
-   grep -q 'intentionally leaves `/octo:doctor` unregistered' "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md"; then
-    echo -e "${GREEN}✓${NC} docs/COMMAND-REFERENCE.md mentions retired /octo:doctor only to explain its absence"
-    PASSED=$((PASSED + 1))
+   grep -Fq 'intentionally leaves `/octo:doctor` unregistered' "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md"; then
+    test_pass
 else
-    echo -e "${RED}✗${NC} docs/COMMAND-REFERENCE.md must explain retired /octo:doctor exactly once"
-    FAILED=$((FAILED + 1))
+    test_fail "docs/COMMAND-REFERENCE.md must explain retired /octo:doctor exactly once"
 fi
 
 for cmd_file in "$COMMANDS_DIR"/*.md; do

--- a/tests/unit/test-command-frontmatter.sh
+++ b/tests/unit/test-command-frontmatter.sh
@@ -56,6 +56,35 @@ else
     PASSED=$((PASSED + 1))
 fi
 
+echo "Testing: Current public guidance does not advertise retired /octo:doctor..."
+PUBLIC_DOCTOR_SURFACES="
+README.md
+docs/README.md
+docs/TROUBLESHOOTING.md
+.claude/skills/skill-copilot-provider/SKILL.md
+scripts/lib/review.sh
+scripts/install-deps.sh
+"
+for relative_path in $PUBLIC_DOCTOR_SURFACES; do
+    if grep -q '/octo:doctor' "$PROJECT_ROOT/$relative_path"; then
+        echo -e "${RED}✗${NC} $relative_path advertises retired /octo:doctor"
+        FAILED=$((FAILED + 1))
+    else
+        echo -e "${GREEN}✓${NC} $relative_path uses a supported Doctor entrypoint"
+        PASSED=$((PASSED + 1))
+    fi
+done
+
+doctor_reference_count=$(grep -c '/octo:doctor' "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md" 2>/dev/null || true)
+if [[ "$doctor_reference_count" -eq 1 ]] &&
+   grep -q 'intentionally leaves `/octo:doctor` unregistered' "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md"; then
+    echo -e "${GREEN}✓${NC} docs/COMMAND-REFERENCE.md mentions retired /octo:doctor only to explain its absence"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "${RED}✗${NC} docs/COMMAND-REFERENCE.md must explain retired /octo:doctor exactly once"
+    FAILED=$((FAILED + 1))
+fi
+
 for cmd_file in "$COMMANDS_DIR"/*.md; do
     if [ ! -f "$cmd_file" ]; then
         continue

--- a/tests/unit/test-migrate-stale-gpt5-line.sh
+++ b/tests/unit/test-migrate-stale-gpt5-line.sh
@@ -33,7 +33,7 @@ cat > "$CONFIG_FILE" <<'JSON'
       "default": "gpt-5.4",
       "fallback": "gpt-5.4",
       "spark": "gpt-5.4",
-      "mini": "gpt-5.4",
+      "mini": "gpt-5-codex-mini",
       "reasoning": "o1-preview",
       "large_context": "gpt-5.4"
     },
@@ -64,6 +64,10 @@ val="$(jq -r '.providers.codex.default' "$CONFIG_FILE")"
 test_case "stale codex.fallback (gpt-5.4) migrates to the current default"
 val="$(jq -r '.providers.codex.fallback' "$CONFIG_FILE")"
 [[ "$val" == "gpt-5.6-sol" ]] && test_pass || test_fail "expected gpt-5.6-sol, got: $val"
+
+test_case "unsupported codex.mini migrates to the current budget model"
+val="$(jq -r '.providers.codex.mini' "$CONFIG_FILE")"
+[[ "$val" == "gpt-5.6-luna" ]] && test_pass || test_fail "expected gpt-5.6-luna, got: $val"
 
 assert_stale_model_migrates() {
     local stale_model="$1"
@@ -133,12 +137,10 @@ agy_val="$(jq -r '.providers.agy.default' "$CONFIG_FILE")"
     test_fail "expected gemini removal and the AGY default, got gemini=$legacy_val agy=$agy_val"
 
 # Known, deliberately out-of-scope gap this fix does NOT close: stale_paths
-# only lists .providers.codex.{default,fallback} and the gemini equivalents,
-# so codex.spark/mini/reasoning/large_context are never inspected at all —
-# stale or not, they pass through untouched. That's issue #798's second,
-# separate limitation ("no other provider's pins are ever migrated"), left
-# for a follow-up. Documented here so a future stale_paths widening updates
-# this assertion instead of silently leaving it stale itself.
+# still omits codex.spark/reasoning/large_context. Those slots may contain
+# deliberate supported pins, so only the known unsupported generated mini
+# defaults are migrated here. Documented so future widening updates this
+# assertion instead of silently leaving it stale itself.
 test_case "codex.spark is NOT migrated (stale_paths doesn't cover it — known gap, not this fix's scope)"
 val="$(jq -r '.providers.codex.spark' "$CONFIG_FILE")"
 [[ "$val" == "gpt-5.4" ]] && test_pass || test_fail "expected gpt-5.4 (still untouched — if this now migrates, stale_paths grew; update this test), got: $val"


### PR DESCRIPTION
## Summary

- migrate legacy generated `codex-mini` pins to the supported GPT-5.6 Luna tier
- correct Doctor guidance to use `/octo:skill-doctor` or `octopus doctor`
- align release-validation assertions with Provider Registry 2.0 and report skill-registration results independently
- refresh public v10 help, changelog, documentation, generated Factory output, and handoff evidence

## Validation

- installed-package v10.0.0 authentication, plugin load, Doctor, whats-new, skill-doctor, and real quick-dispatch checks passed
- `make sync-check` passed
- `make ci-changed` selected the full CI-parity rule and passed 16/16 smoke, 289/289 unit, and 8/8 integration suites
- `git diff --check` passed with no executable-mode changes

This PR intentionally contains no private environment, network, authentication, or operational UAT details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer diagnostic options through `/octo:skill-doctor` and `octopus doctor`.
  * Added provider, authentication, live-check, and JSON diagnostic commands.
  * Updated help and agent listings with GPT-5.6 model tiers.

* **Bug Fixes**
  * Migrated legacy Codex Mini model settings to the supported GPT-5.6 Luna model.
  * Prevented the retired `/octo:doctor` entry point from conflicting with Claude Code’s native command.

* **Documentation**
  * Updated troubleshooting, command references, quick starts, and setup guidance with the new diagnostic workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->