### PR TITLE
fix: surface council "blind" seats that verdict without reading the artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@
   that remain bound to the running session.
 - Council now surfaces "blind" seats — a provider that returns a verdict without
   reading the artifact (dispatched without file-read tools, and saying so:
-  "cannot read the files", "permission restriction"). Such a seat was already
-  excluded from quorum but only as a generic `degenerate`, so operators
-  discovered a silently single-vendor council reactively, several ~17-minute
-  rounds in. Blind seats now get a distinct `blind` status, are listed in
+  "cannot read the files", "permission restriction"). Artifact-access failures
+  were previously reported only as generic `degenerate` responses, while
+  standalone permission or access refusals could still count as substantive and
+  enter quorum. Operators therefore discovered a silently single-vendor council
+  reactively, several ~17-minute rounds in. Blind seats now get a distinct
+  `blind` status, are listed in
   `summary.json` under `quorum.blind_seats`, and trigger an end-of-run warning
   naming the provider — so the seat's mode/model can be switched after the first
   blind round. (The default per-seat dispatch mode is unchanged.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@
 - Refuse Codex plugin updates from inside the Codex session using the loaded
   version. This prevents cache replacement from deleting hook and skill paths
   that remain bound to the running session.
+- Council now surfaces "blind" seats — a provider that returns a verdict without
+  reading the artifact (dispatched without file-read tools, and saying so:
+  "cannot read the files", "permission restriction"). Such a seat was already
+  excluded from quorum but only as a generic `degenerate`, so operators
+  discovered a silently single-vendor council reactively, several ~17-minute
+  rounds in. Blind seats now get a distinct `blind` status, are listed in
+  `summary.json` under `quorum.blind_seats`, and trigger an end-of-run warning
+  naming the provider — so the seat's mode/model can be switched after the first
+  blind round. (The default per-seat dispatch mode is unchanged.)
 
 ## [10.1.0] - 2026-08-30
 
@@ -29,7 +38,6 @@
   extension and MCP integration remain supported.
 
 ### Fixed
-
 - Migrate legacy generated `codex-mini` pins such as `gpt-5-codex-mini` to
   `gpt-5.6-luna`, preventing quick workflows from selecting a model that is
   unsupported for ChatGPT-authenticated Codex CLI sessions. Agent help now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
   extension and MCP integration remain supported.
 
 ### Fixed
+
 - Migrate legacy generated `codex-mini` pins such as `gpt-5-codex-mini` to
   `gpt-5.6-luna`, preventing quick workflows from selecting a model that is
   unsupported for ChatGPT-authenticated Codex CLI sessions. Agent help now

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -57,6 +57,7 @@ COUNCIL_ABORTED_FOR_COST=""
 COUNCIL_DIVERSITY_REPLACED=""
 COUNCIL_DIVERSITY_WARNING=""
 COUNCIL_TIMEOUT_WARNINGS=""
+COUNCIL_BLIND_SEATS=""
 COUNCIL_LAST_DISPATCH_TIMEOUT_PROVENANCE=""
 COUNCIL_BENCHMARK_FRESHNESS_WEIGHT=""
 COUNCIL_COST_CHECK_ESTIMATED=""
@@ -1900,6 +1901,23 @@ council_response_is_substantive() {
     return 0
 }
 
+council_response_is_blind() {
+    # A "blind" seat returned a verdict WITHOUT reading the artifact — it was
+    # dispatched without file-read tools (e.g. permissionMode "plan") and says so.
+    # This is a specific, high-confidence subset of the non-substantive set: the
+    # provider explicitly reports it could not reach the file/permission, rather
+    # than a host self-dispatch stub. Surfacing it (vs a generic "degenerate")
+    # lets the operator switch that provider's mode/model after the FIRST blind
+    # round instead of eating several. Brevity-gated so a long real review that
+    # merely quotes such a phrase is never flagged.
+    local f="$1"
+    [[ -f "$f" ]] || return 1
+    local nlen
+    nlen="$(tr -d '[:space:]' < "$f" | wc -c | tr -d '[:space:]')"
+    (( nlen < 1600 )) || return 1
+    grep -ciE "(cannot|could not|couldn'?t|unable to|can'?t)[[:space:]]+(access|read|open|locate|find|view|retrieve)[^.]{0,60}(file|plan|prd|diff|patch|artifact|document|spec)|permission[[:space:]-]*(restriction|denied|error)|no[[:space:]]+(file|read)[[:space:]]+access" "$f" >/dev/null
+}
+
 council_response_verdict() {
     # The seat's self-declared verdict, read from the LAST "VERDICT:" line. Fail
     # safe: anything that is not a clean APPROVE (REVISE / BLOCK / missing /
@@ -2013,6 +2031,17 @@ council_note_seat_timeout() {
 }${line}"
 }
 
+council_note_blind_seat() {
+    # Record a provider that returned a verdict without reading the artifact, so
+    # summary.json (blind_seats) and the end-of-run warnings name it immediately.
+    # De-duplicated so one provider blind across many rounds is listed once.
+    local provider="$1"
+    case " $COUNCIL_BLIND_SEATS " in
+        *" $provider "*) ;;
+        *) COUNCIL_BLIND_SEATS="${COUNCIL_BLIND_SEATS:+$COUNCIL_BLIND_SEATS }$provider" ;;
+    esac
+}
+
 council_chair_is_host_native() {
     # The chair can be the active host runtime (e.g. Claude Code running the
     # council). A host-native chair cannot self-dispatch, so it never produces a
@@ -2037,6 +2066,7 @@ council_run_advice_phase() {
     COUNCIL_RESPONDING_MODEL_FAMILIES=""
     COUNCIL_SEAT_RECORDS_JSON="[]"
     COUNCIL_TIMEOUT_WARNINGS=""
+    COUNCIL_BLIND_SEATS=""
     local dissenting_providers="" dissenting_model_families=""
 
     local index=0 member persona slug output_path seat mprovider mprovider_spec verdict
@@ -2100,8 +2130,15 @@ council_run_advice_phase() {
                 # A timed-out/truncated review without a final verdict is preserved
                 # for diagnosis, but cannot count as a response or approver.
                 seat_status="no-response"
+            elif council_response_is_blind "$output_path"; then
+                # Returned a verdict without reading the artifact (no file tools /
+                # permission). Label it distinctly and surface which provider, so
+                # the operator can switch its mode after ROUND ONE, not round six.
+                # Still excluded from quorum (not "responded").
+                seat_status="blind"
+                council_note_blind_seat "$mprovider"
             else
-                seat_status="degenerate"   # produced bytes but reviewed nothing (host stub / "cannot access")
+                seat_status="degenerate"   # produced bytes but reviewed nothing (host stub)
             fi
         else
             rm -f "$output_path"
@@ -2996,6 +3033,7 @@ council_write_summary_json() {
         --arg responding_providers "${COUNCIL_RESPONDING_PROVIDERS:+${COUNCIL_RESPONDING_PROVIDERS# }}" \
         --arg distinct_approving_providers "${COUNCIL_DISTINCT_APPROVING_PROVIDERS:-0}" \
         --arg approving_providers "${COUNCIL_APPROVING_PROVIDERS:-}" \
+        --arg blind_seats "${COUNCIL_BLIND_SEATS:-}" \
         --arg distinct_model_families "${COUNCIL_DISTINCT_MODEL_FAMILIES:-0}" \
         --arg responding_model_families "${COUNCIL_RESPONDING_MODEL_FAMILIES:+${COUNCIL_RESPONDING_MODEL_FAMILIES# }}" \
         --arg distinct_approving_model_families "${COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES:-0}" \
@@ -3049,6 +3087,7 @@ council_write_summary_json() {
             responding_model_families: $responding_model_families,
             distinct_approving_model_families: ($distinct_approving_model_families | tonumber),
             approving_model_families: $approving_model_families,
+            blind_seats: ($blind_seats | split(" ") | map(select(length > 0))),
             met: ($quorum_met == "true")
           },
           providers: $providers,
@@ -3131,6 +3170,10 @@ council_print_run_warnings() {
         while IFS= read -r _tw; do
             [[ -n "$_tw" ]] && echo "Council warning: $_tw"
         done <<< "$COUNCIL_TIMEOUT_WARNINGS"
+    fi
+
+    if [[ -n "${COUNCIL_BLIND_SEATS:-}" ]]; then
+        echo "Council warning: blind seat(s) returned a verdict without reading the artifact and were excluded from quorum: ${COUNCIL_BLIND_SEATS} — switch that provider's mode/model (e.g. give it file-read tools) or inline the artifact into the prompt. See summary.json quorum.blind_seats."
     fi
 }
 

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1898,6 +1898,18 @@ council_response_is_substantive() {
         return 1
     fi
 
+    # 3) A "blind" seat — a verdict returned without reading the artifact (permission
+    #    denied / no file access) — reviewed nothing and must never count toward the
+    #    quorum. council_response_is_blind matches a strict SUPERSET of case 2 (it adds
+    #    the permission-denied / no-file-access shapes), so a reply like
+    #    "Permission denied. VERDICT: REVISE" would otherwise slip past cases 1-2 and
+    #    be scored as a substantive responder. Fold it in here so the single
+    #    substantive gate the quorum tally keys on and the advice-phase `blind` label
+    #    agree; the advice phase still re-tests is_blind to label it distinctly.
+    if council_response_is_blind "$f"; then
+        return 1
+    fi
+
     return 0
 }
 

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1936,7 +1936,7 @@ council_response_is_blind() {
     # code behavior or a finding and is not evidence that the reviewer was blind.
     tr '\n' ' ' < "$f" \
         | tr -s '[:space:]' ' ' \
-        | grep -ciE '^[[:space:]]*permission[[:space:]-]*(restriction|denied|error)[[:space:][:punct:]]*(verdict:[[:space:]]*(approve|revise|block)[[:space:][:punct:]]*)?$' >/dev/null
+        | grep -ciE '^[[:space:]]*(permission[[:space:]-]*(restriction|denied|error)|access[[:space:]-]*denied)[[:space:][:punct:]]*(verdict:[[:space:]]*(approve|revise|block)[[:space:][:punct:]]*)?$' >/dev/null
 }
 
 council_response_verdict() {

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1898,10 +1898,10 @@ council_response_is_substantive() {
         return 1
     fi
 
-    # 3) A "blind" seat — a verdict returned without reading the artifact (permission
-    #    denied / no file access) — reviewed nothing and must never count toward the
-    #    quorum. council_response_is_blind matches a strict SUPERSET of case 2 (it adds
-    #    the permission-denied / no-file-access shapes), so a reply like
+    # 3) A "blind" seat — a verdict returned without reading the artifact (a
+    #    refusal-only permission error / no file access) — reviewed nothing and must
+    #    never count toward the quorum. council_response_is_blind matches a strict
+    #    SUPERSET of case 2, so a reply like
     #    "Permission denied. VERDICT: REVISE" would otherwise slip past cases 1-2 and
     #    be scored as a substantive responder. Fold it in here so the single
     #    substantive gate the quorum tally keys on and the advice-phase `blind` label
@@ -1927,7 +1927,16 @@ council_response_is_blind() {
     local nlen
     nlen="$(tr -d '[:space:]' < "$f" | wc -c | tr -d '[:space:]')"
     (( nlen < 1600 )) || return 1
-    grep -ciE "(cannot|could not|couldn'?t|unable to|can'?t)[[:space:]]+(access|read|open|locate|find|view|retrieve)[^.]{0,60}(file|plan|prd|diff|patch|artifact|document|spec)|permission[[:space:]-]*(restriction|denied|error)|no[[:space:]]+(file|read)[[:space:]]+access" "$f" >/dev/null
+    if grep -ciE "(cannot|could not|couldn'?t|unable to|can'?t)[[:space:]]+(access|read|open|locate|find|view|retrieve)[^.]{0,60}(file|plan|prd|diff|patch|artifact|document|spec)|no[[:space:]]+(file|read)[[:space:]]+access" "$f" >/dev/null; then
+        return 0
+    fi
+
+    # A bare permission error is only conclusive when it is the whole response,
+    # apart from an optional verdict. In review prose, the same phrase can describe
+    # code behavior or a finding and is not evidence that the reviewer was blind.
+    tr '\n' ' ' < "$f" \
+        | tr -s '[:space:]' ' ' \
+        | grep -ciE '^[[:space:]]*permission[[:space:]-]*(restriction|denied|error)[[:space:][:punct:]]*(verdict:[[:space:]]*(approve|revise|block)[[:space:][:punct:]]*)?$' >/dev/null
 }
 
 council_response_verdict() {

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1936,7 +1936,7 @@ council_response_is_blind() {
     # code behavior or a finding and is not evidence that the reviewer was blind.
     tr '\n' ' ' < "$f" \
         | tr -s '[:space:]' ' ' \
-        | grep -ciE '^[[:space:]]*(permission[[:space:]-]*(restriction|denied|error)|access[[:space:]-]*denied)[[:space:][:punct:]]*(verdict:[[:space:]]*(approve|revise|block)[[:space:][:punct:]]*)?$' >/dev/null
+        | grep -ciE '^[[:space:]]*(permission[[:space:]-]*((is[[:space:]-]+)?denied|restriction|error)|access[[:space:]-]*((is[[:space:]-]+)?denied))[[:space:][:punct:]]*(verdict:[[:space:]]*(approve|revise|block)[[:space:][:punct:]]*)?$' >/dev/null
 }
 
 council_response_verdict() {

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2099,18 +2099,26 @@ test_council_advice_marks_blind_seat() {
     local bd; bd="$(mktemp -d "$TEST_TMP_DIR/council-blindunit.XXXXXX")"
     printf 'I cannot read the files due to a permission restriction.\n\nVERDICT: REVISE\n' > "$bd/blind.md"
     printf '## Review\n\nsrc/app.ts:42 is missing the guard; otherwise sound.\n\nVERDICT: APPROVE\n' > "$bd/real.md"
-    local blind_yes=n blind_no=n
+    # The CodeRabbit fixture: a permission-only refusal that never names the
+    # artifact. It matches is_blind (permission-denied shape) but slips past the
+    # narrower is_substantive read-failure pattern — so the SHARED gate must
+    # still reject it, or it counts toward quorum as a responder (Finding 1).
+    printf 'Permission denied. VERDICT: REVISE\n' > "$bd/perm.md"
+    local blind_yes=n blind_no=n perm_blind=n perm_not_substantive=n
     council_response_is_blind "$bd/blind.md" && blind_yes=y
     council_response_is_blind "$bd/real.md" || blind_no=y
+    council_response_is_blind "$bd/perm.md" && perm_blind=y
+    council_response_is_substantive "$bd/perm.md" || perm_not_substantive=y
 
-    # Integration: a blind agy seat is classified "blind", excluded from the
-    # responder set, recorded in COUNCIL_BLIND_SEATS, and warned about.
+    # Integration: a permission-only refusal (the Finding-1 case) is classified
+    # "blind", excluded from the responder/quorum set, recorded in
+    # COUNCIL_BLIND_SEATS, and warned about — NOT scored as a responder.
     local d; d="$(mktemp -d "$TEST_TMP_DIR/council-blind.XXXXXX")"; mkdir -p "$d/responses"
     COUNCIL_RUN_DIR="$d"
     COUNCIL_ROSTER_JSON='[{"persona":"security-auditor","seat":"member","provider":"agy","provider_org":"google","model":"gemini"}]'
     COUNCIL_FIXTURE=""
     COUNCIL_BLIND_SEATS=""
-    council_dispatch_member_detached() { printf 'I cannot read the files due to a permission restriction.\n\nVERDICT: REVISE\n' > "$3"; return 0; }
+    council_dispatch_member_detached() { printf 'Permission denied. VERDICT: REVISE\n' > "$3"; return 0; }
     council_run_chair_fallback() { :; }
 
     council_run_advice_phase >/dev/null 2>&1 || true
@@ -2124,11 +2132,12 @@ test_council_advice_marks_blind_seat() {
     unset -f council_dispatch_member_detached council_run_chair_fallback
 
     if [[ "$blind_yes" == "y" && "$blind_no" == "y" \
+          && "$perm_blind" == "y" && "$perm_not_substantive" == "y" \
           && "$status" == "blind" && "$blind" == *"agy"* && "$responding" != *"agy"* \
           && "$output" == *"blind seat"* && "$output" == *"agy"* ]]; then
         test_pass
     else
-        test_fail "blind detection wrong: unit(blind=$blind_yes real_not_blind=$blind_no) status='$status' blind=[$blind] responding=[$responding] output=[$output]"
+        test_fail "blind detection wrong: unit(blind=$blind_yes real_not_blind=$blind_no perm_blind=$perm_blind perm_not_substantive=$perm_not_substantive) status='$status' blind=[$blind] responding=[$responding] output=[$output]"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2142,6 +2142,22 @@ test_council_advice_marks_blind_seat() {
     fi
 }
 
+test_council_permission_denied_finding_is_substantive() {
+    test_case "a short grounded review may mention permission denied without being blind"
+    load_council_lib || return 1
+
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-permission-finding.XXXXXX")"
+    printf 'The permission denied branch in src/auth.sh:42 returns the wrong status code.\n\nVERDICT: REVISE\n' > "$d/review.md"
+
+    if ! council_response_is_blind "$d/review.md" &&
+       council_response_is_substantive "$d/review.md"; then
+        test_pass
+    else
+        test_fail "grounded permission-denied finding was misclassified as blind"
+        return 1
+    fi
+}
+
 test_council_advice_does_not_infer_timeout_from_provider_rc() {
     test_case "advice phase keeps provider-returned 137 as no-response without a timeout hint"
     load_council_lib || return 1
@@ -2600,6 +2616,7 @@ test_council_live_response_uses_synthesis_timeout_for_chair
 test_council_rc_is_timeout_requires_watchdog_provenance
 test_council_advice_marks_timed_out_seat
 test_council_advice_marks_blind_seat
+test_council_permission_denied_finding_is_substantive
 test_council_advice_does_not_infer_timeout_from_provider_rc
 test_council_seat_timeout_rejects_zero_and_nonnumeric
 test_council_response_has_verdict_salvage

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2105,13 +2105,17 @@ test_council_advice_marks_blind_seat() {
     # still reject it, or it counts toward quorum as a responder (Finding 1).
     printf 'Permission denied. VERDICT: REVISE\n' > "$bd/perm.md"
     printf 'Access denied. VERDICT: REVISE\n' > "$bd/access.md"
-    local blind_yes=n blind_no=n perm_blind=n perm_not_substantive=n access_blind=n access_not_substantive=n
+    printf 'Permission is denied. VERDICT: REVISE\n' > "$bd/perm-is.md"
+    printf 'Access is denied. VERDICT: REVISE\n' > "$bd/access-is.md"
+    local blind_yes=n blind_no=n perm_blind=n perm_not_substantive=n access_blind=n access_not_substantive=n perm_is_blind=n access_is_blind=n
     council_response_is_blind "$bd/blind.md" && blind_yes=y
     council_response_is_blind "$bd/real.md" || blind_no=y
     council_response_is_blind "$bd/perm.md" && perm_blind=y
     council_response_is_substantive "$bd/perm.md" || perm_not_substantive=y
     council_response_is_blind "$bd/access.md" && access_blind=y
     council_response_is_substantive "$bd/access.md" || access_not_substantive=y
+    council_response_is_blind "$bd/perm-is.md" && perm_is_blind=y
+    council_response_is_blind "$bd/access-is.md" && access_is_blind=y
 
     # Integration: a permission-only refusal (the Finding-1 case) is classified
     # "blind", excluded from the responder/quorum set, recorded in
@@ -2121,10 +2125,12 @@ test_council_advice_marks_blind_seat() {
     COUNCIL_ROSTER_JSON='[{"persona":"security-auditor","seat":"member","provider":"agy","provider_org":"google","model":"gemini"}]'
     COUNCIL_FIXTURE=""
     COUNCIL_BLIND_SEATS=""
-    council_dispatch_member_detached() { printf 'Access denied. VERDICT: REVISE\n' > "$3"; return 0; }
+    council_dispatch_member_detached() { printf 'Access is denied. VERDICT: REVISE\n' > "$3"; return 0; }
     council_run_chair_fallback() { :; }
 
     council_run_advice_phase >/dev/null 2>&1 || true
+    council_note_blind_seat agy
+    council_note_blind_seat agy
 
     local status blind responding output
     status="$(jq -r '.[0].status' <<< "$COUNCIL_SEAT_RECORDS_JSON" 2>/dev/null)"
@@ -2137,6 +2143,7 @@ test_council_advice_marks_blind_seat() {
     if [[ "$blind_yes" == "y" && "$blind_no" == "y" \
           && "$perm_blind" == "y" && "$perm_not_substantive" == "y" \
           && "$access_blind" == "y" && "$access_not_substantive" == "y" \
+          && "$perm_is_blind" == "y" && "$access_is_blind" == "y" && "$blind" == "agy" \
           && "$status" == "blind" && "$blind" == *"agy"* && "$responding" != *"agy"* \
           && "$output" == *"blind seat"* && "$output" == *"agy"* ]]; then
         test_pass
@@ -2594,6 +2601,7 @@ test_council_seats_array_makes_quorum_inspectable() {
                           or (.status == "responded" and .verdict == "APPROVE")))
         and (.quorum.distinct_approving_providers
              == ([.seats[] | select(.counted_as_approver) | .provider] | unique | length))
+        and (.quorum.blind_seats | type == "array")
     ' "$s" >/dev/null; then
         test_pass
     else

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2104,11 +2104,14 @@ test_council_advice_marks_blind_seat() {
     # narrower is_substantive read-failure pattern — so the SHARED gate must
     # still reject it, or it counts toward quorum as a responder (Finding 1).
     printf 'Permission denied. VERDICT: REVISE\n' > "$bd/perm.md"
-    local blind_yes=n blind_no=n perm_blind=n perm_not_substantive=n
+    printf 'Access denied. VERDICT: REVISE\n' > "$bd/access.md"
+    local blind_yes=n blind_no=n perm_blind=n perm_not_substantive=n access_blind=n access_not_substantive=n
     council_response_is_blind "$bd/blind.md" && blind_yes=y
     council_response_is_blind "$bd/real.md" || blind_no=y
     council_response_is_blind "$bd/perm.md" && perm_blind=y
     council_response_is_substantive "$bd/perm.md" || perm_not_substantive=y
+    council_response_is_blind "$bd/access.md" && access_blind=y
+    council_response_is_substantive "$bd/access.md" || access_not_substantive=y
 
     # Integration: a permission-only refusal (the Finding-1 case) is classified
     # "blind", excluded from the responder/quorum set, recorded in
@@ -2118,7 +2121,7 @@ test_council_advice_marks_blind_seat() {
     COUNCIL_ROSTER_JSON='[{"persona":"security-auditor","seat":"member","provider":"agy","provider_org":"google","model":"gemini"}]'
     COUNCIL_FIXTURE=""
     COUNCIL_BLIND_SEATS=""
-    council_dispatch_member_detached() { printf 'Permission denied. VERDICT: REVISE\n' > "$3"; return 0; }
+    council_dispatch_member_detached() { printf 'Access denied. VERDICT: REVISE\n' > "$3"; return 0; }
     council_run_chair_fallback() { :; }
 
     council_run_advice_phase >/dev/null 2>&1 || true
@@ -2133,11 +2136,12 @@ test_council_advice_marks_blind_seat() {
 
     if [[ "$blind_yes" == "y" && "$blind_no" == "y" \
           && "$perm_blind" == "y" && "$perm_not_substantive" == "y" \
+          && "$access_blind" == "y" && "$access_not_substantive" == "y" \
           && "$status" == "blind" && "$blind" == *"agy"* && "$responding" != *"agy"* \
           && "$output" == *"blind seat"* && "$output" == *"agy"* ]]; then
         test_pass
     else
-        test_fail "blind detection wrong: unit(blind=$blind_yes real_not_blind=$blind_no perm_blind=$perm_blind perm_not_substantive=$perm_not_substantive) status='$status' blind=[$blind] responding=[$responding] output=[$output]"
+        test_fail "blind detection wrong: unit(blind=$blind_yes real_not_blind=$blind_no perm_blind=$perm_blind perm_not_substantive=$perm_not_substantive access_blind=$access_blind access_not_substantive=$access_not_substantive) status='$status' blind=[$blind] responding=[$responding] output=[$output]"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2091,6 +2091,48 @@ test_council_advice_marks_timed_out_seat() {
     fi
 }
 
+test_council_advice_marks_blind_seat() {
+    test_case "advice phase flags a seat that verdicts without reading the artifact as blind, excludes it from quorum, and surfaces it"
+    load_council_lib || return 1
+
+    # Unit: the read-failure signature is blind; a grounded review is not.
+    local bd; bd="$(mktemp -d "$TEST_TMP_DIR/council-blindunit.XXXXXX")"
+    printf 'I cannot read the files due to a permission restriction.\n\nVERDICT: REVISE\n' > "$bd/blind.md"
+    printf '## Review\n\nsrc/app.ts:42 is missing the guard; otherwise sound.\n\nVERDICT: APPROVE\n' > "$bd/real.md"
+    local blind_yes=n blind_no=n
+    council_response_is_blind "$bd/blind.md" && blind_yes=y
+    council_response_is_blind "$bd/real.md" || blind_no=y
+
+    # Integration: a blind agy seat is classified "blind", excluded from the
+    # responder set, recorded in COUNCIL_BLIND_SEATS, and warned about.
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-blind.XXXXXX")"; mkdir -p "$d/responses"
+    COUNCIL_RUN_DIR="$d"
+    COUNCIL_ROSTER_JSON='[{"persona":"security-auditor","seat":"member","provider":"agy","provider_org":"google","model":"gemini"}]'
+    COUNCIL_FIXTURE=""
+    COUNCIL_BLIND_SEATS=""
+    council_dispatch_member_detached() { printf 'I cannot read the files due to a permission restriction.\n\nVERDICT: REVISE\n' > "$3"; return 0; }
+    council_run_chair_fallback() { :; }
+
+    council_run_advice_phase >/dev/null 2>&1 || true
+
+    local status blind responding output
+    status="$(jq -r '.[0].status' <<< "$COUNCIL_SEAT_RECORDS_JSON" 2>/dev/null)"
+    blind="$COUNCIL_BLIND_SEATS"
+    responding="$COUNCIL_RESPONDING_PROVIDERS"
+    output="$(council_print_run_warnings)"
+
+    unset -f council_dispatch_member_detached council_run_chair_fallback
+
+    if [[ "$blind_yes" == "y" && "$blind_no" == "y" \
+          && "$status" == "blind" && "$blind" == *"agy"* && "$responding" != *"agy"* \
+          && "$output" == *"blind seat"* && "$output" == *"agy"* ]]; then
+        test_pass
+    else
+        test_fail "blind detection wrong: unit(blind=$blind_yes real_not_blind=$blind_no) status='$status' blind=[$blind] responding=[$responding] output=[$output]"
+        return 1
+    fi
+}
+
 test_council_advice_does_not_infer_timeout_from_provider_rc() {
     test_case "advice phase keeps provider-returned 137 as no-response without a timeout hint"
     load_council_lib || return 1
@@ -2548,6 +2590,7 @@ test_council_synthesis_timeout_overrides_seat_cap
 test_council_live_response_uses_synthesis_timeout_for_chair
 test_council_rc_is_timeout_requires_watchdog_provenance
 test_council_advice_marks_timed_out_seat
+test_council_advice_marks_blind_seat
 test_council_advice_does_not_infer_timeout_from_provider_rc
 test_council_seat_timeout_rejects_zero_and_nonnumeric
 test_council_response_has_verdict_salvage


### PR DESCRIPTION
## Problem

A council seat is dispatched by default without file-read tools (`permissionMode: "plan"`). A provider in that mode can return a fully-formatted verdict (`VERDICT: APPROVE`, prose, the works) **without ever reading the plan/PRD/diff it is supposed to review** — a "blind" seat.

Such a seat was *already* excluded from the distinct-approving-vendor quorum (`council_response_is_substantive()` catches the short "cannot read the file" replies), but only as a generic `degenerate` seat. So from the operator's side there was no mechanical signal that a nominally 2-vendor quorum had silently degraded to 1. It was discovered reactively — several ~17-minute rounds in — by noticing one vendor's reviews were content-free.

This is the "blind seat" finding from a governed-council run (companion to the per-session pool isolation in #973; that PR removes the cross-session seat-reaping, this one surfaces the read-failure mode that #973 does not address).

## Change

Add mechanical blind-seat detection and surface it distinctly. `council_response_is_blind()` is a **brevity-gated** match (seat text < 1600 non-space chars) on a response that explicitly reports it could not access/read the artifact or hit a permission restriction. The brevity gate means a long, genuine review that merely *quotes* such a phrase is never flagged.

A blind seat now:
- gets a distinct `blind` classification (instead of `degenerate`),
- is accumulated, de-duplicated, in `COUNCIL_BLIND_SEATS` (one provider blind across many rounds is listed once),
- is listed in `summary.json` under `quorum.blind_seats`, and
- triggers an end-of-run warning naming the provider, so its mode/model can be switched after the **first** blind round instead of round six.

**Scope, deliberately narrow:** this only *surfaces* the condition. The default per-seat dispatch mode is unchanged — no file tools are granted automatically. Changing the default dispatch mode is a separate, maintainer-owned decision.

## Test

`test_council_advice_marks_blind_seat` covers: the detector flags a blind file but not a real review; a blind `agy` seat gets status `blind`, lands in `COUNCIL_BLIND_SEATS`, is excluded from responders/quorum, and the warning is printed.

Full suite: `tests/unit/test-council-command.sh` → 87 passed, 0 failed, 1 skipped (pre-existing pty skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses indicating providers could not access required artifacts are identified as “blind” seats.
  * Blind seats are excluded from quorum calculations and listed in `summary.json`.
  * End-of-run warnings identify providers with blind responses.
  * Substantive findings that mention permission issues continue to count as valid responses.

* **Documentation**
  * Added changelog documentation for blind-seat handling and unchanged default dispatch behavior.

* **Tests**
  * Added coverage for detection, quorum exclusion, summary reporting, and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->