### PR TITLE
fix(review): support model-qualified contextual seats

### DIFF
--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,21 +1,24 @@
 # AI Agent Handoff
 
-Last updated: 2026-09-02
-Status: The five verified maintainer findings for PR #972 are fixed on the
-local worktree. Exact provider/model routing, blank override rejection,
-model-aware status and proof records, and fleet-preview policy parity have
-focused regression coverage. A follow-up lifecycle guard now finalizes failed
-proof state and removes temporary provider status when fleet validation rejects
-an override under `set -e`. The follow-up's eight focused suites pass 106/106;
-`make sync-check`, Bash 3.2 syntax, diff checks, and executable-mode checks pass.
-Branch: `maint/pr-972-fix`, based on exact PR head
-`ccd66e1f77f37f08c893847162437879b973deb9`.
-Delivery: Local maintainer commit only. No push or full CI run was authorized.
-Current release: [v10.1.0](https://github.com/nyldn/claude-octopus/releases/tag/v10.1.0)
+Last updated: 2026-08-30
+Status: PR #984 contains the install, setup, readiness, dispatch, cost, and
+uninstall simplification. Two findings from the latest exact-head CodeRabbit
+round have verified fixes in the branch head, independent Fable 5 review
+returned PASS/PASS, and the complete local matrix is green. The final head
+still needs exact-head hosted review before merge.
+Branch: `feat/simplify-install-setup-use`, reconciled with `origin/main` at
+`f9b8c92aa228a4b3f6bc9132c6c0a06f3142b73e`.
+Delivery: PR [#984](https://github.com/nyldn/claude-octopus/pull/984) is open.
+Its branch head includes the final reviewed follow-up after
+`d412469ce7345496793849b88b1803a0b23c4d28`.
+Current release: [v10.0.0](https://github.com/nyldn/claude-octopus/releases/tag/v10.0.0)
 Tracking: `bd` is unavailable in this checkout, so no Beads issue was created or
-updated.
-Next action: inspect the local commit, then push and update PR #972 only when
-explicitly authorized. Run the normal hosted review and full CI before merge.
+updated for this cleanup.
+Next action: commit and push the review follow-up, resolve the verified review
+threads, wait for exact-head checks and approval, then squash-merge PR #984 and
+run the guarded v10.1.0 release workflow. The user authorized merge, release,
+shared-marketplace publication, and cleanup of only the related worktrees
+proven safe to remove.
 
 ## Install, Setup, and Everyday-Use Simplification
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -4,9 +4,10 @@ Last updated: 2026-09-02
 Status: The five verified maintainer findings for PR #972 are fixed on the
 local worktree. Exact provider/model routing, blank override rejection,
 model-aware status and proof records, and fleet-preview policy parity have
-focused regression coverage. Twenty-two relevant suites pass 364/364; `make
-sync`, `make sync-check`, Bash 3.2 syntax and feature-floor checks, diff checks,
-and executable-mode checks pass.
+focused regression coverage. A follow-up lifecycle guard now finalizes failed
+proof state and removes temporary provider status when fleet validation rejects
+an override under `set -e`. The follow-up's eight focused suites pass 106/106;
+`make sync-check`, Bash 3.2 syntax, diff checks, and executable-mode checks pass.
 Branch: `maint/pr-972-fix`, based on exact PR head
 `ccd66e1f77f37f08c893847162437879b973deb9`.
 Delivery: Local maintainer commit only. No push or full CI run was authorized.

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,24 +1,20 @@
 # AI Agent Handoff
 
-Last updated: 2026-08-30
-Status: PR #984 contains the install, setup, readiness, dispatch, cost, and
-uninstall simplification. Two findings from the latest exact-head CodeRabbit
-round have verified fixes in the branch head, independent Fable 5 review
-returned PASS/PASS, and the complete local matrix is green. The final head
-still needs exact-head hosted review before merge.
-Branch: `feat/simplify-install-setup-use`, reconciled with `origin/main` at
-`f9b8c92aa228a4b3f6bc9132c6c0a06f3142b73e`.
-Delivery: PR [#984](https://github.com/nyldn/claude-octopus/pull/984) is open.
-Its branch head includes the final reviewed follow-up after
-`d412469ce7345496793849b88b1803a0b23c4d28`.
-Current release: [v10.0.0](https://github.com/nyldn/claude-octopus/releases/tag/v10.0.0)
+Last updated: 2026-09-02
+Status: The five verified maintainer findings for PR #972 are fixed on the
+local worktree. Exact provider/model routing, blank override rejection,
+model-aware status and proof records, and fleet-preview policy parity have
+focused regression coverage. Twenty-two relevant suites pass 364/364; `make
+sync`, `make sync-check`, Bash 3.2 syntax and feature-floor checks, diff checks,
+and executable-mode checks pass.
+Branch: `maint/pr-972-fix`, based on exact PR head
+`ccd66e1f77f37f08c893847162437879b973deb9`.
+Delivery: Local maintainer commit only. No push or full CI run was authorized.
+Current release: [v10.1.0](https://github.com/nyldn/claude-octopus/releases/tag/v10.1.0)
 Tracking: `bd` is unavailable in this checkout, so no Beads issue was created or
-updated for this cleanup.
-Next action: commit and push the review follow-up, resolve the verified review
-threads, wait for exact-head checks and approval, then squash-merge PR #984 and
-run the guarded v10.1.0 release workflow. The user authorized merge, release,
-shared-marketplace publication, and cleanup of only the related worktrees
-proven safe to remove.
+updated.
+Next action: inspect the local commit, then push and update PR #972 only when
+explicitly authorized. Run the normal hosted review and full CI before merge.
 
 ## Install, Setup, and Everyday-Use Simplification
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@
 
 ### Fixed
 
+- Contextual code review now accepts explicit `provider:model` overrides for
+  logic, security, architecture, CVE research, diversity, verification, debate,
+  and synthesis seats. Seat overrides remain allowlist-gated, preserve the
+  global `OCTOPUS_REVIEW_SINGLE_PROVIDER` precedence, and support CommandCode
+  providers without falling back to hardcoded Codex/Claude executors.
 - Migrate legacy generated `codex-mini` pins such as `gpt-5-codex-mini` to
   `gpt-5.6-luna`, preventing quick workflows from selecting a model that is
   unsupported for ChatGPT-authenticated Codex CLI sessions. Agent help now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@
   message directing the operator to the per-seat verdicts in `responses/`.
 - Harden provider/model routing and OpenAI-compatible reasoning handling: canonicalize route-provider aliases, let cross-provider legacy role routes fall through to matching phase routes, preserve Bash 3.2-compatible execution-profile overrides, normalize `xhigh`/`max` reasoning to `high`, and only drop `reasoning_effort` when the API specifically rejects that field.
 - Keep contextual review warnings fatal without fabricating a severity=normal blocker. Warning-only or partial-review results with zero actionable findings now stop cleanly instead of entering no-op correction loops, while warnings with real normal findings still allow bounded correction attempts.
+- Contextual code review now canonicalizes provider aliases in explicit
+  `provider:model` seat overrides, rejects malformed or policy-blocked seats,
+  carries exact models through provider dispatch, reports every configured
+  provider under its canonical key, and shows all eight effective seats in
+  `octopus fleet review`.
 
 ## [10.1.0] - 2026-08-30
 
@@ -56,11 +61,6 @@
 
 ### Fixed
 
-- Contextual code review now accepts explicit `provider:model` overrides for
-  logic, security, architecture, CVE research, diversity, verification, debate,
-  and synthesis seats. Seat overrides remain allowlist-gated, preserve the
-  global `OCTOPUS_REVIEW_SINGLE_PROVIDER` precedence, and support CommandCode
-  providers without falling back to hardcoded Codex/Claude executors.
 - Migrate legacy generated `codex-mini` pins such as `gpt-5-codex-mini` to
   `gpt-5.6-luna`, preventing quick workflows from selecting a model that is
   unsupported for ChatGPT-authenticated Codex CLI sessions. Agent help now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,12 @@
 - Keep contextual review warnings fatal without fabricating a severity=normal blocker. Warning-only or partial-review results with zero actionable findings now stop cleanly instead of entering no-op correction loops, while warnings with real normal findings still allow bounded correction attempts.
 - Contextual code review now canonicalizes provider aliases in explicit
   `provider:model` seat overrides, rejects malformed or policy-blocked seats,
-  carries exact models through provider dispatch, reports every configured
-  provider under its canonical key, and shows all eight effective seats in
-  `octopus fleet review`.
+  carries exact models through provider dispatch and status reporting, and
+  shows all eight effective seats in `octopus fleet review`. Fleet previews now
+  apply the same model allowlists and Fable security guard as dispatch.
+  OpenAI-compatible seats resolve provider-file credentials by canonical
+  provider while retaining their exact model, and explicit Claude model IDs are
+  passed to `--model` without legacy alias normalization.
 
 ## [10.1.0] - 2026-08-30
 

--- a/docs/MODEL-ROUTING-STRATEGY.md
+++ b/docs/MODEL-ROUTING-STRATEGY.md
@@ -58,10 +58,24 @@ providers instead of inheriting the review fleet's provider defaults:
 | Synthesizer | `OCTOPUS_REVIEW_SYNTHESIZER_AGENT` |
 
 For example, `OCTOPUS_REVIEW_SYNTHESIZER_AGENT=commandcode:thinkingmachines/inkling-small`
-keeps the synthesis seat on that exact provider and model. Explicit seat overrides
-remain subject to the active provider allowlist and fail closed when the requested
-provider is not admitted. `OCTOPUS_REVIEW_SINGLE_PROVIDER` remains the global
-compatibility override and takes precedence over individual seat overrides.
+keeps the synthesis seat on that exact provider and model. Registered aliases
+such as `command-code` and `anthropic` are accepted at the configuration boundary
+and normalized to executable provider names.
+
+Each seat override must contain both a provider and a model. Blank values,
+provider-only values, unsafe whitespace, unknown providers, and models blocked by
+the provider's model restriction are rejected. Exact seat overrides never use a
+restriction-service fallback because that would run a different model than the
+one requested. Update the seat or its model allowlist instead. The Fable 5
+security guard follows the same rule: an exact Fable pin on a security seat is
+rejected rather than rerouted to another model.
+
+Provider admission still applies independently. A seat fails closed when its
+provider is not admitted by the active provider allowlist.
+`OCTOPUS_REVIEW_SINGLE_PROVIDER` remains the global compatibility override and
+takes precedence over individual seat overrides. Run `octopus fleet review` to
+inspect the effective logic, security, architecture, CVE, diversity, verifier,
+debater, and synthesizer seats before starting a review.
 
 Round-1 seat overrides are additive when their semantic role is absent from the
 configured review fleet; unconfigured seats retain the existing fleet behavior.

--- a/docs/MODEL-ROUTING-STRATEGY.md
+++ b/docs/MODEL-ROUTING-STRATEGY.md
@@ -39,6 +39,33 @@ does not count as independent provider diversity.
 4. Model choice never changes permissions, repository rules, or quality gates.
 5. User and project configuration always beats release defaults.
 
+### Contextual review seat overrides
+
+The contextual code-review pipeline supports explicit model-qualified seat identities
+using the same `provider:model` convention as the design-review ceremony. These
+overrides are useful when a curated lineup must preserve semantic roles across
+providers instead of inheriting the review fleet's provider defaults:
+
+| Review seat | Environment override |
+|---|---|
+| Logic | `OCTOPUS_REVIEW_LOGIC_AGENT` |
+| Security | `OCTOPUS_REVIEW_SECURITY_AGENT` |
+| Architecture | `OCTOPUS_REVIEW_ARCHITECTURE_AGENT` |
+| CVE research | `OCTOPUS_REVIEW_CVE_AGENT` |
+| Diversity / independent perspective | `OCTOPUS_REVIEW_DIVERSITY_AGENT` |
+| Verifier | `OCTOPUS_REVIEW_VERIFIER_AGENT` |
+| Debater | `OCTOPUS_REVIEW_DEBATER_AGENT` |
+| Synthesizer | `OCTOPUS_REVIEW_SYNTHESIZER_AGENT` |
+
+For example, `OCTOPUS_REVIEW_SYNTHESIZER_AGENT=commandcode:thinkingmachines/inkling-small`
+keeps the synthesis seat on that exact provider and model. Explicit seat overrides
+remain subject to the active provider allowlist and fail closed when the requested
+provider is not admitted. `OCTOPUS_REVIEW_SINGLE_PROVIDER` remains the global
+compatibility override and takes precedence over individual seat overrides.
+
+Round-1 seat overrides are additive when their semantic role is absent from the
+configured review fleet; unconfigured seats retain the existing fleet behavior.
+
 ## Eval-backed routing in v10
 
 V10 exposes deterministic routing decisions through

--- a/docs/MODEL-ROUTING-STRATEGY.md
+++ b/docs/MODEL-ROUTING-STRATEGY.md
@@ -70,6 +70,10 @@ one requested. Update the seat or its model allowlist instead. The Fable 5
 security guard follows the same rule: an exact Fable pin on a security seat is
 rejected rather than rerouted to another model.
 
+Review lifecycle records and the final provider report keep the canonical
+provider and exact model as separate fields, so two models served by one
+provider remain distinct. Legacy provider-only status records are still read.
+
 Provider admission still applies independently. A seat fails closed when its
 provider is not admitted by the active provider allowlist.
 `OCTOPUS_REVIEW_SINGLE_PROVIDER` remains the global compatibility override and

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -97,6 +97,28 @@ is_available() {
     _contains "${AVAILABLE_CLI[*]:-}" "$p"
 }
 
+# review.sh validates identity, capability, and policy. This caller supplies
+# the authoritative live admission decision produced by check-providers.sh.
+review_single_provider_is_available() {
+    local canonical="$1" executor="$2" status_provider="$1" available_executor="$2"
+    case "$canonical" in
+        claude)
+            # Claude is the host runtime and is intentionally absent from
+            # AVAILABLE_CLI/check-providers admission.
+            return 0
+            ;;
+        atlascloud)
+            status_provider=atlascloud
+            available_executor=atlascloud-agent
+            ;;
+        openai-tools|openai-compatible-agent)
+            status_provider=openai-compatible
+            available_executor=openai-compatible
+            ;;
+    esac
+    provider_status_is_available "$status_provider" && is_available "$available_executor"
+}
+
 # Pick first available provider from a preference list, with fallback
 pick_provider() {
     local fallback="${1}"
@@ -330,14 +352,7 @@ build_council_order() {
 }
 
 build_review_fleet() {
-    local order
     review_validate_configured_seat_overrides || return $?
-    order="$(build_council_order)" || return $?
-    # shellcheck disable=SC2206
-    local providers=($order)
-    local count=${#providers[@]}
-    [[ $count -gt 0 ]] || return 0
-
     local roles=(
         implementation-logic-reviewer
         implementation-security-reviewer
@@ -359,6 +374,23 @@ build_review_fleet() {
         "Challenge disputed findings and test competing interpretations in: $PROMPT"
         "Synthesize the verified review findings for: $PROMPT"
     )
+
+    local i provider
+    if [[ -n "${OCTOPUS_REVIEW_SINGLE_PROVIDER:-}" ]]; then
+        provider="$(review_single_provider_override)" || return $?
+        for ((i=0; i<8; i++)); do
+            emit "$provider" "${labels[$i]}" "${prompts[$i]}"
+        done
+        return 0
+    fi
+
+    local order
+    order="$(build_council_order)" || return $?
+    # shellcheck disable=SC2206
+    local providers=($order)
+    local count=${#providers[@]}
+    [[ $count -gt 0 ]] || return 0
+
     local verifier_default="${providers[0]}" synthesis_default="${providers[0]}"
     if is_available codex && octo_provider_allowed codex; then
         verifier_default=codex
@@ -377,7 +409,6 @@ build_review_fleet() {
         "$verifier_default"
         "$synthesis_default"
     )
-    local i provider
     for ((i=0; i<8; i++)); do
         provider="$(review_agent_for_seat "${defaults[$i]}" "${roles[$i]}")" || return $?
         emit "$provider" "${labels[$i]}" "${prompts[$i]}"

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -31,6 +31,7 @@ fi
 source "${SCRIPT_DIR}/../lib/provider-registry.sh"
 source "${SCRIPT_DIR}/../lib/provider-policy.sh"
 source "${SCRIPT_DIR}/../lib/agent-spec.sh"
+source "${SCRIPT_DIR}/../lib/review.sh"
 
 WORKFLOW="${1:-research}"
 INTENSITY="${2:-standard}"
@@ -335,16 +336,48 @@ build_review_fleet() {
     local count=${#providers[@]}
     [[ $count -gt 0 ]] || return 0
 
-    local labels=("Logic Reviewer" "Security Reviewer" "Architecture Reviewer" "CVE Reviewer")
+    local roles=(
+        implementation-logic-reviewer
+        implementation-security-reviewer
+        implementation-architecture-reviewer
+        implementation-cve-reviewer
+        implementation-diversity-reviewer
+        implementation-verifier
+        implementation-debater
+        implementation-synthesizer
+    )
+    local labels=("Logic Reviewer" "Security Reviewer" "Architecture Reviewer" "CVE Reviewer" "Diversity Reviewer" "Verifier" "Debater" "Synthesizer")
     local prompts=(
         "Review for correctness and logic bugs, edge cases, regressions in: $PROMPT"
         "Review for OWASP vulnerabilities, injection, auth flaws, data exposure in: $PROMPT"
         "Review architecture, integration, API contracts, breaking changes in: $PROMPT"
         "Check for known CVEs, library advisories, and security bulletins related to: $PROMPT"
+        "Review for blind spots, missed assumptions, and provider-family divergence in: $PROMPT"
+        "Verify confirmed findings against the code and evidence in: $PROMPT"
+        "Challenge disputed findings and test competing interpretations in: $PROMPT"
+        "Synthesize the verified review findings for: $PROMPT"
+    )
+    local verifier_default="${providers[0]}" synthesis_default="${providers[0]}"
+    if is_available codex && octo_provider_allowed codex; then
+        verifier_default=codex
+    fi
+    if octo_provider_allowed claude-sonnet; then
+        synthesis_default=claude-sonnet
+    fi
+
+    local defaults=(
+        "${providers[0]}"
+        "${providers[$((1 % count))]}"
+        "${providers[$((2 % count))]}"
+        "${providers[$((3 % count))]}"
+        "${providers[$((4 % count))]}"
+        "$verifier_default"
+        "$verifier_default"
+        "$synthesis_default"
     )
     local i provider
-    for ((i=0; i<4; i++)); do
-        provider="${providers[$((i % count))]}"
+    for ((i=0; i<8; i++)); do
+        provider="$(review_agent_for_seat "${defaults[$i]}" "${roles[$i]}")" || return $?
         emit "$provider" "${labels[$i]}" "${prompts[$i]}"
     done
     return 0

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -330,6 +330,7 @@ build_council_order() {
 
 build_review_fleet() {
     local order
+    review_validate_configured_seat_overrides || return $?
     order="$(build_council_order)" || return $?
     # shellcheck disable=SC2206
     local providers=($order)

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -31,6 +31,7 @@ fi
 source "${SCRIPT_DIR}/../lib/provider-registry.sh"
 source "${SCRIPT_DIR}/../lib/provider-policy.sh"
 source "${SCRIPT_DIR}/../lib/agent-spec.sh"
+source "${SCRIPT_DIR}/../lib/model-resolver.sh"
 source "${SCRIPT_DIR}/../lib/review.sh"
 
 WORKFLOW="${1:-research}"

--- a/scripts/helpers/vibe-exec.sh
+++ b/scripts/helpers/vibe-exec.sh
@@ -18,4 +18,10 @@ if [[ -z "${prompt//[[:space:]]/}" ]]; then
     exit 64
 fi
 
-exec vibe "$@" -p "$prompt"
+model_args=()
+case "${OCTOPUS_VIBE_MODEL:-default}" in
+    ''|default) ;;
+    *) model_args=(--model "$OCTOPUS_VIBE_MODEL") ;;
+esac
+
+exec vibe "$@" "${model_args[@]+"${model_args[@]}"}" -p "$prompt"

--- a/scripts/lib/agent-spec.sh
+++ b/scripts/lib/agent-spec.sh
@@ -53,6 +53,31 @@ octo_agent_spec_explicit_model() {
     printf '%s\n' "$model"
 }
 
+# Parse one provider-status record without applying caller-specific provider
+# normalization. Versioned records are v2|provider|model|status|detail; legacy
+# records are provider|status|detail. Detail may itself contain pipe characters.
+octo_parse_provider_status_record() {
+    local record="${1-}" field1 field2 field3 field4 remainder
+    OCTO_PROVIDER_STATUS_PROVIDER=""
+    OCTO_PROVIDER_STATUS_MODEL=""
+    OCTO_PROVIDER_STATUS_VALUE=""
+    OCTO_PROVIDER_STATUS_DETAIL=""
+
+    IFS='|' read -r field1 field2 field3 field4 remainder <<< "$record"
+    [[ -n "$field1" ]] || return 1
+
+    if [[ "$field1" == "v2" ]]; then
+        OCTO_PROVIDER_STATUS_PROVIDER="$field2"
+        OCTO_PROVIDER_STATUS_MODEL="$field3"
+        OCTO_PROVIDER_STATUS_VALUE="$field4"
+        OCTO_PROVIDER_STATUS_DETAIL="$remainder"
+    else
+        OCTO_PROVIDER_STATUS_PROVIDER="$field1"
+        OCTO_PROVIDER_STATUS_VALUE="$field2"
+        OCTO_PROVIDER_STATUS_DETAIL="${field3}${field4:+|${field4}}${remainder:+|${remainder}}"
+    fi
+}
+
 # Run-contract identity keeps legacy executor aliases unchanged, but exact
 # provider:model seats must use separate canonical provider and model fields.
 octo_agent_spec_contract_provider() {

--- a/scripts/lib/agent-spec.sh
+++ b/scripts/lib/agent-spec.sh
@@ -53,6 +53,35 @@ octo_agent_spec_explicit_model() {
     printf '%s\n' "$model"
 }
 
+# Normalize a model-qualified seat to the executable name consumed by
+# dispatch.sh. Provider aliases belong at the configuration boundary; runtime
+# agent specs must use dispatchable executors.
+octo_agent_spec_canonicalize_exact() {
+    local spec="${1-}" executor model provider canonical_executor
+    [[ -n "$spec" && "$spec" == *:* ]] || return 1
+    [[ "$spec" != *[[:space:]]* && "$spec" != *\\* ]] || return 1
+
+    executor="${spec%%:*}"
+    model="${spec#*:}"
+    [[ -n "$executor" && -n "$model" ]] || return 1
+    provider="$(octo_provider_canonical "$executor" 2>/dev/null)" || return 1
+
+    case "$provider" in
+        atlascloud) canonical_executor="atlascloud-agent" ;;
+        *) canonical_executor="$provider" ;;
+    esac
+
+    octo_provider_has_capability "$provider" dispatch || return 1
+
+    # Exact contextual seats are serialized into a shell command string and
+    # later split into argv. Keep the accepted model grammar to one safe token.
+    case "$model" in
+        /*|*[[:space:]]*|*\\*|*\**|*";"*|*"|"*|*"&"*|*'$'*|*'`'*|*"'"*|*'"'*|*"("*|*")"*|*"<"*|*">"*|*"!"*|*"?"*|*"["*|*"]"*|*"{"*|*"}"*) return 1 ;;
+    esac
+
+    printf '%s:%s\n' "$canonical_executor" "$model"
+}
+
 octo_agent_spec_slug() {
     local spec="${1:-unknown}"
     # Keep the full seat identity while making it safe for filenames and

--- a/scripts/lib/agent-spec.sh
+++ b/scripts/lib/agent-spec.sh
@@ -53,6 +53,28 @@ octo_agent_spec_explicit_model() {
     printf '%s\n' "$model"
 }
 
+# Run-contract identity keeps legacy executor aliases unchanged, but exact
+# provider:model seats must use separate canonical provider and model fields.
+octo_agent_spec_contract_provider() {
+    local spec="${1:-unknown}" provider
+    if [[ "$spec" != *:* ]]; then
+        printf '%s\n' "$spec"
+        return 0
+    fi
+    provider="$(octo_agent_spec_provider "$spec")" || return 1
+    [[ -n "$provider" ]] || return 1
+    printf '%s\n' "$provider"
+}
+
+octo_agent_spec_contract_model() {
+    local spec="${1:-}" fallback="${2:-}"
+    if [[ "$spec" == *:* ]]; then
+        octo_agent_spec_explicit_model "$spec"
+    else
+        printf '%s\n' "$fallback"
+    fi
+}
+
 # Normalize a model-qualified seat to the executable name consumed by
 # dispatch.sh. Provider aliases belong at the configuration boundary; runtime
 # agent specs must use dispatchable executors.

--- a/scripts/lib/agent-spec.sh
+++ b/scripts/lib/agent-spec.sh
@@ -82,6 +82,69 @@ octo_agent_spec_canonicalize_exact() {
     printf '%s:%s\n' "$canonical_executor" "$model"
 }
 
+# Return the environment variable that constrains models for a canonical
+# provider. Dispatch and review-seat previews share this map so a preview can
+# never advertise an exact model that runtime dispatch will reject.
+octo_provider_model_allowlist_var() {
+    local provider="${1:-}"
+    provider="$(octo_agent_spec_provider "$provider")"
+    case "$provider" in
+        gemini) provider="agy" ;;
+    esac
+
+    case "$provider" in
+        codex) echo "OCTOPUS_CODEX_ALLOWED_MODELS" ;;
+        agy) echo "OCTOPUS_AGY_ALLOWED_MODELS" ;;
+        claude-sdk) echo "OCTOPUS_CLAUDE_SDK_ALLOWED_MODELS" ;;
+        claude) echo "OCTOPUS_CLAUDE_ALLOWED_MODELS" ;;
+        openrouter) echo "OCTOPUS_OPENROUTER_ALLOWED_MODELS" ;;
+        orcarouter) echo "OCTOPUS_ORCAROUTER_ALLOWED_MODELS" ;;
+        atlascloud|atlascloud-agent) echo "ATLASCLOUD_ALLOWED_MODELS" ;;
+        openai-compatible|openai-tools|openai-compatible-agent) echo "OPENAI_COMPAT_ALLOWED_MODELS" ;;
+        perplexity) echo "OCTOPUS_PERPLEXITY_ALLOWED_MODELS" ;;
+        qwen) echo "OCTOPUS_QWEN_ALLOWED_MODELS" ;;
+        cursor-agent) echo "OCTOPUS_CURSOR_AGENT_ALLOWED_MODELS" ;;
+        commandcode) echo "OCTOPUS_COMMANDCODE_ALLOWED_MODELS" ;;
+        opencode) echo "OCTOPUS_OPENCODE_ALLOWED_MODELS" ;;
+        ollama) echo "OCTOPUS_OLLAMA_ALLOWED_MODELS" ;;
+        copilot) echo "OCTOPUS_COPILOT_ALLOWED_MODELS" ;;
+        vibe) echo "OCTOPUS_VIBE_ALLOWED_MODELS" ;;
+        *) return 1 ;;
+    esac
+}
+
+octo_agent_spec_exact_model_allowed() {
+    local spec="${1:-}" model allowlist_var allowlist
+    model="$(octo_agent_spec_explicit_model "$spec")" || return 1
+    allowlist_var="$(octo_provider_model_allowlist_var "$spec" 2>/dev/null || true)"
+    [[ -n "$allowlist_var" ]] || return 0
+    allowlist="${!allowlist_var:-}"
+    [[ -z "$allowlist" || ",$allowlist," == *",$model,"* ]]
+}
+
+octo_agent_spec_is_security_dispatch() {
+    local combined="${1:-} ${2:-} ${3:-}"
+    case "$combined" in
+        *security*|*squeeze*|*red-team*|*redteam*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+octo_agent_spec_exact_role_allowed() {
+    local spec="${1:-}" role="${2:-}" phase="${3:-}" provider model
+    provider="$(octo_agent_spec_provider "$spec")"
+    model="$(octo_agent_spec_explicit_model "$spec")" || return 1
+    case "$provider" in
+        claude|claude-sdk)
+            if [[ "$model" == "${FABLE5_MODEL_ID:-claude-fable-5}" ]] &&
+               octo_agent_spec_is_security_dispatch "$role" "$spec" "$phase"; then
+                return 1
+            fi
+            ;;
+    esac
+    return 0
+}
+
 octo_agent_spec_slug() {
     local spec="${1:-unknown}"
     # Keep the full seat identity while making it safe for filenames and

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -277,12 +277,15 @@ run_agent_sync() {
     fi
     local _sync_seat_id
     _sync_seat_id="sync-${phase:-unknown}-$(octo_agent_spec_slug "$agent_type")-${_progress_unique}"
+    local _contract_provider _contract_requested_model
+    _contract_provider="$(octo_agent_spec_contract_provider "$agent_type")" || return 74
+    _contract_requested_model="$(octo_agent_spec_contract_model "$agent_type" "${OCTOPUS_REQUESTED_MODEL:-}")" || return 74
     if [[ "${OCTOPUS_PERSISTENCE_AVAILABLE:-true}" == "false" ]]; then
         log ERROR "Persistence unavailable; refusing untracked provider dispatch for $agent_type"
     fi
     run_contract_transition "$_sync_seat_id" planned \
-        "requested_provider=$agent_type" \
-        "requested_model=${OCTOPUS_REQUESTED_MODEL:-}" \
+        "requested_provider=$_contract_provider" \
+        "requested_model=$_contract_requested_model" \
         "requested_effort=${OCTOPUS_REQUESTED_EFFORT:-}" \
         "phase=${phase:-unknown}" "role=${role:-none}" \
         "attempt_id=${_sync_seat_id}-attempt-1" || return 74
@@ -389,7 +392,7 @@ ${provider_ctx}"
         _estimated_cost=$(estimate_agent_call_cost "$agent_type" "$model" "$enhanced_prompt")
     fi
     run_contract_transition "$_sync_seat_id" starting \
-        "resolved_provider=$agent_type" "resolved_model=$model" \
+        "resolved_provider=$_contract_provider" "resolved_model=$model" \
         "resolved_effort=${OCTOPUS_RESOLVED_EFFORT:-${OCTOPUS_REQUESTED_EFFORT:-}}" \
         "estimated_cost_usd=$_estimated_cost" || return 74
 

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -91,6 +91,11 @@ _octopus_openai_compatible_runtime_config() {
         log ERROR "Invalid OpenAI-compatible base_url for provider '$provider'"
         return 1
     fi
+    if [[ "$base_url" == http://* ]] &&
+       [[ ! "$base_url" =~ ^http://(localhost|127\.0\.0\.1)(:[0-9]+)?(/|$) ]]; then
+        log ERROR "OpenAI-compatible provider '$config_provider' requires HTTPS for non-loopback endpoints"
+        return 1
+    fi
     if ! _octopus_is_safe_env_var_name "$api_key_env"; then
         log ERROR "Invalid api_key_env for OpenAI-compatible provider '$provider': '$api_key_env'"
         return 1

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -505,7 +505,11 @@ get_agent_command() {
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then return 1; fi
             _octopus_validate_exact_claude_dispatch_model "$model" "$role" "$agent_type" "$phase" || return 1
             if [[ -n "$model" && "$model" != "default" ]]; then
-                echo "env OCTOPUS_CLAUDE_SDK_MODEL=${model} ${PLUGIN_DIR}/scripts/helpers/claude-sdk-exec.sh"
+                if [[ "$agent_type" == *:* && "$model" == "${FABLE5_MODEL_ID:-claude-fable-5}" ]]; then
+                    echo "env OCTOPUS_CLAUDE_SDK_MODEL=${model} OCTOPUS_FABLE5_NO_RETRY=1 ${PLUGIN_DIR}/scripts/helpers/claude-sdk-exec.sh"
+                else
+                    echo "env OCTOPUS_CLAUDE_SDK_MODEL=${model} ${PLUGIN_DIR}/scripts/helpers/claude-sdk-exec.sh"
+                fi
             else
                 echo "${PLUGIN_DIR}/scripts/helpers/claude-sdk-exec.sh"
             fi

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -46,6 +46,20 @@ _octopus_claude_reasoning_fragment() {
     octopus_reasoning_cli_fragment claude "$level" "$policy"
 }
 
+# Exact model pins must stay exact, so an unsafe Fable security pin is rejected
+# instead of being silently rerouted to a different model.
+_octopus_validate_exact_claude_dispatch_model() {
+    local model="$1" role="${2:-}" agent_type="${3:-}" phase="${4:-}"
+    [[ "$agent_type" == *:* ]] || return 0
+    [[ "$model" == "${FABLE5_MODEL_ID:-claude-fable-5}" ]] || return 0
+    if declare -f fable5_is_security_dispatch >/dev/null 2>&1 && \
+       fable5_is_security_dispatch "$role" "$agent_type" "$phase"; then
+        log "ERROR" "Exact Fable 5 model pins cannot be used for security dispatches"
+        return 1
+    fi
+    return 0
+}
+
 _octopus_openai_compatible_runtime_config() {
     local provider="$1"
     local config_provider="$provider" base_url api_key_env credential_value
@@ -220,7 +234,14 @@ get_agent_command() {
         # gemini* is a compatibility alias for stale saved workflows. It must
         # never invoke gemini-cli; all Google seats execute through AGY.
         gemini|gemini-fast|gemini-image|agy|agy-research|antigravity)
-            echo "${PLUGIN_DIR}/scripts/helpers/agy-exec.sh"
+            if [[ "$agent_type" == *:* ]]; then
+                if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
+                    return 1
+                fi
+                echo "env OCTOPUS_AGY_MODEL=${model} ${PLUGIN_DIR}/scripts/helpers/agy-exec.sh"
+            else
+                echo "${PLUGIN_DIR}/scripts/helpers/agy-exec.sh"
+            fi
             ;;
         codex-review)
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
@@ -240,6 +261,7 @@ get_agent_command() {
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
                 return 1
             fi
+            _octopus_validate_exact_claude_dispatch_model "$model" "$role" "$agent_type" "$phase" || return 1
             model="${model//./-}"
             echo "${_claude_bin}${_BARE_OPT} --print --model ${model} ${reasoning_fragment} ${claude_perm}" ;;
         claude-sonnet)
@@ -250,6 +272,7 @@ get_agent_command() {
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
                 return 1
             fi
+            _octopus_validate_exact_claude_dispatch_model "$model" "$role" "$agent_type" "$phase" || return 1
             model="${model//./-}"
             echo "${_claude_bin}${_BARE_OPT} --print --model ${model} ${reasoning_fragment} ${claude_perm}" ;;
         claude-opus|claude-opus-fast)
@@ -270,36 +293,39 @@ get_agent_command() {
                 opus_effort="$OCTOPUS_EFFORT_OVERRIDE"
             fi
             local opus_model_flag
-            opus_model_flag="$(opus_default_model)"
-            # Selective Fable 5 escalation for judgment-class roles, before the
-            # security reroute so a security dispatch can never end up on Fable
-            # even if the allowlist is later widened. Escalation is applied here
-            # rather than in the model resolver because the resolver's cache has
-            # no liveness component and would keep serving a cached Fable model
-            # after the seat was marked quota-dead.
-            if declare -f fable5_resolve_dispatch_model >/dev/null 2>&1; then
-                local fable_decision fable_requested fable_reason
-                if ! fable_decision="$(fable5_resolve_dispatch_model "$opus_model_flag" "$role" "$agent_type" "$phase" "$prompt_bytes")"; then
-                    log "ERROR" "Invalid Fable 5 input-gate configuration"
-                    return 1
-                fi
-                fable_requested="$(jq -r '.requested_model' <<< "$fable_decision")"
-                opus_model_flag="$(jq -r '.resolved_model' <<< "$fable_decision")"
-                fable_reason="$(jq -r '.reason' <<< "$fable_decision")"
-                if [[ "${OCTOPUS_DISPATCH_PREVIEW:-false}" != "true" ]] && \
-                   declare -f run_contract_record_event >/dev/null 2>&1; then
-                    run_contract_record_event "routing.decision" \
-                        "requested_model=$fable_requested" \
-                        "resolved_model=$opus_model_flag" \
-                        "reason=$fable_reason" "prompt_bytes=$prompt_bytes" \
-                        "phase=${phase:-unknown}" "role=${role:-none}" >/dev/null 2>&1 || true
-                fi
+            if [[ "$agent_type" == *:* ]]; then
+                opus_model_flag="$(get_agent_model "$agent_type" "$phase" "$role")" || return 1
+                _octopus_validate_exact_claude_dispatch_model "$opus_model_flag" "$role" "$agent_type" "$phase" || return 1
             else
-                if declare -f fable5_maybe_escalate >/dev/null 2>&1; then
-                    opus_model_flag="$(fable5_maybe_escalate "$opus_model_flag" "$role" "$agent_type" "$phase")"
-                fi
-                if declare -f fable5_maybe_reroute >/dev/null 2>&1; then
-                    opus_model_flag="$(fable5_maybe_reroute "$opus_model_flag" "$role" "$agent_type" "$phase")"
+                opus_model_flag="$(opus_default_model)"
+                # Selective Fable 5 escalation for judgment-class roles, before
+                # the security reroute so a security dispatch can never end up
+                # on Fable even if the allowlist is later widened. Exact seats
+                # bypass escalation because changing their model breaks the pin.
+                if declare -f fable5_resolve_dispatch_model >/dev/null 2>&1; then
+                    local fable_decision fable_requested fable_reason
+                    if ! fable_decision="$(fable5_resolve_dispatch_model "$opus_model_flag" "$role" "$agent_type" "$phase" "$prompt_bytes")"; then
+                        log "ERROR" "Invalid Fable 5 input-gate configuration"
+                        return 1
+                    fi
+                    fable_requested="$(jq -r '.requested_model' <<< "$fable_decision")"
+                    opus_model_flag="$(jq -r '.resolved_model' <<< "$fable_decision")"
+                    fable_reason="$(jq -r '.reason' <<< "$fable_decision")"
+                    if [[ "${OCTOPUS_DISPATCH_PREVIEW:-false}" != "true" ]] && \
+                       declare -f run_contract_record_event >/dev/null 2>&1; then
+                        run_contract_record_event "routing.decision" \
+                            "requested_model=$fable_requested" \
+                            "resolved_model=$opus_model_flag" \
+                            "reason=$fable_reason" "prompt_bytes=$prompt_bytes" \
+                            "phase=${phase:-unknown}" "role=${role:-none}" >/dev/null 2>&1 || true
+                    fi
+                else
+                    if declare -f fable5_maybe_escalate >/dev/null 2>&1; then
+                        opus_model_flag="$(fable5_maybe_escalate "$opus_model_flag" "$role" "$agent_type" "$phase")"
+                    fi
+                    if declare -f fable5_maybe_reroute >/dev/null 2>&1; then
+                        opus_model_flag="$(fable5_maybe_reroute "$opus_model_flag" "$role" "$agent_type" "$phase")"
+                    fi
                 fi
             fi
             # Clamp on the resolved model, so an escalated dispatch is clamped
@@ -333,8 +359,22 @@ get_agent_command() {
             echo "${_claude_bin}${_BARE_OPT} --print --model ${opus_model_flag}${opus_reasoning_fragment:+ ${opus_reasoning_fragment}} ${claude_perm}"
             ;;
         claude-opus-legacy) echo "${_claude_bin}${_BARE_OPT} --print --model claude-opus-4-6 ${claude_perm}" ;; # v9.23: explicit 4.6 opt-in
-        openrouter) echo "openrouter_execute" ;;                 # OpenRouter API (v4.8)
-        orcarouter) echo "orcarouter_execute" ;;                 # OrcaRouter gateway (OpenAI-compatible)
+        openrouter)
+            if [[ "$agent_type" == *:* ]]; then
+                model="$(get_agent_model "$agent_type" "$phase" "$role")" || return 1
+                echo "openrouter_execute_model ${model}"
+            else
+                echo "openrouter_execute"
+            fi
+            ;;                 # OpenRouter API (v4.8)
+        orcarouter)
+            if [[ "$agent_type" == *:* ]]; then
+                model="$(get_agent_model "$agent_type" "$phase" "$role")" || return 1
+                echo "orcarouter_execute_model ${model}"
+            else
+                echo "orcarouter_execute"
+            fi
+            ;;                 # OrcaRouter gateway (OpenAI-compatible)
         openrouter-glm5) echo "openrouter_execute_model z-ai/glm-5" ;;           # v8.11.0: GLM-5 via OpenRouter
         openrouter-kimi) echo "openrouter_execute_model moonshotai/kimi-k2.5" ;; # v8.11.0: Kimi K2.5 via OpenRouter
         openrouter-deepseek) echo "openrouter_execute_model deepseek/deepseek-v4-pro" ;;
@@ -364,13 +404,17 @@ get_agent_command() {
             echo "${PLUGIN_DIR}/scripts/helpers/openai-compatible-agent.py --provider generic --base-url ${base_url} --api-key-env ${api_key_env} --model ${model} ${reasoning_fragment} ${tool_fragment} --cwd ${PWD}"
             ;;
         atlascloud-agent)  # Atlas Cloud via the OpenAI-compatible tool-loop agent
-            model="${ATLASCLOUD_MODEL:-${OCTOPUS_ATLASCLOUD_MODEL:-${OPENAI_COMPAT_MODEL:-}}}"
-            if [[ -z "$model" && -f "${HOME}/.claude-octopus/config/providers.json" ]] && command -v jq &>/dev/null; then
-                model="$(jq -r '.providers.atlascloud.default // empty' "${HOME}/.claude-octopus/config/providers.json" 2>/dev/null || true)"
-            fi
-            if [[ -z "$model" ]]; then
-                log ERROR "ATLASCLOUD_MODEL, OCTOPUS_ATLASCLOUD_MODEL, OPENAI_COMPAT_MODEL, or providers.json atlascloud.default is required"
-                return 1
+            if [[ "$agent_type" == *:* ]]; then
+                model="$(get_agent_model "$agent_type" "$phase" "$role")" || return 1
+            else
+                model="${ATLASCLOUD_MODEL:-${OCTOPUS_ATLASCLOUD_MODEL:-${OPENAI_COMPAT_MODEL:-}}}"
+                if [[ -z "$model" && -f "${HOME}/.claude-octopus/config/providers.json" ]] && command -v jq &>/dev/null; then
+                    model="$(jq -r '.providers.atlascloud.default // empty' "${HOME}/.claude-octopus/config/providers.json" 2>/dev/null || true)"
+                fi
+                if [[ -z "$model" ]]; then
+                    log ERROR "ATLASCLOUD_MODEL, OCTOPUS_ATLASCLOUD_MODEL, OPENAI_COMPAT_MODEL, or providers.json atlascloud.default is required"
+                    return 1
+                fi
             fi
             if ! validate_model_name "$model"; then
                 log ERROR "Invalid Atlas Cloud model name: ${model}"
@@ -456,6 +500,7 @@ get_agent_command() {
             # unlocks Opus 5 + 1M context independent of the host session. Model
             # wiring mirrors grok: env prefix so providers.json picks reach the shim.
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then return 1; fi
+            _octopus_validate_exact_claude_dispatch_model "$model" "$role" "$agent_type" "$phase" || return 1
             if [[ -n "$model" && "$model" != "default" ]]; then
                 echo "env OCTOPUS_CLAUDE_SDK_MODEL=${model} ${PLUGIN_DIR}/scripts/helpers/claude-sdk-exec.sh"
             else
@@ -500,7 +545,12 @@ get_agent_command() {
             # prompt as argv (stdin yields "No prompt provided"), so the shim
             # reads stdin and re-passes it as `-p "<prompt>"`. Keeps spawn.sh's
             # uniform stdin contract intact (Issue #173).
-            echo "${PLUGIN_DIR}/scripts/helpers/vibe-exec.sh --output text"
+            if [[ "$agent_type" == *:* ]]; then
+                model="$(get_agent_model "$agent_type" "$phase" "$role")" || return 1
+                echo "env OCTOPUS_VIBE_MODEL=${model} ${PLUGIN_DIR}/scripts/helpers/vibe-exec.sh --output text"
+            else
+                echo "${PLUGIN_DIR}/scripts/helpers/vibe-exec.sh --output text"
+            fi
             ;;
         opencode|opencode-fast|opencode-research)  # v9.11.0: OpenCode CLI — multi-provider router
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
@@ -753,15 +803,21 @@ get_agent_model() {
 
     # v8.31.0: Apply model restriction service if configured
     if [[ -n "$provider" ]]; then
-        local fallback
-        fallback=$(validate_model_allowed "$provider" "$resolved_model")
-        if [[ $? -ne 0 && -n "$fallback" ]]; then
+        local fallback=""
+        if fallback=$(validate_model_allowed "$provider" "$resolved_model"); then
+            :
+        elif [[ "$agent_type" == *:* ]]; then
+            log ERROR "Explicit model '$resolved_model' is blocked for provider '$provider'; refusing to substitute '$fallback'"
+            return 1
+        elif [[ -n "$fallback" ]]; then
             if ! validate_model_name "$fallback"; then
                 log ERROR "Invalid fallback model name for $provider"
                 return 1
             fi
             echo "$fallback"
             return 0
+        else
+            return 1
         fi
     fi
     echo "$resolved_model"

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -49,11 +49,9 @@ _octopus_claude_reasoning_fragment() {
 # Exact model pins must stay exact, so an unsafe Fable security pin is rejected
 # instead of being silently rerouted to a different model.
 _octopus_validate_exact_claude_dispatch_model() {
-    local model="$1" role="${2:-}" agent_type="${3:-}" phase="${4:-}"
+    local role="${2:-}" agent_type="${3:-}" phase="${4:-}"
     [[ "$agent_type" == *:* ]] || return 0
-    [[ "$model" == "${FABLE5_MODEL_ID:-claude-fable-5}" ]] || return 0
-    if declare -f fable5_is_security_dispatch >/dev/null 2>&1 && \
-       fable5_is_security_dispatch "$role" "$agent_type" "$phase"; then
+    if ! octo_agent_spec_exact_role_allowed "$agent_type" "$role" "$phase"; then
         log "ERROR" "Exact Fable 5 model pins cannot be used for security dispatches"
         return 1
     fi
@@ -63,6 +61,11 @@ _octopus_validate_exact_claude_dispatch_model() {
 _octopus_openai_compatible_runtime_config() {
     local provider="$1"
     local config_provider="$provider" base_url api_key_env credential_value
+    provider="${provider%%:*}"
+    if declare -f octo_provider_canonical >/dev/null 2>&1; then
+        provider="$(octo_provider_canonical "$provider" 2>/dev/null || printf '%s' "$provider")"
+    fi
+    config_provider="$provider"
     case "$provider" in
         openai-compatible|openai-tools|openai-compatible-agent) config_provider="openai-compatible-agent" ;;
     esac
@@ -262,7 +265,7 @@ get_agent_command() {
                 return 1
             fi
             _octopus_validate_exact_claude_dispatch_model "$model" "$role" "$agent_type" "$phase" || return 1
-            model="${model//./-}"
+            [[ "$agent_type" == *:* ]] || model="${model//./-}"
             echo "${_claude_bin}${_BARE_OPT} --print --model ${model} ${reasoning_fragment} ${claude_perm}" ;;
         claude-sonnet)
             local reasoning_level reasoning_policy reasoning_fragment
@@ -273,7 +276,7 @@ get_agent_command() {
                 return 1
             fi
             _octopus_validate_exact_claude_dispatch_model "$model" "$role" "$agent_type" "$phase" || return 1
-            model="${model//./-}"
+            [[ "$agent_type" == *:* ]] || model="${model//./-}"
             echo "${_claude_bin}${_BARE_OPT} --print --model ${model} ${reasoning_fragment} ${claude_perm}" ;;
         claude-opus|claude-opus-fast)
             # Resolve a concrete model so current-host detection and user pins
@@ -353,7 +356,7 @@ get_agent_command() {
                     return 1
                     ;;
             esac
-            opus_model_flag="${opus_model_flag//./-}"
+            [[ "$agent_type" == *:* ]] || opus_model_flag="${opus_model_flag//./-}"
             local opus_reasoning_fragment=""
             opus_reasoning_fragment="$(_octopus_claude_reasoning_fragment "$opus_effort" best_effort)" || return 1
             echo "${_claude_bin}${_BARE_OPT} --print --model ${opus_model_flag}${opus_reasoning_fragment:+ ${opus_reasoning_fragment}} ${claude_perm}"
@@ -829,32 +832,9 @@ get_agent_model() {
 validate_model_allowed() {
     local provider="$1"
     local model="$2"
-
-    case "$provider" in
-        gemini|gemini-*) provider="agy" ;;
-        antigravity|agy-research) provider="agy" ;;
-    esac
-
     local allowlist_var=""
-    case "$provider" in
-        codex)      allowlist_var="OCTOPUS_CODEX_ALLOWED_MODELS" ;;
-        agy)        allowlist_var="OCTOPUS_AGY_ALLOWED_MODELS" ;;
-        claude-sdk) allowlist_var="OCTOPUS_CLAUDE_SDK_ALLOWED_MODELS" ;;
-        claude)     allowlist_var="OCTOPUS_CLAUDE_ALLOWED_MODELS" ;;
-        openrouter) allowlist_var="OCTOPUS_OPENROUTER_ALLOWED_MODELS" ;;
-        orcarouter) allowlist_var="OCTOPUS_ORCAROUTER_ALLOWED_MODELS" ;;
-        atlascloud) allowlist_var="ATLASCLOUD_ALLOWED_MODELS" ;;
-        openai-compatible|openai-tools|openai-compatible-agent) allowlist_var="OPENAI_COMPAT_ALLOWED_MODELS" ;;
-        perplexity) allowlist_var="OCTOPUS_PERPLEXITY_ALLOWED_MODELS" ;;
-        qwen)       allowlist_var="OCTOPUS_QWEN_ALLOWED_MODELS" ;;
-        cursor-agent) allowlist_var="OCTOPUS_CURSOR_AGENT_ALLOWED_MODELS" ;;
-        commandcode) allowlist_var="OCTOPUS_COMMANDCODE_ALLOWED_MODELS" ;;
-        opencode)   allowlist_var="OCTOPUS_OPENCODE_ALLOWED_MODELS" ;;
-        ollama)     allowlist_var="OCTOPUS_OLLAMA_ALLOWED_MODELS" ;;
-        copilot)    allowlist_var="OCTOPUS_COPILOT_ALLOWED_MODELS" ;;
-        vibe)       allowlist_var="OCTOPUS_VIBE_ALLOWED_MODELS" ;;
-        *)          return 0 ;;  # Unknown provider — allow
-    esac
+    allowlist_var="$(octo_provider_model_allowlist_var "$provider" 2>/dev/null || true)"
+    [[ -n "$allowlist_var" ]] || return 0
 
     local allowlist="${!allowlist_var:-}"
     [[ -z "$allowlist" ]] && return 0  # No allowlist = all allowed

--- a/scripts/lib/fable5.sh
+++ b/scripts/lib/fable5.sh
@@ -113,6 +113,12 @@ fable5_clamp_effort() {
 # the dispatch identifiers indicate security work (security-auditor persona,
 # squeeze red/blue workflow, red-team roles).
 fable5_is_security_dispatch() {
+    if declare -f octo_agent_spec_is_security_dispatch >/dev/null 2>&1; then
+        if octo_agent_spec_is_security_dispatch "${1:-}" "${2:-}" "${3:-}"; then
+            return 0
+        fi
+        return 1
+    fi
     local combined="${1:-} ${2:-} ${3:-}"
     case "$combined" in
         *security*|*squeeze*|*red-team*|*redteam*) return 0 ;;

--- a/scripts/lib/proof-packet.sh
+++ b/scripts/lib/proof-packet.sh
@@ -4,6 +4,10 @@
 # Proof packets are local-only run artifacts. They make escalated Octopus
 # workflows auditable without turning the plugin into a full project manager.
 
+_proof_packet_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_proof_packet_lib_dir}/agent-spec.sh" 2>/dev/null || true
+unset _proof_packet_lib_dir
+
 octo_proof_enabled() {
     case "${OCTOPUS_PROOF_PACKET:-1}" in
         0|false|FALSE|off|OFF|no|NO) return 1 ;;
@@ -147,20 +151,13 @@ octo_proof_capture_provider_status() {
     [[ -n "$run_dir" && -d "$run_dir" && -f "$status_file" ]] || return 0
     octo_proof_enabled || return 0
 
-    local record field1 field2 field3 field4 remainder provider model provider_status detail
+    local record provider model provider_status detail
     while IFS= read -r record; do
-        IFS='|' read -r field1 field2 field3 field4 remainder <<< "$record"
-        if [[ "$field1" == "v2" ]]; then
-            provider="$field2"
-            model="$field3"
-            provider_status="$field4"
-            detail="$remainder"
-        else
-            provider="$field1"
-            model=""
-            provider_status="$field2"
-            detail="${field3}${field4:+|${field4}}${remainder:+|${remainder}}"
-        fi
+        octo_parse_provider_status_record "$record" || continue
+        provider="$OCTO_PROVIDER_STATUS_PROVIDER"
+        model="$OCTO_PROVIDER_STATUS_MODEL"
+        provider_status="$OCTO_PROVIDER_STATUS_VALUE"
+        detail="$OCTO_PROVIDER_STATUS_DETAIL"
         [[ -z "${provider:-}" ]] && continue
         octo_proof_event "$run_dir" "provider_status" "$(jq -n \
             --arg provider "$provider" \

--- a/scripts/lib/proof-packet.sh
+++ b/scripts/lib/proof-packet.sh
@@ -147,14 +147,28 @@ octo_proof_capture_provider_status() {
     [[ -n "$run_dir" && -d "$run_dir" && -f "$status_file" ]] || return 0
     octo_proof_enabled || return 0
 
-    while IFS='|' read -r provider provider_status detail; do
+    local record field1 field2 field3 field4 remainder provider model provider_status detail
+    while IFS= read -r record; do
+        IFS='|' read -r field1 field2 field3 field4 remainder <<< "$record"
+        if [[ "$field1" == "v2" ]]; then
+            provider="$field2"
+            model="$field3"
+            provider_status="$field4"
+            detail="$remainder"
+        else
+            provider="$field1"
+            model=""
+            provider_status="$field2"
+            detail="${field3}${field4:+|${field4}}${remainder:+|${remainder}}"
+        fi
         [[ -z "${provider:-}" ]] && continue
-        detail="${detail:-}"
         octo_proof_event "$run_dir" "provider_status" "$(jq -n \
             --arg provider "$provider" \
+            --arg model "$model" \
             --arg status "$provider_status" \
             --arg detail "$detail" \
-            '{provider:$provider, status:$status, detail:$detail}')"
+            '{provider:$provider, status:$status, detail:$detail}
+             + if ($model | length) > 0 then {model:$model} else {} end')"
 
         case "$provider_status" in
             fallback|auth-failed)
@@ -165,10 +179,12 @@ octo_proof_capture_provider_status() {
                 fi
                 octo_proof_event "$run_dir" "provider_substitution" "$(jq -n \
                     --arg provider "$provider" \
+                    --arg model "$model" \
                     --arg status "$provider_status" \
                     --arg detail "$detail" \
                     --arg replacement "$replacement" \
-                    '{provider:$provider, status:$status, detail:$detail, replacement:$replacement}')"
+                    '{provider:$provider, status:$status, detail:$detail, replacement:$replacement}
+                     + if ($model | length) > 0 then {model:$model} else {} end')"
                 ;;
         esac
     done < "$status_file"

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 _agent_spec_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_agent_spec_lib_dir}/agent-spec.sh" 2>/dev/null || true
+source "${_agent_spec_lib_dir}/provider-allowlist.sh" 2>/dev/null || true
 # Claude Octopus — Code Review Pipeline
 # Extracted from orchestrate.sh
 # Source-safe: no main execution block.
@@ -157,17 +158,66 @@ _review_fleet_from_config() {
 # Returns a newline-separated list of "agent_type:role:specialty" triples.
 # NOTE: Uses command -v for provider detection — safe with set -euo pipefail.
 review_single_provider_override() {
-    local provider="${OCTOPUS_REVIEW_SINGLE_PROVIDER:-}"
+    local provider="${OCTOPUS_REVIEW_SINGLE_PROVIDER:-}" canonical="" executor=""
     [[ -n "$provider" ]] || return 1
     [[ "$provider" =~ ^[A-Za-z0-9_-]+$ ]] || {
         log ERROR "Invalid OCTOPUS_REVIEW_SINGLE_PROVIDER: $provider"
         return 2
     }
-    if [[ -n "${AVAILABLE_AGENTS:-}" && " $AVAILABLE_AGENTS " != *" $provider "* ]]; then
+
+    if ! declare -f octo_provider_canonical >/dev/null 2>&1 ||
+       ! canonical="$(octo_provider_canonical "$provider" 2>/dev/null)"; then
         log ERROR "Unknown OCTOPUS_REVIEW_SINGLE_PROVIDER: $provider"
         return 2
     fi
-    printf '%s\n' "$provider"
+    if ! declare -f octo_provider_has_capability >/dev/null 2>&1 ||
+       ! octo_provider_has_capability "$canonical" dispatch; then
+        log ERROR "OCTOPUS_REVIEW_SINGLE_PROVIDER '$canonical' does not support dispatch"
+        return 2
+    fi
+    if ! declare -f octo_provider_allowed >/dev/null 2>&1 ||
+       ! octo_provider_allowed "$canonical"; then
+        log ERROR "OCTOPUS_REVIEW_SINGLE_PROVIDER '$canonical' is not admitted by the active allowlist"
+        return 2
+    fi
+
+    case "$canonical" in
+        atlascloud) executor="atlascloud-agent" ;;
+        *) executor="$canonical" ;;
+    esac
+
+    if declare -f review_single_provider_is_available >/dev/null 2>&1; then
+        if ! review_single_provider_is_available "$canonical" "$executor"; then
+            log ERROR "OCTOPUS_REVIEW_SINGLE_PROVIDER '$canonical' is unavailable"
+            return 2
+        fi
+    elif [[ -n "${AVAILABLE_AGENTS:-}" ]]; then
+        local candidate candidate_canonical available=false had_noglob=false
+        local -a available_candidates
+        local IFS=$' \t\n'
+        case "$-" in *f*) had_noglob=true ;; esac
+        set -f
+        # shellcheck disable=SC2206 # Deliberate trusted inventory split; globbing is disabled.
+        available_candidates=($AVAILABLE_AGENTS)
+        [[ "$had_noglob" == true ]] || set +f
+        for candidate in "${available_candidates[@]}"; do
+            candidate="${candidate%%:*}"
+            candidate_canonical="$(octo_provider_canonical "$candidate" 2>/dev/null || true)"
+            if [[ "$candidate" == "$executor" || "$candidate_canonical" == "$canonical" ]]; then
+                available=true
+                break
+            fi
+        done
+        if [[ "$available" != true ]]; then
+            log ERROR "OCTOPUS_REVIEW_SINGLE_PROVIDER '$canonical' is unavailable"
+            return 2
+        fi
+    else
+        log ERROR "OCTOPUS_REVIEW_SINGLE_PROVIDER '$canonical' cannot be validated without provider availability data"
+        return 2
+    fi
+
+    printf '%s\n' "$executor"
 }
 
 review_seat_override_env_name() {
@@ -756,21 +806,37 @@ review_provider_key_from_agent_type() {
     esac
 }
 
+# Versioned provider records represent one exact dispatch seat. Preserve the
+# registry ID instead of applying the broad legacy reporting-family mapping.
+review_exact_provider_key_from_agent_type() {
+    local executor="${1%%:*}" canonical=""
+    canonical="$(octo_provider_canonical "$executor" 2>/dev/null || true)"
+    if [[ -n "$canonical" ]]; then
+        printf '%s\n' "$canonical"
+        return 0
+    fi
+    case "$executor" in
+        openai-compatible|openai-tools|openai-compatible-agent) printf '%s\n' "$executor" ;;
+        *) review_provider_key_from_agent_type "$executor" ;;
+    esac
+}
+
 # Versioned records carry provider and model as separate fields. The marker
 # avoids confusing a model named "ok" or "fallback" with a legacy status.
 # The report parser still accepts provider|status|detail records.
 review_append_provider_status() {
     local status_file="$1" agent_type="$2" role="$3" status="$4" detail="$5"
     local provider model=""
-    provider="$(review_provider_key_from_agent_type "$agent_type")"
     model="$(octo_agent_spec_explicit_model "$agent_type" 2>/dev/null || true)"
     if [[ -z "$model" ]] && declare -f get_agent_model >/dev/null 2>&1; then
         model="$(get_agent_model "$agent_type" review "$role" 2>/dev/null || true)"
     fi
 
     if [[ -n "$model" ]]; then
+        provider="$(review_exact_provider_key_from_agent_type "$agent_type")"
         printf 'v2|%s|%s|%s|%s\n' "$provider" "$model" "$status" "$detail" >> "$status_file"
     else
+        provider="$(review_provider_key_from_agent_type "$agent_type")"
         printf '%s|%s|%s\n' "$provider" "$status" "$detail" >> "$status_file"
     fi
 }
@@ -778,8 +844,12 @@ review_append_provider_status() {
 review_parse_provider_status_record() {
     local record="$1"
     octo_parse_provider_status_record "$record" || return $?
-    REVIEW_STATUS_PROVIDER="$(review_provider_key_from_agent_type "$OCTO_PROVIDER_STATUS_PROVIDER")"
     REVIEW_STATUS_MODEL="$OCTO_PROVIDER_STATUS_MODEL"
+    if [[ -n "$REVIEW_STATUS_MODEL" ]]; then
+        REVIEW_STATUS_PROVIDER="$(review_exact_provider_key_from_agent_type "$OCTO_PROVIDER_STATUS_PROVIDER")"
+    else
+        REVIEW_STATUS_PROVIDER="$(review_provider_key_from_agent_type "$OCTO_PROVIDER_STATUS_PROVIDER")"
+    fi
     REVIEW_STATUS_VALUE="$OCTO_PROVIDER_STATUS_VALUE"
     REVIEW_STATUS_DETAIL="$OCTO_PROVIDER_STATUS_DETAIL"
 }
@@ -1162,7 +1232,7 @@ print_provider_report() {
                 agy) agy_model_status=true ;;
                 claude) claude_model_status=true ;;
                 perplexity) perplexity_model_status=true ;;
-                openai-compatible) compatible_model_status=true ;;
+                openai-compatible|openai-tools|openai-compatible-agent) compatible_model_status=true ;;
                 copilot) copilot_model_status=true ;;
                 commandcode) commandcode_model_status=true ;;
             esac

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -196,7 +196,7 @@ review_seat_specialty() {
 }
 
 review_seat_agent_override() {
-    local role="${1:-}" env_name="" agent=""
+    local role="${1:-}" env_name="" agent="" provider="" model=""
     env_name="$(review_seat_override_env_name "$role" 2>/dev/null || true)"
     [[ -n "$env_name" ]] || return 1
     [[ "${!env_name+x}" == "x" ]] || return 1
@@ -214,6 +214,20 @@ review_seat_agent_override() {
 
     if ! octo_agent_spec_exact_model_allowed "$agent"; then
         log ERROR "Review seat override ${env_name}='${agent}' is blocked by the provider model allowlist"
+        return 2
+    fi
+
+    provider="$(octo_agent_spec_provider "$agent")"
+    model="$(octo_agent_spec_explicit_model "$agent")" || {
+        log ERROR "Review seat override ${env_name}='${agent}' has no exact model"
+        return 2
+    }
+    if ! declare -f validate_model_name_for_provider >/dev/null 2>&1; then
+        log ERROR "Review seat override ${env_name}='${agent}' cannot be validated because provider model validation is unavailable"
+        return 2
+    fi
+    if ! validate_model_name_for_provider "$provider" "$model"; then
+        log ERROR "Review seat override ${env_name}='${agent}' is not a valid model for provider '${provider}'"
         return 2
     fi
 
@@ -1612,10 +1626,6 @@ Use this context as the requested behavior and constraints. Flag severity=normal
     local fleet
     fleet=$(build_review_fleet)
 
-    if [[ -n "$proof_dir" ]]; then
-        octo_proof_event "$proof_dir" "provider_fleet" "$(printf '%s\n' "$fleet" | jq -R -s 'split("\n")[:-1]')"
-    fi
-
     local agent_prompt_base
     agent_prompt_base="You are a code reviewer. Review the following diff and return ONLY a JSON object with a 'findings' array.
 
@@ -1682,6 +1692,17 @@ ${agent_prompt_base}"
         fi
         round1_pids+=("$round1_pid")
     done <<< "$fleet"
+
+    if [[ -n "$proof_dir" ]]; then
+        local resolved_provider_fleet_json="[]"
+        if [[ "${#round1_agent_types[@]}" -gt 0 ]]; then
+            resolved_provider_fleet_json="$(
+                printf '%s\n' "${round1_agent_types[@]}" |
+                    jq -c -R -s 'split("\n")[:-1]'
+            )"
+        fi
+        octo_proof_event "$proof_dir" "provider_fleet" "$resolved_provider_fleet_json"
+    fi
 
     fleet_dispatch_end
 

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -170,15 +170,96 @@ review_single_provider_override() {
     printf '%s\n' "$provider"
 }
 
-review_phase_provider() {
-    local default_provider="$1"
-    local override=""
-    if [[ -n "${OCTOPUS_REVIEW_SINGLE_PROVIDER:-}" ]]; then
-        override="$(review_single_provider_override)" || return $?
-        printf '%s\n' "$override"
-    else
-        printf '%s\n' "$default_provider"
+review_seat_override_env_name() {
+    case "${1:-}" in
+        implementation-logic-reviewer) echo "OCTOPUS_REVIEW_LOGIC_AGENT" ;;
+        implementation-security-reviewer) echo "OCTOPUS_REVIEW_SECURITY_AGENT" ;;
+        implementation-architecture-reviewer) echo "OCTOPUS_REVIEW_ARCHITECTURE_AGENT" ;;
+        implementation-cve-reviewer) echo "OCTOPUS_REVIEW_CVE_AGENT" ;;
+        implementation-diversity-reviewer) echo "OCTOPUS_REVIEW_DIVERSITY_AGENT" ;;
+        implementation-verifier) echo "OCTOPUS_REVIEW_VERIFIER_AGENT" ;;
+        implementation-debater) echo "OCTOPUS_REVIEW_DEBATER_AGENT" ;;
+        implementation-synthesizer) echo "OCTOPUS_REVIEW_SYNTHESIZER_AGENT" ;;
+        *) return 1 ;;
+    esac
+}
+
+review_seat_specialty() {
+    case "${1:-}" in
+        implementation-logic-reviewer) echo "correctness and logic bugs, edge cases, regressions" ;;
+        implementation-security-reviewer) echo "OWASP vulnerabilities, injection, auth flaws, data exposure" ;;
+        implementation-architecture-reviewer) echo "architecture, integration, API contracts, breaking changes" ;;
+        implementation-cve-reviewer) echo "known CVEs, library advisories, live web search" ;;
+        implementation-diversity-reviewer) echo "cross-family perspective on logic, missed assumptions, and training-data divergence" ;;
+        *) return 1 ;;
+    esac
+}
+
+review_seat_agent_override() {
+    local role="${1:-}" env_name="" agent=""
+    env_name="$(review_seat_override_env_name "$role" 2>/dev/null || true)"
+    [[ -n "$env_name" ]] || return 1
+    agent="${!env_name:-}"
+    [[ -n "$agent" ]] || return 1
+
+    if ! declare -f octo_provider_allowed >/dev/null 2>&1 || ! octo_provider_allowed "$agent"; then
+        log ERROR "Review seat override ${env_name}='${agent}' is not admitted by the active allowlist"
+        return 2
     fi
+
+    printf '%s\n' "$agent"
+}
+
+review_agent_for_seat() {
+    local default_agent="$1"
+    local role="${2:-}"
+    local override="" rc=0
+
+    if [[ -n "${OCTOPUS_REVIEW_SINGLE_PROVIDER:-}" ]]; then
+        review_single_provider_override
+        return $?
+    fi
+
+    override="$(review_seat_agent_override "$role")" || rc=$?
+    case "$rc" in
+        0) printf '%s\n' "$override" ;;
+        1) printf '%s\n' "$default_agent" ;;
+        *) return "$rc" ;;
+    esac
+}
+
+review_fleet_with_override_seats() {
+    local fleet="${1:-}"
+    local role="" env_name="" override="" executor="" specialty="" rc=0
+    local roles=(
+        implementation-logic-reviewer
+        implementation-security-reviewer
+        implementation-architecture-reviewer
+        implementation-cve-reviewer
+        implementation-diversity-reviewer
+    )
+
+    for role in "${roles[@]}"; do
+        env_name="$(review_seat_override_env_name "$role")" || continue
+        [[ -n "${!env_name:-}" ]] || continue
+
+        rc=0
+        override="$(review_seat_agent_override "$role")" || rc=$?
+        [[ "$rc" -eq 0 ]] || return "$rc"
+
+        if ! grep -Fq ":${role}:" <<< "$fleet"; then
+            executor="$(octo_agent_spec_executor "$override")"
+            specialty="$(review_seat_specialty "$role")"
+            fleet+="${executor}:${role}:${specialty}"$'\n'
+        fi
+    done
+
+    printf '%s' "$fleet"
+}
+
+# Backward-compatible wrapper for callers/tests that only choose a phase provider.
+review_phase_provider() {
+    review_agent_for_seat "$1" "${2:-}"
 }
 
 build_review_fleet() {
@@ -197,8 +278,8 @@ build_review_fleet() {
     # v9.31.0: honor wizard-configured participants if present
     fleet=$(_review_fleet_from_config)
     if [[ -n "$fleet" ]]; then
-        echo "$fleet"
-        return 0
+        review_fleet_with_override_seats "$fleet"
+        return $?
     fi
 
     # ── Cascade fallback (original behavior — no config or empty config) ──
@@ -246,7 +327,7 @@ build_review_fleet() {
         log WARN "CVE lookup: no dedicated web-search provider, using Claude WebSearch (degraded)"
     fi
 
-    echo "$fleet"
+    review_fleet_with_override_seats "$fleet"
 }
 
 review_file_mtime_epoch() {
@@ -604,6 +685,7 @@ review_provider_key_from_agent_type() {
         claude*) echo "claude" ;;
         copilot*) echo "copilot" ;;
         codex*) echo "codex" ;;
+        commandcode*) echo "commandcode" ;;
         agy*|antigravity|gemini*) echo "agy" ;;
         perplexity*) echo "perplexity" ;;
         *) printf '%s\n' "${1%%[-_]*}" ;;
@@ -949,8 +1031,8 @@ print_provider_report() {
     fi
 
     # Determine status per provider
-    local codex_status="not used" agy_status="not used" claude_status="not used" perplexity_status="not used" compatible_status="not used" copilot_status="not used"
-    local codex_detail="" agy_detail="" claude_detail="" perplexity_detail="" compatible_detail="" copilot_detail=""
+    local codex_status="not used" agy_status="not used" claude_status="not used" perplexity_status="not used" compatible_status="not used" copilot_status="not used" commandcode_status="not used"
+    local codex_detail="" agy_detail="" claude_detail="" perplexity_detail="" compatible_detail="" copilot_detail="" commandcode_detail=""
     local had_fallback=false
 
     while IFS='|' read -r provider status detail; do
@@ -1012,6 +1094,19 @@ print_provider_report() {
                     had_fallback=true
                 fi
                 ;;
+            commandcode)
+                if [[ "$status" == "ok" ]]; then
+                    commandcode_status="✓ OK"
+                elif [[ "$status" == "fallback" ]]; then
+                    commandcode_status="✗ FALLBACK"
+                    commandcode_detail="$detail"
+                    had_fallback=true
+                elif [[ "$status" == "auth-failed" ]]; then
+                    commandcode_status="✗ AUTH FAILED"
+                    commandcode_detail="$detail"
+                    had_fallback=true
+                fi
+                ;;
             copilot)
                 if [[ "$status" == "ok" ]]; then
                     copilot_status="✓ OK"
@@ -1045,6 +1140,8 @@ print_provider_report() {
     [[ -n "$compatible_detail" ]] && printf "│    → %-38.38s│\n" "$compatible_detail"
     printf "│ 🟡 Copilot:     %-27s│\n" "$copilot_status"
     [[ -n "$copilot_detail" ]] && printf "│    → %-38.38s│\n" "$copilot_detail"
+    printf "│ 🟠 CommandCode: %-27s│\n" "$commandcode_status"
+    [[ -n "$commandcode_detail" ]] && printf "│    → %-38.38s│\n" "$commandcode_detail"
     if [[ "$had_fallback" == "true" ]]; then
         echo "│                                             │"
         echo "│ ⚠ Some providers failed — run octopus doctor│"
@@ -1363,6 +1460,7 @@ CRITICAL OUTPUT FORMAT: Return ONLY a valid JSON object. No markdown, no prose, 
     fleet_dispatch_begin
     while IFS=: read -r agent_type role specialty; do
         [[ -z "$agent_type" ]] && continue
+        agent_type="$(review_agent_for_seat "$agent_type" "$role")" || return 1
         local task_id="review-r1-${role}-${timestamp}"
         # Use spawn_agent's actual output path convention: ${RESULTS_DIR}/$(octo_agent_spec_slug "$agent_type")-${task_id}.md
         local result_file
@@ -1575,10 +1673,10 @@ $(echo "$all_findings" | jq -c '.')
 Return ONLY valid JSON with 'findings' array including verdict field."
 
     local verified_findings verifier_provider verifier_provider_key
-    verifier_provider="$(review_phase_provider "codex")" || return 1
+    verifier_provider="$(review_phase_provider "codex" "implementation-verifier")" || return 1
     verifier_provider_key="$(review_provider_key_from_agent_type "$verifier_provider")"
-    if [[ -n "${OCTOPUS_REVIEW_SINGLE_PROVIDER:-}" ]]; then
-        verified_findings=$(review_run_agent_sync_progress "$verifier_provider" "$verifier_prompt" "implementation-verifier" "review" "verifier-${verifier_provider}") && {
+    if [[ -n "${OCTOPUS_REVIEW_SINGLE_PROVIDER:-}" || -n "${OCTOPUS_REVIEW_VERIFIER_AGENT:-}" ]]; then
+        verified_findings=$(review_run_agent_sync_progress "$verifier_provider" "$verifier_prompt" "implementation-verifier" "review" "verifier-$(octo_agent_spec_slug "$verifier_provider")") && {
             echo "${verifier_provider_key}|ok|Round 2 verification" >> "$provider_status_file"
         } || {
             log WARN "review_run: ${verifier_provider} verification failed, using all findings as confirmed"
@@ -1636,9 +1734,9 @@ Return ONLY valid JSON with 'findings' array including verdict field."
 Findings: $(echo "$debate_candidates" | jq -c '.')
 Return JSON: {\"include\": [...finding titles...], \"exclude\": [...finding titles...]}"
             local debate_result debate_provider debate_provider_key
-            debate_provider="$(review_phase_provider "codex")" || return 1
+            debate_provider="$(review_phase_provider "codex" "implementation-debater")" || return 1
             debate_provider_key="$(review_provider_key_from_agent_type "$debate_provider")"
-            debate_result=$(review_run_agent_sync_progress "$debate_provider" "$debate_prompt" "implementation-debater" "review" "debate-${debate_provider}") && {
+            debate_result=$(review_run_agent_sync_progress "$debate_provider" "$debate_prompt" "implementation-debater" "review" "debate-$(octo_agent_spec_slug "$debate_provider")") && {
                 echo "${debate_provider_key}|ok|Round 3 debate" >> "$provider_status_file"
             } || {
                 log WARN "review_run: ${debate_provider} debate agent failed, including all contested findings"
@@ -1670,9 +1768,9 @@ Findings: $(echo "$confirmed_findings" | jq -c '.')
 Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
 
     local final_json synth_ok="true" synthesis_provider synthesis_provider_key
-    synthesis_provider="$(review_phase_provider "claude-sonnet")" || return 1
+    synthesis_provider="$(review_phase_provider "claude-sonnet" "implementation-synthesizer")" || return 1
     synthesis_provider_key="$(review_provider_key_from_agent_type "$synthesis_provider")"
-    final_json=$(review_run_agent_sync_progress "$synthesis_provider" "$synthesis_prompt" "implementation-synthesizer" "review" "synthesis-${synthesis_provider}") || {
+    final_json=$(review_run_agent_sync_progress "$synthesis_provider" "$synthesis_prompt" "implementation-synthesizer" "review" "synthesis-$(octo_agent_spec_slug "$synthesis_provider")") || {
         synth_ok="false"
         log WARN "review_run: ${synthesis_provider} synthesis failed, using confirmed findings sorted as-is"
         echo "${synthesis_provider_key}|fallback|Round 3 synthesis failed; using local deterministic fallback" >> "$provider_status_file"

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -247,7 +247,7 @@ review_fleet_with_override_seats() {
         override="$(review_seat_agent_override "$role")" || rc=$?
         [[ "$rc" -eq 0 ]] || return "$rc"
 
-        if ! grep -Fq ":${role}:" <<< "$fleet"; then
+        if ! grep -Fc ":${role}:" <<< "$fleet" >/dev/null; then
             executor="$(octo_agent_spec_executor "$override")"
             specialty="$(review_seat_specialty "$role")"
             fleet+="${executor}:${role}:${specialty}"$'\n'

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -191,24 +191,12 @@ review_single_provider_override() {
             log ERROR "OCTOPUS_REVIEW_SINGLE_PROVIDER '$canonical' is unavailable"
             return 2
         fi
-    elif [[ -n "${AVAILABLE_AGENTS:-}" ]]; then
-        local candidate candidate_canonical available=false had_noglob=false
-        local -a available_candidates
-        local IFS=$' \t\n'
-        case "$-" in *f*) had_noglob=true ;; esac
-        set -f
-        # shellcheck disable=SC2206 # Deliberate trusted inventory split; globbing is disabled.
-        available_candidates=($AVAILABLE_AGENTS)
-        [[ "$had_noglob" == true ]] || set +f
-        for candidate in "${available_candidates[@]}"; do
-            candidate="${candidate%%:*}"
-            candidate_canonical="$(octo_provider_canonical "$candidate" 2>/dev/null || true)"
-            if [[ "$candidate" == "$executor" || "$candidate_canonical" == "$canonical" ]]; then
-                available=true
-                break
-            fi
-        done
-        if [[ "$available" != true ]]; then
+    elif [[ "$canonical" == claude ]]; then
+        # Claude is the host runtime and intentionally absent from external
+        # provider admission inventories.
+        :
+    elif declare -f is_agent_available_v2 >/dev/null 2>&1; then
+        if ! is_agent_available_v2 "$executor"; then
             log ERROR "OCTOPUS_REVIEW_SINGLE_PROVIDER '$canonical' is unavailable"
             return 2
         fi

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -199,8 +199,13 @@ review_seat_agent_override() {
     local role="${1:-}" env_name="" agent=""
     env_name="$(review_seat_override_env_name "$role" 2>/dev/null || true)"
     [[ -n "$env_name" ]] || return 1
-    agent="${!env_name:-}"
-    [[ -n "$agent" ]] || return 1
+    [[ "${!env_name+x}" == "x" ]] || return 1
+    agent="${!env_name-}"
+
+    if ! agent="$(octo_agent_spec_canonicalize_exact "$agent")"; then
+        log ERROR "Review seat override ${env_name} must be a supported provider:model spec"
+        return 2
+    fi
 
     if ! declare -f octo_provider_allowed >/dev/null 2>&1 || ! octo_provider_allowed "$agent"; then
         log ERROR "Review seat override ${env_name}='${agent}' is not admitted by the active allowlist"
@@ -250,6 +255,9 @@ review_fleet_with_override_seats() {
         if ! grep -Fc ":${role}:" <<< "$fleet" >/dev/null; then
             executor="$(octo_agent_spec_executor "$override")"
             specialty="$(review_seat_specialty "$role")"
+            if [[ -n "$fleet" && "$fleet" != *$'\n' ]]; then
+                fleet+=$'\n'
+            fi
             fleet+="${executor}:${role}:${specialty}"$'\n'
         fi
     done
@@ -679,16 +687,20 @@ review_result_failure_detail() {
 }
 
 review_provider_key_from_agent_type() {
-    case "${1:-}" in
+    local executor="${1%%:*}" canonical=""
+    case "$executor" in
         openai-compatible*|openai-tools*) echo "openai-compatible" ;;
-        claude-sdk*) echo "claude" ;;
+        claude-sdk*) echo "claude-sdk" ;;
         claude*) echo "claude" ;;
         copilot*) echo "copilot" ;;
         codex*) echo "codex" ;;
         commandcode*) echo "commandcode" ;;
         agy*|antigravity|gemini*) echo "agy" ;;
         perplexity*) echo "perplexity" ;;
-        *) printf '%s\n' "${1%%[-_]*}" ;;
+        *)
+            canonical="$(octo_provider_canonical "$executor" 2>/dev/null || true)"
+            printf '%s\n' "${canonical:-${executor%%[-_]*}}"
+            ;;
     esac
 }
 
@@ -1025,10 +1037,12 @@ review_collect_diff() {
 print_provider_report() {
     local status_file="$1"
     local fallback_log="${HOME}/.claude-octopus/provider-fallbacks.log"
+    local extra_status_file
 
     if [[ ! -f "$status_file" ]]; then
         return 0
     fi
+    extra_status_file="$(mktemp "${TMPDIR:-/tmp}/octopus-provider-report.XXXXXX")" || return 1
 
     # Determine status per provider
     local codex_status="not used" agy_status="not used" claude_status="not used" perplexity_status="not used" compatible_status="not used" copilot_status="not used" commandcode_status="not used"
@@ -1036,6 +1050,7 @@ print_provider_report() {
     local had_fallback=false
 
     while IFS='|' read -r provider status detail; do
+        provider="$(review_provider_key_from_agent_type "$provider")"
         case "$provider" in
             codex)
                 if [[ "$status" == "ok" ]]; then
@@ -1120,6 +1135,25 @@ print_provider_report() {
                     had_fallback=true
                 fi
                 ;;
+            *)
+                local extra_status=""
+                case "$status" in
+                    ok) extra_status="✓ OK" ;;
+                    fallback)
+                        extra_status="✗ FALLBACK"
+                        had_fallback=true
+                        ;;
+                    auth-failed)
+                        extra_status="✗ AUTH FAILED"
+                        had_fallback=true
+                        ;;
+                esac
+                if [[ -n "$extra_status" ]]; then
+                    awk -F'|' -v key="$provider" '$1 != key' "$extra_status_file" > "${extra_status_file}.tmp"
+                    mv "${extra_status_file}.tmp" "$extra_status_file"
+                    printf '%s|%s|%s\n' "$provider" "$extra_status" "$detail" >> "$extra_status_file"
+                fi
+                ;;
         esac
     done < "$status_file"
 
@@ -1142,6 +1176,13 @@ print_provider_report() {
     [[ -n "$copilot_detail" ]] && printf "│    → %-38.38s│\n" "$copilot_detail"
     printf "│ 🟠 CommandCode: %-27s│\n" "$commandcode_status"
     [[ -n "$commandcode_detail" ]] && printf "│    → %-38.38s│\n" "$commandcode_detail"
+    while IFS='|' read -r provider status detail; do
+        [[ -n "$provider" ]] || continue
+        local provider_label
+        provider_label="$(printf '%s' "$provider" | awk '{ print toupper(substr($0,1,1)) substr($0,2) }')"
+        printf "│ %-14s %-27s│\n" "${provider_label}:" "$status"
+        [[ -n "$detail" && "$status" != "✓ OK" ]] && printf "│    → %-38.38s│\n" "$detail"
+    done < "$extra_status_file"
     if [[ "$had_fallback" == "true" ]]; then
         echo "│                                             │"
         echo "│ ⚠ Some providers failed — run octopus doctor│"
@@ -1153,6 +1194,7 @@ print_provider_report() {
         echo "Provider failure details:"
         while IFS='|' read -r provider status detail; do
             if [[ "$status" == "fallback" || "$status" == "auth-failed" ]]; then
+                provider="$(review_provider_key_from_agent_type "$provider")"
                 printf -- '- %s: %s\n' "$provider" "$detail"
             fi
         done < "$status_file"
@@ -1165,6 +1207,7 @@ print_provider_report() {
         ts=$(date -Iseconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S)
         while IFS='|' read -r provider status detail; do
             if [[ "$status" == "fallback" || "$status" == "auth-failed" ]]; then
+                provider="$(review_provider_key_from_agent_type "$provider")"
                 echo "[$ts] provider=$provider status=$status detail=$detail" >> "$fallback_log"
             fi
         done < "$status_file"
@@ -1175,6 +1218,7 @@ print_provider_report() {
     fi
 
     rm -f "$status_file"
+    rm -f "$extra_status_file"
 }
 
 # parallel fleet (Round 1) + verification (Round 2) + synthesis (Round 3)
@@ -1810,7 +1854,7 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
         if ! _synth_count=$(review_findings_count "$final_json"); then
             _synth_count=0
         fi
-        octo_event_emit "synthesis" phase="review" provider="$synthesis_provider" provider_label_kind="legacy-alias" executor_alias="$synthesis_provider" configured_provider="$(octo_provider_identity_from_agent_type "$synthesis_provider")" configured_model="$(get_agent_model "$synthesis_provider" "review" "implementation-synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="implementation-synthesizer" synthesis_strategy="review" count="${_synth_count:-0}" || true
+        octo_event_emit "synthesis" phase="review" provider="$synthesis_provider_key" provider_label_kind="canonical" executor_alias="$synthesis_provider" configured_provider="$(octo_provider_identity_from_agent_type "$synthesis_provider")" configured_model="$(get_agent_model "$synthesis_provider" "review" "implementation-synthesizer" 2>/dev/null || echo unresolved)" runtime_provider="unknown" runtime_model="unknown" council_role="implementation-synthesizer" synthesis_strategy="review" count="${_synth_count:-0}" || true
     fi
 
     if [[ -n "$proof_dir" ]]; then

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -1623,8 +1623,22 @@ Use this context as the requested behavior and constraints. Flag severity=normal
 
     # ── ROUND 1: Parallel agent fleet ────────────────────────────────────────
     log INFO "review_run: Round 1 — parallel specialist fleet (no wall timeout, stall_window=${review_stall_window}s, diff=${diff_lines} lines)"
-    local fleet
-    fleet=$(build_review_fleet)
+    local fleet fleet_status=0
+    fleet=$(build_review_fleet) || fleet_status=$?
+    if [[ "$fleet_status" -ne 0 ]]; then
+        local fleet_failure_summary="Review fleet validation failed with status ${fleet_status}. Check configured review seat overrides and provider availability."
+        log ERROR "review_run: ${fleet_failure_summary}"
+        printf '{"findings":[],"warning":"%s"}\n' "$fleet_failure_summary" > "$findings_file"
+        if [[ -n "$proof_dir" ]]; then
+            octo_proof_artifact "$proof_dir" "review-findings" "$findings_file" "review fleet validation failed"
+            octo_proof_capture_provider_status "$proof_dir" "$provider_status_file"
+            octo_proof_finalize "$proof_dir" "fail" "$fleet_failure_summary"
+            echo "Proof packet: $proof_dir"
+        fi
+        rm -f "$provider_status_file"
+        render_terminal_report "$findings_file"
+        return "$fleet_status"
+    fi
 
     local agent_prompt_base
     agent_prompt_base="You are a code reviewer. Review the following diff and return ONLY a JSON object with a 'findings' array.

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -212,7 +212,43 @@ review_seat_agent_override() {
         return 2
     fi
 
+    if ! octo_agent_spec_exact_model_allowed "$agent"; then
+        log ERROR "Review seat override ${env_name}='${agent}' is blocked by the provider model allowlist"
+        return 2
+    fi
+
+    if ! octo_agent_spec_exact_role_allowed "$agent" "$role" review; then
+        log ERROR "Review seat override ${env_name}='${agent}' is unsafe for role '${role}'"
+        return 2
+    fi
+
     printf '%s\n' "$agent"
+}
+
+review_validate_configured_seat_overrides() {
+    local role env_name rc=0
+    local roles=(
+        implementation-logic-reviewer
+        implementation-security-reviewer
+        implementation-architecture-reviewer
+        implementation-cve-reviewer
+        implementation-diversity-reviewer
+        implementation-verifier
+        implementation-debater
+        implementation-synthesizer
+    )
+
+    # The global provider override supersedes all seat-specific configuration.
+    [[ -n "${OCTOPUS_REVIEW_SINGLE_PROVIDER:-}" ]] && return 0
+
+    for role in "${roles[@]}"; do
+        env_name="$(review_seat_override_env_name "$role")" || continue
+        [[ "${!env_name+x}" == "x" ]] || continue
+        rc=0
+        review_seat_agent_override "$role" >/dev/null || rc=$?
+        [[ "$rc" -eq 0 ]] || return "$rc"
+    done
+    return 0
 }
 
 review_agent_for_seat() {
@@ -246,7 +282,7 @@ review_fleet_with_override_seats() {
 
     for role in "${roles[@]}"; do
         env_name="$(review_seat_override_env_name "$role")" || continue
-        [[ -n "${!env_name:-}" ]] || continue
+        [[ "${!env_name+x}" == "x" ]] || continue
 
         rc=0
         override="$(review_seat_agent_override "$role")" || rc=$?
@@ -272,6 +308,8 @@ review_phase_provider() {
 
 build_review_fleet() {
     local fleet=""
+
+    review_validate_configured_seat_overrides || return $?
 
     if [[ -n "${OCTOPUS_REVIEW_SINGLE_PROVIDER:-}" ]]; then
         local override_provider
@@ -704,6 +742,43 @@ review_provider_key_from_agent_type() {
     esac
 }
 
+# Versioned records carry provider and model as separate fields. The marker
+# avoids confusing a model named "ok" or "fallback" with a legacy status.
+# The report parser still accepts provider|status|detail records.
+review_append_provider_status() {
+    local status_file="$1" agent_type="$2" role="$3" status="$4" detail="$5"
+    local provider model=""
+    provider="$(review_provider_key_from_agent_type "$agent_type")"
+    model="$(octo_agent_spec_explicit_model "$agent_type" 2>/dev/null || true)"
+    if [[ -z "$model" ]] && declare -f get_agent_model >/dev/null 2>&1; then
+        model="$(get_agent_model "$agent_type" review "$role" 2>/dev/null || true)"
+    fi
+
+    if [[ -n "$model" ]]; then
+        printf 'v2|%s|%s|%s|%s\n' "$provider" "$model" "$status" "$detail" >> "$status_file"
+    else
+        printf '%s|%s|%s\n' "$provider" "$status" "$detail" >> "$status_file"
+    fi
+}
+
+review_parse_provider_status_record() {
+    local record="$1" raw_provider field2 field3 field4 remainder
+    IFS='|' read -r raw_provider field2 field3 field4 remainder <<< "$record"
+    [[ -n "$raw_provider" ]] || return 1
+
+    if [[ "$raw_provider" == "v2" ]]; then
+        REVIEW_STATUS_PROVIDER="$(review_provider_key_from_agent_type "$field2")"
+        REVIEW_STATUS_MODEL="$field3"
+        REVIEW_STATUS_VALUE="$field4"
+        REVIEW_STATUS_DETAIL="$remainder"
+    else
+        REVIEW_STATUS_PROVIDER="$(review_provider_key_from_agent_type "$raw_provider")"
+        REVIEW_STATUS_MODEL=""
+        REVIEW_STATUS_VALUE="$field2"
+        REVIEW_STATUS_DETAIL="${field3}${field4:+|${field4}}${remainder:+|${remainder}}"
+    fi
+}
+
 # review_wait_for_result_status: waits for one result file to become terminal,
 # using the same progress-stall semantics as Round 1. No wall-clock cap.
 review_wait_for_result_status() {
@@ -1031,7 +1106,8 @@ review_collect_diff() {
 # review_run: canonical 3-round multi-LLM code review pipeline
 # WHY: replaces the single-model "codex exec review" dispatch with a
 # v9.0: Provider report card — prints post-run summary of provider status
-# Args: provider_status_file (one line per event: "provider|status|detail")
+# Args: provider_status_file. New records use "v2|provider|model|status|detail";
+# legacy "provider|status|detail" records remain supported.
 # WHY: Mid-stream warnings vanish in terminal scroll. This prints AFTER all output,
 # making provider failures impossible to miss.
 print_provider_report() {
@@ -1048,11 +1124,54 @@ print_provider_report() {
     local codex_status="not used" agy_status="not used" claude_status="not used" perplexity_status="not used" compatible_status="not used" copilot_status="not used" commandcode_status="not used"
     local codex_detail="" agy_detail="" claude_detail="" perplexity_detail="" compatible_detail="" copilot_detail="" commandcode_detail=""
     local had_fallback=false
+    local codex_model_status=false agy_model_status=false claude_model_status=false perplexity_model_status=false
+    local compatible_model_status=false copilot_model_status=false commandcode_model_status=false
+    local codex_legacy_status=false agy_legacy_status=false claude_legacy_status=false perplexity_legacy_status=false
+    local compatible_legacy_status=false copilot_legacy_status=false commandcode_legacy_status=false
 
-    while IFS='|' read -r provider status detail; do
-        provider="$(review_provider_key_from_agent_type "$provider")"
+    local record provider model status detail identity extra_status
+    while IFS= read -r record; do
+        review_parse_provider_status_record "$record" || continue
+        provider="$REVIEW_STATUS_PROVIDER"
+        model="$REVIEW_STATUS_MODEL"
+        status="$REVIEW_STATUS_VALUE"
+        detail="$REVIEW_STATUS_DETAIL"
+
+        if [[ -n "$model" ]]; then
+            identity="${provider}/${model}"
+            extra_status=""
+            case "$status" in
+                ok) extra_status="✓ OK" ;;
+                fallback)
+                    extra_status="✗ FALLBACK"
+                    had_fallback=true
+                    ;;
+                auth-failed)
+                    extra_status="✗ AUTH FAILED"
+                    had_fallback=true
+                    ;;
+                not-installed) extra_status="not installed" ;;
+            esac
+            case "$provider" in
+                codex) codex_model_status=true ;;
+                agy) agy_model_status=true ;;
+                claude) claude_model_status=true ;;
+                perplexity) perplexity_model_status=true ;;
+                openai-compatible) compatible_model_status=true ;;
+                copilot) copilot_model_status=true ;;
+                commandcode) commandcode_model_status=true ;;
+            esac
+            if [[ -n "$extra_status" ]]; then
+                awk -F'|' -v key="$identity" '$1 != key' "$extra_status_file" > "${extra_status_file}.tmp"
+                mv "${extra_status_file}.tmp" "$extra_status_file"
+                printf '%s|%s|%s\n' "$identity" "$extra_status" "$detail" >> "$extra_status_file"
+            fi
+            continue
+        fi
+
         case "$provider" in
             codex)
+                codex_legacy_status=true
                 if [[ "$status" == "ok" ]]; then
                     codex_status="✓ OK"
                 elif [[ "$status" == "fallback" ]]; then
@@ -1066,6 +1185,7 @@ print_provider_report() {
                 fi
                 ;;
             agy|gemini)
+                agy_legacy_status=true
                 if [[ "$status" == "ok" ]]; then
                     agy_status="✓ OK"
                 elif [[ "$status" == "fallback" ]]; then
@@ -1075,6 +1195,7 @@ print_provider_report() {
                 fi
                 ;;
             claude)
+                claude_legacy_status=true
                 if [[ "$status" == "ok" ]]; then
                     claude_status="✓ OK"
                 elif [[ "$status" == "fallback" ]]; then
@@ -1088,6 +1209,7 @@ print_provider_report() {
                 fi
                 ;;
             perplexity)
+                perplexity_legacy_status=true
                 if [[ "$status" == "ok" ]]; then
                     perplexity_status="✓ OK"
                 elif [[ "$status" == "fallback" ]]; then
@@ -1097,6 +1219,7 @@ print_provider_report() {
                 fi
                 ;;
             openai-compatible|openai-tools|openai-compatible-agent)
+                compatible_legacy_status=true
                 if [[ "$status" == "ok" ]]; then
                     compatible_status="✓ OK"
                 elif [[ "$status" == "fallback" ]]; then
@@ -1110,6 +1233,7 @@ print_provider_report() {
                 fi
                 ;;
             commandcode)
+                commandcode_legacy_status=true
                 if [[ "$status" == "ok" ]]; then
                     commandcode_status="✓ OK"
                 elif [[ "$status" == "fallback" ]]; then
@@ -1123,6 +1247,7 @@ print_provider_report() {
                 fi
                 ;;
             copilot)
+                copilot_legacy_status=true
                 if [[ "$status" == "ok" ]]; then
                     copilot_status="✓ OK"
                 elif [[ "$status" == "fallback" ]]; then
@@ -1136,7 +1261,7 @@ print_provider_report() {
                 fi
                 ;;
             *)
-                local extra_status=""
+                extra_status=""
                 case "$status" in
                     ok) extra_status="✓ OK" ;;
                     fallback)
@@ -1162,20 +1287,34 @@ print_provider_report() {
     echo "┌─────────────────────────────────────────────┐"
     echo "│ 🐙 Provider Status                          │"
     echo "│                                             │"
-    printf "│ 🔴 Codex:      %-28s│\n" "$codex_status"
-    [[ -n "$codex_detail" ]] && printf "│    → %-38.38s│\n" "$codex_detail"
-    printf "│ 🧭 AGY:        %-28s│\n" "$agy_status"
-    [[ -n "$agy_detail" ]] && printf "│    → %-38.38s│\n" "$agy_detail"
-    printf "│ 🔵 Claude:     %-28s│\n" "$claude_status"
-    [[ -n "$claude_detail" ]] && printf "│    → %-38.38s│\n" "$claude_detail"
-    printf "│ 🟣 Perplexity: %-28s│\n" "$perplexity_status"
-    [[ -n "$perplexity_detail" ]] && printf "│    → %-38.38s│\n" "$perplexity_detail"
-    printf "│ 🟢 Compatible:  %-25s│\n" "$compatible_status"
-    [[ -n "$compatible_detail" ]] && printf "│    → %-38.38s│\n" "$compatible_detail"
-    printf "│ 🟡 Copilot:     %-27s│\n" "$copilot_status"
-    [[ -n "$copilot_detail" ]] && printf "│    → %-38.38s│\n" "$copilot_detail"
-    printf "│ 🟠 CommandCode: %-27s│\n" "$commandcode_status"
-    [[ -n "$commandcode_detail" ]] && printf "│    → %-38.38s│\n" "$commandcode_detail"
+    if [[ "$codex_legacy_status" == true || "$codex_model_status" != true ]]; then
+        printf "│ 🔴 Codex:      %-28s│\n" "$codex_status"
+        [[ -n "$codex_detail" ]] && printf "│    → %-38.38s│\n" "$codex_detail"
+    fi
+    if [[ "$agy_legacy_status" == true || "$agy_model_status" != true ]]; then
+        printf "│ 🧭 AGY:        %-28s│\n" "$agy_status"
+        [[ -n "$agy_detail" ]] && printf "│    → %-38.38s│\n" "$agy_detail"
+    fi
+    if [[ "$claude_legacy_status" == true || "$claude_model_status" != true ]]; then
+        printf "│ 🔵 Claude:     %-28s│\n" "$claude_status"
+        [[ -n "$claude_detail" ]] && printf "│    → %-38.38s│\n" "$claude_detail"
+    fi
+    if [[ "$perplexity_legacy_status" == true || "$perplexity_model_status" != true ]]; then
+        printf "│ 🟣 Perplexity: %-28s│\n" "$perplexity_status"
+        [[ -n "$perplexity_detail" ]] && printf "│    → %-38.38s│\n" "$perplexity_detail"
+    fi
+    if [[ "$compatible_legacy_status" == true || "$compatible_model_status" != true ]]; then
+        printf "│ 🟢 Compatible:  %-25s│\n" "$compatible_status"
+        [[ -n "$compatible_detail" ]] && printf "│    → %-38.38s│\n" "$compatible_detail"
+    fi
+    if [[ "$copilot_legacy_status" == true || "$copilot_model_status" != true ]]; then
+        printf "│ 🟡 Copilot:     %-27s│\n" "$copilot_status"
+        [[ -n "$copilot_detail" ]] && printf "│    → %-38.38s│\n" "$copilot_detail"
+    fi
+    if [[ "$commandcode_legacy_status" == true || "$commandcode_model_status" != true ]]; then
+        printf "│ 🟠 CommandCode: %-27s│\n" "$commandcode_status"
+        [[ -n "$commandcode_detail" ]] && printf "│    → %-38.38s│\n" "$commandcode_detail"
+    fi
     while IFS='|' read -r provider status detail; do
         [[ -n "$provider" ]] || continue
         local provider_label
@@ -1192,10 +1331,15 @@ print_provider_report() {
     if [[ "$had_fallback" == "true" ]]; then
         echo ""
         echo "Provider failure details:"
-        while IFS='|' read -r provider status detail; do
+        while IFS= read -r record; do
+            review_parse_provider_status_record "$record" || continue
+            provider="$REVIEW_STATUS_PROVIDER"
+            model="$REVIEW_STATUS_MODEL"
+            status="$REVIEW_STATUS_VALUE"
+            detail="$REVIEW_STATUS_DETAIL"
             if [[ "$status" == "fallback" || "$status" == "auth-failed" ]]; then
-                provider="$(review_provider_key_from_agent_type "$provider")"
-                printf -- '- %s: %s\n' "$provider" "$detail"
+                identity="${provider}${model:+/${model}}"
+                printf -- '- %s: %s\n' "$identity" "$detail"
             fi
         done < "$status_file"
     fi
@@ -1205,10 +1349,15 @@ print_provider_report() {
         mkdir -p "$(dirname "$fallback_log")"
         local ts
         ts=$(date -Iseconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S)
-        while IFS='|' read -r provider status detail; do
+        while IFS= read -r record; do
+            review_parse_provider_status_record "$record" || continue
+            provider="$REVIEW_STATUS_PROVIDER"
+            model="$REVIEW_STATUS_MODEL"
+            status="$REVIEW_STATUS_VALUE"
+            detail="$REVIEW_STATUS_DETAIL"
             if [[ "$status" == "fallback" || "$status" == "auth-failed" ]]; then
-                provider="$(review_provider_key_from_agent_type "$provider")"
-                echo "[$ts] provider=$provider status=$status detail=$detail" >> "$fallback_log"
+                identity="${provider}${model:+/${model}}"
+                echo "[$ts] provider=$identity status=$status detail=$detail" >> "$fallback_log"
             fi
         done < "$status_file"
         # Keep only last 50 entries
@@ -1602,7 +1751,7 @@ ${round1_prompts[$retry_idx]}"
         provider_key="$(review_provider_key_from_agent_type "$atype")"
         if [[ ! -f "$f" ]]; then
             ((round1_partial_count++)) || true
-            echo "${provider_key}|fallback|Round 1 agent missing result" >> "$provider_status_file"
+            review_append_provider_status "$provider_status_file" "$atype" "${round1_roles[$idx]}" fallback "Round 1 agent missing result"
             ((idx++)) || true
             continue
         fi
@@ -1649,9 +1798,9 @@ ${round1_prompts[$retry_idx]}"
             local failure_detail
             failure_detail="$(review_result_failure_detail "$f" 2>/dev/null || true)"
             failure_detail="${failure_detail:-Round 1 agent did not complete successfully}"
-            echo "${provider_key}|fallback|${failure_detail}" >> "$provider_status_file"
+            review_append_provider_status "$provider_status_file" "$atype" "${round1_roles[$idx]}" fallback "$failure_detail"
         else
-            echo "${provider_key}|ok|Round 1 completed" >> "$provider_status_file"
+            review_append_provider_status "$provider_status_file" "$atype" "${round1_roles[$idx]}" ok "Round 1 completed"
         fi
         ((idx++)) || true
     done
@@ -1716,26 +1865,25 @@ $(echo "$all_findings" | jq -c '.')
 
 Return ONLY valid JSON with 'findings' array including verdict field."
 
-    local verified_findings verifier_provider verifier_provider_key
+    local verified_findings verifier_provider
     verifier_provider="$(review_phase_provider "codex" "implementation-verifier")" || return 1
-    verifier_provider_key="$(review_provider_key_from_agent_type "$verifier_provider")"
     if [[ -n "${OCTOPUS_REVIEW_SINGLE_PROVIDER:-}" || -n "${OCTOPUS_REVIEW_VERIFIER_AGENT:-}" ]]; then
         verified_findings=$(review_run_agent_sync_progress "$verifier_provider" "$verifier_prompt" "implementation-verifier" "review" "verifier-$(octo_agent_spec_slug "$verifier_provider")") && {
-            echo "${verifier_provider_key}|ok|Round 2 verification" >> "$provider_status_file"
+            review_append_provider_status "$provider_status_file" "$verifier_provider" implementation-verifier ok "Round 2 verification"
         } || {
             log WARN "review_run: ${verifier_provider} verification failed, using all findings as confirmed"
-            echo "${verifier_provider_key}|fallback|Round 2 verification failed; preserving Round 1 findings" >> "$provider_status_file"
+            review_append_provider_status "$provider_status_file" "$verifier_provider" implementation-verifier fallback "Round 2 verification failed; preserving Round 1 findings"
             verified_findings=$(printf '{"findings":%s}' "$(
                 echo "$all_findings" | jq 'map(. + {"verdict":"confirmed"})' 2>/dev/null || echo "[]"
             )")
         }
     else
         verified_findings=$(review_run_agent_sync_progress "codex" "$verifier_prompt" "implementation-verifier" "review" "verifier-codex") && {
-            echo "codex|ok|Round 2 verification" >> "$provider_status_file"
+            review_append_provider_status "$provider_status_file" codex implementation-verifier ok "Round 2 verification"
         } || {
             log WARN "review_run: codex verifier failed, falling back to claude-sonnet"
             log "USER" "⚠ Round 2: Codex unavailable → claude-sonnet (fallback). Codex API usage will NOT change."
-            echo "codex|fallback|Round 2 → claude-sonnet" >> "$provider_status_file"
+            review_append_provider_status "$provider_status_file" codex implementation-verifier fallback "Round 2 → claude-sonnet"
             verified_findings=$(review_run_agent_sync_progress "claude-sonnet" "$verifier_prompt" "implementation-verifier" "review" "verifier-claude-sonnet") || {
                 log WARN "review_run: verification failed entirely, using all findings as confirmed"
                 verified_findings=$(printf '{"findings":%s}' "$(
@@ -1777,15 +1925,14 @@ Return ONLY valid JSON with 'findings' array including verdict field."
             local debate_prompt="Challenge these $debate_count contested code review findings. For each, state whether it is a real bug (include) or false positive (exclude). Be adversarial.
 Findings: $(echo "$debate_candidates" | jq -c '.')
 Return JSON: {\"include\": [...finding titles...], \"exclude\": [...finding titles...]}"
-            local debate_result debate_provider debate_provider_key
+            local debate_result debate_provider
             debate_provider="$(review_phase_provider "codex" "implementation-debater")" || return 1
-            debate_provider_key="$(review_provider_key_from_agent_type "$debate_provider")"
             debate_result=$(review_run_agent_sync_progress "$debate_provider" "$debate_prompt" "implementation-debater" "review" "debate-$(octo_agent_spec_slug "$debate_provider")") && {
-                echo "${debate_provider_key}|ok|Round 3 debate" >> "$provider_status_file"
+                review_append_provider_status "$provider_status_file" "$debate_provider" implementation-debater ok "Round 3 debate"
             } || {
                 log WARN "review_run: ${debate_provider} debate agent failed, including all contested findings"
                 log "USER" "⚠ Round 3: ${debate_provider} debate gate unavailable — including all contested findings without debate."
-                echo "${debate_provider_key}|fallback|Round 3 debate → skipped" >> "$provider_status_file"
+                review_append_provider_status "$provider_status_file" "$debate_provider" implementation-debater fallback "Round 3 debate → skipped"
                 debate_result="{\"include\":[],\"exclude\":[]}"
             }
             # v9.3.1: Strip markdown fences from debate result (#188)
@@ -1814,10 +1961,12 @@ Return ONLY JSON: {\"findings\": [...ranked, deduplicated findings...]}"
     local final_json synth_ok="true" synthesis_provider synthesis_provider_key
     synthesis_provider="$(review_phase_provider "claude-sonnet" "implementation-synthesizer")" || return 1
     synthesis_provider_key="$(review_provider_key_from_agent_type "$synthesis_provider")"
-    final_json=$(review_run_agent_sync_progress "$synthesis_provider" "$synthesis_prompt" "implementation-synthesizer" "review" "synthesis-$(octo_agent_spec_slug "$synthesis_provider")") || {
+    final_json=$(review_run_agent_sync_progress "$synthesis_provider" "$synthesis_prompt" "implementation-synthesizer" "review" "synthesis-$(octo_agent_spec_slug "$synthesis_provider")") && {
+        review_append_provider_status "$provider_status_file" "$synthesis_provider" implementation-synthesizer ok "Round 3 synthesis"
+    } || {
         synth_ok="false"
         log WARN "review_run: ${synthesis_provider} synthesis failed, using confirmed findings sorted as-is"
-        echo "${synthesis_provider_key}|fallback|Round 3 synthesis failed; using local deterministic fallback" >> "$provider_status_file"
+        review_append_provider_status "$provider_status_file" "$synthesis_provider" implementation-synthesizer fallback "Round 3 synthesis failed; using local deterministic fallback"
         final_json="$(review_local_synthesis_json "$confirmed_findings" "$round1_warning")"
     }
 

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -776,21 +776,12 @@ review_append_provider_status() {
 }
 
 review_parse_provider_status_record() {
-    local record="$1" raw_provider field2 field3 field4 remainder
-    IFS='|' read -r raw_provider field2 field3 field4 remainder <<< "$record"
-    [[ -n "$raw_provider" ]] || return 1
-
-    if [[ "$raw_provider" == "v2" ]]; then
-        REVIEW_STATUS_PROVIDER="$(review_provider_key_from_agent_type "$field2")"
-        REVIEW_STATUS_MODEL="$field3"
-        REVIEW_STATUS_VALUE="$field4"
-        REVIEW_STATUS_DETAIL="$remainder"
-    else
-        REVIEW_STATUS_PROVIDER="$(review_provider_key_from_agent_type "$raw_provider")"
-        REVIEW_STATUS_MODEL=""
-        REVIEW_STATUS_VALUE="$field2"
-        REVIEW_STATUS_DETAIL="${field3}${field4:+|${field4}}${remainder:+|${remainder}}"
-    fi
+    local record="$1"
+    octo_parse_provider_status_record "$record" || return $?
+    REVIEW_STATUS_PROVIDER="$(review_provider_key_from_agent_type "$OCTO_PROVIDER_STATUS_PROVIDER")"
+    REVIEW_STATUS_MODEL="$OCTO_PROVIDER_STATUS_MODEL"
+    REVIEW_STATUS_VALUE="$OCTO_PROVIDER_STATUS_VALUE"
+    REVIEW_STATUS_DETAIL="$OCTO_PROVIDER_STATUS_DETAIL"
 }
 
 # review_wait_for_result_status: waits for one result file to become terminal,

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -33,7 +33,10 @@ octo_spawn_contract_seat_id() {
 octo_spawn_contract_plan() {
     local task_id="${1:-}" agent_type="${2:-unknown}" model="${3:-}"
     local effort="${4:-}" phase="${5:-unknown}" role="${6:-none}" seat_id
+    local contract_provider contract_model
     local source_root source_sha="" source_dirty="not-a-git-worktree" worktree=""
+    contract_provider="$(octo_agent_spec_contract_provider "$agent_type")" || return 74
+    contract_model="$(octo_agent_spec_contract_model "$agent_type" "$model")" || return 74
     seat_id="$(octo_spawn_contract_seat_id "$task_id")"
     source_root="${OCTOPUS_PROJECT_DIR:-$PWD}"
     worktree="$(git -C "$source_root" rev-parse --show-toplevel 2>/dev/null || true)"
@@ -51,7 +54,7 @@ octo_spawn_contract_plan() {
     fi
 
     run_contract_transition "$seat_id" planned \
-        "requested_provider=$agent_type" "requested_model=$model" \
+        "requested_provider=$contract_provider" "requested_model=$contract_model" \
         "requested_effort=$effort" "phase=$phase" "role=$role" \
         "isolation=background" "attempt_id=${seat_id}-attempt-1" \
         "checkpoint=$phase" "source_sha=$source_sha" \
@@ -60,9 +63,10 @@ octo_spawn_contract_plan() {
 
 octo_spawn_contract_resolve() {
     local seat_id="${1:-}" agent_type="${2:-unknown}" model="${3:-unresolved}"
-    local effort="${4:-}" estimated_cost="${5:-}"
+    local effort="${4:-}" estimated_cost="${5:-}" contract_provider
+    contract_provider="$(octo_agent_spec_contract_provider "$agent_type")" || return 74
     run_contract_transition "$seat_id" starting \
-        "resolved_provider=$agent_type" "resolved_model=$model" \
+        "resolved_provider=$contract_provider" "resolved_model=$model" \
         "resolved_effort=$effort" "estimated_cost_usd=$estimated_cost" || return 74
 }
 

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -735,6 +735,7 @@ ${heuristic_ctx}"
     case "$agent_type" in
         codex*) _provider_for_health="codex" ;;
         gemini*|agy*|antigravity) _provider_for_health="agy" ;;
+        claude-sdk*) _provider_for_health="claude-sdk" ;;
         claude*) _provider_for_health="claude" ;;
         openrouter*) _provider_for_health="openrouter" ;;
         perplexity*) _provider_for_health="perplexity" ;;

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -228,6 +228,30 @@ _validate_env_prefixed_shim_command() {
     return 0
 }
 
+_validate_claude_sdk_env_command() {
+    local cmd="$1" shim_suffix="/scripts/helpers/claude-sdk-exec.sh"
+    local -a parts
+    local model=""
+    [[ "$cmd" != *$'\n'* && "$cmd" != *$'\r'* ]] || return 1
+    read -r -a parts <<< "$cmd"
+    [[ "${parts[0]:-}" == env ]] || return 1
+    [[ "${parts[1]:-}" == OCTOPUS_CLAUDE_SDK_MODEL=* ]] || return 1
+    model="${parts[1]#OCTOPUS_CLAUDE_SDK_MODEL=}"
+    _octopus_is_safe_openai_compatible_value "$model" || return 1
+
+    case "${#parts[@]}" in
+        3)
+            [[ "${parts[2]}" == *"$shim_suffix" ]]
+            ;;
+        4)
+            [[ "$model" == "${FABLE5_MODEL_ID:-claude-fable-5}" ]] || return 1
+            [[ "${parts[2]}" == OCTOPUS_FABLE5_NO_RETRY=1 ]] || return 1
+            [[ "${parts[3]}" == *"$shim_suffix" ]]
+            ;;
+        *) return 1 ;;
+    esac
+}
+
 _validate_openai_compatible_agent_command() {
     local cmd="$1"
     local -a parts
@@ -431,7 +455,7 @@ validate_agent_command() {
         if _validate_env_prefixed_shim_command "$cmd" "OCTOPUS_COPILOT_MODEL" "/scripts/helpers/copilot-exec.sh"; then
             return 0
         fi
-        if _validate_env_prefixed_shim_command "$cmd" "OCTOPUS_CLAUDE_SDK_MODEL" "/scripts/helpers/claude-sdk-exec.sh"; then
+        if _validate_claude_sdk_env_command "$cmd"; then
             return 0
         fi
         if _validate_env_prefixed_shim_command "$cmd" "OCTOPUS_AGY_MODEL" "/scripts/helpers/agy-exec.sh"; then

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -213,10 +213,15 @@ _octopus_is_safe_openai_compatible_value() {
 # later in the string), so `env OCTOPUS_GROK_MODEL=x echo pwned <shim>` is
 # rejected instead of matching on a fixed prefix/suffix pair.
 _validate_env_prefixed_shim_command() {
-    local cmd="$1" env_prefix="$2" shim_suffix="$3"
+    local cmd="$1" env_prefix="$2" shim_suffix="$3" allowed_tail="${4:-}"
     local -a parts
     read -r -a parts <<< "$cmd"
-    [[ "${#parts[@]}" -eq 3 ]] || return 1
+    if [[ -n "$allowed_tail" ]]; then
+        [[ "${#parts[@]}" -eq 5 ]] || return 1
+        [[ "${parts[3]} ${parts[4]}" == "$allowed_tail" ]] || return 1
+    else
+        [[ "${#parts[@]}" -eq 3 ]] || return 1
+    fi
     [[ "${parts[0]}" == "env" ]] || return 1
     [[ "${parts[1]}" == "${env_prefix}="* ]] || return 1
     [[ "${parts[2]}" == *"$shim_suffix" ]] || return 1
@@ -247,8 +252,11 @@ _validate_openai_compatible_agent_command() {
         local value="${parts[$((i + 1))]}"
         case "$flag" in
             --provider)
-                [[ -z "$provider" && "$value" == "generic" ]] || return 1
-                provider="$value"
+                [[ -z "$provider" ]] || return 1
+                case "$value" in
+                    generic|atlascloud) provider="$value" ;;
+                    *) return 1 ;;
+                esac
                 ;;
             --model)
                 [[ -z "$model" ]] || return 1
@@ -424,6 +432,12 @@ validate_agent_command() {
             return 0
         fi
         if _validate_env_prefixed_shim_command "$cmd" "OCTOPUS_CLAUDE_SDK_MODEL" "/scripts/helpers/claude-sdk-exec.sh"; then
+            return 0
+        fi
+        if _validate_env_prefixed_shim_command "$cmd" "OCTOPUS_AGY_MODEL" "/scripts/helpers/agy-exec.sh"; then
+            return 0
+        fi
+        if _validate_env_prefixed_shim_command "$cmd" "OCTOPUS_VIBE_MODEL" "/scripts/helpers/vibe-exec.sh" "--output text"; then
             return 0
         fi
     fi

--- a/tests/unit/fixtures/env-var-effects.tsv
+++ b/tests/unit/fixtures/env-var-effects.tsv
@@ -51,6 +51,15 @@ OCTOPUS_RELEASE_SMOKE_MAX_BUDGET_USD	skip	release-smoke harness only; not reacha
 OCTOPUS_RELEASE_SMOKE_PORT	skip	release-smoke harness only; not reachable from unit scope
 OCTOPUS_REQUIRE_ALL	covered-by	test-agent-summary.sh
 OCTOPUS_RESEARCH_BREADTH	skip	changes how many provider seats a research run fans out to
+OCTOPUS_REVIEW_ARCHITECTURE_AGENT	covered-by	test-contextual-review-seat-overrides.sh
+OCTOPUS_REVIEW_CVE_AGENT	covered-by	test-contextual-review-seat-overrides.sh
+OCTOPUS_REVIEW_DEBATER_AGENT	covered-by	test-contextual-review-seat-overrides.sh
+OCTOPUS_REVIEW_DIVERSITY_AGENT	covered-by	test-contextual-review-seat-overrides.sh
+OCTOPUS_REVIEW_LOGIC_AGENT	covered-by	test-contextual-review-seat-overrides.sh
+OCTOPUS_REVIEW_SECURITY_AGENT	covered-by	test-contextual-review-seat-overrides.sh
+OCTOPUS_REVIEW_SINGLE_PROVIDER	covered-by	test-contextual-review-seat-overrides.sh
+OCTOPUS_REVIEW_SYNTHESIZER_AGENT	covered-by	test-contextual-review-seat-overrides.sh
+OCTOPUS_REVIEW_VERIFIER_AGENT	covered-by	test-contextual-review-seat-overrides.sh
 OCTOPUS_REVIEWER_FLIP	covered-by	test-fable5-escalation.sh
 OCTOPUS_ROUTING_POLICY	covered-by	test-routing-evals-v10.sh
 OCTOPUS_RUN_ID	covered-by	test-agent-summary.sh

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -316,6 +316,41 @@ else
     test_fail "expected env-prefixed claude-sdk-exec shim path to be accepted"
 fi
 
+test_case "validate_agent_command allows the exact Fable no-retry SDK command"
+if validate_agent_command "env OCTOPUS_CLAUDE_SDK_MODEL=claude-fable-5 OCTOPUS_FABLE5_NO_RETRY=1 $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh"; then
+    test_pass
+else
+    test_fail "expected exact Fable no-retry command to be accepted"
+fi
+
+test_case "validate_agent_command rejects no-retry on a non-Fable SDK model"
+if validate_agent_command "env OCTOPUS_CLAUDE_SDK_MODEL=claude-opus-5 OCTOPUS_FABLE5_NO_RETRY=1 $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected non-Fable no-retry assignment to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects a forged Fable no-retry value"
+if validate_agent_command "env OCTOPUS_CLAUDE_SDK_MODEL=claude-fable-5 OCTOPUS_FABLE5_NO_RETRY=0 $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected forged no-retry value to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects reordered Fable SDK assignments"
+if validate_agent_command "env OCTOPUS_FABLE5_NO_RETRY=1 OCTOPUS_CLAUDE_SDK_MODEL=claude-fable-5 $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected reordered SDK assignments to be rejected"
+else
+    test_pass
+fi
+
+test_case "validate_agent_command rejects an executable injected before the Fable SDK shim"
+if validate_agent_command "env OCTOPUS_CLAUDE_SDK_MODEL=claude-fable-5 OCTOPUS_FABLE5_NO_RETRY=1 echo pwned $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh" >/dev/null 2>&1; then
+    test_fail "expected injected executable before the SDK shim to be rejected"
+else
+    test_pass
+fi
+
 test_case "validate_agent_command rejects embedded claude-sdk-exec shim path"
 if validate_agent_command "echo $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh" >/dev/null 2>&1; then
     test_fail "expected embedded claude-sdk-exec shim path to be rejected"

--- a/tests/unit/test-agent-command-validation.sh
+++ b/tests/unit/test-agent-command-validation.sh
@@ -40,6 +40,20 @@ else
     test_fail "expected agy-exec shim path to be accepted"
 fi
 
+test_case "validate_agent_command allows agy-exec shim with exact model env prefix"
+if validate_agent_command "env OCTOPUS_AGY_MODEL=gemini-exact $PROJECT_ROOT/scripts/helpers/agy-exec.sh"; then
+    test_pass
+else
+    test_fail "expected env-prefixed agy-exec shim path to be accepted"
+fi
+
+test_case "validate_agent_command allows vibe-exec shim with exact model env prefix"
+if validate_agent_command "env OCTOPUS_VIBE_MODEL=mistral-large-latest $PROJECT_ROOT/scripts/helpers/vibe-exec.sh --output text"; then
+    test_pass
+else
+    test_fail "expected env-prefixed vibe-exec shim path to be accepted"
+fi
+
 test_case "validate_agent_command rejects embedded agy-exec shim path"
 if validate_agent_command "echo $PROJECT_ROOT/scripts/helpers/agy-exec.sh" >/dev/null 2>&1; then
     test_fail "expected embedded agy-exec shim path to be rejected"

--- a/tests/unit/test-agent-sync-run-contract.sh
+++ b/tests/unit/test-agent-sync-run-contract.sh
@@ -24,7 +24,7 @@ attempt=0
 attempt=$((attempt + 1))
 printf '%s\n' "$attempt" >> "$FIXTURE_CALLS"
 case "$FIXTURE_SCENARIO" in
-    success) printf '%s\n' 'Substantive provider result.' ;;
+    success|exact-seat) printf '%s\n' 'Substantive provider result.' ;;
     empty) : ;;
     whitespace) printf ' \n\t\n' ;;
     placeholder) printf '%s\n' 'Provider available' ;;
@@ -71,13 +71,21 @@ octo_dispatch_command_model() {
 }
 get_agent_model() {
     [[ "${FIXTURE_SCENARIO:-}" == model-fail ]] && return 1
+    if [[ "${1:-}" == *:* ]]; then
+        printf '%s\n' "${1#*:}"
+        return 0
+    fi
     printf '%s\n' fixture-model
 }
 estimate_agent_call_cost() { printf '%s\n' 0.000000; }
 record_agent_call() { :; }
 get_agent_command() {
+    local command_model="routed-model"
+    if [[ "${1:-}" == *:* ]]; then
+        command_model="${1#*:}"
+    fi
     printf '%s\n' "${4:-missing}" > "$FIXTURE_ROOT/prompt-bytes"
-    printf '%s\n' "$fixture_provider --model routed-model"
+    printf '%s\n' "$fixture_provider --model $command_model"
 }
 build_provider_env() { PROVIDER_ENV_ARRAY=(); }
 run_with_timeout() { shift; "$@"; }
@@ -100,6 +108,11 @@ export CODEX_SUBAGENT_PREAMBLE=""
 
 run_fixture() {
     local scenario="$1" agent_type="${2:-codex}"
+    local role="reviewer" phase="probe"
+    if [[ "$scenario" == exact-seat ]]; then
+        role="implementation-verifier"
+        phase="review"
+    fi
     export FIXTURE_SCENARIO="$scenario"
     export FIXTURE_ROOT="$TEST_TMP_DIR/$scenario"
     export FIXTURE_CALLS="$FIXTURE_ROOT/provider-calls"
@@ -114,7 +127,7 @@ run_fixture() {
     mkdir -p "$RESULTS_DIR"
 
     set +e
-    run_agent_sync "$agent_type" 'Review the fixture.' 5 reviewer probe \
+    run_agent_sync "$agent_type" 'Review the fixture.' 5 "$role" "$phase" \
         > "$FIXTURE_ROOT/stdout" 2> "$FIXTURE_ROOT/stderr"
     fixture_rc=$?
     set -e
@@ -161,6 +174,9 @@ assert_scenario() {
 assert_scenario success 0 1 \
     planned,starting,authenticated,running,output_received,validated,contributed \
     contributed eligible ''
+assert_scenario exact-seat 0 1 \
+    planned,starting,authenticated,running,output_received,validated,contributed \
+    contributed eligible '' 'command-code:thinkingmachines/inkling-small'
 assert_scenario auth-fail 1 0 planned,starting,failed failed none \
     'Provider unavailable: fixture authentication rejected'
 assert_scenario health-fail-qwen 1 0 planned,starting,failed failed none \
@@ -240,6 +256,22 @@ if [[ "$(jq -r '.seats[0].resolved.model' "$success_snapshot")" == routed-model 
     test_pass
 else
     test_fail "manifest retained the pre-routing model identity"
+fi
+
+test_case "exact synchronous seat records canonical provider and literal model"
+exact_sync_model="thinkingmachines/inkling-small"
+exact_sync_snapshot="$TEST_TMP_DIR/exact-seat/workspace/runs/sync-exact-seat/seats.json"
+if jq -e --arg model "$exact_sync_model" '
+    .seats[0].requested.provider == "commandcode" and
+    .seats[0].requested.model == $model and
+    .seats[0].resolved.provider == "commandcode" and
+    .seats[0].resolved.model == $model and
+    .seats[0].execution.phase == "review" and
+    .seats[0].execution.role == "implementation-verifier"
+' "$exact_sync_snapshot" >/dev/null; then
+    test_pass
+else
+    test_fail "exact synchronous lifecycle did not split canonical provider from literal model"
 fi
 
 test_summary

--- a/tests/unit/test-agent-sync-run-contract.sh
+++ b/tests/unit/test-agent-sync-run-contract.sh
@@ -274,4 +274,61 @@ else
     test_fail "exact synchronous lifecycle did not split canonical provider from literal model"
 fi
 
+test_case "exact synchronous Fable SDK seat executes with no retry and retains lifecycle identity"
+if (
+    export FIXTURE_SCENARIO=exact-fable-runtime
+    export FIXTURE_ROOT="$TEST_TMP_DIR/exact-fable-runtime"
+    export FIXTURE_CALLS="$FIXTURE_ROOT/provider-calls"
+    export WORKSPACE_DIR="$FIXTURE_ROOT/workspace"
+    export RESULTS_DIR="$FIXTURE_ROOT/results"
+    export OCTOPUS_RUN_ID=sync-exact-fable-runtime
+    export OCTOPUS_PERSISTENCE_AVAILABLE=true
+    export OCTOPUS_AGENT_MAX_OUTPUT_BYTES=262144
+    export CLAUDE_SDK_API_KEY=fixture-key
+    export PLUGIN_DIR="$PROJECT_ROOT"
+    mkdir -p "$RESULTS_DIR" "$FIXTURE_ROOT/bin"
+    sdk_capture="$FIXTURE_ROOT/sdk-capture"
+    export SDK_CAPTURE="$sdk_capture"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'printf "%s\n" "no_retry=${OCTOPUS_FABLE5_NO_RETRY:-unset}" > "$SDK_CAPTURE"' \
+        'printf "%s\n" "$@" >> "$SDK_CAPTURE"' \
+        'cat >/dev/null' \
+        'printf "%s\n" "Substantive exact Fable SDK result."' > "$FIXTURE_ROOT/bin/claude-agent"
+    chmod 755 "$FIXTURE_ROOT/bin/claude-agent"
+    export PATH="$FIXTURE_ROOT/bin:$PATH"
+    source "$PROJECT_ROOT/scripts/lib/provider-registry.sh"
+    source "$PROJECT_ROOT/scripts/lib/validation.sh"
+    source "$PROJECT_ROOT/scripts/lib/model-cache-path.sh"
+    source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+    source "$PROJECT_ROOT/scripts/lib/provider-routing.sh"
+    source "$PROJECT_ROOT/scripts/lib/dispatch.sh"
+    apply_persona() { printf '%s\n' "$2"; }
+    load_earned_skills() { :; }
+    build_provider_context() { :; }
+    enforce_context_budget() { printf '%s\n' "$1"; }
+    build_provider_env() { PROVIDER_ENV_ARRAY=(); }
+    sync_rc=0
+    run_agent_sync 'claude-sdk:claude-fable-5' 'Review the exact Fable fixture.' 5 \
+        implementation-logic-reviewer review > "$FIXTURE_ROOT/stdout" 2> "$FIXTURE_ROOT/stderr" || sync_rc=$?
+    if [[ "$sync_rc" -ne 0 ]]; then
+        printf 'exact Fable sync rc=%s stderr=%s\n' "$sync_rc" "$(tr '\n' ';' < "$FIXTURE_ROOT/stderr")" >&2
+        exit 1
+    fi
+    snapshot="$WORKSPACE_DIR/runs/$OCTOPUS_RUN_ID/seats.json"
+    grep -Fxq 'no_retry=1' "$sdk_capture" &&
+    grep -Fxq 'claude-fable-5' "$sdk_capture" &&
+    jq -e '
+        .seats[0].requested.provider == "claude-sdk" and
+        .seats[0].requested.model == "claude-fable-5" and
+        .seats[0].resolved.provider == "claude-sdk" and
+        .seats[0].resolved.model == "claude-fable-5" and
+        .seats[0].transition == "contributed"
+    ' "$snapshot" >/dev/null
+); then
+    test_pass
+else
+    test_fail "synchronous exact Fable execution retried or lost its lifecycle identity"
+fi
+
 test_summary

--- a/tests/unit/test-contextual-review-fleet-cli.sh
+++ b/tests/unit/test-contextual-review-fleet-cli.sh
@@ -21,9 +21,22 @@ printf '%s\n' \
 CHECKER
 chmod +x "$checker"
 
+agy_bin="$TEST_TMP_DIR/agy-bin"
+mkdir -p "$agy_bin"
+cat > "$agy_bin/agy" <<'AGY'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "models" ]]; then
+  printf '%s\n' 'gemini-exact' 'gemini-known'
+  exit 0
+fi
+exit 1
+AGY
+chmod +x "$agy_bin/agy"
+
 run_fleet() {
   env \
     "HOME=$TEST_TMP_DIR/home" \
+    "PATH=$agy_bin:$PATH" \
     "OCTOPUS_PROVIDER_CHECKER=$checker" \
     "OCTO_ALLOWED_PROVIDERS=codex commandcode claude agy openrouter orcarouter vibe atlascloud" \
     "$@" \
@@ -79,6 +92,18 @@ if [[ "$fable_rc" -ne 0 && "$fable_fleet" != *'claude:claude-fable-5'* ]]; then
   test_pass
 else
   test_fail "fleet review called an unsafe Fable security seat effective: rc=$fable_rc fleet=[$fable_fleet]"
+fi
+
+test_case "fleet review rejects an AGY model absent from the live catalog"
+agy_rc=0
+agy_error="$TEST_TMP_DIR/agy-missing-model.err"
+agy_fleet="$(run_fleet \
+  OCTOPUS_REVIEW_SECURITY_AGENT='agy:missing-model' 2>"$agy_error")" || agy_rc=$?
+if [[ "$agy_rc" -ne 0 && "$agy_fleet" != *'agy:missing-model'* ]] && \
+   grep -Fq "is not a valid model for provider 'agy'" "$agy_error"; then
+  test_pass
+else
+  test_fail "fleet review did not clearly reject a dispatch-rejected AGY model: rc=$agy_rc fleet=[$agy_fleet] error=[$(tr '\n' ';' < "$agy_error")]"
 fi
 
 test_summary

--- a/tests/unit/test-contextual-review-fleet-cli.sh
+++ b/tests/unit/test-contextual-review-fleet-cli.sh
@@ -45,14 +45,14 @@ run_fleet() {
 
 test_case "fleet review shows all eight effective model-qualified seat overrides"
 fleet="$(run_fleet \
-  OCTOPUS_REVIEW_LOGIC_AGENT='openai:gpt-5.6-luna' \
-  OCTOPUS_REVIEW_SECURITY_AGENT='agy:gemini-exact' \
-  OCTOPUS_REVIEW_ARCHITECTURE_AGENT='anthropic:claude-opus-5' \
-  OCTOPUS_REVIEW_CVE_AGENT='command-code:tencent/hy3-paid' \
-  OCTOPUS_REVIEW_DIVERSITY_AGENT='openrouter:deepseek/deepseek-v4' \
-  OCTOPUS_REVIEW_VERIFIER_AGENT='orcarouter:anthropic/claude-sonnet-4.6' \
-  OCTOPUS_REVIEW_DEBATER_AGENT='vibe:mistral-large-latest' \
-  OCTOPUS_REVIEW_SYNTHESIZER_AGENT='atlas-cloud:qwen/qwen3.5')"
+  "OCTOPUS_REVIEW_LOGIC_AGENT=openai:gpt-5.6-luna" \
+  "OCTOPUS_REVIEW_SECURITY_AGENT=agy:gemini-exact" \
+  "OCTOPUS_REVIEW_ARCHITECTURE_AGENT=anthropic:claude-opus-5" \
+  "OCTOPUS_REVIEW_CVE_AGENT=command-code:tencent/hy3-paid" \
+  "OCTOPUS_REVIEW_DIVERSITY_AGENT=openrouter:deepseek/deepseek-v4" \
+  "OCTOPUS_REVIEW_VERIFIER_AGENT=orcarouter:anthropic/claude-sonnet-4.6" \
+  "OCTOPUS_REVIEW_DEBATER_AGENT=vibe:mistral-large-latest" \
+  "OCTOPUS_REVIEW_SYNTHESIZER_AGENT=atlas-cloud:qwen/qwen3.5")"
 expected_specs=$'codex:gpt-5.6-luna\nagy:gemini-exact\nclaude:claude-opus-5\ncommandcode:tencent/hy3-paid\nopenrouter:deepseek/deepseek-v4\norcarouter:anthropic/claude-sonnet-4.6\nvibe:mistral-large-latest\natlascloud-agent:qwen/qwen3.5'
 actual_specs="$(printf '%s\n' "$fleet" | cut -d'|' -f1)"
 if [[ "$(printf '%s\n' "$fleet" | grep -c .)" -eq 8 && "$actual_specs" == "$expected_specs" ]]; then
@@ -63,9 +63,9 @@ fi
 
 test_case "single-provider override takes precedence over all seat overrides in fleet review"
 fleet="$(run_fleet \
-  OCTOPUS_REVIEW_SINGLE_PROVIDER=codex \
-  OCTOPUS_REVIEW_LOGIC_AGENT='commandcode:model-a' \
-  OCTOPUS_REVIEW_SYNTHESIZER_AGENT='vibe:model-b')"
+  "OCTOPUS_REVIEW_SINGLE_PROVIDER=codex" \
+  "OCTOPUS_REVIEW_LOGIC_AGENT=commandcode:model-a" \
+  "OCTOPUS_REVIEW_SYNTHESIZER_AGENT=vibe:model-b")"
 if [[ "$(printf '%s\n' "$fleet" | grep -c .)" -eq 8 ]] && \
    [[ "$(printf '%s\n' "$fleet" | cut -d'|' -f1 | grep -vc '^codex$' || true)" -eq 0 ]]; then
   test_pass
@@ -76,8 +76,8 @@ fi
 test_case "fleet review rejects an exact model outside the dispatch allowlist"
 restricted_rc=0
 restricted_fleet="$(run_fleet \
-  OCTOPUS_CODEX_ALLOWED_MODELS='gpt-allowed' \
-  OCTOPUS_REVIEW_LOGIC_AGENT='codex:gpt-blocked' 2>/dev/null)" || restricted_rc=$?
+  "OCTOPUS_CODEX_ALLOWED_MODELS=gpt-allowed" \
+  "OCTOPUS_REVIEW_LOGIC_AGENT=codex:gpt-blocked" 2>/dev/null)" || restricted_rc=$?
 if [[ "$restricted_rc" -ne 0 && "$restricted_fleet" != *'codex:gpt-blocked'* ]]; then
   test_pass
 else
@@ -87,7 +87,7 @@ fi
 test_case "fleet review rejects an exact Fable security seat"
 fable_rc=0
 fable_fleet="$(run_fleet \
-  OCTOPUS_REVIEW_SECURITY_AGENT='anthropic:claude-fable-5' 2>/dev/null)" || fable_rc=$?
+  "OCTOPUS_REVIEW_SECURITY_AGENT=anthropic:claude-fable-5" 2>/dev/null)" || fable_rc=$?
 if [[ "$fable_rc" -ne 0 && "$fable_fleet" != *'claude:claude-fable-5'* ]]; then
   test_pass
 else
@@ -98,7 +98,7 @@ test_case "fleet review rejects an AGY model absent from the live catalog"
 agy_rc=0
 agy_error="$TEST_TMP_DIR/agy-missing-model.err"
 agy_fleet="$(run_fleet \
-  OCTOPUS_REVIEW_SECURITY_AGENT='agy:missing-model' 2>"$agy_error")" || agy_rc=$?
+  "OCTOPUS_REVIEW_SECURITY_AGENT=agy:missing-model" 2>"$agy_error")" || agy_rc=$?
 if [[ "$agy_rc" -ne 0 && "$agy_fleet" != *'agy:missing-model'* ]] && \
    grep -Fq "is not a valid model for provider 'agy'" "$agy_error"; then
   test_pass

--- a/tests/unit/test-contextual-review-fleet-cli.sh
+++ b/tests/unit/test-contextual-review-fleet-cli.sh
@@ -61,16 +61,49 @@ else
   test_fail "fleet review did not render all effective overrides: $(tr '\n' ';' <<< "$fleet")"
 fi
 
-test_case "single-provider override takes precedence over all seat overrides in fleet review"
+test_case "single-provider override takes precedence and canonicalizes registry aliases"
 fleet="$(run_fleet \
-  "OCTOPUS_REVIEW_SINGLE_PROVIDER=codex" \
+  "OCTOPUS_REVIEW_SINGLE_PROVIDER=openai" \
   "OCTOPUS_REVIEW_LOGIC_AGENT=commandcode:model-a" \
   "OCTOPUS_REVIEW_SYNTHESIZER_AGENT=vibe:model-b")"
 if [[ "$(printf '%s\n' "$fleet" | grep -c .)" -eq 8 ]] && \
    [[ "$(printf '%s\n' "$fleet" | cut -d'|' -f1 | grep -vc '^codex$' || true)" -eq 0 ]]; then
   test_pass
 else
-  test_fail "single-provider precedence was not reflected in fleet review: $(tr '\n' ';' <<< "$fleet")"
+  test_fail "single-provider precedence or canonical identity was not reflected in fleet review: $(tr '\n' ';' <<< "$fleet")"
+fi
+
+test_case "fleet review rejects an unavailable single-provider override"
+unavailable_rc=0
+unavailable_fleet="$(run_fleet \
+  "OCTO_ALLOWED_PROVIDERS=codex commandcode claude agy openrouter orcarouter vibe atlascloud perplexity" \
+  "OCTOPUS_REVIEW_SINGLE_PROVIDER=perplexity" 2>/dev/null)" || unavailable_rc=$?
+if [[ "$unavailable_rc" -ne 0 && -z "$unavailable_fleet" ]]; then
+  test_pass
+else
+  test_fail "unavailable single-provider override escaped admission: rc=$unavailable_rc fleet=[$unavailable_fleet]"
+fi
+
+test_case "fleet review rejects an unknown single-provider override"
+unknown_rc=0
+unknown_fleet="$(run_fleet \
+  "OCTO_ALLOWED_PROVIDERS=mystery-provider" \
+  "OCTOPUS_REVIEW_SINGLE_PROVIDER=mystery-provider" 2>/dev/null)" || unknown_rc=$?
+if [[ "$unknown_rc" -ne 0 && -z "$unknown_fleet" ]]; then
+  test_pass
+else
+  test_fail "unknown single-provider override escaped registry validation: rc=$unknown_rc fleet=[$unknown_fleet]"
+fi
+
+test_case "fleet review rejects a policy-disallowed single-provider override"
+disallowed_rc=0
+disallowed_fleet="$(run_fleet \
+  "OCTO_ALLOWED_PROVIDERS=agy" \
+  "OCTOPUS_REVIEW_SINGLE_PROVIDER=codex" 2>/dev/null)" || disallowed_rc=$?
+if [[ "$disallowed_rc" -ne 0 && -z "$disallowed_fleet" ]]; then
+  test_pass
+else
+  test_fail "policy-disallowed single-provider override escaped admission: rc=$disallowed_rc fleet=[$disallowed_fleet]"
 fi
 
 test_case "fleet review rejects an exact model outside the dispatch allowlist"

--- a/tests/unit/test-contextual-review-fleet-cli.sh
+++ b/tests/unit/test-contextual-review-fleet-cli.sh
@@ -60,4 +60,25 @@ else
   test_fail "single-provider precedence was not reflected in fleet review: $(tr '\n' ';' <<< "$fleet")"
 fi
 
+test_case "fleet review rejects an exact model outside the dispatch allowlist"
+restricted_rc=0
+restricted_fleet="$(run_fleet \
+  OCTOPUS_CODEX_ALLOWED_MODELS='gpt-allowed' \
+  OCTOPUS_REVIEW_LOGIC_AGENT='codex:gpt-blocked' 2>/dev/null)" || restricted_rc=$?
+if [[ "$restricted_rc" -ne 0 && "$restricted_fleet" != *'codex:gpt-blocked'* ]]; then
+  test_pass
+else
+  test_fail "fleet review called a dispatch-rejected model effective: rc=$restricted_rc fleet=[$restricted_fleet]"
+fi
+
+test_case "fleet review rejects an exact Fable security seat"
+fable_rc=0
+fable_fleet="$(run_fleet \
+  OCTOPUS_REVIEW_SECURITY_AGENT='anthropic:claude-fable-5' 2>/dev/null)" || fable_rc=$?
+if [[ "$fable_rc" -ne 0 && "$fable_fleet" != *'claude:claude-fable-5'* ]]; then
+  test_pass
+else
+  test_fail "fleet review called an unsafe Fable security seat effective: rc=$fable_rc fleet=[$fable_fleet]"
+fi
+
 test_summary

--- a/tests/unit/test-contextual-review-fleet-cli.sh
+++ b/tests/unit/test-contextual-review-fleet-cli.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Contextual review fleet CLI"
+
+checker="$TEST_TMP_DIR/provider-checker.sh"
+cat > "$checker" <<'CHECKER'
+#!/usr/bin/env bash
+printf '%s\n' \
+  'codex:available' \
+  'commandcode:available' \
+  'claude:available' \
+  'agy:available' \
+  'openrouter:available' \
+  'orcarouter:available' \
+  'vibe:available' \
+  'atlascloud:available'
+CHECKER
+chmod +x "$checker"
+
+run_fleet() {
+  env \
+    "HOME=$TEST_TMP_DIR/home" \
+    "OCTOPUS_PROVIDER_CHECKER=$checker" \
+    "OCTO_ALLOWED_PROVIDERS=codex commandcode claude agy openrouter orcarouter vibe atlascloud" \
+    "$@" \
+    "$PROJECT_ROOT/bin/octopus" fleet review standard target
+}
+
+test_case "fleet review shows all eight effective model-qualified seat overrides"
+fleet="$(run_fleet \
+  OCTOPUS_REVIEW_LOGIC_AGENT='openai:gpt-5.6-luna' \
+  OCTOPUS_REVIEW_SECURITY_AGENT='agy:gemini-exact' \
+  OCTOPUS_REVIEW_ARCHITECTURE_AGENT='anthropic:claude-opus-5' \
+  OCTOPUS_REVIEW_CVE_AGENT='command-code:tencent/hy3-paid' \
+  OCTOPUS_REVIEW_DIVERSITY_AGENT='openrouter:deepseek/deepseek-v4' \
+  OCTOPUS_REVIEW_VERIFIER_AGENT='orcarouter:anthropic/claude-sonnet-4.6' \
+  OCTOPUS_REVIEW_DEBATER_AGENT='vibe:mistral-large-latest' \
+  OCTOPUS_REVIEW_SYNTHESIZER_AGENT='atlas-cloud:qwen/qwen3.5')"
+expected_specs=$'codex:gpt-5.6-luna\nagy:gemini-exact\nclaude:claude-opus-5\ncommandcode:tencent/hy3-paid\nopenrouter:deepseek/deepseek-v4\norcarouter:anthropic/claude-sonnet-4.6\nvibe:mistral-large-latest\natlascloud-agent:qwen/qwen3.5'
+actual_specs="$(printf '%s\n' "$fleet" | cut -d'|' -f1)"
+if [[ "$(printf '%s\n' "$fleet" | grep -c .)" -eq 8 && "$actual_specs" == "$expected_specs" ]]; then
+  test_pass
+else
+  test_fail "fleet review did not render all effective overrides: $(tr '\n' ';' <<< "$fleet")"
+fi
+
+test_case "single-provider override takes precedence over all seat overrides in fleet review"
+fleet="$(run_fleet \
+  OCTOPUS_REVIEW_SINGLE_PROVIDER=codex \
+  OCTOPUS_REVIEW_LOGIC_AGENT='commandcode:model-a' \
+  OCTOPUS_REVIEW_SYNTHESIZER_AGENT='vibe:model-b')"
+if [[ "$(printf '%s\n' "$fleet" | grep -c .)" -eq 8 ]] && \
+   [[ "$(printf '%s\n' "$fleet" | cut -d'|' -f1 | grep -vc '^codex$' || true)" -eq 0 ]]; then
+  test_pass
+else
+  test_fail "single-provider precedence was not reflected in fleet review: $(tr '\n' ';' <<< "$fleet")"
+fi
+
+test_summary

--- a/tests/unit/test-contextual-review-fleet-cli.sh
+++ b/tests/unit/test-contextual-review-fleet-cli.sh
@@ -34,7 +34,7 @@ AGY
 chmod +x "$agy_bin/agy"
 
 run_fleet() {
-  env \
+  env -i \
     "HOME=$TEST_TMP_DIR/home" \
     "PATH=$agy_bin:$PATH" \
     "OCTOPUS_PROVIDER_CHECKER=$checker" \
@@ -44,6 +44,7 @@ run_fleet() {
 }
 
 test_case "fleet review shows all eight effective model-qualified seat overrides"
+export OCTOPUS_REVIEW_SINGLE_PROVIDER=claude
 fleet="$(run_fleet \
   "OCTOPUS_REVIEW_LOGIC_AGENT=openai:gpt-5.6-luna" \
   "OCTOPUS_REVIEW_SECURITY_AGENT=agy:gemini-exact" \
@@ -53,6 +54,7 @@ fleet="$(run_fleet \
   "OCTOPUS_REVIEW_VERIFIER_AGENT=orcarouter:anthropic/claude-sonnet-4.6" \
   "OCTOPUS_REVIEW_DEBATER_AGENT=vibe:mistral-large-latest" \
   "OCTOPUS_REVIEW_SYNTHESIZER_AGENT=atlas-cloud:qwen/qwen3.5")"
+unset OCTOPUS_REVIEW_SINGLE_PROVIDER
 expected_specs=$'codex:gpt-5.6-luna\nagy:gemini-exact\nclaude:claude-opus-5\ncommandcode:tencent/hy3-paid\nopenrouter:deepseek/deepseek-v4\norcarouter:anthropic/claude-sonnet-4.6\nvibe:mistral-large-latest\natlascloud-agent:qwen/qwen3.5'
 actual_specs="$(printf '%s\n' "$fleet" | cut -d'|' -f1)"
 if [[ "$(printf '%s\n' "$fleet" | grep -c .)" -eq 8 && "$actual_specs" == "$expected_specs" ]]; then
@@ -75,10 +77,12 @@ fi
 
 test_case "fleet review rejects an unavailable single-provider override"
 unavailable_rc=0
+unavailable_error="$TEST_TMP_DIR/unavailable.err"
 unavailable_fleet="$(run_fleet \
   "OCTO_ALLOWED_PROVIDERS=codex commandcode claude agy openrouter orcarouter vibe atlascloud perplexity" \
-  "OCTOPUS_REVIEW_SINGLE_PROVIDER=perplexity" 2>/dev/null)" || unavailable_rc=$?
-if [[ "$unavailable_rc" -ne 0 && -z "$unavailable_fleet" ]]; then
+  "OCTOPUS_REVIEW_SINGLE_PROVIDER=perplexity" 2>"$unavailable_error")" || unavailable_rc=$?
+if [[ "$unavailable_rc" -ne 0 && -z "$unavailable_fleet" ]] && \
+   grep -Fc "OCTOPUS_REVIEW_SINGLE_PROVIDER 'perplexity' is unavailable" "$unavailable_error" >/dev/null; then
   test_pass
 else
   test_fail "unavailable single-provider override escaped admission: rc=$unavailable_rc fleet=[$unavailable_fleet]"
@@ -86,10 +90,12 @@ fi
 
 test_case "fleet review rejects an unknown single-provider override"
 unknown_rc=0
+unknown_error="$TEST_TMP_DIR/unknown.err"
 unknown_fleet="$(run_fleet \
   "OCTO_ALLOWED_PROVIDERS=mystery-provider" \
-  "OCTOPUS_REVIEW_SINGLE_PROVIDER=mystery-provider" 2>/dev/null)" || unknown_rc=$?
-if [[ "$unknown_rc" -ne 0 && -z "$unknown_fleet" ]]; then
+  "OCTOPUS_REVIEW_SINGLE_PROVIDER=mystery-provider" 2>"$unknown_error")" || unknown_rc=$?
+if [[ "$unknown_rc" -ne 0 && -z "$unknown_fleet" ]] && \
+   grep -Fc "Unknown OCTOPUS_REVIEW_SINGLE_PROVIDER: mystery-provider" "$unknown_error" >/dev/null; then
   test_pass
 else
   test_fail "unknown single-provider override escaped registry validation: rc=$unknown_rc fleet=[$unknown_fleet]"
@@ -97,10 +103,12 @@ fi
 
 test_case "fleet review rejects a policy-disallowed single-provider override"
 disallowed_rc=0
+disallowed_error="$TEST_TMP_DIR/disallowed.err"
 disallowed_fleet="$(run_fleet \
   "OCTO_ALLOWED_PROVIDERS=agy" \
-  "OCTOPUS_REVIEW_SINGLE_PROVIDER=codex" 2>/dev/null)" || disallowed_rc=$?
-if [[ "$disallowed_rc" -ne 0 && -z "$disallowed_fleet" ]]; then
+  "OCTOPUS_REVIEW_SINGLE_PROVIDER=codex" 2>"$disallowed_error")" || disallowed_rc=$?
+if [[ "$disallowed_rc" -ne 0 && -z "$disallowed_fleet" ]] && \
+   grep -Fc "OCTOPUS_REVIEW_SINGLE_PROVIDER 'codex' is not admitted by the active allowlist" "$disallowed_error" >/dev/null; then
   test_pass
 else
   test_fail "policy-disallowed single-provider override escaped admission: rc=$disallowed_rc fleet=[$disallowed_fleet]"
@@ -108,10 +116,12 @@ fi
 
 test_case "fleet review rejects an exact model outside the dispatch allowlist"
 restricted_rc=0
+restricted_error="$TEST_TMP_DIR/restricted.err"
 restricted_fleet="$(run_fleet \
   "OCTOPUS_CODEX_ALLOWED_MODELS=gpt-allowed" \
-  "OCTOPUS_REVIEW_LOGIC_AGENT=codex:gpt-blocked" 2>/dev/null)" || restricted_rc=$?
-if [[ "$restricted_rc" -ne 0 && "$restricted_fleet" != *'codex:gpt-blocked'* ]]; then
+  "OCTOPUS_REVIEW_LOGIC_AGENT=codex:gpt-blocked" 2>"$restricted_error")" || restricted_rc=$?
+if [[ "$restricted_rc" -ne 0 && "$restricted_fleet" != *'codex:gpt-blocked'* ]] && \
+   grep -Fc "is blocked by the provider model allowlist" "$restricted_error" >/dev/null; then
   test_pass
 else
   test_fail "fleet review called a dispatch-rejected model effective: rc=$restricted_rc fleet=[$restricted_fleet]"
@@ -119,9 +129,11 @@ fi
 
 test_case "fleet review rejects an exact Fable security seat"
 fable_rc=0
+fable_error="$TEST_TMP_DIR/fable.err"
 fable_fleet="$(run_fleet \
-  "OCTOPUS_REVIEW_SECURITY_AGENT=anthropic:claude-fable-5" 2>/dev/null)" || fable_rc=$?
-if [[ "$fable_rc" -ne 0 && "$fable_fleet" != *'claude:claude-fable-5'* ]]; then
+  "OCTOPUS_REVIEW_SECURITY_AGENT=anthropic:claude-fable-5" 2>"$fable_error")" || fable_rc=$?
+if [[ "$fable_rc" -ne 0 && "$fable_fleet" != *'claude:claude-fable-5'* ]] && \
+   grep -Fc "is unsafe for role 'implementation-security-reviewer'" "$fable_error" >/dev/null; then
   test_pass
 else
   test_fail "fleet review called an unsafe Fable security seat effective: rc=$fable_rc fleet=[$fable_fleet]"
@@ -133,7 +145,7 @@ agy_error="$TEST_TMP_DIR/agy-missing-model.err"
 agy_fleet="$(run_fleet \
   "OCTOPUS_REVIEW_SECURITY_AGENT=agy:missing-model" 2>"$agy_error")" || agy_rc=$?
 if [[ "$agy_rc" -ne 0 && "$agy_fleet" != *'agy:missing-model'* ]] && \
-   grep -Fq "is not a valid model for provider 'agy'" "$agy_error"; then
+   grep -Fc "is not a valid model for provider 'agy'" "$agy_error" >/dev/null; then
   test_pass
 else
   test_fail "fleet review did not clearly reject a dispatch-rejected AGY model: rc=$agy_rc fleet=[$agy_fleet] error=[$(tr '\n' ';' < "$agy_error")]"

--- a/tests/unit/test-contextual-review-seat-overrides.sh
+++ b/tests/unit/test-contextual-review-seat-overrides.sh
@@ -57,6 +57,45 @@ else
 fi
 OCTOPUS_REVIEW_SECURITY_AGENT='claude:claude-opus-5'
 
+test_case "every explicitly blank review seat override fails closed"
+blank_overrides_ok=true
+for role in \
+  implementation-logic-reviewer \
+  implementation-security-reviewer \
+  implementation-architecture-reviewer \
+  implementation-cve-reviewer \
+  implementation-diversity-reviewer \
+  implementation-verifier \
+  implementation-debater \
+  implementation-synthesizer; do
+  env_name="$(review_seat_override_env_name "$role")"
+  saved_value="${!env_name-}"
+  printf -v "$env_name" '%s' ''
+  export "$env_name"
+  rc=0
+  review_agent_for_seat codex "$role" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -ne 0 ]] || blank_overrides_ok=false
+  printf -v "$env_name" '%s' "$saved_value"
+  export "$env_name"
+done
+if [[ "$blank_overrides_ok" == true ]]; then
+  test_pass
+else
+  test_fail "an explicitly blank review seat override was treated as unset"
+fi
+
+test_case "Round 1 rejects an explicitly blank diversity override"
+saved_diversity="$OCTOPUS_REVIEW_DIVERSITY_AGENT"
+OCTOPUS_REVIEW_DIVERSITY_AGENT=''
+blank_diversity_rc=0
+review_fleet_with_override_seats 'codex:implementation-logic-reviewer:logic' >/dev/null 2>&1 || blank_diversity_rc=$?
+OCTOPUS_REVIEW_DIVERSITY_AGENT="$saved_diversity"
+if [[ "$blank_diversity_rc" -ne 0 ]]; then
+  test_pass
+else
+  test_fail "blank diversity override was skipped instead of rejected"
+fi
+
 test_case "single-provider override keeps global precedence"
 OCTOPUS_REVIEW_SINGLE_PROVIDER=codex
 if [[ "$(review_agent_for_seat claude-sonnet implementation-synthesizer)" == 'codex' ]]; then

--- a/tests/unit/test-contextual-review-seat-overrides.sh
+++ b/tests/unit/test-contextual-review-seat-overrides.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Contextual review seat overrides"
+
+export PLUGIN_DIR="$PROJECT_ROOT"
+export HOME="$TEST_TMP_DIR/contextual-review-seat-overrides"
+mkdir -p "$HOME/.claude-octopus/config"
+source "$PROJECT_ROOT/scripts/lib/agent-spec.sh"
+source "$PROJECT_ROOT/scripts/lib/review.sh"
+
+log() { :; }
+octo_provider_allowed() {
+  case "$(octo_agent_spec_provider "$1")" in
+    codex|claude|commandcode) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+unset OCTOPUS_REVIEW_SINGLE_PROVIDER
+export OCTOPUS_REVIEW_LOGIC_AGENT='codex:gpt-5.6-luna'
+export OCTOPUS_REVIEW_SECURITY_AGENT='claude:claude-opus-5'
+export OCTOPUS_REVIEW_ARCHITECTURE_AGENT='claude:claude-opus-5'
+export OCTOPUS_REVIEW_CVE_AGENT='commandcode:tencent/hy3-paid'
+export OCTOPUS_REVIEW_DIVERSITY_AGENT='commandcode:qwen/qwen3.8-27b'
+export OCTOPUS_REVIEW_VERIFIER_AGENT='codex:gpt-5.6-luna'
+export OCTOPUS_REVIEW_DEBATER_AGENT='commandcode:qwen/qwen3.8-27b'
+export OCTOPUS_REVIEW_SYNTHESIZER_AGENT='commandcode:thinkingmachines/inkling-small'
+
+test_case "semantic seats return literal provider:model overrides"
+if [[ "$(review_agent_for_seat codex implementation-verifier)" == 'codex:gpt-5.6-luna' ]] && \
+   [[ "$(review_agent_for_seat codex implementation-debater)" == 'commandcode:qwen/qwen3.8-27b' ]] && \
+   [[ "$(review_agent_for_seat claude-sonnet implementation-synthesizer)" == 'commandcode:thinkingmachines/inkling-small' ]]; then
+  test_pass
+else
+  test_fail "semantic seat override mismatch"
+fi
+
+test_case "single-provider override keeps global precedence"
+OCTOPUS_REVIEW_SINGLE_PROVIDER=codex
+if [[ "$(review_agent_for_seat claude-sonnet implementation-synthesizer)" == 'codex' ]]; then
+  test_pass
+else
+  test_fail "single-provider override did not take precedence"
+fi
+unset OCTOPUS_REVIEW_SINGLE_PROVIDER
+
+test_case "disallowed seat override fails closed"
+OCTOPUS_REVIEW_SECURITY_AGENT='agy:gemini-3.1-pro'
+rc=0
+review_agent_for_seat claude-sonnet implementation-security-reviewer >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  test_pass
+else
+  test_fail "disallowed seat override was accepted"
+fi
+OCTOPUS_REVIEW_SECURITY_AGENT='claude:claude-opus-5'
+
+test_case "Round 1 override seats are appended when config fleet lacks their roles"
+fleet=$'codex:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions\nclaude-sonnet:implementation-architecture-reviewer:architecture, integration, API contracts, breaking changes\n'
+expanded="$(review_fleet_with_override_seats "$fleet")"
+if grep -Fq ':implementation-security-reviewer:' <<< "$expanded" && \
+   grep -Fq ':implementation-cve-reviewer:' <<< "$expanded" && \
+   grep -Fq ':implementation-diversity-reviewer:' <<< "$expanded"; then
+  test_pass
+else
+  test_fail "explicit Round 1 seats were not appended: $(tr '\n' '|' <<< "$expanded")"
+fi
+
+test_case "Round 1 dispatch replaces executor placeholder with literal seat identity"
+if [[ "$(review_agent_for_seat commandcode implementation-cve-reviewer)" == 'commandcode:tencent/hy3-paid' ]] && \
+   [[ "$(review_agent_for_seat commandcode implementation-diversity-reviewer)" == 'commandcode:qwen/qwen3.8-27b' ]]; then
+  test_pass
+else
+  test_fail "Round 1 literal seat identities were not preserved"
+fi
+
+test_case "unconfigured roles preserve upstream default executor"
+unset OCTOPUS_REVIEW_LOGIC_AGENT
+if [[ "$(review_agent_for_seat codex implementation-logic-reviewer)" == 'codex' ]]; then
+  test_pass
+else
+  test_fail "unconfigured seat changed upstream default"
+fi
+
+test_case "model-qualified CommandCode seats retain provider telemetry identity"
+if [[ "$(review_provider_key_from_agent_type 'commandcode:qwen/qwen3.8-27b')" == 'commandcode' ]]; then
+  test_pass
+else
+  test_fail "CommandCode review seat was not classified as commandcode"
+fi
+
+test_summary

--- a/tests/unit/test-contextual-review-seat-overrides.sh
+++ b/tests/unit/test-contextual-review-seat-overrides.sh
@@ -61,23 +61,25 @@ else
 fi
 OCTOPUS_REVIEW_SECURITY_AGENT='claude:claude-opus-5'
 
-test_case "Round 1 override seats are appended when config fleet lacks their roles"
+test_case "Round 1 override seats are emitted exactly once with configured providers"
 fleet=$'codex:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions\nclaude-sonnet:implementation-architecture-reviewer:architecture, integration, API contracts, breaking changes\n'
 expanded="$(review_fleet_with_override_seats "$fleet")"
-if grep -Fc ':implementation-security-reviewer:' <<< "$expanded" >/dev/null && \
-   grep -Fc ':implementation-cve-reviewer:' <<< "$expanded" >/dev/null && \
-   grep -Fc ':implementation-diversity-reviewer:' <<< "$expanded" >/dev/null; then
+logic_provider="${OCTOPUS_REVIEW_LOGIC_AGENT%%:*}"
+security_provider="${OCTOPUS_REVIEW_SECURITY_AGENT%%:*}"
+cve_provider="${OCTOPUS_REVIEW_CVE_AGENT%%:*}"
+diversity_provider="${OCTOPUS_REVIEW_DIVERSITY_AGENT%%:*}"
+if [[ "$(grep -Fc ':implementation-logic-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -Fc ':implementation-architecture-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -Fc ':implementation-security-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -Fc ':implementation-cve-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -Fc ':implementation-diversity-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -Fc "${logic_provider}:implementation-logic-reviewer:" <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -Fc "${security_provider}:implementation-security-reviewer:" <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -Fc "${cve_provider}:implementation-cve-reviewer:" <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -Fc "${diversity_provider}:implementation-diversity-reviewer:" <<< "$expanded")" -eq 1 ]]; then
   test_pass
 else
-  test_fail "explicit Round 1 seats were not appended: $(tr '\n' '|' <<< "$expanded")"
-fi
-
-test_case "Round 1 dispatch replaces executor placeholder with literal seat identity"
-if [[ "$(review_agent_for_seat commandcode implementation-cve-reviewer)" == "$OCTOPUS_REVIEW_CVE_AGENT" ]] && \
-   [[ "$(review_agent_for_seat commandcode implementation-diversity-reviewer)" == "$OCTOPUS_REVIEW_DIVERSITY_AGENT" ]]; then
-  test_pass
-else
-  test_fail "Round 1 literal seat identities were not preserved"
+  test_fail "Round 1 generated fleet did not preserve unique configured-provider seats: $(tr '\n' '|' <<< "$expanded")"
 fi
 
 test_case "unconfigured roles preserve upstream default executor"

--- a/tests/unit/test-contextual-review-seat-overrides.sh
+++ b/tests/unit/test-contextual-review-seat-overrides.sh
@@ -10,6 +10,7 @@ export HOME="$TEST_TMP_DIR/contextual-review-seat-overrides"
 mkdir -p "$HOME/.claude-octopus/config"
 source "$PROJECT_ROOT/scripts/lib/provider-registry.sh"
 source "$PROJECT_ROOT/scripts/lib/agent-spec.sh"
+source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
 source "$PROJECT_ROOT/scripts/lib/review.sh"
 
 log() { :; }

--- a/tests/unit/test-contextual-review-seat-overrides.sh
+++ b/tests/unit/test-contextual-review-seat-overrides.sh
@@ -8,6 +8,7 @@ test_suite "Contextual review seat overrides"
 export PLUGIN_DIR="$PROJECT_ROOT"
 export HOME="$TEST_TMP_DIR/contextual-review-seat-overrides"
 mkdir -p "$HOME/.claude-octopus/config"
+source "$PROJECT_ROOT/scripts/lib/provider-registry.sh"
 source "$PROJECT_ROOT/scripts/lib/agent-spec.sh"
 source "$PROJECT_ROOT/scripts/lib/review.sh"
 
@@ -18,21 +19,21 @@ octo_provider_allowed() {
     *) return 1 ;;
   esac
 }
-
 unset OCTOPUS_REVIEW_SINGLE_PROVIDER
-export OCTOPUS_REVIEW_LOGIC_AGENT='codex:gpt-5.6-luna'
+export OCTOPUS_REVIEW_LOGIC_AGENT='openai:gpt-5.6-luna'
 export OCTOPUS_REVIEW_SECURITY_AGENT='claude:claude-opus-5'
-export OCTOPUS_REVIEW_ARCHITECTURE_AGENT='claude:claude-opus-5'
-export OCTOPUS_REVIEW_CVE_AGENT='commandcode:tencent/hy3-paid'
+export OCTOPUS_REVIEW_ARCHITECTURE_AGENT='anthropic:claude-opus-5'
+export OCTOPUS_REVIEW_CVE_AGENT='command-code:tencent/hy3-paid'
 export OCTOPUS_REVIEW_DIVERSITY_AGENT='commandcode:qwen/qwen3.8-27b'
 export OCTOPUS_REVIEW_VERIFIER_AGENT='codex:gpt-5.6-luna'
 export OCTOPUS_REVIEW_DEBATER_AGENT='commandcode:qwen/qwen3.8-27b'
 export OCTOPUS_REVIEW_SYNTHESIZER_AGENT='commandcode:thinkingmachines/inkling-small'
 
-test_case "semantic seats return literal provider:model overrides"
-if [[ "$(review_agent_for_seat codex implementation-logic-reviewer)" == "$OCTOPUS_REVIEW_LOGIC_AGENT" ]] && \
+test_case "semantic seats canonicalize registered aliases to executable provider:model specs"
+if [[ "$(review_agent_for_seat codex implementation-logic-reviewer)" == 'codex:gpt-5.6-luna' ]] && \
    [[ "$(review_agent_for_seat claude-sonnet implementation-security-reviewer)" == "$OCTOPUS_REVIEW_SECURITY_AGENT" ]] && \
-   [[ "$(review_agent_for_seat claude-sonnet implementation-architecture-reviewer)" == "$OCTOPUS_REVIEW_ARCHITECTURE_AGENT" ]] && \
+   [[ "$(review_agent_for_seat claude-sonnet implementation-architecture-reviewer)" == 'claude:claude-opus-5' ]] && \
+   [[ "$(review_agent_for_seat perplexity implementation-cve-reviewer)" == 'commandcode:tencent/hy3-paid' ]] && \
    [[ "$(review_agent_for_seat codex implementation-verifier)" == "$OCTOPUS_REVIEW_VERIFIER_AGENT" ]] && \
    [[ "$(review_agent_for_seat codex implementation-debater)" == "$OCTOPUS_REVIEW_DEBATER_AGENT" ]] && \
    [[ "$(review_agent_for_seat claude-sonnet implementation-synthesizer)" == "$OCTOPUS_REVIEW_SYNTHESIZER_AGENT" ]]; then
@@ -40,6 +41,21 @@ if [[ "$(review_agent_for_seat codex implementation-logic-reviewer)" == "$OCTOPU
 else
   test_fail "semantic seat override mismatch"
 fi
+
+test_case "blank whitespace and provider-only seat overrides fail closed"
+malformed_ok=true
+for malformed in '' '   ' 'claude' 'claude:' ' claude:claude-opus-5' 'claude:claude-opus-5 '; do
+  OCTOPUS_REVIEW_SECURITY_AGENT="$malformed"
+  rc=0
+  review_agent_for_seat claude-sonnet implementation-security-reviewer >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -ne 0 ]] || malformed_ok=false
+done
+if [[ "$malformed_ok" == true ]]; then
+  test_pass
+else
+  test_fail "a malformed contextual seat override was admitted"
+fi
+OCTOPUS_REVIEW_SECURITY_AGENT='claude:claude-opus-5'
 
 test_case "single-provider override keeps global precedence"
 OCTOPUS_REVIEW_SINGLE_PROVIDER=codex
@@ -61,22 +77,44 @@ else
 fi
 OCTOPUS_REVIEW_SECURITY_AGENT='claude:claude-opus-5'
 
+test_case "unknown seat providers fail closed when the allowlist is unset"
+octo_provider_allowed() { return 0; }
+OCTOPUS_REVIEW_SECURITY_AGENT='unknown-provider:some-model'
+rc=0
+review_agent_for_seat claude-sonnet implementation-security-reviewer >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  test_pass
+else
+  test_fail "unknown provider was admitted when the allowlist allowed all registered providers"
+fi
+octo_provider_allowed() {
+  case "$(octo_agent_spec_provider "$1")" in
+    codex|claude|commandcode) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+OCTOPUS_REVIEW_SECURITY_AGENT='claude:claude-opus-5'
+
 test_case "Round 1 override seats are emitted exactly once with configured providers"
-fleet=$'codex:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions\nclaude-sonnet:implementation-architecture-reviewer:architecture, integration, API contracts, breaking changes\n'
+# build_review_fleet obtains its configured fleet through command substitution,
+# which strips the producer's trailing newline before override seats are added.
+fleet=$'codex:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions\nclaude-sonnet:implementation-architecture-reviewer:architecture, integration, API contracts, breaking changes'
 expanded="$(review_fleet_with_override_seats "$fleet")"
 logic_provider="${OCTOPUS_REVIEW_LOGIC_AGENT%%:*}"
 security_provider="${OCTOPUS_REVIEW_SECURITY_AGENT%%:*}"
 cve_provider="${OCTOPUS_REVIEW_CVE_AGENT%%:*}"
 diversity_provider="${OCTOPUS_REVIEW_DIVERSITY_AGENT%%:*}"
-if [[ "$(grep -Fc ':implementation-logic-reviewer:' <<< "$expanded")" -eq 1 ]] && \
-   [[ "$(grep -Fc ':implementation-architecture-reviewer:' <<< "$expanded")" -eq 1 ]] && \
-   [[ "$(grep -Fc ':implementation-security-reviewer:' <<< "$expanded")" -eq 1 ]] && \
-   [[ "$(grep -Fc ':implementation-cve-reviewer:' <<< "$expanded")" -eq 1 ]] && \
-   [[ "$(grep -Fc ':implementation-diversity-reviewer:' <<< "$expanded")" -eq 1 ]] && \
-   [[ "$(grep -Fc "${logic_provider}:implementation-logic-reviewer:" <<< "$expanded")" -eq 1 ]] && \
-   [[ "$(grep -Fc "${security_provider}:implementation-security-reviewer:" <<< "$expanded")" -eq 1 ]] && \
-   [[ "$(grep -Fc "${cve_provider}:implementation-cve-reviewer:" <<< "$expanded")" -eq 1 ]] && \
-   [[ "$(grep -Fc "${diversity_provider}:implementation-diversity-reviewer:" <<< "$expanded")" -eq 1 ]]; then
+expanded_line_count="$(printf '%s\n' "$expanded" | sed '/^$/d' | wc -l | tr -d '[:space:]')"
+if [[ "$expanded_line_count" -eq 5 ]] && \
+   [[ "$(grep -cE '^[^:]+:implementation-logic-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -cE '^[^:]+:implementation-architecture-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -cE '^[^:]+:implementation-security-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -cE '^[^:]+:implementation-cve-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -cE '^[^:]+:implementation-diversity-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -cE '^codex:implementation-logic-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -cE "^${security_provider}:implementation-security-reviewer:" <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -cE '^commandcode:implementation-cve-reviewer:' <<< "$expanded")" -eq 1 ]] && \
+   [[ "$(grep -cE "^${diversity_provider}:implementation-diversity-reviewer:" <<< "$expanded")" -eq 1 ]]; then
   test_pass
 else
   test_fail "Round 1 generated fleet did not preserve unique configured-provider seats: $(tr '\n' '|' <<< "$expanded")"
@@ -95,6 +133,13 @@ if [[ "$(review_provider_key_from_agent_type "$OCTOPUS_REVIEW_DIVERSITY_AGENT")"
   test_pass
 else
   test_fail "CommandCode review seat was not classified as commandcode"
+fi
+
+test_case "model-qualified registry seats omit the model from provider telemetry"
+if [[ "$(review_provider_key_from_agent_type 'vibe:provider/model-id')" == 'vibe' ]]; then
+  test_pass
+else
+  test_fail "model-qualified Vibe review seat leaked its model into provider telemetry"
 fi
 
 test_summary

--- a/tests/unit/test-contextual-review-seat-overrides.sh
+++ b/tests/unit/test-contextual-review-seat-overrides.sh
@@ -99,7 +99,7 @@ fi
 
 test_case "single-provider override keeps global precedence"
 OCTOPUS_REVIEW_SINGLE_PROVIDER=codex
-if [[ "$(review_agent_for_seat claude-sonnet implementation-synthesizer)" == 'codex' ]]; then
+if [[ "$(AVAILABLE_AGENTS=codex review_agent_for_seat claude-sonnet implementation-synthesizer)" == 'codex' ]]; then
   test_pass
 else
   test_fail "single-provider override did not take precedence"

--- a/tests/unit/test-contextual-review-seat-overrides.sh
+++ b/tests/unit/test-contextual-review-seat-overrides.sh
@@ -30,9 +30,12 @@ export OCTOPUS_REVIEW_DEBATER_AGENT='commandcode:qwen/qwen3.8-27b'
 export OCTOPUS_REVIEW_SYNTHESIZER_AGENT='commandcode:thinkingmachines/inkling-small'
 
 test_case "semantic seats return literal provider:model overrides"
-if [[ "$(review_agent_for_seat codex implementation-verifier)" == 'codex:gpt-5.6-luna' ]] && \
-   [[ "$(review_agent_for_seat codex implementation-debater)" == 'commandcode:qwen/qwen3.8-27b' ]] && \
-   [[ "$(review_agent_for_seat claude-sonnet implementation-synthesizer)" == 'commandcode:thinkingmachines/inkling-small' ]]; then
+if [[ "$(review_agent_for_seat codex implementation-logic-reviewer)" == "$OCTOPUS_REVIEW_LOGIC_AGENT" ]] && \
+   [[ "$(review_agent_for_seat claude-sonnet implementation-security-reviewer)" == "$OCTOPUS_REVIEW_SECURITY_AGENT" ]] && \
+   [[ "$(review_agent_for_seat claude-sonnet implementation-architecture-reviewer)" == "$OCTOPUS_REVIEW_ARCHITECTURE_AGENT" ]] && \
+   [[ "$(review_agent_for_seat codex implementation-verifier)" == "$OCTOPUS_REVIEW_VERIFIER_AGENT" ]] && \
+   [[ "$(review_agent_for_seat codex implementation-debater)" == "$OCTOPUS_REVIEW_DEBATER_AGENT" ]] && \
+   [[ "$(review_agent_for_seat claude-sonnet implementation-synthesizer)" == "$OCTOPUS_REVIEW_SYNTHESIZER_AGENT" ]]; then
   test_pass
 else
   test_fail "semantic seat override mismatch"
@@ -61,17 +64,17 @@ OCTOPUS_REVIEW_SECURITY_AGENT='claude:claude-opus-5'
 test_case "Round 1 override seats are appended when config fleet lacks their roles"
 fleet=$'codex:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions\nclaude-sonnet:implementation-architecture-reviewer:architecture, integration, API contracts, breaking changes\n'
 expanded="$(review_fleet_with_override_seats "$fleet")"
-if grep -Fq ':implementation-security-reviewer:' <<< "$expanded" && \
-   grep -Fq ':implementation-cve-reviewer:' <<< "$expanded" && \
-   grep -Fq ':implementation-diversity-reviewer:' <<< "$expanded"; then
+if grep -Fc ':implementation-security-reviewer:' <<< "$expanded" >/dev/null && \
+   grep -Fc ':implementation-cve-reviewer:' <<< "$expanded" >/dev/null && \
+   grep -Fc ':implementation-diversity-reviewer:' <<< "$expanded" >/dev/null; then
   test_pass
 else
   test_fail "explicit Round 1 seats were not appended: $(tr '\n' '|' <<< "$expanded")"
 fi
 
 test_case "Round 1 dispatch replaces executor placeholder with literal seat identity"
-if [[ "$(review_agent_for_seat commandcode implementation-cve-reviewer)" == 'commandcode:tencent/hy3-paid' ]] && \
-   [[ "$(review_agent_for_seat commandcode implementation-diversity-reviewer)" == 'commandcode:qwen/qwen3.8-27b' ]]; then
+if [[ "$(review_agent_for_seat commandcode implementation-cve-reviewer)" == "$OCTOPUS_REVIEW_CVE_AGENT" ]] && \
+   [[ "$(review_agent_for_seat commandcode implementation-diversity-reviewer)" == "$OCTOPUS_REVIEW_DIVERSITY_AGENT" ]]; then
   test_pass
 else
   test_fail "Round 1 literal seat identities were not preserved"
@@ -86,7 +89,7 @@ else
 fi
 
 test_case "model-qualified CommandCode seats retain provider telemetry identity"
-if [[ "$(review_provider_key_from_agent_type 'commandcode:qwen/qwen3.8-27b')" == 'commandcode' ]]; then
+if [[ "$(review_provider_key_from_agent_type "$OCTOPUS_REVIEW_DIVERSITY_AGENT")" == 'commandcode' ]]; then
   test_pass
 else
   test_fail "CommandCode review seat was not classified as commandcode"

--- a/tests/unit/test-contextual-review-seat-overrides.sh
+++ b/tests/unit/test-contextual-review-seat-overrides.sh
@@ -99,7 +99,10 @@ fi
 
 test_case "single-provider override keeps global precedence"
 OCTOPUS_REVIEW_SINGLE_PROVIDER=codex
-if [[ "$(AVAILABLE_AGENTS=codex review_agent_for_seat claude-sonnet implementation-synthesizer)" == 'codex' ]]; then
+if [[ "$({
+  review_single_provider_is_available() { [[ "$1" == codex ]]; }
+  review_agent_for_seat claude-sonnet implementation-synthesizer
+})" == 'codex' ]]; then
   test_pass
 else
   test_fail "single-provider override did not take precedence"

--- a/tests/unit/test-model-aware-seats.sh
+++ b/tests/unit/test-model-aware-seats.sh
@@ -75,6 +75,28 @@ else
   test_fail "an exact contextual model was omitted: agy=[$agy_cmd] claude=[$claude_cmd] opus=[$opus_cmd] openrouter=[$openrouter_cmd] orcarouter=[$orcarouter_cmd] vibe=[$vibe_cmd] atlas=[$atlas_cmd]"
 fi
 
+test_case "explicit Claude seats preserve dotted model IDs byte-for-byte"
+claude_dotted_cmd="$(get_agent_command 'claude:claude-3.5-sonnet' review implementation-architecture-reviewer 2>/dev/null || true)"
+opus_dotted_cmd="$(get_agent_command 'claude-opus:claude-3.5-sonnet' review implementation-architecture-reviewer 2>/dev/null || true)"
+if [[ "$claude_dotted_cmd" == *'--model claude-3.5-sonnet'* ]] &&
+   [[ "$opus_dotted_cmd" == *'--model claude-3.5-sonnet'* ]] &&
+   [[ "$claude_dotted_cmd" != *'--model claude-3-5-sonnet'* ]] &&
+   [[ "$opus_dotted_cmd" != *'--model claude-3-5-sonnet'* ]]; then
+  test_pass
+else
+  test_fail "explicit dotted Claude model was normalized: claude=[$claude_dotted_cmd] opus=[$opus_dotted_cmd]"
+fi
+
+test_case "unqualified Claude routes retain legacy dotted-model normalization"
+legacy_claude_cmd="$(OCTOPUS_CLAUDE_MODEL='claude-3.5-sonnet' get_agent_command claude review implementation-architecture-reviewer 2>/dev/null || true)"
+legacy_opus_cmd="$(OCTOPUS_OPUS_MODEL='claude-3.5-sonnet' get_agent_command claude-opus review implementation-architecture-reviewer 2>/dev/null || true)"
+if [[ "$legacy_claude_cmd" == *'--model claude-3-5-sonnet'* ]] &&
+   [[ "$legacy_opus_cmd" == *'--model claude-3-5-sonnet'* ]]; then
+  test_pass
+else
+  test_fail "legacy Claude normalization changed: claude=[$legacy_claude_cmd] opus=[$legacy_opus_cmd]"
+fi
+
 test_case "an explicit model blocked by restrictions fails instead of falling back"
 OCTOPUS_CODEX_ALLOWED_MODELS='gpt-5.6-luna'
 restricted_rc=0

--- a/tests/unit/test-model-aware-seats.sh
+++ b/tests/unit/test-model-aware-seats.sh
@@ -30,9 +30,15 @@ if [[ "$(octo_model_family 'commandcode:minimaxai/minimax-m3')" == minimax ]] &&
 
 log(){ :; }
 PLUGIN_DIR="$PROJECT_ROOT"
+_BARE_OPT=""
+source scripts/lib/utils.sh
 source scripts/lib/validation.sh
 source scripts/lib/model-resolver.sh
 source scripts/lib/dispatch.sh
+
+# Keep exact-model command-shape coverage independent of the host AGY catalog.
+# Provider catalog membership is covered by test-agy-provider.sh.
+validate_agy_model_name() { validate_model_name "$1"; }
 
 test_case "model-qualified dispatch preserves CommandCode and Codex pins"
 cc_model="$(get_agent_model 'commandcode:stealth/ox-alpha' ceremony code-reviewer)"
@@ -40,6 +46,54 @@ codex_model="$(get_agent_model 'codex:gpt-5.6-luna' ceremony code-reviewer)"
 cc_cmd="$(get_agent_command 'commandcode:stealth/ox-alpha' ceremony code-reviewer)"
 codex_cmd="$(get_agent_command 'codex:gpt-5.6-luna' ceremony code-reviewer)"
 if [[ "$cc_model" == stealth/ox-alpha && "$codex_model" == gpt-5.6-luna && "$cc_cmd" == *'commandcode-exec.sh stealth/ox-alpha'* && "$codex_cmd" == *'--model gpt-5.6-luna'* ]]; then test_pass; else test_fail "model-qualified dispatch mismatch"; fi
+
+test_case "qualified contextual providers carry the exact model into dispatch"
+exact_model='vendor/seat-exact-model'
+agy_cmd="$(get_agent_command "agy:${exact_model}" review implementation-security-reviewer 2>/dev/null || true)"
+claude_cmd="$(get_agent_command "claude:${exact_model}" review implementation-architecture-reviewer 2>/dev/null || true)"
+opus_cmd="$(get_agent_command "claude-opus:${exact_model}" review implementation-architecture-reviewer 2>/dev/null || true)"
+openrouter_cmd="$(get_agent_command "openrouter:${exact_model}" review implementation-diversity-reviewer 2>/dev/null || true)"
+orcarouter_cmd="$(get_agent_command "orcarouter:${exact_model}" review implementation-diversity-reviewer 2>/dev/null || true)"
+vibe_cmd="$(get_agent_command "vibe:${exact_model}" review implementation-diversity-reviewer 2>/dev/null || true)"
+atlas_cmd="$(get_agent_command "atlascloud-agent:${exact_model}" review implementation-cve-reviewer 2>/dev/null || true)"
+if [[ "$agy_cmd" == *"OCTOPUS_AGY_MODEL=${exact_model}"* ]] && \
+   [[ "$claude_cmd" == *"--model ${exact_model}"* ]] && \
+   [[ "$opus_cmd" == *"--model ${exact_model}"* ]] && \
+   [[ "$openrouter_cmd" == "openrouter_execute_model ${exact_model}" ]] && \
+   [[ "$orcarouter_cmd" == "orcarouter_execute_model ${exact_model}" ]] && \
+   [[ "$vibe_cmd" == *"OCTOPUS_VIBE_MODEL=${exact_model}"* ]] && \
+   [[ "$atlas_cmd" == *"--provider atlascloud --model ${exact_model}"* ]] && \
+   validate_agent_command "$agy_cmd" && \
+   validate_agent_command "$claude_cmd" && \
+   validate_agent_command "$opus_cmd" && \
+   validate_agent_command "$openrouter_cmd" && \
+   validate_agent_command "$orcarouter_cmd" && \
+   validate_agent_command "$vibe_cmd" && \
+   validate_agent_command "$atlas_cmd"; then
+  test_pass
+else
+  test_fail "an exact contextual model was omitted: agy=[$agy_cmd] claude=[$claude_cmd] opus=[$opus_cmd] openrouter=[$openrouter_cmd] orcarouter=[$orcarouter_cmd] vibe=[$vibe_cmd] atlas=[$atlas_cmd]"
+fi
+
+test_case "an explicit model blocked by restrictions fails instead of falling back"
+OCTOPUS_CODEX_ALLOWED_MODELS='gpt-5.6-luna'
+restricted_rc=0
+restricted_out="$(get_agent_model 'codex:gpt-5.6-sol' review implementation-logic-reviewer 2>/dev/null)" || restricted_rc=$?
+unset OCTOPUS_CODEX_ALLOWED_MODELS
+if [[ "$restricted_rc" -ne 0 && -z "$restricted_out" ]]; then
+  test_pass
+else
+  test_fail "explicit model restriction silently substituted rc=$restricted_rc out=[$restricted_out]"
+fi
+
+test_case "an exact Fable model fails closed for security dispatches"
+fable_security_rc=0
+fable_security_out="$(get_agent_command 'claude-opus:claude-fable-5' review implementation-security-reviewer 2>/dev/null)" || fable_security_rc=$?
+if [[ "$fable_security_rc" -ne 0 && -z "$fable_security_out" ]]; then
+  test_pass
+else
+  test_fail "unsafe exact Fable security pin was dispatched rc=$fable_security_rc out=[$fable_security_out]"
+fi
 
 test_case "review order keeps same-provider model variants and Ox Alpha before Luna"
 fake="$TEST_TMP_DIR/provider-check.sh"

--- a/tests/unit/test-model-aware-seats.sh
+++ b/tests/unit/test-model-aware-seats.sh
@@ -117,6 +117,16 @@ else
   test_fail "unsafe exact Fable security pin was dispatched rc=$fable_security_rc out=[$fable_security_out]"
 fi
 
+test_case "an exact Claude SDK Fable seat disables the shim retry without changing compatibility routes"
+exact_fable_sdk_cmd="$(get_agent_command 'claude-sdk:claude-fable-5' review implementation-logic-reviewer 2>/dev/null || true)"
+compat_fable_sdk_cmd="$(OCTOPUS_CLAUDE_SDK_MODEL=claude-fable-5 get_agent_command claude-sdk review implementation-logic-reviewer 2>/dev/null || true)"
+if [[ "$exact_fable_sdk_cmd" == "env OCTOPUS_CLAUDE_SDK_MODEL=claude-fable-5 OCTOPUS_FABLE5_NO_RETRY=1 $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh" ]] && \
+   [[ "$compat_fable_sdk_cmd" == "env OCTOPUS_CLAUDE_SDK_MODEL=claude-fable-5 $PROJECT_ROOT/scripts/helpers/claude-sdk-exec.sh" ]]; then
+  test_pass
+else
+  test_fail "exact/default Fable retry contract mismatch: exact=[$exact_fable_sdk_cmd] compatibility=[$compat_fable_sdk_cmd]"
+fi
+
 test_case "review order keeps same-provider model variants and Ox Alpha before Luna"
 fake="$TEST_TMP_DIR/provider-check.sh"
 cat > "$fake" <<'CHECK'

--- a/tests/unit/test-openai-compatible-agent.sh
+++ b/tests/unit/test-openai-compatible-agent.sh
@@ -93,6 +93,32 @@ if assert_contains "$cmd" "scripts/helpers/openai-compatible-agent.py" "helper p
     test_pass
 fi
 
+test_case "qualified openai-compatible seat uses provider-file runtime config and exact model"
+CONFIG_ONLY_HOME="$TEST_TMP_DIR/config-only-home"
+mkdir -p "$CONFIG_ONLY_HOME/.claude-octopus/config"
+cat > "$CONFIG_ONLY_HOME/.claude-octopus/config/providers.json" <<'JSON'
+{
+  "version": "3.0",
+  "providers": {
+    "openai-compatible-agent": {
+      "base_url": "https://config-only.invalid/v1",
+      "api_key_env": "CONFIG_ONLY_COMPAT_KEY"
+    }
+  }
+}
+JSON
+qualified_cmd="$({
+    unset OPENAI_COMPAT_BASE_URL OPENAI_COMPAT_API_KEY_ENV OPENAI_API_KEY
+    HOME="$CONFIG_ONLY_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-qualified" \
+      CONFIG_ONLY_COMPAT_KEY="config-key" \
+      get_agent_command 'openai-compatible-agent:vendor/exact-model' review code-reviewer
+} 2>/dev/null || true)"
+if assert_contains "$qualified_cmd" "--base-url https://config-only.invalid/v1" "provider-file base URL" &&
+   assert_contains "$qualified_cmd" "--api-key-env CONFIG_ONLY_COMPAT_KEY" "provider-file credential name" &&
+   assert_contains "$qualified_cmd" "--model vendor/exact-model" "exact qualified model"; then
+    test_pass
+fi
+
 test_case "openai-compatible review dispatch disables model tools"
 cmd=$(HOME="$TEST_HOME" USER="octo-test-$$" CLAUDE_CODE_SESSION="compat-review-no-tools" PWD="/tmp/octo-cwd" OPENAI_COMPAT_MODEL="vendor/model-fast" get_agent_command openai-compatible-agent review code-reviewer 2>/dev/null)
 if assert_contains "$cmd" "--tool-policy none" "review tool policy"; then

--- a/tests/unit/test-openai-compatible-provider-config.sh
+++ b/tests/unit/test-openai-compatible-provider-config.sh
@@ -14,7 +14,12 @@ mkdir -p "$HOME/.claude-octopus/config"
 export PLUGIN_DIR="$PROJECT_ROOT"
 export PWD="$TEST_TMP_DIR/project"
 mkdir -p "$PWD"
-log() { :; }
+log() {
+  local level="$1"
+  shift
+  [[ "$level" == ERROR ]] && printf '[%s] %s\n' "$level" "$*" >&2
+  return 0
+}
 get_agent_model() { printf '%s\n' 'deepseek-ai/DeepSeek-V4-Pro'; }
 validate_model_name() { return 0; }
 octopus_resolve_reasoning_level() { printf '%s\n' 'none'; }
@@ -65,10 +70,13 @@ write_config <<'JSON'
 {"providers":{"openai-compatible-agent":{"default":"deepseek-ai/DeepSeek-V4-Pro","base_url":"http://api.example.com/v1","api_key_env":"DEEPSEEK_API_KEY"}}}
 JSON
 export DEEPSEEK_API_KEY="test-secret"
-if get_agent_command openai-compatible-agent tangle implementer >/dev/null 2>&1; then
+http_error="$TEST_TMP_DIR/public-http.err"
+if get_agent_command openai-compatible-agent tangle implementer >/dev/null 2>"$http_error"; then
   test_fail "credentialed public HTTP endpoint was accepted"
-else
+elif grep -Fc "requires HTTPS for non-loopback endpoints" "$http_error" >/dev/null; then
   test_pass
+else
+  test_fail "credentialed public HTTP endpoint failed for an unexpected reason"
 fi
 
 test_case "loopback HTTP endpoints remain available for local development"
@@ -88,10 +96,13 @@ test_case "lookalike loopback authority cannot bypass HTTPS"
 write_config <<'JSON'
 {"providers":{"openai-compatible-agent":{"default":"deepseek-ai/DeepSeek-V4-Pro","base_url":"http://localhost:8000@api.example.com/v1","api_key_env":"DEEPSEEK_API_KEY"}}}
 JSON
-if get_agent_command openai-compatible-agent tangle implementer >/dev/null 2>&1; then
+lookalike_error="$TEST_TMP_DIR/lookalike-http.err"
+if get_agent_command openai-compatible-agent tangle implementer >/dev/null 2>"$lookalike_error"; then
   test_fail "lookalike loopback authority was accepted"
-else
+elif grep -Fc "requires HTTPS for non-loopback endpoints" "$lookalike_error" >/dev/null; then
   test_pass
+else
+  test_fail "lookalike loopback authority failed for an unexpected reason"
 fi
 
 test_case "legacy environment fallback remains supported"

--- a/tests/unit/test-openai-compatible-provider-config.sh
+++ b/tests/unit/test-openai-compatible-provider-config.sh
@@ -60,6 +60,40 @@ else
   test_pass
 fi
 
+test_case "credentialed public HTTP endpoint is rejected before helper launch"
+write_config <<'JSON'
+{"providers":{"openai-compatible-agent":{"default":"deepseek-ai/DeepSeek-V4-Pro","base_url":"http://api.example.com/v1","api_key_env":"DEEPSEEK_API_KEY"}}}
+JSON
+export DEEPSEEK_API_KEY="test-secret"
+if get_agent_command openai-compatible-agent tangle implementer >/dev/null 2>&1; then
+  test_fail "credentialed public HTTP endpoint was accepted"
+else
+  test_pass
+fi
+
+test_case "loopback HTTP endpoints remain available for local development"
+loopback_ok=true
+for loopback_url in http://localhost:8000/v1 http://127.0.0.1:8000/v1; do
+  printf '%s\n' '{"providers":{"openai-compatible-agent":{"default":"deepseek-ai/DeepSeek-V4-Pro","base_url":"'"$loopback_url"'","api_key_env":"DEEPSEEK_API_KEY"}}}' > "$HOME/.claude-octopus/config/providers.json"
+  cmd=$(get_agent_command openai-compatible-agent tangle implementer)
+  [[ "$cmd" == *"--base-url $loopback_url"* ]] || loopback_ok=false
+done
+if [[ "$loopback_ok" == true ]]; then
+  test_pass
+else
+  test_fail "a loopback OpenAI-compatible endpoint was rejected"
+fi
+
+test_case "lookalike loopback authority cannot bypass HTTPS"
+write_config <<'JSON'
+{"providers":{"openai-compatible-agent":{"default":"deepseek-ai/DeepSeek-V4-Pro","base_url":"http://localhost:8000@api.example.com/v1","api_key_env":"DEEPSEEK_API_KEY"}}}
+JSON
+if get_agent_command openai-compatible-agent tangle implementer >/dev/null 2>&1; then
+  test_fail "lookalike loopback authority was accepted"
+else
+  test_pass
+fi
+
 test_case "legacy environment fallback remains supported"
 write_config <<'JSON'
 {"providers":{"openai-compatible-agent":{"default":"deepseek-ai/DeepSeek-V4-Pro"}}}

--- a/tests/unit/test-proof-packet.sh
+++ b/tests/unit/test-proof-packet.sh
@@ -140,6 +140,36 @@ else
     test_fail "octo_proof_capture_provider_status is not defined"
 fi
 
+test_case "provider status capture preserves distinct model identities"
+if declare -F octo_proof_capture_provider_status >/dev/null 2>&1; then
+    tmp_home=$(mktemp -d)
+    HOME="$tmp_home"
+    OCTOPUS_PROOF_ROOT="$tmp_home/proofs"
+    OCTOPUS_PROOF_RUN_ID="provider-models"
+    run_dir=$(octo_proof_init "review" "goal" '{}')
+    status_file="$tmp_home/provider-model-status.txt"
+    {
+        echo "v2|commandcode|model-one.v1|ok|Round 1 findings"
+        echo "v2|commandcode|model-two.v2|fallback|Round 1 failed"
+    } > "$status_file"
+    octo_proof_capture_provider_status "$run_dir" "$status_file"
+    if jq -s -e '
+        [.[] | select(.type == "provider_status" and .data.provider == "commandcode") | .data.model]
+        | sort == ["model-one.v1", "model-two.v2"]
+      ' "$run_dir/proof.jsonl" >/dev/null \
+       && jq -s -e '
+        [.[] | select(.type == "provider_substitution" and .data.provider == "commandcode" and .data.model == "model-two.v2")]
+        | length == 1
+      ' "$run_dir/proof.jsonl" >/dev/null; then
+        test_pass
+    else
+        test_fail "proof packet collapsed or misparsed model-qualified provider status"
+    fi
+    rm -rf "$tmp_home"
+else
+    test_fail "octo_proof_capture_provider_status is not defined"
+fi
+
 test_case "finalize updates state and writes markdown summary"
 if declare -F octo_proof_finalize >/dev/null 2>&1; then
     tmp_home=$(mktemp -d)

--- a/tests/unit/test-proof-packet.sh
+++ b/tests/unit/test-proof-packet.sh
@@ -35,6 +35,7 @@ else
 fi
 
 for fn in \
+    octo_parse_provider_status_record \
     octo_proof_enabled \
     octo_proof_sanitize_id \
     octo_proof_init \
@@ -47,6 +48,42 @@ for fn in \
 do
     assert_function_exists "$fn"
 done
+
+test_case "shared provider-status parser preserves v2 legacy and failure contracts"
+if declare -F octo_parse_provider_status_record >/dev/null 2>&1; then
+    parser_ok=true
+    octo_parse_provider_status_record 'v2|commandcode|model-one.v1|fallback|detail|with|pipes' || parser_ok=false
+    [[ "${OCTO_PROVIDER_STATUS_PROVIDER:-}" == commandcode && \
+       "${OCTO_PROVIDER_STATUS_MODEL:-}" == model-one.v1 && \
+       "${OCTO_PROVIDER_STATUS_VALUE:-}" == fallback && \
+       "${OCTO_PROVIDER_STATUS_DETAIL:-}" == 'detail|with|pipes' ]] || parser_ok=false
+
+    octo_parse_provider_status_record 'codex|auth-failed|legacy|detail|with|pipes' || parser_ok=false
+    [[ "${OCTO_PROVIDER_STATUS_PROVIDER:-}" == codex && \
+       -z "${OCTO_PROVIDER_STATUS_MODEL:-}" && \
+       "${OCTO_PROVIDER_STATUS_VALUE:-}" == auth-failed && \
+       "${OCTO_PROVIDER_STATUS_DETAIL:-}" == 'legacy|detail|with|pipes' ]] || parser_ok=false
+
+    OCTO_PROVIDER_STATUS_PROVIDER=stale
+    OCTO_PROVIDER_STATUS_MODEL=stale
+    OCTO_PROVIDER_STATUS_VALUE=stale
+    OCTO_PROVIDER_STATUS_DETAIL=stale
+    empty_rc=0
+    octo_parse_provider_status_record '' || empty_rc=$?
+    [[ "$empty_rc" -eq 1 && \
+       -z "${OCTO_PROVIDER_STATUS_PROVIDER:-}" && \
+       -z "${OCTO_PROVIDER_STATUS_MODEL:-}" && \
+       -z "${OCTO_PROVIDER_STATUS_VALUE:-}" && \
+       -z "${OCTO_PROVIDER_STATUS_DETAIL:-}" ]] || parser_ok=false
+
+    if [[ "$parser_ok" == true ]]; then
+        test_pass
+    else
+        test_fail "shared provider-status parser changed field or failure semantics"
+    fi
+else
+    test_fail "shared provider-status parser is unavailable"
+fi
 
 test_case "OCTOPUS_PROOF_PACKET=0 disables proof packets"
 if declare -F octo_proof_enabled >/dev/null 2>&1; then
@@ -164,6 +201,29 @@ if declare -F octo_proof_capture_provider_status >/dev/null 2>&1; then
         test_pass
     else
         test_fail "proof packet collapsed or misparsed model-qualified provider status"
+    fi
+    rm -rf "$tmp_home"
+else
+    test_fail "octo_proof_capture_provider_status is not defined"
+fi
+
+test_case "provider status capture delegates malformed-record handling to the shared parser"
+if declare -F octo_proof_capture_provider_status >/dev/null 2>&1; then
+    tmp_home=$(mktemp -d)
+    HOME="$tmp_home"
+    OCTOPUS_PROOF_ROOT="$tmp_home/proofs"
+    OCTOPUS_PROOF_RUN_ID="provider-parser-delegation"
+    run_dir=$(octo_proof_init "review" "goal" '{}')
+    status_file="$tmp_home/provider-status-delegation.txt"
+    printf '%s\n' 'v2|commandcode|model-one.v1|ok|completed' > "$status_file"
+    octo_parse_provider_status_record() { return 1; }
+    octo_proof_capture_provider_status "$run_dir" "$status_file"
+    provider_event_count=$(jq -s '[.[] | select(.type == "provider_status")] | length' "$run_dir/proof.jsonl")
+    unset -f octo_parse_provider_status_record
+    if [[ "$provider_event_count" -eq 0 ]]; then
+        test_pass
+    else
+        test_fail "proof packet bypassed the shared provider-status parser"
     fi
     rm -rf "$tmp_home"
 else

--- a/tests/unit/test-provider-neutral-council.sh
+++ b/tests/unit/test-provider-neutral-council.sh
@@ -58,13 +58,13 @@ case "$provider_ids" in
     ;;
 esac
 
-test_case "review council emits four seats in deterministic policy order"
+test_case "review fleet inspection emits all eight effective seats in deterministic order"
 seat_count="$(printf '%s\n' "$provider_ids" | sed '/^$/d' | wc -l | tr -d ' ')"
-expected_provider_ids="$(printf '%s\n' claude-sonnet codex commandcode claude-sonnet)"
-if [[ "$seat_count" != "4" ]]; then
-  test_fail "expected four review seats, got $seat_count: $output"
+expected_provider_ids="$(printf '%s\n' claude-sonnet codex commandcode claude-sonnet codex codex codex claude-sonnet)"
+if [[ "$seat_count" != "8" ]]; then
+  test_fail "expected eight review seats, got $seat_count: $output"
 elif [[ "$provider_ids" != "$expected_provider_ids" ]]; then
-  test_fail "expected provider order [claude-sonnet,codex,commandcode,claude-sonnet], got [$(printf '%s' "$provider_ids" | paste -sd, -)]"
+  test_fail "unexpected effective provider order: [$(printf '%s' "$provider_ids" | paste -sd, -)]"
 else
   test_pass
 fi
@@ -79,7 +79,7 @@ fi
 test_case "review seats remain role labels rather than provider identities"
 labels="$(echo "$output" | cut -d'|' -f2 | tr '\n' '|')"
 case "$labels" in
-  *"Logic Reviewer"*"Security Reviewer"*"Architecture Reviewer"*"CVE Reviewer"*) test_pass ;;
+  *"Logic Reviewer"*"Security Reviewer"*"Architecture Reviewer"*"CVE Reviewer"*"Diversity Reviewer"*"Verifier"*"Debater"*"Synthesizer"*) test_pass ;;
   *) test_fail "review role labels changed: $labels" ;;
 esac
 

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -380,10 +380,16 @@ multiline_prompt=$'line one\r\nPROJECT_DOCUMENTATION_PATH:\r/data/example\nline 
 fleet_output="$(bash "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" review standard "$multiline_prompt" 2>/dev/null)"
 record_count="$(printf '%s\n' "$fleet_output" | grep -c '|')"
 line_count="$(printf '%s\n' "$fleet_output" | wc -l | tr -d ' ')"
-if [[ "$record_count" -eq 4 && "$line_count" -eq 4 ]] && ! printf '%s\n' "$fleet_output" | grep -q '^PROJECT_DOCUMENTATION_PATH:$' && ! printf '%s' "$fleet_output" | grep -q $'\r'; then
+expected_labels=$'Logic Reviewer\nSecurity Reviewer\nArchitecture Reviewer\nCVE Reviewer\nDiversity Reviewer\nVerifier\nDebater\nSynthesizer'
+actual_labels="$(printf '%s\n' "$fleet_output" | cut -d'|' -f2)"
+expected_count="$(printf '%s\n' "$expected_labels" | wc -l | tr -d ' ')"
+if [[ "$record_count" -eq "$expected_count" && "$line_count" -eq "$expected_count" ]] && \
+   [[ "$actual_labels" == "$expected_labels" ]] && \
+   ! printf '%s\n' "$fleet_output" | grep -q '^PROJECT_DOCUMENTATION_PATH:$' && \
+   ! printf '%s' "$fleet_output" | grep -q $'\r'; then
   test_pass
 else
-  test_fail "multiline prompt escaped fleet record boundaries: records=$record_count lines=$line_count"
+  test_fail "review fleet records did not match the eight semantic seats: records=$record_count lines=$line_count labels=[$(tr '\n' ';' <<< "$actual_labels")]"
 fi
 
 test_summary

--- a/tests/unit/test-review-provider-report.sh
+++ b/tests/unit/test-review-provider-report.sh
@@ -108,8 +108,14 @@ else
 fi
 
 test_case "single-provider override keeps every review phase on the requested provider"
-override_fleet="$(OCTO_ALLOWED_PROVIDERS=openai-compatible-agent AVAILABLE_AGENTS=openai-compatible-agent OCTOPUS_REVIEW_SINGLE_PROVIDER=openai-compatible-agent build_review_fleet)"
-override_phase="$(OCTO_ALLOWED_PROVIDERS=openai-compatible-agent AVAILABLE_AGENTS=openai-compatible-agent OCTOPUS_REVIEW_SINGLE_PROVIDER=openai-compatible-agent review_phase_provider claude-sonnet)"
+override_fleet="$({
+    review_single_provider_is_available() { [[ "$1" == openai-compatible-agent ]]; }
+    OCTO_ALLOWED_PROVIDERS=openai-compatible-agent OCTOPUS_REVIEW_SINGLE_PROVIDER=openai-compatible-agent build_review_fleet
+})"
+override_phase="$({
+    review_single_provider_is_available() { [[ "$1" == openai-compatible-agent ]]; }
+    OCTO_ALLOWED_PROVIDERS=openai-compatible-agent OCTOPUS_REVIEW_SINGLE_PROVIDER=openai-compatible-agent review_phase_provider claude-sonnet
+})"
 debate_block="$(sed -n '/# ── Debate gate/,/# ── ROUND 3/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
 if [[ "$(wc -l <<< "$override_fleet" | tr -d ' ')" -eq 1 ]] &&
    [[ "$override_fleet" == openai-compatible-agent:general-reviewer:* ]] &&
@@ -129,6 +135,34 @@ if [[ "$override_rc" -ne 0 && -z "$override_output" ]]; then
     test_pass
 else
     test_fail "override was accepted without an availability authority: rc=$override_rc output=[$override_output]"
+fi
+
+test_case "static provider inventory is not live availability authority"
+override_rc=0
+override_output="$({
+    is_agent_available_v2() { return 1; }
+    AVAILABLE_AGENTS=perplexity \
+        OCTO_ALLOWED_PROVIDERS=perplexity \
+        OCTOPUS_REVIEW_SINGLE_PROVIDER=perplexity \
+        review_single_provider_override 2>/dev/null
+})" || override_rc=$?
+if [[ "$override_rc" -ne 0 && -z "$override_output" ]]; then
+    test_pass
+else
+    test_fail "static inventory admitted an unavailable provider: rc=$override_rc output=[$override_output]"
+fi
+
+test_case "shared live resolver may admit a non-host single provider"
+override_output="$({
+    is_agent_available_v2() { [[ "$1" == perplexity ]]; }
+    OCTO_ALLOWED_PROVIDERS=perplexity \
+        OCTOPUS_REVIEW_SINGLE_PROVIDER=perplexity \
+        review_single_provider_override 2>/dev/null
+})"
+if [[ "$override_output" == perplexity ]]; then
+    test_pass
+else
+    test_fail "live resolver did not admit the available provider: output=[$override_output]"
 fi
 
 test_case "review provider mapping keeps claude-sdk before the broad Claude glob"

--- a/tests/unit/test-review-provider-report.sh
+++ b/tests/unit/test-review-provider-report.sh
@@ -152,6 +152,26 @@ else
     test_fail "provider report omitted or mis-keyed a contextual provider: $report"
 fi
 
+test_case "provider report keeps distinct models from the same provider"
+: > "$status_file"
+review_append_provider_status "$status_file" 'commandcode:model-one.v1' implementation-logic-reviewer ok completed
+review_append_provider_status "$status_file" 'commandcode:model-two.v2' implementation-security-reviewer fallback 'second model failed'
+status_records="$(cat "$status_file")"
+report="$(env "HOME=${TEST_TMP_DIR}" bash -c '
+    source "$1/scripts/lib/provider-registry.sh"
+    source "$1/scripts/lib/review.sh"
+    print_provider_report "$2"
+' _ "$PROJECT_ROOT" "$status_file")"
+if [[ "$status_records" == *'v2|commandcode|model-one.v1|ok|completed'* ]] && \
+   [[ "$status_records" == *'v2|commandcode|model-two.v2|fallback|second model failed'* ]] && \
+   grep -Eq 'Commandcode/model-one\.v1:.*OK' <<< "$report" && \
+   grep -Eq 'Commandcode/model-two\.v2:.*FALLBACK' <<< "$report" && \
+   [[ "$(grep -cE 'Commandcode/model-(one\.v1|two\.v2):' <<< "$report")" -eq 2 ]]; then
+    test_pass
+else
+    test_fail "same-provider model identities collapsed in report: $report"
+fi
+
 test_case "synthesis lifecycle event uses the canonical provider key"
 synthesis_event="$(sed -n '/# #498: emit a synthesis lifecycle event/,/if \[\[ -n "$proof_dir" \]\]/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
 if grep -Fq 'provider="$synthesis_provider_key"' <<< "$synthesis_event" && \

--- a/tests/unit/test-review-provider-report.sh
+++ b/tests/unit/test-review-provider-report.sh
@@ -133,4 +133,32 @@ else
     test_fail "Copilot provider failure was hidden or truncated: $report"
 fi
 
+test_case "provider report renders admitted contextual providers with canonical keys"
+printf '%s\n' \
+  'vibe|ok|completed' \
+  'atlas-cloud|fallback|Atlas request failed' \
+  'anthropic|ok|completed' > "$status_file"
+report="$(env "HOME=${TEST_TMP_DIR}" bash -c '
+    source "$1/scripts/lib/provider-registry.sh"
+    source "$1/scripts/lib/review.sh"
+    print_provider_report "$2"
+' _ "$PROJECT_ROOT" "$status_file")"
+if grep -Eq 'Vibe:[[:space:]]+.*OK' <<< "$report" && \
+   grep -Eq 'Atlascloud:[[:space:]]+.*FALLBACK' <<< "$report" && \
+   grep -Eq 'Claude:[[:space:]]+.*OK' <<< "$report" && \
+   [[ "$report" == *'Atlas request failed'* ]]; then
+    test_pass
+else
+    test_fail "provider report omitted or mis-keyed a contextual provider: $report"
+fi
+
+test_case "synthesis lifecycle event uses the canonical provider key"
+synthesis_event="$(sed -n '/# #498: emit a synthesis lifecycle event/,/if \[\[ -n "$proof_dir" \]\]/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
+if grep -Fq 'provider="$synthesis_provider_key"' <<< "$synthesis_event" && \
+   ! grep -Fq 'provider="$synthesis_provider"' <<< "$synthesis_event"; then
+    test_pass
+else
+    test_fail "synthesis event does not use the canonical provider key"
+fi
+
 test_summary

--- a/tests/unit/test-review-provider-report.sh
+++ b/tests/unit/test-review-provider-report.sh
@@ -108,8 +108,8 @@ else
 fi
 
 test_case "single-provider override keeps every review phase on the requested provider"
-override_fleet="$(OCTOPUS_REVIEW_SINGLE_PROVIDER=openai-compatible-agent build_review_fleet)"
-override_phase="$(OCTOPUS_REVIEW_SINGLE_PROVIDER=openai-compatible-agent review_phase_provider claude-sonnet)"
+override_fleet="$(OCTO_ALLOWED_PROVIDERS=openai-compatible-agent AVAILABLE_AGENTS=openai-compatible-agent OCTOPUS_REVIEW_SINGLE_PROVIDER=openai-compatible-agent build_review_fleet)"
+override_phase="$(OCTO_ALLOWED_PROVIDERS=openai-compatible-agent AVAILABLE_AGENTS=openai-compatible-agent OCTOPUS_REVIEW_SINGLE_PROVIDER=openai-compatible-agent review_phase_provider claude-sonnet)"
 debate_block="$(sed -n '/# ── Debate gate/,/# ── ROUND 3/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
 if [[ "$(wc -l <<< "$override_fleet" | tr -d ' ')" -eq 1 ]] &&
    [[ "$override_fleet" == openai-compatible-agent:general-reviewer:* ]] &&
@@ -120,6 +120,15 @@ if [[ "$(wc -l <<< "$override_fleet" | tr -d ' ')" -eq 1 ]] &&
     test_pass
 else
     test_fail "single-provider review escaped to another provider: fleet=$override_fleet phase=$override_phase"
+fi
+
+test_case "single-provider override fails closed without caller availability authority"
+override_rc=0
+override_output="$(unset AVAILABLE_AGENTS; OCTO_ALLOWED_PROVIDERS=openai-compatible-agent OCTOPUS_REVIEW_SINGLE_PROVIDER=openai-compatible-agent review_single_provider_override 2>/dev/null)" || override_rc=$?
+if [[ "$override_rc" -ne 0 && -z "$override_output" ]]; then
+    test_pass
+else
+    test_fail "override was accepted without an availability authority: rc=$override_rc output=[$override_output]"
 fi
 
 test_case "review provider mapping keeps claude-sdk before the broad Claude glob"
@@ -194,6 +203,43 @@ if [[ "$status_records" == *'v2|commandcode|model-one.v1|ok|completed'* ]] && \
     test_pass
 else
     test_fail "same-provider model identities collapsed in report: $report"
+fi
+
+test_case "v2 provider status keeps exact OpenAI-compatible registry identities"
+: > "$status_file"
+for exact_provider in openai-compatible openai-tools openai-compatible-agent; do
+    review_append_provider_status "$status_file" "${exact_provider}:shared-model" implementation-logic-reviewer ok completed
+done
+status_records="$(cat "$status_file")"
+report="$(env "HOME=${TEST_TMP_DIR}" bash -c '
+    source "$1/scripts/lib/provider-registry.sh"
+    source "$1/scripts/lib/review.sh"
+    print_provider_report "$2"
+' _ "$PROJECT_ROOT" "$status_file")"
+if [[ "$status_records" == *'v2|openai-compatible|shared-model|ok|completed'* ]] && \
+   [[ "$status_records" == *'v2|openai-tools|shared-model|ok|completed'* ]] && \
+   [[ "$status_records" == *'v2|openai-compatible-agent|shared-model|ok|completed'* ]] && \
+   [[ "$(grep -cE 'Openai-(compatible|tools|compatible-agent)/shared-model:.*OK' <<< "$report")" -eq 3 ]]; then
+    test_pass
+else
+    test_fail "exact v2 provider identities collided: records=[$status_records] report=[$report]"
+fi
+
+test_case "legacy OpenAI-compatible status still aggregates by provider family"
+printf '%s\n' \
+  'openai-compatible|ok|completed' \
+  'openai-tools|fallback|tool loop failed' \
+  'openai-compatible-agent|ok|completed' > "$status_file"
+report="$(env "HOME=${TEST_TMP_DIR}" bash -c '
+    source "$1/scripts/lib/provider-registry.sh"
+    source "$1/scripts/lib/review.sh"
+    print_provider_report "$2"
+' _ "$PROJECT_ROOT" "$status_file")"
+if [[ "$(grep -cE 'Compatible:[[:space:]]+' <<< "$report")" -eq 1 ]] && \
+   ! grep -Eq 'Openai-(tools|compatible-agent):' <<< "$report"; then
+    test_pass
+else
+    test_fail "legacy provider family status stopped aggregating: $report"
 fi
 
 test_case "synthesis lifecycle event uses the canonical provider key"

--- a/tests/unit/test-review-provider-report.sh
+++ b/tests/unit/test-review-provider-report.sh
@@ -13,6 +13,30 @@ test_suite "Review provider report"
 
 status_file="$TEST_TMP_DIR/provider-status.txt"
 
+test_case "review provider-status parsing delegates to the shared parser"
+if (
+    octo_parse_provider_status_record() {
+        OCTO_PROVIDER_STATUS_PROVIDER=commandcode
+        OCTO_PROVIDER_STATUS_MODEL=model-one.v1
+        OCTO_PROVIDER_STATUS_VALUE=fallback
+        OCTO_PROVIDER_STATUS_DETAIL='shared parser detail'
+        return 0
+    }
+    review_parse_provider_status_record 'ignored|input|that|must|not be parsed locally' &&
+    [[ "$REVIEW_STATUS_PROVIDER" == commandcode &&
+       "$REVIEW_STATUS_MODEL" == model-one.v1 &&
+       "$REVIEW_STATUS_VALUE" == fallback &&
+       "$REVIEW_STATUS_DETAIL" == 'shared parser detail' ]] || exit 1
+    octo_parse_provider_status_record() { return 73; }
+    parse_rc=0
+    review_parse_provider_status_record 'ignored|input' || parse_rc=$?
+    [[ "$parse_rc" -eq 73 ]]
+); then
+    test_pass
+else
+    test_fail "review parser bypassed the shared provider-status parser"
+fi
+
 test_case "Claude is not reported healthy without a successful execution"
 printf '%s\n' 'codex|fallback|Round 1 agent did not complete successfully' > "$status_file"
 report="$(env "HOME=${TEST_TMP_DIR}" bash -c '

--- a/tests/unit/test-review-round1-spawn-failure.sh
+++ b/tests/unit/test-review-round1-spawn-failure.sh
@@ -60,6 +60,7 @@ gemini:reviewer2:style"'
         echo 'log() { :; }'
         echo 'fleet_dispatch_begin() { :; }'
         echo 'fleet_dispatch_end() { :; }'
+        echo 'review_agent_for_seat() { printf "%s\n" "$1"; }'
         # First fleet member fails PID capture (the #736 scenario); second succeeds.
         echo 'spawn_agent_capture_pid() {'
         echo '    if [[ "$1" == "codex" ]]; then'

--- a/tests/unit/test-review-round1-spawn-failure.sh
+++ b/tests/unit/test-review-round1-spawn-failure.sh
@@ -92,4 +92,46 @@ gemini:reviewer2:style"'
     fi
 fi
 
+test_case "provider fleet proof records resolved exact Round 1 identities"
+
+LOOP_SRC=$(sed -n '/^    fleet_dispatch_begin$/,/^    fleet_dispatch_end$/p' "$REVIEW_SH")
+if [[ -z "$LOOP_SRC" ]]; then
+    test_fail "could not extract the Round 1 dispatch loop from review.sh (source drift?)"
+else
+    PROOF_HARNESS="$TEST_TMP_DIR/proof-harness.sh"
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'set -eo pipefail'
+        printf 'source %q\n' "$PROJECT_ROOT/scripts/lib/agent-spec.sh"
+        echo 'RESULTS_DIR="'"$TEST_TMP_DIR"'"'
+        echo 'timestamp="ts-proof"'
+        echo 'fleet="codex:reviewer1:logic
+claude-sonnet:reviewer2:architecture"'
+        echo 'round1_files=(); round1_agent_types=(); round1_roles=(); round1_task_ids=(); round1_prompts=(); round1_pids=()'
+        echo 'agent_prompt_base="base prompt"'
+        echo 'proof_dir="proof-enabled"'
+        echo 'log() { :; }'
+        echo 'fleet_dispatch_begin() { :; }'
+        echo 'fleet_dispatch_end() { :; }'
+        echo 'review_agent_for_seat() {'
+        echo '    if [[ "$2" == "reviewer1" ]]; then printf "%s\n" "commandcode:model-exact"; else printf "%s\n" "$1"; fi'
+        echo '}'
+        echo 'spawn_agent_capture_pid() { echo 424242; }'
+        echo 'octo_proof_event() { printf "proof_type=%s\nproof_data=%s\n" "$2" "$3"; }'
+        echo 'run_round1() {'
+        printf '%s\n' "$LOOP_SRC"
+        echo '}'
+        echo 'run_round1'
+    } > "$PROOF_HARNESS"
+
+    if PROOF_OUT=$(bash "$PROOF_HARNESS" 2>&1) && \
+       [[ "$PROOF_OUT" == *'proof_type=provider_fleet'* ]] && \
+       [[ "$PROOF_OUT" == *'["commandcode:model-exact","claude-sonnet"]'* ]] && \
+       [[ "$PROOF_OUT" != *'["codex","claude-sonnet"]'* ]]; then
+        test_pass
+    else
+        test_fail "provider_fleet proof did not capture resolved identities: ${PROOF_OUT:-<empty>}"
+    fi
+fi
+
 test_summary

--- a/tests/unit/test-review-round1-spawn-failure.sh
+++ b/tests/unit/test-review-round1-spawn-failure.sh
@@ -134,4 +134,52 @@ claude-sonnet:reviewer2:architecture"'
     fi
 fi
 
+test_case "invalid fleet override finalizes proof and removes provider status under set -e"
+
+LIFECYCLE_DIR="$TEST_TMP_DIR/fleet-validation-lifecycle"
+mkdir -p "$LIFECYCLE_DIR/tmp" "$LIFECYCLE_DIR/results" "$LIFECYCLE_DIR/proof"
+LIFECYCLE_HARNESS="$LIFECYCLE_DIR/harness.sh"
+{
+    echo '#!/usr/bin/env bash'
+    echo 'set -eo pipefail'
+    printf 'export HOME=%q\n' "$LIFECYCLE_DIR/home"
+    printf 'export TMPDIR=%q\n' "$LIFECYCLE_DIR/tmp"
+    printf 'export RESULTS_DIR=%q\n' "$LIFECYCLE_DIR/results"
+    printf 'export PROOF_DIR=%q\n' "$LIFECYCLE_DIR/proof"
+    echo "export OCTOPUS_REVIEW_LOGIC_AGENT='invalid-override'"
+    printf 'source %q\n' "$REVIEW_SH"
+    echo 'log() { printf "%s: %s\n" "$1" "$2" >&2; }'
+    echo 'check_codex_auth_freshness() { return 0; }'
+    echo 'parse_review_md() { REVIEW_ALWAYS_CHECK=""; REVIEW_STYLE_RULES=""; REVIEW_SKIP_PATTERNS=""; }'
+    echo 'review_collect_diff() { printf "%s\n" "diff --git a/a b/a" "+changed"; }'
+    echo 'octo_proof_enabled() { return 0; }'
+    echo 'octo_proof_init() { mkdir -p "$PROOF_DIR"; printf "%s\n" "$PROOF_DIR"; }'
+    echo 'octo_proof_event() { :; }'
+    echo 'octo_proof_artifact() { cp "$3" "$PROOF_DIR/findings.json"; }'
+    echo 'octo_proof_capture_provider_status() {'
+    echo '    [[ -f "$2" ]] || return 91'
+    echo '    printf "captured=%s\n" "$2" > "$PROOF_DIR/provider-status-captured"'
+    echo '}'
+    echo 'octo_proof_finalize() {'
+    echo '    printf "status=%s\nsummary=%s\n" "$2" "$3" > "$PROOF_DIR/finalized"'
+    echo '}'
+    echo 'render_terminal_report() { :; }'
+    echo 'review_run "{}"'
+} > "$LIFECYCLE_HARNESS"
+
+lifecycle_rc=0
+/bin/bash "$LIFECYCLE_HARNESS" >"$LIFECYCLE_DIR/output" 2>&1 || lifecycle_rc=$?
+status_file_count="$(find "$LIFECYCLE_DIR/tmp" -name 'octopus-provider-status.*' -type f | wc -l | tr -d ' ')"
+if [[ "$lifecycle_rc" -eq 2 ]] && \
+   grep -Fq 'status=fail' "$LIFECYCLE_DIR/proof/finalized" 2>/dev/null && \
+   grep -Fq 'Review fleet validation failed with status 2.' "$LIFECYCLE_DIR/proof/finalized" 2>/dev/null && \
+   [[ -s "$LIFECYCLE_DIR/proof/provider-status-captured" ]] && \
+   jq -e '.findings == [] and (.warning | contains("Review fleet validation failed"))' \
+      "$LIFECYCLE_DIR/proof/findings.json" >/dev/null 2>&1 && \
+   [[ "$status_file_count" -eq 0 ]]; then
+    test_pass
+else
+    test_fail "invalid fleet lifecycle was incomplete: rc=$lifecycle_rc temp_status_files=$status_file_count output=[$(tr '\n' ';' < "$LIFECYCLE_DIR/output")]"
+fi
+
 test_summary

--- a/tests/unit/test-spawn-run-contract.sh
+++ b/tests/unit/test-spawn-run-contract.sh
@@ -284,8 +284,12 @@ get_agent_command() {
         octo_real_get_agent_command "$@"
         return
     fi
+    local command_model="routed-model"
+    if [[ "${1:-}" == *:* ]]; then
+        command_model="${1#*:}"
+    fi
     printf '%s\n' "${4:-missing}" > "$TEST_TMP_DIR/background-prompt-bytes"
-    printf '%s\n' "$fake_provider --model routed-model"
+    printf '%s\n' "$fake_provider --model $command_model"
 }
 validate_agent_command() {
     if [[ "$1" == "$fake_provider "* || "$1" == "$fake_provider" ]]; then
@@ -295,6 +299,10 @@ validate_agent_command() {
 }
 get_agent_model() {
     [[ "${FAKE_SCENARIO:-}" == model-fail ]] && return 1
+    if [[ "${1:-}" == *:* ]]; then
+        printf '%s\n' "${1#*:}"
+        return 0
+    fi
     printf '%s\n' fixture-model
 }
 record_agent_call() { :; }
@@ -336,9 +344,10 @@ octopus_capture_provider_output() {
 }
 
 run_external_fixture() {
-    local scenario="$1" task="$2" pid
+    local scenario="$1" task="$2" agent_type="${3:-fake-api}"
+    local role="${4:-reviewer}" phase="${5:-probe}" pid
     export FAKE_SCENARIO="$scenario"
-    pid="$(spawn_agent fake-api "External $scenario fixture" "$task" reviewer probe)" || return $?
+    pid="$(spawn_agent "$agent_type" "External $scenario fixture" "$task" "$role" "$phase")" || return $?
     wait "$pid" 2>/dev/null || true
 }
 
@@ -392,6 +401,25 @@ if [[ "$external_success_transitions" == "planned,starting,authenticated,running
     test_pass
 else
     test_fail "supervised success contract mismatch (transitions=${external_success_transitions:-missing}, eligible=$external_success_eligible, model=${external_success_model:-missing}, reason=${external_success_reason:-none})"
+fi
+
+test_case "exact background seat records canonical provider and literal model"
+exact_background_model="thinkingmachines/inkling-small"
+run_external_fixture success external-exact "command-code:${exact_background_model}" \
+    implementation-logic-reviewer review
+if jq -e --arg model "$exact_background_model" '
+    .seats[] |
+    select(.seat_id == "spawn-external-exact") |
+    .requested.provider == "commandcode" and
+    .requested.model == $model and
+    .resolved.provider == "commandcode" and
+    .resolved.model == $model and
+    .execution.phase == "review" and
+    .execution.role == "implementation-logic-reviewer"
+' "$WORKSPACE_DIR/runs/$OCTOPUS_RUN_ID/seats.json" >/dev/null; then
+    test_pass
+else
+    test_fail "exact background lifecycle did not split canonical provider from literal model"
 fi
 
 test_case "background model-resolution failure terminalizes before provider execution"

--- a/tests/unit/test-spawn-run-contract.sh
+++ b/tests/unit/test-spawn-run-contract.sh
@@ -427,6 +427,7 @@ fi
 test_case "exact background Fable SDK seat executes with no retry and retains lifecycle identity"
 sdk_stub_dir="$TEST_TMP_DIR/fable-sdk-bin"
 sdk_capture="$TEST_TMP_DIR/spawn-fable-sdk-capture"
+sdk_health_capture="$TEST_TMP_DIR/spawn-fable-sdk-health-capture"
 mkdir -p "$sdk_stub_dir"
 printf '%s\n' \
     '#!/usr/bin/env bash' \
@@ -438,11 +439,22 @@ chmod 755 "$sdk_stub_dir/claude-agent"
 export SDK_CAPTURE="$sdk_capture" CLAUDE_SDK_API_KEY=fixture-key
 old_path="$PATH"
 PATH="$sdk_stub_dir:$PATH"
-run_external_fixture exact-fable-contract external-exact-fable \
-    'claude-sdk:claude-fable-5' implementation-logic-reviewer review
+eval "$(declare -f check_provider_health | sed '1s/check_provider_health/octo_real_check_provider_health/')"
+check_provider_health() {
+    printf '%s\n' "$1" >> "$sdk_health_capture"
+    octo_real_check_provider_health "$@"
+}
+exact_fable_ran=false
+if run_external_fixture exact-fable-contract external-exact-fable \
+    'claude-sdk:claude-fable-5' implementation-logic-reviewer review; then
+    exact_fable_ran=true
+fi
+eval "$(declare -f octo_real_check_provider_health | sed '1s/octo_real_check_provider_health/check_provider_health/')"
 PATH="$old_path"
 unset CLAUDE_SDK_API_KEY SDK_CAPTURE
-if grep -Fxq 'no_retry=1' "$sdk_capture" && \
+if [[ "$exact_fable_ran" == true ]] && \
+   grep -Fxq 'claude-sdk' "$sdk_health_capture" && \
+   grep -Fxq 'no_retry=1' "$sdk_capture" && \
    grep -Fxq 'claude-fable-5' "$sdk_capture" && \
    jq -e '
        .seats[] |

--- a/tests/unit/test-spawn-run-contract.sh
+++ b/tests/unit/test-spawn-run-contract.sh
@@ -280,10 +280,12 @@ octo_dispatch_command_model() {
 }
 is_provider_available() { return 0; }
 get_agent_command() {
-    if [[ "${FAKE_SCENARIO:-}" == claude-contract ]]; then
-        octo_real_get_agent_command "$@"
-        return
-    fi
+    case "${FAKE_SCENARIO:-}" in
+        claude-contract|exact-fable-contract)
+            octo_real_get_agent_command "$@"
+            return
+            ;;
+    esac
     local command_model="routed-model"
     if [[ "${1:-}" == *:* ]]; then
         command_model="${1#*:}"
@@ -420,6 +422,40 @@ if jq -e --arg model "$exact_background_model" '
     test_pass
 else
     test_fail "exact background lifecycle did not split canonical provider from literal model"
+fi
+
+test_case "exact background Fable SDK seat executes with no retry and retains lifecycle identity"
+sdk_stub_dir="$TEST_TMP_DIR/fable-sdk-bin"
+sdk_capture="$TEST_TMP_DIR/spawn-fable-sdk-capture"
+mkdir -p "$sdk_stub_dir"
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "%s\n" "no_retry=${OCTOPUS_FABLE5_NO_RETRY:-unset}" > "$SDK_CAPTURE"' \
+    'printf "%s\n" "$@" >> "$SDK_CAPTURE"' \
+    'cat >/dev/null' \
+    'printf "%s\n" "Substantive exact Fable background result."' > "$sdk_stub_dir/claude-agent"
+chmod 755 "$sdk_stub_dir/claude-agent"
+export SDK_CAPTURE="$sdk_capture" CLAUDE_SDK_API_KEY=fixture-key
+old_path="$PATH"
+PATH="$sdk_stub_dir:$PATH"
+run_external_fixture exact-fable-contract external-exact-fable \
+    'claude-sdk:claude-fable-5' implementation-logic-reviewer review
+PATH="$old_path"
+unset CLAUDE_SDK_API_KEY SDK_CAPTURE
+if grep -Fxq 'no_retry=1' "$sdk_capture" && \
+   grep -Fxq 'claude-fable-5' "$sdk_capture" && \
+   jq -e '
+       .seats[] |
+       select(.seat_id == "spawn-external-exact-fable") |
+       .requested.provider == "claude-sdk" and
+       .requested.model == "claude-fable-5" and
+       .resolved.provider == "claude-sdk" and
+       .resolved.model == "claude-fable-5" and
+       .transition == "contributed"
+   ' "$WORKSPACE_DIR/runs/$OCTOPUS_RUN_ID/seats.json" >/dev/null; then
+    test_pass
+else
+    test_fail "background exact Fable execution retried or lost its lifecycle identity"
 fi
 
 test_case "background model-resolution failure terminalizes before provider execution"

--- a/tests/unit/test-vibe-provider.sh
+++ b/tests/unit/test-vibe-provider.sh
@@ -43,6 +43,17 @@ else
     test_fail "helper failed unexpectedly: $output"
 fi
 
+test_case "vibe-exec forwards an exact contextual model"
+if output=$(printf 'Reply ACK' | PATH="$MOCK_BIN_DIR:$PATH" OCTOPUS_VIBE_MODEL=mistral-large-latest "$HELPER" --output text 2>&1); then
+    if [[ "$output" == *"--output text --model mistral-large-latest -p Reply ACK"* ]]; then
+        test_pass
+    else
+        test_fail "expected exact model to be forwarded; got: $output"
+    fi
+else
+    test_fail "helper failed unexpectedly: $output"
+fi
+
 test_case "vibe-exec fails clearly on empty stdin prompt"
 set +e
 empty_output=$(printf '' | PATH="$MOCK_BIN_DIR:$PATH" "$HELPER" --output text 2>&1)


### PR DESCRIPTION
Adds explicit provider:model overrides for contextual review seats, following the existing provider-neutral Design Review pattern.\n\nSeats covered: logic, security, architecture, CVE research, diversity, verifier, debater, and synthesizer. Overrides remain allowlist-gated; OCTOPUS_REVIEW_SINGLE_PROVIDER retains global precedence; CommandCode providers are reported correctly.\n\nValidated with targeted review, routing, aggregation, contextual-review-loop, and correction-loop unit suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assign specific provider and model combinations to individual contextual code-review roles.
  * Support exact model selection across review dispatch, previews, lifecycle records, and status reporting.
  * Support CommandCode providers and optional model selection for Vibe execution.
  * Display all eight effective review seats, with role assignments able to extend configured fleets.

* **Bug Fixes**
  * Reject invalid, unavailable, or policy-blocked model assignments before dispatch.
  * Improved provider credential resolution and endpoint validation for OpenAI-compatible models.
  * Improved reliability when capturing provider process IDs fails.

* **Documentation**
  * Documented role-specific overrides, validation rules, model allowlists, and precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->