### PR TITLE
refactor(routing): unify configurable fallback chains

### DIFF
--- a/docs/MODEL-ROUTING-STRATEGY.md
+++ b/docs/MODEL-ROUTING-STRATEGY.md
@@ -159,6 +159,11 @@ failures, empty output, and caller-defined semantic/protocol validation
 failures. The task's semantic role and phase remain unchanged while the routing
 candidate changes. Exhausting the chain fails closed.
 
+Invalid JSON, unknown roles, malformed candidates, and incorrect chain types
+stop fallback dispatch. Provider aliases are canonicalized, equivalent attempts
+are deduplicated, and session model overrides retain precedence over role
+defaults.
+
 The existing model-version fallbacks below are separate: they resolve a model
 within a provider family rather than selecting a different dispatch candidate.
 

--- a/docs/MODEL-ROUTING-STRATEGY.md
+++ b/docs/MODEL-ROUTING-STRATEGY.md
@@ -127,6 +127,41 @@ Role defaults:
 
 ## Fallbacks
 
+Dispatch fallback policy is configuration-driven. The built-in `default` chain
+tries these routing roles after the workflow's preferred agent fails:
+
+1. `code-reviewer`
+2. `implementer-heavy`
+3. `architect`
+
+Each role resolves through the existing `routing.roles` table, so the fallback
+chain does not hard-code a provider or model. A user can replace the chain in
+`~/.claude-octopus/config/providers.json`:
+
+```json
+{
+  "routing": {
+    "fallbackChains": {
+      "default": [
+        { "role": "code-reviewer" },
+        { "role": "implementer-heavy" },
+        { "role": "architect" }
+      ]
+    }
+  }
+}
+```
+
+Candidates may also use explicit `{ "provider": "...", "model": "..." }`
+objects when pinning is required, but role-based candidates are preferred.
+`run_agent_sync_fallback_chain` applies the same ordered chain to process
+failures, empty output, and caller-defined semantic/protocol validation
+failures. The task's semantic role and phase remain unchanged while the routing
+candidate changes. Exhausting the chain fails closed.
+
+The existing model-version fallbacks below are separate: they resolve a model
+within a provider family rather than selecting a different dispatch candidate.
+
 - Opus: Opus 5 → Opus 4.8 → Opus 4.7 → Opus 4.6.
 - Sonnet: Sonnet 5 → Sonnet 4.6.
 - Fable refusal/security fallback: Opus 5, overridable with

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -2,6 +2,7 @@
 _agent_sync_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_agent_sync_lib_dir}/agent-spec.sh" 2>/dev/null || true
 source "${_agent_sync_lib_dir}/provider-registry.sh" || { echo "agent-sync: failed to load provider-registry.sh" >&2; return 1 2>/dev/null || exit 1; }
+source "${_agent_sync_lib_dir}/fallback-chain.sh" 2>/dev/null || true
 # ═══════════════════════════════════════════════════════════════════════════════
 # agent-sync.sh — Agent synchronous dispatch & Agent Teams routing
 # Extracted from orchestrate.sh (v9.7.4)

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -44,6 +44,29 @@ fleet_dispatch_end() {
     unset OCTOPUS_FORCE_LEGACY_DISPATCH
 }
 
+# Bind a resolved AGY model to the exact argv environment used by agy-exec.
+# This keeps provider execution aligned with lifecycle and cost records, while
+# preserving model labels containing spaces as one environment argument.
+octopus_sync_bind_resolved_model() {
+    local agent_type="${1:-}" model="${2:-}" provider="" entry
+    local -a filtered_env
+    provider="$(octo_agent_spec_provider "$agent_type" 2>/dev/null || true)"
+    [[ "$provider" == "agy" && -n "$model" ]] || return 0
+
+    filtered_env=()
+    if [[ ${#PROVIDER_ENV_ARRAY[@]} -gt 0 ]]; then
+        for entry in "${PROVIDER_ENV_ARRAY[@]}"; do
+            [[ "$entry" == OCTOPUS_AGY_MODEL=* ]] && continue
+            filtered_env+=("$entry")
+        done
+    fi
+    if [[ ${#filtered_env[@]} -eq 0 ]]; then
+        filtered_env=(env)
+    fi
+    filtered_env+=("OCTOPUS_AGY_MODEL=$model")
+    PROVIDER_ENV_ARRAY=("${filtered_env[@]}")
+}
+
 # Claude Code's native Agent Teams API does not expose a provider PID or a
 # timeout/cancellation handle to plugin scripts. A positive Octopus timeout
 # therefore cannot be enforced on that path: Claude Code documents that team
@@ -457,6 +480,7 @@ ${provider_ctx}"
     local -a cmd_array
     local -a inner_cmd_array
     build_provider_env "$agent_type"
+    octopus_sync_bind_resolved_model "$agent_type" "$model"
     read -ra inner_cmd_array <<< "$cmd"
     if [[ ${#PROVIDER_ENV_ARRAY[@]} -gt 0 ]]; then
         cmd_array=("${PROVIDER_ENV_ARRAY[@]}" "${inner_cmd_array[@]}")

--- a/scripts/lib/agents.sh
+++ b/scripts/lib/agents.sh
@@ -815,6 +815,7 @@ get_tiered_agent() {
             ;;
     esac
 
-    # Apply API key fallback (v4.5)
-    get_fallback_agent "$agent" "$task_type" 2>/dev/null || echo "$agent"
+    # Apply API key fallback (v4.5). Resolver failure is terminal: returning
+    # the known-unavailable preferred identity would defer the error to dispatch.
+    get_fallback_agent "$agent" "$task_type"
 }

--- a/scripts/lib/execution-profile.sh
+++ b/scripts/lib/execution-profile.sh
@@ -167,12 +167,12 @@ _octopus_profile_route_json() {
     if ($role != "" and (.routing.roles[$role] != null)) then .routing.roles[$role]
     elif ($phase != "" and (.routing.phases[$phase] != null)) then .routing.phases[$phase]
     else null end
-  ' "$cfg" 2>/dev/null || printf "%s\n" "null"
+  ' "$cfg" 2>/dev/null
 }
 
 _octopus_profile_field() {
   local phase="${1:-}" role="${2:-}" field="$3" route
-  route="$(_octopus_profile_route_json "$phase" "$role")"
+  route="$(_octopus_profile_route_json "$phase" "$role")" || return $?
   [[ "$route" != "null" ]] || return 1
   if [[ "$route" == \{* ]]; then
     jq -r --arg field "$field" '.[$field] // empty' <<<"$route" 2>/dev/null

--- a/scripts/lib/fallback-chain.sh
+++ b/scripts/lib/fallback-chain.sh
@@ -36,6 +36,8 @@ octo_fallback_chain_json() {
         selection="$(jq -ce --arg name "$name" '
             if type != "object" then error("providers config must be an object")
             elif (has("routing") and .routing != null and (.routing | type) != "object") then error("routing must be an object")
+            elif (.routing != null and (.routing | has("roles")) and .routing.roles != null and (.routing.roles | type) != "object") then error("routing.roles must be an object")
+            elif (.routing != null and (.routing | has("phases")) and .routing.phases != null and (.routing.phases | type) != "object") then error("routing.phases must be an object")
             else (.routing.fallbackChains? // null) as $chains
             | if $chains == null then {found:false}
               elif ($chains | type) != "object" then error("routing.fallbackChains must be an object")
@@ -109,7 +111,7 @@ octo_fallback_role_agent_spec() {
 
     provider="$routed_provider"
     if declare -f _octopus_profile_route_json >/dev/null 2>&1; then
-        route="$(_octopus_profile_route_json "$phase" "$role" 2>/dev/null || printf '%s\n' null)"
+        route="$(_octopus_profile_route_json "$phase" "$role" 2>/dev/null)" || return 2
         route_type="$(jq -r 'type' <<<"$route" 2>/dev/null || printf '%s\n' null)"
     fi
 

--- a/scripts/lib/fallback-chain.sh
+++ b/scripts/lib/fallback-chain.sh
@@ -57,22 +57,49 @@ _octo_fallback_ensure_role_resolver() {
 
 octo_fallback_role_agent_spec() {
     local role="$1" phase="${2:-}" provider="" model="" routed_provider=""
+    local route="null" route_type="null" route_value="" route_provider="" route_model=""
 
     _octo_fallback_ensure_role_resolver || return 1
     routed_provider="$(get_role_agent "$role" 2>/dev/null || true)"
     model="$(get_role_model "$role" 2>/dev/null || true)"
     [[ -n "$routed_provider" ]] || return 1
 
-    if declare -f octopus_profile_provider >/dev/null 2>&1; then
-        provider="$(octopus_profile_provider "$phase" "$role" "$routed_provider" 2>/dev/null || true)"
+    provider="$routed_provider"
+    if declare -f _octopus_profile_route_json >/dev/null 2>&1; then
+        route="$(_octopus_profile_route_json "$phase" "$role" 2>/dev/null || printf '%s\n' null)"
+        route_type="$(jq -r 'type' <<<"$route" 2>/dev/null || printf '%s\n' null)"
     fi
-    provider="${provider:-$routed_provider}"
 
-    if declare -f octopus_profile_model >/dev/null 2>&1; then
-        local configured_model
-        configured_model="$(octopus_profile_model "$phase" "$role" 2>/dev/null || true)"
-        [[ -n "$configured_model" ]] && model="$configured_model"
-    fi
+    case "$route_type" in
+        object)
+            route_provider="$(jq -r '.provider // empty' <<<"$route" 2>/dev/null || true)"
+            route_model="$(jq -r '.model // empty' <<<"$route" 2>/dev/null || true)"
+            if [[ -n "$route_provider" ]]; then
+                provider="$route_provider"
+                model=""
+            fi
+            [[ -n "$route_model" ]] && model="$route_model"
+            ;;
+        string)
+            route_value="$(jq -r '.' <<<"$route" 2>/dev/null || true)"
+            if [[ "$route_value" == *:* ]]; then
+                route_provider="${route_value%%:*}"
+                route_model="${route_value#*:}"
+                [[ -n "$route_provider" && -n "$route_model" ]] || return 1
+                declare -f resolve_octopus_model >/dev/null 2>&1 || return 1
+                model="$(resolve_octopus_model "$route_provider" "$route_model" "" "")" || return 1
+                provider="$route_provider"
+            elif [[ -n "$route_value" ]]; then
+                if declare -f octo_provider_canonical >/dev/null 2>&1 && \
+                   route_provider="$(octo_provider_canonical "$route_value" 2>/dev/null)"; then
+                    provider="$route_provider"
+                    model=""
+                else
+                    model="$route_value"
+                fi
+            fi
+            ;;
+    esac
 
     if [[ -n "$model" ]]; then
         printf '%s:%s\n' "$provider" "$model"

--- a/scripts/lib/fallback-chain.sh
+++ b/scripts/lib/fallback-chain.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Unified configurable fallback-chain helpers.
+# Source-safe: defines functions only and resolves providers/models lazily.
+
+_octo_fallback_config_file() {
+    if declare -f _octopus_profile_config_file >/dev/null 2>&1; then
+        _octopus_profile_config_file
+    else
+        printf '%s\n' "${OCTOPUS_PROVIDERS_CONFIG:-${HOME}/.claude-octopus/config/providers.json}"
+    fi
+}
+
+octo_fallback_builtin_chain_json() {
+    local name="${1:-default}"
+    case "$name" in
+        default)
+            printf '%s\n' '[{"role":"code-reviewer"},{"role":"implementer-heavy"},{"role":"architect"}]'
+            ;;
+        *)
+            printf '%s\n' '[]'
+            ;;
+    esac
+}
+
+octo_fallback_chain_json() {
+    local name="${1:-default}" cfg configured=""
+    cfg="$(_octo_fallback_config_file)"
+
+    if [[ -f "$cfg" ]]; then
+        configured="$(jq -c --arg name "$name" '
+            (.routing.fallbackChains[$name] //
+             (if $name != "default" then .routing.fallbackChains.default else null end) //
+             null) as $chain
+            | if $chain == null then empty
+              elif ($chain | type) == "array" then $chain
+              elif (($chain | type) == "object" and (($chain.attempts // null) | type) == "array") then $chain.attempts
+              else empty end
+        ' "$cfg" 2>/dev/null || true)"
+    fi
+
+    if [[ -n "$configured" ]]; then
+        printf '%s\n' "$configured"
+    else
+        octo_fallback_builtin_chain_json "$name"
+    fi
+}
+
+_octo_fallback_ensure_role_resolver() {
+    declare -f get_role_agent >/dev/null 2>&1 && declare -f get_role_model >/dev/null 2>&1 && return 0
+    local lib_dir nounset_was_on="false"
+    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    [[ "$-" == *u* ]] && nounset_was_on="true" && set +u
+    source "${lib_dir}/agent-utils.sh" 2>/dev/null || true
+    [[ "$nounset_was_on" == "true" ]] && set -u
+    declare -f get_role_agent >/dev/null 2>&1 && declare -f get_role_model >/dev/null 2>&1
+}
+
+octo_fallback_role_agent_spec() {
+    local role="$1" phase="${2:-}" provider="" model="" routed_provider=""
+
+    _octo_fallback_ensure_role_resolver || return 1
+    routed_provider="$(get_role_agent "$role" 2>/dev/null || true)"
+    model="$(get_role_model "$role" 2>/dev/null || true)"
+    [[ -n "$routed_provider" ]] || return 1
+
+    if declare -f octopus_profile_provider >/dev/null 2>&1; then
+        provider="$(octopus_profile_provider "$phase" "$role" "$routed_provider" 2>/dev/null || true)"
+    fi
+    provider="${provider:-$routed_provider}"
+
+    if declare -f octopus_profile_model >/dev/null 2>&1; then
+        local configured_model
+        configured_model="$(octopus_profile_model "$phase" "$role" 2>/dev/null || true)"
+        [[ -n "$configured_model" ]] && model="$configured_model"
+    fi
+
+    if [[ -n "$model" ]]; then
+        printf '%s:%s\n' "$provider" "$model"
+    else
+        printf '%s\n' "$provider"
+    fi
+}
+
+octo_fallback_candidate_agent_spec() {
+    local candidate="$1" phase="${2:-}" type role provider model agent
+    type="$(jq -r 'type' <<<"$candidate" 2>/dev/null || true)"
+
+    if [[ "$type" == "string" ]]; then
+        role="$(jq -r '.' <<<"$candidate")"
+        octo_fallback_role_agent_spec "$role" "$phase"
+        return
+    fi
+    [[ "$type" == "object" ]] || return 1
+
+    role="$(jq -r '.role // empty' <<<"$candidate")"
+    if [[ -n "$role" ]]; then
+        octo_fallback_role_agent_spec "$role" "$phase"
+        return
+    fi
+
+    agent="$(jq -r '.agent // empty' <<<"$candidate")"
+    if [[ -n "$agent" ]]; then
+        printf '%s\n' "$agent"
+        return
+    fi
+
+    provider="$(jq -r '.provider // empty' <<<"$candidate")"
+    model="$(jq -r '.model // empty' <<<"$candidate")"
+    [[ -n "$provider" ]] || return 1
+    if [[ -n "$model" ]]; then
+        printf '%s:%s\n' "$provider" "$model"
+    else
+        printf '%s\n' "$provider"
+    fi
+}
+
+octo_fallback_chain_agent_specs() {
+    local name="${1:-default}" phase="${2:-}" chain candidate spec
+    chain="$(octo_fallback_chain_json "$name")"
+    while IFS= read -r candidate; do
+        [[ -n "$candidate" ]] || continue
+        spec="$(octo_fallback_candidate_agent_spec "$candidate" "$phase" 2>/dev/null || true)"
+        [[ -n "$spec" ]] && printf '%s\n' "$spec"
+    done < <(jq -c '.[]' <<<"$chain" 2>/dev/null)
+}
+
+_octo_fallback_provider_identity() {
+    local spec="${1:-}" executor=""
+    executor="${spec%%:*}"
+    if declare -f octo_agent_spec_provider >/dev/null 2>&1; then
+        octo_agent_spec_provider "$spec" 2>/dev/null && return 0
+    fi
+    case "$executor" in
+        codex|codex-*) echo codex ;;
+        claude|claude-*|claude-opus|claude-opus-*) echo claude ;;
+        agy|agy-*|antigravity|gemini|gemini-*) echo agy ;;
+        commandcode|commandcode-*) echo commandcode ;;
+        openrouter|openrouter-*) echo openrouter ;;
+        *) echo "$executor" ;;
+    esac
+}
+
+octo_fallback_first_available() {
+    local name="${1:-default}" preferred="${2:-}" phase="${3:-}" spec executor
+    local preferred_provider="" candidate_provider=""
+    preferred_provider="$(_octo_fallback_provider_identity "$preferred")"
+    while IFS= read -r spec; do
+        [[ -n "$spec" ]] || continue
+        executor="${spec%%:*}"
+        candidate_provider="$(_octo_fallback_provider_identity "$spec")"
+        [[ -n "$preferred_provider" && "$candidate_provider" == "$preferred_provider" ]] && continue
+        if declare -f is_agent_available >/dev/null 2>&1 && is_agent_available "$executor"; then
+            printf '%s\n' "$spec"
+            return 0
+        fi
+    done < <(octo_fallback_chain_agent_specs "$name" "$phase")
+    return 1
+}
+
+octo_fallback_output_usable() {
+    local output="${1:-}" validator="${2:-}"
+    [[ -n "${output//[[:space:]]/}" ]] || return 1
+    if [[ -n "$validator" ]]; then
+        declare -F "$validator" >/dev/null 2>&1 || return 2
+        "$validator" "$output" >/dev/null
+        return $?
+    fi
+    return 0
+}
+
+run_agent_sync_fallback_chain() {
+    local primary_agent="$1" prompt="$2" timeout_secs="${3:-120}" semantic_role="${4:-}" phase="${5:-}"
+    local validator="${6:-}" chain_name="${7:-default}"
+    local spec output="" rc=0 reason="" attempted="|"
+
+    while IFS= read -r spec; do
+        [[ -n "$spec" ]] || continue
+        [[ "$attempted" == *"|$spec|"* ]] && continue
+        attempted+="$spec|"
+
+        output=""
+        rc=0
+        if output=$(run_agent_sync "$spec" "$prompt" "$timeout_secs" "$semantic_role" "$phase"); then
+            if octo_fallback_output_usable "$output" "$validator"; then
+                printf '%s\n' "$output"
+                return 0
+            fi
+            reason="semantic-invalid"
+        else
+            rc=$?
+            reason="process-error:$rc"
+        fi
+        if declare -f log >/dev/null 2>&1; then
+            log WARN "Fallback chain '$chain_name': $spec failed ($reason); trying next candidate"
+        fi
+    done < <(
+        printf '%s\n' "$primary_agent"
+        octo_fallback_chain_agent_specs "$chain_name" "$phase"
+    )
+
+    if declare -f log >/dev/null 2>&1; then
+        log ERROR "Fallback chain '$chain_name' exhausted without a usable result"
+    fi
+    return 1
+}

--- a/scripts/lib/fallback-chain.sh
+++ b/scripts/lib/fallback-chain.sh
@@ -94,6 +94,13 @@ _octo_fallback_bare_route_provider() {
     done <<EOF
 $(octo_provider_registry_rows)
 EOF
+
+    # Keep the legacy AGY research seat aligned with model-resolver's bare-route
+    # classifier. It predates registry-backed canonical provider prefixes.
+    if [[ "$normalized" == "agy-research" ]]; then
+        printf '%s\n' "agy"
+        return 0
+    fi
     return 1
 }
 

--- a/scripts/lib/fallback-chain.sh
+++ b/scripts/lib/fallback-chain.sh
@@ -132,7 +132,7 @@ _octo_fallback_provider_identity() {
     fi
     case "$executor" in
         codex|codex-*) echo codex ;;
-        claude|claude-*|claude-opus|claude-opus-*) echo claude ;;
+        claude|claude-*) echo claude ;;
         agy|agy-*|antigravity|gemini|gemini-*) echo agy ;;
         commandcode|commandcode-*) echo commandcode ;;
         openrouter|openrouter-*) echo openrouter ;;

--- a/scripts/lib/fallback-chain.sh
+++ b/scripts/lib/fallback-chain.sh
@@ -124,6 +124,22 @@ octo_fallback_chain_agent_specs() {
     done < <(jq -c '.[]' <<<"$chain" 2>/dev/null)
 }
 
+octo_fallback_agent_available() {
+    local spec="${1:-}" executor=""
+    executor="${spec%%:*}"
+    [[ -n "$executor" ]] || return 1
+
+    if declare -f is_agent_available_v2 >/dev/null 2>&1; then
+        is_agent_available_v2 "$executor"
+        return $?
+    fi
+    if declare -f is_agent_available >/dev/null 2>&1; then
+        is_agent_available "$executor"
+        return $?
+    fi
+    return 1
+}
+
 _octo_fallback_provider_identity() {
     local spec="${1:-}" executor=""
     executor="${spec%%:*}"
@@ -149,7 +165,7 @@ octo_fallback_first_available() {
         executor="${spec%%:*}"
         candidate_provider="$(_octo_fallback_provider_identity "$spec")"
         [[ -n "$preferred_provider" && "$candidate_provider" == "$preferred_provider" ]] && continue
-        if declare -f is_agent_available >/dev/null 2>&1 && is_agent_available "$executor"; then
+        if octo_fallback_agent_available "$spec"; then
             printf '%s\n' "$spec"
             return 0
         fi

--- a/scripts/lib/fallback-chain.sh
+++ b/scripts/lib/fallback-chain.sh
@@ -2,6 +2,12 @@
 # Unified configurable fallback-chain helpers.
 # Source-safe: defines functions only and resolves providers/models lazily.
 
+_octo_fallback_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ! declare -f octo_provider_canonical >/dev/null 2>&1; then
+    source "${_octo_fallback_lib_dir}/provider-registry.sh" 2>/dev/null || true
+fi
+unset _octo_fallback_lib_dir
+
 _octo_fallback_config_file() {
     if declare -f _octopus_profile_config_file >/dev/null 2>&1; then
         _octopus_profile_config_file
@@ -23,45 +29,82 @@ octo_fallback_builtin_chain_json() {
 }
 
 octo_fallback_chain_json() {
-    local name="${1:-default}" cfg configured=""
+    local name="${1:-default}" cfg selection="" configured=""
     cfg="$(_octo_fallback_config_file)"
 
     if [[ -f "$cfg" ]]; then
-        configured="$(jq -c --arg name "$name" '
-            (.routing.fallbackChains[$name] //
-             (if $name != "default" then .routing.fallbackChains.default else null end) //
-             null) as $chain
-            | if $chain == null then empty
-              elif ($chain | type) == "array" then $chain
-              elif (($chain | type) == "object" and (($chain.attempts // null) | type) == "array") then $chain.attempts
-              else empty end
-        ' "$cfg" 2>/dev/null || true)"
+        selection="$(jq -ce --arg name "$name" '
+            if type != "object" then error("providers config must be an object")
+            elif (has("routing") and .routing != null and (.routing | type) != "object") then error("routing must be an object")
+            else (.routing.fallbackChains? // null) as $chains
+            | if $chains == null then {found:false}
+              elif ($chains | type) != "object" then error("routing.fallbackChains must be an object")
+              elif ($chains | has($name)) then {found:true,value:$chains[$name]}
+              elif ($name != "default" and ($chains | has("default"))) then {found:true,value:$chains.default}
+              else {found:false} end end
+        ' "$cfg" 2>/dev/null)" || return 2
+
+        if [[ "$(jq -r '.found' <<<"$selection")" == "true" ]]; then
+            configured="$(jq -ce '
+                .value as $chain
+                | if ($chain | type) == "array" then $chain
+                  elif (($chain | type) == "object" and ($chain | has("attempts")) and ($chain.attempts | type) == "array") then $chain.attempts
+                  else error("fallback chain must be an array or an object with an attempts array") end
+            ' <<<"$selection" 2>/dev/null)" || return 2
+            printf '%s\n' "$configured"
+            return 0
+        fi
     fi
 
-    if [[ -n "$configured" ]]; then
-        printf '%s\n' "$configured"
-    else
-        octo_fallback_builtin_chain_json "$name"
-    fi
+    octo_fallback_builtin_chain_json "$name"
 }
 
 _octo_fallback_ensure_role_resolver() {
-    declare -f get_role_agent >/dev/null 2>&1 && declare -f get_role_model >/dev/null 2>&1 && return 0
+    declare -f get_role_agent >/dev/null 2>&1 && return 0
     local lib_dir nounset_was_on="false"
     lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     [[ "$-" == *u* ]] && nounset_was_on="true" && set +u
     source "${lib_dir}/agent-utils.sh" 2>/dev/null || true
     [[ "$nounset_was_on" == "true" ]] && set -u
-    declare -f get_role_agent >/dev/null 2>&1 && declare -f get_role_model >/dev/null 2>&1
+    declare -f get_role_agent >/dev/null 2>&1
+}
+
+_octo_fallback_bare_route_provider() {
+    local requested="${1:-}" normalized="" id aliases command org caps alias old_ifs
+    declare -f octo_provider_normalize >/dev/null 2>&1 || return 1
+    normalized="$(octo_provider_normalize "$requested")"
+    [[ -n "$normalized" ]] || return 1
+
+    while IFS='|' read -r id aliases command org caps; do
+        [[ "$normalized" == "$id" ]] && { printf '%s\n' "$id"; return 0; }
+        old_ifs="$IFS"
+        IFS=','
+        for alias in $aliases; do
+            IFS="$old_ifs"
+            alias="${alias%\*}"
+            if [[ -n "$alias" && "$normalized" == "$alias" ]]; then
+                printf '%s\n' "$id"
+                return 0
+            fi
+            IFS=','
+        done
+        IFS="$old_ifs"
+    done <<EOF
+$(octo_provider_registry_rows)
+EOF
+    return 1
 }
 
 octo_fallback_role_agent_spec() {
     local role="$1" phase="${2:-}" provider="" model="" routed_provider=""
     local route="null" route_type="null" route_value="" route_provider="" route_model=""
 
+    case "$role" in
+        architect|researcher|reviewer|code-reviewer|security-reviewer|implementer|implementer-heavy|synthesizer|strategist) ;;
+        *) return 1 ;;
+    esac
     _octo_fallback_ensure_role_resolver || return 1
     routed_provider="$(get_role_agent "$role" 2>/dev/null || true)"
-    model="$(get_role_model "$role" 2>/dev/null || true)"
     [[ -n "$routed_provider" ]] || return 1
 
     provider="$routed_provider"
@@ -72,13 +115,21 @@ octo_fallback_role_agent_spec() {
 
     case "$route_type" in
         object)
-            route_provider="$(jq -r '.provider // empty' <<<"$route" 2>/dev/null || true)"
-            route_model="$(jq -r '.model // empty' <<<"$route" 2>/dev/null || true)"
-            if [[ -n "$route_provider" ]]; then
-                provider="$route_provider"
-                model=""
+            jq -e '
+                ((has("provider") | not) or (.provider | type) == "string") and
+                ((has("model") | not) or (.model | type) == "string") and
+                ((.provider // "") != "" or (.model // "") != "")
+            ' <<<"$route" >/dev/null 2>&1 || return 1
+            route_provider="$(jq -r '.provider // empty' <<<"$route")"
+            route_model="$(jq -r '.model // empty' <<<"$route")"
+            local route_has_provider=false resolution_provider=""
+            [[ -n "$route_provider" ]] && { provider="$route_provider"; route_has_provider=true; }
+            if [[ -n "$route_model" ]]; then
+                declare -f resolve_octopus_model >/dev/null 2>&1 || return 1
+                resolution_provider="$(octo_provider_canonical "$provider" 2>/dev/null)" || return 1
+                model="$(resolve_octopus_model "$resolution_provider" "$provider" "$phase" "$role")" || return 1
+                [[ "$route_has_provider" == true ]] && provider="$resolution_provider"
             fi
-            [[ -n "$route_model" ]] && model="$route_model"
             ;;
         string)
             route_value="$(jq -r '.' <<<"$route" 2>/dev/null || true)"
@@ -90,21 +141,43 @@ octo_fallback_role_agent_spec() {
                 model="$(resolve_octopus_model "$route_provider" "$route_model" "" "")" || return 1
                 provider="$route_provider"
             elif [[ -n "$route_value" ]]; then
-                if declare -f octo_provider_canonical >/dev/null 2>&1 && \
-                   route_provider="$(octo_provider_canonical "$route_value" 2>/dev/null)"; then
+                if route_provider="$(_octo_fallback_bare_route_provider "$route_value" 2>/dev/null)"; then
                     provider="$route_provider"
-                    model=""
                 else
-                    model="$route_value"
+                    declare -f resolve_octopus_model >/dev/null 2>&1 || return 1
+                    route_provider="$(octo_provider_canonical "$provider" 2>/dev/null)" || return 1
+                    model="$(resolve_octopus_model "$route_provider" "$provider" "$phase" "$role")" || return 1
                 fi
             fi
             ;;
+        null) ;;
+        *) return 1 ;;
     esac
 
-    if [[ -n "$model" ]]; then
-        printf '%s:%s\n' "$provider" "$model"
+    octo_fallback_canonical_agent_spec "${provider}${model:+:$model}"
+}
+
+octo_fallback_canonical_agent_spec() {
+    local spec="${1:-}" executor="" provider="" model="" canonical_executor=""
+    executor="${spec%%:*}"
+    [[ -n "$executor" ]] || return 1
+    declare -f octo_provider_canonical >/dev/null 2>&1 || return 1
+    provider="$(octo_provider_canonical "$executor" 2>/dev/null)" || return 1
+
+    canonical_executor="$executor"
+    case "$executor" in
+        "$provider"|"$provider"-*) ;;
+        *) canonical_executor="$provider" ;;
+    esac
+
+    if [[ "$spec" == *:* ]]; then
+        model="${spec#*:}"
+        [[ -n "$model" ]] || return 1
+        declare -f validate_model_name_for_provider >/dev/null 2>&1 || return 1
+        validate_model_name_for_provider "$provider" "$model" >/dev/null 2>&1 || return 1
+        printf '%s:%s\n' "$canonical_executor" "$model"
     else
-        printf '%s\n' "$provider"
+        printf '%s\n' "$canonical_executor"
     fi
 }
 
@@ -114,10 +187,19 @@ octo_fallback_candidate_agent_spec() {
 
     if [[ "$type" == "string" ]]; then
         role="$(jq -r '.' <<<"$candidate")"
+        [[ -n "$role" ]] || return 1
         octo_fallback_role_agent_spec "$role" "$phase"
         return
     fi
     [[ "$type" == "object" ]] || return 1
+
+    jq -e '
+        (([has("role"),has("agent"),has("provider")] | map(select(.)) | length) == 1) and
+        ((keys - ["agent","model","provider","role"]) | length == 0) and
+        ((has("role") | not) or ((.role | type) == "string" and .role != "" and (has("agent") | not) and (has("provider") | not) and (has("model") | not))) and
+        ((has("agent") | not) or ((.agent | type) == "string" and .agent != "" and (has("model") | not))) and
+        ((has("provider") | not) or ((.provider | type) == "string" and .provider != "" and ((has("model") | not) or ((.model | type) == "string" and .model != ""))))
+    ' <<<"$candidate" >/dev/null 2>&1 || return 1
 
     role="$(jq -r '.role // empty' <<<"$candidate")"
     if [[ -n "$role" ]]; then
@@ -127,28 +209,32 @@ octo_fallback_candidate_agent_spec() {
 
     agent="$(jq -r '.agent // empty' <<<"$candidate")"
     if [[ -n "$agent" ]]; then
-        printf '%s\n' "$agent"
+        octo_fallback_canonical_agent_spec "$agent"
         return
     fi
 
     provider="$(jq -r '.provider // empty' <<<"$candidate")"
     model="$(jq -r '.model // empty' <<<"$candidate")"
     [[ -n "$provider" ]] || return 1
-    if [[ -n "$model" ]]; then
-        printf '%s:%s\n' "$provider" "$model"
-    else
-        printf '%s\n' "$provider"
-    fi
+    octo_fallback_canonical_agent_spec "${provider}${model:+:$model}"
 }
 
 octo_fallback_chain_agent_specs() {
-    local name="${1:-default}" phase="${2:-}" chain candidate spec
-    chain="$(octo_fallback_chain_json "$name")"
+    local name="${1:-default}" phase="${2:-}" chain candidates candidate spec specs="" seen="|"
+    chain="$(octo_fallback_chain_json "$name")" || return $?
+    candidates="$(jq -ce '.[]' <<<"$chain" 2>/dev/null)" || {
+        [[ "$chain" == "[]" ]] && return 0
+        return 2
+    }
     while IFS= read -r candidate; do
         [[ -n "$candidate" ]] || continue
-        spec="$(octo_fallback_candidate_agent_spec "$candidate" "$phase" 2>/dev/null || true)"
-        [[ -n "$spec" ]] && printf '%s\n' "$spec"
-    done < <(jq -c '.[]' <<<"$chain" 2>/dev/null)
+        spec="$(octo_fallback_candidate_agent_spec "$candidate" "$phase" 2>/dev/null)" || return 2
+        [[ -n "$spec" ]] || return 2
+        [[ "$seen" == *"|$spec|"* ]] && continue
+        seen+="$spec|"
+        specs+="${spec}"$'\n'
+    done <<<"$candidates"
+    printf '%s' "$specs"
 }
 
 octo_fallback_agent_available() {
@@ -194,9 +280,10 @@ _octo_fallback_provider_identity() {
 }
 
 octo_fallback_first_available() {
-    local name="${1:-default}" preferred="${2:-}" phase="${3:-}" spec executor
+    local name="${1:-default}" preferred="${2:-}" phase="${3:-}" spec executor specs
     local preferred_provider="" candidate_provider=""
     preferred_provider="$(_octo_fallback_provider_identity "$preferred")"
+    specs="$(octo_fallback_chain_agent_specs "$name" "$phase")" || return $?
     while IFS= read -r spec; do
         [[ -n "$spec" ]] || continue
         executor="${spec%%:*}"
@@ -206,7 +293,7 @@ octo_fallback_first_available() {
             printf '%s\n' "$spec"
             return 0
         fi
-    done < <(octo_fallback_chain_agent_specs "$name" "$phase")
+    done <<<"$specs"
     return 1
 }
 
@@ -223,14 +310,27 @@ octo_fallback_output_usable() {
 
 run_agent_sync_fallback_chain() {
     local primary_agent="$1" prompt="$2" timeout_secs="${3:-120}" semantic_role="${4:-}" phase="${5:-}"
-    local validator="${6:-}" chain_name="${7:-default}"
-    local spec output="" rc=0 reason="" attempted="|"
+    local validator="${6:-}" chain_name="${7:-default}" preferred_fallback="${8:-}"
+    local spec raw_spec output="" rc=0 reason="" candidates="" fallback_specs="" seen="|"
+
+    fallback_specs="$(octo_fallback_chain_agent_specs "$chain_name" "$phase")" || return $?
+    for raw_spec in "$primary_agent" "$preferred_fallback"; do
+        [[ -n "$raw_spec" ]] || continue
+        spec="$(octo_fallback_canonical_agent_spec "$raw_spec")" || return 2
+        [[ "$seen" == *"|$spec|"* ]] && continue
+        seen+="$spec|"
+        candidates+="${spec}"$'\n'
+    done
+    while IFS= read -r raw_spec; do
+        [[ -n "$raw_spec" ]] || continue
+        spec="$(octo_fallback_canonical_agent_spec "$raw_spec")" || return 2
+        [[ "$seen" == *"|$spec|"* ]] && continue
+        seen+="$spec|"
+        candidates+="${spec}"$'\n'
+    done <<<"$fallback_specs"
 
     while IFS= read -r spec; do
         [[ -n "$spec" ]] || continue
-        [[ "$attempted" == *"|$spec|"* ]] && continue
-        attempted+="$spec|"
-
         output=""
         rc=0
         if output=$(run_agent_sync "$spec" "$prompt" "$timeout_secs" "$semantic_role" "$phase"); then
@@ -246,10 +346,7 @@ run_agent_sync_fallback_chain() {
         if declare -f log >/dev/null 2>&1; then
             log WARN "Fallback chain '$chain_name': $spec failed ($reason); trying next candidate"
         fi
-    done < <(
-        printf '%s\n' "$primary_agent"
-        octo_fallback_chain_agent_specs "$chain_name" "$phase"
-    )
+    done <<<"$candidates"
 
     if declare -f log >/dev/null 2>&1; then
         log ERROR "Fallback chain '$chain_name' exhausted without a usable result"

--- a/scripts/lib/fallback-chain.sh
+++ b/scripts/lib/fallback-chain.sh
@@ -152,9 +152,19 @@ octo_fallback_chain_agent_specs() {
 }
 
 octo_fallback_agent_available() {
-    local spec="${1:-}" executor=""
+    local spec="${1:-}" executor="" provider="" model=""
     executor="${spec%%:*}"
     [[ -n "$executor" ]] || return 1
+
+    if [[ "$spec" == *:* ]]; then
+        model="${spec#*:}"
+        [[ -n "$model" ]] || return 1
+        declare -f octo_agent_spec_provider >/dev/null 2>&1 || return 1
+        provider="$(octo_agent_spec_provider "$spec" 2>/dev/null)" || return 1
+        [[ -n "$provider" ]] || return 1
+        declare -f validate_model_name_for_provider >/dev/null 2>&1 || return 1
+        validate_model_name_for_provider "$provider" "$model" >/dev/null 2>&1 || return 1
+    fi
 
     if declare -f is_agent_available_v2 >/dev/null 2>&1; then
         is_agent_available_v2 "$executor"

--- a/scripts/lib/fallback-chain.sh
+++ b/scripts/lib/fallback-chain.sh
@@ -133,10 +133,10 @@ octo_fallback_agent_available() {
         is_agent_available_v2 "$executor"
         return $?
     fi
-    if declare -f is_agent_available >/dev/null 2>&1; then
-        is_agent_available "$executor"
-        return $?
-    fi
+    # Fallback candidates must fail closed. The legacy is_agent_available()
+    # assumes unknown providers are available, which can defer an invalid seat
+    # until dispatch. Callers that use configurable fallback chains must provide
+    # the v2 availability contract from model-resolver.sh.
     return 1
 }
 

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -3,6 +3,7 @@ _profile_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if ! declare -f octopus_resolve_reasoning_level >/dev/null 2>&1; then
     source "${_profile_lib_dir}/execution-profile.sh" 2>/dev/null || true
 fi
+source "${_profile_lib_dir}/fallback-chain.sh" 2>/dev/null || true
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONFIGURATION v3.0: Unified Model Resolver (v8.50.0)
 # Consolidated logic for provider, phase, and role-based model selection.
@@ -890,80 +891,38 @@ is_agent_available_v2() {
 get_fallback_agent() {
     local preferred="$1"
     local task_type="$2"
+    local candidate=""
 
     if is_agent_available "$preferred"; then
         echo "$preferred"
         return 0
     fi
 
-    # Fallback logic (v8.9.0: extended with spark, reasoning, large-context fallbacks)
+    # Retired Gemini IDs remain compatibility aliases for Antigravity. Treat
+    # the alias translation separately from fallback policy so the policy can
+    # be fully configuration-driven.
     case "$preferred" in
         gemini|gemini-fast|gemini-image)
-            # Retired Gemini IDs are compatibility aliases for Antigravity.
-            echo "agy"
-            ;;
-        codex|codex-standard|codex-mini)
-            # Codex unavailable, try Antigravity
             if is_agent_available "agy"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: $preferred -> agy (no OpenAI)" || true
                 echo "agy"
-            else
-                echo "$preferred"
+                return 0
             fi
-            ;;
-        codex-spark)
-            # Spark unavailable or unsupported → fall back to standard codex → Antigravity
-            if is_agent_available "codex"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-spark -> codex (spark unavailable)" || true
-                echo "codex"
-            elif is_agent_available "agy"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-spark -> agy (no OpenAI)" || true
-                echo "agy"
-            else
-                echo "$preferred"
-            fi
-            ;;
-        codex-reasoning)
-            # Reasoning model unavailable → fall back to codex (deep reasoning) → Antigravity
-            if is_agent_available "codex"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-reasoning -> codex (reasoning unavailable)" || true
-                echo "codex"
-            elif is_agent_available "agy"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-reasoning -> agy (no OpenAI)" || true
-                echo "agy"
-            else
-                echo "$preferred"
-            fi
-            ;;
-        codex-large-context)
-            # Large context unavailable → fall back to codex (400K ctx) → Antigravity
-            if is_agent_available "codex"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-large-context -> codex (large-ctx unavailable)" || true
-                echo "codex"
-            elif is_agent_available "agy"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: codex-large-context -> agy (no OpenAI)" || true
-                echo "agy"
-            else
-                echo "$preferred"
-            fi
-            ;;
-        openrouter-glm5|openrouter-kimi|openrouter-deepseek)
-            # v8.11.0: Model-specific OpenRouter → generic openrouter → codex → Antigravity
-            if is_agent_available "openrouter"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: $preferred -> openrouter (model-specific unavailable)" || true
-                echo "openrouter"
-            elif is_agent_available "codex"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: $preferred -> codex (no OpenRouter)" || true
-                echo "codex"
-            elif is_agent_available "agy"; then
-                [[ "$VERBOSE" == "true" ]] && log DEBUG "Fallback: $preferred -> agy (no OpenRouter/OpenAI)" || true
-                echo "agy"
-            else
-                echo "$preferred"
-            fi
-            ;;
-        *)
-            echo "$preferred"
             ;;
     esac
+
+    # Unified fallback policy. routing.fallbackChains.default may override the
+    # built-in role chain; role candidates resolve through routing.roles.
+    if declare -f octo_fallback_first_available >/dev/null 2>&1; then
+        candidate="$(octo_fallback_first_available default "$preferred" "" 2>/dev/null || true)"
+    fi
+    if [[ -n "$candidate" ]]; then
+        [[ "${VERBOSE:-false}" == "true" ]] && log DEBUG "Fallback: $preferred -> $candidate (chain: default, task: $task_type)" || true
+        echo "$candidate"
+        return 0
+    fi
+
+    # Fail closed on the preferred identity when the configured/default chain
+    # has no available candidate. Callers retain the historical contract of
+    # receiving an agent identity rather than an empty string.
+    echo "$preferred"
 }

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -893,7 +893,7 @@ get_fallback_agent() {
     local task_type="$2"
     local candidate=""
 
-    if is_agent_available "$preferred"; then
+    if octo_fallback_agent_available "$preferred"; then
         echo "$preferred"
         return 0
     fi
@@ -903,7 +903,7 @@ get_fallback_agent() {
     # be fully configuration-driven.
     case "$preferred" in
         gemini|gemini-fast|gemini-image)
-            if is_agent_available "agy"; then
+            if octo_fallback_agent_available "agy"; then
                 echo "agy"
                 return 0
             fi

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -328,7 +328,7 @@ resolve_octopus_model() {
     local agent_type="$2"
     local phase="${3:-}"
     local role="${4:-}"
-    local config_file="${HOME}/.claude-octopus/config/providers.json"
+    local config_file="${OCTOPUS_PROVIDERS_CONFIG:-${HOME}/.claude-octopus/config/providers.json}"
     local resolved_model=""
     local cost_mode routing_policy
     cost_mode="$(_octo_effective_cost_mode "$config_file")"

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -888,6 +888,8 @@ is_agent_available_v2() {
     esac
 }
 
+# Print one verified available agent and return 0. If neither the preferred
+# agent nor any fallback is available, print nothing and return non-zero.
 get_fallback_agent() {
     local preferred="$1"
     local task_type="$2"
@@ -921,8 +923,10 @@ get_fallback_agent() {
         return 0
     fi
 
-    # Fail closed on the preferred identity when the configured/default chain
-    # has no available candidate. Callers retain the historical contract of
-    # receiving an agent identity rather than an empty string.
-    echo "$preferred"
+    if declare -f log >/dev/null 2>&1; then
+        log ERROR "No available agent for '$preferred' and fallback chain 'default'"
+    else
+        printf "No available agent for '%s' and fallback chain 'default'\n" "$preferred" >&2
+    fi
+    return 1
 }

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -7,6 +7,11 @@ if ! type probe_result_file_status >/dev/null 2>&1; then
     _octo_probe_results_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/probe-results.sh"
     [[ -f "$_octo_probe_results_lib" ]] && source "$_octo_probe_results_lib"
 fi
+if ! type run_agent_sync_fallback_chain >/dev/null 2>&1; then
+    _octo_fallback_chain_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fallback-chain.sh"
+    [[ -f "$_octo_fallback_chain_lib" ]] && source "$_octo_fallback_chain_lib"
+    unset _octo_fallback_chain_lib
+fi
 if ! type review_kill_process_tree_frozen >/dev/null 2>&1; then
     _octo_review_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/review.sh"
     if [[ -f "$_octo_review_lib" ]]; then
@@ -1657,6 +1662,33 @@ tangle_parseable_coding_subtask_count() {
     echo "$count"
 }
 
+tangle_decomposition_output_usable() {
+    local subtasks="${1:-}" parseable_count coding_count line subtask scopes
+    parseable_count="$(tangle_parseable_subtask_count "$subtasks")"
+    coding_count="$(tangle_parseable_coding_subtask_count "$subtasks")"
+    [[ "$parseable_count" -gt 0 && "$coding_count" -gt 0 ]] || return 1
+
+    # Overlap is repairable by tangle_consolidate_overlapping_subtasks after
+    # routing completes. Missing Files clauses are not: treat those as semantic
+    # provider failures so the shared chain can try another candidate.
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        tangle_line_is_numbered_subtask "$line" || continue
+        [[ "$line" =~ \[CODING\] ]] || continue
+        subtask="$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]*(\*\*)?[0-9]+[\.\)][[:space:]]*//; s/^[[:space:]]+//')"
+        scopes="$(tangle_extract_write_scopes "$subtask")"
+        [[ -n "$scopes" ]] || return 1
+    done <<<"$subtasks"
+    return 0
+}
+
+tangle_run_decomposition_fallbacks() {
+    local primary_agent="$1" preferred_fallback="$2" prompt="$3" timeout_secs="${4:-0}"
+    run_agent_sync_fallback_chain \
+        "$primary_agent" "$prompt" "$timeout_secs" researcher tangle \
+        tangle_decomposition_output_usable default "$preferred_fallback"
+}
+
 tangle_reformat_decomposition() {
     local original_task="$1"
     local previous_decomposition="$2"
@@ -1695,8 +1727,9 @@ ${previous_decomposition}
         tangle_decompose_fallback_agent=$(octopus_execution_profile_provider "tangle" "decompose_fallback" "implementer" "codex")
     fi
 
-    OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-reformat-validation" run_agent_sync "$tangle_decompose_agent" "$reformat_prompt" 0 "researcher" "tangle" || \
-    OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-reformat-validation" run_agent_sync "$tangle_decompose_fallback_agent" "$reformat_prompt" 0 "researcher" "tangle"
+    OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-reformat-validation" \
+        tangle_run_decomposition_fallbacks \
+        "$tangle_decompose_agent" "$tangle_decompose_fallback_agent" "$reformat_prompt" 0
 }
 
 tangle_effective_write_scopes() {
@@ -3364,8 +3397,9 @@ Every [CODING] line must include a same-line Files: clause."
     fi
 
     local subtasks
-    subtasks=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-dispatch-watcher" run_agent_sync "$tangle_decompose_agent" "$decompose_prompt" 0 "researcher" "tangle") || \
-    subtasks=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-dispatch-watcher" run_agent_sync "$tangle_decompose_fallback_agent" "$decompose_prompt" 0 "researcher" "tangle") || {
+    subtasks=$(OCTOPUS_UNBOUNDED_EXECUTION_SUPERVISED="tangle-dispatch-watcher" \
+        tangle_run_decomposition_fallbacks \
+        "$tangle_decompose_agent" "$tangle_decompose_fallback_agent" "$decompose_prompt" 0) || {
         log ERROR "Decomposition failed with all providers; refusing monolithic direct fallback"
         return 1
     }

--- a/tests/unit/test-agent-sync-run-contract.sh
+++ b/tests/unit/test-agent-sync-run-contract.sh
@@ -25,6 +25,10 @@ attempt=$((attempt + 1))
 printf '%s\n' "$attempt" >> "$FIXTURE_CALLS"
 case "$FIXTURE_SCENARIO" in
     success|exact-seat) printf '%s\n' 'Substantive provider result.' ;;
+    agy-pin)
+        printf '%s\n' "${OCTOPUS_AGY_MODEL:-missing}" > "$FIXTURE_ROOT/executed-agy-model"
+        printf '%s\n' 'Substantive AGY result.'
+        ;;
     empty) : ;;
     whitespace) printf ' \n\t\n' ;;
     placeholder) printf '%s\n' 'Provider available' ;;
@@ -75,6 +79,7 @@ get_agent_model() {
         printf '%s\n' "${1#*:}"
         return 0
     fi
+    [[ "${FIXTURE_SCENARIO:-}" == agy-pin ]] && { printf '%s\n' 'Gemini 3.1 Pro (High)'; return 0; }
     printf '%s\n' fixture-model
 }
 estimate_agent_call_cost() { printf '%s\n' 0.000000; }
@@ -85,6 +90,10 @@ get_agent_command() {
         command_model="${1#*:}"
     fi
     printf '%s\n' "${4:-missing}" > "$FIXTURE_ROOT/prompt-bytes"
+    if [[ "${FIXTURE_SCENARIO:-}" == agy-pin ]]; then
+        printf '%s\n' "$fixture_provider"
+        return 0
+    fi
     printf '%s\n' "$fixture_provider --model $command_model"
 }
 build_provider_env() { PROVIDER_ENV_ARRAY=(); }
@@ -177,6 +186,9 @@ assert_scenario success 0 1 \
 assert_scenario exact-seat 0 1 \
     planned,starting,authenticated,running,output_received,validated,contributed \
     contributed eligible '' 'command-code:thinkingmachines/inkling-small'
+assert_scenario agy-pin 0 1 \
+    planned,starting,authenticated,running,output_received,validated,contributed \
+    contributed eligible '' 'agy:Gemini 3.1 Pro (High)'
 assert_scenario auth-fail 1 0 planned,starting,failed failed none \
     'Provider unavailable: fixture authentication rejected'
 assert_scenario health-fail-qwen 1 0 planned,starting,failed failed none \
@@ -329,6 +341,16 @@ if (
     test_pass
 else
     test_fail "synchronous exact Fable execution retried or lost its lifecycle identity"
+fi
+
+test_case "exact AGY model pins reach execution and match lifecycle truth"
+agy_pin_snapshot="$TEST_TMP_DIR/agy-pin/workspace/runs/sync-agy-pin/seats.json"
+if [[ "$(cat "$TEST_TMP_DIR/agy-pin/executed-agy-model" 2>/dev/null || true)" == 'Gemini 3.1 Pro (High)' ]] && \
+   [[ "$(jq -r '.seats[0].resolved.model' "$agy_pin_snapshot")" == 'Gemini 3.1 Pro (High)' ]] && \
+   [[ "$(jq -r '.seats[0].resolved.provider' "$agy_pin_snapshot")" == 'agy' ]]; then
+    test_pass
+else
+    test_fail "AGY execution model and lifecycle model diverged: executed=[$(cat "$TEST_TMP_DIR/agy-pin/executed-agy-model" 2>/dev/null || true)] lifecycle-model=[$(jq -r '.seats[0].resolved.model' "$agy_pin_snapshot" 2>/dev/null || true)] lifecycle-provider=[$(jq -r '.seats[0].resolved.provider' "$agy_pin_snapshot" 2>/dev/null || true)]"
 fi
 
 test_summary

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -1143,6 +1143,59 @@ UNBOUNDED_BASH_ENV
     fi
 }
 
+test_agy_doctor_skips_version_probe() {
+    test_case "AGY live doctor does not run the unrelated version probe"
+
+    local tmp_bin="$TEST_TMP_DIR/agy-doctor-version-bin"
+    local tmp_home="$TEST_TMP_DIR/agy-doctor-version-home"
+    local marker="$TEST_TMP_DIR/agy-doctor-version-called"
+    local output
+    mkdir -p "$tmp_bin" "$tmp_home"
+    rm -f "$marker"
+    cat > "$tmp_bin/agy" <<'MOCK_AGY'
+#!/usr/bin/env bash
+case "${1:-}" in
+    --version)
+        printf '%s\n' called > "${AGY_VERSION_MARKER:?}"
+        sleep 5
+        exit 0
+        ;;
+    models)
+        printf '%s\t%s\n' 'gemini-test' 'Gemini Test'
+        exit 0
+        ;;
+esac
+while (( $# > 0 )); do
+    if [[ "$1" == "--print" && $# -ge 2 ]]; then
+        printf '%s\n' 'OCTOPUS_AGY_HEALTH_OK'
+        printf '%s\n' 'LOCAL_PROVIDER_DISPATCH_WORKS'
+        exit 0
+    fi
+    shift
+done
+exit 2
+MOCK_AGY
+    chmod +x "$tmp_bin/agy"
+
+    output="$(
+        HOME="$tmp_home" \
+        OCTO_ROOT="$PROJECT_ROOT" \
+        AGY_VERSION_MARKER="$marker" \
+        OCTOPUS_AGY_MODEL='gemini-test' \
+        OCTOPUS_AGY_HEALTH_TIMEOUT=1 \
+        PATH="$tmp_bin:/usr/bin:/bin" \
+            bash "$PROJECT_ROOT/scripts/doctor.sh" providers --live --json
+    )"
+
+    if [[ ! -e "$marker" ]] && \
+       jq -e '.results[] | select(.name == "agy-live-dispatch" and .status == "pass")' \
+           <<< "$output" >/dev/null; then
+        test_pass
+    else
+        test_fail "Doctor invoked the unrelated AGY version probe or live dispatch failed: $output"
+    fi
+}
+
 test_agy_auth_guidance_uses_real_cli_flow() {
     test_case "user-facing AGY auth guidance never advertises a nonexistent login subcommand"
 
@@ -1637,6 +1690,7 @@ test_agy_doctor_provider_check
 test_agy_doctor_live_probe
 test_agy_doctor_auth_remediation
 test_agy_doctor_catalog_timeout_is_bounded
+test_agy_doctor_skips_version_probe
 test_agy_auth_guidance_uses_real_cli_flow
 test_agy_setup_visibility
 test_agy_status_visibility

--- a/tests/unit/test-agy-workflow-routing.sh
+++ b/tests/unit/test-agy-workflow-routing.sh
@@ -16,13 +16,28 @@ test_role_map_research_design_copywriting_is_agy() {
     else test_fail "expected 3x agy, got: $(echo "$out" | tr '\n' ' ')"; fi
 }
 
-test_fallback_chain_prefers_agy() {
-    test_case "get_fallback_agent falls back to agy (not gemini) when codex is down"
+test_fallback_chain_is_configuration_driven() {
+    test_case "get_fallback_agent no longer hardcodes codex -> agy"
     local out
     out="$(bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
         is_agent_available(){ [[ "$1" == agy ]]; }
         get_fallback_agent codex')"
-    [[ "$out" == "agy" ]] && test_pass || test_fail "expected agy, got: $out"
+    [[ "$out" == "codex" ]] && test_pass || test_fail "expected preferred identity when configured/default chain has no available candidate, got: $out"
+}
+
+test_configured_fallback_chain_routes_native_resolver() {
+    test_case "get_fallback_agent honors routing.fallbackChains and routing.roles"
+    local tmp cfg out
+    tmp=$(mktemp -d)
+    cfg="$tmp/providers.json"
+    cat > "$cfg" <<'JSON'
+{"routing":{"roles":{"architect":{"provider":"claude","model":"claude-opus-test"}},"fallbackChains":{"default":[{"role":"architect"}]}}}
+JSON
+    out="$(OCTOPUS_PROVIDERS_CONFIG="$cfg" bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+        is_agent_available(){ [[ "$1" == claude ]]; }
+        get_fallback_agent codex coding')"
+    rm -rf "$tmp"
+    [[ "$out" == "claude:claude-opus-test" ]] && test_pass || test_fail "expected configured qualified claude fallback, got: $out"
 }
 
 test_no_functional_gemini_dispatch() {
@@ -46,7 +61,8 @@ test_tangle_decompose_default_is_agy() {
 }
 
 test_role_map_research_design_copywriting_is_agy
-test_fallback_chain_prefers_agy
+test_fallback_chain_is_configuration_driven
+test_configured_fallback_chain_routes_native_resolver
 test_no_functional_gemini_dispatch
 test_tangle_decompose_default_is_agy
 

--- a/tests/unit/test-agy-workflow-routing.sh
+++ b/tests/unit/test-agy-workflow-routing.sh
@@ -18,16 +18,39 @@ test_role_map_research_design_copywriting_is_agy() {
 }
 
 test_fallback_chain_is_configuration_driven() {
-    test_case "get_fallback_agent no longer hardcodes codex -> agy"
-    local out
+    test_case "get_fallback_agent fails closed when every candidate is unavailable"
+    local out rc=0
     out="$(env \
         "HOME=$TEST_TMP_DIR/home-default" \
         "OCTOPUS_PROVIDERS_CONFIG=$TEST_TMP_DIR/missing-providers.json" \
         bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
         is_agent_available(){ [[ "$1" == agy ]]; }
         is_agent_available_v2(){ [[ "$1" == agy ]]; }
-        get_fallback_agent codex')"
-    [[ "$out" == "codex" ]] && test_pass || test_fail "expected preferred identity when configured/default chain has no available candidate, got: $out"
+        get_fallback_agent codex coding')" || rc=$?
+    if [[ "$rc" -ne 0 && -z "$out" ]]; then
+        test_pass
+    else
+        test_fail "expected empty output and non-zero status, got rc=$rc out=[$out]"
+    fi
+}
+
+test_tiered_routing_propagates_exhaustion() {
+    test_case "get_tiered_agent propagates fallback exhaustion"
+    local out rc=0
+    out="$(env \
+        "HOME=$TEST_TMP_DIR/home-tiered" \
+        "OCTOPUS_PROVIDERS_CONFIG=$TEST_TMP_DIR/missing-tiered-providers.json" \
+        bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+        source "'"$PROJECT_ROOT"'/scripts/lib/agents.sh" 2>/dev/null
+        load_user_config(){ USER_RESOURCE_TIER=standard; }
+        get_resource_adjusted_tier(){ printf "%s\n" "$1"; }
+        is_agent_available_v2(){ return 1; }
+        get_tiered_agent coding 2' 2>/dev/null)" || rc=$?
+    if [[ "$rc" -ne 0 && -z "$out" ]]; then
+        test_pass
+    else
+        test_fail "expected routing failure to propagate, got rc=$rc out=[$out]"
+    fi
 }
 
 test_configured_fallback_chain_routes_native_resolver() {
@@ -69,6 +92,7 @@ test_tangle_decompose_default_is_agy() {
 
 test_role_map_research_design_copywriting_is_agy
 test_fallback_chain_is_configuration_driven
+test_tiered_routing_propagates_exhaustion
 test_configured_fallback_chain_routes_native_resolver
 test_no_functional_gemini_dispatch
 test_tangle_decompose_default_is_agy

--- a/tests/unit/test-agy-workflow-routing.sh
+++ b/tests/unit/test-agy-workflow-routing.sh
@@ -5,9 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
-TEST_TMP_DIR="/tmp/octopus-tests-$$"
 mkdir -p "$TEST_TMP_DIR/home-default" "$TEST_TMP_DIR/home-configured"
-trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
 test_suite "agy is the Google seat across workflows (Gemini CLI sunset 2026-06-18)"
 
 test_role_map_research_design_copywriting_is_agy() {
@@ -22,7 +20,10 @@ test_role_map_research_design_copywriting_is_agy() {
 test_fallback_chain_is_configuration_driven() {
     test_case "get_fallback_agent no longer hardcodes codex -> agy"
     local out
-    out="$(HOME="$TEST_TMP_DIR/home-default" OCTOPUS_PROVIDERS_CONFIG="$TEST_TMP_DIR/missing-providers.json" bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+    out="$(env \
+        "HOME=$TEST_TMP_DIR/home-default" \
+        "OCTOPUS_PROVIDERS_CONFIG=$TEST_TMP_DIR/missing-providers.json" \
+        bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
         is_agent_available(){ [[ "$1" == agy ]]; }
         is_agent_available_v2(){ [[ "$1" == agy ]]; }
         get_fallback_agent codex')"
@@ -36,7 +37,10 @@ test_configured_fallback_chain_routes_native_resolver() {
     cat > "$cfg" <<'JSON'
 {"routing":{"roles":{"architect":{"provider":"claude","model":"claude-opus-test"}},"fallbackChains":{"default":[{"role":"architect"}]}}}
 JSON
-    out="$(HOME="$TEST_TMP_DIR/home-configured" OCTOPUS_PROVIDERS_CONFIG="$cfg" bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+    out="$(env \
+        "HOME=$TEST_TMP_DIR/home-configured" \
+        "OCTOPUS_PROVIDERS_CONFIG=$cfg" \
+        bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
         is_agent_available(){ [[ "$1" == claude ]]; }
         is_agent_available_v2(){ [[ "$1" == claude ]]; }
         get_fallback_agent codex coding')"

--- a/tests/unit/test-agy-workflow-routing.sh
+++ b/tests/unit/test-agy-workflow-routing.sh
@@ -5,6 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
+mkdir -p "$TEST_TMP_DIR/home-default" "$TEST_TMP_DIR/home-configured"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
 test_suite "agy is the Google seat across workflows (Gemini CLI sunset 2026-06-18)"
 
 test_role_map_research_design_copywriting_is_agy() {
@@ -19,24 +22,24 @@ test_role_map_research_design_copywriting_is_agy() {
 test_fallback_chain_is_configuration_driven() {
     test_case "get_fallback_agent no longer hardcodes codex -> agy"
     local out
-    out="$(bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+    out="$(HOME="$TEST_TMP_DIR/home-default" OCTOPUS_PROVIDERS_CONFIG="$TEST_TMP_DIR/missing-providers.json" bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
         is_agent_available(){ [[ "$1" == agy ]]; }
+        is_agent_available_v2(){ [[ "$1" == agy ]]; }
         get_fallback_agent codex')"
     [[ "$out" == "codex" ]] && test_pass || test_fail "expected preferred identity when configured/default chain has no available candidate, got: $out"
 }
 
 test_configured_fallback_chain_routes_native_resolver() {
     test_case "get_fallback_agent honors routing.fallbackChains and routing.roles"
-    local tmp cfg out
-    tmp=$(mktemp -d)
-    cfg="$tmp/providers.json"
+    local cfg out
+    cfg="$TEST_TMP_DIR/providers-configured.json"
     cat > "$cfg" <<'JSON'
 {"routing":{"roles":{"architect":{"provider":"claude","model":"claude-opus-test"}},"fallbackChains":{"default":[{"role":"architect"}]}}}
 JSON
-    out="$(OCTOPUS_PROVIDERS_CONFIG="$cfg" bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
+    out="$(HOME="$TEST_TMP_DIR/home-configured" OCTOPUS_PROVIDERS_CONFIG="$cfg" bash -c 'source "'"$PROJECT_ROOT"'/scripts/lib/model-resolver.sh" 2>/dev/null
         is_agent_available(){ [[ "$1" == claude ]]; }
+        is_agent_available_v2(){ [[ "$1" == claude ]]; }
         get_fallback_agent codex coding')"
-    rm -rf "$tmp"
     [[ "$out" == "claude:claude-opus-test" ]] && test_pass || test_fail "expected configured qualified claude fallback, got: $out"
 }
 

--- a/tests/unit/test-configurable-fallback-chains.sh
+++ b/tests/unit/test-configurable-fallback-chains.sh
@@ -59,7 +59,10 @@ if [[ "$chosen" == "claude:claude-opus-test" ]]; then test_pass; else test_fail 
 test_case "technical fallback fails closed when v2 availability is absent"
 unset -f is_agent_available_v2
 is_agent_available() { return 0; }
-if chosen=$(octo_fallback_first_available default commandcode); then
+chain_specs="$(octo_fallback_chain_agent_specs default)"
+if [[ -z "$chain_specs" ]]; then
+  test_fail "default fallback chain unexpectedly empty; fail-closed assertion would be vacuous"
+elif chosen=$(octo_fallback_first_available default commandcode); then
   test_fail "legacy fail-open availability selected an unverified fallback: $chosen"
 else
   test_pass

--- a/tests/unit/test-configurable-fallback-chains.sh
+++ b/tests/unit/test-configurable-fallback-chains.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+source "$PROJECT_ROOT/scripts/lib/workflows.sh"
 
 test_suite "configurable fallback chains"
 
@@ -47,6 +48,37 @@ specs=$(octo_fallback_chain_agent_specs default)
 expected=$'codex:gpt-luna-test\ncodex:gpt-sol-test\nclaude:claude-opus-test'
 if [[ "$specs" == "$expected" ]]; then test_pass; else test_fail "unexpected specs: [$specs]"; fi
 
+test_case "built-in role defaults remain bare so session model precedence is preserved"
+printf '%s\n' '{"routing":{"fallbackChains":{"default":[{"role":"code-reviewer"}]}}}' > "$CFG"
+specs=$(octo_fallback_chain_agent_specs default)
+resolved=$(OCTOPUS_CODEX_MODEL=gpt-session-override resolve_octopus_model codex "$specs" "tangle" "code-reviewer")
+if [[ "$specs" == "codex-review" && "$resolved" == "gpt-session-override" ]]; then
+    test_pass
+else
+    test_fail "role default became an exact pin or bypassed session precedence: spec=[$specs] model=[$resolved]"
+fi
+write_config
+
+test_case "session model overrides beat configured fallback role models"
+printf '%s\n' '{"routing":{"roles":{"code-reviewer":{"provider":"codex","model":"gpt-role-default"}},"fallbackChains":{"default":[{"role":"code-reviewer"}]}}}' > "$CFG"
+specs=$(OCTOPUS_CODEX_MODEL=gpt-session-override octo_fallback_chain_agent_specs default)
+if [[ "$specs" == "codex:gpt-session-override" ]]; then
+    test_pass
+else
+    test_fail "configured role model bypassed session precedence: [$specs]"
+fi
+write_config
+
+test_case "session model overrides beat legacy string role models"
+printf '%s\n' '{"routing":{"roles":{"code-reviewer":"gpt-role-default"},"fallbackChains":{"default":[{"role":"code-reviewer"}]}}}' > "$CFG"
+specs=$(OCTOPUS_CODEX_MODEL=gpt-session-override octo_fallback_chain_agent_specs default)
+if [[ "$specs" == "codex-review:gpt-session-override" ]]; then
+    test_pass
+else
+    test_fail "legacy role model bypassed session precedence: [$specs]"
+fi
+write_config
+
 test_case "bare-provider role routes clear the inherited static-role model"
 jq '.routing.roles["code-reviewer"]="claude" | .routing.fallbackChains.default=[{"role":"code-reviewer"}]' "$CFG" > "$CFG.tmp"
 mv "$CFG.tmp" "$CFG"
@@ -66,6 +98,44 @@ mv "$CFG.tmp" "$CFG"
 specs=$(octo_fallback_chain_agent_specs default)
 expected=$'claude:claude-opus-test\ncommandcode:custom/model'
 if [[ "$specs" == "$expected" ]]; then test_pass; else test_fail "override not honored: [$specs]"; fi
+
+test_case "provider aliases canonicalize and equivalent candidates are deduplicated"
+printf '%s\n' '{"routing":{"fallbackChains":{"default":[{"provider":"anthropic","model":"claude-opus-test"},{"provider":"agy"},{"provider":"antigravity"},{"provider":"gemini"}]}}}' > "$CFG"
+specs=$(octo_fallback_chain_agent_specs default)
+expected=$'claude:claude-opus-test\nagy'
+if [[ "$specs" == "$expected" ]]; then
+    test_pass
+else
+    test_fail "aliases were rejected or retried: [$specs]"
+fi
+
+assert_invalid_chain_fails_closed() {
+    local description="$1" contents="$2" output="" rc=0
+    test_case "$description"
+    printf '%s\n' "$contents" > "$CFG"
+    output=$(octo_fallback_chain_agent_specs default 2>/dev/null) || rc=$?
+    if [[ "$rc" -ne 0 && -z "$output" ]]; then
+        test_pass
+    else
+        test_fail "invalid chain fell back or partially dispatched: rc=$rc output=[$output]"
+    fi
+}
+
+assert_invalid_chain_fails_closed \
+    "malformed providers JSON fails closed" \
+    '{"routing":{"fallbackChains":'
+assert_invalid_chain_fails_closed \
+    "wrong fallback chain type fails closed" \
+    '{"routing":{"fallbackChains":{"default":{"attempts":"codex"}}}}'
+assert_invalid_chain_fails_closed \
+    "wrong routing object type fails closed" \
+    '{"routing":"codex"}'
+assert_invalid_chain_fails_closed \
+    "unknown fallback role fails closed" \
+    '{"routing":{"fallbackChains":{"default":[{"role":"made-up-role"}]}}}'
+assert_invalid_chain_fails_closed \
+    "invalid fallback candidate fails the whole chain" \
+    '{"routing":{"fallbackChains":{"default":[{"provider":"claude"},{"provider":"not-a-provider"}]}}}'
 
 write_config
 is_agent_available_v2() { [[ "$1" == "claude" ]]; }
@@ -99,11 +169,13 @@ chosen=$(octo_fallback_first_available default commandcode)
 if [[ "$chosen" == "claude:claude-pinned-test" ]]; then test_pass; else test_fail "explicit model was lost: $chosen"; fi
 write_config
 
-test_case "technical fallback skips an invalid qualified candidate"
+test_case "technical fallback rejects a chain containing an invalid qualified candidate"
 jq '.routing.fallbackChains.default=[{"provider":"claude","model":"bad model"},{"provider":"claude","model":"claude-pinned-test"}]' "$CFG" > "$CFG.tmp"
 mv "$CFG.tmp" "$CFG"
-chosen=$(octo_fallback_first_available default commandcode)
-if [[ "$chosen" == "claude:claude-pinned-test" ]]; then test_pass; else test_fail "invalid qualified candidate blocked the valid fallback: $chosen"; fi
+chosen=""
+rc=0
+chosen=$(octo_fallback_first_available default commandcode) || rc=$?
+if [[ "$rc" -ne 0 && -z "$chosen" ]]; then test_pass; else test_fail "invalid qualified candidate was skipped: rc=$rc chosen=[$chosen]"; fi
 
 test_case "technical fallback fails closed when every qualified candidate is invalid"
 jq '.routing.fallbackChains.default=[{"provider":"claude","model":"bad model"},{"provider":"claude","model":"also\tbad"}]' "$CFG" > "$CFG.tmp"
@@ -168,5 +240,34 @@ run_agent_sync() {
 rc=0
 run_agent_sync_fallback_chain commandcode:primary 'plan it' 30 researcher tangle validate_protocol default >/dev/null || rc=$?
 if [[ "$rc" -ne 0 ]] && grep -c 'claude:claude-opus-test' "$ATTEMPTS" >/dev/null; then test_pass; else test_fail "chain did not exhaust safely"; fi
+
+test_case "runtime, empty, and semantic failures use one real decomposition fallback path"
+if (
+    : > "$ATTEMPTS"
+    tangle_decomposition_output_usable() { validate_protocol "$1"; }
+    octo_fallback_chain_agent_specs() {
+        printf '%s\n' agy antigravity gemini codex:gpt-luna-test codex:gpt-sol-test
+    }
+    run_agent_sync() {
+        local spec="$1" role="$4" phase="$5"
+        printf '%s|%s|%s\n' "$spec" "$role" "$phase" >> "$ATTEMPTS"
+        case "$spec" in
+            commandcode:primary) return 42 ;;
+            codex:explicit-fallback) printf '   \n' ;;
+            agy) printf 'not a decomposition\n' ;;
+            codex:gpt-luna-test) printf 'still not a decomposition\n' ;;
+            codex:gpt-sol-test) printf 'DECISIONS:\n- ACCEPT\nDECOMPOSITION:\n1. [CODING] valid\n' ;;
+            *) return 7 ;;
+        esac
+    }
+    out=$(tangle_run_decomposition_fallbacks commandcode:primary codex:explicit-fallback 'plan it' 30)
+    attempted_specs=$(cut -d'|' -f1 "$ATTEMPTS" | paste -sd, -)
+    [[ "$out" == *"DECOMPOSITION:"* ]] && \
+        [[ "$attempted_specs" == "commandcode:primary,codex:explicit-fallback,agy,codex:gpt-luna-test,codex:gpt-sol-test" ]]
+); then
+    test_pass
+else
+    test_fail "real fallback path did not handle all failure classes or deduplicate aliases"
+fi
 
 test_summary

--- a/tests/unit/test-configurable-fallback-chains.sh
+++ b/tests/unit/test-configurable-fallback-chains.sh
@@ -45,7 +45,7 @@ expected=$'claude:claude-opus-test\ncommandcode:custom/model'
 if [[ "$specs" == "$expected" ]]; then test_pass; else test_fail "override not honored: [$specs]"; fi
 
 write_config
-is_agent_available() { [[ "$1" == "claude" ]]; }
+is_agent_available_v2() { [[ "$1" == "claude" ]]; }
 test_case "technical availability uses the same configured/default chain"
 chosen=$(octo_fallback_first_available default commandcode)
 if [[ "$chosen" == "claude:claude-opus-test" ]]; then test_pass; else test_fail "expected qualified claude spec, got $chosen"; fi
@@ -55,8 +55,16 @@ is_agent_available() { return 0; }
 is_agent_available_v2() { [[ "$1" == "claude" ]]; }
 chosen=$(octo_fallback_first_available default commandcode)
 if [[ "$chosen" == "claude:claude-opus-test" ]]; then test_pass; else test_fail "legacy fail-open availability leaked into fallback selection: $chosen"; fi
+
+test_case "technical fallback fails closed when v2 availability is absent"
 unset -f is_agent_available_v2
-is_agent_available() { [[ "$1" == "claude" ]]; }
+is_agent_available() { return 0; }
+if chosen=$(octo_fallback_first_available default commandcode); then
+  test_fail "legacy fail-open availability selected an unverified fallback: $chosen"
+else
+  test_pass
+fi
+is_agent_available_v2() { [[ "$1" == "claude" ]]; }
 
 test_case "technical fallback preserves explicit provider:model candidates"
 jq '.routing.fallbackChains.default=[{"provider":"claude","model":"claude-pinned-test"}]' "$CFG" > "$CFG.tmp"

--- a/tests/unit/test-configurable-fallback-chains.sh
+++ b/tests/unit/test-configurable-fallback-chains.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+source "$PROJECT_ROOT/scripts/lib/execution-profile.sh"
+source "$PROJECT_ROOT/scripts/lib/fallback-chain.sh"
+
+test_suite "configurable fallback chains"
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+CFG="$TMP_ROOT/providers.json"
+export OCTOPUS_PROVIDERS_CONFIG="$CFG"
+
+write_config() {
+    cat > "$CFG" <<'JSON'
+{
+  "routing": {
+    "roles": {
+      "code-reviewer": {"provider":"codex","model":"gpt-luna-test"},
+      "implementer-heavy": {"provider":"codex","model":"gpt-sol-test"},
+      "architect": {"provider":"claude","model":"claude-opus-test"}
+    }
+  }
+}
+JSON
+}
+write_config
+
+test_case "built-in default chain is code-reviewer -> implementer-heavy -> architect"
+chain=$(octo_fallback_builtin_chain_json default | jq -r '[.[].role] | join(",")')
+if [[ "$chain" == "code-reviewer,implementer-heavy,architect" ]]; then test_pass; else test_fail "unexpected default: $chain"; fi
+
+test_case "default roles resolve through routing.roles provider and model"
+specs=$(octo_fallback_chain_agent_specs default)
+expected=$'codex:gpt-luna-test\ncodex:gpt-sol-test\nclaude:claude-opus-test'
+if [[ "$specs" == "$expected" ]]; then test_pass; else test_fail "unexpected specs: [$specs]"; fi
+
+test_case "providers.json may replace the fallback chain"
+jq '.routing.fallbackChains.default=[{"role":"architect"},{"provider":"commandcode","model":"custom/model"}]' "$CFG" > "$CFG.tmp"
+mv "$CFG.tmp" "$CFG"
+specs=$(octo_fallback_chain_agent_specs default)
+expected=$'claude:claude-opus-test\ncommandcode:custom/model'
+if [[ "$specs" == "$expected" ]]; then test_pass; else test_fail "override not honored: [$specs]"; fi
+
+write_config
+is_agent_available() { [[ "$1" == "claude" ]]; }
+test_case "technical availability uses the same configured/default chain"
+chosen=$(octo_fallback_first_available default commandcode)
+if [[ "$chosen" == "claude:claude-opus-test" ]]; then test_pass; else test_fail "expected qualified claude spec, got $chosen"; fi
+
+test_case "technical fallback preserves explicit provider:model candidates"
+jq '.routing.fallbackChains.default=[{"provider":"claude","model":"claude-pinned-test"}]' "$CFG" > "$CFG.tmp"
+mv "$CFG.tmp" "$CFG"
+chosen=$(octo_fallback_first_available default commandcode)
+if [[ "$chosen" == "claude:claude-pinned-test" ]]; then test_pass; else test_fail "explicit model was lost: $chosen"; fi
+write_config
+
+ATTEMPTS="$TMP_ROOT/attempts.log"
+: > "$ATTEMPTS"
+validate_protocol() {
+    [[ "$1" == *"DECISIONS:"* && "$1" == *"DECOMPOSITION:"* ]]
+}
+run_agent_sync() {
+    local spec="$1" role="$4" phase="$5"
+    printf '%s|%s|%s\n' "$spec" "$role" "$phase" >> "$ATTEMPTS"
+    case "$spec" in
+        commandcode:primary) printf '   \n'; return 0 ;;
+        codex:gpt-luna-test) printf 'I will inspect this first.\n'; return 0 ;;
+        codex:gpt-sol-test) printf 'DECISIONS:\n- ACCEPT fix\nDECOMPOSITION:\n1. [CODING] valid\n'; return 0 ;;
+        claude:claude-opus-test) printf 'DECISIONS:\n- ACCEPT last\nDECOMPOSITION:\n1. [CODING] last\n'; return 0 ;;
+        commandcode:technical-fail) return 42 ;;
+        *) return 7 ;;
+    esac
+}
+log() { :; }
+
+test_case "empty and semantically invalid success both advance the same chain"
+: > "$ATTEMPTS"
+out=$(run_agent_sync_fallback_chain commandcode:primary 'plan it' 30 researcher tangle validate_protocol default)
+count=$(wc -l < "$ATTEMPTS" | tr -d ' ')
+roles=$(cut -d'|' -f2 "$ATTEMPTS" | sort -u)
+phases=$(cut -d'|' -f3 "$ATTEMPTS" | sort -u)
+if [[ "$out" == *"DECOMPOSITION:"* && "$count" -eq 3 && "$roles" == "researcher" && "$phases" == "tangle" ]]; then
+    test_pass
+else
+    test_fail "semantic fallback failed: count=$count roles=$roles phases=$phases out=[$out]"
+fi
+
+test_case "process failure advances through the same chain"
+: > "$ATTEMPTS"
+out=$(run_agent_sync_fallback_chain commandcode:technical-fail 'plan it' 30 researcher tangle validate_protocol default)
+first=$(sed -n '1p' "$ATTEMPTS" | cut -d'|' -f1)
+second=$(sed -n '2p' "$ATTEMPTS" | cut -d'|' -f1)
+if [[ "$first" == "commandcode:technical-fail" && "$second" == "codex:gpt-luna-test" && "$out" == *"DECOMPOSITION:"* ]]; then
+    # Luna is semantically invalid, so Sol should ultimately satisfy the validator.
+    [[ $(wc -l < "$ATTEMPTS") -eq 3 ]] && test_pass || test_fail "expected three attempts"
+else
+    test_fail "technical fallback did not use common chain"
+fi
+
+test_case "chain exhausts and fails closed when every candidate is unusable"
+run_agent_sync() {
+    printf '%s\n' "$1" >> "$ATTEMPTS"
+    printf 'not-valid\n'
+    return 0
+}
+: > "$ATTEMPTS"
+rc=0
+run_agent_sync_fallback_chain commandcode:primary 'plan it' 30 researcher tangle validate_protocol default >/dev/null || rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'claude:claude-opus-test' "$ATTEMPTS"; then test_pass; else test_fail "chain did not exhaust safely"; fi
+
+test_summary

--- a/tests/unit/test-configurable-fallback-chains.sh
+++ b/tests/unit/test-configurable-fallback-chains.sh
@@ -4,18 +4,28 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
-source "$PROJECT_ROOT/scripts/lib/execution-profile.sh"
-source "$PROJECT_ROOT/scripts/lib/fallback-chain.sh"
+source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
 
 test_suite "configurable fallback chains"
 
 TMP_ROOT="$TEST_TMP_DIR"
 CFG="$TEST_TMP_DIR/providers.json"
+mkdir -p "$TEST_TMP_DIR/model-cache"
+export TMPDIR="$TEST_TMP_DIR/model-cache"
 export OCTOPUS_PROVIDERS_CONFIG="$CFG"
 
 write_config() {
     cat > "$CFG" <<'JSON'
 {
+  "providers": {
+    "codex": {
+      "default": "gpt-default-test",
+      "council": "gpt-council-test"
+    },
+    "claude": {
+      "default": "claude-default-test"
+    }
+  },
   "routing": {
     "roles": {
       "code-reviewer": {"provider":"codex","model":"gpt-luna-test"},
@@ -36,6 +46,19 @@ test_case "default roles resolve through routing.roles provider and model"
 specs=$(octo_fallback_chain_agent_specs default)
 expected=$'codex:gpt-luna-test\ncodex:gpt-sol-test\nclaude:claude-opus-test'
 if [[ "$specs" == "$expected" ]]; then test_pass; else test_fail "unexpected specs: [$specs]"; fi
+
+test_case "bare-provider role routes clear the inherited static-role model"
+jq '.routing.roles["code-reviewer"]="claude" | .routing.fallbackChains.default=[{"role":"code-reviewer"}]' "$CFG" > "$CFG.tmp"
+mv "$CFG.tmp" "$CFG"
+specs=$(octo_fallback_chain_agent_specs default)
+if [[ "$specs" == "claude" ]]; then test_pass; else test_fail "bare provider retained the prior role model: [$specs]"; fi
+
+test_case "provider capability role routes resolve to a concrete model"
+jq '.routing.roles["code-reviewer"]="codex:council" | .routing.fallbackChains.default=[{"role":"code-reviewer"}]' "$CFG" > "$CFG.tmp"
+mv "$CFG.tmp" "$CFG"
+specs=$(octo_fallback_chain_agent_specs default)
+if [[ "$specs" == "codex:gpt-council-test" ]]; then test_pass; else test_fail "provider capability was not recursively resolved: [$specs]"; fi
+write_config
 
 test_case "providers.json may replace the fallback chain"
 jq '.routing.fallbackChains.default=[{"role":"architect"},{"provider":"commandcode","model":"custom/model"}]' "$CFG" > "$CFG.tmp"

--- a/tests/unit/test-configurable-fallback-chains.sh
+++ b/tests/unit/test-configurable-fallback-chains.sh
@@ -131,11 +131,35 @@ assert_invalid_chain_fails_closed \
     "wrong routing object type fails closed" \
     '{"routing":"codex"}'
 assert_invalid_chain_fails_closed \
+    "wrong routing roles type fails closed" \
+    '{"routing":{"roles":"broken"}}'
+assert_invalid_chain_fails_closed \
+    "wrong routing phases type fails closed" \
+    '{"routing":{"phases":["codex"]}}'
+assert_invalid_chain_fails_closed \
     "unknown fallback role fails closed" \
     '{"routing":{"fallbackChains":{"default":[{"role":"made-up-role"}]}}}'
 assert_invalid_chain_fails_closed \
     "invalid fallback candidate fails the whole chain" \
     '{"routing":{"fallbackChains":{"default":[{"provider":"claude"},{"provider":"not-a-provider"}]}}}'
+
+test_case "malformed nested routing blocks every runtime dispatch"
+printf '%s\n' '{"routing":{"roles":"broken"}}' > "$CFG"
+dispatch_marker="$TEST_TMP_DIR/malformed-routing-dispatched"
+rm -f "$dispatch_marker"
+malformed_rc=0
+malformed_output="$({
+    run_agent_sync() {
+        : > "$dispatch_marker"
+        printf '%s\n' 'usable result'
+    }
+    run_agent_sync_fallback_chain agy 'plan it' 30 researcher tangle '' default
+} 2>/dev/null)" || malformed_rc=$?
+if [[ "$malformed_rc" -ne 0 && -z "$malformed_output" && ! -e "$dispatch_marker" ]]; then
+    test_pass
+else
+    test_fail "malformed nested routing dispatched: rc=$malformed_rc output=[$malformed_output]"
+fi
 
 write_config
 is_agent_available_v2() { [[ "$1" == "claude" ]]; }

--- a/tests/unit/test-configurable-fallback-chains.sh
+++ b/tests/unit/test-configurable-fallback-chains.sh
@@ -9,9 +9,6 @@ source "$PROJECT_ROOT/scripts/lib/fallback-chain.sh"
 
 test_suite "configurable fallback chains"
 
-TEST_TMP_DIR="/tmp/octopus-tests-$$"
-mkdir -p "$TEST_TMP_DIR"
-trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
 TMP_ROOT="$TEST_TMP_DIR"
 CFG="$TEST_TMP_DIR/providers.json"
 export OCTOPUS_PROVIDERS_CONFIG="$CFG"

--- a/tests/unit/test-configurable-fallback-chains.sh
+++ b/tests/unit/test-configurable-fallback-chains.sh
@@ -9,9 +9,11 @@ source "$PROJECT_ROOT/scripts/lib/fallback-chain.sh"
 
 test_suite "configurable fallback chains"
 
-TMP_ROOT=$(mktemp -d)
-trap 'rm -rf "$TMP_ROOT"' EXIT
-CFG="$TMP_ROOT/providers.json"
+TEST_TMP_DIR="/tmp/octopus-tests-$$"
+mkdir -p "$TEST_TMP_DIR"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
+TMP_ROOT="$TEST_TMP_DIR"
+CFG="$TEST_TMP_DIR/providers.json"
 export OCTOPUS_PROVIDERS_CONFIG="$CFG"
 
 write_config() {
@@ -50,6 +52,14 @@ is_agent_available() { [[ "$1" == "claude" ]]; }
 test_case "technical availability uses the same configured/default chain"
 chosen=$(octo_fallback_first_available default commandcode)
 if [[ "$chosen" == "claude:claude-opus-test" ]]; then test_pass; else test_fail "expected qualified claude spec, got $chosen"; fi
+
+test_case "technical fallback prefers fail-closed v2 availability when present"
+is_agent_available() { return 0; }
+is_agent_available_v2() { [[ "$1" == "claude" ]]; }
+chosen=$(octo_fallback_first_available default commandcode)
+if [[ "$chosen" == "claude:claude-opus-test" ]]; then test_pass; else test_fail "legacy fail-open availability leaked into fallback selection: $chosen"; fi
+unset -f is_agent_available_v2
+is_agent_available() { [[ "$1" == "claude" ]]; }
 
 test_case "technical fallback preserves explicit provider:model candidates"
 jq '.routing.fallbackChains.default=[{"provider":"claude","model":"claude-pinned-test"}]' "$CFG" > "$CFG.tmp"
@@ -110,6 +120,6 @@ run_agent_sync() {
 : > "$ATTEMPTS"
 rc=0
 run_agent_sync_fallback_chain commandcode:primary 'plan it' 30 researcher tangle validate_protocol default >/dev/null || rc=$?
-if [[ "$rc" -ne 0 ]] && grep -q 'claude:claude-opus-test' "$ATTEMPTS"; then test_pass; else test_fail "chain did not exhaust safely"; fi
+if [[ "$rc" -ne 0 ]] && grep -c 'claude:claude-opus-test' "$ATTEMPTS" >/dev/null; then test_pass; else test_fail "chain did not exhaust safely"; fi
 
 test_summary

--- a/tests/unit/test-configurable-fallback-chains.sh
+++ b/tests/unit/test-configurable-fallback-chains.sh
@@ -85,6 +85,12 @@ mv "$CFG.tmp" "$CFG"
 specs=$(octo_fallback_chain_agent_specs default)
 if [[ "$specs" == "claude" ]]; then test_pass; else test_fail "bare provider retained the prior role model: [$specs]"; fi
 
+test_case "legacy agy-research role routes remain on the AGY provider"
+jq '.routing.roles["code-reviewer"]="agy-research" | .routing.fallbackChains.default=[{"role":"code-reviewer"}]' "$CFG" > "$CFG.tmp"
+mv "$CFG.tmp" "$CFG"
+specs=$(octo_fallback_chain_agent_specs default)
+if [[ "$specs" == "agy" ]]; then test_pass; else test_fail "agy-research was treated as a model or rerouted: [$specs]"; fi
+
 test_case "provider capability role routes resolve to a concrete model"
 jq '.routing.roles["code-reviewer"]="codex:council" | .routing.fallbackChains.default=[{"role":"code-reviewer"}]' "$CFG" > "$CFG.tmp"
 mv "$CFG.tmp" "$CFG"

--- a/tests/unit/test-configurable-fallback-chains.sh
+++ b/tests/unit/test-configurable-fallback-chains.sh
@@ -99,6 +99,22 @@ chosen=$(octo_fallback_first_available default commandcode)
 if [[ "$chosen" == "claude:claude-pinned-test" ]]; then test_pass; else test_fail "explicit model was lost: $chosen"; fi
 write_config
 
+test_case "technical fallback skips an invalid qualified candidate"
+jq '.routing.fallbackChains.default=[{"provider":"claude","model":"bad model"},{"provider":"claude","model":"claude-pinned-test"}]' "$CFG" > "$CFG.tmp"
+mv "$CFG.tmp" "$CFG"
+chosen=$(octo_fallback_first_available default commandcode)
+if [[ "$chosen" == "claude:claude-pinned-test" ]]; then test_pass; else test_fail "invalid qualified candidate blocked the valid fallback: $chosen"; fi
+
+test_case "technical fallback fails closed when every qualified candidate is invalid"
+jq '.routing.fallbackChains.default=[{"provider":"claude","model":"bad model"},{"provider":"claude","model":"also\tbad"}]' "$CFG" > "$CFG.tmp"
+mv "$CFG.tmp" "$CFG"
+if chosen=$(octo_fallback_first_available default commandcode); then
+  test_fail "invalid qualified chain selected a candidate: $chosen"
+else
+  test_pass
+fi
+write_config
+
 ATTEMPTS="$TMP_ROOT/attempts.log"
 : > "$ATTEMPTS"
 validate_protocol() {

--- a/tests/unit/test-tangle-cancellation-cleanup.sh
+++ b/tests/unit/test-tangle-cancellation-cleanup.sh
@@ -124,7 +124,7 @@ fi
 
 workspace_definition="$(declare -f _tangle_develop_in_workspace)"
 helper_guard_line=$(awk '/declare -F review_kill_process_tree_frozen/ { print NR; exit }' <<< "$workspace_definition")
-dispatch_line=$(awk '/run_agent_sync/ { print NR; exit }' <<< "$workspace_definition")
+dispatch_line=$(awk '/run_agent_sync|tangle_run_decomposition_fallbacks/ { print NR; exit }' <<< "$workspace_definition")
 trap_line=$(awk "/trap 'octopus_tangle_handle_signal/ { print NR; exit }" <<< "$workspace_definition")
 if [[ "$behavioral_guarded" == "true" ]] \
    && [[ "$helper_guard_line" =~ ^[0-9]+$ ]] \

--- a/tests/unit/test-tangle-reformat-agent-routing.sh
+++ b/tests/unit/test-tangle-reformat-agent-routing.sh
@@ -45,7 +45,7 @@ if (
     export OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT="codex"
     result=$(tangle_reformat_decomposition "task" "bad decomposition" "overlap" "")
     [[ "$result" == *"Reformatted task"* ]] &&
-    [[ "$(sed -n '1p' "$CALL_LOG")" == "gemini|0|researcher|tangle" ]] &&
+    [[ "$(sed -n '1p' "$CALL_LOG")" == "agy|0|researcher|tangle" ]] &&
     [[ "$(wc -l < "$CALL_LOG")" -eq 1 ]]
 ); then
     test_pass
@@ -53,19 +53,19 @@ else
     test_fail "reformat did not use OCTOPUS_TANGLE_DECOMPOSE_AGENT first"
 fi
 
-test_case "reformat falls back to OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT"
+test_case "invalid explicit reformat provider fails closed before dispatch"
 if (
     rm -f "$CALL_LOG"
     export OCTOPUS_TANGLE_DECOMPOSE_AGENT="unavailable-agent"
     export OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT="gemini"
-    result=$(tangle_reformat_decomposition "task" "bad decomposition" "overlap" "")
-    [[ "$result" == *"Reformatted task"* ]] &&
-    [[ "$(sed -n '1p' "$CALL_LOG")" == "unavailable-agent|0|researcher|tangle" ]] &&
-    [[ "$(sed -n '2p' "$CALL_LOG")" == "gemini|0|researcher|tangle" ]]
+    if tangle_reformat_decomposition "task" "bad decomposition" "overlap" "" >/dev/null 2>&1; then
+        exit 1
+    fi
+    [[ ! -s "$CALL_LOG" ]]
 ); then
     test_pass
 else
-    test_fail "reformat did not use OCTOPUS_TANGLE_DECOMPOSE_FALLBACK_AGENT"
+    test_fail "invalid explicit provider reached dispatch or fell back"
 fi
 
 


### PR DESCRIPTION
## Summary

Unify Octopus dispatch fallbacks behind a configurable routing chain instead of keeping provider-specific fallback policy hard-coded in `get_fallback_agent()`.

- add `routing.fallbackChains` with a built-in default chain of routing roles: `code-reviewer -> implementer-heavy -> architect`
- resolve role candidates through the existing `routing.roles` provider/model table
- preserve explicit `provider:model` candidates end-to-end
- migrate native technical availability fallback to the same configurable chain
- add `run_agent_sync_fallback_chain` so workflows can use the same ordered policy for process failures, empty output, and caller-defined semantic/protocol validation failures
- keep the task's semantic role/phase unchanged while only the routing candidate changes
- retain the retired Gemini -> Antigravity compatibility alias separately from fallback policy
- fail closed when no configured/default candidate is usable

## Configuration

The built-in default requires no configuration. Users may replace it in `providers.json`:

```json
{
  "routing": {
    "fallbackChains": {
      "default": [
        { "role": "code-reviewer" },
        { "role": "implementer-heavy" },
        { "role": "architect" }
      ]
    }
  }
}
```

Role-based candidates are preferred because provider/model selection remains centralized in `routing.roles`. Explicit `{ "provider": "...", "model": "..." }` candidates are also supported when pinning is required.

## Scope

This PR introduces the generic engine and migrates the existing native availability fallback. It intentionally does not rewrite every workflow-specific retry/candidate loop in one change; those can adopt `run_agent_sync_fallback_chain` incrementally.

## Tests

Local regression coverage includes:

- configurable fallback chains: 8/8
- Antigravity/native fallback routing: 5/5
- model-config role routing: 4/4
- role production reachability: 5/5
- model-aware seats: 10/10
- current provider/model defaults: 11/11
- agent-sync run contract: 19/19
- agent-sync signal retry: 8/8
- agent output cap: 14/14
- persona spawn routing: 9/9
- retired Gemini boundary: 11/11
- Tangle direct fallback: 3/3
- provider-neutral Design Review: 21/21
- `bash -n` and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable fallback routing for agent execution, including ordered role-based and explicitly pinned provider/model candidates.
  - Fallbacks now evaluate availability and output validity across execution, empty-result, semantic, and technical failures.
  - Decomposition workflows can retry providers while requiring valid subtasks and file declarations.
  - AGY execution now uses the resolved model consistently.

- **Bug Fixes**
  - Routing failures now stop safely instead of silently continuing with unavailable agents.
  - Provider health checks no longer run an unrelated version probe.

- **Documentation**
  - Clarified dispatch fallbacks versus model-version fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->