### PR TITLE
fix(council): isolate the councils pool per session (stop cross-session dir/diagnostic collisions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
   a sibling session's runs appeared as "the newest run", its `run-status.json`
   misled this session's diagnostics, and foreign/duplicate run directories
   collided. The default pool is now namespaced by session
-  (`councils/session-<id>/…`, keyed on the Claude Code session id, falling back to
-  the worktree basename then the pid), so each session owns its runs and the
-  newest directory is always its own. An explicit `--output-dir` is honored
+  (`councils/session-<id>/…`, keyed on the Claude Code or Codex session id, with
+  Codex task id, worktree basename, and pid fallbacks), so each session owns its
+  runs and the newest directory is always its own. An explicit `--output-dir` is honored
   unchanged; set `OCTOPUS_COUNCIL_SHARED_POOL=1` to restore the flat shared pool.
 
 ## [10.1.0] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@
   misled this session's diagnostics, and foreign/duplicate run directories
   collided. The default pool is now namespaced by session
   (`councils/session-<id>/…`, keyed on the Claude Code or Codex session id, with
-  Codex task id, worktree basename, and pid fallbacks), so each session owns its
-  runs and the newest directory is always its own. An explicit `--output-dir` is honored
-  unchanged; set `OCTOPUS_COUNCIL_SHARED_POOL=1` to restore the flat shared pool.
+  Codex task id, worktree basename, and pid fallbacks). This isolates normal
+  sessions while treating fallback and checksum collisions as a best-effort
+  edge case; an explicit `--output-dir` is honored unchanged. Set
+  `OCTOPUS_COUNCIL_SHARED_POOL=1` to restore the flat shared pool.
 
 ## [10.1.0] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 - Make review-fleet construction fail closed when the provider allowlist library cannot be loaded, and remove the unused optional cursor-agent library load.
 - Harden Tangle scope and verification safety: keep repository context out of implicit write authorization, share effective-scope resolution between validation and consolidation, verify overlap repair before worker dispatch, and terminate cleanly after INT/TERM verification cleanup while preserving caller traps.
+- Council runs are isolated per session by default. Concurrent governed sessions
+  on one machine previously shared a single `~/.claude-octopus/councils/` pool, so
+  a sibling session's runs appeared as "the newest run", its `run-status.json`
+  misled this session's diagnostics, and foreign/duplicate run directories
+  collided. The default pool is now namespaced by session
+  (`councils/session-<id>/…`, keyed on the Claude Code session id, falling back to
+  the worktree basename then the pid), so each session owns its runs and the
+  newest directory is always its own. An explicit `--output-dir` is honored
+  unchanged; set `OCTOPUS_COUNCIL_SHARED_POOL=1` to restore the flat shared pool.
 
 ## [10.1.0] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
   misled this session's diagnostics, and foreign/duplicate run directories
   collided. The default pool is now namespaced by session
   (`councils/session-<id>/…`, keyed on the Claude Code or Codex session id, with
-  Codex task id, worktree basename, and pid fallbacks). This isolates normal
-  sessions while treating fallback and checksum collisions as a best-effort
-  edge case; an explicit `--output-dir` is honored unchanged. Set
+  Codex task id, current-working-directory basename, and pid fallbacks). This
+  isolates normal sessions while treating fallback and checksum collisions as a
+  best-effort edge case; an explicit `--output-dir` is honored unchanged. Set
   `OCTOPUS_COUNCIL_SHARED_POOL=1` to restore the flat shared pool.
 
 ## [10.1.0] - 2026-08-30

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2903,8 +2903,8 @@ council_create_run_dir() {
         # otherwise share this single councils/ pool: a sibling session's runs
         # then appear as "the newest run", its run-status.json misleads this
         # session's diagnostics (the reported cross-session confusion), and
-        # foreign/duplicate dirs collide. Namespace the DEFAULT pool by session so
-        # each session owns its runs and the newest dir is always its own. An
+        # foreign/duplicate dirs collide. Namespace the DEFAULT pool by a
+        # best-effort session slug so normal sessions select their own runs. An
         # explicit --output-dir is honored unchanged; OCTOPUS_COUNCIL_SHARED_POOL=1
         # restores the flat shared pool.
         if [[ "${OCTOPUS_COUNCIL_SHARED_POOL:-}" != "1" ]]; then

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -103,6 +103,7 @@ Options:
   --output-dir <path>
 
 Budget values are USD decimal numbers only, for example: 2, 2.00, 0.50.
+Default runs are isolated per session; set OCTOPUS_COUNCIL_SHARED_POOL=1 to share the default pool.
 EOF
 }
 
@@ -2878,7 +2879,9 @@ council_session_slug() {
     local key
     key="$(octo_resolve_session_id "" 2>/dev/null || true)"
     [[ -z "$key" ]] && key="$(basename "$(pwd -P 2>/dev/null)" 2>/dev/null)"
-    [[ -z "$key" || "$key" == "/" || "$key" == "." ]] && key="${BASHPID:-$$}"
+    # Use the stable top-level shell pid. BASHPID changes when this function is
+    # called through command substitution on Bash 4+, producing a new pool per call.
+    [[ -z "$key" || "$key" == "/" || "$key" == "." ]] && key="$$"
     # Sanitizing alone is lossy: distinct ids that differ only in unsafe chars
     # (e.g. "a/b" vs "a?b") would collapse to the same slug and share a pool.
     # Append a checksum of the RAW key to disambiguate them. This is best-effort

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2877,7 +2877,13 @@ council_session_slug() {
     local key="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
     [[ -z "$key" ]] && key="$(basename "$(pwd -P 2>/dev/null)" 2>/dev/null)"
     [[ -z "$key" || "$key" == "/" || "$key" == "." ]] && key="${BASHPID:-$$}"
-    printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_' | cut -c1-64
+    # Sanitizing alone is lossy: distinct ids that differ only in unsafe chars
+    # (e.g. "a/b" vs "a?b") would collapse to the same slug and share a pool.
+    # Append a checksum of the RAW key so the slug stays readable but injective.
+    local safe hash
+    safe="$(printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_' | cut -c1-48)"
+    hash="$(printf '%s' "$key" | cksum | cut -d' ' -f1)"
+    printf '%s-%s' "$safe" "$hash"
 }
 
 council_create_run_dir() {

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2869,10 +2869,32 @@ council_write_run_status() {
     return 0
 }
 
+council_session_slug() {
+    # A stable, filesystem-safe per-session key so concurrent governed sessions on
+    # one machine do not share a councils/ pool. Prefer the Claude Code session id;
+    # fall back to the worktree/cwd basename (governed sessions run one worktree
+    # each), then the pid.
+    local key="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+    [[ -z "$key" ]] && key="$(basename "$(pwd -P 2>/dev/null)" 2>/dev/null)"
+    [[ -z "$key" || "$key" == "/" || "$key" == "." ]] && key="${BASHPID:-$$}"
+    printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_' | cut -c1-64
+}
+
 council_create_run_dir() {
     local parent="$COUNCIL_OUTPUT_DIR"
     if [[ -z "$parent" ]]; then
         parent="${WORKSPACE_DIR:-${HOME}/.claude-octopus}/councils"
+        # Per-session isolation. Concurrent governed sessions on one machine
+        # otherwise share this single councils/ pool: a sibling session's runs
+        # then appear as "the newest run", its run-status.json misleads this
+        # session's diagnostics (the reported cross-session confusion), and
+        # foreign/duplicate dirs collide. Namespace the DEFAULT pool by session so
+        # each session owns its runs and the newest dir is always its own. An
+        # explicit --output-dir is honored unchanged; OCTOPUS_COUNCIL_SHARED_POOL=1
+        # restores the flat shared pool.
+        if [[ "${OCTOPUS_COUNCIL_SHARED_POOL:-}" != "1" ]]; then
+            parent="${parent}/session-$(council_session_slug)"
+        fi
     fi
 
     mkdir -p "$parent" || return 1

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2879,7 +2879,11 @@ council_session_slug() {
     [[ -z "$key" || "$key" == "/" || "$key" == "." ]] && key="${BASHPID:-$$}"
     # Sanitizing alone is lossy: distinct ids that differ only in unsafe chars
     # (e.g. "a/b" vs "a?b") would collapse to the same slug and share a pool.
-    # Append a checksum of the RAW key so the slug stays readable but injective.
+    # Append a checksum of the RAW key to disambiguate them. This is best-effort
+    # collision mitigation, not a guarantee: a real Claude session id is a UUID
+    # that fits the 48-char cap and is unique, and the cwd/pid fallbacks make a
+    # same-machine collision astronomically unlikely — but a 32-bit cksum over a
+    # capped prefix is not provably injective.
     local safe hash
     safe="$(printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_' | cut -c1-48)"
     hash="$(printf '%s' "$key" | cksum | cut -d' ' -f1)"

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -17,6 +17,7 @@ _council_registry_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_council_registry_dir}/agent-spec.sh" 2>/dev/null || true
 source "${_council_registry_dir}/provider-registry.sh" 2>/dev/null || true
 source "${_council_registry_dir}/provider-policy.sh" 2>/dev/null || true
+source "${_council_registry_dir}/session-id.sh" 2>/dev/null || true
 COUNCIL_PROVIDER_POLICY_VALID="true"
 COUNCIL_DEFAULT_PROVIDERS="$(octo_council_default_providers)" || COUNCIL_PROVIDER_POLICY_VALID="false"
 COUNCIL_MAX_COST=""
@@ -2871,10 +2872,11 @@ council_write_run_status() {
 
 council_session_slug() {
     # A stable, filesystem-safe per-session key so concurrent governed sessions on
-    # one machine do not share a councils/ pool. Prefer the Claude Code session id;
+    # one machine do not share a councils/ pool. Prefer the host session id;
     # fall back to the worktree/cwd basename (governed sessions run one worktree
     # each), then the pid.
-    local key="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+    local key
+    key="$(octo_resolve_session_id "" 2>/dev/null || true)"
     [[ -z "$key" ]] && key="$(basename "$(pwd -P 2>/dev/null)" 2>/dev/null)"
     [[ -z "$key" || "$key" == "/" || "$key" == "." ]] && key="${BASHPID:-$$}"
     # Sanitizing alone is lossy: distinct ids that differ only in unsafe chars

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -853,8 +853,10 @@ test_agy_spawn_bypasses_timeout_wrapper() {
 test_agy_sync_bypasses_timeout_wrapper() {
     test_case "sync dispatch enforces timeout wrapper for agy"
 
+    local sync_block
+    sync_block="$(sed -n '/^run_agent_sync() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/agent-sync.sh")"
     if grep -q 'agent_type.*agy' "$PROJECT_ROOT/scripts/lib/agent-sync.sh" && \
-       sed -n '/^run_agent_sync() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/agent-sync.sh" | grep -q 'run_with_timeout'; then
+       [[ "$sync_block" == *"run_with_timeout"* ]]; then
         test_pass
     else
         test_fail "agent-sync.sh should wrap agy in run_with_timeout"

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -1050,6 +1050,7 @@ MOCK_AGY
         OCTO_ROOT="$PROJECT_ROOT" \
         OCTOPUS_AGY_MODEL='gemini-test' \
         OCTOPUS_AGY_HEALTH_TIMEOUT=1 \
+        OCTOPUS_PROVIDER_LIVE_TIMEOUT=1 \
         PATH="$tmp_bin:/usr/bin:/bin" \
             bash "$PROJECT_ROOT/scripts/doctor.sh" providers --live --json
     )"

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1678,8 +1678,8 @@ test_council_per_session_pool_isolation() {
     # slug is filesystem-safe and collision-resistant: two ids that sanitize to
     # the same prefix ("sess/A b!" and "sess?A b!") must not collapse to one pool.
     local slug1 slug2 codex_slug1 codex_slug2 codex_precedence_slug codex_task_slug claude_host_slug
-    slug1="$(CLAUDE_CODE_SESSION_ID='sess/A b!' council_session_slug)"
-    slug2="$(CLAUDE_CODE_SESSION_ID='sess?A b!' council_session_slug)"
+    slug1="$(OCTOPUS_HOST=claude CLAUDE_CODE_SESSION_ID='sess/A b!' council_session_slug)"
+    slug2="$(OCTOPUS_HOST=claude CLAUDE_CODE_SESSION_ID='sess?A b!' council_session_slug)"
     codex_slug1="$(OCTOPUS_HOST=codex CODEX_SESSION_ID='codex/A' CODEX_TASK_ID= \
         CLAUDE_CODE_SESSION_ID= CLAUDE_SESSION_ID= council_session_slug)"
     codex_slug2="$(OCTOPUS_HOST=codex CODEX_SESSION_ID='codex?A' CODEX_TASK_ID= \
@@ -1696,12 +1696,12 @@ test_council_per_session_pool_isolation() {
 
     # Default pool is namespaced per session; two sessions get separate pools.
     local dirA dirB shared explicit
-    COUNCIL_OUTPUT_DIR="" WORKSPACE_DIR="$ws" CLAUDE_CODE_SESSION_ID="sessA" council_create_run_dir >/dev/null 2>&1
+    OCTOPUS_HOST=claude COUNCIL_OUTPUT_DIR="" WORKSPACE_DIR="$ws" CLAUDE_CODE_SESSION_ID="sessA" council_create_run_dir >/dev/null 2>&1
     dirA="$COUNCIL_RUN_DIR"
-    COUNCIL_OUTPUT_DIR="" WORKSPACE_DIR="$ws" CLAUDE_CODE_SESSION_ID="sessB" council_create_run_dir >/dev/null 2>&1
+    OCTOPUS_HOST=claude COUNCIL_OUTPUT_DIR="" WORKSPACE_DIR="$ws" CLAUDE_CODE_SESSION_ID="sessB" council_create_run_dir >/dev/null 2>&1
     dirB="$COUNCIL_RUN_DIR"
     # Opt-out restores the flat shared pool (no session- segment).
-    COUNCIL_OUTPUT_DIR="" WORKSPACE_DIR="$ws" CLAUDE_CODE_SESSION_ID="sessA" OCTOPUS_COUNCIL_SHARED_POOL=1 council_create_run_dir >/dev/null 2>&1
+    OCTOPUS_HOST=claude COUNCIL_OUTPUT_DIR="" WORKSPACE_DIR="$ws" CLAUDE_CODE_SESSION_ID="sessA" OCTOPUS_COUNCIL_SHARED_POOL=1 council_create_run_dir >/dev/null 2>&1
     shared="$COUNCIL_RUN_DIR"
     # An explicit --output-dir (COUNCIL_OUTPUT_DIR) must select $out DIRECTLY —
     # the run dir's parent is $out, never $out/session-<slug>.

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1670,9 +1670,45 @@ test_council_one_vote_per_vendor_opt_in() {
     fi
 }
 
+test_council_per_session_pool_isolation() {
+    test_case "council namespaces the default pool per session; --output-dir and opt-out are unaffected"
+    load_council_lib || return 1
+    local ws; ws="$(mktemp -d "$TEST_TMP_DIR/council-pool.XXXXXX")"
+
+    # slug is filesystem-safe and reflects the session id.
+    local slug; slug="$(CLAUDE_CODE_SESSION_ID='sess/A b!' council_session_slug)"
+
+    # Default pool is namespaced per session; two sessions get separate pools.
+    local dirA dirB shared explicit
+    COUNCIL_OUTPUT_DIR="" WORKSPACE_DIR="$ws" CLAUDE_CODE_SESSION_ID="sessA" council_create_run_dir >/dev/null 2>&1
+    dirA="$COUNCIL_RUN_DIR"
+    COUNCIL_OUTPUT_DIR="" WORKSPACE_DIR="$ws" CLAUDE_CODE_SESSION_ID="sessB" council_create_run_dir >/dev/null 2>&1
+    dirB="$COUNCIL_RUN_DIR"
+    # Opt-out restores the flat shared pool (no session- segment).
+    COUNCIL_OUTPUT_DIR="" WORKSPACE_DIR="$ws" CLAUDE_CODE_SESSION_ID="sessA" OCTOPUS_COUNCIL_SHARED_POOL=1 council_create_run_dir >/dev/null 2>&1
+    shared="$COUNCIL_RUN_DIR"
+    # An explicit --output-dir (COUNCIL_OUTPUT_DIR) is honored unchanged.
+    local out; out="$(mktemp -d "$TEST_TMP_DIR/council-explicit.XXXXXX")"
+    COUNCIL_OUTPUT_DIR="$out" council_create_run_dir >/dev/null 2>&1
+    explicit="$COUNCIL_RUN_DIR"
+
+    if [[ "$slug" == "sess_A_b_" \
+          && "$dirA" == "$ws/councils/session-sessA/"* \
+          && "$dirB" == "$ws/councils/session-sessB/"* \
+          && "$dirA" != "$dirB" \
+          && "$shared" == "$ws/councils/"* && "$shared" != *"/session-"* \
+          && "$explicit" == "$out/"* ]]; then
+        test_pass
+    else
+        test_fail "pool isolation wrong: slug=$slug A=$dirA B=$dirB shared=$shared explicit=$explicit"
+        return 1
+    fi
+}
+
 test_council_command_files_are_registered
 test_council_orchestrate_route_exists
 test_council_run_status_beacon_lifecycle
+test_council_per_session_pool_isolation
 test_council_benchmark_routing_lib_is_extracted
 test_council_chair_is_host_native_detects_status
 test_council_quorum_met_with_host_native_chair

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1677,9 +1677,22 @@ test_council_per_session_pool_isolation() {
 
     # slug is filesystem-safe and collision-resistant: two ids that sanitize to
     # the same prefix ("sess/A b!" and "sess?A b!") must not collapse to one pool.
-    local slug1 slug2
+    local slug1 slug2 codex_slug1 codex_slug2 codex_precedence_slug codex_task_slug claude_host_slug
     slug1="$(CLAUDE_CODE_SESSION_ID='sess/A b!' council_session_slug)"
     slug2="$(CLAUDE_CODE_SESSION_ID='sess?A b!' council_session_slug)"
+    codex_slug1="$(OCTOPUS_HOST=codex CODEX_SESSION_ID='codex/A' CODEX_TASK_ID= \
+        CLAUDE_CODE_SESSION_ID= CLAUDE_SESSION_ID= council_session_slug)"
+    codex_slug2="$(OCTOPUS_HOST=codex CODEX_SESSION_ID='codex?A' CODEX_TASK_ID= \
+        CLAUDE_CODE_SESSION_ID= CLAUDE_SESSION_ID= council_session_slug)"
+    codex_precedence_slug="$(OCTOPUS_HOST=codex CODEX_SESSION_ID='codex/A' CODEX_TASK_ID='task/B' \
+        CLAUDE_CODE_SESSION_ID= CLAUDE_SESSION_ID= council_session_slug)"
+    codex_task_slug="$(
+        unset CODEX_SESSION_ID
+        OCTOPUS_HOST=codex CODEX_TASK_ID='task/A' \
+            CLAUDE_CODE_SESSION_ID= CLAUDE_SESSION_ID= council_session_slug
+    )"
+    claude_host_slug="$(OCTOPUS_HOST=claude CODEX_SESSION_ID='codex/A' \
+        CLAUDE_CODE_SESSION_ID='claude/A' CLAUDE_SESSION_ID= council_session_slug)"
 
     # Default pool is namespaced per session; two sessions get separate pools.
     local dirA dirB shared explicit
@@ -1697,6 +1710,9 @@ test_council_per_session_pool_isolation() {
     explicit="$COUNCIL_RUN_DIR"
 
     if [[ "$slug1" == "sess_A_b_-"* && "$slug2" == "sess_A_b_-"* && "$slug1" != "$slug2" \
+          && "$codex_slug1" == "codex_A-"* && "$codex_slug2" == "codex_A-"* \
+          && "$codex_slug1" != "$codex_slug2" && "$codex_precedence_slug" == "$codex_slug1" \
+          && "$codex_task_slug" == "task_A-"* && "$claude_host_slug" == "claude_A-"* \
           && "$dirA" == "$ws/councils/session-sessA-"*/* \
           && "$dirB" == "$ws/councils/session-sessB-"*/* \
           && "$dirA" != "$dirB" \
@@ -1704,7 +1720,7 @@ test_council_per_session_pool_isolation() {
           && "$(dirname "$explicit")" == "$out" ]]; then
         test_pass
     else
-        test_fail "pool isolation wrong: slug1=$slug1 slug2=$slug2 A=$dirA B=$dirB shared=$shared explicit=$explicit"
+        test_fail "pool isolation wrong: slug1=$slug1 slug2=$slug2 codex1=$codex_slug1 codex2=$codex_slug2 codex_precedence=$codex_precedence_slug codex_task=$codex_task_slug claude_host=$claude_host_slug A=$dirA B=$dirB shared=$shared explicit=$explicit"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1675,8 +1675,8 @@ test_council_per_session_pool_isolation() {
     load_council_lib || return 1
     local ws; ws="$(mktemp -d "$TEST_TMP_DIR/council-pool.XXXXXX")"
 
-    # slug is filesystem-safe and INJECTIVE: two ids that sanitize to the same
-    # prefix ("sess/A b!" and "sess?A b!") must not collapse to one pool.
+    # slug is filesystem-safe and collision-resistant: two ids that sanitize to
+    # the same prefix ("sess/A b!" and "sess?A b!") must not collapse to one pool.
     local slug1 slug2
     slug1="$(CLAUDE_CODE_SESSION_ID='sess/A b!' council_session_slug)"
     slug2="$(CLAUDE_CODE_SESSION_ID='sess?A b!' council_session_slug)"

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1675,8 +1675,11 @@ test_council_per_session_pool_isolation() {
     load_council_lib || return 1
     local ws; ws="$(mktemp -d "$TEST_TMP_DIR/council-pool.XXXXXX")"
 
-    # slug is filesystem-safe and reflects the session id.
-    local slug; slug="$(CLAUDE_CODE_SESSION_ID='sess/A b!' council_session_slug)"
+    # slug is filesystem-safe and INJECTIVE: two ids that sanitize to the same
+    # prefix ("sess/A b!" and "sess?A b!") must not collapse to one pool.
+    local slug1 slug2
+    slug1="$(CLAUDE_CODE_SESSION_ID='sess/A b!' council_session_slug)"
+    slug2="$(CLAUDE_CODE_SESSION_ID='sess?A b!' council_session_slug)"
 
     # Default pool is namespaced per session; two sessions get separate pools.
     local dirA dirB shared explicit
@@ -1687,20 +1690,21 @@ test_council_per_session_pool_isolation() {
     # Opt-out restores the flat shared pool (no session- segment).
     COUNCIL_OUTPUT_DIR="" WORKSPACE_DIR="$ws" CLAUDE_CODE_SESSION_ID="sessA" OCTOPUS_COUNCIL_SHARED_POOL=1 council_create_run_dir >/dev/null 2>&1
     shared="$COUNCIL_RUN_DIR"
-    # An explicit --output-dir (COUNCIL_OUTPUT_DIR) is honored unchanged.
+    # An explicit --output-dir (COUNCIL_OUTPUT_DIR) must select $out DIRECTLY —
+    # the run dir's parent is $out, never $out/session-<slug>.
     local out; out="$(mktemp -d "$TEST_TMP_DIR/council-explicit.XXXXXX")"
     COUNCIL_OUTPUT_DIR="$out" council_create_run_dir >/dev/null 2>&1
     explicit="$COUNCIL_RUN_DIR"
 
-    if [[ "$slug" == "sess_A_b_" \
-          && "$dirA" == "$ws/councils/session-sessA/"* \
-          && "$dirB" == "$ws/councils/session-sessB/"* \
+    if [[ "$slug1" == "sess_A_b_-"* && "$slug2" == "sess_A_b_-"* && "$slug1" != "$slug2" \
+          && "$dirA" == "$ws/councils/session-sessA-"*/* \
+          && "$dirB" == "$ws/councils/session-sessB-"*/* \
           && "$dirA" != "$dirB" \
           && "$shared" == "$ws/councils/"* && "$shared" != *"/session-"* \
-          && "$explicit" == "$out/"* ]]; then
+          && "$(dirname "$explicit")" == "$out" ]]; then
         test_pass
     else
-        test_fail "pool isolation wrong: slug=$slug A=$dirA B=$dirB shared=$shared explicit=$explicit"
+        test_fail "pool isolation wrong: slug1=$slug1 slug2=$slug2 A=$dirA B=$dirB shared=$shared explicit=$explicit"
         return 1
     fi
 }


### PR DESCRIPTION
## Problem

When several governed Claude Code sessions run concurrently in sibling worktrees on one machine, they all write council runs into a single shared `~/.claude-octopus/councils/` pool. Reported symptoms: a sibling session's runs appear as "the newest run", its `run-status.json` `pid` misleads this session's diagnostics (a killed session inspected the newest dir and found a *foreign* worktree's pid), and foreign/duplicate run directories collide (the lead had to content-grep to find its own).

## Root-cause note (important)

Code review found **no cross-session process reaping**: every kill in the runner (`heartbeat.sh`, `council.sh`) is pid-scoped (`kill -P <cmd_pid>`, tree-kill of a specific seat) — there is no broad `pkill -f`/`killall` and no cleanup that scans the pool and reaps by another dir's `run-status.json` pid. So the "foreign pid" is a **diagnostic artifact of the shared pool**, not evidence that a sibling killed this session. The reported `rc 143` (SIGTERM) kills are most plausibly the **host Bash-tool timeout** on the long (~17 min) council call, which fires more under contention — a separate concern this PR does not claim to fix.

What this PR fixes is the confirmed shared-state problem: dir/diagnostic collisions.

## Change

Namespace the **default** pool by session:

- `council_session_slug()` — filesystem-safe key: Claude Code session id → worktree/cwd basename → pid.
- Default pool becomes `…/councils/session-<slug>/…`, so each session owns its runs and "the newest dir" is always its own.
- An explicit `--output-dir` (`COUNCIL_OUTPUT_DIR`) is **honored unchanged**.
- `OCTOPUS_COUNCIL_SHARED_POOL=1` restores the flat shared pool.

Preserves concurrency; no serialization.

## Tests

`council_per_session_pool_isolation` — two sessions get separate pools (`session-sessA` vs `session-sessB`), the opt-out restores the flat pool (no `session-` segment), and an explicit `--output-dir` is unaffected. Slug sanitization checked.

`tests/unit/test-council-command.sh`: **87 passed, 0 failed, 1 skipped** (pre-existing macOS-CI pty flake). No file-mode changes.

## Not in scope (from the report)

- #2 "never reap by broad match" — N/A; no broad-match kill exists in the code.
- #3 resume-a-killed-seat-from-`.partial` — would reduce the *cost* of a kill; happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Council runs are now isolated by session by default, preventing runs from different sessions from sharing storage.
  * Session-based storage names are safely formatted for filesystem use.
  * Explicit output directory settings continue to work unchanged.
  * Shared storage remains available with `OCTOPUS_COUNCIL_SHARED_POOL=1`.

* **Tests**
  * Added coverage for session isolation, shared storage, safe naming, and custom output directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->