### PR TITLE
fix(tangle): avoid warning-only phantom blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 
 ### Fixed
 
+- Keep contextual review warnings fatal without fabricating a severity=normal blocker. Warning-only or partial-review results with zero actionable findings now stop cleanly instead of entering no-op correction loops, while warnings with real normal findings still allow bounded correction attempts.
 - Migrate legacy generated `codex-mini` pins such as `gpt-5-codex-mini` to
   `gpt-5.6-luna`, preventing quick workflows from selecting a model that is
   unsupported for ChatGPT-authenticated Codex CLI sessions. Agent help now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
   flag and an end-of-run warning, and the run stops before synthesis with a clear
   message directing the operator to the per-seat verdicts in `responses/`.
 - Harden provider/model routing and OpenAI-compatible reasoning handling: canonicalize route-provider aliases, let cross-provider legacy role routes fall through to matching phase routes, preserve Bash 3.2-compatible execution-profile overrides, normalize `xhigh`/`max` reasoning to `high`, and only drop `reasoning_effort` when the API specifically rejects that field.
+- Keep contextual review warnings fatal without fabricating a severity=normal blocker. Warning-only or partial-review results with zero actionable findings now stop cleanly instead of entering no-op correction loops, while warnings with real normal findings still allow bounded correction attempts.
 
 ## [10.1.0] - 2026-08-30
 
@@ -55,7 +56,6 @@
 
 ### Fixed
 
-- Keep contextual review warnings fatal without fabricating a severity=normal blocker. Warning-only or partial-review results with zero actionable findings now stop cleanly instead of entering no-op correction loops, while warnings with real normal findings still allow bounded correction attempts.
 - Migrate legacy generated `codex-mini` pins such as `gpt-5-codex-mini` to
   `gpt-5.6-luna`, preventing quick workflows from selecting a model that is
   unsupported for ChatGPT-authenticated Codex CLI sessions. Agent help now

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1948,12 +1948,6 @@ tangle_review_warning_text() {
 tangle_review_blocking_count() {
     local findings_file="$1"
     [[ -f "$findings_file" ]] || { echo 0; return 0; }
-    local review_warning
-    review_warning=$(tangle_review_warning_text "$findings_file")
-    if [[ -n "$review_warning" ]]; then
-        echo 1
-        return 0
-    fi
     local count
     if ! count=$(jq '[.findings[]? | select((.severity // "") == "normal")] | length' "$findings_file" 2>/dev/null); then
         # fail closed: malformed/truncated findings must block delivery.

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1958,7 +1958,7 @@ tangle_review_findings_valid() {
 
 tangle_review_blocking_count() {
     local findings_file="$1"
-    [[ -f "$findings_file" ]] || { echo 0; return 0; }
+    [[ -f "$findings_file" ]] || { echo 1; return 0; }
     local count
     if ! tangle_review_findings_valid "$findings_file" \
           || ! count=$(jq '[.findings[] | select((.severity // "") == "normal")] | length' "$findings_file" 2>/dev/null); then

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -1945,12 +1945,25 @@ tangle_review_warning_text() {
     jq -r '(.warning // (if ((.message // "") | test("No changes found to review"; "i")) then .message else "" end)) // ""' "$findings_file" 2>/dev/null || true
 }
 
+tangle_review_findings_valid() {
+    local findings_file="$1"
+    [[ -f "$findings_file" ]] || return 1
+    jq -e -s '
+        length == 1
+        and (.[0] | type == "object")
+        and (.[0].findings | type == "array")
+        and all(.[0].findings[]; type == "object")
+    ' "$findings_file" >/dev/null 2>&1
+}
+
 tangle_review_blocking_count() {
     local findings_file="$1"
     [[ -f "$findings_file" ]] || { echo 0; return 0; }
     local count
-    if ! count=$(jq '[.findings[]? | select((.severity // "") == "normal")] | length' "$findings_file" 2>/dev/null); then
-        # fail closed: malformed/truncated findings must block delivery.
+    if ! tangle_review_findings_valid "$findings_file" \
+          || ! count=$(jq '[.findings[] | select((.severity // "") == "normal")] | length' "$findings_file" 2>/dev/null); then
+        # Fail closed for callers that only consume the count. The contextual
+        # gate rejects the invalid artifact before attempting corrections.
         echo 1
         return 0
     fi
@@ -3744,6 +3757,10 @@ tangle_contextual_review_gate() {
     local review_rc=0
     tangle_run_context_code_review "$task_group" "$review_context_file" "initial" || review_rc=$?
     local findings_file="$TANGLE_REVIEW_FINDINGS_FILE"
+    if ! tangle_review_findings_valid "$findings_file"; then
+        log ERROR "Contextual code review produced an invalid findings document: ${findings_file}"
+        return 1
+    fi
     local normal_count
     normal_count=$(tangle_review_blocking_count "$findings_file")
 
@@ -3826,6 +3843,10 @@ tangle_contextual_review_gate() {
         review_rc=0
         tangle_run_context_code_review "$task_group" "$review_context_file" "correction-${correction_round}" || review_rc=$?
         findings_file="$TANGLE_REVIEW_FINDINGS_FILE"
+        if ! tangle_review_findings_valid "$findings_file"; then
+            log ERROR "Contextual code review produced an invalid findings document after correction round ${correction_round}: ${findings_file}"
+            return 1
+        fi
         normal_count=$(tangle_review_blocking_count "$findings_file")
         local current_signature
         current_signature=$(tangle_findings_signature "$findings_file")

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -53,13 +53,22 @@ else
     test_fail "warning must not alter the number of severity=normal findings"
 fi
 
-test_case "malformed review findings remain fail-closed"
+test_case "schema-invalid review findings remain fail-closed"
 malformed_findings="$TEST_TMP_DIR/review-malformed.json"
+missing_findings="$TEST_TMP_DIR/review-missing.json"
+null_findings="$TEST_TMP_DIR/review-null.json"
+non_object_findings="$TEST_TMP_DIR/review-non-object.json"
 printf '%s\n' '{"findings":[' > "$malformed_findings"
-if [[ "$(tangle_review_blocking_count "$malformed_findings")" == "1" ]]; then
+printf '%s\n' '{}' > "$missing_findings"
+printf '%s\n' '{"findings":null}' > "$null_findings"
+printf '%s\n' '{"findings":["not-an-object"]}' > "$non_object_findings"
+if [[ "$(tangle_review_blocking_count "$malformed_findings")" == "1" ]] &&
+   [[ "$(tangle_review_blocking_count "$missing_findings")" == "1" ]] &&
+   [[ "$(tangle_review_blocking_count "$null_findings")" == "1" ]] &&
+   [[ "$(tangle_review_blocking_count "$non_object_findings")" == "1" ]]; then
     test_pass
 else
-    test_fail "malformed review findings must retain one blocking failure"
+    test_fail "invalid review schemas must retain one blocking failure"
 fi
 
 run_warning_review_gate() {
@@ -157,6 +166,28 @@ if [[ "$out" == "rc=0 corrections=1 reviews=2" ]]; then
     test_pass
 else
     test_fail "actionable warning did not complete one bounded recovery: $out"
+fi
+
+test_case "missing findings array is fatal without a correction call"
+out=$(run_warning_review_gate \
+    missing-findings \
+    '{}' 0 \
+    '{"findings":[]}' 0)
+if [[ "$out" == "rc=1 corrections=0 reviews=1" ]]; then
+    test_pass
+else
+    test_fail "missing findings array entered correction or passed: $out"
+fi
+
+test_case "truncated findings are fatal without a correction call"
+out=$(run_warning_review_gate \
+    truncated-findings \
+    '{"findings":[' 0 \
+    '{"findings":[]}' 0)
+if [[ "$out" == "rc=1 corrections=0 reviews=1" ]]; then
+    test_pass
+else
+    test_fail "truncated findings entered correction or passed: $out"
 fi
 
 assert_contains "$WORKFLOWS" "tangle_build_develop_review_context" "tangle builds review context"

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -53,6 +53,112 @@ else
     test_fail "warning must not alter the number of severity=normal findings"
 fi
 
+test_case "malformed review findings remain fail-closed"
+malformed_findings="$TEST_TMP_DIR/review-malformed.json"
+printf '%s\n' '{"findings":[' > "$malformed_findings"
+if [[ "$(tangle_review_blocking_count "$malformed_findings")" == "1" ]]; then
+    test_pass
+else
+    test_fail "malformed review findings must retain one blocking failure"
+fi
+
+run_warning_review_gate() {
+    local case_name="$1"
+    local initial_findings="$2"
+    local initial_rc="$3"
+    local recovery_findings="$4"
+    local recovery_rc="$5"
+    local case_dir="$TEST_TMP_DIR/review-gate-$case_name"
+    rm -rf "$case_dir"
+    mkdir -p "$case_dir"
+
+    bash -c '
+        set -u
+        project_root="$1"
+        case_dir="$2"
+        initial_findings="$3"
+        initial_rc="$4"
+        recovery_findings="$5"
+        recovery_rc="$6"
+        export RESULTS_DIR="$case_dir/results"
+        mkdir -p "$RESULTS_DIR"
+
+        initial_file="$case_dir/initial.json"
+        recovery_file="$case_dir/recovery.json"
+        review_calls_file="$case_dir/review-calls"
+        correction_calls_file="$case_dir/correction-calls"
+        validation_file="$case_dir/validation.md"
+        printf "%s\n" "$initial_findings" > "$initial_file"
+        printf "%s\n" "$recovery_findings" > "$recovery_file"
+        printf "0" > "$review_calls_file"
+        printf "0" > "$correction_calls_file"
+        : > "$validation_file"
+
+        source "$project_root/scripts/lib/workflows.sh" 2>/dev/null
+        log() { :; }
+        tangle_build_develop_review_context() {
+            printf "%s\n" "$case_dir/context-$7.md"
+        }
+        tangle_run_context_code_review() {
+            local calls rc
+            calls=$(<"$review_calls_file")
+            if [[ "$calls" -eq 0 ]]; then
+                TANGLE_REVIEW_FINDINGS_FILE="$initial_file"
+                rc="$initial_rc"
+            else
+                TANGLE_REVIEW_FINDINGS_FILE="$recovery_file"
+                rc="$recovery_rc"
+            fi
+            printf "%s" "$((calls + 1))" > "$review_calls_file"
+            return "$rc"
+        }
+        tangle_apply_review_corrections() {
+            local calls
+            calls=$(<"$correction_calls_file")
+            printf "%s" "$((calls + 1))" > "$correction_calls_file"
+            TANGLE_CORRECTION_STATUS="completed"
+            TANGLE_CORRECTION_CHANGED=1
+            TANGLE_CORRECTION_CONTAMINATION=""
+            TANGLE_CORRECTION_FILE="$case_dir/correction.md"
+            return 0
+        }
+        validate_tangle_results() { return 0; }
+
+        rc=0
+        OCTOPUS_TANGLE_REVIEW_CORRECTION_MODE=bounded \
+        OCTOPUS_TANGLE_REVIEW_CORRECTION_ROUNDS=1 \
+            tangle_contextual_review_gate \
+                test "prompt" "context" "subtasks" \
+                "$validation_file" "$case_dir/worktree-before" 0 codex || rc=$?
+
+        printf "rc=%s corrections=%s reviews=%s\n" \
+            "$rc" "$(<"$correction_calls_file")" "$(<"$review_calls_file")"
+    ' _ "$PROJECT_ROOT" "$case_dir" "$initial_findings" "$initial_rc" \
+        "$recovery_findings" "$recovery_rc"
+}
+
+test_case "warning-only review is fatal without a correction call"
+out=$(run_warning_review_gate \
+    warning-only \
+    '{"findings":[],"warning":"Round 1 was partial"}' 1 \
+    '{"findings":[]}' 0)
+if [[ "$out" == "rc=1 corrections=0 reviews=1" ]]; then
+    test_pass
+else
+    test_fail "warning-only review entered correction or lost fatal status: $out"
+fi
+
+test_case "warning with a real blocker can recover after one bounded correction"
+out=$(run_warning_review_gate \
+    warning-with-blocker \
+    '{"findings":[{"severity":"normal","title":"real blocker","file":"src/app.sh","line":1}],"warning":"Round 1 was partial"}' 1 \
+    '{"findings":[]}' 0)
+if [[ "$out" == "rc=0 corrections=1 reviews=2" ]]; then
+    test_pass
+else
+    test_fail "actionable warning did not complete one bounded recovery: $out"
+fi
+
 assert_contains "$WORKFLOWS" "tangle_build_develop_review_context" "tangle builds review context"
 assert_contains "$WORKFLOWS" "tangle_run_context_code_review" "tangle runs contextual code review"
 assert_contains "$WORKFLOWS" "contextFile" "review profile passes contextFile"

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -62,7 +62,8 @@ printf '%s\n' '{"findings":[' > "$malformed_findings"
 printf '%s\n' '{}' > "$missing_findings"
 printf '%s\n' '{"findings":null}' > "$null_findings"
 printf '%s\n' '{"findings":["not-an-object"]}' > "$non_object_findings"
-if [[ "$(tangle_review_blocking_count "$malformed_findings")" == "1" ]] &&
+if [[ "$(tangle_review_blocking_count "$TEST_TMP_DIR/review-absent.json")" == "1" ]] &&
+   [[ "$(tangle_review_blocking_count "$malformed_findings")" == "1" ]] &&
    [[ "$(tangle_review_blocking_count "$missing_findings")" == "1" ]] &&
    [[ "$(tangle_review_blocking_count "$null_findings")" == "1" ]] &&
    [[ "$(tangle_review_blocking_count "$non_object_findings")" == "1" ]]; then

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -34,6 +34,25 @@ make_test_dir() {
     printf '%s\n' "$dir"
 }
 
+test_case "review warning does not fabricate an actionable blocker"
+warning_only="$TEST_TMP_DIR/review-warning-only.json"
+printf '%s\n' '{"findings":[],"warning":"Round 1 was partial"}' > "$warning_only"
+if [[ "$(tangle_review_blocking_count "$warning_only")" == "0" ]] &&
+   [[ "$(tangle_review_warning_text "$warning_only")" == "Round 1 was partial" ]]; then
+    test_pass
+else
+    test_fail "warning-only review must remain blocking through review_rc without becoming severity=normal"
+fi
+
+test_case "review warning preserves the count of real actionable blockers"
+warning_with_blocker="$TEST_TMP_DIR/review-warning-with-blocker.json"
+printf '%s\n' '{"findings":[{"severity":"normal","title":"real blocker"}],"warning":"Round 1 was partial"}' > "$warning_with_blocker"
+if [[ "$(tangle_review_blocking_count "$warning_with_blocker")" == "1" ]]; then
+    test_pass
+else
+    test_fail "warning must not alter the number of severity=normal findings"
+fi
+
 assert_contains "$WORKFLOWS" "tangle_build_develop_review_context" "tangle builds review context"
 assert_contains "$WORKFLOWS" "tangle_run_context_code_review" "tangle runs contextual code review"
 assert_contains "$WORKFLOWS" "contextFile" "review profile passes contextFile"

--- a/tests/unit/test-tangle-correction-loop-behavior.sh
+++ b/tests/unit/test-tangle-correction-loop-behavior.sh
@@ -137,6 +137,14 @@ else
     test_fail "expected rounds=0 rc=0, got '$out'"
 fi
 
+test_case "initial review warning with zero actionable blockers is fatal without correction rounds"
+out=$(REVIEW_RC_SEQUENCE="1" run_gate "0")
+if [[ "$out" == "rounds=0 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=0 rc=1, got '$out'"
+fi
+
 test_case "decreasing blockers converge to zero: exit 0 after 3 rounds"
 out=$(run_gate "3 2 1 0")
 if [[ "$out" == "rounds=3 rc=0" ]]; then

--- a/tests/unit/test-tangle-correction-loop-behavior.sh
+++ b/tests/unit/test-tangle-correction-loop-behavior.sh
@@ -137,6 +137,14 @@ else
     test_fail "expected rounds=0 rc=0, got '$out'"
 fi
 
+test_case "warning-only initial review stays fatal without a no-op correction"
+out=$(REVIEW_RC_SEQUENCE="1" run_gate "0")
+if [[ "$out" == "rounds=0 rc=1" ]]; then
+    test_pass
+else
+    test_fail "expected rounds=0 rc=1, got '$out'"
+fi
+
 test_case "decreasing blockers converge to zero: exit 0 after 3 rounds"
 out=$(run_gate "3 2 1 0")
 if [[ "$out" == "rounds=3 rc=0" ]]; then

--- a/tests/unit/test-tangle-correction-loop-behavior.sh
+++ b/tests/unit/test-tangle-correction-loop-behavior.sh
@@ -137,14 +137,6 @@ else
     test_fail "expected rounds=0 rc=0, got '$out'"
 fi
 
-test_case "initial review warning with zero actionable blockers is fatal without correction rounds"
-out=$(REVIEW_RC_SEQUENCE="1" run_gate "0")
-if [[ "$out" == "rounds=0 rc=1" ]]; then
-    test_pass
-else
-    test_fail "expected rounds=0 rc=1, got '$out'"
-fi
-
 test_case "decreasing blockers converge to zero: exit 0 after 3 rounds"
 out=$(run_gate "3 2 1 0")
 if [[ "$out" == "rounds=3 rc=0" ]]; then


### PR DESCRIPTION
Separates fatal contextual-review warnings from actionable severity=normal finding counts. Warning-only partial reviews now return non-zero without entering no-op correction loops; warnings with real normal findings still allow correction.\n\nRegression coverage includes the exact initial-warning/zero-blocker path plus warning-with-real-blocker counting. The preserved Shopping artifact that previously logged normal=1 now resolves to blocking_count=0 while retaining the warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Contextual reviews containing only warnings or no actionable findings now stop cleanly without unnecessary correction loops.
  - Warnings with actionable normal-severity findings continue to allow bounded correction attempts.
  - Review warnings no longer create artificial blockers, while warning messages remain visible.
  - Invalid or malformed review results now fail safely and stop processing without triggering corrections.

- **Documentation**
  - Updated the changelog to document the revised contextual review behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->