### PR TITLE
fix: honor .gitignore in consultative workspace copy

### DIFF
--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -156,15 +156,131 @@ should_use_agent_teams() {
     return 1
 }
 
-# Add a small, private Git directory to the disposable workspace. The object
-# database remains read-only through an alternate, while HEAD and the index are
-# local copies so reviewer Git commands work without copying the source .git.
+_octopus_clear_repository_env() {
+    unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
+    unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE
+    unset GIT_CEILING_DIRECTORIES GIT_PREFIX GIT_SUPER_PREFIX
+    unset GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT GIT_QUARANTINE_PATH
+    unset GIT_DEFAULT_HASH
+}
+
+# Repository-selection environment variables override `git -C`. Clear them for
+# workspace discovery and initialization so an exported GIT_DIR or index path
+# cannot redirect reads, writes, or cleanup decisions to another checkout.
+_octopus_git_without_repository_env() (
+    _octopus_clear_repository_env
+    command git "$@"
+)
+
+_octopus_resolve_git_path() {
+    local worktree_root="$1"
+    local git_path="$2"
+    local path_parent path_name
+
+    case "$git_path" in
+        /*) ;;
+        *) git_path="${worktree_root}/${git_path}" ;;
+    esac
+    path_parent="$(cd "$(dirname "$git_path")" 2>/dev/null && pwd -P)" || return 1
+    path_name="$(basename "$git_path")"
+    printf '%s/%s\n' "$path_parent" "$path_name"
+}
+
+_octopus_copy_workspace_refs() {
+    local source_root="$1"
+    local workspace="$2"
+    local refs_file oid refname symref failed
+
+    refs_file="$(mktemp "${TMPDIR:-/tmp}/octopus-workspace-refs.XXXXXX")" || return 1
+    _octopus_git_without_repository_env -C "$source_root" for-each-ref \
+        --format='%(objectname)%09%(refname)%09%(symref)' > "$refs_file" 2>/dev/null || {
+        rm -f "$refs_file"
+        return 1
+    }
+
+    failed=false
+    while IFS=$'\t' read -r oid refname symref; do
+        [[ -n "$oid" && -n "$refname" ]] || continue
+        _octopus_git_without_repository_env -C "$workspace" update-ref "$refname" "$oid" || {
+            failed=true
+            break
+        }
+    done < "$refs_file"
+
+    if [[ "$failed" == "false" ]]; then
+        while IFS=$'\t' read -r oid refname symref; do
+            [[ -n "$refname" && -n "$symref" ]] || continue
+            _octopus_git_without_repository_env -C "$workspace" symbolic-ref "$refname" "$symref" || {
+                failed=true
+                break
+            }
+        done < "$refs_file"
+    fi
+
+    rm -f "$refs_file"
+    [[ "$failed" == "false" ]]
+}
+
+_octopus_copy_workspace_index() {
+    local source_root="$1"
+    local workspace="$2"
+    local source_index source_shared_index workspace_shared_index
+    local index_before index_after attempt
+
+    source_index="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --git-path index 2>/dev/null)" || return 1
+    source_index="$(_octopus_resolve_git_path "$source_root" "$source_index")" || return 1
+
+    # An unborn empty repository may not have an index yet.
+    [[ -e "$source_index" ]] || return 0
+    [[ -f "$source_index" && ! -L "$source_index" ]] || return 1
+
+    attempt=1
+    while [[ "$attempt" -le 3 ]]; do
+        index_before="$(cksum "$source_index" 2>/dev/null)" || return 1
+        source_shared_index="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --shared-index-path 2>/dev/null)" || return 1
+        workspace_shared_index=""
+        if [[ -n "$source_shared_index" ]]; then
+            source_shared_index="$(_octopus_resolve_git_path "$source_root" "$source_shared_index")" || return 1
+            [[ -f "$source_shared_index" && ! -L "$source_shared_index" ]] || return 1
+            workspace_shared_index="$workspace/.git/$(basename "$source_shared_index")"
+            cp -p "$source_shared_index" "$workspace_shared_index" || return 1
+        fi
+
+        cp -p "$source_index" "$workspace/.git/index" || return 1
+        index_after="$(cksum "$source_index" 2>/dev/null)" || return 1
+        if [[ "$index_after" == "$index_before" ]]; then
+            chmod u+rw "$workspace/.git/index" || return 1
+            [[ -z "$workspace_shared_index" ]] || chmod u+rw "$workspace_shared_index" || return 1
+            return 0
+        fi
+        attempt=$((attempt + 1))
+    done
+
+    return 1
+}
+
+_octopus_copy_workspace_shallow_boundary() {
+    local source_root="$1"
+    local workspace="$2"
+    local source_shallow
+
+    source_shallow="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --git-path shallow 2>/dev/null)" || return 1
+    source_shallow="$(_octopus_resolve_git_path "$source_root" "$source_shallow")" || return 1
+    [[ -e "$source_shallow" ]] || return 0
+    [[ -f "$source_shallow" && ! -L "$source_shallow" ]] || return 1
+    cp -p "$source_shallow" "$workspace/.git/shallow" || return 1
+    chmod u+rw "$workspace/.git/shallow" || return 1
+}
+
+# Add a private Git directory to the disposable workspace. Refs and the exact
+# worktree index are copied locally. Commit objects remain readable through an
+# alternate, so workspace Git writes cannot update source refs or index state.
 _octopus_initialize_workspace_git_context() {
     local source_root="$1"
     local workspace="$2"
-    local common_dir object_dir head_oid head_ref
+    local common_dir object_dir head_oid head_ref object_format
 
-    common_dir="$(git -C "$source_root" rev-parse --git-common-dir 2>/dev/null)" || return 1
+    common_dir="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --git-common-dir 2>/dev/null)" || return 1
     case "$common_dir" in
         /*) ;;
         *) common_dir="${source_root}/${common_dir}" ;;
@@ -173,28 +289,27 @@ _octopus_initialize_workspace_git_context() {
     object_dir="${common_dir}/objects"
     [[ -d "$object_dir" ]] || return 1
 
-    git -C "$workspace" init -q || return 1
+    object_format="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --show-object-format 2>/dev/null || printf 'sha1\n')"
+    if [[ "$object_format" == "sha1" ]]; then
+        _octopus_git_without_repository_env -C "$workspace" init -q || return 1
+    else
+        _octopus_git_without_repository_env -C "$workspace" init -q --object-format="$object_format" || return 1
+    fi
     mkdir -p "$workspace/.git/objects/info" || return 1
     printf '%s\n' "$object_dir" > "$workspace/.git/objects/info/alternates" || return 1
 
-    head_oid="$(git -C "$source_root" rev-parse --verify HEAD 2>/dev/null || true)"
-    if [[ -n "$head_oid" ]]; then
-        head_ref="$(git -C "$source_root" symbolic-ref -q HEAD 2>/dev/null || true)"
-        if [[ -n "$head_ref" ]]; then
-            git -C "$workspace" symbolic-ref HEAD "$head_ref" || return 1
-            git -C "$workspace" update-ref "$head_ref" "$head_oid" || return 1
-        else
-            git -C "$workspace" update-ref --no-deref HEAD "$head_oid" || return 1
-        fi
+    _octopus_copy_workspace_shallow_boundary "$source_root" "$workspace" || return 1
+    _octopus_copy_workspace_refs "$source_root" "$workspace" || return 1
+
+    head_oid="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --verify HEAD 2>/dev/null || true)"
+    head_ref="$(_octopus_git_without_repository_env -C "$source_root" symbolic-ref -q HEAD 2>/dev/null || true)"
+    if [[ -n "$head_ref" ]]; then
+        _octopus_git_without_repository_env -C "$workspace" symbolic-ref HEAD "$head_ref" || return 1
+    elif [[ -n "$head_oid" ]]; then
+        _octopus_git_without_repository_env -C "$workspace" update-ref --no-deref HEAD "$head_oid" || return 1
     fi
 
-    # Rebuild the index from Git's portable stage records. Copying the index
-    # file itself would break split-index and worktree-specific configurations.
-    (
-        set -o pipefail
-        git -C "$source_root" ls-files --stage -z |
-            git -C "$workspace" update-index -z --index-info
-    ) || return 1
+    _octopus_copy_workspace_index "$source_root" "$workspace"
 }
 
 # Copy only tracked plus untracked-but-not-ignored files from a Git work tree.
@@ -207,7 +322,7 @@ _octopus_copy_git_tracked_tree() {
     local filelist copylist nestedlist entry rel entry_path
     local nested_top nested_rel resolved
 
-    git -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+    _octopus_git_without_repository_env -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
     source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
 
     filelist="$(mktemp "${TMPDIR:-/tmp}/octopus-tracked-tree.XXXXXX")" || return 1
@@ -219,7 +334,7 @@ _octopus_copy_git_tracked_tree() {
         rm -f "$filelist" "$copylist"
         return 1
     }
-    git -C "$source_root" ls-files -z --cached --others --exclude-standard >"$filelist" 2>/dev/null || {
+    _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached --others --exclude-standard >"$filelist" 2>/dev/null || {
         rm -f "$filelist" "$copylist" "$nestedlist"
         return 1
     }
@@ -254,7 +369,7 @@ _octopus_copy_git_tracked_tree() {
                     ;;
             esac
         elif [[ -d "$entry_path" ]]; then
-            nested_top="$(git -C "$entry_path" rev-parse --show-toplevel 2>/dev/null || true)"
+            nested_top="$(_octopus_git_without_repository_env -C "$entry_path" rev-parse --show-toplevel 2>/dev/null || true)"
             if [[ -n "$nested_top" ]]; then
                 nested_top="$(cd "$nested_top" 2>/dev/null && pwd -P)" || {
                     rm -f "$filelist" "$copylist" "$nestedlist"
@@ -309,50 +424,100 @@ _octopus_copy_git_tracked_tree() {
 # retain the original private whole-tree copy because they have no ignore index.
 _octopus_prepare_consultative_workspace() {
     local source_root="$1"
-    local temp_root workspace git_root source_prefix
-    temp_root="$(mktemp -d "${TMPDIR:-/tmp}/octopus-consultative.XXXXXX")" || return 1
-    workspace="${temp_root}/workspace"
-    mkdir -p "$workspace" || { rm -rf "$temp_root"; return 1; }
+    local workspace_result_var="${2:-}"
+    local temp_root_result_var="${3:-}"
+    local prepared_temp_root prepared_temp_root_raw prepared_workspace git_root source_prefix
 
-    if git -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [[ -n "$workspace_result_var" || -n "$temp_root_result_var" ]]; then
+        [[ "$workspace_result_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
+        [[ "$temp_root_result_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
+    fi
+
+    prepared_temp_root_raw="$(mktemp -d "${TMPDIR:-/tmp}/octopus-consultative.XXXXXX")" || return 1
+    prepared_temp_root="$(cd "$prepared_temp_root_raw" 2>/dev/null && pwd -P)" || {
+        rm -rf "$prepared_temp_root_raw"
+        return 1
+    }
+    prepared_workspace="${prepared_temp_root}/workspace"
+    mkdir -p "$prepared_workspace" || { rm -rf "$prepared_temp_root"; return 1; }
+
+    if _octopus_git_without_repository_env -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || {
-            rm -rf "$temp_root"
+            rm -rf "$prepared_temp_root"
             return 1
         }
-        git_root="$(git -C "$source_root" rev-parse --show-toplevel 2>/dev/null)" || {
-            rm -rf "$temp_root"
+        git_root="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --show-toplevel 2>/dev/null)" || {
+            rm -rf "$prepared_temp_root"
             return 1
         }
         git_root="$(cd "$git_root" 2>/dev/null && pwd -P)" || {
-            rm -rf "$temp_root"
+            rm -rf "$prepared_temp_root"
             return 1
         }
         case "$source_root" in
             "$git_root") source_prefix="" ;;
             "$git_root"/*) source_prefix="${source_root#"$git_root"/}" ;;
             *)
-                rm -rf "$temp_root"
+                rm -rf "$prepared_temp_root"
                 return 1
                 ;;
         esac
 
-        _octopus_copy_git_tracked_tree "$git_root" "$workspace" || {
-            rm -rf "$temp_root"
+        _octopus_copy_git_tracked_tree "$git_root" "$prepared_workspace" || {
+            rm -rf "$prepared_temp_root"
             return 1
         }
         if [[ -n "$source_prefix" ]]; then
-            workspace="${workspace}/${source_prefix}"
-            [[ -d "$workspace" ]] || { rm -rf "$temp_root"; return 1; }
+            mkdir -p "${prepared_workspace}/${source_prefix}" || {
+                rm -rf "$prepared_temp_root"
+                return 1
+            }
+            prepared_workspace="${prepared_workspace}/${source_prefix}"
         fi
     else
-        if ! cp -a --reflink=auto "${source_root}/." "${workspace}/" 2>/dev/null; then
-            rm -rf "$workspace"
-            mkdir -p "$workspace" || { rm -rf "$temp_root"; return 1; }
-            cp -a "${source_root}/." "${workspace}/" || { rm -rf "$temp_root"; return 1; }
+        if ! cp -a --reflink=auto "${source_root}/." "${prepared_workspace}/" 2>/dev/null; then
+            rm -rf "$prepared_workspace"
+            mkdir -p "$prepared_workspace" || { rm -rf "$prepared_temp_root"; return 1; }
+            cp -a "${source_root}/." "${prepared_workspace}/" || { rm -rf "$prepared_temp_root"; return 1; }
         fi
     fi
 
-    printf '%s\n' "$workspace"
+    if [[ -n "$workspace_result_var" && -n "$temp_root_result_var" ]]; then
+        printf -v "$workspace_result_var" '%s' "$prepared_workspace"
+        printf -v "$temp_root_result_var" '%s' "$prepared_temp_root"
+    else
+        printf '%s\n' "$prepared_workspace"
+    fi
+}
+
+_octopus_consultative_temp_root_is_safe() {
+    local temp_root="$1"
+    local workspace="$2"
+    local physical_temp_root temp_name
+
+    [[ "$temp_root" == /* && -d "$temp_root" && ! -L "$temp_root" ]] || return 1
+    physical_temp_root="$(cd "$temp_root" 2>/dev/null && pwd -P)" || return 1
+    [[ "$physical_temp_root" == "$temp_root" ]] || return 1
+    temp_name="$(basename "$temp_root")"
+    case "$temp_name" in
+        octopus-consultative.??????) ;;
+        *) return 1 ;;
+    esac
+    case "$workspace" in
+        "$temp_root/workspace"|"$temp_root/workspace"/*) ;;
+        *) return 1 ;;
+    esac
+}
+
+_octopus_remove_consultative_temp_root() {
+    local temp_root="$1"
+    local workspace="$2"
+
+    if [[ ! -e "$temp_root" && ! -L "$temp_root" ]]; then
+        return 0
+    fi
+    _octopus_consultative_temp_root_is_safe "$temp_root" "$workspace" || return 1
+    rm -rf "$temp_root"
 }
 
 # Run a synchronous agent in a strictly consultative context.
@@ -373,17 +538,19 @@ run_agent_sync_consultative() {
     local old_codex_sandbox="${OCTOPUS_CODEX_SANDBOX:-}"
     local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
     local old_autonomy="${CLAUDE_OCTOPUS_AUTONOMY:-}"
-    local source_root source_root_logical workspace workspace_root temp_root rc original_prompt isolated_prompt agent_output cleanup_note
+    local source_root source_root_logical workspace temp_root rc original_prompt isolated_prompt agent_output cleanup_note
     local -a consultative_args
 
     source_root_logical="$PWD"
     source_root="$(pwd -P)"
-    workspace="$(_octopus_prepare_consultative_workspace "$source_root")" || {
+    _octopus_prepare_consultative_workspace "$source_root" workspace temp_root || {
         log ERROR "Failed to prepare disposable consultative workspace from: $source_root"
         return 1
     }
-    workspace_root="$(git -C "$workspace" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$workspace")"
-    temp_root="$(dirname "$workspace_root")"
+    _octopus_consultative_temp_root_is_safe "$temp_root" "$workspace" || {
+        log ERROR "Refusing unsafe consultative workspace paths"
+        return 1
+    }
 
     consultative_args=("$@")
     original_prompt="${consultative_args[1]:-}"
@@ -403,14 +570,17 @@ Treat ${workspace} as the working copy for this advisory task. Any relative-path
     unset CLAUDE_OCTOPUS_AUTONOMY
     export OCTOPUS_CODEX_SANDBOX="danger-full-access"
 
-    if agent_output=$(cd "$workspace" && run_agent_sync "${consultative_args[@]}"); then
+    if agent_output=$(
+        _octopus_clear_repository_env
+        cd "$workspace" && run_agent_sync "${consultative_args[@]}"
+    ); then
         rc=0
     else
         rc=$?
     fi
 
     cleanup_note="Octopus deleted the workspace before returning."
-    if ! rm -rf "$temp_root" 2>/dev/null; then
+    if ! _octopus_remove_consultative_temp_root "$temp_root" "$workspace" 2>/dev/null; then
         cleanup_note="Octopus attempted cleanup before returning but could not confirm deletion."
         if declare -F log >/dev/null 2>&1; then
             log WARN "Failed to remove consultative workspace: $temp_root"

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -319,26 +319,24 @@ _octopus_replace_literal() {
 # must be a real directory. Symlink leaves must stay lexically within the copied
 # tree, and resolved targets must remain in the source. Any failure is fatal for
 # a Git source.
-_octopus_copy_git_tracked_tree() {
+_octopus_copy_git_tracked_tree() (
     local source_root="$1"
     local workspace="$2"
-    local filelist copylist nestedlist entry rel entry_path
+    local list_dir filelist copylist nestedlist entry rel entry_path copy_rc
     local nested_top nested_rel
 
     _octopus_git_without_repository_env -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
     source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
 
-    filelist="$(mktemp "${TMPDIR:-/tmp}/octopus-tracked-tree.XXXXXX")" || return 1
-    copylist="$(mktemp "${TMPDIR:-/tmp}/octopus-copy-tree.XXXXXX")" || {
-        rm -f "$filelist"
-        return 1
-    }
-    nestedlist="$(mktemp "${TMPDIR:-/tmp}/octopus-nested-tree.XXXXXX")" || {
-        rm -f "$filelist" "$copylist"
-        return 1
-    }
+    list_dir="$(mktemp -d "${TMPDIR:-/tmp}/octopus-copy-lists.XXXXXX")" || return 1
+    trap 'copy_rc=$?; trap - EXIT INT TERM; command rm -rf "$list_dir" || copy_rc=1; exit "$copy_rc"' EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    filelist="${list_dir}/tracked"
+    copylist="${list_dir}/copy"
+    nestedlist="${list_dir}/nested"
+    : > "$filelist" && : > "$copylist" && : > "$nestedlist" || return 1
     _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached --others --exclude-standard >"$filelist" 2>/dev/null || {
-        rm -f "$filelist" "$copylist" "$nestedlist"
         return 1
     }
 
@@ -350,7 +348,6 @@ _octopus_copy_git_tracked_tree() {
         # Deleted tracked paths remain in the index but have no bytes to copy.
         [[ -e "$entry_path" || -L "$entry_path" ]] || continue
         _octopus_validate_copy_source_path "$source_root" "$rel" || {
-            rm -f "$filelist" "$copylist" "$nestedlist"
             return 1
         }
 
@@ -358,14 +355,12 @@ _octopus_copy_git_tracked_tree() {
             nested_top="$(_octopus_git_without_repository_env -C "$entry_path" rev-parse --show-toplevel 2>/dev/null || true)"
             if [[ -n "$nested_top" ]]; then
                 nested_top="$(cd "$nested_top" 2>/dev/null && pwd -P)" || {
-                    rm -f "$filelist" "$copylist" "$nestedlist"
                     return 1
                 }
                 if [[ "$nested_top" != "$source_root" ]]; then
                     case "$nested_top" in
                         "$source_root"/*) nested_rel="${nested_top#"$source_root"/}" ;;
                         *)
-                            rm -f "$filelist" "$copylist" "$nestedlist"
                             return 1
                             ;;
                     esac
@@ -382,40 +377,34 @@ _octopus_copy_git_tracked_tree() {
     # closes the path-list-to-copy gap for an ancestor replaced by a symlink.
     while IFS= read -r -d '' rel; do
         _octopus_validate_copy_source_path "$source_root" "$rel" || {
-            rm -f "$filelist" "$copylist" "$nestedlist"
             return 1
         }
     done < "$copylist"
 
-    if ! (
-        set -o pipefail
-        tar --null -C "$source_root" -T "$copylist" -cf - | tar -xf - -C "$workspace"
-    ); then
-        rm -f "$filelist" "$copylist" "$nestedlist"
-        return 1
+    if [[ -s "$copylist" ]]; then
+        if ! (
+            set -o pipefail
+            tar --null -C "$source_root" -T "$copylist" -cf - | tar -xf - -C "$workspace"
+        ); then
+            return 1
+        fi
     fi
 
     while IFS= read -r -d '' nested_rel; do
         _octopus_source_path_has_safe_ancestry "$source_root" "$nested_rel" || {
-            rm -f "$filelist" "$copylist" "$nestedlist"
             return 1
         }
         [[ -d "$source_root/$nested_rel" && ! -L "$source_root/$nested_rel" ]] || {
-            rm -f "$filelist" "$copylist" "$nestedlist"
             return 1
         }
         mkdir -p "$workspace/$nested_rel" || {
-            rm -f "$filelist" "$copylist" "$nestedlist"
             return 1
         }
         _octopus_copy_git_tracked_tree "$source_root/$nested_rel" "$workspace/$nested_rel" || {
-            rm -f "$filelist" "$copylist" "$nestedlist"
             return 1
         }
     done < "$nestedlist"
-
-    rm -f "$filelist" "$copylist" "$nestedlist"
-}
+)
 
 # Prepare an isolated copy-on-write workspace for advisory agents.
 # Git sources fail closed if their selective copy fails. Non-Git directories

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -157,170 +157,112 @@ should_use_agent_teams() {
 }
 
 _octopus_clear_repository_env() {
+    local git_env_name
+
     unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
     unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE
-    unset GIT_CEILING_DIRECTORIES GIT_PREFIX GIT_SUPER_PREFIX
-    unset GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT GIT_QUARANTINE_PATH
-    unset GIT_DEFAULT_HASH
+    unset GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM
+    unset GIT_IMPLICIT_WORK_TREE GIT_PREFIX GIT_SUPER_PREFIX GIT_INTERNAL_SUPER_PREFIX
+    unset GIT_GRAFT_FILE GIT_SHALLOW_FILE GIT_REPLACE_REF_BASE GIT_NO_REPLACE_OBJECTS
+    unset GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM
+    unset GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT GIT_QUARANTINE_PATH GIT_DEFAULT_HASH
+
+    # Git's command-scope config protocol uses numbered variable names. Clear
+    # every inherited pair even when GIT_CONFIG_COUNT itself is malformed or
+    # absent, so advisory code cannot reactivate stale injected configuration.
+    while IFS= read -r git_env_name; do
+        case "$git_env_name" in
+            GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*) unset "$git_env_name" 2>/dev/null || true ;;
+        esac
+    done < <(compgen -v)
 }
 
 # Repository-selection environment variables override `git -C`. Clear them for
-# workspace discovery and initialization so an exported GIT_DIR or index path
-# cannot redirect reads, writes, or cleanup decisions to another checkout.
+# workspace discovery so an exported GIT_DIR, config, or index path cannot
+# redirect reads or writes to another checkout.
 _octopus_git_without_repository_env() (
     _octopus_clear_repository_env
     command git "$@"
 )
 
-_octopus_resolve_git_path() {
-    local worktree_root="$1"
-    local git_path="$2"
-    local path_parent path_name
+_octopus_source_path_has_safe_ancestry() {
+    local source_root="$1"
+    local rel="$2"
+    local current="$source_root"
+    local remaining="$rel"
+    local component
 
-    case "$git_path" in
-        /*) ;;
-        *) git_path="${worktree_root}/${git_path}" ;;
+    case "$rel" in
+        ""|/*) return 1 ;;
     esac
-    path_parent="$(cd "$(dirname "$git_path")" 2>/dev/null && pwd -P)" || return 1
-    path_name="$(basename "$git_path")"
-    printf '%s/%s\n' "$path_parent" "$path_name"
-}
 
-_octopus_copy_workspace_refs() {
-    local source_root="$1"
-    local workspace="$2"
-    local refs_file oid refname symref failed
-
-    refs_file="$(mktemp "${TMPDIR:-/tmp}/octopus-workspace-refs.XXXXXX")" || return 1
-    _octopus_git_without_repository_env -C "$source_root" for-each-ref \
-        --format='%(objectname)%09%(refname)%09%(symref)' > "$refs_file" 2>/dev/null || {
-        rm -f "$refs_file"
-        return 1
-    }
-
-    failed=false
-    while IFS=$'\t' read -r oid refname symref; do
-        [[ -n "$oid" && -n "$refname" ]] || continue
-        _octopus_git_without_repository_env -C "$workspace" update-ref "$refname" "$oid" || {
-            failed=true
-            break
-        }
-    done < "$refs_file"
-
-    if [[ "$failed" == "false" ]]; then
-        while IFS=$'\t' read -r oid refname symref; do
-            [[ -n "$refname" && -n "$symref" ]] || continue
-            _octopus_git_without_repository_env -C "$workspace" symbolic-ref "$refname" "$symref" || {
-                failed=true
-                break
-            }
-        done < "$refs_file"
-    fi
-
-    rm -f "$refs_file"
-    [[ "$failed" == "false" ]]
-}
-
-_octopus_copy_workspace_index() {
-    local source_root="$1"
-    local workspace="$2"
-    local source_index source_shared_index workspace_shared_index
-    local index_before index_after attempt
-
-    source_index="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --git-path index 2>/dev/null)" || return 1
-    source_index="$(_octopus_resolve_git_path "$source_root" "$source_index")" || return 1
-
-    # An unborn empty repository may not have an index yet.
-    [[ -e "$source_index" ]] || return 0
-    [[ -f "$source_index" && ! -L "$source_index" ]] || return 1
-
-    attempt=1
-    while [[ "$attempt" -le 3 ]]; do
-        index_before="$(cksum "$source_index" 2>/dev/null)" || return 1
-        source_shared_index="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --shared-index-path 2>/dev/null)" || return 1
-        workspace_shared_index=""
-        if [[ -n "$source_shared_index" ]]; then
-            source_shared_index="$(_octopus_resolve_git_path "$source_root" "$source_shared_index")" || return 1
-            [[ -f "$source_shared_index" && ! -L "$source_shared_index" ]] || return 1
-            workspace_shared_index="$workspace/.git/$(basename "$source_shared_index")"
-            cp -p "$source_shared_index" "$workspace_shared_index" || return 1
-        fi
-
-        cp -p "$source_index" "$workspace/.git/index" || return 1
-        index_after="$(cksum "$source_index" 2>/dev/null)" || return 1
-        if [[ "$index_after" == "$index_before" ]]; then
-            chmod u+rw "$workspace/.git/index" || return 1
-            [[ -z "$workspace_shared_index" ]] || chmod u+rw "$workspace_shared_index" || return 1
-            return 0
-        fi
-        attempt=$((attempt + 1))
+    while [[ "$remaining" == */* ]]; do
+        component="${remaining%%/*}"
+        case "$component" in
+            ""|.|..) return 1 ;;
+        esac
+        current="${current}/${component}"
+        [[ -d "$current" && ! -L "$current" ]] || return 1
+        remaining="${remaining#*/}"
     done
 
-    return 1
-}
-
-_octopus_copy_workspace_shallow_boundary() {
-    local source_root="$1"
-    local workspace="$2"
-    local source_shallow
-
-    source_shallow="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --git-path shallow 2>/dev/null)" || return 1
-    source_shallow="$(_octopus_resolve_git_path "$source_root" "$source_shallow")" || return 1
-    [[ -e "$source_shallow" ]] || return 0
-    [[ -f "$source_shallow" && ! -L "$source_shallow" ]] || return 1
-    cp -p "$source_shallow" "$workspace/.git/shallow" || return 1
-    chmod u+rw "$workspace/.git/shallow" || return 1
-}
-
-# Add a private Git directory to the disposable workspace. Refs and the exact
-# worktree index are copied locally. Commit objects remain readable through an
-# alternate, so workspace Git writes cannot update source refs or index state.
-_octopus_initialize_workspace_git_context() {
-    local source_root="$1"
-    local workspace="$2"
-    local common_dir object_dir head_oid head_ref object_format
-
-    common_dir="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --git-common-dir 2>/dev/null)" || return 1
-    case "$common_dir" in
-        /*) ;;
-        *) common_dir="${source_root}/${common_dir}" ;;
+    case "$remaining" in
+        ""|.|..) return 1 ;;
     esac
-    common_dir="$(cd "$common_dir" 2>/dev/null && pwd -P)" || return 1
-    object_dir="${common_dir}/objects"
-    [[ -d "$object_dir" ]] || return 1
+}
 
-    object_format="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --show-object-format 2>/dev/null || printf 'sha1\n')"
-    if [[ "$object_format" == "sha1" ]]; then
-        _octopus_git_without_repository_env -C "$workspace" init -q || return 1
-    else
-        _octopus_git_without_repository_env -C "$workspace" init -q --object-format="$object_format" || return 1
+_octopus_validate_copy_source_path() {
+    local source_root="$1"
+    local rel="$2"
+    local entry_path link_target resolved
+
+    _octopus_source_path_has_safe_ancestry "$source_root" "$rel" || return 1
+    entry_path="${source_root}/${rel}"
+    [[ -e "$entry_path" || -L "$entry_path" ]] || return 1
+
+    if [[ -L "$entry_path" ]]; then
+        link_target="$(readlink "$entry_path" 2>/dev/null)" || return 1
+        case "$link_target" in
+            /*) return 1 ;;
+        esac
+        resolved="$(realpath "$entry_path" 2>/dev/null)" || return 1
+        case "$resolved" in
+            "$source_root"|"$source_root"/*) ;;
+            *) return 1 ;;
+        esac
+    elif [[ -f "$entry_path" ]]; then
+        [[ -r "$entry_path" ]] || return 1
+    elif [[ ! -d "$entry_path" ]]; then
+        return 1
     fi
-    mkdir -p "$workspace/.git/objects/info" || return 1
-    printf '%s\n' "$object_dir" > "$workspace/.git/objects/info/alternates" || return 1
+}
 
-    _octopus_copy_workspace_shallow_boundary "$source_root" "$workspace" || return 1
-    _octopus_copy_workspace_refs "$source_root" "$workspace" || return 1
+_octopus_replace_literal() {
+    local value="$1"
+    local needle="$2"
+    local replacement="$3"
+    local result=""
+    local prefix
 
-    head_oid="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --verify HEAD 2>/dev/null || true)"
-    head_ref="$(_octopus_git_without_repository_env -C "$source_root" symbolic-ref -q HEAD 2>/dev/null || true)"
-    if [[ -n "$head_ref" ]]; then
-        _octopus_git_without_repository_env -C "$workspace" symbolic-ref HEAD "$head_ref" || return 1
-    elif [[ -n "$head_oid" ]]; then
-        _octopus_git_without_repository_env -C "$workspace" update-ref --no-deref HEAD "$head_oid" || return 1
-    fi
-
-    _octopus_copy_workspace_index "$source_root" "$workspace"
+    [[ -n "$needle" ]] || { printf '%s' "$value"; return 0; }
+    while [[ "$value" == *"$needle"* ]]; do
+        prefix="${value%%"$needle"*}"
+        result="${result}${prefix}${replacement}"
+        value="${value#*"$needle"}"
+    done
+    printf '%s' "${result}${value}"
 }
 
 # Copy only tracked plus untracked-but-not-ignored files from a Git work tree.
 # Nested repositories are removed from the parent archive list before tar runs,
-# then copied recursively under their own ignore rules. Symlinks must resolve
-# within their source repository. Any failure is fatal for a Git source.
+# then copied recursively under their own ignore rules. Every path ancestor
+# must be a real directory, and symlink leaves must resolve within their source
+# repository. Any failure is fatal for a Git source.
 _octopus_copy_git_tracked_tree() {
     local source_root="$1"
     local workspace="$2"
     local filelist copylist nestedlist entry rel entry_path
-    local nested_top nested_rel resolved
+    local nested_top nested_rel
 
     _octopus_git_without_repository_env -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
     source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
@@ -346,29 +288,12 @@ _octopus_copy_git_tracked_tree() {
 
         # Deleted tracked paths remain in the index but have no bytes to copy.
         [[ -e "$entry_path" || -L "$entry_path" ]] || continue
+        _octopus_validate_copy_source_path "$source_root" "$rel" || {
+            rm -f "$filelist" "$copylist" "$nestedlist"
+            return 1
+        }
 
-        if [[ -L "$entry_path" ]]; then
-            # An absolute link would still point back into the source checkout
-            # after tar preserves it, so fail closed even when its target is
-            # physically inside source_root.
-            case "$(readlink "$entry_path" 2>/dev/null)" in
-                /*)
-                    rm -f "$filelist" "$copylist" "$nestedlist"
-                    return 1
-                    ;;
-            esac
-            resolved="$(realpath "$entry_path" 2>/dev/null)" || {
-                rm -f "$filelist" "$copylist" "$nestedlist"
-                return 1
-            }
-            case "$resolved" in
-                "$source_root"|"$source_root"/*) ;;
-                *)
-                    rm -f "$filelist" "$copylist" "$nestedlist"
-                    return 1
-                    ;;
-            esac
-        elif [[ -d "$entry_path" ]]; then
+        if [[ -d "$entry_path" && ! -L "$entry_path" ]]; then
             nested_top="$(_octopus_git_without_repository_env -C "$entry_path" rev-parse --show-toplevel 2>/dev/null || true)"
             if [[ -n "$nested_top" ]]; then
                 nested_top="$(cd "$nested_top" 2>/dev/null && pwd -P)" || {
@@ -392,6 +317,15 @@ _octopus_copy_git_tracked_tree() {
         printf '%s\0' "$rel" >> "$copylist"
     done < "$filelist"
 
+    # Recheck after enumeration and immediately before archive traversal. This
+    # closes the path-list-to-copy gap for an ancestor replaced by a symlink.
+    while IFS= read -r -d '' rel; do
+        _octopus_validate_copy_source_path "$source_root" "$rel" || {
+            rm -f "$filelist" "$copylist" "$nestedlist"
+            return 1
+        }
+    done < "$copylist"
+
     if ! (
         set -o pipefail
         tar --null -C "$source_root" -T "$copylist" -cf - | tar -xf - -C "$workspace"
@@ -401,6 +335,14 @@ _octopus_copy_git_tracked_tree() {
     fi
 
     while IFS= read -r -d '' nested_rel; do
+        _octopus_source_path_has_safe_ancestry "$source_root" "$nested_rel" || {
+            rm -f "$filelist" "$copylist" "$nestedlist"
+            return 1
+        }
+        [[ -d "$source_root/$nested_rel" && ! -L "$source_root/$nested_rel" ]] || {
+            rm -f "$filelist" "$copylist" "$nestedlist"
+            return 1
+        }
         mkdir -p "$workspace/$nested_rel" || {
             rm -f "$filelist" "$copylist" "$nestedlist"
             return 1
@@ -410,11 +352,6 @@ _octopus_copy_git_tracked_tree() {
             return 1
         }
     done < "$nestedlist"
-
-    _octopus_initialize_workspace_git_context "$source_root" "$workspace" || {
-        rm -f "$filelist" "$copylist" "$nestedlist"
-        return 1
-    }
 
     rm -f "$filelist" "$copylist" "$nestedlist"
 }
@@ -554,15 +491,16 @@ run_agent_sync_consultative() {
 
     consultative_args=("$@")
     original_prompt="${consultative_args[1]:-}"
-    isolated_prompt="${original_prompt//$source_root/$workspace}"
+    isolated_prompt="$(_octopus_replace_literal "$original_prompt" "$source_root" "$workspace")"
     if [[ "$source_root_logical" != "$source_root" ]]; then
-        isolated_prompt="${isolated_prompt//$source_root_logical/$workspace}"
+        isolated_prompt="$(_octopus_replace_literal "$isolated_prompt" "$source_root_logical" "$workspace")"
     fi
     isolated_prompt="${isolated_prompt}
 
 ## Consultative Workspace Boundary
 Work only inside this disposable workspace: ${workspace}
-Treat ${workspace} as the working copy for this advisory task. Any relative-path workspace changes are exploratory and will be discarded. Return analysis and recommendations only."
+Treat ${workspace} as the working copy for this advisory task. Any relative-path workspace changes are exploratory and will be discarded. Return analysis and recommendations only.
+This copy intentionally contains no Git control-plane metadata. Inspect the copied working-tree files directly."
     consultative_args[1]="$isolated_prompt"
 
     unset OCTOPUS_SECURITY_V870

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -314,6 +314,8 @@ _octopus_replace_literal() {
 }
 
 # Copy only tracked plus untracked-but-not-ignored files from a Git work tree.
+# An optional root-relative scope limits enumeration while paths remain rooted at
+# the repository for validation and archive extraction.
 # Nested repositories are removed from the parent archive list before tar runs,
 # then copied recursively under their own ignore rules. Every path ancestor
 # must be a real directory. Symlink leaves must stay lexically within the copied
@@ -322,8 +324,9 @@ _octopus_replace_literal() {
 _octopus_copy_git_tracked_tree() (
     local source_root="$1"
     local workspace="$2"
+    local copy_scope="${3:-}"
     local list_dir filelist copylist nestedlist entry rel entry_path
-    local nested_top nested_rel
+    local nested_top nested_rel scope_pathspec
 
     _octopus_cleanup_copy_list_dir() {
         local cleanup_rc="$1"
@@ -334,6 +337,11 @@ _octopus_copy_git_tracked_tree() (
 
     _octopus_git_without_repository_env -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
     source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
+    if [[ -n "$copy_scope" ]]; then
+        _octopus_source_path_has_safe_ancestry "$source_root" "$copy_scope" || return 1
+        [[ -d "$source_root/$copy_scope" && ! -L "$source_root/$copy_scope" ]] || return 1
+        scope_pathspec=":(literal,top)${copy_scope}"
+    fi
 
     list_dir="$(mktemp -d "${TMPDIR:-/tmp}/octopus-copy-lists.XXXXXX")" || return 1
     trap '_octopus_cleanup_copy_list_dir "$?"' EXIT
@@ -343,13 +351,25 @@ _octopus_copy_git_tracked_tree() (
     copylist="${list_dir}/copy"
     nestedlist="${list_dir}/nested"
     : > "$filelist" && : > "$copylist" && : > "$nestedlist" || return 1
-    _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached --others --exclude-standard >"$filelist" 2>/dev/null || {
-        return 1
-    }
+    if [[ -n "$copy_scope" ]]; then
+        _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached --others --exclude-standard -- "$scope_pathspec" >"$filelist" 2>/dev/null || {
+            return 1
+        }
+    else
+        _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached --others --exclude-standard >"$filelist" 2>/dev/null || {
+            return 1
+        }
+    fi
 
     while IFS= read -r -d '' entry; do
         rel="${entry%/}"
         [[ -n "$rel" ]] || continue
+        if [[ -n "$copy_scope" ]]; then
+            case "$rel" in
+                "$copy_scope"|"$copy_scope"/*) ;;
+                *) return 1 ;;
+            esac
+        fi
         entry_path="${source_root}/${rel}"
 
         # Deleted tracked paths remain in the index but have no bytes to copy.
@@ -456,7 +476,7 @@ _octopus_prepare_consultative_workspace() {
                 ;;
         esac
 
-        _octopus_copy_git_tracked_tree "$git_root" "$prepared_workspace" || {
+        _octopus_copy_git_tracked_tree "$git_root" "$prepared_workspace" "$source_prefix" || {
             rm -rf "$prepared_temp_root"
             return 1
         }

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -156,81 +156,200 @@ should_use_agent_teams() {
     return 1
 }
 
-# Copy only the tracked plus untracked-but-not-ignored files from a git work
-# tree into workspace, so gitignored build/vendor trees never enter the
-# per-seat disposable workspace (#980). Returns non-zero when source_root is
-# not a git work tree, or when any step of the copy fails, so the caller can
-# fall back to a full copy.
-#
-# `git ls-files` reports a submodule, or an untracked nested git checkout
-# that isn't itself gitignored, as a single opaque path rather than
-# descending into it. Left alone, tar would copy that path wholesale,
-# reintroducing whatever the nested work tree's own .gitignore excludes. So
-# after the top-level copy, re-copy every such nested git work tree with this
-# same rule, recursively.
+# Add a small, private Git directory to the disposable workspace. The object
+# database remains read-only through an alternate, while HEAD and the index are
+# local copies so reviewer Git commands work without copying the source .git.
+_octopus_initialize_workspace_git_context() {
+    local source_root="$1"
+    local workspace="$2"
+    local common_dir object_dir head_oid head_ref
+
+    common_dir="$(git -C "$source_root" rev-parse --git-common-dir 2>/dev/null)" || return 1
+    case "$common_dir" in
+        /*) ;;
+        *) common_dir="${source_root}/${common_dir}" ;;
+    esac
+    common_dir="$(cd "$common_dir" 2>/dev/null && pwd -P)" || return 1
+    object_dir="${common_dir}/objects"
+    [[ -d "$object_dir" ]] || return 1
+
+    git -C "$workspace" init -q || return 1
+    mkdir -p "$workspace/.git/objects/info" || return 1
+    printf '%s\n' "$object_dir" > "$workspace/.git/objects/info/alternates" || return 1
+
+    head_oid="$(git -C "$source_root" rev-parse --verify HEAD 2>/dev/null || true)"
+    if [[ -n "$head_oid" ]]; then
+        head_ref="$(git -C "$source_root" symbolic-ref -q HEAD 2>/dev/null || true)"
+        if [[ -n "$head_ref" ]]; then
+            git -C "$workspace" symbolic-ref HEAD "$head_ref" || return 1
+            git -C "$workspace" update-ref "$head_ref" "$head_oid" || return 1
+        else
+            git -C "$workspace" update-ref --no-deref HEAD "$head_oid" || return 1
+        fi
+    fi
+
+    # Rebuild the index from Git's portable stage records. Copying the index
+    # file itself would break split-index and worktree-specific configurations.
+    (
+        set -o pipefail
+        git -C "$source_root" ls-files --stage -z |
+            git -C "$workspace" update-index -z --index-info
+    ) || return 1
+}
+
+# Copy only tracked plus untracked-but-not-ignored files from a Git work tree.
+# Nested repositories are removed from the parent archive list before tar runs,
+# then copied recursively under their own ignore rules. Symlinks must resolve
+# within their source repository. Any failure is fatal for a Git source.
 _octopus_copy_git_tracked_tree() {
     local source_root="$1"
     local workspace="$2"
-    local filelist entry rel
-    local nested_copy_failed=0
+    local filelist copylist nestedlist entry rel entry_path
+    local nested_top nested_rel resolved
 
     git -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+    source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
 
     filelist="$(mktemp "${TMPDIR:-/tmp}/octopus-tracked-tree.XXXXXX")" || return 1
-    git -C "$source_root" ls-files -z --cached --others --exclude-standard >"$filelist" 2>/dev/null || {
+    copylist="$(mktemp "${TMPDIR:-/tmp}/octopus-copy-tree.XXXXXX")" || {
         rm -f "$filelist"
         return 1
     }
+    nestedlist="$(mktemp "${TMPDIR:-/tmp}/octopus-nested-tree.XXXXXX")" || {
+        rm -f "$filelist" "$copylist"
+        return 1
+    }
+    git -C "$source_root" ls-files -z --cached --others --exclude-standard >"$filelist" 2>/dev/null || {
+        rm -f "$filelist" "$copylist" "$nestedlist"
+        return 1
+    }
+
+    while IFS= read -r -d '' entry; do
+        rel="${entry%/}"
+        [[ -n "$rel" ]] || continue
+        entry_path="${source_root}/${rel}"
+
+        # Deleted tracked paths remain in the index but have no bytes to copy.
+        [[ -e "$entry_path" || -L "$entry_path" ]] || continue
+
+        if [[ -L "$entry_path" ]]; then
+            # An absolute link would still point back into the source checkout
+            # after tar preserves it, so fail closed even when its target is
+            # physically inside source_root.
+            case "$(readlink "$entry_path" 2>/dev/null)" in
+                /*)
+                    rm -f "$filelist" "$copylist" "$nestedlist"
+                    return 1
+                    ;;
+            esac
+            resolved="$(realpath "$entry_path" 2>/dev/null)" || {
+                rm -f "$filelist" "$copylist" "$nestedlist"
+                return 1
+            }
+            case "$resolved" in
+                "$source_root"|"$source_root"/*) ;;
+                *)
+                    rm -f "$filelist" "$copylist" "$nestedlist"
+                    return 1
+                    ;;
+            esac
+        elif [[ -d "$entry_path" ]]; then
+            nested_top="$(git -C "$entry_path" rev-parse --show-toplevel 2>/dev/null || true)"
+            if [[ -n "$nested_top" ]]; then
+                nested_top="$(cd "$nested_top" 2>/dev/null && pwd -P)" || {
+                    rm -f "$filelist" "$copylist" "$nestedlist"
+                    return 1
+                }
+                if [[ "$nested_top" != "$source_root" ]]; then
+                    case "$nested_top" in
+                        "$source_root"/*) nested_rel="${nested_top#"$source_root"/}" ;;
+                        *)
+                            rm -f "$filelist" "$copylist" "$nestedlist"
+                            return 1
+                            ;;
+                    esac
+                    printf '%s\0' "$nested_rel" >> "$nestedlist"
+                    continue
+                fi
+            fi
+        fi
+
+        printf '%s\0' "$rel" >> "$copylist"
+    done < "$filelist"
 
     if ! (
         set -o pipefail
-        tar --null -C "$source_root" -T "$filelist" -cf - | tar -xf - -C "$workspace"
+        tar --null -C "$source_root" -T "$copylist" -cf - | tar -xf - -C "$workspace"
     ); then
-        rm -f "$filelist"
+        rm -f "$filelist" "$copylist" "$nestedlist"
         return 1
     fi
 
-    # A tracked symlink can also satisfy -d (it is excluded here, not
-    # resolved) and must not be treated as a nested work tree to descend
-    # into — tar already copied it above as the symlink itself, and
-    # resolving it would materialize content from outside source_root.
-    while IFS= read -r -d '' entry; do
-        rel="${entry%/}"
-        [[ -n "$rel" && -d "${source_root}/${rel}" && ! -L "${source_root}/${rel}" ]] || continue
-        git -C "${source_root}/${rel}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || continue
-        rm -rf "${workspace:?}/${rel}"
-        mkdir -p "${workspace}/${rel}"
-        if ! _octopus_copy_git_tracked_tree "${source_root}/${rel}" "${workspace}/${rel}"; then
-            cp -a "${source_root}/${rel}/." "${workspace}/${rel}/" 2>/dev/null || nested_copy_failed=1
-        fi
-    done < "$filelist"
+    while IFS= read -r -d '' nested_rel; do
+        mkdir -p "$workspace/$nested_rel" || {
+            rm -f "$filelist" "$copylist" "$nestedlist"
+            return 1
+        }
+        _octopus_copy_git_tracked_tree "$source_root/$nested_rel" "$workspace/$nested_rel" || {
+            rm -f "$filelist" "$copylist" "$nestedlist"
+            return 1
+        }
+    done < "$nestedlist"
 
-    rm -f "$filelist"
-    [[ "$nested_copy_failed" -eq 0 ]]
+    _octopus_initialize_workspace_git_context "$source_root" "$workspace" || {
+        rm -f "$filelist" "$copylist" "$nestedlist"
+        return 1
+    }
+
+    rm -f "$filelist" "$copylist" "$nestedlist"
 }
 
 # Prepare an isolated copy-on-write workspace for advisory agents.
-# GNU cp uses reflinks when the backing filesystem supports them; otherwise it
-# falls back to an ordinary private copy. This protects the source checkout from
-# incidental relative-path mutations by keeping advisory work in a throwaway cwd.
+# Git sources fail closed if their selective copy fails. Non-Git directories
+# retain the original private whole-tree copy because they have no ignore index.
 _octopus_prepare_consultative_workspace() {
     local source_root="$1"
-    local temp_root workspace
+    local temp_root workspace git_root source_prefix
     temp_root="$(mktemp -d "${TMPDIR:-/tmp}/octopus-consultative.XXXXXX")" || return 1
     workspace="${temp_root}/workspace"
     mkdir -p "$workspace" || { rm -rf "$temp_root"; return 1; }
 
-    if _octopus_copy_git_tracked_tree "$source_root" "$workspace"; then
-        printf '%s\n' "$workspace"
-        return 0
-    fi
-    rm -rf "$workspace"
-    mkdir -p "$workspace" || { rm -rf "$temp_root"; return 1; }
+    if git -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || {
+            rm -rf "$temp_root"
+            return 1
+        }
+        git_root="$(git -C "$source_root" rev-parse --show-toplevel 2>/dev/null)" || {
+            rm -rf "$temp_root"
+            return 1
+        }
+        git_root="$(cd "$git_root" 2>/dev/null && pwd -P)" || {
+            rm -rf "$temp_root"
+            return 1
+        }
+        case "$source_root" in
+            "$git_root") source_prefix="" ;;
+            "$git_root"/*) source_prefix="${source_root#"$git_root"/}" ;;
+            *)
+                rm -rf "$temp_root"
+                return 1
+                ;;
+        esac
 
-    if ! cp -a --reflink=auto "${source_root}/." "${workspace}/" 2>/dev/null; then
-        rm -rf "$workspace"
-        mkdir -p "$workspace" || { rm -rf "$temp_root"; return 1; }
-        cp -a "${source_root}/." "${workspace}/" || { rm -rf "$temp_root"; return 1; }
+        _octopus_copy_git_tracked_tree "$git_root" "$workspace" || {
+            rm -rf "$temp_root"
+            return 1
+        }
+        if [[ -n "$source_prefix" ]]; then
+            workspace="${workspace}/${source_prefix}"
+            [[ -d "$workspace" ]] || { rm -rf "$temp_root"; return 1; }
+        fi
+    else
+        if ! cp -a --reflink=auto "${source_root}/." "${workspace}/" 2>/dev/null; then
+            rm -rf "$workspace"
+            mkdir -p "$workspace" || { rm -rf "$temp_root"; return 1; }
+            cp -a "${source_root}/." "${workspace}/" || { rm -rf "$temp_root"; return 1; }
+        fi
     fi
 
     printf '%s\n' "$workspace"
@@ -254,7 +373,7 @@ run_agent_sync_consultative() {
     local old_codex_sandbox="${OCTOPUS_CODEX_SANDBOX:-}"
     local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
     local old_autonomy="${CLAUDE_OCTOPUS_AUTONOMY:-}"
-    local source_root source_root_logical workspace temp_root rc original_prompt isolated_prompt agent_output cleanup_note
+    local source_root source_root_logical workspace workspace_root temp_root rc original_prompt isolated_prompt agent_output cleanup_note
     local -a consultative_args
 
     source_root_logical="$PWD"
@@ -263,7 +382,8 @@ run_agent_sync_consultative() {
         log ERROR "Failed to prepare disposable consultative workspace from: $source_root"
         return 1
     }
-    temp_root="$(dirname "$workspace")"
+    workspace_root="$(git -C "$workspace" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$workspace")"
+    temp_root="$(dirname "$workspace_root")"
 
     consultative_args=("$@")
     original_prompt="${consultative_args[1]:-}"

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -185,6 +185,37 @@ _octopus_git_without_repository_env() (
     command git "$@"
 )
 
+_octopus_source_has_git_marker() {
+    local current="$1"
+
+    while :; do
+        [[ -e "$current/.git" || -L "$current/.git" ]] && return 0
+        [[ "$current" == "/" ]] && return 1
+        current="${current%/*}"
+        [[ -n "$current" ]] || current="/"
+    done
+}
+
+# Print git-work-tree or non-git. Any other discovery result is an error.
+_octopus_classify_git_source() {
+    local source_root="$1"
+    local discovery_result discovery_rc
+
+    if discovery_result="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --is-inside-work-tree 2>/dev/null)"; then
+        [[ "$discovery_result" == "true" ]] || return 1
+        printf 'git-work-tree\n'
+        return 0
+    else
+        discovery_rc=$?
+    fi
+
+    # Git uses 128 when no repository exists. A marker in the ancestry means
+    # that the same status came from a broken or unreadable repository instead.
+    [[ "$discovery_rc" -eq 128 ]] || return 1
+    _octopus_source_has_git_marker "$source_root" && return 1
+    printf 'non-git\n'
+}
+
 _octopus_source_path_has_safe_ancestry() {
     local source_root="$1"
     local rel="$2"
@@ -211,6 +242,36 @@ _octopus_source_path_has_safe_ancestry() {
     esac
 }
 
+_octopus_relative_symlink_target_is_confined() {
+    local rel="$1"
+    local link_target="$2"
+    local base combined remaining component
+    local depth=0
+
+    case "$link_target" in
+        ""|/*) return 1 ;;
+    esac
+
+    base="${rel%/*}"
+    [[ "$base" == "$rel" ]] && base=""
+    combined="${base:+$base/}${link_target}"
+    remaining="$combined"
+
+    while :; do
+        component="${remaining%%/*}"
+        case "$component" in
+            ""|.) ;;
+            ..)
+                [[ "$depth" -gt 0 ]] || return 1
+                depth=$((depth - 1))
+                ;;
+            *) depth=$((depth + 1)) ;;
+        esac
+        [[ "$remaining" == */* ]] || break
+        remaining="${remaining#*/}"
+    done
+}
+
 _octopus_validate_copy_source_path() {
     local source_root="$1"
     local rel="$2"
@@ -222,14 +283,13 @@ _octopus_validate_copy_source_path() {
 
     if [[ -L "$entry_path" ]]; then
         link_target="$(readlink "$entry_path" 2>/dev/null)" || return 1
-        case "$link_target" in
-            /*) return 1 ;;
-        esac
-        resolved="$(realpath "$entry_path" 2>/dev/null)" || return 1
-        case "$resolved" in
-            "$source_root"|"$source_root"/*) ;;
-            *) return 1 ;;
-        esac
+        _octopus_relative_symlink_target_is_confined "$rel" "$link_target" || return 1
+        if resolved="$(realpath "$entry_path" 2>/dev/null)"; then
+            case "$resolved" in
+                "$source_root"|"$source_root"/*) ;;
+                *) return 1 ;;
+            esac
+        fi
     elif [[ -f "$entry_path" ]]; then
         [[ -r "$entry_path" ]] || return 1
     elif [[ ! -d "$entry_path" ]]; then
@@ -256,8 +316,9 @@ _octopus_replace_literal() {
 # Copy only tracked plus untracked-but-not-ignored files from a Git work tree.
 # Nested repositories are removed from the parent archive list before tar runs,
 # then copied recursively under their own ignore rules. Every path ancestor
-# must be a real directory, and symlink leaves must resolve within their source
-# repository. Any failure is fatal for a Git source.
+# must be a real directory. Symlink leaves must stay lexically within the copied
+# tree, and resolved targets must remain in the source. Any failure is fatal for
+# a Git source.
 _octopus_copy_git_tracked_tree() {
     local source_root="$1"
     local workspace="$2"
@@ -363,12 +424,15 @@ _octopus_prepare_consultative_workspace() {
     local source_root="$1"
     local workspace_result_var="${2:-}"
     local temp_root_result_var="${3:-}"
-    local prepared_temp_root prepared_temp_root_raw prepared_workspace git_root source_prefix
+    local prepared_temp_root prepared_temp_root_raw prepared_workspace git_root source_prefix git_source_kind
 
     if [[ -n "$workspace_result_var" || -n "$temp_root_result_var" ]]; then
         [[ "$workspace_result_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
         [[ "$temp_root_result_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
     fi
+
+    source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
+    git_source_kind="$(_octopus_classify_git_source "$source_root")" || return 1
 
     prepared_temp_root_raw="$(mktemp -d "${TMPDIR:-/tmp}/octopus-consultative.XXXXXX")" || return 1
     prepared_temp_root="$(cd "$prepared_temp_root_raw" 2>/dev/null && pwd -P)" || {
@@ -378,11 +442,7 @@ _octopus_prepare_consultative_workspace() {
     prepared_workspace="${prepared_temp_root}/workspace"
     mkdir -p "$prepared_workspace" || { rm -rf "$prepared_temp_root"; return 1; }
 
-    if _octopus_git_without_repository_env -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || {
-            rm -rf "$prepared_temp_root"
-            return 1
-        }
+    if [[ "$git_source_kind" == "git-work-tree" ]]; then
         git_root="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --show-toplevel 2>/dev/null)" || {
             rm -rf "$prepared_temp_root"
             return 1
@@ -411,12 +471,15 @@ _octopus_prepare_consultative_workspace() {
             }
             prepared_workspace="${prepared_workspace}/${source_prefix}"
         fi
-    else
+    elif [[ "$git_source_kind" == "non-git" ]]; then
         if ! cp -a --reflink=auto "${source_root}/." "${prepared_workspace}/" 2>/dev/null; then
             rm -rf "$prepared_workspace"
             mkdir -p "$prepared_workspace" || { rm -rf "$prepared_temp_root"; return 1; }
             cp -a "${source_root}/." "${prepared_workspace}/" || { rm -rf "$prepared_temp_root"; return 1; }
         fi
+    else
+        rm -rf "$prepared_temp_root"
+        return 1
     fi
 
     if [[ -n "$workspace_result_var" && -n "$temp_root_result_var" ]]; then

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -1192,15 +1192,28 @@ run_agent_sync_consultative() {
     local cleanup_waits completion_parent completion_state completion_owner completion_exclusion_root
     local _octopus_consultative_completion_file=""
 
-    completion_exclusion_root="$(_octopus_temp_exclusion_root_for_source "$(pwd -P)")" || return 1
-    completion_parent="$(_octopus_temp_parent_outside_source "$completion_exclusion_root")" || return 1
-    completion_owner="$(/bin/sh -c 'printf "%s\n" "$PPID"')" || return 1
+    completion_exclusion_root="$(_octopus_temp_exclusion_root_for_source "$(pwd -P)")" || {
+        log ERROR "Failed to resolve a safe consultative completion exclusion root"
+        return 1
+    }
+    completion_parent="$(_octopus_temp_parent_outside_source "$completion_exclusion_root")" || {
+        log ERROR "Failed to select a safe consultative completion directory"
+        return 1
+    }
+    completion_owner="$(/bin/sh -c 'printf "%s\n" "$PPID"')" || {
+        log ERROR "Failed to determine the consultative completion owner"
+        return 1
+    }
     case "$completion_owner" in
-        ""|*[!0-9]*) return 1 ;;
+        ""|*[!0-9]*)
+            log ERROR "Refusing an invalid consultative completion owner"
+            return 1
+            ;;
     esac
     _octopus_consultative_completion_file="$completion_parent/.octopus-consultative-completion.${completion_owner}.${RANDOM}${RANDOM}"
     (umask 077; set -o noclobber; printf 'running\n' > "$_octopus_consultative_completion_file") 2>/dev/null || {
         rm -f "$_octopus_consultative_completion_file" 2>/dev/null || true
+        log ERROR "Failed to create a consultative completion marker in: $completion_parent"
         return 1
     }
     old_int_trap="$(trap -p INT)"

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -172,6 +172,7 @@ _octopus_copy_git_tracked_tree() {
     local source_root="$1"
     local workspace="$2"
     local filelist entry rel
+    local nested_copy_failed=0
 
     git -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
 
@@ -189,18 +190,23 @@ _octopus_copy_git_tracked_tree() {
         return 1
     fi
 
+    # A tracked symlink can also satisfy -d (it is excluded here, not
+    # resolved) and must not be treated as a nested work tree to descend
+    # into — tar already copied it above as the symlink itself, and
+    # resolving it would materialize content from outside source_root.
     while IFS= read -r -d '' entry; do
         rel="${entry%/}"
-        [[ -n "$rel" && -d "${source_root}/${rel}" ]] || continue
+        [[ -n "$rel" && -d "${source_root}/${rel}" && ! -L "${source_root}/${rel}" ]] || continue
         git -C "${source_root}/${rel}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || continue
         rm -rf "${workspace:?}/${rel}"
         mkdir -p "${workspace}/${rel}"
-        _octopus_copy_git_tracked_tree "${source_root}/${rel}" "${workspace}/${rel}" \
-            || cp -a "${source_root}/${rel}/." "${workspace}/${rel}/" 2>/dev/null
+        if ! _octopus_copy_git_tracked_tree "${source_root}/${rel}" "${workspace}/${rel}"; then
+            cp -a "${source_root}/${rel}/." "${workspace}/${rel}/" 2>/dev/null || nested_copy_failed=1
+        fi
     done < "$filelist"
 
     rm -f "$filelist"
-    return 0
+    [[ "$nested_copy_failed" -eq 0 ]]
 }
 
 # Prepare an isolated copy-on-write workspace for advisory agents.

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -346,6 +346,91 @@ _octopus_temp_parent_outside_source() {
     return 1
 }
 
+_octopus_temp_name_matches() {
+    local temp_name="$1"
+    local stem="$2"
+    local remainder owner_pid owner_nonce suffix
+
+    case "$temp_name" in
+        "$stem".??????) return 0 ;;
+    esac
+
+    remainder="${temp_name#"$stem".}"
+    [[ "$remainder" != "$temp_name" && "$remainder" == *.*.* ]] || return 1
+    owner_pid="${remainder%%.*}"
+    remainder="${remainder#*.}"
+    owner_nonce="${remainder%%.*}"
+    suffix="${remainder#*.}"
+    [[ "$suffix" != "$remainder" && "$suffix" != *.* ]] || return 1
+    case "$owner_pid" in
+        ""|*[!0-9]*) return 1 ;;
+    esac
+    case "$owner_nonce" in
+        ""|*[!0-9]*) return 1 ;;
+    esac
+    case "$suffix" in
+        ??????) return 0 ;;
+    esac
+    return 1
+}
+
+# Build a process-owned prefix before mktemp can create anything. Signal
+# cleanup can then identify this invocation's directory even while the mktemp
+# command substitution has not yet assigned its output.
+_octopus_prepare_owned_temp_prefix() {
+    local result_var="$1"
+    local temp_parent="$2"
+    local stem="$3"
+    local owner_pid owner_nonce prefix
+
+    [[ "$result_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
+    case "$stem" in
+        octopus-consultative|octopus-copy-lists) ;;
+        *) return 1 ;;
+    esac
+    [[ "$temp_parent" == /* && -d "$temp_parent" && ! -L "$temp_parent" ]] || return 1
+    [[ "$(cd "$temp_parent" 2>/dev/null && pwd -P)" == "$temp_parent" ]] || return 1
+    owner_pid="$(/bin/sh -c 'printf "%s\n" "$PPID"')" || return 1
+    case "$owner_pid" in
+        ""|*[!0-9]*) return 1 ;;
+    esac
+    owner_nonce="${RANDOM}${RANDOM}"
+    prefix="${temp_parent}/${stem}.${owner_pid}.${owner_nonce}"
+    printf -v "$result_var" '%s' "$prefix"
+}
+
+_octopus_owned_temp_dir_is_safe() {
+    local allocation_prefix="$1"
+    local candidate="$2"
+    local physical_candidate
+
+    [[ -n "$allocation_prefix" && "$allocation_prefix" == /* ]] || return 1
+    case "$candidate" in
+        "$allocation_prefix".??????) ;;
+        *) return 1 ;;
+    esac
+    [[ -d "$candidate" && ! -L "$candidate" ]] || return 1
+    physical_candidate="$(cd "$candidate" 2>/dev/null && pwd -P)" || return 1
+    [[ "$physical_candidate" == "$candidate" ]]
+}
+
+_octopus_remove_owned_temp_dirs() {
+    local allocation_prefix="$1"
+    local candidate cleanup_failed=false
+
+    [[ -n "$allocation_prefix" ]] || return 0
+    [[ "$allocation_prefix" == /* ]] || return 1
+    for candidate in "$allocation_prefix".??????; do
+        [[ -e "$candidate" || -L "$candidate" ]] || continue
+        if ! _octopus_owned_temp_dir_is_safe "$allocation_prefix" "$candidate"; then
+            cleanup_failed=true
+            continue
+        fi
+        command rm -rf "$candidate" || cleanup_failed=true
+    done
+    [[ "$cleanup_failed" == "false" ]]
+}
+
 # Ignore only untracked remnants created by Octopus itself. Tracked paths with
 # the same shape remain eligible so repository contents and selected-subtree
 # semantics are not weakened.
@@ -355,9 +440,8 @@ _octopus_path_is_generated_temp_artifact() {
 
     while :; do
         component="${remaining%%/*}"
-        case "$component" in
-            octopus-consultative.??????|octopus-copy-lists.??????) return 0 ;;
-        esac
+        _octopus_temp_name_matches "$component" "octopus-consultative" && return 0
+        _octopus_temp_name_matches "$component" "octopus-copy-lists" && return 0
         [[ "$remaining" == */* ]] || break
         remaining="${remaining#*/}"
     done
@@ -377,12 +461,12 @@ _octopus_copy_git_tracked_tree() (
     local workspace="$2"
     local copy_scope="${3:-}"
     local list_dir filelist untrackedlist copylist nestedlist entry rel entry_path
-    local nested_top nested_rel nested_stage scope_pathspec copy_confinement_root temp_parent
+    local nested_top nested_rel nested_stage scope_pathspec copy_confinement_root temp_parent list_dir_prefix
 
     _octopus_cleanup_copy_list_dir() {
         local cleanup_rc="$1"
         trap - EXIT INT TERM
-        if ! command rm -rf "$list_dir"; then
+        if ! _octopus_remove_owned_temp_dirs "$list_dir_prefix"; then
             [[ "$cleanup_rc" -ne 0 ]] || cleanup_rc=1
         fi
         exit "$cleanup_rc"
@@ -400,10 +484,15 @@ _octopus_copy_git_tracked_tree() (
     fi
 
     temp_parent="$(_octopus_temp_parent_outside_source "$copy_confinement_root")" || return 1
-    list_dir="$(mktemp -d "${temp_parent}/octopus-copy-lists.XXXXXX")" || return 1
+    list_dir=""
+    list_dir_prefix=""
+    # The handler owns the unique prefix before mktemp can create its directory.
     trap '_octopus_cleanup_copy_list_dir "$?"' EXIT
     trap '_octopus_cleanup_copy_list_dir 130' INT
     trap '_octopus_cleanup_copy_list_dir 143' TERM
+    _octopus_prepare_owned_temp_prefix list_dir_prefix "$temp_parent" "octopus-copy-lists" || return 1
+    list_dir="$(mktemp -d "${list_dir_prefix}.XXXXXX")" || return 1
+    _octopus_owned_temp_dir_is_safe "$list_dir_prefix" "$list_dir" || return 1
     filelist="${list_dir}/tracked"
     untrackedlist="${list_dir}/untracked"
     copylist="${list_dir}/copy"
@@ -513,7 +602,7 @@ _octopus_prepare_consultative_workspace() {
     local source_root="$1"
     local workspace_result_var="${2:-}"
     local temp_root_result_var="${3:-}"
-    local prepared_temp_root prepared_temp_root_raw prepared_workspace git_root source_prefix git_source_kind temp_parent
+    local prepared_temp_root prepared_temp_root_raw prepared_workspace git_root source_prefix git_source_kind temp_parent temp_root_prefix
 
     if [[ -n "$workspace_result_var" || -n "$temp_root_result_var" ]]; then
         [[ "$workspace_result_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
@@ -524,7 +613,22 @@ _octopus_prepare_consultative_workspace() {
     git_source_kind="$(_octopus_classify_git_source "$source_root")" || return 1
 
     temp_parent="$(_octopus_temp_parent_outside_source "$source_root")" || return 1
-    prepared_temp_root_raw="$(mktemp -d "${temp_parent}/octopus-consultative.XXXXXX")" || return 1
+    temp_root_prefix=""
+    _octopus_prepare_owned_temp_prefix temp_root_prefix "$temp_parent" "octopus-consultative" || return 1
+    if [[ -n "${4:-}" ]]; then
+        [[ "$4" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
+        # Publish ownership before mktemp so the caller's signal trap can clean
+        # a directory whose command substitution has not returned yet.
+        printf -v "$4" '%s' "$temp_root_prefix"
+    fi
+    prepared_temp_root_raw="$(mktemp -d "${temp_root_prefix}.XXXXXX")" || {
+        _octopus_remove_owned_temp_dirs "$temp_root_prefix" >/dev/null 2>&1 || true
+        return 1
+    }
+    _octopus_owned_temp_dir_is_safe "$temp_root_prefix" "$prepared_temp_root_raw" || {
+        _octopus_remove_owned_temp_dirs "$temp_root_prefix" >/dev/null 2>&1 || true
+        return 1
+    }
     prepared_temp_root="$prepared_temp_root_raw"
     prepared_workspace="${prepared_temp_root}/workspace"
     if [[ -n "$workspace_result_var" && -n "$temp_root_result_var" ]]; then
@@ -595,10 +699,7 @@ _octopus_consultative_temp_root_is_safe() {
     physical_temp_root="$(cd "$temp_root" 2>/dev/null && pwd -P)" || return 1
     [[ "$physical_temp_root" == "$temp_root" ]] || return 1
     temp_name="$(basename "$temp_root")"
-    case "$temp_name" in
-        octopus-consultative.??????) ;;
-        *) return 1 ;;
-    esac
+    _octopus_temp_name_matches "$temp_name" "octopus-consultative" || return 1
     case "$workspace" in
         "$temp_root/workspace"|"$temp_root/workspace"/*) ;;
         *) return 1 ;;
@@ -634,15 +735,21 @@ run_agent_sync_consultative() (
     local old_codex_sandbox="${OCTOPUS_CODEX_SANDBOX:-}"
     local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
     local old_autonomy="${CLAUDE_OCTOPUS_AUTONOMY:-}"
-    local source_root source_root_logical workspace temp_root rc original_prompt isolated_prompt agent_output cleanup_note
+    local source_root source_root_logical workspace temp_root temp_root_prefix rc original_prompt isolated_prompt agent_output cleanup_note
     local -a consultative_args
 
     _octopus_handle_consultative_signal() {
         local signal_rc="$1"
+        local cleanup_failed=false
 
         # Do not let a second foreground signal interrupt validated cleanup.
         trap '' INT TERM
-        if ! _octopus_remove_consultative_temp_root "$temp_root" "$workspace" 2>/dev/null; then
+        if [[ -n "$temp_root" ]]; then
+            _octopus_remove_consultative_temp_root "$temp_root" "$workspace" 2>/dev/null || cleanup_failed=true
+        else
+            _octopus_remove_owned_temp_dirs "$temp_root_prefix" 2>/dev/null || cleanup_failed=true
+        fi
+        if [[ "$cleanup_failed" == "true" ]]; then
             if declare -F log >/dev/null 2>&1; then
                 log WARN "Failed to remove consultative workspace after signal: $temp_root"
             else
@@ -654,9 +761,12 @@ run_agent_sync_consultative() (
 
     source_root_logical="$PWD"
     source_root="$(pwd -P)"
+    workspace=""
+    temp_root=""
+    temp_root_prefix=""
     trap '_octopus_handle_consultative_signal 130' INT
     trap '_octopus_handle_consultative_signal 143' TERM
-    _octopus_prepare_consultative_workspace "$source_root" workspace temp_root || {
+    _octopus_prepare_consultative_workspace "$source_root" workspace temp_root temp_root_prefix || {
         _octopus_remove_consultative_temp_root "$temp_root" "$workspace" 2>/dev/null || true
         log ERROR "Failed to prepare disposable consultative workspace from: $source_root"
         return 1

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -161,18 +161,46 @@ should_use_agent_teams() {
 # per-seat disposable workspace (#980). Returns non-zero when source_root is
 # not a git work tree, or when any step of the copy fails, so the caller can
 # fall back to a full copy.
+#
+# `git ls-files` reports a submodule, or an untracked nested git checkout
+# that isn't itself gitignored, as a single opaque path rather than
+# descending into it. Left alone, tar would copy that path wholesale,
+# reintroducing whatever the nested work tree's own .gitignore excludes. So
+# after the top-level copy, re-copy every such nested git work tree with this
+# same rule, recursively.
 _octopus_copy_git_tracked_tree() {
     local source_root="$1"
     local workspace="$2"
+    local filelist entry rel
 
     git -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
 
-    (
+    filelist="$(mktemp "${TMPDIR:-/tmp}/octopus-tracked-tree.XXXXXX")" || return 1
+    git -C "$source_root" ls-files -z --cached --others --exclude-standard >"$filelist" 2>/dev/null || {
+        rm -f "$filelist"
+        return 1
+    }
+
+    if ! (
         set -o pipefail
-        git -C "$source_root" ls-files -z --cached --others --exclude-standard \
-            | tar --null -C "$source_root" -T - -cf - \
-            | tar -xf - -C "$workspace"
-    )
+        tar --null -C "$source_root" -T "$filelist" -cf - | tar -xf - -C "$workspace"
+    ); then
+        rm -f "$filelist"
+        return 1
+    fi
+
+    while IFS= read -r -d '' entry; do
+        rel="${entry%/}"
+        [[ -n "$rel" && -d "${source_root}/${rel}" ]] || continue
+        git -C "${source_root}/${rel}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || continue
+        rm -rf "${workspace:?}/${rel}"
+        mkdir -p "${workspace}/${rel}"
+        _octopus_copy_git_tracked_tree "${source_root}/${rel}" "${workspace}/${rel}" \
+            || cp -a "${source_root}/${rel}/." "${workspace}/${rel}/" 2>/dev/null
+    done < "$filelist"
+
+    rm -f "$filelist"
+    return 0
 }
 
 # Prepare an isolated copy-on-write workspace for advisory agents.

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -157,15 +157,19 @@ should_use_agent_teams() {
 }
 
 _octopus_clear_repository_env() {
-    local git_env_name
+    local git_env_name clear_failed=false
+    local repository_env_names="
+GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
+GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE
+GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM
+GIT_IMPLICIT_WORK_TREE GIT_PREFIX GIT_SUPER_PREFIX GIT_INTERNAL_SUPER_PREFIX
+GIT_GRAFT_FILE GIT_SHALLOW_FILE GIT_REPLACE_REF_BASE GIT_NO_REPLACE_OBJECTS
+GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM
+GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT GIT_QUARANTINE_PATH GIT_DEFAULT_HASH"
 
-    unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
-    unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE
-    unset GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM
-    unset GIT_IMPLICIT_WORK_TREE GIT_PREFIX GIT_SUPER_PREFIX GIT_INTERNAL_SUPER_PREFIX
-    unset GIT_GRAFT_FILE GIT_SHALLOW_FILE GIT_REPLACE_REF_BASE GIT_NO_REPLACE_OBJECTS
-    unset GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM
-    unset GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT GIT_QUARANTINE_PATH GIT_DEFAULT_HASH
+    for git_env_name in $repository_env_names; do
+        unset "$git_env_name" 2>/dev/null || clear_failed=true
+    done
 
     # Git's command-scope config protocol uses numbered variable names. Clear
     # every inherited pair even when GIT_CONFIG_COUNT itself is malformed or
@@ -174,18 +178,38 @@ _octopus_clear_repository_env() {
     while IFS= read -r git_env_name; do
         case "$git_env_name" in
             GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*|GIT_TRACE*|GIT_REDIRECT_STDIN|GIT_REDIRECT_STDOUT|GIT_REDIRECT_STDERR)
-                unset "$git_env_name" 2>/dev/null || true
+                unset "$git_env_name" 2>/dev/null || clear_failed=true
                 ;;
         esac
     done < <(compgen -v)
+
+    [[ "$clear_failed" == "false" ]]
 }
 
 # Repository-selection environment variables override `git -C`. Clear them for
 # workspace discovery so an exported GIT_DIR, config, or index path cannot
 # redirect reads or writes to another checkout.
 _octopus_git_without_repository_env() (
-    _octopus_clear_repository_env
-    command git "$@"
+    local git_env_name
+    local -a clean_env
+
+    clean_env=(
+        -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY
+        -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_COMMON_DIR -u GIT_NAMESPACE
+        -u GIT_CEILING_DIRECTORIES -u GIT_DISCOVERY_ACROSS_FILESYSTEM
+        -u GIT_IMPLICIT_WORK_TREE -u GIT_PREFIX -u GIT_SUPER_PREFIX -u GIT_INTERNAL_SUPER_PREFIX
+        -u GIT_GRAFT_FILE -u GIT_SHALLOW_FILE -u GIT_REPLACE_REF_BASE -u GIT_NO_REPLACE_OBJECTS
+        -u GIT_CONFIG -u GIT_CONFIG_GLOBAL -u GIT_CONFIG_SYSTEM -u GIT_CONFIG_NOSYSTEM
+        -u GIT_CONFIG_PARAMETERS -u GIT_CONFIG_COUNT -u GIT_QUARANTINE_PATH -u GIT_DEFAULT_HASH
+    )
+    while IFS= read -r git_env_name; do
+        case "$git_env_name" in
+            GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*|GIT_TRACE*|GIT_REDIRECT_STDIN|GIT_REDIRECT_STDOUT|GIT_REDIRECT_STDERR)
+                clean_env+=( -u "$git_env_name" )
+                ;;
+        esac
+    done < <(compgen -v)
+    command env "${clean_env[@]}" git "$@"
 )
 
 _octopus_source_has_git_marker() {
@@ -310,6 +334,63 @@ _octopus_validate_copy_source_path() {
         return 1
     fi
 }
+
+# Copy one leaf without ever reopening a validated ancestor by pathname. Each
+# directory component becomes the subshell's working directory and is checked
+# physically before the next component is entered. `cp -P` preserves a leaf
+# symlink instead of following it; destination validation then rejects any
+# target that would escape the copied tree.
+_octopus_copy_leaf_safely() (
+    local source_root="$1"
+    local workspace="$2"
+    local rel="$3"
+    local copy_scope="${4:-}"
+    local remaining component physical_dir destination_parent
+
+    _octopus_validate_copy_source_path "$source_root" "$rel" "$copy_scope" || return 1
+    destination_parent="${rel%/*}"
+    [[ "$destination_parent" == "$rel" ]] && destination_parent=""
+    if [[ -n "$destination_parent" ]]; then
+        mkdir -p "$workspace/$destination_parent" || return 1
+    fi
+
+    cd "$source_root" 2>/dev/null || return 1
+    remaining="$rel"
+    while [[ "$remaining" == */* ]]; do
+        component="${remaining%%/*}"
+        case "$component" in
+            ""|.|..) return 1 ;;
+        esac
+        cd "./$component" 2>/dev/null || return 1
+        physical_dir="$(pwd -P)" || return 1
+        case "$physical_dir" in
+            "$source_root"|"$source_root"/*) ;;
+            *) return 1 ;;
+        esac
+        remaining="${remaining#*/}"
+    done
+    case "$remaining" in
+        ""|.|..) return 1 ;;
+    esac
+    [[ -f "./$remaining" || -L "./$remaining" ]] || return 1
+    command cp -pP "./$remaining" "$workspace/$rel" || return 1
+    _octopus_validate_copy_source_path "$workspace" "$rel" "$copy_scope"
+)
+
+_octopus_validate_materialized_symlinks() (
+    local copied_root="$1"
+    local copied_path rel
+
+    copied_root="$(cd "$copied_root" 2>/dev/null && pwd -P)" || return 1
+    set -o pipefail
+    find "$copied_root" -type l -print0 | while IFS= read -r -d '' copied_path; do
+        case "$copied_path" in
+            "$copied_root"/*) rel="${copied_path#"$copied_root"/}" ;;
+            *) return 1 ;;
+        esac
+        _octopus_validate_copy_source_path "$copied_root" "$rel" || return 1
+    done
+)
 
 _octopus_replace_literal() {
     local value="$1"
@@ -450,12 +531,12 @@ _octopus_path_is_generated_temp_artifact() {
 
 # Copy only tracked plus untracked-but-not-ignored files from a Git work tree.
 # An optional root-relative scope limits enumeration while paths remain rooted at
-# the repository for validation and archive extraction.
-# Nested repositories are removed from the parent archive list before tar runs,
-# then copied recursively under their own ignore rules. Every path ancestor
-# must be a real directory. Symlink leaves must stay lexically within the copied
-# tree, and resolved targets must remain in the source. Any failure is fatal for
-# a Git source.
+# the repository for validation and destination placement.
+# Nested repositories are removed from the parent leaf list, then copied
+# recursively under their own ignore rules. Every path ancestor must be a real
+# directory. Symlink leaves must stay lexically within the copied tree, and
+# resolved targets must remain in the source. Any failure is fatal for a Git
+# source.
 _octopus_copy_git_tracked_tree() (
     local source_root="$1"
     local workspace="$2"
@@ -474,6 +555,7 @@ _octopus_copy_git_tracked_tree() (
 
     _octopus_git_without_repository_env -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
     source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
+    workspace="$(cd "$workspace" 2>/dev/null && pwd -P)" || return 1
     if [[ -n "$copy_scope" ]]; then
         _octopus_source_path_has_safe_ancestry "$source_root" "$copy_scope" || return 1
         [[ -d "$source_root/$copy_scope" && ! -L "$source_root/$copy_scope" ]] || return 1
@@ -562,22 +644,9 @@ _octopus_copy_git_tracked_tree() (
         printf '%s\0' "$rel" >> "$copylist" || return 1
     done < "$filelist"
 
-    # Recheck after enumeration and immediately before archive traversal. This
-    # closes the path-list-to-copy gap for an ancestor replaced by a symlink.
     while IFS= read -r -d '' rel; do
-        _octopus_validate_copy_source_path "$source_root" "$rel" "$copy_scope" || {
-            return 1
-        }
+        _octopus_copy_leaf_safely "$source_root" "$workspace" "$rel" "$copy_scope" || return 1
     done < "$copylist"
-
-    if [[ -s "$copylist" ]]; then
-        if ! (
-            set -o pipefail
-            tar --null -C "$source_root" -T "$copylist" -cf - | tar -xf - -C "$workspace"
-        ); then
-            return 1
-        fi
-    fi
 
     while IFS= read -r -d '' nested_rel; do
         _octopus_source_path_has_safe_ancestry "$source_root" "$nested_rel" || {
@@ -677,6 +746,10 @@ _octopus_prepare_consultative_workspace() {
             mkdir -p "$prepared_workspace" || { rm -rf "$prepared_temp_root"; return 1; }
             cp -a "${source_root}/." "${prepared_workspace}/" || { rm -rf "$prepared_temp_root"; return 1; }
         fi
+        _octopus_validate_materialized_symlinks "$prepared_workspace" || {
+            rm -rf "$prepared_temp_root"
+            return 1
+        }
     else
         rm -rf "$prepared_temp_root"
         return 1
@@ -726,7 +799,7 @@ _octopus_remove_consultative_temp_root() {
 # writes made during normal advisory work are discarded with that workspace.
 # This is mutation isolation for accidental workspace edits, not a security
 # boundary against deliberate access to absolute paths outside the workspace.
-run_agent_sync_consultative() (
+_octopus_run_agent_sync_consultative_impl() (
     local old_security_set="${OCTOPUS_SECURITY_V870+x}"
     local old_security="${OCTOPUS_SECURITY_V870:-}"
     local old_agy_sandbox_set="${OCTOPUS_AGY_SANDBOX+x}"
@@ -736,6 +809,7 @@ run_agent_sync_consultative() (
     local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
     local old_autonomy="${CLAUDE_OCTOPUS_AUTONOMY:-}"
     local source_root source_root_logical workspace temp_root temp_root_prefix rc original_prompt isolated_prompt agent_output cleanup_note
+    local agent_pid agent_output_file
     local -a consultative_args
 
     _octopus_handle_consultative_signal() {
@@ -744,6 +818,15 @@ run_agent_sync_consultative() (
 
         # Do not let a second foreground signal interrupt validated cleanup.
         trap '' INT TERM
+        if [[ -n "$agent_pid" ]]; then
+            kill -TERM -- "-$agent_pid" 2>/dev/null || true
+            kill -TERM "$agent_pid" 2>/dev/null || true
+            /bin/sleep 1
+            kill -KILL -- "-$agent_pid" 2>/dev/null || true
+            kill -KILL "$agent_pid" 2>/dev/null || true
+            wait "$agent_pid" 2>/dev/null || true
+            agent_pid=""
+        fi
         if [[ -n "$temp_root" ]]; then
             _octopus_remove_consultative_temp_root "$temp_root" "$workspace" 2>/dev/null || cleanup_failed=true
         else
@@ -756,6 +839,9 @@ run_agent_sync_consultative() (
                 printf 'WARN: failed to remove consultative workspace after signal: %s\n' "$temp_root" >&2
             fi
         fi
+        if [[ -n "${_octopus_consultative_completion_file:-}" ]]; then
+            printf 'done\n' > "$_octopus_consultative_completion_file" 2>/dev/null || true
+        fi
         exit "$signal_rc"
     }
 
@@ -764,6 +850,8 @@ run_agent_sync_consultative() (
     workspace=""
     temp_root=""
     temp_root_prefix=""
+    agent_pid=""
+    agent_output_file=""
     trap '_octopus_handle_consultative_signal 130' INT
     trap '_octopus_handle_consultative_signal 143' TERM
     _octopus_prepare_consultative_workspace "$source_root" workspace temp_root temp_root_prefix || {
@@ -795,14 +883,22 @@ This copy intentionally contains no Git control-plane metadata. Inspect the copi
     unset CLAUDE_OCTOPUS_AUTONOMY
     export OCTOPUS_CODEX_SANDBOX="danger-full-access"
 
-    if agent_output=$(
-        _octopus_clear_repository_env
+    agent_output_file="$temp_root/agent-output"
+    set -m
+    (
+        _octopus_clear_repository_env || exit 125
         cd "$workspace" && run_agent_sync "${consultative_args[@]}"
-    ); then
+    ) >"$agent_output_file" &
+    agent_pid=$!
+    set +m
+    if wait "$agent_pid"; then
         rc=0
     else
         rc=$?
     fi
+    agent_pid=""
+    agent_output="$(cat "$agent_output_file" 2>/dev/null || true)"
+    rm -f "$agent_output_file" 2>/dev/null || true
 
     cleanup_note="Octopus deleted the workspace before returning."
     if ! _octopus_remove_consultative_temp_root "$temp_root" "$workspace" 2>/dev/null; then
@@ -836,8 +932,77 @@ ${agent_output}
 EOF
     fi
 
+    if [[ -n "${_octopus_consultative_completion_file:-}" ]]; then
+        printf 'done\n' > "$_octopus_consultative_completion_file" 2>/dev/null || true
+    fi
+
     return "$rc"
 )
+
+# Keep the signal trap in the caller's shell while the isolated implementation
+# runs as a background job. Bash defers traps while waiting for a foreground
+# subshell or command substitution, but `wait` on a background job is
+# interruptible. Monitor mode gives the implementation a private process group
+# so cancellation reaches its cleanup handler and all wrapper descendants.
+run_agent_sync_consultative() {
+    local implementation_pid="" rc=0 interrupted_rc=""
+    local monitor_was_enabled=false old_int_trap old_term_trap
+    local cleanup_waits completion_parent completion_state completion_owner
+    local _octopus_consultative_completion_file=""
+
+    completion_parent="$(_octopus_temp_parent_outside_source "$(pwd -P)")" || return 1
+    completion_owner="$(/bin/sh -c 'printf "%s\n" "$PPID"')" || return 1
+    case "$completion_owner" in
+        ""|*[!0-9]*) return 1 ;;
+    esac
+    _octopus_consultative_completion_file="$completion_parent/.octopus-consultative-completion.${completion_owner}.${RANDOM}${RANDOM}"
+    (umask 077; set -o noclobber; printf 'running\n' > "$_octopus_consultative_completion_file") 2>/dev/null || {
+        rm -f "$_octopus_consultative_completion_file" 2>/dev/null || true
+        return 1
+    }
+    old_int_trap="$(trap -p INT)"
+    old_term_trap="$(trap -p TERM)"
+    trap 'interrupted_rc=130; trap "" INT TERM; if [[ -n "$implementation_pid" ]]; then kill -INT -- "-$implementation_pid" 2>/dev/null || kill -INT "$implementation_pid" 2>/dev/null || true; fi' INT
+    trap 'interrupted_rc=143; trap "" INT TERM; if [[ -n "$implementation_pid" ]]; then kill -TERM -- "-$implementation_pid" 2>/dev/null || kill -TERM "$implementation_pid" 2>/dev/null || true; fi' TERM
+    [[ "$-" == *m* ]] && monitor_was_enabled=true
+    set -m
+    _octopus_run_agent_sync_consultative_impl "$@" &
+    implementation_pid=$!
+    set +m
+    if [[ "$interrupted_rc" == "130" ]]; then
+        kill -INT -- "-$implementation_pid" 2>/dev/null || kill -INT "$implementation_pid" 2>/dev/null || true
+    elif [[ "$interrupted_rc" == "143" ]]; then
+        kill -TERM -- "-$implementation_pid" 2>/dev/null || kill -TERM "$implementation_pid" 2>/dev/null || true
+    fi
+    if wait "$implementation_pid"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [[ -n "$interrupted_rc" ]]; then
+        # The first wait returns as soon as the trap runs. Reap the isolated
+        # implementation so its signal handler finishes provider and workspace
+        # cleanup before cancellation is reported to the caller.
+        cleanup_waits=0
+        while [[ "$cleanup_waits" -lt 60 ]]; do
+            completion_state="$(cat "$_octopus_consultative_completion_file" 2>/dev/null || true)"
+            [[ "$completion_state" == "done" ]] && break
+            /bin/sleep 0.05
+            cleanup_waits=$((cleanup_waits + 1))
+        done
+        # Do not signal the numeric PID again after the initial wait. If the
+        # implementation exited without writing its completion marker, that
+        # PID could already have been reused by an unrelated process.
+        wait "$implementation_pid" 2>/dev/null || true
+    fi
+
+    if [[ -n "$old_int_trap" ]]; then eval "$old_int_trap"; else trap - INT; fi
+    if [[ -n "$old_term_trap" ]]; then eval "$old_term_trap"; else trap - TERM; fi
+    [[ "$monitor_was_enabled" == "true" ]] && set -m
+    rm -f "$_octopus_consultative_completion_file" 2>/dev/null || true
+    [[ -n "$interrupted_rc" ]] && return "$interrupted_rc"
+    return "$rc"
+}
 
 # Synchronous agent execution (for sequential steps within phases)
 run_agent_sync() {

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -275,18 +275,29 @@ _octopus_relative_symlink_target_is_confined() {
 _octopus_validate_copy_source_path() {
     local source_root="$1"
     local rel="$2"
-    local entry_path link_target resolved
+    local copy_scope="${3:-}"
+    local entry_path link_target resolved confinement_rel confinement_root
 
     _octopus_source_path_has_safe_ancestry "$source_root" "$rel" || return 1
     entry_path="${source_root}/${rel}"
     [[ -e "$entry_path" || -L "$entry_path" ]] || return 1
 
+    confinement_rel="$rel"
+    confinement_root="$source_root"
+    if [[ -n "$copy_scope" ]]; then
+        case "$rel" in
+            "$copy_scope"/*) confinement_rel="${rel#"$copy_scope"/}" ;;
+            *) return 1 ;;
+        esac
+        confinement_root="${source_root}/${copy_scope}"
+    fi
+
     if [[ -L "$entry_path" ]]; then
         link_target="$(readlink "$entry_path" 2>/dev/null)" || return 1
-        _octopus_relative_symlink_target_is_confined "$rel" "$link_target" || return 1
+        _octopus_relative_symlink_target_is_confined "$confinement_rel" "$link_target" || return 1
         if resolved="$(realpath "$entry_path" 2>/dev/null)"; then
             case "$resolved" in
-                "$source_root"|"$source_root"/*) ;;
+                "$confinement_root"|"$confinement_root"/*) ;;
                 *) return 1 ;;
             esac
         fi
@@ -326,7 +337,7 @@ _octopus_copy_git_tracked_tree() (
     local workspace="$2"
     local copy_scope="${3:-}"
     local list_dir filelist copylist nestedlist entry rel entry_path
-    local nested_top nested_rel scope_pathspec
+    local nested_top nested_rel nested_stage scope_pathspec
 
     _octopus_cleanup_copy_list_dir() {
         local cleanup_rc="$1"
@@ -374,36 +385,41 @@ _octopus_copy_git_tracked_tree() (
 
         # Deleted tracked paths remain in the index but have no bytes to copy.
         [[ -e "$entry_path" || -L "$entry_path" ]] || continue
-        _octopus_validate_copy_source_path "$source_root" "$rel" || {
+        _octopus_validate_copy_source_path "$source_root" "$rel" "$copy_scope" || {
             return 1
         }
 
         if [[ -d "$entry_path" && ! -L "$entry_path" ]]; then
-            nested_top="$(_octopus_git_without_repository_env -C "$entry_path" rev-parse --show-toplevel 2>/dev/null || true)"
-            if [[ -n "$nested_top" ]]; then
+            # Nested repositories appear as directory entries. An exact .git
+            # marker catches embedded and untracked repositories; index mode
+            # 160000 still identifies a registered gitlink if its marker broke.
+            nested_stage=""
+            if [[ ! -e "$entry_path/.git" && ! -L "$entry_path/.git" ]]; then
+                nested_stage="$(_octopus_git_without_repository_env -C "$source_root" ls-files --stage -- ":(literal,top)${rel}" 2>/dev/null)" || {
+                    return 1
+                }
+            fi
+            if [[ -e "$entry_path/.git" || -L "$entry_path/.git" || "$nested_stage" == 160000\ * ]]; then
+                nested_top="$(_octopus_git_without_repository_env -C "$entry_path" rev-parse --show-toplevel 2>/dev/null)" || {
+                    return 1
+                }
                 nested_top="$(cd "$nested_top" 2>/dev/null && pwd -P)" || {
                     return 1
                 }
-                if [[ "$nested_top" != "$source_root" ]]; then
-                    case "$nested_top" in
-                        "$source_root"/*) nested_rel="${nested_top#"$source_root"/}" ;;
-                        *)
-                            return 1
-                            ;;
-                    esac
-                    printf '%s\0' "$nested_rel" >> "$nestedlist"
-                    continue
-                fi
+                [[ "$nested_top" == "$entry_path" ]] || return 1
+                nested_rel="$rel"
+                printf '%s\0' "$nested_rel" >> "$nestedlist" || return 1
+                continue
             fi
         fi
 
-        printf '%s\0' "$rel" >> "$copylist"
+        printf '%s\0' "$rel" >> "$copylist" || return 1
     done < "$filelist"
 
     # Recheck after enumeration and immediately before archive traversal. This
     # closes the path-list-to-copy gap for an ancestor replaced by a symlink.
     while IFS= read -r -d '' rel; do
-        _octopus_validate_copy_source_path "$source_root" "$rel" || {
+        _octopus_validate_copy_source_path "$source_root" "$rel" "$copy_scope" || {
             return 1
         }
     done < "$copylist"

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -169,10 +169,13 @@ _octopus_clear_repository_env() {
 
     # Git's command-scope config protocol uses numbered variable names. Clear
     # every inherited pair even when GIT_CONFIG_COUNT itself is malformed or
-    # absent, so advisory code cannot reactivate stale injected configuration.
+    # absent. Trace and redirect variables can write to absolute paths, so they
+    # must not cross the advisory boundary either.
     while IFS= read -r git_env_name; do
         case "$git_env_name" in
-            GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*) unset "$git_env_name" 2>/dev/null || true ;;
+            GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*|GIT_TRACE*|GIT_REDIRECT_STDIN|GIT_REDIRECT_STDOUT|GIT_REDIRECT_STDERR)
+                unset "$git_env_name" 2>/dev/null || true
+                ;;
         esac
     done < <(compgen -v)
 }
@@ -324,6 +327,43 @@ _octopus_replace_literal() {
     printf '%s' "${result}${value}"
 }
 
+# Print a writable temporary-file parent that is not inside the source scope.
+# Physicalize every candidate before comparison so a symlinked TMPDIR cannot
+# place control files or the destination back under the tree being copied.
+_octopus_temp_parent_outside_source() {
+    local source_scope="$1"
+    local candidate physical_candidate
+
+    for candidate in "${TMPDIR:-/tmp}" /tmp /var/tmp; do
+        [[ -d "$candidate" && -w "$candidate" ]] || continue
+        physical_candidate="$(cd "$candidate" 2>/dev/null && pwd -P)" || continue
+        case "$physical_candidate" in
+            "$source_scope"|"$source_scope"/*) continue ;;
+        esac
+        printf '%s\n' "$physical_candidate"
+        return 0
+    done
+    return 1
+}
+
+# Ignore only untracked remnants created by Octopus itself. Tracked paths with
+# the same shape remain eligible so repository contents and selected-subtree
+# semantics are not weakened.
+_octopus_path_is_generated_temp_artifact() {
+    local remaining="$1"
+    local component
+
+    while :; do
+        component="${remaining%%/*}"
+        case "$component" in
+            octopus-consultative.??????|octopus-copy-lists.??????) return 0 ;;
+        esac
+        [[ "$remaining" == */* ]] || break
+        remaining="${remaining#*/}"
+    done
+    return 1
+}
+
 # Copy only tracked plus untracked-but-not-ignored files from a Git work tree.
 # An optional root-relative scope limits enumeration while paths remain rooted at
 # the repository for validation and archive extraction.
@@ -336,13 +376,15 @@ _octopus_copy_git_tracked_tree() (
     local source_root="$1"
     local workspace="$2"
     local copy_scope="${3:-}"
-    local list_dir filelist copylist nestedlist entry rel entry_path
-    local nested_top nested_rel nested_stage scope_pathspec
+    local list_dir filelist untrackedlist copylist nestedlist entry rel entry_path
+    local nested_top nested_rel nested_stage scope_pathspec copy_confinement_root temp_parent
 
     _octopus_cleanup_copy_list_dir() {
         local cleanup_rc="$1"
         trap - EXIT INT TERM
-        command rm -rf "$list_dir" || cleanup_rc=1
+        if ! command rm -rf "$list_dir"; then
+            [[ "$cleanup_rc" -ne 0 ]] || cleanup_rc=1
+        fi
         exit "$cleanup_rc"
     }
 
@@ -352,25 +394,40 @@ _octopus_copy_git_tracked_tree() (
         _octopus_source_path_has_safe_ancestry "$source_root" "$copy_scope" || return 1
         [[ -d "$source_root/$copy_scope" && ! -L "$source_root/$copy_scope" ]] || return 1
         scope_pathspec=":(literal,top)${copy_scope}"
+        copy_confinement_root="$(cd "$source_root/$copy_scope" 2>/dev/null && pwd -P)" || return 1
+    else
+        copy_confinement_root="$source_root"
     fi
 
-    list_dir="$(mktemp -d "${TMPDIR:-/tmp}/octopus-copy-lists.XXXXXX")" || return 1
+    temp_parent="$(_octopus_temp_parent_outside_source "$copy_confinement_root")" || return 1
+    list_dir="$(mktemp -d "${temp_parent}/octopus-copy-lists.XXXXXX")" || return 1
     trap '_octopus_cleanup_copy_list_dir "$?"' EXIT
     trap '_octopus_cleanup_copy_list_dir 130' INT
     trap '_octopus_cleanup_copy_list_dir 143' TERM
     filelist="${list_dir}/tracked"
+    untrackedlist="${list_dir}/untracked"
     copylist="${list_dir}/copy"
     nestedlist="${list_dir}/nested"
-    : > "$filelist" && : > "$copylist" && : > "$nestedlist" || return 1
+    : > "$filelist" && : > "$untrackedlist" && : > "$copylist" && : > "$nestedlist" || return 1
     if [[ -n "$copy_scope" ]]; then
-        _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached --others --exclude-standard -- "$scope_pathspec" >"$filelist" 2>/dev/null || {
+        _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached -- "$scope_pathspec" >"$filelist" 2>/dev/null || {
             return 1
         }
+        _octopus_git_without_repository_env -C "$source_root" \
+            ls-files -z --others --exclude-standard -- "$scope_pathspec" \
+            >"$untrackedlist" 2>/dev/null || return 1
     else
-        _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached --others --exclude-standard >"$filelist" 2>/dev/null || {
+        _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached >"$filelist" 2>/dev/null || {
             return 1
         }
+        _octopus_git_without_repository_env -C "$source_root" \
+            ls-files -z --others --exclude-standard \
+            >"$untrackedlist" 2>/dev/null || return 1
     fi
+    while IFS= read -r -d '' entry; do
+        _octopus_path_is_generated_temp_artifact "${entry%/}" && continue
+        printf '%s\0' "$entry" >> "$filelist" || return 1
+    done < "$untrackedlist"
 
     while IFS= read -r -d '' entry; do
         rel="${entry%/}"
@@ -456,7 +513,7 @@ _octopus_prepare_consultative_workspace() {
     local source_root="$1"
     local workspace_result_var="${2:-}"
     local temp_root_result_var="${3:-}"
-    local prepared_temp_root prepared_temp_root_raw prepared_workspace git_root source_prefix git_source_kind
+    local prepared_temp_root prepared_temp_root_raw prepared_workspace git_root source_prefix git_source_kind temp_parent
 
     if [[ -n "$workspace_result_var" || -n "$temp_root_result_var" ]]; then
         [[ "$workspace_result_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
@@ -466,7 +523,14 @@ _octopus_prepare_consultative_workspace() {
     source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
     git_source_kind="$(_octopus_classify_git_source "$source_root")" || return 1
 
-    prepared_temp_root_raw="$(mktemp -d "${TMPDIR:-/tmp}/octopus-consultative.XXXXXX")" || return 1
+    temp_parent="$(_octopus_temp_parent_outside_source "$source_root")" || return 1
+    prepared_temp_root_raw="$(mktemp -d "${temp_parent}/octopus-consultative.XXXXXX")" || return 1
+    prepared_temp_root="$prepared_temp_root_raw"
+    prepared_workspace="${prepared_temp_root}/workspace"
+    if [[ -n "$workspace_result_var" && -n "$temp_root_result_var" ]]; then
+        printf -v "$workspace_result_var" '%s' "$prepared_workspace"
+        printf -v "$temp_root_result_var" '%s' "$prepared_temp_root"
+    fi
     prepared_temp_root="$(cd "$prepared_temp_root_raw" 2>/dev/null && pwd -P)" || {
         rm -rf "$prepared_temp_root_raw"
         return 1
@@ -590,12 +654,13 @@ run_agent_sync_consultative() (
 
     source_root_logical="$PWD"
     source_root="$(pwd -P)"
+    trap '_octopus_handle_consultative_signal 130' INT
+    trap '_octopus_handle_consultative_signal 143' TERM
     _octopus_prepare_consultative_workspace "$source_root" workspace temp_root || {
+        _octopus_remove_consultative_temp_root "$temp_root" "$workspace" 2>/dev/null || true
         log ERROR "Failed to prepare disposable consultative workspace from: $source_root"
         return 1
     }
-    trap '_octopus_handle_consultative_signal 130' INT
-    trap '_octopus_handle_consultative_signal 143' TERM
     _octopus_consultative_temp_root_is_safe "$temp_root" "$workspace" || {
         log ERROR "Refusing unsafe consultative workspace paths"
         return 1
@@ -632,6 +697,7 @@ This copy intentionally contains no Git control-plane metadata. Inspect the copi
     cleanup_note="Octopus deleted the workspace before returning."
     if ! _octopus_remove_consultative_temp_root "$temp_root" "$workspace" 2>/dev/null; then
         cleanup_note="Octopus attempted cleanup before returning but could not confirm deletion."
+        [[ "$rc" -ne 0 ]] || rc=1
         if declare -F log >/dev/null 2>&1; then
             log WARN "Failed to remove consultative workspace: $temp_root"
         else

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -561,7 +561,7 @@ _octopus_remove_consultative_temp_root() {
 # writes made during normal advisory work are discarded with that workspace.
 # This is mutation isolation for accidental workspace edits, not a security
 # boundary against deliberate access to absolute paths outside the workspace.
-run_agent_sync_consultative() {
+run_agent_sync_consultative() (
     local old_security_set="${OCTOPUS_SECURITY_V870+x}"
     local old_security="${OCTOPUS_SECURITY_V870:-}"
     local old_agy_sandbox_set="${OCTOPUS_AGY_SANDBOX+x}"
@@ -573,12 +573,29 @@ run_agent_sync_consultative() {
     local source_root source_root_logical workspace temp_root rc original_prompt isolated_prompt agent_output cleanup_note
     local -a consultative_args
 
+    _octopus_handle_consultative_signal() {
+        local signal_rc="$1"
+
+        # Do not let a second foreground signal interrupt validated cleanup.
+        trap '' INT TERM
+        if ! _octopus_remove_consultative_temp_root "$temp_root" "$workspace" 2>/dev/null; then
+            if declare -F log >/dev/null 2>&1; then
+                log WARN "Failed to remove consultative workspace after signal: $temp_root"
+            else
+                printf 'WARN: failed to remove consultative workspace after signal: %s\n' "$temp_root" >&2
+            fi
+        fi
+        exit "$signal_rc"
+    }
+
     source_root_logical="$PWD"
     source_root="$(pwd -P)"
     _octopus_prepare_consultative_workspace "$source_root" workspace temp_root || {
         log ERROR "Failed to prepare disposable consultative workspace from: $source_root"
         return 1
     }
+    trap '_octopus_handle_consultative_signal 130' INT
+    trap '_octopus_handle_consultative_signal 143' TERM
     _octopus_consultative_temp_root_is_safe "$temp_root" "$workspace" || {
         log ERROR "Refusing unsafe consultative workspace paths"
         return 1
@@ -644,7 +661,7 @@ EOF
     fi
 
     return "$rc"
-}
+)
 
 # Synchronous agent execution (for sequential steps within phases)
 run_agent_sync() {

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -245,9 +245,14 @@ _octopus_classify_git_source() {
 _octopus_source_path_has_safe_ancestry() {
     local source_root="$1"
     local rel="$2"
+    local identity_result_var="${3:-}"
     local current="$source_root"
     local remaining="$rel"
-    local component
+    local component component_identity captured_identities=""
+
+    if [[ -n "$identity_result_var" ]]; then
+        [[ "$identity_result_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
+    fi
 
     case "$rel" in
         ""|/*) return 1 ;;
@@ -260,12 +265,19 @@ _octopus_source_path_has_safe_ancestry() {
         esac
         current="${current}/${component}"
         [[ -d "$current" && ! -L "$current" ]] || return 1
+        if [[ -n "$identity_result_var" ]]; then
+            component_identity="$(_octopus_directory_identity "$current")" || return 1
+            captured_identities="${captured_identities}${captured_identities:+ }${component_identity}"
+        fi
         remaining="${remaining#*/}"
     done
 
     case "$remaining" in
         ""|.|..) return 1 ;;
     esac
+    if [[ -n "$identity_result_var" ]]; then
+        printf -v "$identity_result_var" '%s' "$captured_identities"
+    fi
 }
 
 _octopus_relative_symlink_target_is_confined() {
@@ -302,9 +314,10 @@ _octopus_validate_copy_source_path() {
     local source_root="$1"
     local rel="$2"
     local copy_scope="${3:-}"
+    local ancestor_identity_result_var="${4:-}"
     local entry_path link_target resolved confinement_rel confinement_root
 
-    _octopus_source_path_has_safe_ancestry "$source_root" "$rel" || return 1
+    _octopus_source_path_has_safe_ancestry "$source_root" "$rel" "$ancestor_identity_result_var" || return 1
     entry_path="${source_root}/${rel}"
     [[ -e "$entry_path" || -L "$entry_path" ]] || return 1
 
@@ -393,7 +406,7 @@ _octopus_directory_identity_matches() {
 }
 
 # Pure shell cannot make a pathname lookup and the following operation atomic.
-# Revalidate both the original pathname and the entered directory at every
+# Revalidate both the original pathname and each entered directory at every
 # deterministic reopen boundary, then use paths relative to the entered cwd.
 _octopus_revalidate_directory_anchor() {
     local anchor_path="$1"
@@ -414,7 +427,7 @@ _octopus_copy_leaf_safely() (
     local rel="$3"
     local copy_scope="${4:-}"
     local remaining component physical_dir destination_parent expected_source_root source_is_anchored=false
-    local source_anchor_path source_identity
+    local source_anchor_path source_identity ancestor_identities="" ancestor_identity
 
     if [[ "$source_root" == "." ]]; then
         source_root="$(pwd -P)" || return 1
@@ -423,7 +436,7 @@ _octopus_copy_leaf_safely() (
     source_anchor_path="$source_root"
     source_identity="$(_octopus_directory_identity "$source_anchor_path")" || return 1
 
-    _octopus_validate_copy_source_path "$source_root" "$rel" "$copy_scope" || return 1
+    _octopus_validate_copy_source_path "$source_root" "$rel" "$copy_scope" ancestor_identities || return 1
     destination_parent="${rel%/*}"
     [[ "$destination_parent" == "$rel" ]] && destination_parent=""
     if [[ -n "$destination_parent" ]]; then
@@ -447,7 +460,20 @@ _octopus_copy_leaf_safely() (
         case "$component" in
             ""|.|..) return 1 ;;
         esac
+        case "$ancestor_identities" in
+            *" "*)
+                ancestor_identity="${ancestor_identities%% *}"
+                ancestor_identities="${ancestor_identities#* }"
+                ;;
+            *)
+                ancestor_identity="$ancestor_identities"
+                ancestor_identities=""
+                ;;
+        esac
+        [[ -n "$ancestor_identity" ]] || return 1
+        _octopus_directory_identity_matches "./$component" "$ancestor_identity" || return 1
         cd "./$component" 2>/dev/null || return 1
+        _octopus_directory_identity_matches . "$ancestor_identity" || return 1
         physical_dir="$(pwd -P)" || return 1
         case "$physical_dir" in
             "$source_root"|"$source_root"/*) ;;
@@ -455,6 +481,7 @@ _octopus_copy_leaf_safely() (
         esac
         remaining="${remaining#*/}"
     done
+    [[ -z "$ancestor_identities" ]] || return 1
     case "$remaining" in
         ""|.|..) return 1 ;;
     esac

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -309,13 +309,13 @@ _octopus_validate_copy_source_path() {
     [[ -e "$entry_path" || -L "$entry_path" ]] || return 1
 
     confinement_rel="$rel"
-    confinement_root="$source_root"
+    confinement_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
     if [[ -n "$copy_scope" ]]; then
         case "$rel" in
             "$copy_scope"/*) confinement_rel="${rel#"$copy_scope"/}" ;;
             *) return 1 ;;
         esac
-        confinement_root="${source_root}/${copy_scope}"
+        confinement_root="$(cd "${source_root}/${copy_scope}" 2>/dev/null && pwd -P)" || return 1
     fi
 
     if [[ -L "$entry_path" ]]; then
@@ -354,6 +354,55 @@ _octopus_expected_physical_entry_path() {
     printf '%s/%s\n' "${physical_parent%/}" "$leaf"
 }
 
+_octopus_print_valid_directory_identity() {
+    local identity="$1"
+    local device inode
+
+    device="${identity%%:*}"
+    inode="${identity#*:}"
+    [[ "$inode" != "$identity" ]] || return 1
+    case "$device" in ""|*[!0-9]*) return 1 ;; esac
+    case "$inode" in ""|*[!0-9]*) return 1 ;; esac
+    printf '%s:%s\n' "$device" "$inode"
+}
+
+# Print a directory's device and inode using the native stat dialect on macOS
+# or Linux. Pathname checks alone cannot distinguish a real-directory swap at
+# the same location.
+_octopus_directory_identity() {
+    local directory="$1"
+    local identity
+
+    [[ -d "$directory" && ! -L "$directory" ]] || return 1
+    if identity="$(command stat -f '%d:%i' "$directory" 2>/dev/null)" &&
+       _octopus_print_valid_directory_identity "$identity"; then
+        return 0
+    fi
+    identity="$(command stat -c '%d:%i' "$directory" 2>/dev/null)" || return 1
+    _octopus_print_valid_directory_identity "$identity"
+}
+
+_octopus_directory_identity_matches() {
+    local directory="$1"
+    local expected_identity="$2"
+    local current_identity
+
+    [[ -n "$expected_identity" ]] || return 1
+    current_identity="$(_octopus_directory_identity "$directory")" || return 1
+    [[ "$current_identity" == "$expected_identity" ]]
+}
+
+# Pure shell cannot make a pathname lookup and the following operation atomic.
+# Revalidate both the original pathname and the entered directory at every
+# deterministic reopen boundary, then use paths relative to the entered cwd.
+_octopus_revalidate_directory_anchor() {
+    local anchor_path="$1"
+    local expected_identity="$2"
+
+    _octopus_directory_identity_matches "$anchor_path" "$expected_identity" || return 1
+    _octopus_directory_identity_matches . "$expected_identity"
+}
+
 # Copy one leaf without ever reopening a validated ancestor by pathname. Each
 # directory component becomes the subshell's working directory and is checked
 # physically before the next component is entered. `cp -P` preserves a leaf
@@ -365,11 +414,14 @@ _octopus_copy_leaf_safely() (
     local rel="$3"
     local copy_scope="${4:-}"
     local remaining component physical_dir destination_parent expected_source_root source_is_anchored=false
+    local source_anchor_path source_identity
 
     if [[ "$source_root" == "." ]]; then
         source_root="$(pwd -P)" || return 1
         source_is_anchored=true
     fi
+    source_anchor_path="$source_root"
+    source_identity="$(_octopus_directory_identity "$source_anchor_path")" || return 1
 
     _octopus_validate_copy_source_path "$source_root" "$rel" "$copy_scope" || return 1
     destination_parent="${rel%/*}"
@@ -380,11 +432,13 @@ _octopus_copy_leaf_safely() (
 
     if [[ "$source_is_anchored" == "true" ]]; then
         [[ "$(pwd -P)" == "$source_root" ]] || return 1
+        _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
     else
         expected_source_root="$(_octopus_expected_physical_entry_path "$source_root")" || return 1
         cd "$source_root" 2>/dev/null || return 1
         physical_dir="$(pwd -P)" || return 1
         [[ "$physical_dir" == "$expected_source_root" ]] || return 1
+        _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
         source_root="$physical_dir"
     fi
     remaining="$rel"
@@ -406,6 +460,7 @@ _octopus_copy_leaf_safely() (
     esac
     [[ -f "./$remaining" || -L "./$remaining" ]] || return 1
     command cp -pP "./$remaining" "$workspace/$rel" || return 1
+    _octopus_directory_identity_matches "$source_anchor_path" "$source_identity" || return 1
     _octopus_validate_copy_source_path "$workspace" "$rel" "$copy_scope"
 )
 
@@ -418,7 +473,9 @@ _octopus_copy_nested_git_tree_safely() (
     local workspace="$2"
     local nested_rel="$3"
     local temp_exclusion_root="${4:-$source_root}"
+    local expected_nested_identity="${5:-}"
     local remaining component physical_dir expected_dir nested_top source_is_anchored=false
+    local component_identity nested_identity nested_anchor_path
 
     case "$nested_rel" in
         ""|/*) return 1 ;;
@@ -450,19 +507,28 @@ _octopus_copy_nested_git_tree_safely() (
             ""|.|..) return 1 ;;
         esac
         [[ -d "./$component" && ! -L "./$component" ]] || return 1
+        component_identity="$(_octopus_directory_identity "./$component")" || return 1
+        if [[ "$remaining" != */* && -n "$expected_nested_identity" ]]; then
+            [[ "$component_identity" == "$expected_nested_identity" ]] || return 1
+        fi
         cd "./$component" 2>/dev/null || return 1
         expected_dir="${expected_dir}/${component}"
         physical_dir="$(pwd -P)" || return 1
         [[ "$physical_dir" == "$expected_dir" ]] || return 1
+        _octopus_directory_identity_matches . "$component_identity" || return 1
         [[ "$remaining" == */* ]] || break
         remaining="${remaining#*/}"
     done
 
+    nested_anchor_path="$expected_dir"
+    nested_identity="$component_identity"
+    _octopus_revalidate_directory_anchor "$nested_anchor_path" "$nested_identity" || return 1
     nested_top="$(_octopus_git_without_repository_env -C . rev-parse --show-toplevel 2>/dev/null)" || return 1
+    _octopus_revalidate_directory_anchor "$nested_anchor_path" "$nested_identity" || return 1
     nested_top="$(cd "$nested_top" 2>/dev/null && pwd -P)" || return 1
     [[ "$nested_top" == "$physical_dir" ]] || return 1
     mkdir -p "$workspace/$nested_rel" || return 1
-    _octopus_copy_git_tracked_tree . "$workspace/$nested_rel" "" "$temp_exclusion_root"
+    _octopus_copy_git_tracked_tree . "$workspace/$nested_rel" "" "$temp_exclusion_root" "$nested_anchor_path" "$nested_identity"
 )
 
 _octopus_validate_materialized_symlinks() (
@@ -513,6 +579,27 @@ _octopus_temp_parent_outside_source() {
         return 0
     done
     return 1
+}
+
+# Resolve the full physical Git root for control-file placement. A launch from
+# a repository subdirectory must not treat a repository-local TMPDIR as safe.
+_octopus_temp_exclusion_root_for_source() {
+    local source_root="$1"
+    local source_kind git_root
+
+    source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
+    source_kind="$(_octopus_classify_git_source "$source_root")" || return 1
+    if [[ "$source_kind" == "git-work-tree" ]]; then
+        git_root="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --show-toplevel 2>/dev/null)" || return 1
+        git_root="$(cd "$git_root" 2>/dev/null && pwd -P)" || return 1
+        case "$source_root" in
+            "$git_root"|"$git_root"/*) ;;
+            *) return 1 ;;
+        esac
+        printf '%s\n' "$git_root"
+    else
+        printf '%s\n' "$source_root"
+    fi
 }
 
 _octopus_temp_name_matches() {
@@ -630,8 +717,10 @@ _octopus_copy_git_tracked_tree() (
     local workspace="$2"
     local copy_scope="${3:-}"
     local temp_exclusion_root="${4:-$source_root}"
+    local source_anchor_path="${5:-}"
+    local source_identity="${6:-}"
     local list_dir filelist untrackedlist copylist entry rel entry_path
-    local nested_stage scope_pathspec temp_parent list_dir_prefix expected_source_root
+    local nested_stage nested_entry_identity scope_pathspec temp_parent list_dir_prefix expected_source_root
 
     _octopus_cleanup_copy_list_dir() {
         local cleanup_rc="$1"
@@ -643,14 +732,23 @@ _octopus_copy_git_tracked_tree() (
     }
 
     case "$source_root" in
-        .) expected_source_root="$(pwd -P)" || return 1 ;;
-        /*) expected_source_root="$(_octopus_expected_physical_entry_path "$source_root")" || return 1 ;;
+        .)
+            expected_source_root="$(pwd -P)" || return 1
+            [[ -n "$source_anchor_path" ]] || source_anchor_path="$expected_source_root"
+            ;;
+        /*)
+            expected_source_root="$(_octopus_expected_physical_entry_path "$source_root")" || return 1
+            [[ -n "$source_anchor_path" ]] || source_anchor_path="$source_root"
+            ;;
         *) return 1 ;;
     esac
+    [[ -n "$source_identity" ]] || source_identity="$(_octopus_directory_identity "$source_anchor_path")" || return 1
     cd "$source_root" 2>/dev/null || return 1
     source_root="$(pwd -P)" || return 1
     [[ "$source_root" == "$expected_source_root" ]] || return 1
+    _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
     _octopus_git_without_repository_env -C . rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+    _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
     workspace="$(cd "$workspace" 2>/dev/null && pwd -P)" || return 1
     temp_exclusion_root="$(cd "$temp_exclusion_root" 2>/dev/null && pwd -P)" || return 1
     case "$source_root" in
@@ -658,8 +756,8 @@ _octopus_copy_git_tracked_tree() (
         *) return 1 ;;
     esac
     if [[ -n "$copy_scope" ]]; then
-        _octopus_source_path_has_safe_ancestry "$source_root" "$copy_scope" || return 1
-        [[ -d "$source_root/$copy_scope" && ! -L "$source_root/$copy_scope" ]] || return 1
+        _octopus_source_path_has_safe_ancestry . "$copy_scope" || return 1
+        [[ -d "./$copy_scope" && ! -L "./$copy_scope" ]] || return 1
         scope_pathspec=":(literal,top)${copy_scope}"
     fi
 
@@ -677,27 +775,32 @@ _octopus_copy_git_tracked_tree() (
     untrackedlist="${list_dir}/untracked"
     copylist="${list_dir}/copy"
     : > "$filelist" && : > "$untrackedlist" && : > "$copylist" || return 1
+    _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
     if [[ -n "$copy_scope" ]]; then
-        _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached -- "$scope_pathspec" >"$filelist" 2>/dev/null || {
+        _octopus_git_without_repository_env -C . ls-files -z --cached -- "$scope_pathspec" >"$filelist" 2>/dev/null || {
             return 1
         }
-        _octopus_git_without_repository_env -C "$source_root" \
+        _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
+        _octopus_git_without_repository_env -C . \
             ls-files -z --others --exclude-standard -- "$scope_pathspec" \
             >"$untrackedlist" 2>/dev/null || return 1
     else
-        _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached >"$filelist" 2>/dev/null || {
+        _octopus_git_without_repository_env -C . ls-files -z --cached >"$filelist" 2>/dev/null || {
             return 1
         }
-        _octopus_git_without_repository_env -C "$source_root" \
+        _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
+        _octopus_git_without_repository_env -C . \
             ls-files -z --others --exclude-standard \
             >"$untrackedlist" 2>/dev/null || return 1
     fi
+    _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
     while IFS= read -r -d '' entry; do
         _octopus_path_is_generated_temp_artifact "${entry%/}" && continue
         printf '%s\0' "$entry" >> "$filelist" || return 1
     done < "$untrackedlist"
 
     while IFS= read -r -d '' entry; do
+        _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
         rel="${entry%/}"
         [[ -n "$rel" ]] || continue
         if [[ -n "$copy_scope" ]]; then
@@ -706,26 +809,31 @@ _octopus_copy_git_tracked_tree() (
                 *) return 1 ;;
             esac
         fi
-        entry_path="${source_root}/${rel}"
+        entry_path="./${rel}"
 
         # Deleted tracked paths remain in the index but have no bytes to copy.
         [[ -e "$entry_path" || -L "$entry_path" ]] || continue
-        _octopus_validate_copy_source_path "$source_root" "$rel" "$copy_scope" || {
+        _octopus_validate_copy_source_path . "$rel" "$copy_scope" || {
             return 1
         }
 
         if [[ -d "$entry_path" && ! -L "$entry_path" ]]; then
+            nested_entry_identity="$(_octopus_directory_identity "$entry_path")" || return 1
             # Nested repositories appear as directory entries. An exact .git
             # marker catches embedded and untracked repositories; index mode
             # 160000 still identifies a registered gitlink if its marker broke.
             nested_stage=""
             if [[ ! -e "$entry_path/.git" && ! -L "$entry_path/.git" ]]; then
-                nested_stage="$(_octopus_git_without_repository_env -C "$source_root" ls-files --stage -- ":(literal,top)${rel}" 2>/dev/null)" || {
+                _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
+                nested_stage="$(_octopus_git_without_repository_env -C . ls-files --stage -- ":(literal,top)${rel}" 2>/dev/null)" || {
                     return 1
                 }
+                _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
             fi
             if [[ -e "$entry_path/.git" || -L "$entry_path/.git" || "$nested_stage" == 160000\ * ]]; then
-                _octopus_copy_nested_git_tree_safely . "$workspace" "$rel" "$temp_exclusion_root" || return 1
+                _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
+                _octopus_copy_nested_git_tree_safely . "$workspace" "$rel" "$temp_exclusion_root" "$nested_entry_identity" || return 1
+                _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
                 continue
             fi
         fi
@@ -734,8 +842,11 @@ _octopus_copy_git_tracked_tree() (
     done < "$filelist"
 
     while IFS= read -r -d '' rel; do
+        _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
         _octopus_copy_leaf_safely . "$workspace" "$rel" "$copy_scope" || return 1
+        _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity" || return 1
     done < "$copylist"
+    _octopus_revalidate_directory_anchor "$source_anchor_path" "$source_identity"
 
 )
 
@@ -747,6 +858,7 @@ _octopus_prepare_consultative_workspace() {
     local workspace_result_var="${2:-}"
     local temp_root_result_var="${3:-}"
     local prepared_temp_root prepared_temp_root_raw prepared_workspace git_root source_prefix git_source_kind temp_parent temp_root_prefix temp_exclusion_root
+    local source_identity git_root_identity
 
     if [[ -n "$workspace_result_var" || -n "$temp_root_result_var" ]]; then
         [[ "$workspace_result_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
@@ -754,12 +866,16 @@ _octopus_prepare_consultative_workspace() {
     fi
 
     source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
+    source_identity="$(_octopus_directory_identity "$source_root")" || return 1
     git_source_kind="$(_octopus_classify_git_source "$source_root")" || return 1
+    _octopus_directory_identity_matches "$source_root" "$source_identity" || return 1
 
     temp_exclusion_root="$source_root"
     if [[ "$git_source_kind" == "git-work-tree" ]]; then
         git_root="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --show-toplevel 2>/dev/null)" || return 1
         git_root="$(cd "$git_root" 2>/dev/null && pwd -P)" || return 1
+        git_root_identity="$(_octopus_directory_identity "$git_root")" || return 1
+        _octopus_directory_identity_matches "$source_root" "$source_identity" || return 1
         case "$source_root" in
             "$git_root"|"$git_root"/*) ;;
             *) return 1 ;;
@@ -807,7 +923,7 @@ _octopus_prepare_consultative_workspace() {
                 ;;
         esac
 
-        _octopus_copy_git_tracked_tree "$git_root" "$prepared_workspace" "$source_prefix" "$git_root" || {
+        _octopus_copy_git_tracked_tree "$git_root" "$prepared_workspace" "$source_prefix" "$git_root" "$git_root" "$git_root_identity" || {
             rm -rf "$prepared_temp_root"
             return 1
         }
@@ -868,6 +984,21 @@ _octopus_remove_consultative_temp_root() {
     rm -rf "$temp_root"
 }
 
+# Ask Bash's job table whether a PID still names an unreaped child owned by
+# this shell. Numeric PID probes can match an unrelated process after reuse.
+_octopus_shell_owns_job() {
+    local target_pid="$1"
+    local job_pid job_state
+
+    case "$target_pid" in ""|*[!0-9]*) return 1 ;; esac
+    for job_state in -pr -ps; do
+        while IFS= read -r job_pid; do
+            [[ "$job_pid" == "$target_pid" ]] && return 0
+        done < <(jobs "$job_state")
+    done
+    return 1
+}
+
 # Run a synchronous agent in a strictly consultative context.
 #
 # Council seats and pre-implementation design reviews are advisory. Native
@@ -887,7 +1018,7 @@ _octopus_run_agent_sync_consultative_impl() (
     local old_autonomy_set="${CLAUDE_OCTOPUS_AUTONOMY+x}"
     local old_autonomy="${CLAUDE_OCTOPUS_AUTONOMY:-}"
     local source_root source_root_logical workspace temp_root temp_root_prefix rc original_prompt isolated_prompt agent_output cleanup_note
-    local agent_pid agent_output_file
+    local agent_pid agent_output_file agent_job_owned=false
     local -a consultative_args
 
     _octopus_handle_consultative_signal() {
@@ -896,7 +1027,8 @@ _octopus_run_agent_sync_consultative_impl() (
 
         # Do not let a second foreground signal interrupt validated cleanup.
         trap '' INT TERM
-        if [[ -n "$agent_pid" ]]; then
+        if [[ "$agent_job_owned" == "true" ]] && _octopus_shell_owns_job "$agent_pid"; then
+            agent_job_owned=false
             kill -TERM -- "-$agent_pid" 2>/dev/null || true
             kill -TERM "$agent_pid" 2>/dev/null || true
             /bin/sleep 1
@@ -969,12 +1101,15 @@ This copy intentionally contains no Git control-plane metadata. Inspect the copi
         cd "$workspace" && run_agent_sync "${consultative_args[@]}"
     ) >"$agent_output_file" &
     agent_pid=$!
+    agent_job_owned=true
     set +m
     if wait "$agent_pid"; then
         rc=0
     else
         rc=$?
     fi
+    trap '' INT TERM
+    agent_job_owned=false
     agent_pid=""
     agent_output="$(cat "$agent_output_file" 2>/dev/null || true)"
     rm -f "$agent_output_file" 2>/dev/null || true
@@ -1024,12 +1159,14 @@ EOF
 # interruptible. Monitor mode gives the implementation a private process group
 # so cancellation reaches its cleanup handler and all wrapper descendants.
 run_agent_sync_consultative() {
-    local implementation_pid="" rc=0 interrupted_rc=""
+    local implementation_pid="" implementation_wait_pid="" rc=0 interrupted_rc=""
+    local implementation_job_owned=false
     local monitor_was_enabled=false old_int_trap old_term_trap
-    local cleanup_waits completion_parent completion_state completion_owner
+    local cleanup_waits completion_parent completion_state completion_owner completion_exclusion_root
     local _octopus_consultative_completion_file=""
 
-    completion_parent="$(_octopus_temp_parent_outside_source "$(pwd -P)")" || return 1
+    completion_exclusion_root="$(_octopus_temp_exclusion_root_for_source "$(pwd -P)")" || return 1
+    completion_parent="$(_octopus_temp_parent_outside_source "$completion_exclusion_root")" || return 1
     completion_owner="$(/bin/sh -c 'printf "%s\n" "$PPID"')" || return 1
     case "$completion_owner" in
         ""|*[!0-9]*) return 1 ;;
@@ -1041,23 +1178,32 @@ run_agent_sync_consultative() {
     }
     old_int_trap="$(trap -p INT)"
     old_term_trap="$(trap -p TERM)"
-    trap 'interrupted_rc=130; trap "" INT TERM; if [[ -n "$implementation_pid" ]]; then kill -INT -- "-$implementation_pid" 2>/dev/null || kill -INT "$implementation_pid" 2>/dev/null || true; fi' INT
-    trap 'interrupted_rc=143; trap "" INT TERM; if [[ -n "$implementation_pid" ]]; then kill -TERM -- "-$implementation_pid" 2>/dev/null || kill -TERM "$implementation_pid" 2>/dev/null || true; fi' TERM
+    trap 'interrupted_rc=130; trap "" INT TERM; if [[ "$implementation_job_owned" == "true" ]] && _octopus_shell_owns_job "$implementation_pid"; then kill -INT -- "-$implementation_pid" 2>/dev/null || kill -INT "$implementation_pid" 2>/dev/null || true; fi' INT
+    trap 'interrupted_rc=143; trap "" INT TERM; if [[ "$implementation_job_owned" == "true" ]] && _octopus_shell_owns_job "$implementation_pid"; then kill -TERM -- "-$implementation_pid" 2>/dev/null || kill -TERM "$implementation_pid" 2>/dev/null || true; fi' TERM
     [[ "$-" == *m* ]] && monitor_was_enabled=true
     set -m
     _octopus_run_agent_sync_consultative_impl "$@" &
     implementation_pid=$!
+    implementation_job_owned=true
     set +m
     if [[ "$interrupted_rc" == "130" ]]; then
-        kill -INT -- "-$implementation_pid" 2>/dev/null || kill -INT "$implementation_pid" 2>/dev/null || true
+        if _octopus_shell_owns_job "$implementation_pid"; then
+            kill -INT -- "-$implementation_pid" 2>/dev/null || kill -INT "$implementation_pid" 2>/dev/null || true
+        fi
     elif [[ "$interrupted_rc" == "143" ]]; then
-        kill -TERM -- "-$implementation_pid" 2>/dev/null || kill -TERM "$implementation_pid" 2>/dev/null || true
+        if _octopus_shell_owns_job "$implementation_pid"; then
+            kill -TERM -- "-$implementation_pid" 2>/dev/null || kill -TERM "$implementation_pid" 2>/dev/null || true
+        fi
     fi
     if wait "$implementation_pid"; then
         rc=0
     else
         rc=$?
     fi
+    implementation_wait_pid="$implementation_pid"
+    trap '' INT TERM
+    implementation_job_owned=false
+    implementation_pid=""
     if [[ -n "$interrupted_rc" ]]; then
         # The first wait returns as soon as the trap runs. Reap the isolated
         # implementation so its signal handler finishes provider and workspace
@@ -1072,7 +1218,7 @@ run_agent_sync_consultative() {
         # Do not signal the numeric PID again after the initial wait. If the
         # implementation exited without writing its completion marker, that
         # PID could already have been reused by an unrelated process.
-        wait "$implementation_pid" 2>/dev/null || true
+        wait "$implementation_wait_pid" 2>/dev/null || true
     fi
 
     if [[ -n "$old_int_trap" ]]; then eval "$old_int_trap"; else trap - INT; fi

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -156,6 +156,25 @@ should_use_agent_teams() {
     return 1
 }
 
+# Copy only the tracked plus untracked-but-not-ignored files from a git work
+# tree into workspace, so gitignored build/vendor trees never enter the
+# per-seat disposable workspace (#980). Returns non-zero when source_root is
+# not a git work tree, or when any step of the copy fails, so the caller can
+# fall back to a full copy.
+_octopus_copy_git_tracked_tree() {
+    local source_root="$1"
+    local workspace="$2"
+
+    git -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+
+    (
+        set -o pipefail
+        git -C "$source_root" ls-files -z --cached --others --exclude-standard \
+            | tar --null -C "$source_root" -T - -cf - \
+            | tar -xf - -C "$workspace"
+    )
+}
+
 # Prepare an isolated copy-on-write workspace for advisory agents.
 # GNU cp uses reflinks when the backing filesystem supports them; otherwise it
 # falls back to an ordinary private copy. This protects the source checkout from
@@ -165,6 +184,13 @@ _octopus_prepare_consultative_workspace() {
     local temp_root workspace
     temp_root="$(mktemp -d "${TMPDIR:-/tmp}/octopus-consultative.XXXXXX")" || return 1
     workspace="${temp_root}/workspace"
+    mkdir -p "$workspace" || { rm -rf "$temp_root"; return 1; }
+
+    if _octopus_copy_git_tracked_tree "$source_root" "$workspace"; then
+        printf '%s\n' "$workspace"
+        return 0
+    fi
+    rm -rf "$workspace"
     mkdir -p "$workspace" || { rm -rf "$temp_root"; return 1; }
 
     if ! cp -a --reflink=auto "${source_root}/." "${workspace}/" 2>/dev/null; then

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -156,20 +156,24 @@ should_use_agent_teams() {
     return 1
 }
 
+_octopus_repository_env_names() {
+    printf '%s\n' \
+        GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+        GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE \
+        GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM \
+        GIT_IMPLICIT_WORK_TREE GIT_PREFIX GIT_SUPER_PREFIX GIT_INTERNAL_SUPER_PREFIX \
+        GIT_GRAFT_FILE GIT_SHALLOW_FILE GIT_REPLACE_REF_BASE GIT_NO_REPLACE_OBJECTS \
+        GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM \
+        GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT GIT_QUARANTINE_PATH GIT_DEFAULT_HASH \
+        GIT_LITERAL_PATHSPECS GIT_GLOB_PATHSPECS GIT_NOGLOB_PATHSPECS GIT_ICASE_PATHSPECS
+}
+
 _octopus_clear_repository_env() {
     local git_env_name clear_failed=false
-    local repository_env_names="
-GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
-GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE
-GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM
-GIT_IMPLICIT_WORK_TREE GIT_PREFIX GIT_SUPER_PREFIX GIT_INTERNAL_SUPER_PREFIX
-GIT_GRAFT_FILE GIT_SHALLOW_FILE GIT_REPLACE_REF_BASE GIT_NO_REPLACE_OBJECTS
-GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM
-GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT GIT_QUARANTINE_PATH GIT_DEFAULT_HASH"
 
-    for git_env_name in $repository_env_names; do
+    while IFS= read -r git_env_name; do
         unset "$git_env_name" 2>/dev/null || clear_failed=true
-    done
+    done < <(_octopus_repository_env_names)
 
     # Git's command-scope config protocol uses numbered variable names. Clear
     # every inherited pair even when GIT_CONFIG_COUNT itself is malformed or
@@ -193,15 +197,10 @@ _octopus_git_without_repository_env() (
     local git_env_name
     local -a clean_env
 
-    clean_env=(
-        -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY
-        -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_COMMON_DIR -u GIT_NAMESPACE
-        -u GIT_CEILING_DIRECTORIES -u GIT_DISCOVERY_ACROSS_FILESYSTEM
-        -u GIT_IMPLICIT_WORK_TREE -u GIT_PREFIX -u GIT_SUPER_PREFIX -u GIT_INTERNAL_SUPER_PREFIX
-        -u GIT_GRAFT_FILE -u GIT_SHALLOW_FILE -u GIT_REPLACE_REF_BASE -u GIT_NO_REPLACE_OBJECTS
-        -u GIT_CONFIG -u GIT_CONFIG_GLOBAL -u GIT_CONFIG_SYSTEM -u GIT_CONFIG_NOSYSTEM
-        -u GIT_CONFIG_PARAMETERS -u GIT_CONFIG_COUNT -u GIT_QUARANTINE_PATH -u GIT_DEFAULT_HASH
-    )
+    clean_env=()
+    while IFS= read -r git_env_name; do
+        clean_env+=( -u "$git_env_name" )
+    done < <(_octopus_repository_env_names)
     while IFS= read -r git_env_name; do
         case "$git_env_name" in
             GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*|GIT_TRACE*|GIT_REDIRECT_STDIN|GIT_REDIRECT_STDOUT|GIT_REDIRECT_STDERR)
@@ -335,6 +334,26 @@ _octopus_validate_copy_source_path() {
     fi
 }
 
+# Resolve only an absolute path's parent. Appending the final component gives
+# the physical location an entered directory must have without dereferencing
+# that final component before it is opened.
+_octopus_expected_physical_entry_path() {
+    local entry_path="$1"
+    local parent leaf physical_parent
+
+    case "$entry_path" in
+        /) printf '/\n'; return 0 ;;
+        /*) ;;
+        *) return 1 ;;
+    esac
+    parent="${entry_path%/*}"
+    leaf="${entry_path##*/}"
+    [[ -n "$leaf" ]] || return 1
+    [[ -n "$parent" ]] || parent="/"
+    physical_parent="$(cd "$parent" 2>/dev/null && pwd -P)" || return 1
+    printf '%s/%s\n' "${physical_parent%/}" "$leaf"
+}
+
 # Copy one leaf without ever reopening a validated ancestor by pathname. Each
 # directory component becomes the subshell's working directory and is checked
 # physically before the next component is entered. `cp -P` preserves a leaf
@@ -345,7 +364,12 @@ _octopus_copy_leaf_safely() (
     local workspace="$2"
     local rel="$3"
     local copy_scope="${4:-}"
-    local remaining component physical_dir destination_parent
+    local remaining component physical_dir destination_parent expected_source_root source_is_anchored=false
+
+    if [[ "$source_root" == "." ]]; then
+        source_root="$(pwd -P)" || return 1
+        source_is_anchored=true
+    fi
 
     _octopus_validate_copy_source_path "$source_root" "$rel" "$copy_scope" || return 1
     destination_parent="${rel%/*}"
@@ -354,7 +378,15 @@ _octopus_copy_leaf_safely() (
         mkdir -p "$workspace/$destination_parent" || return 1
     fi
 
-    cd "$source_root" 2>/dev/null || return 1
+    if [[ "$source_is_anchored" == "true" ]]; then
+        [[ "$(pwd -P)" == "$source_root" ]] || return 1
+    else
+        expected_source_root="$(_octopus_expected_physical_entry_path "$source_root")" || return 1
+        cd "$source_root" 2>/dev/null || return 1
+        physical_dir="$(pwd -P)" || return 1
+        [[ "$physical_dir" == "$expected_source_root" ]] || return 1
+        source_root="$physical_dir"
+    fi
     remaining="$rel"
     while [[ "$remaining" == */* ]]; do
         component="${remaining%%/*}"
@@ -375,6 +407,62 @@ _octopus_copy_leaf_safely() (
     [[ -f "./$remaining" || -L "./$remaining" ]] || return 1
     command cp -pP "./$remaining" "$workspace/$rel" || return 1
     _octopus_validate_copy_source_path "$workspace" "$rel" "$copy_scope"
+)
+
+# Enter a nested repository one real directory component at a time, then keep
+# that directory as the recursion anchor. Repository discovery and recursive
+# copying use `.` from the anchored working directory; they never reopen the
+# pathname that identified the nested repository during parent enumeration.
+_octopus_copy_nested_git_tree_safely() (
+    local source_root="$1"
+    local workspace="$2"
+    local nested_rel="$3"
+    local temp_exclusion_root="${4:-$source_root}"
+    local remaining component physical_dir expected_dir nested_top source_is_anchored=false
+
+    case "$nested_rel" in
+        ""|/*) return 1 ;;
+    esac
+    if [[ "$temp_exclusion_root" == "." ]]; then
+        temp_exclusion_root="$(pwd -P)" || return 1
+    fi
+
+    if [[ "$source_root" == "." ]]; then
+        source_root="$(pwd -P)" || return 1
+        source_is_anchored=true
+    fi
+    if [[ "$source_is_anchored" == "true" ]]; then
+        physical_dir="$(pwd -P)" || return 1
+        [[ "$physical_dir" == "$source_root" ]] || return 1
+    else
+        expected_dir="$(_octopus_expected_physical_entry_path "$source_root")" || return 1
+        cd "$source_root" 2>/dev/null || return 1
+        physical_dir="$(pwd -P)" || return 1
+        [[ "$physical_dir" == "$expected_dir" ]] || return 1
+        source_root="$physical_dir"
+    fi
+
+    remaining="$nested_rel"
+    expected_dir="$source_root"
+    while :; do
+        component="${remaining%%/*}"
+        case "$component" in
+            ""|.|..) return 1 ;;
+        esac
+        [[ -d "./$component" && ! -L "./$component" ]] || return 1
+        cd "./$component" 2>/dev/null || return 1
+        expected_dir="${expected_dir}/${component}"
+        physical_dir="$(pwd -P)" || return 1
+        [[ "$physical_dir" == "$expected_dir" ]] || return 1
+        [[ "$remaining" == */* ]] || break
+        remaining="${remaining#*/}"
+    done
+
+    nested_top="$(_octopus_git_without_repository_env -C . rev-parse --show-toplevel 2>/dev/null)" || return 1
+    nested_top="$(cd "$nested_top" 2>/dev/null && pwd -P)" || return 1
+    [[ "$nested_top" == "$physical_dir" ]] || return 1
+    mkdir -p "$workspace/$nested_rel" || return 1
+    _octopus_copy_git_tracked_tree . "$workspace/$nested_rel" "" "$temp_exclusion_root"
 )
 
 _octopus_validate_materialized_symlinks() (
@@ -532,17 +620,18 @@ _octopus_path_is_generated_temp_artifact() {
 # Copy only tracked plus untracked-but-not-ignored files from a Git work tree.
 # An optional root-relative scope limits enumeration while paths remain rooted at
 # the repository for validation and destination placement.
-# Nested repositories are removed from the parent leaf list, then copied
-# recursively under their own ignore rules. Every path ancestor must be a real
-# directory. Symlink leaves must stay lexically within the copied tree, and
-# resolved targets must remain in the source. Any failure is fatal for a Git
-# source.
+# Nested repositories are detected during parent enumeration and copied from an
+# anchored working directory under their own ignore rules. Every path ancestor
+# must be a real directory. Symlink leaves must stay lexically within the copied
+# tree, and resolved targets must remain in the source. Any failure is fatal for
+# a Git source.
 _octopus_copy_git_tracked_tree() (
     local source_root="$1"
     local workspace="$2"
     local copy_scope="${3:-}"
-    local list_dir filelist untrackedlist copylist nestedlist entry rel entry_path
-    local nested_top nested_rel nested_stage scope_pathspec copy_confinement_root temp_parent list_dir_prefix
+    local temp_exclusion_root="${4:-$source_root}"
+    local list_dir filelist untrackedlist copylist entry rel entry_path
+    local nested_stage scope_pathspec temp_parent list_dir_prefix expected_source_root
 
     _octopus_cleanup_copy_list_dir() {
         local cleanup_rc="$1"
@@ -553,19 +642,28 @@ _octopus_copy_git_tracked_tree() (
         exit "$cleanup_rc"
     }
 
-    _octopus_git_without_repository_env -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
-    source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
+    case "$source_root" in
+        .) expected_source_root="$(pwd -P)" || return 1 ;;
+        /*) expected_source_root="$(_octopus_expected_physical_entry_path "$source_root")" || return 1 ;;
+        *) return 1 ;;
+    esac
+    cd "$source_root" 2>/dev/null || return 1
+    source_root="$(pwd -P)" || return 1
+    [[ "$source_root" == "$expected_source_root" ]] || return 1
+    _octopus_git_without_repository_env -C . rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
     workspace="$(cd "$workspace" 2>/dev/null && pwd -P)" || return 1
+    temp_exclusion_root="$(cd "$temp_exclusion_root" 2>/dev/null && pwd -P)" || return 1
+    case "$source_root" in
+        "$temp_exclusion_root"|"$temp_exclusion_root"/*) ;;
+        *) return 1 ;;
+    esac
     if [[ -n "$copy_scope" ]]; then
         _octopus_source_path_has_safe_ancestry "$source_root" "$copy_scope" || return 1
         [[ -d "$source_root/$copy_scope" && ! -L "$source_root/$copy_scope" ]] || return 1
         scope_pathspec=":(literal,top)${copy_scope}"
-        copy_confinement_root="$(cd "$source_root/$copy_scope" 2>/dev/null && pwd -P)" || return 1
-    else
-        copy_confinement_root="$source_root"
     fi
 
-    temp_parent="$(_octopus_temp_parent_outside_source "$copy_confinement_root")" || return 1
+    temp_parent="$(_octopus_temp_parent_outside_source "$temp_exclusion_root")" || return 1
     list_dir=""
     list_dir_prefix=""
     # The handler owns the unique prefix before mktemp can create its directory.
@@ -578,8 +676,7 @@ _octopus_copy_git_tracked_tree() (
     filelist="${list_dir}/tracked"
     untrackedlist="${list_dir}/untracked"
     copylist="${list_dir}/copy"
-    nestedlist="${list_dir}/nested"
-    : > "$filelist" && : > "$untrackedlist" && : > "$copylist" && : > "$nestedlist" || return 1
+    : > "$filelist" && : > "$untrackedlist" && : > "$copylist" || return 1
     if [[ -n "$copy_scope" ]]; then
         _octopus_git_without_repository_env -C "$source_root" ls-files -z --cached -- "$scope_pathspec" >"$filelist" 2>/dev/null || {
             return 1
@@ -628,15 +725,7 @@ _octopus_copy_git_tracked_tree() (
                 }
             fi
             if [[ -e "$entry_path/.git" || -L "$entry_path/.git" || "$nested_stage" == 160000\ * ]]; then
-                nested_top="$(_octopus_git_without_repository_env -C "$entry_path" rev-parse --show-toplevel 2>/dev/null)" || {
-                    return 1
-                }
-                nested_top="$(cd "$nested_top" 2>/dev/null && pwd -P)" || {
-                    return 1
-                }
-                [[ "$nested_top" == "$entry_path" ]] || return 1
-                nested_rel="$rel"
-                printf '%s\0' "$nested_rel" >> "$nestedlist" || return 1
+                _octopus_copy_nested_git_tree_safely . "$workspace" "$rel" "$temp_exclusion_root" || return 1
                 continue
             fi
         fi
@@ -645,23 +734,9 @@ _octopus_copy_git_tracked_tree() (
     done < "$filelist"
 
     while IFS= read -r -d '' rel; do
-        _octopus_copy_leaf_safely "$source_root" "$workspace" "$rel" "$copy_scope" || return 1
+        _octopus_copy_leaf_safely . "$workspace" "$rel" "$copy_scope" || return 1
     done < "$copylist"
 
-    while IFS= read -r -d '' nested_rel; do
-        _octopus_source_path_has_safe_ancestry "$source_root" "$nested_rel" || {
-            return 1
-        }
-        [[ -d "$source_root/$nested_rel" && ! -L "$source_root/$nested_rel" ]] || {
-            return 1
-        }
-        mkdir -p "$workspace/$nested_rel" || {
-            return 1
-        }
-        _octopus_copy_git_tracked_tree "$source_root/$nested_rel" "$workspace/$nested_rel" || {
-            return 1
-        }
-    done < "$nestedlist"
 )
 
 # Prepare an isolated copy-on-write workspace for advisory agents.
@@ -671,7 +746,7 @@ _octopus_prepare_consultative_workspace() {
     local source_root="$1"
     local workspace_result_var="${2:-}"
     local temp_root_result_var="${3:-}"
-    local prepared_temp_root prepared_temp_root_raw prepared_workspace git_root source_prefix git_source_kind temp_parent temp_root_prefix
+    local prepared_temp_root prepared_temp_root_raw prepared_workspace git_root source_prefix git_source_kind temp_parent temp_root_prefix temp_exclusion_root
 
     if [[ -n "$workspace_result_var" || -n "$temp_root_result_var" ]]; then
         [[ "$workspace_result_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 1
@@ -681,7 +756,18 @@ _octopus_prepare_consultative_workspace() {
     source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
     git_source_kind="$(_octopus_classify_git_source "$source_root")" || return 1
 
-    temp_parent="$(_octopus_temp_parent_outside_source "$source_root")" || return 1
+    temp_exclusion_root="$source_root"
+    if [[ "$git_source_kind" == "git-work-tree" ]]; then
+        git_root="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --show-toplevel 2>/dev/null)" || return 1
+        git_root="$(cd "$git_root" 2>/dev/null && pwd -P)" || return 1
+        case "$source_root" in
+            "$git_root"|"$git_root"/*) ;;
+            *) return 1 ;;
+        esac
+        temp_exclusion_root="$git_root"
+    fi
+
+    temp_parent="$(_octopus_temp_parent_outside_source "$temp_exclusion_root")" || return 1
     temp_root_prefix=""
     _octopus_prepare_owned_temp_prefix temp_root_prefix "$temp_parent" "octopus-consultative" || return 1
     if [[ -n "${4:-}" ]]; then
@@ -712,14 +798,6 @@ _octopus_prepare_consultative_workspace() {
     mkdir -p "$prepared_workspace" || { rm -rf "$prepared_temp_root"; return 1; }
 
     if [[ "$git_source_kind" == "git-work-tree" ]]; then
-        git_root="$(_octopus_git_without_repository_env -C "$source_root" rev-parse --show-toplevel 2>/dev/null)" || {
-            rm -rf "$prepared_temp_root"
-            return 1
-        }
-        git_root="$(cd "$git_root" 2>/dev/null && pwd -P)" || {
-            rm -rf "$prepared_temp_root"
-            return 1
-        }
         case "$source_root" in
             "$git_root") source_prefix="" ;;
             "$git_root"/*) source_prefix="${source_root#"$git_root"/}" ;;
@@ -729,7 +807,7 @@ _octopus_prepare_consultative_workspace() {
                 ;;
         esac
 
-        _octopus_copy_git_tracked_tree "$git_root" "$prepared_workspace" "$source_prefix" || {
+        _octopus_copy_git_tracked_tree "$git_root" "$prepared_workspace" "$source_prefix" "$git_root" || {
             rm -rf "$prepared_temp_root"
             return 1
         }
@@ -887,6 +965,7 @@ This copy intentionally contains no Git control-plane metadata. Inspect the copi
     set -m
     (
         _octopus_clear_repository_env || exit 125
+        export GIT_CEILING_DIRECTORIES="$temp_root"
         cd "$workspace" && run_agent_sync "${consultative_args[@]}"
     ) >"$agent_output_file" &
     agent_pid=$!

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -322,16 +322,23 @@ _octopus_replace_literal() {
 _octopus_copy_git_tracked_tree() (
     local source_root="$1"
     local workspace="$2"
-    local list_dir filelist copylist nestedlist entry rel entry_path copy_rc
+    local list_dir filelist copylist nestedlist entry rel entry_path
     local nested_top nested_rel
+
+    _octopus_cleanup_copy_list_dir() {
+        local cleanup_rc="$1"
+        trap - EXIT INT TERM
+        command rm -rf "$list_dir" || cleanup_rc=1
+        exit "$cleanup_rc"
+    }
 
     _octopus_git_without_repository_env -C "$source_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
     source_root="$(cd "$source_root" 2>/dev/null && pwd -P)" || return 1
 
     list_dir="$(mktemp -d "${TMPDIR:-/tmp}/octopus-copy-lists.XXXXXX")" || return 1
-    trap 'copy_rc=$?; trap - EXIT INT TERM; command rm -rf "$list_dir" || copy_rc=1; exit "$copy_rc"' EXIT
-    trap 'exit 130' INT
-    trap 'exit 143' TERM
+    trap '_octopus_cleanup_copy_list_dir "$?"' EXIT
+    trap '_octopus_cleanup_copy_list_dir 130' INT
+    trap '_octopus_cleanup_copy_list_dir 143' TERM
     filelist="${list_dir}/tracked"
     copylist="${list_dir}/copy"
     nestedlist="${list_dir}/nested"

--- a/tests/unit/test-consultative-agent-dispatch.sh
+++ b/tests/unit/test-consultative-agent-dispatch.sh
@@ -13,12 +13,19 @@ mkdir -p "$SOURCE_ROOT"
 printf '%s\n' original > "$SOURCE_ROOT/protected.txt"
 
 _octopus_prepare_consultative_workspace() {
-    local source_root="$1" temp_root workspace
-    temp_root="$(mktemp -d "$TEST_TMP_DIR/workspace.XXXXXX")"
-    workspace="$temp_root/workspace"
-    mkdir -p "$workspace"
-    cp -a "$source_root/." "$workspace/"
-    printf '%s\n' "$workspace"
+    local source_root="$1" workspace_result_var="${2:-}" temp_root_result_var="${3:-}"
+    local stub_temp_root stub_workspace
+    stub_temp_root="$(mktemp -d "$TEST_TMP_DIR/octopus-consultative.XXXXXX")"
+    stub_temp_root="$(cd "$stub_temp_root" && pwd -P)"
+    stub_workspace="$stub_temp_root/workspace"
+    mkdir -p "$stub_workspace"
+    cp -a "$source_root/." "$stub_workspace/"
+    if [[ -n "$workspace_result_var" && -n "$temp_root_result_var" ]]; then
+        printf -v "$workspace_result_var" '%s' "$stub_workspace"
+        printf -v "$temp_root_result_var" '%s' "$stub_temp_root"
+    else
+        printf '%s\n' "$stub_workspace"
+    fi
 }
 
 STUB_RC=0
@@ -77,8 +84,9 @@ fi
 
 test_case "consultative output does not claim deletion when workspace cleanup fails"
 cleanup_attempt="$TEST_TMP_DIR/cleanup-attempt"
+cleanup_test_root="$(cd "$TEST_TMP_DIR" && pwd -P)"
 rm() {
-    if [[ "${1:-}" == "-rf" && "${2:-}" == "$TEST_TMP_DIR"/workspace.* ]]; then
+    if [[ "${1:-}" == "-rf" && "${2:-}" == "$cleanup_test_root"/octopus-consultative.* ]]; then
         printf '%s\n' "$2" > "$cleanup_attempt"
         return 1
     fi

--- a/tests/unit/test-consultative-agent-dispatch.sh
+++ b/tests/unit/test-consultative-agent-dispatch.sh
@@ -68,6 +68,29 @@ else
     test_fail "source checkout path remained in the agent task: $output"
 fi
 
+test_case "bracketed source paths are remapped literally"
+BRACKET_SOURCE="$TEST_TMP_DIR/consultative[source]"
+mkdir -p "$BRACKET_SOURCE"
+printf '%s\n' original > "$BRACKET_SOURCE/protected.txt"
+cd "$BRACKET_SOURCE"
+run_agent_sync_consultative codex "inspect $BRACKET_SOURCE/protected.txt" 120 implementer ceremony
+bracket_output="$(cat "$OBSERVED_FILE")"
+cd "$SOURCE_ROOT"
+if [[ "$bracket_output" != *"$BRACKET_SOURCE/protected.txt"* ]] &&
+   [[ "$bracket_output" == *"/workspace/protected.txt"* ]] &&
+   [[ "$(cat "$BRACKET_SOURCE/protected.txt")" == "original" ]]; then
+    test_pass
+else
+    test_fail "bracketed source path was treated as a pattern: $bracket_output"
+fi
+
+test_case "boundary prompt declares the absence of Git control-plane metadata"
+if [[ "$output" == *"intentionally contains no Git control-plane metadata"* ]]; then
+    test_pass
+else
+    test_fail "consultative boundary did not explain the metadata-free copy"
+fi
+
 test_case "consultative output is marked unverified and non-deliverable"
 STUB_RESPONSE="Implemented files in /tmp/disposable and verified 417 tests plus live probes."
 consultative_output=$(run_agent_sync_consultative codex "design only" 120 implementer ceremony)

--- a/tests/unit/test-consultative-agent-dispatch.sh
+++ b/tests/unit/test-consultative-agent-dispatch.sh
@@ -116,16 +116,21 @@ rm() {
     command rm "$@"
 }
 STUB_RESPONSE="Advisory result from disposable workspace."
-cleanup_failure_output=$(run_agent_sync_consultative codex "design only" 120 implementer ceremony 2>/dev/null)
+if cleanup_failure_output=$(run_agent_sync_consultative codex "design only" 120 implementer ceremony 2>/dev/null); then
+    cleanup_failure_rc=0
+else
+    cleanup_failure_rc=$?
+fi
 STUB_RESPONSE=""
 unset -f rm
 failed_temp_root="$(cat "$cleanup_attempt")"
 command rm -rf "$failed_temp_root"
-if [[ "$cleanup_failure_output" == *"could not confirm deletion"* \
+if [[ "$cleanup_failure_rc" -ne 0 \
+   && "$cleanup_failure_output" == *"could not confirm deletion"* \
    && "$cleanup_failure_output" != *"deleted before returning"* ]]; then
     test_pass
 else
-    test_fail "cleanup failure produced false provenance: $cleanup_failure_output"
+    test_fail "cleanup failure did not fail a successful dispatch or produced false provenance: rc=$cleanup_failure_rc output=$cleanup_failure_output"
 fi
 
 test_case "consultative dispatch restores existing environment after success"

--- a/tests/unit/test-consultative-agent-dispatch.sh
+++ b/tests/unit/test-consultative-agent-dispatch.sh
@@ -73,10 +73,16 @@ BRACKET_SOURCE="$TEST_TMP_DIR/consultative[source]"
 mkdir -p "$BRACKET_SOURCE"
 printf '%s\n' original > "$BRACKET_SOURCE/protected.txt"
 cd "$BRACKET_SOURCE"
-run_agent_sync_consultative codex "inspect $BRACKET_SOURCE/protected.txt" 120 implementer ceremony
-bracket_output="$(cat "$OBSERVED_FILE")"
+rm -f "$OBSERVED_FILE"
+if run_agent_sync_consultative codex "inspect $BRACKET_SOURCE/protected.txt" 120 implementer ceremony; then
+    bracket_rc=0
+else
+    bracket_rc=$?
+fi
+bracket_output="$(cat "$OBSERVED_FILE" 2>/dev/null || true)"
 cd "$SOURCE_ROOT"
-if [[ "$bracket_output" != *"$BRACKET_SOURCE/protected.txt"* ]] &&
+if [[ "$bracket_rc" -eq 0 ]] &&
+   [[ "$bracket_output" != *"$BRACKET_SOURCE/protected.txt"* ]] &&
    [[ "$bracket_output" == *"/workspace/protected.txt"* ]] &&
    [[ "$(cat "$BRACKET_SOURCE/protected.txt")" == "original" ]]; then
     test_pass
@@ -123,9 +129,10 @@ else
 fi
 STUB_RESPONSE=""
 unset -f rm
-failed_temp_root="$(cat "$cleanup_attempt")"
-command rm -rf "$failed_temp_root"
-if [[ "$cleanup_failure_rc" -ne 0 \
+failed_temp_root="$(cat "$cleanup_attempt" 2>/dev/null || true)"
+[[ -z "$failed_temp_root" ]] || command rm -rf "$failed_temp_root"
+if [[ -n "$failed_temp_root" \
+   && "$cleanup_failure_rc" -ne 0 \
    && "$cleanup_failure_output" == *"could not confirm deletion"* \
    && "$cleanup_failure_output" != *"deleted before returning"* ]]; then
     test_pass

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# tests/unit/test-consultative-workspace-gitignore.sh
+# Regression test for #980: the consultative workspace copy must honour
+# .gitignore in a git work tree instead of copying gitignored vendor/build
+# trees into every advisory seat's disposable workspace.
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+source "$PROJECT_ROOT/scripts/lib/agent-sync.sh"
+
+test_suite "Consultative Workspace .gitignore Handling"
+
+SOURCE_ROOT="$TEST_TMP_DIR/gitignore-source"
+mkdir -p "$SOURCE_ROOT/vendor"
+(
+    cd "$SOURCE_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'vendor/\n' > .gitignore
+    printf 'tracked\n' > tracked.txt
+    printf 'vendored\n' > vendor/big.bin
+    git add tracked.txt .gitignore
+    git commit -q -m init
+    printf 'untracked but not ignored\n' > untracked.txt
+)
+
+test_case "gitignored files are excluded from the disposable workspace"
+workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT")"
+if [[ -f "$workspace/tracked.txt" && -f "$workspace/untracked.txt" && ! -e "$workspace/vendor" ]]; then
+    test_pass
+else
+    test_fail "expected tracked.txt and untracked.txt present, vendor/ absent in $workspace"
+fi
+rm -rf "$(dirname "$workspace")"
+
+test_case "non-git source roots still fall back to a full copy"
+PLAIN_ROOT="$TEST_TMP_DIR/plain-source"
+mkdir -p "$PLAIN_ROOT"
+printf 'x\n' > "$PLAIN_ROOT/file.txt"
+workspace="$(_octopus_prepare_consultative_workspace "$PLAIN_ROOT")"
+if [[ -f "$workspace/file.txt" ]]; then
+    test_pass
+else
+    test_fail "expected full copy fallback to include file.txt in $workspace"
+fi
+rm -rf "$(dirname "$workspace")"
+
+test_summary

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -26,6 +26,14 @@ mkdir -p "$SOURCE_ROOT/vendor" "$SOURCE_ROOT/subdir"
     printf 'vendored\n' > vendor/big.bin
     git add tracked.txt inside.txt subdir/context.txt safe-link .gitignore
     git commit -q -m init
+    git branch -M main
+    git checkout -q -b feature
+    printf 'feature commit\n' > feature.txt
+    git add feature.txt
+    git commit -q -m feature
+    git update-ref refs/remotes/origin/main refs/heads/main
+    git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+    git tag review-base refs/heads/main
     printf 'modified\n' > tracked.txt
     printf 'subdirectory modified\n' > subdir/context.txt
     printf 'staged\n' > staged.txt
@@ -43,6 +51,58 @@ else
     test_fail "expected tracked.txt and untracked.txt present, vendor/ absent in $workspace"
 fi
 rm -rf "$(dirname "$workspace")"
+
+test_case "the disposable workspace retains review base refs"
+workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT")"
+source_main="$(git -C "$SOURCE_ROOT" rev-parse main)"
+source_origin_main="$(git -C "$SOURCE_ROOT" rev-parse origin/main)"
+source_tag="$(git -C "$SOURCE_ROOT" rev-parse review-base)"
+source_remote_head="$(git -C "$SOURCE_ROOT" symbolic-ref refs/remotes/origin/HEAD)"
+source_review_diff="$(git -C "$SOURCE_ROOT" diff --stat main...HEAD)"
+if [[ "$(git -C "$workspace" rev-parse main 2>/dev/null)" == "$source_main" ]] &&
+   [[ "$(git -C "$workspace" rev-parse origin/main 2>/dev/null)" == "$source_origin_main" ]] &&
+   [[ "$(git -C "$workspace" rev-parse review-base 2>/dev/null)" == "$source_tag" ]] &&
+   [[ "$(git -C "$workspace" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null)" == "$source_remote_head" ]] &&
+   [[ "$(git -C "$workspace" diff --stat main...HEAD 2>/dev/null)" == "$source_review_diff" ]]; then
+    git -C "$workspace" update-ref refs/heads/main HEAD
+    if [[ "$(git -C "$SOURCE_ROOT" rev-parse main)" == "$source_main" ]] &&
+       [[ "$(git -C "$workspace" rev-parse main)" == "$(git -C "$workspace" rev-parse HEAD)" ]] &&
+       [[ "$(git -C "$workspace" rev-parse main)" != "$source_main" ]]; then
+        test_pass
+    else
+        test_fail "workspace ref writes changed the source repository or failed to remain local"
+    fi
+else
+    test_fail "expected local, remote-tracking, and symbolic review refs inside $workspace"
+fi
+rm -rf "$(dirname "$workspace")"
+
+test_case "shallow repository history remains coherent in the disposable workspace"
+SHALLOW_ORIGIN="$TEST_TMP_DIR/shallow-origin"
+SHALLOW_ROOT="$TEST_TMP_DIR/shallow-source"
+mkdir -p "$SHALLOW_ORIGIN"
+(
+    cd "$SHALLOW_ORIGIN"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'one\n' > history.txt
+    git add history.txt
+    git commit -q -m one
+    printf 'two\n' >> history.txt
+    git commit -qam two
+)
+git -c protocol.file.allow=always clone -q --depth 1 "file://$SHALLOW_ORIGIN" "$SHALLOW_ROOT"
+source_shallow_log="$(git -C "$SHALLOW_ROOT" log --oneline)"
+if workspace="$(_octopus_prepare_consultative_workspace "$SHALLOW_ROOT")" &&
+   workspace_shallow_log="$(git -C "$workspace" log --oneline 2>/dev/null)" &&
+   [[ "$(git -C "$workspace" rev-parse --is-shallow-repository 2>/dev/null)" == "true" ]] &&
+   [[ "$workspace_shallow_log" == "$source_shallow_log" ]]; then
+    test_pass
+else
+    test_fail "expected copied shallow history to stop at the same boundary as the source"
+fi
+[[ -z "${workspace:-}" ]] || rm -rf "$(dirname "$workspace")"
 
 test_case "the disposable workspace retains local Git review context"
 workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT")"
@@ -64,6 +124,34 @@ else
 fi
 rm -rf "$(dirname "$workspace")"
 
+test_case "ambient repository selectors cannot redirect advisory Git writes to the source"
+AMBIENT_ROOT="$TEST_TMP_DIR/ambient-git-source"
+mkdir -p "$AMBIENT_ROOT"
+(
+    cd "$AMBIENT_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'source\n' > source.txt
+    git add source.txt
+    git commit -q -m init
+)
+AMBIENT_GIT_DIR="$(git -C "$AMBIENT_ROOT" rev-parse --absolute-git-dir)"
+run_agent_sync() {
+    git update-ref refs/heads/advisory-write HEAD
+    printf 'review only\n'
+}
+ambient_old_pwd="$PWD"
+cd "$AMBIENT_ROOT"
+GIT_DIR="$AMBIENT_GIT_DIR" GIT_WORK_TREE="$AMBIENT_ROOT" run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1 || true
+cd "$ambient_old_pwd"
+unset -f run_agent_sync
+if ! git -C "$AMBIENT_ROOT" show-ref --verify --quiet refs/heads/advisory-write; then
+    test_pass
+else
+    test_fail "ambient GIT_DIR redirected an advisory Git write into the source repository"
+fi
+
 test_case "a launch from a repository subdirectory keeps coherent Git context"
 source_status="$(git -C "$SOURCE_ROOT/subdir" status --short)"
 workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT/subdir")"
@@ -77,6 +165,21 @@ else
     test_fail "expected the copied repository root and returned subdirectory to match source Git status"
 fi
 rm -rf "$(dirname "$workspace_top")"
+
+test_case "empty and fully ignored launch directories remain valid working directories"
+mkdir -p "$SOURCE_ROOT/empty-subdir"
+if empty_workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT/empty-subdir" 2>/dev/null)" &&
+   ignored_workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT/vendor" 2>/dev/null)" &&
+   [[ -d "$empty_workspace" && -d "$ignored_workspace" ]] &&
+   [[ "$(git -C "$empty_workspace" rev-parse --show-toplevel 2>/dev/null)" == "$(dirname "$empty_workspace")" ]] &&
+   [[ "$(git -C "$ignored_workspace" rev-parse --show-toplevel 2>/dev/null)" == "$(dirname "$ignored_workspace")" ]] &&
+   [[ ! -e "$ignored_workspace/big.bin" ]]; then
+    test_pass
+else
+    test_fail "expected empty and ignored source subdirectories to map to empty copied working directories"
+fi
+[[ -z "${empty_workspace:-}" ]] || rm -rf "$(dirname "$(dirname "$empty_workspace")")"
+[[ -z "${ignored_workspace:-}" ]] || rm -rf "$(dirname "$(dirname "$ignored_workspace")")"
 
 test_case "an internal tracked symlink remains usable"
 workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT")"
@@ -225,6 +328,148 @@ if _octopus_prepare_consultative_workspace "$SYMLINK_ROOT" >/dev/null 2>&1; then
     test_fail "expected an external tracked symlink to make workspace preparation fail closed"
 else
     test_pass
+fi
+
+test_case "sparse checkout index flags remain exact in the disposable workspace"
+SPARSE_ROOT="$TEST_TMP_DIR/sparse-source"
+mkdir -p "$SPARSE_ROOT/keep" "$SPARSE_ROOT/omit"
+(
+    cd "$SPARSE_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'keep\n' > keep/file.txt
+    printf 'omit\n' > omit/file.txt
+    git add keep/file.txt omit/file.txt
+    git commit -q -m init
+    git sparse-checkout init --cone
+    git sparse-checkout set keep
+)
+source_sparse_status="$(git -C "$SPARSE_ROOT" status --short)"
+workspace="$(_octopus_prepare_consultative_workspace "$SPARSE_ROOT")"
+workspace_sparse_status="$(git -C "$workspace" status --short 2>/dev/null)"
+if [[ -z "$source_sparse_status" && "$workspace_sparse_status" == "$source_sparse_status" && ! -e "$workspace/omit/file.txt" ]]; then
+    test_pass
+else
+    test_fail "expected sparse index flags to prevent false copied-workspace deletions: ${workspace_sparse_status:-<clean>}"
+fi
+rm -rf "$(dirname "$workspace")"
+
+test_case "intent-to-add state remains exact and workspace index writes stay private"
+INTENT_ROOT="$TEST_TMP_DIR/intent-source"
+mkdir -p "$INTENT_ROOT"
+(
+    cd "$INTENT_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'base\n' > base.txt
+    git add base.txt
+    git commit -q -m init
+    printf 'intent\n' > intent.txt
+    git add -N intent.txt
+)
+intent_index="$(git -C "$INTENT_ROOT" rev-parse --git-path index)"
+case "$intent_index" in /*) ;; *) intent_index="$INTENT_ROOT/$intent_index" ;; esac
+intent_index_before="$(cksum "$intent_index")"
+source_intent_status="$(git -C "$INTENT_ROOT" status --short)"
+workspace="$(_octopus_prepare_consultative_workspace "$INTENT_ROOT")"
+workspace_intent_status="$(git -C "$workspace" status --short 2>/dev/null)"
+git -C "$workspace" add intent.txt
+intent_index_after="$(cksum "$intent_index")"
+if [[ "$workspace_intent_status" == "$source_intent_status" && "$intent_index_after" == "$intent_index_before" ]]; then
+    test_pass
+else
+    test_fail "expected exact intent-to-add state and an isolated writable workspace index"
+fi
+rm -rf "$(dirname "$workspace")"
+
+test_case "linked worktree split index and shared index stay coherent and private"
+LINKED_REPO="$TEST_TMP_DIR/linked-repo"
+LINKED_ROOT="$TEST_TMP_DIR/linked-worktree"
+mkdir -p "$LINKED_REPO"
+(
+    cd "$LINKED_REPO"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'base\n' > tracked.txt
+    git add tracked.txt
+    git commit -q -m init
+    git branch linked-review
+    git worktree add -q "$LINKED_ROOT" linked-review
+)
+(
+    cd "$LINKED_ROOT"
+    git update-index --split-index
+    printf 'unstaged\n' >> tracked.txt
+    printf 'staged then modified\n' > staged.txt
+    git add staged.txt
+    printf 'worktree tail\n' >> staged.txt
+    printf 'untracked\n' > untracked.txt
+)
+linked_index="$(git -C "$LINKED_ROOT" rev-parse --git-path index)"
+linked_shared_index="$(git -C "$LINKED_ROOT" rev-parse --shared-index-path)"
+case "$linked_index" in /*) ;; *) linked_index="$LINKED_ROOT/$linked_index" ;; esac
+case "$linked_shared_index" in /*) ;; *) linked_shared_index="$LINKED_ROOT/$linked_shared_index" ;; esac
+source_linked_status="$(git -C "$LINKED_ROOT" status --short)"
+linked_index_before="$(cksum "$linked_index")"
+linked_shared_before="$(cksum "$linked_shared_index")"
+workspace="$(_octopus_prepare_consultative_workspace "$LINKED_ROOT")"
+workspace_shared_index="$(git -C "$workspace" rev-parse --shared-index-path 2>/dev/null)"
+case "$workspace_shared_index" in ""|/*) ;; *) workspace_shared_index="$workspace/$workspace_shared_index" ;; esac
+workspace_linked_status="$(git -C "$workspace" status --short 2>/dev/null)"
+git -C "$workspace" add tracked.txt
+linked_index_after="$(cksum "$linked_index")"
+linked_shared_after="$(cksum "$linked_shared_index")"
+if [[ -f "$LINKED_ROOT/.git" && -d "$workspace/.git" && -n "$workspace_shared_index" && -f "$workspace_shared_index" ]] &&
+   [[ "$workspace_linked_status" == "$source_linked_status" ]] &&
+   [[ "$linked_index_after" == "$linked_index_before" && "$linked_shared_after" == "$linked_shared_before" ]]; then
+    test_pass
+else
+    test_fail "expected linked-worktree split index state and private workspace index writes: source=[$source_linked_status] workspace=[$workspace_linked_status] shared=${workspace_shared_index:-missing}"
+fi
+rm -rf "$(dirname "$workspace")"
+
+test_case "cleanup removes only the allocated temp root when TMPDIR is inside another repository"
+CLEANUP_CONTAINER="$TEST_TMP_DIR/cleanup-container"
+CLEANUP_OUTER_REPO="$CLEANUP_CONTAINER/unrelated-repo"
+CLEANUP_TMPDIR="$CLEANUP_OUTER_REPO/tmp"
+CLEANUP_SOURCE="$TEST_TMP_DIR/cleanup-plain-source"
+CLEANUP_SENTINEL="$CLEANUP_CONTAINER/outside-sentinel"
+CLEANUP_REPO_SENTINEL="$CLEANUP_OUTER_REPO/repo-sentinel"
+UNSAFE_CLEANUP_MARKER="$TEST_TMP_DIR/unsafe-cleanup-target"
+mkdir -p "$CLEANUP_TMPDIR" "$CLEANUP_SOURCE"
+git -C "$CLEANUP_OUTER_REPO" init -q
+printf 'outside\n' > "$CLEANUP_SENTINEL"
+printf 'repo\n' > "$CLEANUP_REPO_SENTINEL"
+printf 'plain\n' > "$CLEANUP_SOURCE/file.txt"
+CLEANUP_TMPDIR_PHYSICAL="$(cd "$CLEANUP_TMPDIR" && pwd -P)"
+rm() {
+    if [[ "${1:-}" == "-rf" ]]; then
+        case "${2:-}" in
+            "$CLEANUP_TMPDIR_PHYSICAL"/octopus-consultative.*) ;;
+            *)
+                printf '%s\n' "${2:-missing}" > "$UNSAFE_CLEANUP_MARKER"
+                return 1
+                ;;
+        esac
+    fi
+    command rm "$@"
+}
+run_agent_sync() {
+    printf 'review only\n'
+}
+cleanup_old_pwd="$PWD"
+cd "$CLEANUP_SOURCE"
+TMPDIR="$CLEANUP_TMPDIR" run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1 || true
+cd "$cleanup_old_pwd"
+unset -f rm run_agent_sync
+cleanup_residue="$(find "$CLEANUP_TMPDIR" -maxdepth 1 -type d -name 'octopus-consultative.*' -print)"
+if [[ -f "$CLEANUP_SENTINEL" && -f "$CLEANUP_REPO_SENTINEL" && ! -e "$UNSAFE_CLEANUP_MARKER" && -z "$cleanup_residue" ]]; then
+    test_pass
+else
+    test_fail "expected exact temp-root cleanup without touching the enclosing repository"
 fi
 
 test_case "a Git-aware copy failure never attempts a whole-tree copy"

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-# tests/unit/test-consultative-workspace-gitignore.sh
-# Regression test for #980: the consultative workspace copy must honour
-# .gitignore in a git work tree instead of copying gitignored vendor/build
-# trees into every advisory seat's disposable workspace.
+# Regression tests for #980: advisory copies honor Git ignore rules without
+# exposing source repository control-plane metadata or writable source state.
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -26,157 +24,111 @@ mkdir -p "$SOURCE_ROOT/vendor" "$SOURCE_ROOT/subdir"
     printf 'vendored\n' > vendor/big.bin
     git add tracked.txt inside.txt subdir/context.txt safe-link .gitignore
     git commit -q -m init
-    git branch -M main
-    git checkout -q -b feature
-    printf 'feature commit\n' > feature.txt
-    git add feature.txt
-    git commit -q -m feature
-    git update-ref refs/remotes/origin/main refs/heads/main
-    git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
-    git tag review-base refs/heads/main
-    printf 'modified\n' > tracked.txt
+    printf 'modified working tree\n' > tracked.txt
     printf 'subdirectory modified\n' > subdir/context.txt
     printf 'staged\n' > staged.txt
     git add staged.txt
-    printf 'staged and modified\n' > staged.txt
+    printf 'staged and modified working tree\n' > staged.txt
     printf 'untracked but not ignored\n' > untracked.txt
-    printf 'must not be copied\n' > .git/source-only-sentinel
 )
 
-test_case "gitignored files are excluded from the disposable workspace"
+test_case "Git sources copy exact eligible working-tree bytes without Git metadata"
 workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT")"
-if [[ -f "$workspace/tracked.txt" && -f "$workspace/untracked.txt" && ! -e "$workspace/vendor" ]]; then
+if [[ "$(cat "$workspace/tracked.txt" 2>/dev/null)" == "modified working tree" ]] &&
+   [[ "$(cat "$workspace/staged.txt" 2>/dev/null)" == "staged and modified working tree" ]] &&
+   [[ "$(cat "$workspace/untracked.txt" 2>/dev/null)" == "untracked but not ignored" ]] &&
+   [[ ! -e "$workspace/vendor" && ! -e "$workspace/.git" ]]; then
     test_pass
 else
-    test_fail "expected tracked.txt and untracked.txt present, vendor/ absent in $workspace"
+    test_fail "expected exact tracked/untracked-not-ignored bytes, no vendor tree, and no .git"
 fi
 rm -rf "$(dirname "$workspace")"
 
-test_case "the disposable workspace retains review base refs"
-workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT")"
-source_main="$(git -C "$SOURCE_ROOT" rev-parse main)"
-source_origin_main="$(git -C "$SOURCE_ROOT" rev-parse origin/main)"
-source_tag="$(git -C "$SOURCE_ROOT" rev-parse review-base)"
-source_remote_head="$(git -C "$SOURCE_ROOT" symbolic-ref refs/remotes/origin/HEAD)"
-source_review_diff="$(git -C "$SOURCE_ROOT" diff --stat main...HEAD)"
-if [[ "$(git -C "$workspace" rev-parse main 2>/dev/null)" == "$source_main" ]] &&
-   [[ "$(git -C "$workspace" rev-parse origin/main 2>/dev/null)" == "$source_origin_main" ]] &&
-   [[ "$(git -C "$workspace" rev-parse review-base 2>/dev/null)" == "$source_tag" ]] &&
-   [[ "$(git -C "$workspace" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null)" == "$source_remote_head" ]] &&
-   [[ "$(git -C "$workspace" diff --stat main...HEAD 2>/dev/null)" == "$source_review_diff" ]]; then
-    git -C "$workspace" update-ref refs/heads/main HEAD
-    if [[ "$(git -C "$SOURCE_ROOT" rev-parse main)" == "$source_main" ]] &&
-       [[ "$(git -C "$workspace" rev-parse main)" == "$(git -C "$workspace" rev-parse HEAD)" ]] &&
-       [[ "$(git -C "$workspace" rev-parse main)" != "$source_main" ]]; then
-        test_pass
-    else
-        test_fail "workspace ref writes changed the source repository or failed to remain local"
-    fi
+test_case "ambient Git config is ignored and advisory execution cannot mutate source Git state"
+AMBIENT_EXCLUDES="$TEST_TMP_DIR/ambient-excludes"
+AMBIENT_CONFIG="$TEST_TMP_DIR/ambient-gitconfig"
+AMBIENT_MARKER="$TEST_TMP_DIR/ambient-git-env-leaked"
+printf 'untracked.txt\n' > "$AMBIENT_EXCLUDES"
+printf '[core]\n\texcludesFile = %s\n' "$AMBIENT_EXCLUDES" > "$AMBIENT_CONFIG"
+source_index="$(git -C "$SOURCE_ROOT" rev-parse --git-path index)"
+case "$source_index" in /*) ;; *) source_index="$SOURCE_ROOT/$source_index" ;; esac
+source_index_before="$(cksum "$source_index")"
+source_head_before="$(git -C "$SOURCE_ROOT" rev-parse HEAD)"
+if workspace=$(
+    export GIT_CONFIG="$AMBIENT_CONFIG"
+    export GIT_CONFIG_GLOBAL="$AMBIENT_CONFIG"
+    export GIT_CONFIG_SYSTEM="$AMBIENT_CONFIG"
+    export GIT_CONFIG_NOSYSTEM=1
+    _octopus_prepare_consultative_workspace "$SOURCE_ROOT"
+) && [[ -f "$workspace/untracked.txt" && ! -e "$workspace/.git" ]]; then
+    prepare_isolated=true
 else
-    test_fail "expected local, remote-tracking, and symbolic review refs inside $workspace"
-fi
-rm -rf "$(dirname "$workspace")"
-
-test_case "shallow repository history remains coherent in the disposable workspace"
-SHALLOW_ORIGIN="$TEST_TMP_DIR/shallow-origin"
-SHALLOW_ROOT="$TEST_TMP_DIR/shallow-source"
-mkdir -p "$SHALLOW_ORIGIN"
-(
-    cd "$SHALLOW_ORIGIN"
-    git init -q
-    git config user.email "test@example.com"
-    git config user.name "test"
-    printf 'one\n' > history.txt
-    git add history.txt
-    git commit -q -m one
-    printf 'two\n' >> history.txt
-    git commit -qam two
-)
-git -c protocol.file.allow=always clone -q --depth 1 "file://$SHALLOW_ORIGIN" "$SHALLOW_ROOT"
-source_shallow_log="$(git -C "$SHALLOW_ROOT" log --oneline)"
-if workspace="$(_octopus_prepare_consultative_workspace "$SHALLOW_ROOT")" &&
-   workspace_shallow_log="$(git -C "$workspace" log --oneline 2>/dev/null)" &&
-   [[ "$(git -C "$workspace" rev-parse --is-shallow-repository 2>/dev/null)" == "true" ]] &&
-   [[ "$workspace_shallow_log" == "$source_shallow_log" ]]; then
-    test_pass
-else
-    test_fail "expected copied shallow history to stop at the same boundary as the source"
+    prepare_isolated=false
 fi
 [[ -z "${workspace:-}" ]] || rm -rf "$(dirname "$workspace")"
 
-test_case "the disposable workspace retains local Git review context"
-workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT")"
-source_head="$(git -C "$SOURCE_ROOT" rev-parse HEAD)"
-if [[ "$(git -C "$workspace" rev-parse HEAD 2>/dev/null)" == "$source_head" ]] &&
-   [[ ! -e "$workspace/.git/source-only-sentinel" ]] &&
-   ! git -C "$workspace" diff --quiet -- tracked.txt &&
-   ! git -C "$workspace" diff --cached --quiet -- staged.txt &&
-   ! git -C "$workspace" diff --quiet -- staged.txt &&
-   git -C "$workspace" status --short 2>/dev/null | grep -q '^?? untracked.txt$'; then
-    git -C "$workspace" config octopus.workspace-only true
-    if [[ -z "$(git -C "$SOURCE_ROOT" config --get octopus.workspace-only 2>/dev/null)" ]]; then
-        test_pass
-    else
-        test_fail "workspace Git config mutated the source repository"
-    fi
-else
-    test_fail "expected isolated HEAD, index, worktree changes, and untracked files inside $workspace"
-fi
-rm -rf "$(dirname "$workspace")"
-
-test_case "ambient repository selectors cannot redirect advisory Git writes to the source"
-AMBIENT_ROOT="$TEST_TMP_DIR/ambient-git-source"
-mkdir -p "$AMBIENT_ROOT"
-(
-    cd "$AMBIENT_ROOT"
-    git init -q
-    git config user.email "test@example.com"
-    git config user.name "test"
-    printf 'source\n' > source.txt
-    git add source.txt
-    git commit -q -m init
-)
-AMBIENT_GIT_DIR="$(git -C "$AMBIENT_ROOT" rev-parse --absolute-git-dir)"
 run_agent_sync() {
-    git update-ref refs/heads/advisory-write HEAD
+    local name
+    while IFS= read -r name; do
+        case "$name" in
+            GIT_DIR|GIT_WORK_TREE|GIT_INDEX_FILE|GIT_OBJECT_DIRECTORY|GIT_ALTERNATE_OBJECT_DIRECTORIES|GIT_COMMON_DIR|GIT_NAMESPACE|GIT_CEILING_DIRECTORIES|GIT_PREFIX|GIT_SUPER_PREFIX|GIT_CONFIG|GIT_CONFIG_GLOBAL|GIT_CONFIG_SYSTEM|GIT_CONFIG_NOSYSTEM|GIT_CONFIG_PARAMETERS|GIT_CONFIG_COUNT|GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*|GIT_QUARANTINE_PATH|GIT_DEFAULT_HASH)
+                printf '%s\n' "$name" > "$AMBIENT_MARKER"
+                ;;
+        esac
+    done < <(compgen -v)
+    git update-ref refs/heads/advisory-write HEAD >/dev/null 2>&1 || true
     printf 'review only\n'
 }
-ambient_old_pwd="$PWD"
-cd "$AMBIENT_ROOT"
-GIT_DIR="$AMBIENT_GIT_DIR" GIT_WORK_TREE="$AMBIENT_ROOT" run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1 || true
-cd "$ambient_old_pwd"
+ambient_git_dir="$(git -C "$SOURCE_ROOT" rev-parse --absolute-git-dir)"
+old_pwd="$PWD"
+cd "$SOURCE_ROOT"
+GIT_DIR="$ambient_git_dir" \
+GIT_WORK_TREE="$SOURCE_ROOT" \
+GIT_INDEX_FILE="$source_index" \
+GIT_CONFIG="$AMBIENT_CONFIG" \
+GIT_CONFIG_GLOBAL="$AMBIENT_CONFIG" \
+GIT_CONFIG_SYSTEM="$AMBIENT_CONFIG" \
+GIT_CONFIG_NOSYSTEM=1 \
+GIT_CONFIG_COUNT=1 \
+GIT_CONFIG_KEY_0=core.hooksPath \
+GIT_CONFIG_VALUE_0="$TEST_TMP_DIR/hooks" \
+run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1 || true
+cd "$old_pwd"
 unset -f run_agent_sync
-if ! git -C "$AMBIENT_ROOT" show-ref --verify --quiet refs/heads/advisory-write; then
+source_index_after="$(cksum "$source_index")"
+source_head_after="$(git -C "$SOURCE_ROOT" rev-parse HEAD)"
+if [[ "$prepare_isolated" == "true" && ! -e "$AMBIENT_MARKER" ]] &&
+   [[ "$source_index_after" == "$source_index_before" && "$source_head_after" == "$source_head_before" ]] &&
+   ! git -C "$SOURCE_ROOT" show-ref --verify --quiet refs/heads/advisory-write; then
     test_pass
 else
-    test_fail "ambient GIT_DIR redirected an advisory Git write into the source repository"
+    test_fail "expected Git config isolation and unchanged source index, HEAD, and refs"
 fi
 
-test_case "a launch from a repository subdirectory keeps coherent Git context"
-source_status="$(git -C "$SOURCE_ROOT/subdir" status --short)"
+test_case "a launch from a repository subdirectory returns its copied subdirectory"
 workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT/subdir")"
-workspace_top="$(git -C "$workspace" rev-parse --show-toplevel 2>/dev/null)"
-workspace_status="$(git -C "$workspace" status --short 2>/dev/null)"
-if [[ -f "$workspace/context.txt" ]] &&
-   [[ "$(git -C "$workspace" rev-parse HEAD 2>/dev/null)" == "$(git -C "$SOURCE_ROOT" rev-parse HEAD)" ]] &&
-   [[ "$workspace_status" == "$source_status" ]]; then
+workspace_root="$(dirname "$workspace")"
+if [[ "$workspace" == */workspace/subdir ]] &&
+   [[ "$(cat "$workspace/context.txt" 2>/dev/null)" == "subdirectory modified" ]] &&
+   [[ ! -e "$workspace_root/.git" ]]; then
     test_pass
 else
-    test_fail "expected the copied repository root and returned subdirectory to match source Git status"
+    test_fail "expected current subdirectory bytes at the matching metadata-free copied path"
 fi
-rm -rf "$(dirname "$workspace_top")"
+rm -rf "$(dirname "$workspace_root")"
 
 test_case "empty and fully ignored launch directories remain valid working directories"
 mkdir -p "$SOURCE_ROOT/empty-subdir"
 if empty_workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT/empty-subdir" 2>/dev/null)" &&
    ignored_workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT/vendor" 2>/dev/null)" &&
    [[ -d "$empty_workspace" && -d "$ignored_workspace" ]] &&
-   [[ "$(git -C "$empty_workspace" rev-parse --show-toplevel 2>/dev/null)" == "$(dirname "$empty_workspace")" ]] &&
-   [[ "$(git -C "$ignored_workspace" rev-parse --show-toplevel 2>/dev/null)" == "$(dirname "$ignored_workspace")" ]] &&
-   [[ ! -e "$ignored_workspace/big.bin" ]]; then
+   [[ "$empty_workspace" == */workspace/empty-subdir ]] &&
+   [[ "$ignored_workspace" == */workspace/vendor ]] &&
+   [[ ! -e "$ignored_workspace/big.bin" ]] &&
+   [[ ! -e "$(dirname "$empty_workspace")/.git" && ! -e "$(dirname "$ignored_workspace")/.git" ]]; then
     test_pass
 else
-    test_fail "expected empty and ignored source subdirectories to map to empty copied working directories"
+    test_fail "expected empty and ignored source subdirectories to map to empty copied directories"
 fi
 [[ -z "${empty_workspace:-}" ]] || rm -rf "$(dirname "$(dirname "$empty_workspace")")"
 [[ -z "${ignored_workspace:-}" ]] || rm -rf "$(dirname "$(dirname "$ignored_workspace")")"
@@ -189,6 +141,41 @@ else
     test_fail "expected safe-link to remain a working in-repository symlink"
 fi
 rm -rf "$(dirname "$workspace")"
+
+test_case "a symlink in an eligible path's ancestor chain fails closed"
+ANCESTOR_ROOT="$TEST_TMP_DIR/ancestor-link-source"
+ANCESTOR_GIT_BIN="$TEST_TMP_DIR/ancestor-git-bin"
+REAL_GIT="$(command -v git)"
+mkdir -p "$ANCESTOR_ROOT/tracked-dir"
+(
+    cd "$ANCESTOR_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'tracked\n' > tracked-dir/file.txt
+    git add tracked-dir/file.txt
+    git commit -q -m init
+    mv tracked-dir actual-dir
+    ln -s actual-dir tracked-dir
+)
+mkdir -p "$ANCESTOR_GIT_BIN"
+cat > "$ANCESTOR_GIT_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+    if [[ "$arg" == "ls-files" ]]; then
+        printf 'tracked-dir/file.txt\0'
+        exit 0
+    fi
+done
+exec "$REAL_GIT" "$@"
+EOF
+chmod +x "$ANCESTOR_GIT_BIN/git"
+if PATH="$ANCESTOR_GIT_BIN:$PATH" REAL_GIT="$REAL_GIT" \
+   _octopus_prepare_consultative_workspace "$ANCESTOR_ROOT" >/dev/null 2>&1; then
+    test_fail "expected a tracked path beneath a symlink ancestor to fail closed"
+else
+    test_pass
+fi
 
 test_case "an absolute tracked symlink cannot point back into the source"
 ABSOLUTE_LINK_ROOT="$TEST_TMP_DIR/absolute-link-source"
@@ -209,7 +196,28 @@ else
     test_pass
 fi
 
-test_case "non-git source roots still fall back to a full copy"
+test_case "a tracked symlink outside the source repository is rejected"
+SYMLINK_ROOT="$TEST_TMP_DIR/symlink-source"
+OUTSIDE_ROOT="$TEST_TMP_DIR/symlink-outside"
+mkdir -p "$SYMLINK_ROOT" "$OUTSIDE_ROOT"
+printf 'outside secret\n' > "$OUTSIDE_ROOT/secret.txt"
+(
+    cd "$SYMLINK_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'main tracked\n' > main.txt
+    ln -s "../symlink-outside/secret.txt" evil-link
+    git add main.txt evil-link
+    git commit -q -m "init with symlink"
+)
+if _octopus_prepare_consultative_workspace "$SYMLINK_ROOT" >/dev/null 2>&1; then
+    test_fail "expected an external tracked symlink to make workspace preparation fail closed"
+else
+    test_pass
+fi
+
+test_case "non-Git source roots still fall back to a full copy"
 PLAIN_ROOT="$TEST_TMP_DIR/plain-source"
 mkdir -p "$PLAIN_ROOT"
 printf 'x\n' > "$PLAIN_ROOT/file.txt"
@@ -221,12 +229,7 @@ else
 fi
 rm -rf "$(dirname "$workspace")"
 
-# A nested git work tree (a submodule, or a plain untracked checkout that
-# isn't itself gitignored) is reported by `git ls-files` as a single opaque
-# path. Without recursing into it, a naive tar copy of that path would pull
-# in whatever the nested tree's own .gitignore excludes, defeating the fix
-# one level down.
-test_case "a nested git work tree's own .gitignore is honored too"
+test_case "nested Git work trees recursively honor their own ignore rules without metadata"
 NESTED_ROOT="$TEST_TMP_DIR/nested-source"
 NESTED_CHILD_ROOT="$TEST_TMP_DIR/nested-child"
 mkdir -p "$NESTED_ROOT" "$NESTED_CHILD_ROOT/vendor"
@@ -250,15 +253,18 @@ mkdir -p "$NESTED_ROOT" "$NESTED_CHILD_ROOT/vendor"
     git commit -q -m init
     git -c protocol.file.allow=always submodule add -q "$NESTED_CHILD_ROOT" nested-repo
     git commit -q -am "add nested repository"
+    printf 'nested working tree\n' > nested-repo/nested.txt
     mkdir -p nested-repo/vendor
     printf 'nested vendored\n' > nested-repo/vendor/big.bin
 )
 workspace="$(_octopus_prepare_consultative_workspace "$NESTED_ROOT")"
-if [[ -f "$workspace/parent.txt" && -f "$workspace/nested-repo/nested.txt" && ! -e "$workspace/nested-repo/vendor" ]] &&
-   [[ "$(git -C "$workspace/nested-repo" log -1 --format=%s 2>/dev/null)" == "nested init" ]]; then
+if [[ "$(cat "$workspace/parent.txt" 2>/dev/null)" == "parent tracked" ]] &&
+   [[ "$(cat "$workspace/nested-repo/nested.txt" 2>/dev/null)" == "nested working tree" ]] &&
+   [[ ! -e "$workspace/nested-repo/vendor" ]] &&
+   [[ ! -e "$workspace/.git" && ! -e "$workspace/nested-repo/.git" ]]; then
     test_pass
 else
-    test_fail "expected nested-repo/vendor absent, parent.txt and nested-repo/nested.txt present in $workspace"
+    test_fail "expected recursively filtered nested bytes without parent or nested .git metadata"
 fi
 rm -rf "$(dirname "$workspace")"
 
@@ -300,134 +306,6 @@ if [[ ! -e "$TAR_GUARD_MARKER" && -f "$workspace/nested-repo/nested.txt" && ! -e
     test_pass
 else
     test_fail "expected the parent archive to omit nested-repo before recursively copying it"
-fi
-rm -rf "$(dirname "$workspace")"
-
-# A tracked symlink that leaves source_root still grants the advisory process
-# access to files outside the disposable workspace, even if tar preserves it
-# as a symlink rather than materializing its target.
-test_case "a tracked symlink outside the source repository is rejected"
-SYMLINK_ROOT="$TEST_TMP_DIR/symlink-source"
-OUTSIDE_ROOT="$TEST_TMP_DIR/symlink-outside"
-mkdir -p "$SYMLINK_ROOT" "$OUTSIDE_ROOT"
-(
-    cd "$OUTSIDE_ROOT"
-    printf 'outside secret\n' > secret.txt
-)
-(
-    cd "$SYMLINK_ROOT"
-    git init -q
-    git config user.email "test@example.com"
-    git config user.name "test"
-    printf 'main tracked\n' > main.txt
-    ln -s "../symlink-outside/secret.txt" evil-link
-    git add main.txt evil-link
-    git commit -q -m "init with symlink"
-)
-if _octopus_prepare_consultative_workspace "$SYMLINK_ROOT" >/dev/null 2>&1; then
-    test_fail "expected an external tracked symlink to make workspace preparation fail closed"
-else
-    test_pass
-fi
-
-test_case "sparse checkout index flags remain exact in the disposable workspace"
-SPARSE_ROOT="$TEST_TMP_DIR/sparse-source"
-mkdir -p "$SPARSE_ROOT/keep" "$SPARSE_ROOT/omit"
-(
-    cd "$SPARSE_ROOT"
-    git init -q
-    git config user.email "test@example.com"
-    git config user.name "test"
-    printf 'keep\n' > keep/file.txt
-    printf 'omit\n' > omit/file.txt
-    git add keep/file.txt omit/file.txt
-    git commit -q -m init
-    git sparse-checkout init --cone
-    git sparse-checkout set keep
-)
-source_sparse_status="$(git -C "$SPARSE_ROOT" status --short)"
-workspace="$(_octopus_prepare_consultative_workspace "$SPARSE_ROOT")"
-workspace_sparse_status="$(git -C "$workspace" status --short 2>/dev/null)"
-if [[ -z "$source_sparse_status" && "$workspace_sparse_status" == "$source_sparse_status" && ! -e "$workspace/omit/file.txt" ]]; then
-    test_pass
-else
-    test_fail "expected sparse index flags to prevent false copied-workspace deletions: ${workspace_sparse_status:-<clean>}"
-fi
-rm -rf "$(dirname "$workspace")"
-
-test_case "intent-to-add state remains exact and workspace index writes stay private"
-INTENT_ROOT="$TEST_TMP_DIR/intent-source"
-mkdir -p "$INTENT_ROOT"
-(
-    cd "$INTENT_ROOT"
-    git init -q
-    git config user.email "test@example.com"
-    git config user.name "test"
-    printf 'base\n' > base.txt
-    git add base.txt
-    git commit -q -m init
-    printf 'intent\n' > intent.txt
-    git add -N intent.txt
-)
-intent_index="$(git -C "$INTENT_ROOT" rev-parse --git-path index)"
-case "$intent_index" in /*) ;; *) intent_index="$INTENT_ROOT/$intent_index" ;; esac
-intent_index_before="$(cksum "$intent_index")"
-source_intent_status="$(git -C "$INTENT_ROOT" status --short)"
-workspace="$(_octopus_prepare_consultative_workspace "$INTENT_ROOT")"
-workspace_intent_status="$(git -C "$workspace" status --short 2>/dev/null)"
-git -C "$workspace" add intent.txt
-intent_index_after="$(cksum "$intent_index")"
-if [[ "$workspace_intent_status" == "$source_intent_status" && "$intent_index_after" == "$intent_index_before" ]]; then
-    test_pass
-else
-    test_fail "expected exact intent-to-add state and an isolated writable workspace index"
-fi
-rm -rf "$(dirname "$workspace")"
-
-test_case "linked worktree split index and shared index stay coherent and private"
-LINKED_REPO="$TEST_TMP_DIR/linked-repo"
-LINKED_ROOT="$TEST_TMP_DIR/linked-worktree"
-mkdir -p "$LINKED_REPO"
-(
-    cd "$LINKED_REPO"
-    git init -q
-    git config user.email "test@example.com"
-    git config user.name "test"
-    printf 'base\n' > tracked.txt
-    git add tracked.txt
-    git commit -q -m init
-    git branch linked-review
-    git worktree add -q "$LINKED_ROOT" linked-review
-)
-(
-    cd "$LINKED_ROOT"
-    git update-index --split-index
-    printf 'unstaged\n' >> tracked.txt
-    printf 'staged then modified\n' > staged.txt
-    git add staged.txt
-    printf 'worktree tail\n' >> staged.txt
-    printf 'untracked\n' > untracked.txt
-)
-linked_index="$(git -C "$LINKED_ROOT" rev-parse --git-path index)"
-linked_shared_index="$(git -C "$LINKED_ROOT" rev-parse --shared-index-path)"
-case "$linked_index" in /*) ;; *) linked_index="$LINKED_ROOT/$linked_index" ;; esac
-case "$linked_shared_index" in /*) ;; *) linked_shared_index="$LINKED_ROOT/$linked_shared_index" ;; esac
-source_linked_status="$(git -C "$LINKED_ROOT" status --short)"
-linked_index_before="$(cksum "$linked_index")"
-linked_shared_before="$(cksum "$linked_shared_index")"
-workspace="$(_octopus_prepare_consultative_workspace "$LINKED_ROOT")"
-workspace_shared_index="$(git -C "$workspace" rev-parse --shared-index-path 2>/dev/null)"
-case "$workspace_shared_index" in ""|/*) ;; *) workspace_shared_index="$workspace/$workspace_shared_index" ;; esac
-workspace_linked_status="$(git -C "$workspace" status --short 2>/dev/null)"
-git -C "$workspace" add tracked.txt
-linked_index_after="$(cksum "$linked_index")"
-linked_shared_after="$(cksum "$linked_shared_index")"
-if [[ -f "$LINKED_ROOT/.git" && -d "$workspace/.git" && -n "$workspace_shared_index" && -f "$workspace_shared_index" ]] &&
-   [[ "$workspace_linked_status" == "$source_linked_status" ]] &&
-   [[ "$linked_index_after" == "$linked_index_before" && "$linked_shared_after" == "$linked_shared_before" ]]; then
-    test_pass
-else
-    test_fail "expected linked-worktree split index state and private workspace index writes: source=[$source_linked_status] workspace=[$workspace_linked_status] shared=${workspace_shared_index:-missing}"
 fi
 rm -rf "$(dirname "$workspace")"
 

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -44,6 +44,51 @@ else
 fi
 rm -rf "$(dirname "$workspace")"
 
+test_case "Git discovery errors fail closed without a whole-tree copy"
+DISCOVERY_GIT_BIN="$TEST_TMP_DIR/discovery-git-bin"
+DISCOVERY_CP_MARKER="$TEST_TMP_DIR/discovery-whole-tree-copy"
+DISCOVERY_COUNT="$TEST_TMP_DIR/discovery-count"
+REAL_GIT="$(command -v git)"
+REAL_CP="$(command -v cp)"
+mkdir -p "$DISCOVERY_GIT_BIN"
+cat > "$DISCOVERY_GIT_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+is_discovery=false
+for arg in "$@"; do
+    [[ "$arg" == "--is-inside-work-tree" ]] && is_discovery=true
+done
+if [[ "$is_discovery" == "true" && ! -e "$DISCOVERY_COUNT" ]]; then
+    printf 'failed once\n' > "$DISCOVERY_COUNT"
+    exit 128
+fi
+exec "$REAL_GIT" "$@"
+EOF
+cat > "$DISCOVERY_GIT_BIN/cp" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+    if [[ "$arg" == "$SOURCE_ROOT/." ]]; then
+        printf 'whole-tree copy attempted\n' > "$DISCOVERY_CP_MARKER"
+        exit 91
+    fi
+done
+exec "$REAL_CP" "$@"
+EOF
+chmod +x "$DISCOVERY_GIT_BIN/git" "$DISCOVERY_GIT_BIN/cp"
+if workspace="$(
+    export PATH="$DISCOVERY_GIT_BIN:$PATH"
+    export DISCOVERY_COUNT DISCOVERY_CP_MARKER REAL_GIT REAL_CP SOURCE_ROOT
+    _octopus_prepare_consultative_workspace "$SOURCE_ROOT"
+)"; then
+    discovery_rc=0
+else
+    discovery_rc=$?
+fi
+if [[ "$discovery_rc" -ne 0 && ! -e "$DISCOVERY_CP_MARKER" ]]; then
+    test_pass
+else
+    test_fail "expected discovery failure to prevent copying .git and ignored payloads"
+fi
+
 test_case "ambient Git config is ignored and advisory execution cannot mutate source Git state"
 AMBIENT_EXCLUDES="$TEST_TMP_DIR/ambient-excludes"
 AMBIENT_CONFIG="$TEST_TMP_DIR/ambient-gitconfig"
@@ -141,6 +186,46 @@ else
     test_fail "expected safe-link to remain a working in-repository symlink"
 fi
 rm -rf "$(dirname "$workspace")"
+
+test_case "a confined dangling tracked relative symlink is preserved"
+DANGLING_ROOT="$TEST_TMP_DIR/dangling-link-source"
+mkdir -p "$DANGLING_ROOT/links"
+(
+    cd "$DANGLING_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    ln -s ../future/missing.txt links/pending
+    git add links/pending
+    git commit -q -m "init with confined dangling symlink"
+)
+if workspace="$(_octopus_prepare_consultative_workspace "$DANGLING_ROOT" 2>/dev/null)" &&
+   [[ -L "$workspace/links/pending" ]] &&
+   [[ "$(readlink "$workspace/links/pending")" == "../future/missing.txt" ]] &&
+   [[ ! -e "$workspace/links/pending" ]]; then
+    test_pass
+else
+    test_fail "expected the confined dangling symlink target to remain unchanged"
+fi
+[[ -z "${workspace:-}" ]] || rm -rf "$(dirname "$workspace")"
+
+test_case "a dangling tracked relative symlink with a lexical escape is rejected"
+DANGLING_ESCAPE_ROOT="$TEST_TMP_DIR/dangling-escape-source"
+mkdir -p "$DANGLING_ESCAPE_ROOT/links"
+(
+    cd "$DANGLING_ESCAPE_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    ln -s ../../outside/missing.txt links/escape
+    git add links/escape
+    git commit -q -m "init with escaping dangling symlink"
+)
+if _octopus_prepare_consultative_workspace "$DANGLING_ESCAPE_ROOT" >/dev/null 2>&1; then
+    test_fail "expected a dangling symlink target outside the workspace to fail closed"
+else
+    test_pass
+fi
 
 test_case "a symlink in an eligible path's ancestor chain fails closed"
 ANCESTOR_ROOT="$TEST_TMP_DIR/ancestor-link-source"

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -82,4 +82,77 @@ else
 fi
 rm -rf "$(dirname "$workspace")"
 
+# A tracked symlink satisfies `-d` when it resolves to a directory, and could
+# point outside source_root entirely. It must be left as the symlink tar
+# already copied, never resolved and recursively re-copied — that would
+# materialize content from outside source_root into the workspace.
+test_case "a tracked symlink is left alone, not resolved into the workspace"
+SYMLINK_ROOT="$TEST_TMP_DIR/symlink-source"
+OUTSIDE_ROOT="$TEST_TMP_DIR/symlink-outside"
+mkdir -p "$SYMLINK_ROOT" "$OUTSIDE_ROOT"
+(
+    cd "$OUTSIDE_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'outside secret\n' > secret.txt
+    git add secret.txt
+    git commit -q -m init
+)
+(
+    cd "$SYMLINK_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'main tracked\n' > main.txt
+    ln -s "$OUTSIDE_ROOT" evil-link
+    git add main.txt evil-link
+    git commit -q -m "init with symlink"
+)
+workspace="$(_octopus_prepare_consultative_workspace "$SYMLINK_ROOT")"
+if [[ -L "$workspace/evil-link" && -f "$workspace/main.txt" ]]; then
+    test_pass
+else
+    test_fail "expected evil-link to remain a symlink (not resolved into a real copied directory) in $workspace"
+fi
+rm -rf "$(dirname "$workspace")"
+
+# Bash suppresses errexit inside a function invoked as an `if`/`||` condition,
+# so a bare `nested_copy || fallback` inside the per-entry loop cannot signal
+# a double failure to the caller by relying on errexit — it must track and
+# return it explicitly, or _octopus_prepare_consultative_workspace never
+# knows to fall back to a full copy.
+test_case "a nested copy that fails both ways is reported to the caller, not swallowed"
+if (
+    nested_copy_that_always_fails() { return 1; }
+    cp_fallback_that_always_fails() { return 1; }
+
+    copy_tree_without_tracking() {
+        local entry
+        while IFS= read -r entry; do
+            nested_copy_that_always_fails || cp_fallback_that_always_fails 2>/dev/null
+        done <<< "entry"
+        return 0
+    }
+
+    copy_tree_with_tracking() {
+        local entry
+        local nested_copy_failed=0
+        while IFS= read -r entry; do
+            if ! nested_copy_that_always_fails; then
+                cp_fallback_that_always_fails 2>/dev/null || nested_copy_failed=1
+            fi
+        done <<< "entry"
+        [[ "$nested_copy_failed" -eq 0 ]]
+    }
+
+    if copy_tree_without_tracking; then without_tracking_rc=0; else without_tracking_rc=1; fi
+    if copy_tree_with_tracking; then with_tracking_rc=0; else with_tracking_rc=1; fi
+    [[ "$without_tracking_rc" -eq 0 && "$with_tracking_rc" -eq 1 ]]
+); then
+    test_pass
+else
+    test_fail "expected the untracked shape to mask a double failure and the tracked shape (used by _octopus_copy_git_tracked_tree) to report it"
+fi
+
 test_summary

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -12,7 +12,7 @@ source "$PROJECT_ROOT/scripts/lib/agent-sync.sh"
 test_suite "Consultative Workspace .gitignore Handling"
 
 SOURCE_ROOT="$TEST_TMP_DIR/gitignore-source"
-mkdir -p "$SOURCE_ROOT/vendor"
+mkdir -p "$SOURCE_ROOT/vendor" "$SOURCE_ROOT/subdir"
 (
     cd "$SOURCE_ROOT"
     git init -q
@@ -20,10 +20,19 @@ mkdir -p "$SOURCE_ROOT/vendor"
     git config user.name "test"
     printf 'vendor/\n' > .gitignore
     printf 'tracked\n' > tracked.txt
+    printf 'inside\n' > inside.txt
+    printf 'subdirectory tracked\n' > subdir/context.txt
+    ln -s inside.txt safe-link
     printf 'vendored\n' > vendor/big.bin
-    git add tracked.txt .gitignore
+    git add tracked.txt inside.txt subdir/context.txt safe-link .gitignore
     git commit -q -m init
+    printf 'modified\n' > tracked.txt
+    printf 'subdirectory modified\n' > subdir/context.txt
+    printf 'staged\n' > staged.txt
+    git add staged.txt
+    printf 'staged and modified\n' > staged.txt
     printf 'untracked but not ignored\n' > untracked.txt
+    printf 'must not be copied\n' > .git/source-only-sentinel
 )
 
 test_case "gitignored files are excluded from the disposable workspace"
@@ -34,6 +43,68 @@ else
     test_fail "expected tracked.txt and untracked.txt present, vendor/ absent in $workspace"
 fi
 rm -rf "$(dirname "$workspace")"
+
+test_case "the disposable workspace retains local Git review context"
+workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT")"
+source_head="$(git -C "$SOURCE_ROOT" rev-parse HEAD)"
+if [[ "$(git -C "$workspace" rev-parse HEAD 2>/dev/null)" == "$source_head" ]] &&
+   [[ ! -e "$workspace/.git/source-only-sentinel" ]] &&
+   ! git -C "$workspace" diff --quiet -- tracked.txt &&
+   ! git -C "$workspace" diff --cached --quiet -- staged.txt &&
+   ! git -C "$workspace" diff --quiet -- staged.txt &&
+   git -C "$workspace" status --short 2>/dev/null | grep -q '^?? untracked.txt$'; then
+    git -C "$workspace" config octopus.workspace-only true
+    if [[ -z "$(git -C "$SOURCE_ROOT" config --get octopus.workspace-only 2>/dev/null)" ]]; then
+        test_pass
+    else
+        test_fail "workspace Git config mutated the source repository"
+    fi
+else
+    test_fail "expected isolated HEAD, index, worktree changes, and untracked files inside $workspace"
+fi
+rm -rf "$(dirname "$workspace")"
+
+test_case "a launch from a repository subdirectory keeps coherent Git context"
+source_status="$(git -C "$SOURCE_ROOT/subdir" status --short)"
+workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT/subdir")"
+workspace_top="$(git -C "$workspace" rev-parse --show-toplevel 2>/dev/null)"
+workspace_status="$(git -C "$workspace" status --short 2>/dev/null)"
+if [[ -f "$workspace/context.txt" ]] &&
+   [[ "$(git -C "$workspace" rev-parse HEAD 2>/dev/null)" == "$(git -C "$SOURCE_ROOT" rev-parse HEAD)" ]] &&
+   [[ "$workspace_status" == "$source_status" ]]; then
+    test_pass
+else
+    test_fail "expected the copied repository root and returned subdirectory to match source Git status"
+fi
+rm -rf "$(dirname "$workspace_top")"
+
+test_case "an internal tracked symlink remains usable"
+workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT")"
+if [[ -L "$workspace/safe-link" && "$(cat "$workspace/safe-link")" == "inside" ]]; then
+    test_pass
+else
+    test_fail "expected safe-link to remain a working in-repository symlink"
+fi
+rm -rf "$(dirname "$workspace")"
+
+test_case "an absolute tracked symlink cannot point back into the source"
+ABSOLUTE_LINK_ROOT="$TEST_TMP_DIR/absolute-link-source"
+mkdir -p "$ABSOLUTE_LINK_ROOT"
+(
+    cd "$ABSOLUTE_LINK_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'inside\n' > inside.txt
+    ln -s "$ABSOLUTE_LINK_ROOT/inside.txt" absolute-link
+    git add inside.txt absolute-link
+    git commit -q -m "init with absolute symlink"
+)
+if _octopus_prepare_consultative_workspace "$ABSOLUTE_LINK_ROOT" >/dev/null 2>&1; then
+    test_fail "expected an absolute symlink into the source to fail closed"
+else
+    test_pass
+fi
 
 test_case "non-git source roots still fall back to a full copy"
 PLAIN_ROOT="$TEST_TMP_DIR/plain-source"
@@ -54,7 +125,18 @@ rm -rf "$(dirname "$workspace")"
 # one level down.
 test_case "a nested git work tree's own .gitignore is honored too"
 NESTED_ROOT="$TEST_TMP_DIR/nested-source"
-mkdir -p "$NESTED_ROOT/nested-repo/vendor"
+NESTED_CHILD_ROOT="$TEST_TMP_DIR/nested-child"
+mkdir -p "$NESTED_ROOT" "$NESTED_CHILD_ROOT/vendor"
+(
+    cd "$NESTED_CHILD_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'vendor/\n' > .gitignore
+    printf 'nested tracked\n' > nested.txt
+    git add nested.txt .gitignore
+    git commit -q -m "nested init"
+)
 (
     cd "$NESTED_ROOT"
     git init -q
@@ -63,41 +145,71 @@ mkdir -p "$NESTED_ROOT/nested-repo/vendor"
     printf 'parent tracked\n' > parent.txt
     git add parent.txt
     git commit -q -m init
-
-    cd nested-repo
-    git init -q
-    git config user.email "test@example.com"
-    git config user.name "test"
-    printf 'vendor/\n' > .gitignore
-    printf 'nested tracked\n' > nested.txt
-    printf 'nested vendored\n' > vendor/big.bin
-    git add nested.txt .gitignore
-    git commit -q -m "nested init"
+    git -c protocol.file.allow=always submodule add -q "$NESTED_CHILD_ROOT" nested-repo
+    git commit -q -am "add nested repository"
+    mkdir -p nested-repo/vendor
+    printf 'nested vendored\n' > nested-repo/vendor/big.bin
 )
 workspace="$(_octopus_prepare_consultative_workspace "$NESTED_ROOT")"
-if [[ -f "$workspace/parent.txt" && -f "$workspace/nested-repo/nested.txt" && ! -e "$workspace/nested-repo/vendor" ]]; then
+if [[ -f "$workspace/parent.txt" && -f "$workspace/nested-repo/nested.txt" && ! -e "$workspace/nested-repo/vendor" ]] &&
+   [[ "$(git -C "$workspace/nested-repo" log -1 --format=%s 2>/dev/null)" == "nested init" ]]; then
     test_pass
 else
     test_fail "expected nested-repo/vendor absent, parent.txt and nested-repo/nested.txt present in $workspace"
 fi
 rm -rf "$(dirname "$workspace")"
 
-# A tracked symlink satisfies `-d` when it resolves to a directory, and could
-# point outside source_root entirely. It must be left as the symlink tar
-# already copied, never resolved and recursively re-copied — that would
-# materialize content from outside source_root into the workspace.
-test_case "a tracked symlink is left alone, not resolved into the workspace"
+test_case "nested repositories are excluded before the parent archive runs"
+REAL_TAR="$(command -v tar)"
+TAR_GUARD_BIN="$TEST_TMP_DIR/tar-guard-bin"
+TAR_GUARD_MARKER="$TEST_TMP_DIR/tar-saw-nested-root"
+mkdir -p "$TAR_GUARD_BIN"
+cat > "$TAR_GUARD_BIN/tar" <<'EOF'
+#!/usr/bin/env bash
+original_args=("$@")
+list_file=""
+archive_root=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        -C) archive_root="${2:-}"; shift ;;
+        -T|--files-from) list_file="${2:-}"; shift ;;
+        -T*) list_file="${1#-T}" ;;
+        --files-from=*) list_file="${1#--files-from=}" ;;
+    esac
+    shift
+done
+if [[ "$archive_root" == "$NESTED_ROOT" && -n "$list_file" && "$list_file" != "-" ]]; then
+    while IFS= read -r -d '' entry; do
+        if [[ "${entry%/}" == "nested-repo" || "$entry" == nested-repo/* ]]; then
+            printf 'nested repository reached parent archive\n' > "$TAR_GUARD_MARKER"
+            exit 97
+        fi
+    done < "$list_file"
+fi
+exec "$REAL_TAR" "${original_args[@]}"
+EOF
+chmod +x "$TAR_GUARD_BIN/tar"
+workspace="$(
+    export PATH="$TAR_GUARD_BIN:$PATH" REAL_TAR TAR_GUARD_MARKER NESTED_ROOT
+    _octopus_prepare_consultative_workspace "$NESTED_ROOT"
+)"
+if [[ ! -e "$TAR_GUARD_MARKER" && -f "$workspace/nested-repo/nested.txt" && ! -e "$workspace/nested-repo/vendor" ]]; then
+    test_pass
+else
+    test_fail "expected the parent archive to omit nested-repo before recursively copying it"
+fi
+rm -rf "$(dirname "$workspace")"
+
+# A tracked symlink that leaves source_root still grants the advisory process
+# access to files outside the disposable workspace, even if tar preserves it
+# as a symlink rather than materializing its target.
+test_case "a tracked symlink outside the source repository is rejected"
 SYMLINK_ROOT="$TEST_TMP_DIR/symlink-source"
 OUTSIDE_ROOT="$TEST_TMP_DIR/symlink-outside"
 mkdir -p "$SYMLINK_ROOT" "$OUTSIDE_ROOT"
 (
     cd "$OUTSIDE_ROOT"
-    git init -q
-    git config user.email "test@example.com"
-    git config user.name "test"
     printf 'outside secret\n' > secret.txt
-    git add secret.txt
-    git commit -q -m init
 )
 (
     cd "$SYMLINK_ROOT"
@@ -105,54 +217,47 @@ mkdir -p "$SYMLINK_ROOT" "$OUTSIDE_ROOT"
     git config user.email "test@example.com"
     git config user.name "test"
     printf 'main tracked\n' > main.txt
-    ln -s "$OUTSIDE_ROOT" evil-link
+    ln -s "../symlink-outside/secret.txt" evil-link
     git add main.txt evil-link
     git commit -q -m "init with symlink"
 )
-workspace="$(_octopus_prepare_consultative_workspace "$SYMLINK_ROOT")"
-if [[ -L "$workspace/evil-link" && -f "$workspace/main.txt" ]]; then
-    test_pass
+if _octopus_prepare_consultative_workspace "$SYMLINK_ROOT" >/dev/null 2>&1; then
+    test_fail "expected an external tracked symlink to make workspace preparation fail closed"
 else
-    test_fail "expected evil-link to remain a symlink (not resolved into a real copied directory) in $workspace"
+    test_pass
 fi
-rm -rf "$(dirname "$workspace")"
 
-# Bash suppresses errexit inside a function invoked as an `if`/`||` condition,
-# so a bare `nested_copy || fallback` inside the per-entry loop cannot signal
-# a double failure to the caller by relying on errexit — it must track and
-# return it explicitly, or _octopus_prepare_consultative_workspace never
-# knows to fall back to a full copy.
-test_case "a nested copy that fails both ways is reported to the caller, not swallowed"
-if (
-    nested_copy_that_always_fails() { return 1; }
-    cp_fallback_that_always_fails() { return 1; }
-
-    copy_tree_without_tracking() {
-        local entry
-        while IFS= read -r entry; do
-            nested_copy_that_always_fails || cp_fallback_that_always_fails 2>/dev/null
-        done <<< "entry"
-        return 0
-    }
-
-    copy_tree_with_tracking() {
-        local entry
-        local nested_copy_failed=0
-        while IFS= read -r entry; do
-            if ! nested_copy_that_always_fails; then
-                cp_fallback_that_always_fails 2>/dev/null || nested_copy_failed=1
-            fi
-        done <<< "entry"
-        [[ "$nested_copy_failed" -eq 0 ]]
-    }
-
-    if copy_tree_without_tracking; then without_tracking_rc=0; else without_tracking_rc=1; fi
-    if copy_tree_with_tracking; then with_tracking_rc=0; else with_tracking_rc=1; fi
-    [[ "$without_tracking_rc" -eq 0 && "$with_tracking_rc" -eq 1 ]]
-); then
+test_case "a Git-aware copy failure never attempts a whole-tree copy"
+COPY_GUARD_BIN="$TEST_TMP_DIR/copy-guard-bin"
+COPY_GUARD_MARKER="$TEST_TMP_DIR/whole-tree-copy-attempted"
+REAL_CP="$(command -v cp)"
+mkdir -p "$COPY_GUARD_BIN"
+cat > "$COPY_GUARD_BIN/tar" <<'EOF'
+#!/usr/bin/env bash
+exit 97
+EOF
+cat > "$COPY_GUARD_BIN/cp" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+    if [[ "$arg" == "$SOURCE_ROOT/." ]]; then
+        printf 'whole-tree copy attempted\n' > "$COPY_GUARD_MARKER"
+    fi
+done
+exec "$REAL_CP" "$@"
+EOF
+chmod +x "$COPY_GUARD_BIN/tar" "$COPY_GUARD_BIN/cp"
+if workspace="$(
+    export PATH="$COPY_GUARD_BIN:$PATH" REAL_CP COPY_GUARD_MARKER SOURCE_ROOT
+    _octopus_prepare_consultative_workspace "$SOURCE_ROOT"
+)"; then
+    copy_failure_rc=0
+else
+    copy_failure_rc=$?
+fi
+if [[ "$copy_failure_rc" -ne 0 && ! -e "$COPY_GUARD_MARKER" ]]; then
     test_pass
 else
-    test_fail "expected the untracked shape to mask a double failure and the tracked shape (used by _octopus_copy_git_tracked_tree) to report it"
+    test_fail "expected Git copy failure without any whole-tree cp attempt"
 fi
 
 test_summary

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -47,4 +47,39 @@ else
 fi
 rm -rf "$(dirname "$workspace")"
 
+# A nested git work tree (a submodule, or a plain untracked checkout that
+# isn't itself gitignored) is reported by `git ls-files` as a single opaque
+# path. Without recursing into it, a naive tar copy of that path would pull
+# in whatever the nested tree's own .gitignore excludes, defeating the fix
+# one level down.
+test_case "a nested git work tree's own .gitignore is honored too"
+NESTED_ROOT="$TEST_TMP_DIR/nested-source"
+mkdir -p "$NESTED_ROOT/nested-repo/vendor"
+(
+    cd "$NESTED_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'parent tracked\n' > parent.txt
+    git add parent.txt
+    git commit -q -m init
+
+    cd nested-repo
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'vendor/\n' > .gitignore
+    printf 'nested tracked\n' > nested.txt
+    printf 'nested vendored\n' > vendor/big.bin
+    git add nested.txt .gitignore
+    git commit -q -m "nested init"
+)
+workspace="$(_octopus_prepare_consultative_workspace "$NESTED_ROOT")"
+if [[ -f "$workspace/parent.txt" && -f "$workspace/nested-repo/nested.txt" && ! -e "$workspace/nested-repo/vendor" ]]; then
+    test_pass
+else
+    test_fail "expected nested-repo/vendor absent, parent.txt and nested-repo/nested.txt present in $workspace"
+fi
+rm -rf "$(dirname "$workspace")"
+
 test_summary

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -220,6 +220,42 @@ else
     test_fail "expected Git config isolation and unchanged source index, HEAD, and refs"
 fi
 
+test_case "Git trace and output sinks are cleared for advisory dispatch"
+TRACE_EVENT_SINK="$TEST_TMP_DIR/git-trace2-event.json"
+TRACE_TEXT_SINK="$TEST_TMP_DIR/git-trace.log"
+TRACE_REDIRECT_SINK="$TEST_TMP_DIR/git-redirect.log"
+TRACE_ENV_MARKER="$TEST_TMP_DIR/git-trace-env-leaked"
+TRACE_GIT_MARKER="$TEST_TMP_DIR/git-command-ran"
+run_agent_sync() {
+    local name
+    while IFS= read -r name; do
+        case "$name" in
+            GIT_TRACE*|GIT_REDIRECT_STDIN|GIT_REDIRECT_STDOUT|GIT_REDIRECT_STDERR)
+                printf '%s\n' "$name" > "$TRACE_ENV_MARKER"
+                ;;
+        esac
+    done < <(compgen -v)
+    git --version > "$TRACE_GIT_MARKER"
+    printf 'review only\n'
+}
+trace_old_pwd="$PWD"
+cd "$SOURCE_ROOT"
+(
+    export GIT_TRACE="$TRACE_TEXT_SINK"
+    export GIT_TRACE2_EVENT="$TRACE_EVENT_SINK"
+    export GIT_REDIRECT_STDERR="$TRACE_REDIRECT_SINK"
+    run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1
+)
+trace_dispatch_rc=$?
+cd "$trace_old_pwd"
+unset -f run_agent_sync
+if [[ "$trace_dispatch_rc" -eq 0 && -s "$TRACE_GIT_MARKER" ]] &&
+   [[ ! -e "$TRACE_ENV_MARKER" && ! -e "$TRACE_EVENT_SINK" && ! -e "$TRACE_TEXT_SINK" && ! -e "$TRACE_REDIRECT_SINK" ]]; then
+    test_pass
+else
+    test_fail "expected Git command execution without inherited trace/output sinks: rc=$trace_dispatch_rc leaked=$(cat "$TRACE_ENV_MARKER" 2>/dev/null || printf none)"
+fi
+
 test_case "a repository subdirectory launch copies only eligible content in that subtree"
 workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT/subdir")"
 workspace_root="$(dirname "$workspace")"
@@ -812,6 +848,137 @@ else
     test_fail "expected INT and TERM status with no list residue: $copy_list_signal_failures"
 fi
 
+test_case "copy-list cleanup failure preserves TERM status and fails normal success"
+COPY_LIST_RM_FAILURE_TMPDIR="$TEST_TMP_DIR/copy-list-rm-failure-tmp"
+COPY_LIST_RM_FAILURE_WORKSPACE="$TEST_TMP_DIR/copy-list-rm-failure-workspace"
+COPY_LIST_RM_FAILURE_BIN="$TEST_TMP_DIR/copy-list-rm-failure-bin"
+COPY_LIST_RM_FAILURE_PID_FILE="$TEST_TMP_DIR/copy-list-rm-failure.pid"
+REAL_RM="$(command -v rm)"
+mkdir -p "$COPY_LIST_RM_FAILURE_TMPDIR" "$COPY_LIST_RM_FAILURE_WORKSPACE" "$COPY_LIST_RM_FAILURE_BIN"
+cat > "$COPY_LIST_RM_FAILURE_BIN/rm" <<'EOF'
+#!/usr/bin/env bash
+case "${2:-}" in
+    */octopus-copy-lists.??????) exit 95 ;;
+esac
+exec "$REAL_RM" "$@"
+EOF
+chmod +x "$COPY_LIST_RM_FAILURE_BIN/rm"
+if (
+    export TMPDIR="$COPY_LIST_RM_FAILURE_TMPDIR"
+    export PATH="$COPY_LIST_RM_FAILURE_BIN:$PATH"
+    export REAL_RM COPY_LIST_RM_FAILURE_PID_FILE
+    /bin/bash -c '
+        source "$1/scripts/lib/agent-sync.sh"
+        _octopus_validate_copy_source_path() {
+            /bin/sh -c '\''printf "%s\n" "$PPID" > "$1"'\'' _ "$COPY_LIST_RM_FAILURE_PID_FILE" || return 1
+            IFS= read -r copy_pid < "$COPY_LIST_RM_FAILURE_PID_FILE" || return 1
+            kill -TERM "$copy_pid"
+            return 1
+        }
+        _octopus_copy_git_tracked_tree "$2" "$3"
+    ' _ "$PROJECT_ROOT" "$SOURCE_ROOT" "$COPY_LIST_RM_FAILURE_WORKSPACE"
+) >/dev/null 2>&1; then
+    copy_list_rm_signal_rc=0
+else
+    copy_list_rm_signal_rc=$?
+fi
+copy_list_rm_signal_residue="$(find "$COPY_LIST_RM_FAILURE_TMPDIR" -mindepth 1 -maxdepth 1 -type d -name 'octopus-copy-lists.*' -print)"
+command rm -rf "$COPY_LIST_RM_FAILURE_TMPDIR" "$COPY_LIST_RM_FAILURE_WORKSPACE" "$COPY_LIST_RM_FAILURE_PID_FILE"
+
+mkdir -p "$COPY_LIST_RM_FAILURE_TMPDIR" "$COPY_LIST_RM_FAILURE_WORKSPACE"
+if (
+    export TMPDIR="$COPY_LIST_RM_FAILURE_TMPDIR"
+    export PATH="$COPY_LIST_RM_FAILURE_BIN:$PATH"
+    export REAL_RM
+    _octopus_copy_git_tracked_tree "$SOURCE_ROOT" "$COPY_LIST_RM_FAILURE_WORKSPACE"
+) >/dev/null 2>&1; then
+    copy_list_rm_success_rc=0
+else
+    copy_list_rm_success_rc=$?
+fi
+copy_list_rm_success_residue="$(find "$COPY_LIST_RM_FAILURE_TMPDIR" -mindepth 1 -maxdepth 1 -type d -name 'octopus-copy-lists.*' -print)"
+command rm -rf "$COPY_LIST_RM_FAILURE_TMPDIR" "$COPY_LIST_RM_FAILURE_WORKSPACE" "$COPY_LIST_RM_FAILURE_BIN"
+if [[ "$copy_list_rm_signal_rc" -eq 143 && -n "$copy_list_rm_signal_residue" ]] &&
+   [[ "$copy_list_rm_success_rc" -ne 0 && -n "$copy_list_rm_success_residue" ]]; then
+    test_pass
+else
+    test_fail "expected TERM=143 and normal-success cleanup failure: signal_rc=$copy_list_rm_signal_rc success_rc=$copy_list_rm_success_rc"
+fi
+
+test_case "preparation-phase INT and TERM preserve status, cleanup, and caller state"
+prepare_signal_failed=false
+prepare_signal_failures=""
+for prepare_signal in INT TERM; do
+    case "$prepare_signal" in
+        INT) prepare_signal_expected_rc=130 ;;
+        TERM) prepare_signal_expected_rc=143 ;;
+    esac
+    PREPARE_SIGNAL_TMPDIR="$TEST_TMP_DIR/prepare-signal-${prepare_signal}"
+    PREPARE_SIGNAL_PID_FILE="$TEST_TMP_DIR/prepare-signal-${prepare_signal}.pid"
+    PREPARE_SIGNAL_DISPATCH_MARKER="$TEST_TMP_DIR/prepare-signal-${prepare_signal}.dispatched"
+    PREPARE_SIGNAL_INT_MARKER="$TEST_TMP_DIR/prepare-signal-${prepare_signal}.caller-int"
+    PREPARE_SIGNAL_TERM_MARKER="$TEST_TMP_DIR/prepare-signal-${prepare_signal}.caller-term"
+    mkdir -p "$PREPARE_SIGNAL_TMPDIR"
+    if (
+        export TMPDIR="$PREPARE_SIGNAL_TMPDIR"
+        export SIGNAL_NAME="$prepare_signal"
+        export PREPARE_SIGNAL_PID_FILE PREPARE_SIGNAL_DISPATCH_MARKER
+        export PREPARE_SIGNAL_INT_MARKER PREPARE_SIGNAL_TERM_MARKER
+        export OCTOPUS_SECURITY_V870="caller-security"
+        export OCTOPUS_AGY_SANDBOX="caller-agy"
+        export OCTOPUS_CODEX_SANDBOX="caller-codex"
+        export CLAUDE_OCTOPUS_AUTONOMY="caller-autonomy"
+        /bin/bash -c '
+            source "$1/scripts/lib/agent-sync.sh"
+            log() { :; }
+            run_agent_sync() { printf "ran\n" > "$PREPARE_SIGNAL_DISPATCH_MARKER"; }
+            _octopus_copy_git_tracked_tree() {
+                /bin/sh -c '\''printf "%s\n" "$PPID" > "$1"'\'' _ "$PREPARE_SIGNAL_PID_FILE" || return 1
+                IFS= read -r consultative_pid < "$PREPARE_SIGNAL_PID_FILE" || return 1
+                kill -s "$SIGNAL_NAME" "$consultative_pid"
+                return 99
+            }
+            trap '\''printf "caller INT trap ran\n" > "$PREPARE_SIGNAL_INT_MARKER"'\'' INT
+            trap '\''printf "caller TERM trap ran\n" > "$PREPARE_SIGNAL_TERM_MARKER"'\'' TERM
+            caller_int_before="$(trap -p INT)"
+            caller_term_before="$(trap -p TERM)"
+            cd "$2" || exit 98
+            caller_pwd_before="$(pwd -P)"
+            set +e
+            run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1
+            prepare_rc=$?
+            set -e
+            prepare_residue="$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -type d -name "octopus-consultative.*" -print)"
+            [[ "$prepare_rc" -eq "$3" ]] &&
+                [[ -z "$prepare_residue" ]] &&
+                [[ ! -e "$PREPARE_SIGNAL_DISPATCH_MARKER" ]] &&
+                [[ ! -e "$PREPARE_SIGNAL_INT_MARKER" && ! -e "$PREPARE_SIGNAL_TERM_MARKER" ]] &&
+                [[ "$(trap -p INT)" == "$caller_int_before" ]] &&
+                [[ "$(trap -p TERM)" == "$caller_term_before" ]] &&
+                [[ "$(pwd -P)" == "$caller_pwd_before" ]] &&
+                [[ "$OCTOPUS_SECURITY_V870" == "caller-security" ]] &&
+                [[ "$OCTOPUS_AGY_SANDBOX" == "caller-agy" ]] &&
+                [[ "$OCTOPUS_CODEX_SANDBOX" == "caller-codex" ]] &&
+                [[ "$CLAUDE_OCTOPUS_AUTONOMY" == "caller-autonomy" ]]
+        ' _ "$PROJECT_ROOT" "$SOURCE_ROOT" "$prepare_signal_expected_rc"
+    ); then
+        prepare_signal_case_rc=0
+    else
+        prepare_signal_case_rc=$?
+    fi
+    prepare_signal_residue="$(find "$PREPARE_SIGNAL_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+    if [[ "$prepare_signal_case_rc" -ne 0 || -n "$prepare_signal_residue" ]]; then
+        prepare_signal_failed=true
+        prepare_signal_failures="${prepare_signal_failures}${prepare_signal} case_rc=${prepare_signal_case_rc} residue=${prepare_signal_residue:-none}; "
+    fi
+    command rm -rf "$PREPARE_SIGNAL_TMPDIR" "$PREPARE_SIGNAL_PID_FILE" "$PREPARE_SIGNAL_DISPATCH_MARKER" "$PREPARE_SIGNAL_INT_MARKER" "$PREPARE_SIGNAL_TERM_MARKER"
+done
+if [[ "$prepare_signal_failed" == "false" ]]; then
+    test_pass
+else
+    test_fail "expected preparation signals to preserve status and caller state without residue: $prepare_signal_failures"
+fi
+
 test_case "real Git consultative dispatch removes its full workspace after success and failure"
 dispatch_cleanup_failed=false
 dispatch_cleanup_failures=""
@@ -1053,6 +1220,49 @@ if [[ "$cleanup_tmpdir_isolated" == "true" && -f "$CLEANUP_SENTINEL" && -f "$CLE
 else
     test_fail "expected exact temp-root cleanup without touching the enclosing repository"
 fi
+
+test_case "an in-scope TMPDIR cannot enter or contain the consultative copy"
+IN_SCOPE_TMP_ROOT="$TEST_TMP_DIR/in-scope-tmp-source"
+IN_SCOPE_TMPDIR="$IN_SCOPE_TMP_ROOT/local-tmp"
+IN_SCOPE_OLD_WORKSPACE="$IN_SCOPE_TMPDIR/octopus-consultative.OLD123"
+IN_SCOPE_OLD_LISTS="$IN_SCOPE_TMPDIR/octopus-copy-lists.OLD123"
+IN_SCOPE_TRACKED_LOOKALIKE="$IN_SCOPE_TMPDIR/octopus-consultative.TRK123"
+mkdir -p "$IN_SCOPE_OLD_WORKSPACE/workspace" "$IN_SCOPE_OLD_LISTS" "$IN_SCOPE_TRACKED_LOOKALIKE"
+(
+    cd "$IN_SCOPE_TMP_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'tracked\n' > tracked.txt
+    printf 'tracked lookalike\n' > "$IN_SCOPE_TRACKED_LOOKALIKE/kept.txt"
+    git add tracked.txt "$IN_SCOPE_TRACKED_LOOKALIKE/kept.txt"
+    git commit -q -m init
+)
+printf 'old workspace payload\n' > "$IN_SCOPE_OLD_WORKSPACE/workspace/leak.txt"
+printf 'old list payload\n' > "$IN_SCOPE_OLD_LISTS/tracked"
+if workspace="$(
+    export TMPDIR="$IN_SCOPE_TMPDIR"
+    _octopus_prepare_consultative_workspace "$IN_SCOPE_TMP_ROOT"
+)"; then
+    in_scope_tmp_rc=0
+else
+    in_scope_tmp_rc=$?
+fi
+case "$workspace" in
+    "$IN_SCOPE_TMP_ROOT"/*) in_scope_destination=false ;;
+    *) in_scope_destination=true ;;
+esac
+if [[ "$in_scope_tmp_rc" -eq 0 && "$in_scope_destination" == "true" ]] &&
+   [[ "$(cat "$workspace/tracked.txt" 2>/dev/null)" == "tracked" ]] &&
+   [[ "$(cat "$workspace/local-tmp/octopus-consultative.TRK123/kept.txt" 2>/dev/null)" == "tracked lookalike" ]] &&
+   [[ ! -e "$workspace/local-tmp/octopus-consultative.OLD123" ]] &&
+   [[ ! -e "$workspace/local-tmp/octopus-copy-lists.OLD123" ]] &&
+   [[ -f "$IN_SCOPE_OLD_WORKSPACE/workspace/leak.txt" && -f "$IN_SCOPE_OLD_LISTS/tracked" ]]; then
+    test_pass
+else
+    test_fail "expected an out-of-scope destination and no copied Octopus temp state: rc=$in_scope_tmp_rc workspace=${workspace:-none}"
+fi
+[[ -z "${workspace:-}" ]] || command rm -rf "$(dirname "$workspace")"
 
 test_case "a Git-aware copy failure never attempts a whole-tree copy"
 COPY_GUARD_BIN="$TEST_TMP_DIR/copy-guard-bin"

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -157,7 +157,7 @@ else
     test_fail "expected discovery failure to prevent copying .git and ignored payloads"
 fi
 
-test_case "ambient Git config is ignored and advisory execution cannot mutate source Git state"
+test_case "ambient Git config and pathspec state are ignored before copy and advisory execution"
 AMBIENT_EXCLUDES="$TEST_TMP_DIR/ambient-excludes"
 AMBIENT_CONFIG="$TEST_TMP_DIR/ambient-gitconfig"
 AMBIENT_MARKER="$TEST_TMP_DIR/ambient-git-env-leaked"
@@ -173,6 +173,10 @@ if workspace=$(
     export GIT_CONFIG_GLOBAL="$AMBIENT_CONFIG"
     export GIT_CONFIG_SYSTEM="$AMBIENT_CONFIG"
     export GIT_CONFIG_NOSYSTEM=1
+    export GIT_LITERAL_PATHSPECS=1
+    export GIT_GLOB_PATHSPECS=1
+    export GIT_NOGLOB_PATHSPECS=1
+    export GIT_ICASE_PATHSPECS=1
     _octopus_prepare_consultative_workspace "$SOURCE_ROOT"
 ) && [[ -f "$workspace/untracked.txt" && ! -e "$workspace/.git" ]]; then
     prepare_isolated=true
@@ -186,7 +190,7 @@ run_agent_sync() {
     printf 'dispatched\n' > "$AMBIENT_DISPATCH_MARKER"
     while IFS= read -r name; do
         case "$name" in
-            GIT_DIR|GIT_WORK_TREE|GIT_INDEX_FILE|GIT_OBJECT_DIRECTORY|GIT_ALTERNATE_OBJECT_DIRECTORIES|GIT_COMMON_DIR|GIT_NAMESPACE|GIT_CEILING_DIRECTORIES|GIT_PREFIX|GIT_SUPER_PREFIX|GIT_CONFIG|GIT_CONFIG_GLOBAL|GIT_CONFIG_SYSTEM|GIT_CONFIG_NOSYSTEM|GIT_CONFIG_PARAMETERS|GIT_CONFIG_COUNT|GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*|GIT_QUARANTINE_PATH|GIT_DEFAULT_HASH)
+            GIT_DIR|GIT_WORK_TREE|GIT_INDEX_FILE|GIT_OBJECT_DIRECTORY|GIT_ALTERNATE_OBJECT_DIRECTORIES|GIT_COMMON_DIR|GIT_NAMESPACE|GIT_PREFIX|GIT_SUPER_PREFIX|GIT_CONFIG|GIT_CONFIG_GLOBAL|GIT_CONFIG_SYSTEM|GIT_CONFIG_NOSYSTEM|GIT_CONFIG_PARAMETERS|GIT_CONFIG_COUNT|GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*|GIT_QUARANTINE_PATH|GIT_DEFAULT_HASH|GIT_LITERAL_PATHSPECS|GIT_GLOB_PATHSPECS|GIT_NOGLOB_PATHSPECS|GIT_ICASE_PATHSPECS)
                 printf '%s\n' "$name" > "$AMBIENT_MARKER"
                 ;;
         esac
@@ -207,6 +211,10 @@ GIT_CONFIG_NOSYSTEM=1 \
 GIT_CONFIG_COUNT=1 \
 GIT_CONFIG_KEY_0=core.hooksPath \
 GIT_CONFIG_VALUE_0="$TEST_TMP_DIR/hooks" \
+GIT_LITERAL_PATHSPECS=1 \
+GIT_GLOB_PATHSPECS=1 \
+GIT_NOGLOB_PATHSPECS=1 \
+GIT_ICASE_PATHSPECS=1 \
 run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1 || true
 cd "$old_pwd"
 unset -f run_agent_sync
@@ -303,6 +311,57 @@ else
     test_fail "expected only current tracked and nonignored subdirectory bytes at the matching metadata-free copied path"
 fi
 rm -rf "$(dirname "$workspace_root")"
+
+test_case "a repository-local TMPDIR cannot contain consultative state or expose source Git control data"
+IN_REPO_TMPDIR="$SOURCE_ROOT/.consultative-tmp"
+IN_REPO_WORKSPACE_MARKER="$TEST_TMP_DIR/in-repo-workspace"
+IN_REPO_CEILING_MARKER="$TEST_TMP_DIR/in-repo-ceiling"
+IN_REPO_DISCOVERY_MARKER="$TEST_TMP_DIR/in-repo-discovery"
+IN_REPO_DISPATCH_MARKER="$TEST_TMP_DIR/in-repo-dispatch"
+IN_REPO_REF="refs/heads/in-repo-advisory-write"
+mkdir -p "$IN_REPO_TMPDIR"
+git -C "$SOURCE_ROOT" update-ref -d "$IN_REPO_REF" >/dev/null 2>&1 || true
+run_agent_sync() {
+    local discovered_root
+    printf '%s\n' "$PWD" > "$IN_REPO_WORKSPACE_MARKER"
+    printf '%s\n' "${GIT_CEILING_DIRECTORIES:-}" > "$IN_REPO_CEILING_MARKER"
+    if discovered_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+        printf '%s\n' "$discovered_root" > "$IN_REPO_DISCOVERY_MARKER"
+        git update-ref "$IN_REPO_REF" HEAD >/dev/null 2>&1 || true
+    fi
+    printf 'dispatched\n' > "$IN_REPO_DISPATCH_MARKER"
+    printf 'review only\n'
+}
+in_repo_old_pwd="$PWD"
+cd "$SOURCE_ROOT/subdir"
+if TMPDIR="$IN_REPO_TMPDIR" run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1; then
+    in_repo_rc=0
+else
+    in_repo_rc=$?
+fi
+cd "$in_repo_old_pwd"
+unset -f run_agent_sync
+in_repo_workspace="$(cat "$IN_REPO_WORKSPACE_MARKER" 2>/dev/null || true)"
+in_repo_ceiling="$(cat "$IN_REPO_CEILING_MARKER" 2>/dev/null || true)"
+case "$in_repo_workspace" in
+    "$SOURCE_ROOT"|"$SOURCE_ROOT"/*) in_repo_workspace_outside=false ;;
+    *) in_repo_workspace_outside=true ;;
+esac
+case "$in_repo_ceiling" in
+    ""|"$SOURCE_ROOT"|"$SOURCE_ROOT"/*) in_repo_ceiling_outside=false ;;
+    *) in_repo_ceiling_outside=true ;;
+esac
+in_repo_residue="$(find "$IN_REPO_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if [[ "$in_repo_rc" -eq 0 && -f "$IN_REPO_DISPATCH_MARKER" ]] &&
+   [[ "$in_repo_workspace_outside" == "true" && "$in_repo_ceiling_outside" == "true" ]] &&
+   [[ ! -e "$IN_REPO_DISCOVERY_MARKER" && -z "$in_repo_residue" ]] &&
+   ! git -C "$SOURCE_ROOT" show-ref --verify --quiet "$IN_REPO_REF"; then
+    test_pass
+else
+    test_fail "expected external temp state and a Git discovery ceiling: rc=$in_repo_rc workspace=${in_repo_workspace:-none} ceiling=${in_repo_ceiling:-none} discovery=$(test -e "$IN_REPO_DISCOVERY_MARKER" && printf yes || printf no) residue=${in_repo_residue:-none}"
+fi
+git -C "$SOURCE_ROOT" update-ref -d "$IN_REPO_REF" >/dev/null 2>&1 || true
+rm -rf "$IN_REPO_TMPDIR"
 
 test_case "a selected metacharacter subtree uses a literal pathspec"
 METACHAR_ROOT="$TEST_TMP_DIR/metachar-source"
@@ -788,6 +847,93 @@ else
 fi
 [[ -z "$workspace" ]] || command rm -rf "$(dirname "$workspace")"
 
+test_case "a source-root swap after leaf validation fails closed"
+ROOT_SWAP_ROOT="$TEST_TMP_DIR/root-swap-source"
+ROOT_SWAP_ORIGINAL="$TEST_TMP_DIR/root-swap-source-original"
+ROOT_SWAP_OUTSIDE="$TEST_TMP_DIR/root-swap-outside"
+ROOT_SWAP_WORKSPACE="$TEST_TMP_DIR/root-swap-workspace"
+ROOT_SWAP_MARKER="$TEST_TMP_DIR/root-swap-ran"
+mkdir -p "$ROOT_SWAP_ROOT" "$ROOT_SWAP_OUTSIDE" "$ROOT_SWAP_WORKSPACE"
+printf 'safe root bytes\n' > "$ROOT_SWAP_ROOT/payload.txt"
+printf 'external root bytes\n' > "$ROOT_SWAP_OUTSIDE/payload.txt"
+if (
+    cd() {
+        if [[ "${1:-}" == "$ROOT_SWAP_ROOT" && ! -e "$ROOT_SWAP_MARKER" ]]; then
+            command mv "$ROOT_SWAP_ROOT" "$ROOT_SWAP_ORIGINAL" || return 91
+            command ln -s "$ROOT_SWAP_OUTSIDE" "$ROOT_SWAP_ROOT" || return 92
+            printf 'swapped\n' > "$ROOT_SWAP_MARKER"
+        fi
+        builtin cd "$@"
+    }
+    _octopus_copy_leaf_safely "$ROOT_SWAP_ROOT" "$ROOT_SWAP_WORKSPACE" payload.txt
+); then
+    root_swap_rc=0
+else
+    root_swap_rc=$?
+fi
+if [[ -L "$ROOT_SWAP_ROOT" ]]; then
+    rm -f "$ROOT_SWAP_ROOT"
+    mv "$ROOT_SWAP_ORIGINAL" "$ROOT_SWAP_ROOT"
+fi
+if [[ "$root_swap_rc" -ne 0 && -f "$ROOT_SWAP_MARKER" ]] &&
+   [[ ! -e "$ROOT_SWAP_WORKSPACE/payload.txt" ]]; then
+    test_pass
+else
+    test_fail "expected root identity validation to reject the swapped source: rc=$root_swap_rc swapped=$(test -e "$ROOT_SWAP_MARKER" && printf yes || printf no) copied=$(cat "$ROOT_SWAP_WORKSPACE/payload.txt" 2>/dev/null || printf none)"
+fi
+
+test_case "a nested-repository swap cannot redirect recursive copying"
+NESTED_SWAP_ROOT="$TEST_TMP_DIR/nested-swap-source"
+NESTED_SWAP_CHILD="$TEST_TMP_DIR/nested-swap-child"
+NESTED_SWAP_ORIGINAL="$TEST_TMP_DIR/nested-swap-original"
+NESTED_SWAP_OUTSIDE="$TEST_TMP_DIR/nested-swap-outside"
+NESTED_SWAP_TMPDIR="$TEST_TMP_DIR/nested-swap-tmp"
+NESTED_SWAP_MARKER="$TEST_TMP_DIR/nested-swap-ran"
+mkdir -p "$NESTED_SWAP_ROOT" "$NESTED_SWAP_CHILD" "$NESTED_SWAP_OUTSIDE" "$NESTED_SWAP_TMPDIR"
+for nested_swap_repo in "$NESTED_SWAP_CHILD" "$NESTED_SWAP_OUTSIDE"; do
+    git -C "$nested_swap_repo" init -q
+    git -C "$nested_swap_repo" config user.email "test@example.com"
+    git -C "$nested_swap_repo" config user.name "test"
+done
+printf 'legitimate nested bytes\n' > "$NESTED_SWAP_CHILD/payload.txt"
+git -C "$NESTED_SWAP_CHILD" add payload.txt
+git -C "$NESTED_SWAP_CHILD" commit -q -m init
+printf 'external nested secret\n' > "$NESTED_SWAP_OUTSIDE/payload.txt"
+git -C "$NESTED_SWAP_OUTSIDE" add payload.txt
+git -C "$NESTED_SWAP_OUTSIDE" commit -q -m init
+git -C "$NESTED_SWAP_ROOT" init -q
+git -C "$NESTED_SWAP_ROOT" config user.email "test@example.com"
+git -C "$NESTED_SWAP_ROOT" config user.name "test"
+git -C "$NESTED_SWAP_ROOT" -c protocol.file.allow=always submodule add -q "$NESTED_SWAP_CHILD" nested-repo
+git -C "$NESTED_SWAP_ROOT" commit -q -am "add nested repository"
+NESTED_SWAP_ROOT="$(cd "$NESTED_SWAP_ROOT" && pwd -P)"
+if workspace=$(
+    cd() {
+        if [[ "${1:-}" == "./nested-repo" && ! -e "$NESTED_SWAP_MARKER" ]]; then
+            command mv "$NESTED_SWAP_ROOT/nested-repo" "$NESTED_SWAP_ORIGINAL" || return 91
+            command ln -s "$NESTED_SWAP_OUTSIDE" "$NESTED_SWAP_ROOT/nested-repo" || return 92
+            printf 'swapped\n' > "$NESTED_SWAP_MARKER"
+        fi
+        builtin cd "$@"
+    }
+    TMPDIR="$NESTED_SWAP_TMPDIR" _octopus_prepare_consultative_workspace "$NESTED_SWAP_ROOT"
+); then
+    nested_swap_rc=0
+else
+    nested_swap_rc=$?
+fi
+if [[ -L "$NESTED_SWAP_ROOT/nested-repo" ]]; then
+    rm -f "$NESTED_SWAP_ROOT/nested-repo"
+    mv "$NESTED_SWAP_ORIGINAL" "$NESTED_SWAP_ROOT/nested-repo"
+fi
+nested_swap_residue="$(find "$NESTED_SWAP_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if [[ "$nested_swap_rc" -ne 0 && -f "$NESTED_SWAP_MARKER" ]] &&
+   [[ -z "${workspace:-}" && -z "$nested_swap_residue" ]]; then
+    test_pass
+else
+    test_fail "expected anchored nested traversal to reject the swap: rc=$nested_swap_rc swapped=$(test -e "$NESTED_SWAP_MARKER" && printf yes || printf no) workspace=${workspace:-none} residue=${nested_swap_residue:-none}"
+fi
+
 test_case "Git copy lists use one owned directory and clean it after success"
 COPY_LIST_TMPDIR="$TEST_TMP_DIR/copy-list-tmp"
 COPY_LIST_WORKSPACE="$TEST_TMP_DIR/copy-list-workspace"
@@ -821,7 +967,7 @@ else
     test_fail "expected one cleaned mktemp -d list allocation: rc=$copy_list_rc calls=$copy_list_call_count residue=$copy_list_residue"
 fi
 
-test_case "copy and nested list append failures return nonzero and remove list state"
+test_case "copy-list append and nested-copy failures return nonzero and remove list state"
 append_failure_failed=false
 append_failure_details=""
 for append_failure_kind in copy nested; do
@@ -835,15 +981,14 @@ for append_failure_kind in copy nested; do
     if (
         export TMPDIR="$APPEND_FAILURE_TMPDIR"
         export APPEND_FAILURE_KIND="$append_failure_kind"
-        printf() {
-            if [[ "${1:-}" == '%s\0' ]]; then
-                case "$APPEND_FAILURE_KIND" in
-                    copy) return 91 ;;
-                    nested) [[ "${2:-}" == "nested-repo" ]] && return 92 ;;
-                esac
-            fi
-            builtin printf "$@"
-        }
+        if [[ "$APPEND_FAILURE_KIND" == "copy" ]]; then
+            printf() {
+                [[ "${1:-}" == '%s\0' ]] && return 91
+                builtin printf "$@"
+            }
+        else
+            _octopus_copy_nested_git_tree_safely() { return 92; }
+        fi
         _octopus_copy_git_tracked_tree "$APPEND_FAILURE_SOURCE" "$APPEND_FAILURE_WORKSPACE"
     ); then
         append_failure_rc=0

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -267,13 +267,16 @@ run_agent_sync() {
 }
 trace_old_pwd="$PWD"
 cd "$SOURCE_ROOT"
-(
+if (
     export GIT_TRACE="$TRACE_TEXT_SINK"
     export GIT_TRACE2_EVENT="$TRACE_EVENT_SINK"
     export GIT_REDIRECT_STDERR="$TRACE_REDIRECT_SINK"
     run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1
-)
-trace_dispatch_rc=$?
+); then
+    trace_dispatch_rc=0
+else
+    trace_dispatch_rc=$?
+fi
 cd "$trace_old_pwd"
 unset -f run_agent_sync
 if [[ "$trace_dispatch_rc" -eq 0 && -s "$TRACE_GIT_MARKER" ]] &&

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -10,7 +10,7 @@ source "$PROJECT_ROOT/scripts/lib/agent-sync.sh"
 test_suite "Consultative Workspace .gitignore Handling"
 
 SOURCE_ROOT="$TEST_TMP_DIR/gitignore-source"
-mkdir -p "$SOURCE_ROOT/vendor" "$SOURCE_ROOT/subdir"
+mkdir -p "$SOURCE_ROOT/vendor" "$SOURCE_ROOT/subdir" "$SOURCE_ROOT/ordinary-dir"
 (
     cd "$SOURCE_ROOT"
     git init -q
@@ -31,6 +31,7 @@ mkdir -p "$SOURCE_ROOT/vendor" "$SOURCE_ROOT/subdir"
     printf 'staged and modified working tree\n' > staged.txt
     printf 'untracked but not ignored\n' > untracked.txt
     printf 'subdirectory untracked\n' > subdir/untracked.txt
+    printf 'ordinary untracked directory\n' > ordinary-dir/content.txt
 )
 
 test_case "Git sources copy exact eligible working-tree bytes without Git metadata"
@@ -38,12 +39,78 @@ workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT")"
 if [[ "$(cat "$workspace/tracked.txt" 2>/dev/null)" == "modified working tree" ]] &&
    [[ "$(cat "$workspace/staged.txt" 2>/dev/null)" == "staged and modified working tree" ]] &&
    [[ "$(cat "$workspace/untracked.txt" 2>/dev/null)" == "untracked but not ignored" ]] &&
+   [[ "$(cat "$workspace/ordinary-dir/content.txt" 2>/dev/null)" == "ordinary untracked directory" ]] &&
    [[ ! -e "$workspace/vendor" && ! -e "$workspace/.git" ]]; then
     test_pass
 else
     test_fail "expected exact tracked/untracked-not-ignored bytes, no vendor tree, and no .git"
 fi
 rm -rf "$(dirname "$workspace")"
+
+test_case "broken nested Git discovery fails closed before nested metadata or ignored bytes are archived"
+BROKEN_NESTED_ROOT="$TEST_TMP_DIR/broken-nested-source"
+BROKEN_NESTED_CHILD="$TEST_TMP_DIR/broken-nested-child"
+BROKEN_NESTED_TMPDIR="$TEST_TMP_DIR/broken-nested-tmp"
+mkdir -p "$BROKEN_NESTED_ROOT" "$BROKEN_NESTED_CHILD/vendor" "$BROKEN_NESTED_TMPDIR"
+(
+    cd "$BROKEN_NESTED_CHILD"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'vendor/\n' > .gitignore
+    printf 'nested tracked\n' > nested.txt
+    printf 'nested ignored\n' > vendor/ignored.bin
+    git add .gitignore nested.txt
+    git commit -q -m init
+)
+(
+    cd "$BROKEN_NESTED_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'parent tracked\n' > parent.txt
+    git add parent.txt
+    git commit -q -m init
+    git -c protocol.file.allow=always submodule add -q "$BROKEN_NESTED_CHILD" nested-repo
+    git commit -q -am "add nested repository"
+    printf 'gitdir: /missing/octopus-nested-gitdir\n' > nested-repo/.git
+)
+workspace=""
+if workspace="$(TMPDIR="$BROKEN_NESTED_TMPDIR" _octopus_prepare_consultative_workspace "$BROKEN_NESTED_ROOT" 2>/dev/null)"; then
+    broken_nested_rc=0
+else
+    broken_nested_rc=$?
+fi
+broken_nested_leak=false
+if [[ -n "$workspace" ]] &&
+   { [[ -e "$workspace/nested-repo/.git" ]] || [[ -e "$workspace/nested-repo/vendor/ignored.bin" ]]; }; then
+    broken_nested_leak=true
+fi
+broken_nested_residue="$(find "$BROKEN_NESTED_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if [[ "$broken_nested_rc" -ne 0 && "$broken_nested_leak" == "false" && -z "$broken_nested_residue" ]]; then
+    test_pass
+else
+    test_fail "expected broken nested discovery to fail before archive: rc=$broken_nested_rc leak=$broken_nested_leak residue=${broken_nested_residue:-none}"
+fi
+rm -rf "$BROKEN_NESTED_TMPDIR"
+
+test_case "a registered gitlink with missing nested metadata fails closed"
+MISSING_NESTED_TMPDIR="$TEST_TMP_DIR/missing-nested-tmp"
+rm -f "$BROKEN_NESTED_ROOT/nested-repo/.git"
+mkdir -p "$MISSING_NESTED_TMPDIR"
+workspace=""
+if workspace="$(TMPDIR="$MISSING_NESTED_TMPDIR" _octopus_prepare_consultative_workspace "$BROKEN_NESTED_ROOT" 2>/dev/null)"; then
+    missing_nested_rc=0
+else
+    missing_nested_rc=$?
+fi
+missing_nested_residue="$(find "$MISSING_NESTED_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if [[ "$missing_nested_rc" -ne 0 && -z "$missing_nested_residue" ]]; then
+    test_pass
+else
+    test_fail "expected a registered gitlink without usable metadata to fail closed: rc=$missing_nested_rc residue=${missing_nested_residue:-none}"
+fi
+rm -rf "$MISSING_NESTED_TMPDIR"
 
 test_case "Git discovery errors fail closed without a whole-tree copy"
 DISCOVERY_GIT_BIN="$TEST_TMP_DIR/discovery-git-bin"
@@ -168,6 +235,33 @@ else
 fi
 rm -rf "$(dirname "$workspace_root")"
 
+test_case "a selected metacharacter subtree uses a literal pathspec"
+METACHAR_ROOT="$TEST_TMP_DIR/metachar-source"
+METACHAR_SCOPE='scope[one]:*?'
+mkdir -p "$METACHAR_ROOT/$METACHAR_SCOPE"
+(
+    cd "$METACHAR_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'metachar tracked\n' > "$METACHAR_SCOPE/tracked.txt"
+    printf 'unrelated tracked\n' > unrelated.txt
+    git add -- "$METACHAR_SCOPE/tracked.txt" unrelated.txt
+    git commit -q -m init
+    printf 'metachar untracked\n' > "$METACHAR_SCOPE/untracked.txt"
+)
+workspace="$(_octopus_prepare_consultative_workspace "$METACHAR_ROOT/$METACHAR_SCOPE")"
+workspace_root="$(dirname "$workspace")"
+if [[ "${workspace##*/workspace/}" == "$METACHAR_SCOPE" ]] &&
+   [[ "$(cat "$workspace/tracked.txt" 2>/dev/null)" == "metachar tracked" ]] &&
+   [[ "$(cat "$workspace/untracked.txt" 2>/dev/null)" == "metachar untracked" ]] &&
+   [[ ! -e "$workspace_root/unrelated.txt" ]]; then
+    test_pass
+else
+    test_fail "expected literal scoped copy for a directory containing Git pathspec metacharacters"
+fi
+rm -rf "$(dirname "$workspace_root")"
+
 test_case "empty and fully ignored launch directories remain valid working directories"
 mkdir -p "$SOURCE_ROOT/empty-subdir"
 if empty_workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT/empty-subdir" 2>/dev/null)" &&
@@ -192,6 +286,50 @@ else
     test_fail "expected safe-link to remain a working in-repository symlink"
 fi
 rm -rf "$(dirname "$workspace")"
+
+SCOPED_LINK_ROOT="$TEST_TMP_DIR/scoped-link-source"
+SCOPED_LINK_TMPDIR="$TEST_TMP_DIR/scoped-link-tmp"
+mkdir -p "$SCOPED_LINK_ROOT/selected/deeper" "$SCOPED_LINK_TMPDIR"
+(
+    cd "$SCOPED_LINK_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'selected target\n' > selected/inside.txt
+    printf 'repository sibling\n' > outside.txt
+    ln -s ../inside.txt selected/deeper/safe-link
+    git add selected/inside.txt selected/deeper/safe-link outside.txt
+    git commit -q -m init
+)
+
+test_case "a relative symlink confined to the selected subtree remains usable"
+workspace="$(_octopus_prepare_consultative_workspace "$SCOPED_LINK_ROOT/selected")"
+workspace_root="$(dirname "$workspace")"
+if [[ -L "$workspace/deeper/safe-link" ]] &&
+   [[ "$(cat "$workspace/deeper/safe-link" 2>/dev/null)" == "selected target" ]] &&
+   [[ ! -e "$workspace_root/outside.txt" ]]; then
+    test_pass
+else
+    test_fail "expected an in-scope relative symlink without repository siblings"
+fi
+rm -rf "$(dirname "$workspace_root")"
+
+test_case "a relative symlink cannot escape the selected subtree into a repository sibling"
+ln -s ../outside.txt "$SCOPED_LINK_ROOT/selected/outside-link"
+git -C "$SCOPED_LINK_ROOT" add selected/outside-link
+workspace=""
+if workspace="$(TMPDIR="$SCOPED_LINK_TMPDIR" _octopus_prepare_consultative_workspace "$SCOPED_LINK_ROOT/selected" 2>/dev/null)"; then
+    scoped_link_rc=0
+else
+    scoped_link_rc=$?
+fi
+scoped_link_residue="$(find "$SCOPED_LINK_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if [[ "$scoped_link_rc" -ne 0 && -z "$scoped_link_residue" ]]; then
+    test_pass
+else
+    test_fail "expected selected-subtree symlink escape to fail closed: rc=$scoped_link_rc residue=${scoped_link_residue:-none}"
+fi
+rm -rf "$SCOPED_LINK_TMPDIR"
 
 test_case "a confined dangling tracked relative symlink is preserved"
 DANGLING_ROOT="$TEST_TMP_DIR/dangling-link-source"
@@ -553,6 +691,48 @@ if [[ "$copy_list_rc" -eq 0 && "$copy_list_call_count" == "1" && -z "$copy_list_
     test_pass
 else
     test_fail "expected one cleaned mktemp -d list allocation: rc=$copy_list_rc calls=$copy_list_call_count residue=$copy_list_residue"
+fi
+
+test_case "copy and nested list append failures return nonzero and remove list state"
+append_failure_failed=false
+append_failure_details=""
+for append_failure_kind in copy nested; do
+    APPEND_FAILURE_TMPDIR="$TEST_TMP_DIR/append-failure-${append_failure_kind}-tmp"
+    APPEND_FAILURE_WORKSPACE="$TEST_TMP_DIR/append-failure-${append_failure_kind}-workspace"
+    mkdir -p "$APPEND_FAILURE_TMPDIR" "$APPEND_FAILURE_WORKSPACE"
+    case "$append_failure_kind" in
+        copy) APPEND_FAILURE_SOURCE="$SOURCE_ROOT" ;;
+        nested) APPEND_FAILURE_SOURCE="$NESTED_ROOT" ;;
+    esac
+    if (
+        export TMPDIR="$APPEND_FAILURE_TMPDIR"
+        export APPEND_FAILURE_KIND="$append_failure_kind"
+        printf() {
+            if [[ "${1:-}" == '%s\0' ]]; then
+                case "$APPEND_FAILURE_KIND" in
+                    copy) return 91 ;;
+                    nested) [[ "${2:-}" == "nested-repo" ]] && return 92 ;;
+                esac
+            fi
+            builtin printf "$@"
+        }
+        _octopus_copy_git_tracked_tree "$APPEND_FAILURE_SOURCE" "$APPEND_FAILURE_WORKSPACE"
+    ); then
+        append_failure_rc=0
+    else
+        append_failure_rc=$?
+    fi
+    append_failure_residue="$(find "$APPEND_FAILURE_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+    if [[ "$append_failure_rc" -eq 0 || -n "$append_failure_residue" ]]; then
+        append_failure_failed=true
+        append_failure_details="${append_failure_details}${append_failure_kind} rc=${append_failure_rc} residue=${append_failure_residue:-none}; "
+    fi
+    rm -rf "$APPEND_FAILURE_TMPDIR" "$APPEND_FAILURE_WORKSPACE"
+done
+if [[ "$append_failure_failed" == "false" ]]; then
+    test_pass
+else
+    test_fail "expected append failures to propagate with no list residue: $append_failure_details"
 fi
 
 test_case "Git copy list directory is removed after archive failure"

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -93,6 +93,7 @@ test_case "ambient Git config is ignored and advisory execution cannot mutate so
 AMBIENT_EXCLUDES="$TEST_TMP_DIR/ambient-excludes"
 AMBIENT_CONFIG="$TEST_TMP_DIR/ambient-gitconfig"
 AMBIENT_MARKER="$TEST_TMP_DIR/ambient-git-env-leaked"
+AMBIENT_DISPATCH_MARKER="$TEST_TMP_DIR/ambient-dispatch-ran"
 printf 'untracked.txt\n' > "$AMBIENT_EXCLUDES"
 printf '[core]\n\texcludesFile = %s\n' "$AMBIENT_EXCLUDES" > "$AMBIENT_CONFIG"
 source_index="$(git -C "$SOURCE_ROOT" rev-parse --git-path index)"
@@ -114,6 +115,7 @@ fi
 
 run_agent_sync() {
     local name
+    printf 'dispatched\n' > "$AMBIENT_DISPATCH_MARKER"
     while IFS= read -r name; do
         case "$name" in
             GIT_DIR|GIT_WORK_TREE|GIT_INDEX_FILE|GIT_OBJECT_DIRECTORY|GIT_ALTERNATE_OBJECT_DIRECTORIES|GIT_COMMON_DIR|GIT_NAMESPACE|GIT_CEILING_DIRECTORIES|GIT_PREFIX|GIT_SUPER_PREFIX|GIT_CONFIG|GIT_CONFIG_GLOBAL|GIT_CONFIG_SYSTEM|GIT_CONFIG_NOSYSTEM|GIT_CONFIG_PARAMETERS|GIT_CONFIG_COUNT|GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*|GIT_QUARANTINE_PATH|GIT_DEFAULT_HASH)
@@ -142,7 +144,7 @@ cd "$old_pwd"
 unset -f run_agent_sync
 source_index_after="$(cksum "$source_index")"
 source_head_after="$(git -C "$SOURCE_ROOT" rev-parse HEAD)"
-if [[ "$prepare_isolated" == "true" && ! -e "$AMBIENT_MARKER" ]] &&
+if [[ "$prepare_isolated" == "true" && -f "$AMBIENT_DISPATCH_MARKER" && ! -e "$AMBIENT_MARKER" ]] &&
    [[ "$source_index_after" == "$source_index_before" && "$source_head_after" == "$source_head_before" ]] &&
    ! git -C "$SOURCE_ROOT" show-ref --verify --quiet refs/heads/advisory-write; then
     test_pass
@@ -230,7 +232,7 @@ fi
 test_case "a symlink in an eligible path's ancestor chain fails closed"
 ANCESTOR_ROOT="$TEST_TMP_DIR/ancestor-link-source"
 ANCESTOR_GIT_BIN="$TEST_TMP_DIR/ancestor-git-bin"
-REAL_GIT="$(command -v git)"
+ANCESTOR_REAL_GIT="$(command -v git)"
 mkdir -p "$ANCESTOR_ROOT/tracked-dir"
 (
     cd "$ANCESTOR_ROOT"
@@ -255,11 +257,32 @@ done
 exec "$REAL_GIT" "$@"
 EOF
 chmod +x "$ANCESTOR_GIT_BIN/git"
-if PATH="$ANCESTOR_GIT_BIN:$PATH" REAL_GIT="$REAL_GIT" \
-   _octopus_prepare_consultative_workspace "$ANCESTOR_ROOT" >/dev/null 2>&1; then
-    test_fail "expected a tracked path beneath a symlink ancestor to fail closed"
+ancestor_path_before="$PATH"
+ancestor_real_git_before="${REAL_GIT:-}"
+REAL_GIT="caller-real-git-sentinel"
+set -o posix
+if (
+    export PATH="$ANCESTOR_GIT_BIN:$PATH"
+    export REAL_GIT="$ANCESTOR_REAL_GIT"
+    _octopus_prepare_consultative_workspace "$ANCESTOR_ROOT" >/dev/null 2>&1
+); then
+    ancestor_rejected=false
 else
+    ancestor_rejected=true
+fi
+if [[ "$PATH" == "$ancestor_path_before" && "$REAL_GIT" == "caller-real-git-sentinel" ]]; then
+    ancestor_env_isolated=true
+else
+    ancestor_env_isolated=false
+fi
+set +o posix
+PATH="$ancestor_path_before"
+export PATH
+REAL_GIT="$ancestor_real_git_before"
+if [[ "$ancestor_rejected" == "true" && "$ancestor_env_isolated" == "true" ]]; then
     test_pass
+else
+    test_fail "expected a symlink-ancestor rejection without PATH or REAL_GIT leakage"
 fi
 
 test_case "an absolute tracked symlink cannot point back into the source"
@@ -353,10 +376,64 @@ else
 fi
 rm -rf "$(dirname "$workspace")"
 
+test_case "an empty parent copy list skips tar and still copies nested work trees"
+NESTED_ONLY_ROOT="$TEST_TMP_DIR/nested-only-source"
+NESTED_ONLY_TAR_BIN="$TEST_TMP_DIR/nested-only-tar-bin"
+NESTED_ONLY_TAR_MARKER="$TEST_TMP_DIR/nested-only-parent-tar-ran"
+REAL_TAR="$(command -v tar)"
+mkdir -p "$NESTED_ONLY_ROOT" "$NESTED_ONLY_TAR_BIN"
+git -C "$NESTED_ONLY_ROOT" init -q
+git -C "$NESTED_ONLY_ROOT" config user.email "test@example.com"
+git -C "$NESTED_ONLY_ROOT" config user.name "test"
+git clone -q "$NESTED_CHILD_ROOT" "$NESTED_ONLY_ROOT/nested-repo"
+nested_only_oid="$(git -C "$NESTED_ONLY_ROOT/nested-repo" rev-parse HEAD)"
+git -C "$NESTED_ONLY_ROOT" update-index --add --cacheinfo 160000 "$nested_only_oid" nested-repo
+git -C "$NESTED_ONLY_ROOT" commit -q -m "nested-only parent"
+printf 'nested-only working tree\n' > "$NESTED_ONLY_ROOT/nested-repo/nested.txt"
+NESTED_ONLY_ROOT="$(cd "$NESTED_ONLY_ROOT" && pwd -P)"
+cat > "$NESTED_ONLY_TAR_BIN/tar" <<'EOF'
+#!/usr/bin/env bash
+original_args=("$@")
+archive_root=""
+while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "-C" ]]; then
+        archive_root="${2:-}"
+        shift
+    fi
+    shift
+done
+if [[ "$archive_root" == "$NESTED_ONLY_ROOT" ]]; then
+    printf 'parent tar ran\n' > "$NESTED_ONLY_TAR_MARKER"
+    exit 97
+fi
+exec "$REAL_TAR" "${original_args[@]}"
+EOF
+chmod +x "$NESTED_ONLY_TAR_BIN/tar"
+nested_only_rc=0
+if workspace="$(
+    export PATH="$NESTED_ONLY_TAR_BIN:$PATH"
+    export REAL_TAR NESTED_ONLY_ROOT NESTED_ONLY_TAR_MARKER
+    _octopus_prepare_consultative_workspace "$NESTED_ONLY_ROOT"
+)"; then
+    nested_only_rc=0
+else
+    nested_only_rc=$?
+fi
+if [[ "$nested_only_rc" -eq 0 && ! -e "$NESTED_ONLY_TAR_MARKER" ]] &&
+   [[ "$(cat "$workspace/nested-repo/nested.txt" 2>/dev/null)" == "nested-only working tree" ]] &&
+   [[ ! -e "$workspace/nested-repo/.git" ]]; then
+    test_pass
+else
+    test_fail "expected nested copy without invoking tar for an empty parent list: rc=$nested_only_rc"
+fi
+[[ -z "${workspace:-}" ]] || rm -rf "$(dirname "$workspace")"
+
 test_case "nested repositories are excluded before the parent archive runs"
+NESTED_ROOT="$(cd "$NESTED_ROOT" && pwd -P)"
 REAL_TAR="$(command -v tar)"
 TAR_GUARD_BIN="$TEST_TMP_DIR/tar-guard-bin"
 TAR_GUARD_MARKER="$TEST_TMP_DIR/tar-saw-nested-root"
+TAR_GUARD_EXECUTED="$TEST_TMP_DIR/tar-guard-executed"
 mkdir -p "$TAR_GUARD_BIN"
 cat > "$TAR_GUARD_BIN/tar" <<'EOF'
 #!/usr/bin/env bash
@@ -373,6 +450,7 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 if [[ "$archive_root" == "$NESTED_ROOT" && -n "$list_file" && "$list_file" != "-" ]]; then
+    printf 'guard executed\n' > "$TAR_GUARD_EXECUTED"
     while IFS= read -r -d '' entry; do
         if [[ "${entry%/}" == "nested-repo" || "$entry" == nested-repo/* ]]; then
             printf 'nested repository reached parent archive\n' > "$TAR_GUARD_MARKER"
@@ -384,15 +462,113 @@ exec "$REAL_TAR" "${original_args[@]}"
 EOF
 chmod +x "$TAR_GUARD_BIN/tar"
 workspace="$(
-    export PATH="$TAR_GUARD_BIN:$PATH" REAL_TAR TAR_GUARD_MARKER NESTED_ROOT
+    export PATH="$TAR_GUARD_BIN:$PATH" REAL_TAR TAR_GUARD_MARKER TAR_GUARD_EXECUTED NESTED_ROOT
     _octopus_prepare_consultative_workspace "$NESTED_ROOT"
 )"
-if [[ ! -e "$TAR_GUARD_MARKER" && -f "$workspace/nested-repo/nested.txt" && ! -e "$workspace/nested-repo/vendor" ]]; then
+if [[ -f "$TAR_GUARD_EXECUTED" && ! -e "$TAR_GUARD_MARKER" ]] &&
+   [[ -f "$workspace/nested-repo/nested.txt" && ! -e "$workspace/nested-repo/vendor" ]]; then
     test_pass
 else
     test_fail "expected the parent archive to omit nested-repo before recursively copying it"
 fi
 rm -rf "$(dirname "$workspace")"
+
+test_case "Git copy lists use one owned directory and clean it after success"
+COPY_LIST_TMPDIR="$TEST_TMP_DIR/copy-list-tmp"
+COPY_LIST_WORKSPACE="$TEST_TMP_DIR/copy-list-workspace"
+COPY_LIST_MKTEMP_BIN="$TEST_TMP_DIR/copy-list-mktemp-bin"
+COPY_LIST_MKTEMP_CALLS="$TEST_TMP_DIR/copy-list-mktemp-calls"
+REAL_MKTEMP="$(command -v mktemp)"
+mkdir -p "$COPY_LIST_TMPDIR" "$COPY_LIST_WORKSPACE" "$COPY_LIST_MKTEMP_BIN"
+cat > "$COPY_LIST_MKTEMP_BIN/mktemp" <<'EOF'
+#!/usr/bin/env bash
+printf 'argc=%s first=%s second=%s\n' "$#" "${1:-}" "${2:-}" >> "$COPY_LIST_MKTEMP_CALLS"
+exec "$REAL_MKTEMP" "$@"
+EOF
+chmod +x "$COPY_LIST_MKTEMP_BIN/mktemp"
+copy_list_rc=0
+if (
+    export TMPDIR="$COPY_LIST_TMPDIR"
+    export PATH="$COPY_LIST_MKTEMP_BIN:$PATH"
+    export COPY_LIST_MKTEMP_CALLS REAL_MKTEMP
+    _octopus_copy_git_tracked_tree "$SOURCE_ROOT" "$COPY_LIST_WORKSPACE"
+); then
+    copy_list_rc=0
+else
+    copy_list_rc=$?
+fi
+copy_list_call_count="$(wc -l < "$COPY_LIST_MKTEMP_CALLS" | tr -d ' ')"
+copy_list_residue="$(find "$COPY_LIST_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if [[ "$copy_list_rc" -eq 0 && "$copy_list_call_count" == "1" && -z "$copy_list_residue" ]] &&
+   grep -Eq '^argc=2 first=-d second=.*/octopus-copy-lists\.XXXXXX$' "$COPY_LIST_MKTEMP_CALLS"; then
+    test_pass
+else
+    test_fail "expected one cleaned mktemp -d list allocation: rc=$copy_list_rc calls=$copy_list_call_count residue=$copy_list_residue"
+fi
+
+test_case "Git copy list directory is removed after archive failure"
+COPY_LIST_FAILURE_TMPDIR="$TEST_TMP_DIR/copy-list-failure-tmp"
+COPY_LIST_FAILURE_WORKSPACE="$TEST_TMP_DIR/copy-list-failure-workspace"
+COPY_LIST_FAILURE_BIN="$TEST_TMP_DIR/copy-list-failure-bin"
+mkdir -p "$COPY_LIST_FAILURE_TMPDIR" "$COPY_LIST_FAILURE_WORKSPACE" "$COPY_LIST_FAILURE_BIN"
+cat > "$COPY_LIST_FAILURE_BIN/tar" <<'EOF'
+#!/usr/bin/env bash
+exit 97
+EOF
+chmod +x "$COPY_LIST_FAILURE_BIN/tar"
+copy_list_failure_rc=0
+if (
+    export TMPDIR="$COPY_LIST_FAILURE_TMPDIR"
+    export PATH="$COPY_LIST_FAILURE_BIN:$PATH"
+    _octopus_copy_git_tracked_tree "$SOURCE_ROOT" "$COPY_LIST_FAILURE_WORKSPACE"
+); then
+    copy_list_failure_rc=0
+else
+    copy_list_failure_rc=$?
+fi
+copy_list_failure_residue="$(find "$COPY_LIST_FAILURE_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if [[ "$copy_list_failure_rc" -ne 0 && -z "$copy_list_failure_residue" ]]; then
+    test_pass
+else
+    test_fail "expected archive failure to remove its list directory: rc=$copy_list_failure_rc residue=$copy_list_failure_residue"
+fi
+
+test_case "Git copy list directory is removed after INT and TERM"
+copy_list_signal_failed=false
+copy_list_signal_failures=""
+for copy_list_signal in INT TERM; do
+    COPY_LIST_SIGNAL_TMPDIR="$TEST_TMP_DIR/copy-list-signal-${copy_list_signal}"
+    COPY_LIST_SIGNAL_WORKSPACE="$TEST_TMP_DIR/copy-list-signal-workspace-${copy_list_signal}"
+    mkdir -p "$COPY_LIST_SIGNAL_TMPDIR" "$COPY_LIST_SIGNAL_WORKSPACE"
+    copy_list_signal_rc=0
+    if (
+        export TMPDIR="$COPY_LIST_SIGNAL_TMPDIR"
+        export SIGNAL_NAME="$copy_list_signal"
+        /bin/bash -c '
+            source "$1/scripts/lib/agent-sync.sh"
+            _octopus_validate_copy_source_path() {
+                kill -s "$SIGNAL_NAME" "${BASHPID:-$$}"
+                return 1
+            }
+            _octopus_copy_git_tracked_tree "$2" "$3"
+        ' _ "$PROJECT_ROOT" "$SOURCE_ROOT" "$COPY_LIST_SIGNAL_WORKSPACE"
+    ) >/dev/null 2>&1; then
+        copy_list_signal_rc=0
+    else
+        copy_list_signal_rc=$?
+    fi
+    copy_list_signal_residue="$(find "$COPY_LIST_SIGNAL_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+    if [[ "$copy_list_signal_rc" -eq 0 || -n "$copy_list_signal_residue" ]]; then
+        copy_list_signal_failed=true
+        copy_list_signal_failures="${copy_list_signal_failures}${copy_list_signal} rc=${copy_list_signal_rc} residue=${copy_list_signal_residue:-none}; "
+    fi
+    rm -rf "$COPY_LIST_SIGNAL_TMPDIR" "$COPY_LIST_SIGNAL_WORKSPACE"
+done
+if [[ "$copy_list_signal_failed" == "false" ]]; then
+    test_pass
+else
+    test_fail "expected INT and TERM status with no list residue: $copy_list_signal_failures"
+fi
 
 test_case "cleanup removes only the allocated temp root when TMPDIR is inside another repository"
 CLEANUP_CONTAINER="$TEST_TMP_DIR/cleanup-container"
@@ -425,11 +601,30 @@ run_agent_sync() {
 }
 cleanup_old_pwd="$PWD"
 cd "$CLEANUP_SOURCE"
-TMPDIR="$CLEANUP_TMPDIR" run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1 || true
+cleanup_tmpdir_set="${TMPDIR+x}"
+cleanup_tmpdir_before="${TMPDIR:-}"
+set -o posix
+(
+    export TMPDIR="$CLEANUP_TMPDIR"
+    run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1
+) || true
+if [[ "${TMPDIR+x}" == "$cleanup_tmpdir_set" && "${TMPDIR:-}" == "$cleanup_tmpdir_before" ]]; then
+    cleanup_tmpdir_isolated=true
+else
+    cleanup_tmpdir_isolated=false
+fi
+set +o posix
+if [[ -n "$cleanup_tmpdir_set" ]]; then
+    TMPDIR="$cleanup_tmpdir_before"
+    export TMPDIR
+else
+    unset TMPDIR
+fi
 cd "$cleanup_old_pwd"
 unset -f rm run_agent_sync
 cleanup_residue="$(find "$CLEANUP_TMPDIR" -maxdepth 1 -type d -name 'octopus-consultative.*' -print)"
-if [[ -f "$CLEANUP_SENTINEL" && -f "$CLEANUP_REPO_SENTINEL" && ! -e "$UNSAFE_CLEANUP_MARKER" && -z "$cleanup_residue" ]]; then
+if [[ "$cleanup_tmpdir_isolated" == "true" && -f "$CLEANUP_SENTINEL" && -f "$CLEANUP_REPO_SENTINEL" ]] &&
+   [[ ! -e "$UNSAFE_CLEANUP_MARKER" && -z "$cleanup_residue" ]]; then
     test_pass
 else
     test_fail "expected exact temp-root cleanup without touching the enclosing repository"

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -723,7 +723,7 @@ fi
 copy_list_call_count="$(wc -l < "$COPY_LIST_MKTEMP_CALLS" | tr -d ' ')"
 copy_list_residue="$(find "$COPY_LIST_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
 if [[ "$copy_list_rc" -eq 0 && "$copy_list_call_count" == "1" && -z "$copy_list_residue" ]] &&
-   grep -Eq '^argc=2 first=-d second=.*/octopus-copy-lists\.XXXXXX$' "$COPY_LIST_MKTEMP_CALLS"; then
+   grep -Eq '^argc=2 first=-d second=.*/octopus-copy-lists\.[0-9]+\.[0-9]+\.XXXXXX$' "$COPY_LIST_MKTEMP_CALLS"; then
     test_pass
 else
     test_fail "expected one cleaned mktemp -d list allocation: rc=$copy_list_rc calls=$copy_list_call_count residue=$copy_list_residue"
@@ -848,6 +848,76 @@ else
     test_fail "expected INT and TERM status with no list residue: $copy_list_signal_failures"
 fi
 
+test_case "copy-list allocation owns real mktemp output before INT and TERM"
+COPY_LIST_ALLOCATION_BIN="$TEST_TMP_DIR/copy-list-allocation-bin"
+COPY_LIST_ALLOCATION_MARKER="$TEST_TMP_DIR/copy-list-allocation-created"
+COPY_LIST_ALLOCATION_INT_MARKER="$TEST_TMP_DIR/copy-list-allocation-caller-int"
+COPY_LIST_ALLOCATION_TERM_MARKER="$TEST_TMP_DIR/copy-list-allocation-caller-term"
+REAL_MKTEMP="$(command -v mktemp)"
+mkdir -p "$COPY_LIST_ALLOCATION_BIN"
+cat > "$COPY_LIST_ALLOCATION_BIN/mktemp" <<'EOF'
+#!/usr/bin/env bash
+allocated="$($REAL_MKTEMP "$@")" || exit 91
+printf '%s\n' "$allocated" > "$COPY_LIST_ALLOCATION_MARKER" || exit 92
+kill -s "$SIGNAL_NAME" "$PPID" || exit 93
+printf '%s\n' "$allocated"
+EOF
+chmod +x "$COPY_LIST_ALLOCATION_BIN/mktemp"
+copy_list_allocation_failed=false
+copy_list_allocation_failures=""
+for copy_list_allocation_signal in INT TERM; do
+    case "$copy_list_allocation_signal" in
+        INT) copy_list_allocation_expected_rc=130 ;;
+        TERM) copy_list_allocation_expected_rc=143 ;;
+    esac
+    COPY_LIST_ALLOCATION_TMPDIR="$TEST_TMP_DIR/copy-list-allocation-${copy_list_allocation_signal}"
+    COPY_LIST_ALLOCATION_WORKSPACE="$TEST_TMP_DIR/copy-list-allocation-workspace-${copy_list_allocation_signal}"
+    rm -f "$COPY_LIST_ALLOCATION_MARKER" "$COPY_LIST_ALLOCATION_INT_MARKER" "$COPY_LIST_ALLOCATION_TERM_MARKER"
+    mkdir -p "$COPY_LIST_ALLOCATION_TMPDIR" "$COPY_LIST_ALLOCATION_WORKSPACE"
+    if (
+        export TMPDIR="$COPY_LIST_ALLOCATION_TMPDIR"
+        export PATH="$COPY_LIST_ALLOCATION_BIN:$PATH"
+        export REAL_MKTEMP COPY_LIST_ALLOCATION_MARKER
+        export SIGNAL_NAME="$copy_list_allocation_signal"
+        export COPY_LIST_ALLOCATION_INT_MARKER COPY_LIST_ALLOCATION_TERM_MARKER
+        export OCTOPUS_ALLOCATION_CALLER_ENV="preserved"
+        trap 'printf "caller INT trap ran\n" > "$COPY_LIST_ALLOCATION_INT_MARKER"' INT
+        trap 'printf "caller TERM trap ran\n" > "$COPY_LIST_ALLOCATION_TERM_MARKER"' TERM
+        caller_int_before="$(trap -p INT)"
+        caller_term_before="$(trap -p TERM)"
+        caller_pwd_before="$(pwd -P)"
+        set +e
+        _octopus_copy_git_tracked_tree "$SOURCE_ROOT" "$COPY_LIST_ALLOCATION_WORKSPACE"
+        allocation_rc=$?
+        set -e
+        allocation_residue="$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+        [[ "$allocation_rc" -eq "$copy_list_allocation_expected_rc" ]] &&
+            [[ -f "$COPY_LIST_ALLOCATION_MARKER" ]] &&
+            [[ -z "$allocation_residue" ]] &&
+            [[ ! -e "$COPY_LIST_ALLOCATION_INT_MARKER" && ! -e "$COPY_LIST_ALLOCATION_TERM_MARKER" ]] &&
+            [[ "$(trap -p INT)" == "$caller_int_before" ]] &&
+            [[ "$(trap -p TERM)" == "$caller_term_before" ]] &&
+            [[ "$(pwd -P)" == "$caller_pwd_before" ]] &&
+            [[ "$OCTOPUS_ALLOCATION_CALLER_ENV" == "preserved" ]]
+    ); then
+        copy_list_allocation_case_rc=0
+    else
+        copy_list_allocation_case_rc=$?
+    fi
+    copy_list_allocation_residue="$(find "$COPY_LIST_ALLOCATION_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+    if [[ "$copy_list_allocation_case_rc" -ne 0 || -n "$copy_list_allocation_residue" ]]; then
+        copy_list_allocation_failed=true
+        copy_list_allocation_failures="${copy_list_allocation_failures}${copy_list_allocation_signal} case_rc=${copy_list_allocation_case_rc} residue=${copy_list_allocation_residue:-none}; "
+    fi
+    command rm -rf "$COPY_LIST_ALLOCATION_TMPDIR" "$COPY_LIST_ALLOCATION_WORKSPACE"
+done
+command rm -rf "$COPY_LIST_ALLOCATION_BIN" "$COPY_LIST_ALLOCATION_MARKER" "$COPY_LIST_ALLOCATION_INT_MARKER" "$COPY_LIST_ALLOCATION_TERM_MARKER"
+if [[ "$copy_list_allocation_failed" == "false" ]]; then
+    test_pass
+else
+    test_fail "expected allocation-time signals to preserve status and caller state without list residue: $copy_list_allocation_failures"
+fi
+
 test_case "copy-list cleanup failure preserves TERM status and fails normal success"
 COPY_LIST_RM_FAILURE_TMPDIR="$TEST_TMP_DIR/copy-list-rm-failure-tmp"
 COPY_LIST_RM_FAILURE_WORKSPACE="$TEST_TMP_DIR/copy-list-rm-failure-workspace"
@@ -858,7 +928,7 @@ mkdir -p "$COPY_LIST_RM_FAILURE_TMPDIR" "$COPY_LIST_RM_FAILURE_WORKSPACE" "$COPY
 cat > "$COPY_LIST_RM_FAILURE_BIN/rm" <<'EOF'
 #!/usr/bin/env bash
 case "${2:-}" in
-    */octopus-copy-lists.??????) exit 95 ;;
+    */octopus-copy-lists.*.*.??????) exit 95 ;;
 esac
 exec "$REAL_RM" "$@"
 EOF
@@ -979,6 +1049,138 @@ else
     test_fail "expected preparation signals to preserve status and caller state without residue: $prepare_signal_failures"
 fi
 
+test_case "consultative root allocation owns real mktemp output before INT and TERM"
+ROOT_ALLOCATION_BIN="$TEST_TMP_DIR/root-allocation-bin"
+ROOT_ALLOCATION_MARKER="$TEST_TMP_DIR/root-allocation-created"
+ROOT_ALLOCATION_DISPATCH_MARKER="$TEST_TMP_DIR/root-allocation-dispatched"
+ROOT_ALLOCATION_INT_MARKER="$TEST_TMP_DIR/root-allocation-caller-int"
+ROOT_ALLOCATION_TERM_MARKER="$TEST_TMP_DIR/root-allocation-caller-term"
+REAL_MKTEMP="$(command -v mktemp)"
+mkdir -p "$ROOT_ALLOCATION_BIN"
+cat > "$ROOT_ALLOCATION_BIN/mktemp" <<'EOF'
+#!/usr/bin/env bash
+allocated="$($REAL_MKTEMP "$@")" || exit 91
+printf '%s\n' "$allocated" > "$ROOT_ALLOCATION_MARKER" || exit 92
+kill -s "$SIGNAL_NAME" "$PPID" || exit 93
+printf '%s\n' "$allocated"
+EOF
+chmod +x "$ROOT_ALLOCATION_BIN/mktemp"
+root_allocation_failed=false
+root_allocation_failures=""
+for root_allocation_signal in INT TERM; do
+    case "$root_allocation_signal" in
+        INT) root_allocation_expected_rc=130 ;;
+        TERM) root_allocation_expected_rc=143 ;;
+    esac
+    ROOT_ALLOCATION_TMPDIR="$TEST_TMP_DIR/root-allocation-${root_allocation_signal}"
+    rm -f "$ROOT_ALLOCATION_MARKER" "$ROOT_ALLOCATION_DISPATCH_MARKER" "$ROOT_ALLOCATION_INT_MARKER" "$ROOT_ALLOCATION_TERM_MARKER"
+    mkdir -p "$ROOT_ALLOCATION_TMPDIR"
+    if (
+        export TMPDIR="$ROOT_ALLOCATION_TMPDIR"
+        export PATH="$ROOT_ALLOCATION_BIN:$PATH"
+        export REAL_MKTEMP ROOT_ALLOCATION_MARKER ROOT_ALLOCATION_DISPATCH_MARKER
+        export SIGNAL_NAME="$root_allocation_signal"
+        export ROOT_ALLOCATION_INT_MARKER ROOT_ALLOCATION_TERM_MARKER
+        export OCTOPUS_SECURITY_V870="caller-security"
+        export OCTOPUS_AGY_SANDBOX="caller-agy"
+        export OCTOPUS_CODEX_SANDBOX="caller-codex"
+        export CLAUDE_OCTOPUS_AUTONOMY="caller-autonomy"
+        log() { :; }
+        run_agent_sync() { printf "ran\n" > "$ROOT_ALLOCATION_DISPATCH_MARKER"; }
+        trap 'printf "caller INT trap ran\n" > "$ROOT_ALLOCATION_INT_MARKER"' INT
+        trap 'printf "caller TERM trap ran\n" > "$ROOT_ALLOCATION_TERM_MARKER"' TERM
+        caller_int_before="$(trap -p INT)"
+        caller_term_before="$(trap -p TERM)"
+        cd "$SOURCE_ROOT" || exit 98
+        source_pwd="$(pwd -P)"
+        set +e
+        run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1
+        allocation_rc=$?
+        set -e
+        allocation_residue="$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+        [[ "$allocation_rc" -eq "$root_allocation_expected_rc" ]] &&
+            [[ -f "$ROOT_ALLOCATION_MARKER" ]] &&
+            [[ -z "$allocation_residue" ]] &&
+            [[ ! -e "$ROOT_ALLOCATION_DISPATCH_MARKER" ]] &&
+            [[ ! -e "$ROOT_ALLOCATION_INT_MARKER" && ! -e "$ROOT_ALLOCATION_TERM_MARKER" ]] &&
+            [[ "$(trap -p INT)" == "$caller_int_before" ]] &&
+            [[ "$(trap -p TERM)" == "$caller_term_before" ]] &&
+            [[ "$(pwd -P)" == "$source_pwd" ]] &&
+            [[ "$OCTOPUS_SECURITY_V870" == "caller-security" ]] &&
+            [[ "$OCTOPUS_AGY_SANDBOX" == "caller-agy" ]] &&
+            [[ "$OCTOPUS_CODEX_SANDBOX" == "caller-codex" ]] &&
+            [[ "$CLAUDE_OCTOPUS_AUTONOMY" == "caller-autonomy" ]]
+    ); then
+        root_allocation_case_rc=0
+    else
+        root_allocation_case_rc=$?
+    fi
+    root_allocation_residue="$(find "$ROOT_ALLOCATION_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+    if [[ "$root_allocation_case_rc" -ne 0 || -n "$root_allocation_residue" ]]; then
+        root_allocation_failed=true
+        root_allocation_failures="${root_allocation_failures}${root_allocation_signal} case_rc=${root_allocation_case_rc} residue=${root_allocation_residue:-none}; "
+    fi
+    command rm -rf "$ROOT_ALLOCATION_TMPDIR"
+done
+command rm -rf "$ROOT_ALLOCATION_BIN" "$ROOT_ALLOCATION_MARKER" "$ROOT_ALLOCATION_DISPATCH_MARKER" "$ROOT_ALLOCATION_INT_MARKER" "$ROOT_ALLOCATION_TERM_MARKER"
+if [[ "$root_allocation_failed" == "false" ]]; then
+    test_pass
+else
+    test_fail "expected allocation-time signals to preserve status and caller state without root residue or dispatch: $root_allocation_failures"
+fi
+
+test_case "failed mktemp calls clean created allocations and prevent dispatch"
+MKTEMP_FAILURE_BIN="$TEST_TMP_DIR/mktemp-failure-bin"
+MKTEMP_FAILURE_MARKER="$TEST_TMP_DIR/mktemp-failure-created"
+MKTEMP_FAILURE_DISPATCH_MARKER="$TEST_TMP_DIR/mktemp-failure-dispatched"
+MKTEMP_FAILURE_COPY_TMPDIR="$TEST_TMP_DIR/mktemp-failure-copy-tmp"
+MKTEMP_FAILURE_ROOT_TMPDIR="$TEST_TMP_DIR/mktemp-failure-root-tmp"
+MKTEMP_FAILURE_WORKSPACE="$TEST_TMP_DIR/mktemp-failure-workspace"
+REAL_MKTEMP="$(command -v mktemp)"
+mkdir -p "$MKTEMP_FAILURE_BIN" "$MKTEMP_FAILURE_COPY_TMPDIR" "$MKTEMP_FAILURE_ROOT_TMPDIR" "$MKTEMP_FAILURE_WORKSPACE"
+cat > "$MKTEMP_FAILURE_BIN/mktemp" <<'EOF'
+#!/usr/bin/env bash
+allocated="$($REAL_MKTEMP "$@")" || exit 91
+printf '%s\n' "$allocated" >> "$MKTEMP_FAILURE_MARKER" || exit 92
+exit 97
+EOF
+chmod +x "$MKTEMP_FAILURE_BIN/mktemp"
+if (
+    export TMPDIR="$MKTEMP_FAILURE_COPY_TMPDIR"
+    export PATH="$MKTEMP_FAILURE_BIN:$PATH"
+    export REAL_MKTEMP MKTEMP_FAILURE_MARKER
+    _octopus_copy_git_tracked_tree "$SOURCE_ROOT" "$MKTEMP_FAILURE_WORKSPACE"
+); then
+    mktemp_failure_copy_rc=0
+else
+    mktemp_failure_copy_rc=$?
+fi
+mktemp_failure_copy_residue="$(find "$MKTEMP_FAILURE_COPY_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if (
+    export TMPDIR="$MKTEMP_FAILURE_ROOT_TMPDIR"
+    export PATH="$MKTEMP_FAILURE_BIN:$PATH"
+    export REAL_MKTEMP MKTEMP_FAILURE_MARKER MKTEMP_FAILURE_DISPATCH_MARKER
+    log() { :; }
+    run_agent_sync() { printf 'ran\n' > "$MKTEMP_FAILURE_DISPATCH_MARKER"; }
+    cd "$SOURCE_ROOT" || exit 98
+    run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1
+); then
+    mktemp_failure_root_rc=0
+else
+    mktemp_failure_root_rc=$?
+fi
+mktemp_failure_root_residue="$(find "$MKTEMP_FAILURE_ROOT_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+mktemp_failure_calls="$(wc -l < "$MKTEMP_FAILURE_MARKER" | tr -d ' ')"
+if [[ "$mktemp_failure_copy_rc" -ne 0 && "$mktemp_failure_root_rc" -ne 0 ]] &&
+   [[ "$mktemp_failure_calls" == "2" ]] &&
+   [[ -z "$mktemp_failure_copy_residue" && -z "$mktemp_failure_root_residue" ]] &&
+   [[ ! -e "$MKTEMP_FAILURE_DISPATCH_MARKER" ]]; then
+    test_pass
+else
+    test_fail "expected both post-create mktemp failures to fail closed without residue or dispatch: copy_rc=$mktemp_failure_copy_rc root_rc=$mktemp_failure_root_rc calls=$mktemp_failure_calls"
+fi
+command rm -rf "$MKTEMP_FAILURE_BIN" "$MKTEMP_FAILURE_MARKER" "$MKTEMP_FAILURE_COPY_TMPDIR" "$MKTEMP_FAILURE_ROOT_TMPDIR" "$MKTEMP_FAILURE_WORKSPACE" "$MKTEMP_FAILURE_DISPATCH_MARKER"
+
 test_case "real Git consultative dispatch removes its full workspace after success and failure"
 dispatch_cleanup_failed=false
 dispatch_cleanup_failures=""
@@ -1008,7 +1210,7 @@ for dispatch_mode in success failure; do
             log() { :; }
             run_agent_sync() {
                 case "$PWD" in
-                    "$TMPDIR"/octopus-consultative.??????/workspace) ;;
+                    "$TMPDIR"/octopus-consultative.*.*.??????/workspace) ;;
                     *) return 96 ;;
                 esac
                 [[ -d "$PWD" ]] || return 96
@@ -1035,7 +1237,7 @@ for dispatch_mode in success failure; do
             dispatch_residue="$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -print)"
             IFS= read -r dispatch_workspace < "$DISPATCH_CLEANUP_STARTED" || exit 1
             dispatch_temp_root="${dispatch_workspace%/workspace}"
-            [[ "$dispatch_workspace" == "$TMPDIR"/octopus-consultative.??????/workspace ]] &&
+            [[ "$dispatch_workspace" == "$TMPDIR"/octopus-consultative.*.*.??????/workspace ]] &&
                 [[ ! -e "$dispatch_temp_root" ]] &&
                 [[ "$dispatch_rc" -eq "$3" ]] &&
                 [[ -z "$dispatch_residue" ]] &&
@@ -1097,7 +1299,7 @@ for dispatch_signal in INT TERM; do
             run_agent_sync() {
                 local command_subshell_pid consultative_pid
                 case "$PWD" in
-                    "$TMPDIR"/octopus-consultative.??????/workspace) ;;
+                    "$TMPDIR"/octopus-consultative.*.*.??????/workspace) ;;
                     *) return 96 ;;
                 esac
                 [[ -d "$PWD" ]] || return 96
@@ -1129,7 +1331,7 @@ for dispatch_signal in INT TERM; do
             dispatch_residue="$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -print)"
             IFS= read -r dispatch_workspace < "$DISPATCH_SIGNAL_STARTED" || exit 1
             dispatch_temp_root="${dispatch_workspace%/workspace}"
-            [[ "$dispatch_workspace" == "$TMPDIR"/octopus-consultative.??????/workspace ]] &&
+            [[ "$dispatch_workspace" == "$TMPDIR"/octopus-consultative.*.*.??????/workspace ]] &&
                 [[ ! -e "$dispatch_temp_root" ]] &&
                 [[ "$dispatch_rc" -eq "$3" ]] &&
                 [[ -z "$dispatch_residue" ]] &&
@@ -1224,9 +1426,9 @@ fi
 test_case "an in-scope TMPDIR cannot enter or contain the consultative copy"
 IN_SCOPE_TMP_ROOT="$TEST_TMP_DIR/in-scope-tmp-source"
 IN_SCOPE_TMPDIR="$IN_SCOPE_TMP_ROOT/local-tmp"
-IN_SCOPE_OLD_WORKSPACE="$IN_SCOPE_TMPDIR/octopus-consultative.OLD123"
-IN_SCOPE_OLD_LISTS="$IN_SCOPE_TMPDIR/octopus-copy-lists.OLD123"
-IN_SCOPE_TRACKED_LOOKALIKE="$IN_SCOPE_TMPDIR/octopus-consultative.TRK123"
+IN_SCOPE_OLD_WORKSPACE="$IN_SCOPE_TMPDIR/octopus-consultative.12345.67890.OLD123"
+IN_SCOPE_OLD_LISTS="$IN_SCOPE_TMPDIR/octopus-copy-lists.12345.67890.OLD123"
+IN_SCOPE_TRACKED_LOOKALIKE="$IN_SCOPE_TMPDIR/octopus-consultative.13579.24680.TRK123"
 mkdir -p "$IN_SCOPE_OLD_WORKSPACE/workspace" "$IN_SCOPE_OLD_LISTS" "$IN_SCOPE_TRACKED_LOOKALIKE"
 (
     cd "$IN_SCOPE_TMP_ROOT"
@@ -1254,9 +1456,9 @@ case "$workspace" in
 esac
 if [[ "$in_scope_tmp_rc" -eq 0 && "$in_scope_destination" == "true" ]] &&
    [[ "$(cat "$workspace/tracked.txt" 2>/dev/null)" == "tracked" ]] &&
-   [[ "$(cat "$workspace/local-tmp/octopus-consultative.TRK123/kept.txt" 2>/dev/null)" == "tracked lookalike" ]] &&
-   [[ ! -e "$workspace/local-tmp/octopus-consultative.OLD123" ]] &&
-   [[ ! -e "$workspace/local-tmp/octopus-copy-lists.OLD123" ]] &&
+   [[ "$(cat "$workspace/local-tmp/octopus-consultative.13579.24680.TRK123/kept.txt" 2>/dev/null)" == "tracked lookalike" ]] &&
+   [[ ! -e "$workspace/local-tmp/octopus-consultative.12345.67890.OLD123" ]] &&
+   [[ ! -e "$workspace/local-tmp/octopus-copy-lists.12345.67890.OLD123" ]] &&
    [[ -f "$IN_SCOPE_OLD_WORKSPACE/workspace/leak.txt" && -f "$IN_SCOPE_OLD_LISTS/tracked" ]]; then
     test_pass
 else

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -34,6 +34,25 @@ mkdir -p "$SOURCE_ROOT/vendor" "$SOURCE_ROOT/subdir" "$SOURCE_ROOT/ordinary-dir"
     printf 'ordinary untracked directory\n' > ordinary-dir/content.txt
 )
 
+test_case "directory identity falls back from malformed BSD stat output to GNU stat"
+STAT_DIALECT_BIN="$TEST_TMP_DIR/stat-dialect-bin"
+mkdir -p "$STAT_DIALECT_BIN"
+cat > "$STAT_DIALECT_BIN/stat" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    -f) printf 'malformed BSD response\n' ;;
+    -c) printf '42:84\n' ;;
+    *) exit 91 ;;
+esac
+EOF
+chmod +x "$STAT_DIALECT_BIN/stat"
+if stat_identity="$(PATH="$STAT_DIALECT_BIN:$PATH" _octopus_directory_identity "$SOURCE_ROOT")" &&
+   [[ "$stat_identity" == "42:84" ]]; then
+    test_pass
+else
+    test_fail "expected GNU stat fallback after an unusable BSD response: identity=${stat_identity:-none}"
+fi
+
 test_case "Git sources copy exact eligible working-tree bytes without Git metadata"
 workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT")"
 if [[ "$(cat "$workspace/tracked.txt" 2>/dev/null)" == "modified working tree" ]] &&
@@ -318,6 +337,7 @@ IN_REPO_WORKSPACE_MARKER="$TEST_TMP_DIR/in-repo-workspace"
 IN_REPO_CEILING_MARKER="$TEST_TMP_DIR/in-repo-ceiling"
 IN_REPO_DISCOVERY_MARKER="$TEST_TMP_DIR/in-repo-discovery"
 IN_REPO_DISPATCH_MARKER="$TEST_TMP_DIR/in-repo-dispatch"
+IN_REPO_LIVE_CONTROL_MARKER="$TEST_TMP_DIR/in-repo-live-control"
 IN_REPO_REF="refs/heads/in-repo-advisory-write"
 mkdir -p "$IN_REPO_TMPDIR"
 git -C "$SOURCE_ROOT" update-ref -d "$IN_REPO_REF" >/dev/null 2>&1 || true
@@ -328,6 +348,9 @@ run_agent_sync() {
     if discovered_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
         printf '%s\n' "$discovered_root" > "$IN_REPO_DISCOVERY_MARKER"
         git update-ref "$IN_REPO_REF" HEAD >/dev/null 2>&1 || true
+    fi
+    if find "$SOURCE_ROOT" -name '.octopus-consultative-completion.*' -print -quit 2>/dev/null | grep -q .; then
+        printf 'source control state observed\n' > "$IN_REPO_LIVE_CONTROL_MARKER"
     fi
     printf 'dispatched\n' > "$IN_REPO_DISPATCH_MARKER"
     printf 'review only\n'
@@ -354,11 +377,11 @@ esac
 in_repo_residue="$(find "$IN_REPO_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
 if [[ "$in_repo_rc" -eq 0 && -f "$IN_REPO_DISPATCH_MARKER" ]] &&
    [[ "$in_repo_workspace_outside" == "true" && "$in_repo_ceiling_outside" == "true" ]] &&
-   [[ ! -e "$IN_REPO_DISCOVERY_MARKER" && -z "$in_repo_residue" ]] &&
+   [[ ! -e "$IN_REPO_DISCOVERY_MARKER" && ! -e "$IN_REPO_LIVE_CONTROL_MARKER" && -z "$in_repo_residue" ]] &&
    ! git -C "$SOURCE_ROOT" show-ref --verify --quiet "$IN_REPO_REF"; then
     test_pass
 else
-    test_fail "expected external temp state and a Git discovery ceiling: rc=$in_repo_rc workspace=${in_repo_workspace:-none} ceiling=${in_repo_ceiling:-none} discovery=$(test -e "$IN_REPO_DISCOVERY_MARKER" && printf yes || printf no) residue=${in_repo_residue:-none}"
+    test_fail "expected external temp state, no live source control state, and a Git discovery ceiling: rc=$in_repo_rc workspace=${in_repo_workspace:-none} ceiling=${in_repo_ceiling:-none} discovery=$(test -e "$IN_REPO_DISCOVERY_MARKER" && printf yes || printf no) live_control=$(test -e "$IN_REPO_LIVE_CONTROL_MARKER" && printf yes || printf no) residue=${in_repo_residue:-none}"
 fi
 git -C "$SOURCE_ROOT" update-ref -d "$IN_REPO_REF" >/dev/null 2>&1 || true
 rm -rf "$IN_REPO_TMPDIR"
@@ -860,7 +883,7 @@ if (
     cd() {
         if [[ "${1:-}" == "$ROOT_SWAP_ROOT" && ! -e "$ROOT_SWAP_MARKER" ]]; then
             command mv "$ROOT_SWAP_ROOT" "$ROOT_SWAP_ORIGINAL" || return 91
-            command ln -s "$ROOT_SWAP_OUTSIDE" "$ROOT_SWAP_ROOT" || return 92
+            command mv "$ROOT_SWAP_OUTSIDE" "$ROOT_SWAP_ROOT" || return 92
             printf 'swapped\n' > "$ROOT_SWAP_MARKER"
         fi
         builtin cd "$@"
@@ -871,8 +894,8 @@ if (
 else
     root_swap_rc=$?
 fi
-if [[ -L "$ROOT_SWAP_ROOT" ]]; then
-    rm -f "$ROOT_SWAP_ROOT"
+if [[ -d "$ROOT_SWAP_ROOT" && -d "$ROOT_SWAP_ORIGINAL" ]]; then
+    mv "$ROOT_SWAP_ROOT" "$ROOT_SWAP_OUTSIDE"
     mv "$ROOT_SWAP_ORIGINAL" "$ROOT_SWAP_ROOT"
 fi
 if [[ "$root_swap_rc" -ne 0 && -f "$ROOT_SWAP_MARKER" ]] &&
@@ -911,7 +934,7 @@ if workspace=$(
     cd() {
         if [[ "${1:-}" == "./nested-repo" && ! -e "$NESTED_SWAP_MARKER" ]]; then
             command mv "$NESTED_SWAP_ROOT/nested-repo" "$NESTED_SWAP_ORIGINAL" || return 91
-            command ln -s "$NESTED_SWAP_OUTSIDE" "$NESTED_SWAP_ROOT/nested-repo" || return 92
+            command mv "$NESTED_SWAP_OUTSIDE" "$NESTED_SWAP_ROOT/nested-repo" || return 92
             printf 'swapped\n' > "$NESTED_SWAP_MARKER"
         fi
         builtin cd "$@"
@@ -922,8 +945,8 @@ if workspace=$(
 else
     nested_swap_rc=$?
 fi
-if [[ -L "$NESTED_SWAP_ROOT/nested-repo" ]]; then
-    rm -f "$NESTED_SWAP_ROOT/nested-repo"
+if [[ -d "$NESTED_SWAP_ROOT/nested-repo" && -d "$NESTED_SWAP_ORIGINAL" ]]; then
+    mv "$NESTED_SWAP_ROOT/nested-repo" "$NESTED_SWAP_OUTSIDE"
     mv "$NESTED_SWAP_ORIGINAL" "$NESTED_SWAP_ROOT/nested-repo"
 fi
 nested_swap_residue="$(find "$NESTED_SWAP_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
@@ -932,6 +955,56 @@ if [[ "$nested_swap_rc" -ne 0 && -f "$NESTED_SWAP_MARKER" ]] &&
     test_pass
 else
     test_fail "expected anchored nested traversal to reject the swap: rc=$nested_swap_rc swapped=$(test -e "$NESTED_SWAP_MARKER" && printf yes || printf no) workspace=${workspace:-none} residue=${nested_swap_residue:-none}"
+fi
+
+test_case "a source-root swap before Git enumeration fails closed"
+POST_ANCHOR_ROOT="$TEST_TMP_DIR/post-anchor-source"
+POST_ANCHOR_ORIGINAL="$TEST_TMP_DIR/post-anchor-source-original"
+POST_ANCHOR_REPLACEMENT="$TEST_TMP_DIR/post-anchor-replacement"
+POST_ANCHOR_TMPDIR="$TEST_TMP_DIR/post-anchor-tmp"
+POST_ANCHOR_MARKER="$TEST_TMP_DIR/post-anchor-swapped"
+mkdir -p "$POST_ANCHOR_ROOT" "$POST_ANCHOR_REPLACEMENT" "$POST_ANCHOR_TMPDIR"
+for post_anchor_repo in "$POST_ANCHOR_ROOT" "$POST_ANCHOR_REPLACEMENT"; do
+    git -C "$post_anchor_repo" init -q
+    git -C "$post_anchor_repo" config user.email "test@example.com"
+    git -C "$post_anchor_repo" config user.name "test"
+done
+printf 'secret.txt\n' > "$POST_ANCHOR_ROOT/.gitignore"
+printf 'ignored source bytes\n' > "$POST_ANCHOR_ROOT/secret.txt"
+git -C "$POST_ANCHOR_ROOT" add .gitignore
+git -C "$POST_ANCHOR_ROOT" commit -q -m init
+printf 'replacement bytes\n' > "$POST_ANCHOR_REPLACEMENT/secret.txt"
+git -C "$POST_ANCHOR_REPLACEMENT" add secret.txt
+git -C "$POST_ANCHOR_REPLACEMENT" commit -q -m init
+if workspace=$(
+    _octopus_git_without_repository_env() {
+        local arg saw_ls_files=false
+        for arg in "$@"; do
+            [[ "$arg" == "ls-files" ]] && saw_ls_files=true
+        done
+        if [[ "$saw_ls_files" == "true" && ! -e "$POST_ANCHOR_MARKER" ]]; then
+            command mv "$POST_ANCHOR_ROOT" "$POST_ANCHOR_ORIGINAL" || return 91
+            command mv "$POST_ANCHOR_REPLACEMENT" "$POST_ANCHOR_ROOT" || return 92
+            printf 'swapped\n' > "$POST_ANCHOR_MARKER"
+        fi
+        command git "$@"
+    }
+    TMPDIR="$POST_ANCHOR_TMPDIR" _octopus_prepare_consultative_workspace "$POST_ANCHOR_ROOT"
+); then
+    post_anchor_rc=0
+else
+    post_anchor_rc=$?
+fi
+if [[ -d "$POST_ANCHOR_ROOT" && -d "$POST_ANCHOR_ORIGINAL" ]]; then
+    mv "$POST_ANCHOR_ROOT" "$POST_ANCHOR_REPLACEMENT"
+    mv "$POST_ANCHOR_ORIGINAL" "$POST_ANCHOR_ROOT"
+fi
+post_anchor_residue="$(find "$POST_ANCHOR_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if [[ "$post_anchor_rc" -ne 0 && -f "$POST_ANCHOR_MARKER" ]] &&
+   [[ -z "${workspace:-}" && -z "$post_anchor_residue" ]]; then
+    test_pass
+else
+    test_fail "expected source identity revalidation after Git enumeration: rc=$post_anchor_rc swapped=$(test -e "$POST_ANCHOR_MARKER" && printf yes || printf no) copied=$(cat "$workspace/secret.txt" 2>/dev/null || printf none) residue=${post_anchor_residue:-none}"
 fi
 
 test_case "Git copy lists use one owned directory and clean it after success"
@@ -1671,6 +1744,100 @@ else
     test_fail "expected TERM to interrupt provider capture promptly: started=$deferred_term_started stopped=$deferred_term_stopped rc=$deferred_term_rc finished=$(test -e "$DEFERRED_TERM_FINISHED" && printf yes || printf no) residue=${deferred_term_residue:-none}"
 fi
 command rm -rf "$DEFERRED_TERM_TMPDIR" "$DEFERRED_TERM_STARTED" "$DEFERRED_TERM_FINISHED" "$DEFERRED_TERM_CHILD_PID"
+
+test_case "inner signal cleanup never targets a provider identity after wait reaps it"
+INNER_POST_REAP_TMPDIR="$TEST_TMP_DIR/inner-post-reap-tmp"
+INNER_POST_REAP_INJECTED="$TEST_TMP_DIR/inner-post-reap-injected"
+INNER_POST_REAP_KILLS="$TEST_TMP_DIR/inner-post-reap-kills"
+INNER_POST_REAP_PID_FILE="$TEST_TMP_DIR/inner-post-reap-shell.pid"
+mkdir -p "$INNER_POST_REAP_TMPDIR"
+if (
+    export TMPDIR="$INNER_POST_REAP_TMPDIR"
+    export INNER_POST_REAP_INJECTED INNER_POST_REAP_KILLS INNER_POST_REAP_PID_FILE
+    /bin/bash -c '
+        source "$1/scripts/lib/agent-sync.sh"
+        log() { :; }
+        run_agent_sync() { printf "provider complete\n"; }
+        wait() {
+            local waited_pid="${1:-}" wait_rc current_shell
+            builtin wait "$@"
+            wait_rc=$?
+            if [[ -n "${agent_pid:-}" && "$waited_pid" == "$agent_pid" && ! -e "$INNER_POST_REAP_INJECTED" ]]; then
+                printf "injected\n" > "$INNER_POST_REAP_INJECTED"
+                /bin/sh -c '\''printf "%s\n" "$PPID" > "$1"'\'' _ "$INNER_POST_REAP_PID_FILE" || return 97
+                IFS= read -r current_shell < "$INNER_POST_REAP_PID_FILE" || return 97
+                command kill -TERM "$current_shell" || return 98
+            fi
+            return "$wait_rc"
+        }
+        kill() {
+            printf "%s\n" "$*" >> "$INNER_POST_REAP_KILLS"
+            return 0
+        }
+        cd "$2" || exit 96
+        _octopus_run_agent_sync_consultative_impl codex "review only" 120 reviewer ceremony >/dev/null 2>&1
+    ' _ "$PROJECT_ROOT" "$SOURCE_ROOT"
+); then
+    inner_post_reap_rc=0
+else
+    inner_post_reap_rc=$?
+fi
+inner_post_reap_residue="$(find "$INNER_POST_REAP_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if [[ "$inner_post_reap_rc" -eq 143 && -f "$INNER_POST_REAP_INJECTED" ]] &&
+   [[ ! -s "$INNER_POST_REAP_KILLS" && -z "$inner_post_reap_residue" ]]; then
+    test_pass
+else
+    test_fail "expected post-reap TERM cleanup without stale provider signals: rc=$inner_post_reap_rc injected=$(test -e "$INNER_POST_REAP_INJECTED" && printf yes || printf no) kills=$(cat "$INNER_POST_REAP_KILLS" 2>/dev/null || printf none) residue=${inner_post_reap_residue:-none}"
+fi
+command rm -rf "$INNER_POST_REAP_TMPDIR" "$INNER_POST_REAP_INJECTED" "$INNER_POST_REAP_KILLS" "$INNER_POST_REAP_PID_FILE"
+
+test_case "outer signal cleanup never targets an implementation identity after wait reaps it"
+OUTER_POST_REAP_TMPDIR="$TEST_TMP_DIR/outer-post-reap-tmp"
+OUTER_POST_REAP_INJECTED="$TEST_TMP_DIR/outer-post-reap-injected"
+OUTER_POST_REAP_KILLS="$TEST_TMP_DIR/outer-post-reap-kills"
+OUTER_POST_REAP_PID_FILE="$TEST_TMP_DIR/outer-post-reap-shell.pid"
+mkdir -p "$OUTER_POST_REAP_TMPDIR"
+if (
+    export TMPDIR="$OUTER_POST_REAP_TMPDIR"
+    export OUTER_POST_REAP_INJECTED OUTER_POST_REAP_KILLS OUTER_POST_REAP_PID_FILE
+    /bin/bash -c '
+        source "$1/scripts/lib/agent-sync.sh"
+        _octopus_run_agent_sync_consultative_impl() {
+            printf "done\n" > "$_octopus_consultative_completion_file"
+            return 0
+        }
+        wait() {
+            local waited_pid="${1:-}" wait_rc current_shell
+            builtin wait "$@"
+            wait_rc=$?
+            if [[ -n "${implementation_pid:-}" && "$waited_pid" == "$implementation_pid" && ! -e "$OUTER_POST_REAP_INJECTED" ]]; then
+                printf "injected\n" > "$OUTER_POST_REAP_INJECTED"
+                /bin/sh -c '\''printf "%s\n" "$PPID" > "$1"'\'' _ "$OUTER_POST_REAP_PID_FILE" || return 97
+                IFS= read -r current_shell < "$OUTER_POST_REAP_PID_FILE" || return 97
+                command kill -TERM "$current_shell" || return 98
+            fi
+            return "$wait_rc"
+        }
+        kill() {
+            printf "%s\n" "$*" >> "$OUTER_POST_REAP_KILLS"
+            return 0
+        }
+        cd "$2" || exit 96
+        run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1
+    ' _ "$PROJECT_ROOT" "$SOURCE_ROOT"
+); then
+    outer_post_reap_rc=0
+else
+    outer_post_reap_rc=$?
+fi
+outer_post_reap_residue="$(find "$OUTER_POST_REAP_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if [[ "$outer_post_reap_rc" -eq 143 && -f "$OUTER_POST_REAP_INJECTED" ]] &&
+   [[ ! -s "$OUTER_POST_REAP_KILLS" && -z "$outer_post_reap_residue" ]]; then
+    test_pass
+else
+    test_fail "expected post-reap TERM cleanup without stale implementation signals: rc=$outer_post_reap_rc injected=$(test -e "$OUTER_POST_REAP_INJECTED" && printf yes || printf no) kills=$(cat "$OUTER_POST_REAP_KILLS" 2>/dev/null || printf none) residue=${outer_post_reap_residue:-none}"
+fi
+command rm -rf "$OUTER_POST_REAP_TMPDIR" "$OUTER_POST_REAP_INJECTED" "$OUTER_POST_REAP_KILLS" "$OUTER_POST_REAP_PID_FILE"
 
 test_case "cleanup removes only the allocated temp root when TMPDIR is inside another repository"
 CLEANUP_CONTAINER="$TEST_TMP_DIR/cleanup-container"

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -537,6 +537,10 @@ test_case "Git copy list directory is removed after INT and TERM"
 copy_list_signal_failed=false
 copy_list_signal_failures=""
 for copy_list_signal in INT TERM; do
+    case "$copy_list_signal" in
+        INT) copy_list_signal_expected_rc=130 ;;
+        TERM) copy_list_signal_expected_rc=143 ;;
+    esac
     COPY_LIST_SIGNAL_TMPDIR="$TEST_TMP_DIR/copy-list-signal-${copy_list_signal}"
     COPY_LIST_SIGNAL_WORKSPACE="$TEST_TMP_DIR/copy-list-signal-workspace-${copy_list_signal}"
     mkdir -p "$COPY_LIST_SIGNAL_TMPDIR" "$COPY_LIST_SIGNAL_WORKSPACE"
@@ -546,21 +550,30 @@ for copy_list_signal in INT TERM; do
         export SIGNAL_NAME="$copy_list_signal"
         /bin/bash -c '
             source "$1/scripts/lib/agent-sync.sh"
+            copy_list_signal_pid_file="$4"
             _octopus_validate_copy_source_path() {
-                kill -s "$SIGNAL_NAME" "${BASHPID:-$$}"
+                local copy_list_subshell_pid
+                /bin/sh -c '\''printf "%s\n" "$PPID" > "$1"'\'' _ "$copy_list_signal_pid_file" || return 1
+                IFS= read -r copy_list_subshell_pid < "$copy_list_signal_pid_file" || return 1
+                rm -f "$copy_list_signal_pid_file" || return 1
+                case "$copy_list_subshell_pid" in
+                    ""|*[!0-9]*) return 1 ;;
+                esac
+                [[ "$copy_list_subshell_pid" != "$$" ]] || return 1
+                kill -s "$SIGNAL_NAME" "$copy_list_subshell_pid"
                 return 1
             }
             _octopus_copy_git_tracked_tree "$2" "$3"
-        ' _ "$PROJECT_ROOT" "$SOURCE_ROOT" "$COPY_LIST_SIGNAL_WORKSPACE"
+        ' _ "$PROJECT_ROOT" "$SOURCE_ROOT" "$COPY_LIST_SIGNAL_WORKSPACE" "$COPY_LIST_SIGNAL_WORKSPACE/subshell.pid"
     ) >/dev/null 2>&1; then
         copy_list_signal_rc=0
     else
         copy_list_signal_rc=$?
     fi
     copy_list_signal_residue="$(find "$COPY_LIST_SIGNAL_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
-    if [[ "$copy_list_signal_rc" -eq 0 || -n "$copy_list_signal_residue" ]]; then
+    if [[ "$copy_list_signal_rc" -ne "$copy_list_signal_expected_rc" || -n "$copy_list_signal_residue" ]]; then
         copy_list_signal_failed=true
-        copy_list_signal_failures="${copy_list_signal_failures}${copy_list_signal} rc=${copy_list_signal_rc} residue=${copy_list_signal_residue:-none}; "
+        copy_list_signal_failures="${copy_list_signal_failures}${copy_list_signal} rc=${copy_list_signal_rc} expected=${copy_list_signal_expected_rc} residue=${copy_list_signal_residue:-none}; "
     fi
     rm -rf "$COPY_LIST_SIGNAL_TMPDIR" "$COPY_LIST_SIGNAL_WORKSPACE"
 done

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -870,6 +870,41 @@ else
 fi
 [[ -z "$workspace" ]] || command rm -rf "$(dirname "$workspace")"
 
+test_case "a same-path real-directory swap before ordinary ancestor entry fails closed"
+REAL_ANCESTOR_ROOT="$TEST_TMP_DIR/real-ancestor-source"
+REAL_ANCESTOR_ORIGINAL="$TEST_TMP_DIR/real-ancestor-original"
+REAL_ANCESTOR_OUTSIDE="$TEST_TMP_DIR/real-ancestor-outside"
+REAL_ANCESTOR_WORKSPACE="$TEST_TMP_DIR/real-ancestor-workspace"
+REAL_ANCESTOR_MARKER="$TEST_TMP_DIR/real-ancestor-swapped"
+mkdir -p "$REAL_ANCESTOR_ROOT/safe/deep" "$REAL_ANCESTOR_OUTSIDE" "$REAL_ANCESTOR_WORKSPACE"
+printf 'safe ancestor bytes\n' > "$REAL_ANCESTOR_ROOT/safe/deep/payload.txt"
+printf 'external ancestor bytes\n' > "$REAL_ANCESTOR_OUTSIDE/payload.txt"
+if (
+    cd() {
+        if [[ "${1:-}" == "./deep" && "$PWD" == "$REAL_ANCESTOR_ROOT/safe" && ! -e "$REAL_ANCESTOR_MARKER" ]]; then
+            command mv "$REAL_ANCESTOR_ROOT/safe/deep" "$REAL_ANCESTOR_ORIGINAL" || return 91
+            command mv "$REAL_ANCESTOR_OUTSIDE" "$REAL_ANCESTOR_ROOT/safe/deep" || return 92
+            printf 'swapped\n' > "$REAL_ANCESTOR_MARKER"
+        fi
+        builtin cd "$@"
+    }
+    _octopus_copy_leaf_safely "$REAL_ANCESTOR_ROOT" "$REAL_ANCESTOR_WORKSPACE" safe/deep/payload.txt
+); then
+    real_ancestor_swap_rc=0
+else
+    real_ancestor_swap_rc=$?
+fi
+if [[ -d "$REAL_ANCESTOR_ROOT/safe/deep" && -d "$REAL_ANCESTOR_ORIGINAL" ]]; then
+    mv "$REAL_ANCESTOR_ROOT/safe/deep" "$REAL_ANCESTOR_OUTSIDE"
+    mv "$REAL_ANCESTOR_ORIGINAL" "$REAL_ANCESTOR_ROOT/safe/deep"
+fi
+if [[ "$real_ancestor_swap_rc" -ne 0 && -f "$REAL_ANCESTOR_MARKER" ]] &&
+   [[ ! -e "$REAL_ANCESTOR_WORKSPACE/safe/deep/payload.txt" ]]; then
+    test_pass
+else
+    test_fail "expected captured ordinary ancestor identity to reject the replacement: rc=$real_ancestor_swap_rc swapped=$(test -e "$REAL_ANCESTOR_MARKER" && printf yes || printf no) copied=$(cat "$REAL_ANCESTOR_WORKSPACE/safe/deep/payload.txt" 2>/dev/null || printf none)"
+fi
+
 test_case "a source-root swap after leaf validation fails closed"
 ROOT_SWAP_ROOT="$TEST_TMP_DIR/root-swap-source"
 ROOT_SWAP_ORIGINAL="$TEST_TMP_DIR/root-swap-source-original"

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -812,6 +812,188 @@ else
     test_fail "expected INT and TERM status with no list residue: $copy_list_signal_failures"
 fi
 
+test_case "real Git consultative dispatch removes its full workspace after success and failure"
+dispatch_cleanup_failed=false
+dispatch_cleanup_failures=""
+for dispatch_mode in success failure; do
+    DISPATCH_CLEANUP_TMPDIR="$TEST_TMP_DIR/dispatch-cleanup-${dispatch_mode}"
+    DISPATCH_CLEANUP_STARTED="$TEST_TMP_DIR/dispatch-cleanup-${dispatch_mode}-started"
+    DISPATCH_CLEANUP_INT_MARKER="$TEST_TMP_DIR/dispatch-cleanup-${dispatch_mode}-int"
+    DISPATCH_CLEANUP_TERM_MARKER="$TEST_TMP_DIR/dispatch-cleanup-${dispatch_mode}-term"
+    DISPATCH_CLEANUP_EXIT_MARKER="$TEST_TMP_DIR/dispatch-cleanup-${dispatch_mode}-exit"
+    mkdir -p "$DISPATCH_CLEANUP_TMPDIR"
+    DISPATCH_CLEANUP_TMPDIR="$(cd "$DISPATCH_CLEANUP_TMPDIR" && pwd -P)"
+    case "$dispatch_mode" in
+        success) dispatch_expected_rc=0 ;;
+        failure) dispatch_expected_rc=7 ;;
+    esac
+    if (
+        export TMPDIR="$DISPATCH_CLEANUP_TMPDIR"
+        export DISPATCH_MODE="$dispatch_mode"
+        export DISPATCH_CLEANUP_STARTED
+        export DISPATCH_CLEANUP_INT_MARKER DISPATCH_CLEANUP_TERM_MARKER DISPATCH_CLEANUP_EXIT_MARKER
+        export OCTOPUS_SECURITY_V870="caller-security"
+        export OCTOPUS_AGY_SANDBOX="caller-agy"
+        export OCTOPUS_CODEX_SANDBOX="caller-codex"
+        export CLAUDE_OCTOPUS_AUTONOMY="caller-autonomy"
+        /bin/bash -c '
+            source "$1/scripts/lib/agent-sync.sh"
+            log() { :; }
+            run_agent_sync() {
+                case "$PWD" in
+                    "$TMPDIR"/octopus-consultative.??????/workspace) ;;
+                    *) return 96 ;;
+                esac
+                [[ -d "$PWD" ]] || return 96
+                printf "%s\n" "$PWD" > "$DISPATCH_CLEANUP_STARTED"
+                printf "provider ran\n"
+                [[ "$DISPATCH_MODE" == "success" ]] && return 0
+                return 7
+            }
+            trap '\''printf "caller INT trap ran\n" > "$DISPATCH_CLEANUP_INT_MARKER"'\'' INT
+            trap '\''printf "caller TERM trap ran\n" > "$DISPATCH_CLEANUP_TERM_MARKER"'\'' TERM
+            trap '\''printf "caller EXIT trap ran\n" > "$DISPATCH_CLEANUP_EXIT_MARKER"'\'' EXIT
+            caller_int_trap_before="$(trap -p INT)"
+            caller_term_trap_before="$(trap -p TERM)"
+            caller_exit_trap_before="$(trap -p EXIT)"
+            cd "$2" || exit 98
+            caller_pwd_before="$(pwd -P)"
+            set +e
+            run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1
+            dispatch_rc=$?
+            set -e
+            caller_int_trap_after="$(trap -p INT)"
+            caller_term_trap_after="$(trap -p TERM)"
+            caller_exit_trap_after="$(trap -p EXIT)"
+            dispatch_residue="$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+            IFS= read -r dispatch_workspace < "$DISPATCH_CLEANUP_STARTED" || exit 1
+            dispatch_temp_root="${dispatch_workspace%/workspace}"
+            [[ "$dispatch_workspace" == "$TMPDIR"/octopus-consultative.??????/workspace ]] &&
+                [[ ! -e "$dispatch_temp_root" ]] &&
+                [[ "$dispatch_rc" -eq "$3" ]] &&
+                [[ -z "$dispatch_residue" ]] &&
+                [[ ! -e "$DISPATCH_CLEANUP_INT_MARKER" && ! -e "$DISPATCH_CLEANUP_TERM_MARKER" && ! -e "$DISPATCH_CLEANUP_EXIT_MARKER" ]] &&
+                [[ "$caller_int_trap_after" == "$caller_int_trap_before" ]] &&
+                [[ "$caller_term_trap_after" == "$caller_term_trap_before" ]] &&
+                [[ "$caller_exit_trap_after" == "$caller_exit_trap_before" ]] &&
+                [[ "$(pwd -P)" == "$caller_pwd_before" ]] &&
+                [[ "$OCTOPUS_SECURITY_V870" == "caller-security" ]] &&
+                [[ "$OCTOPUS_AGY_SANDBOX" == "caller-agy" ]] &&
+                [[ "$OCTOPUS_CODEX_SANDBOX" == "caller-codex" ]] &&
+                [[ "$CLAUDE_OCTOPUS_AUTONOMY" == "caller-autonomy" ]]
+        ' _ "$PROJECT_ROOT" "$SOURCE_ROOT" "$dispatch_expected_rc"
+    ); then
+        dispatch_cleanup_rc=0
+    else
+        dispatch_cleanup_rc=$?
+    fi
+    if [[ "$dispatch_cleanup_rc" -ne 0 ]]; then
+        dispatch_cleanup_failed=true
+        dispatch_cleanup_failures="${dispatch_cleanup_failures}${dispatch_mode} rc=${dispatch_cleanup_rc}; "
+    fi
+    rm -rf "$DISPATCH_CLEANUP_TMPDIR" "$DISPATCH_CLEANUP_STARTED" "$DISPATCH_CLEANUP_INT_MARKER" "$DISPATCH_CLEANUP_TERM_MARKER" "$DISPATCH_CLEANUP_EXIT_MARKER"
+done
+if [[ "$dispatch_cleanup_failed" == "false" ]]; then
+    test_pass
+else
+    test_fail "expected real dispatch cleanup and caller-state preservation: $dispatch_cleanup_failures"
+fi
+
+test_case "real Git consultative dispatch removes its full workspace after INT and TERM"
+dispatch_signal_failed=false
+dispatch_signal_failures=""
+for dispatch_signal in INT TERM; do
+    case "$dispatch_signal" in
+        INT) dispatch_signal_expected_rc=130 ;;
+        TERM) dispatch_signal_expected_rc=143 ;;
+    esac
+    DISPATCH_SIGNAL_TMPDIR="$TEST_TMP_DIR/dispatch-signal-${dispatch_signal}"
+    DISPATCH_SIGNAL_STARTED="$TEST_TMP_DIR/dispatch-signal-${dispatch_signal}-started"
+    DISPATCH_SIGNAL_PID_FILE="$TEST_TMP_DIR/dispatch-signal-${dispatch_signal}-pid"
+    DISPATCH_SIGNAL_INT_MARKER="$TEST_TMP_DIR/dispatch-signal-${dispatch_signal}-caller-int"
+    DISPATCH_SIGNAL_TERM_MARKER="$TEST_TMP_DIR/dispatch-signal-${dispatch_signal}-caller-term"
+    DISPATCH_SIGNAL_EXIT_MARKER="$TEST_TMP_DIR/dispatch-signal-${dispatch_signal}-caller-exit"
+    mkdir -p "$DISPATCH_SIGNAL_TMPDIR"
+    DISPATCH_SIGNAL_TMPDIR="$(cd "$DISPATCH_SIGNAL_TMPDIR" && pwd -P)"
+    if (
+        export TMPDIR="$DISPATCH_SIGNAL_TMPDIR"
+        export SIGNAL_NAME="$dispatch_signal"
+        export DISPATCH_SIGNAL_STARTED DISPATCH_SIGNAL_PID_FILE
+        export DISPATCH_SIGNAL_INT_MARKER DISPATCH_SIGNAL_TERM_MARKER DISPATCH_SIGNAL_EXIT_MARKER
+        export OCTOPUS_SECURITY_V870="caller-security"
+        export OCTOPUS_AGY_SANDBOX="caller-agy"
+        export OCTOPUS_CODEX_SANDBOX="caller-codex"
+        export CLAUDE_OCTOPUS_AUTONOMY="caller-autonomy"
+        /bin/bash -c '
+            source "$1/scripts/lib/agent-sync.sh"
+            log() { :; }
+            run_agent_sync() {
+                local command_subshell_pid consultative_pid
+                case "$PWD" in
+                    "$TMPDIR"/octopus-consultative.??????/workspace) ;;
+                    *) return 96 ;;
+                esac
+                [[ -d "$PWD" ]] || return 96
+                printf "%s\n" "$PWD" > "$DISPATCH_SIGNAL_STARTED"
+                /bin/sh -c '\''printf "%s\n" "$PPID" > "$1"'\'' _ "$DISPATCH_SIGNAL_PID_FILE" || return 1
+                IFS= read -r command_subshell_pid < "$DISPATCH_SIGNAL_PID_FILE" || return 1
+                consultative_pid="$(/bin/ps -o ppid= -p "$command_subshell_pid" | tr -d "[:space:]")" || return 1
+                case "$consultative_pid" in
+                    ""|*[!0-9]*) return 1 ;;
+                esac
+                kill -s "$SIGNAL_NAME" "$consultative_pid" || return 1
+                return 0
+            }
+            trap '\''printf "caller INT trap ran\n" > "$DISPATCH_SIGNAL_INT_MARKER"'\'' INT
+            trap '\''printf "caller TERM trap ran\n" > "$DISPATCH_SIGNAL_TERM_MARKER"'\'' TERM
+            trap '\''printf "caller EXIT trap ran\n" > "$DISPATCH_SIGNAL_EXIT_MARKER"'\'' EXIT
+            caller_int_trap_before="$(trap -p INT)"
+            caller_term_trap_before="$(trap -p TERM)"
+            caller_exit_trap_before="$(trap -p EXIT)"
+            cd "$2" || exit 98
+            caller_pwd_before="$(pwd -P)"
+            set +e
+            run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1
+            dispatch_rc=$?
+            set -e
+            caller_int_trap_after="$(trap -p INT)"
+            caller_term_trap_after="$(trap -p TERM)"
+            caller_exit_trap_after="$(trap -p EXIT)"
+            dispatch_residue="$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+            IFS= read -r dispatch_workspace < "$DISPATCH_SIGNAL_STARTED" || exit 1
+            dispatch_temp_root="${dispatch_workspace%/workspace}"
+            [[ "$dispatch_workspace" == "$TMPDIR"/octopus-consultative.??????/workspace ]] &&
+                [[ ! -e "$dispatch_temp_root" ]] &&
+                [[ "$dispatch_rc" -eq "$3" ]] &&
+                [[ -z "$dispatch_residue" ]] &&
+                [[ ! -e "$DISPATCH_SIGNAL_INT_MARKER" && ! -e "$DISPATCH_SIGNAL_TERM_MARKER" && ! -e "$DISPATCH_SIGNAL_EXIT_MARKER" ]] &&
+                [[ "$caller_int_trap_after" == "$caller_int_trap_before" ]] &&
+                [[ "$caller_term_trap_after" == "$caller_term_trap_before" ]] &&
+                [[ "$caller_exit_trap_after" == "$caller_exit_trap_before" ]] &&
+                [[ "$(pwd -P)" == "$caller_pwd_before" ]] &&
+                [[ "$OCTOPUS_SECURITY_V870" == "caller-security" ]] &&
+                [[ "$OCTOPUS_AGY_SANDBOX" == "caller-agy" ]] &&
+                [[ "$OCTOPUS_CODEX_SANDBOX" == "caller-codex" ]] &&
+                [[ "$CLAUDE_OCTOPUS_AUTONOMY" == "caller-autonomy" ]]
+        ' _ "$PROJECT_ROOT" "$SOURCE_ROOT" "$dispatch_signal_expected_rc"
+    ); then
+        dispatch_signal_rc=0
+    else
+        dispatch_signal_rc=$?
+    fi
+    dispatch_signal_residue="$(find "$DISPATCH_SIGNAL_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+    if [[ "$dispatch_signal_rc" -ne 0 || -n "$dispatch_signal_residue" ]]; then
+        dispatch_signal_failed=true
+        dispatch_signal_failures="${dispatch_signal_failures}${dispatch_signal} rc=${dispatch_signal_rc} residue=${dispatch_signal_residue:-none}; "
+    fi
+    rm -rf "$DISPATCH_SIGNAL_TMPDIR" "$DISPATCH_SIGNAL_STARTED" "$DISPATCH_SIGNAL_PID_FILE" "$DISPATCH_SIGNAL_INT_MARKER" "$DISPATCH_SIGNAL_TERM_MARKER" "$DISPATCH_SIGNAL_EXIT_MARKER"
+done
+if [[ "$dispatch_signal_failed" == "false" ]]; then
+    test_pass
+else
+    test_fail "expected exact signal status, full cleanup, restored environment, and unchanged caller traps: $dispatch_signal_failures"
+fi
+
 test_case "cleanup removes only the allocated temp root when TMPDIR is inside another repository"
 CLEANUP_CONTAINER="$TEST_TMP_DIR/cleanup-container"
 CLEANUP_OUTER_REPO="$CLEANUP_CONTAINER/unrelated-repo"

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -30,6 +30,7 @@ mkdir -p "$SOURCE_ROOT/vendor" "$SOURCE_ROOT/subdir"
     git add staged.txt
     printf 'staged and modified working tree\n' > staged.txt
     printf 'untracked but not ignored\n' > untracked.txt
+    printf 'subdirectory untracked\n' > subdir/untracked.txt
 )
 
 test_case "Git sources copy exact eligible working-tree bytes without Git metadata"
@@ -152,15 +153,18 @@ else
     test_fail "expected Git config isolation and unchanged source index, HEAD, and refs"
 fi
 
-test_case "a launch from a repository subdirectory returns its copied subdirectory"
+test_case "a repository subdirectory launch copies only eligible content in that subtree"
 workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT/subdir")"
 workspace_root="$(dirname "$workspace")"
 if [[ "$workspace" == */workspace/subdir ]] &&
    [[ "$(cat "$workspace/context.txt" 2>/dev/null)" == "subdirectory modified" ]] &&
+   [[ "$(cat "$workspace/untracked.txt" 2>/dev/null)" == "subdirectory untracked" ]] &&
+   [[ ! -e "$workspace_root/tracked.txt" && ! -e "$workspace_root/staged.txt" ]] &&
+   [[ ! -e "$workspace_root/untracked.txt" && ! -e "$workspace_root/inside.txt" ]] &&
    [[ ! -e "$workspace_root/.git" ]]; then
     test_pass
 else
-    test_fail "expected current subdirectory bytes at the matching metadata-free copied path"
+    test_fail "expected only current tracked and nonignored subdirectory bytes at the matching metadata-free copied path"
 fi
 rm -rf "$(dirname "$workspace_root")"
 
@@ -375,6 +379,51 @@ else
     test_fail "expected recursively filtered nested bytes without parent or nested .git metadata"
 fi
 rm -rf "$(dirname "$workspace")"
+
+test_case "a selected subtree retains nested Git content without copying repository siblings"
+NESTED_SUBTREE_ROOT="$TEST_TMP_DIR/nested-subtree-source"
+NESTED_SUBTREE_CHILD="$TEST_TMP_DIR/nested-subtree-child"
+mkdir -p "$NESTED_SUBTREE_ROOT/selected" "$NESTED_SUBTREE_CHILD/vendor"
+(
+    cd "$NESTED_SUBTREE_CHILD"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'vendor/\n' > .gitignore
+    printf 'nested tracked\n' > nested.txt
+    git add nested.txt .gitignore
+    git commit -q -m "nested init"
+)
+(
+    cd "$NESTED_SUBTREE_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'selected tracked\n' > selected/context.txt
+    printf 'unrelated tracked\n' > unrelated.txt
+    git add selected/context.txt unrelated.txt
+    git commit -q -m init
+    git -c protocol.file.allow=always submodule add -q "$NESTED_SUBTREE_CHILD" selected/nested-repo
+    git commit -q -am "add selected nested repository"
+    printf 'selected untracked\n' > selected/local.txt
+    printf 'unrelated untracked\n' > unrelated-local.txt
+    printf 'nested working tree\n' > selected/nested-repo/nested.txt
+    mkdir -p selected/nested-repo/vendor
+    printf 'nested vendored\n' > selected/nested-repo/vendor/big.bin
+)
+workspace="$(_octopus_prepare_consultative_workspace "$NESTED_SUBTREE_ROOT/selected")"
+workspace_root="$(dirname "$workspace")"
+if [[ "$workspace" == */workspace/selected ]] &&
+   [[ "$(cat "$workspace/context.txt" 2>/dev/null)" == "selected tracked" ]] &&
+   [[ "$(cat "$workspace/local.txt" 2>/dev/null)" == "selected untracked" ]] &&
+   [[ "$(cat "$workspace/nested-repo/nested.txt" 2>/dev/null)" == "nested working tree" ]] &&
+   [[ ! -e "$workspace/nested-repo/vendor" && ! -e "$workspace/nested-repo/.git" ]] &&
+   [[ ! -e "$workspace_root/unrelated.txt" && ! -e "$workspace_root/unrelated-local.txt" ]]; then
+    test_pass
+else
+    test_fail "expected scoped parent bytes and recursively filtered nested content without repository siblings"
+fi
+rm -rf "$(dirname "$workspace_root")"
 
 test_case "an empty parent copy list skips tar and still copies nested work trees"
 NESTED_ONLY_ROOT="$TEST_TMP_DIR/nested-only-source"

--- a/tests/unit/test-consultative-workspace-gitignore.sh
+++ b/tests/unit/test-consultative-workspace-gitignore.sh
@@ -47,7 +47,7 @@ else
 fi
 rm -rf "$(dirname "$workspace")"
 
-test_case "broken nested Git discovery fails closed before nested metadata or ignored bytes are archived"
+test_case "broken nested Git discovery fails closed before nested metadata or ignored bytes are copied"
 BROKEN_NESTED_ROOT="$TEST_TMP_DIR/broken-nested-source"
 BROKEN_NESTED_CHILD="$TEST_TMP_DIR/broken-nested-child"
 BROKEN_NESTED_TMPDIR="$TEST_TMP_DIR/broken-nested-tmp"
@@ -90,7 +90,7 @@ broken_nested_residue="$(find "$BROKEN_NESTED_TMPDIR" -mindepth 1 -maxdepth 1 -p
 if [[ "$broken_nested_rc" -ne 0 && "$broken_nested_leak" == "false" && -z "$broken_nested_residue" ]]; then
     test_pass
 else
-    test_fail "expected broken nested discovery to fail before archive: rc=$broken_nested_rc leak=$broken_nested_leak residue=${broken_nested_residue:-none}"
+    test_fail "expected broken nested discovery to fail before copy: rc=$broken_nested_rc leak=$broken_nested_leak residue=${broken_nested_residue:-none}"
 fi
 rm -rf "$BROKEN_NESTED_TMPDIR"
 
@@ -255,6 +255,39 @@ if [[ "$trace_dispatch_rc" -eq 0 && -s "$TRACE_GIT_MARKER" ]] &&
 else
     test_fail "expected Git command execution without inherited trace/output sinks: rc=$trace_dispatch_rc leaked=$(cat "$TRACE_ENV_MARKER" 2>/dev/null || printf none)"
 fi
+
+test_case "an exported readonly GIT_DIR cannot redirect advisory Git writes"
+READONLY_GIT_DIR_MARKER="$TEST_TMP_DIR/readonly-git-dir-dispatched"
+READONLY_GIT_DIR_REF="refs/heads/readonly-advisory-write"
+ambient_git_dir="$(git -C "$SOURCE_ROOT" rev-parse --absolute-git-dir)"
+git -C "$SOURCE_ROOT" update-ref -d "$READONLY_GIT_DIR_REF" >/dev/null 2>&1 || true
+if (
+    export READONLY_GIT_DIR_MARKER READONLY_GIT_DIR_REF
+    /bin/bash -c '
+        source "$1/scripts/lib/agent-sync.sh"
+        log() { :; }
+        run_agent_sync() {
+            printf "dispatched\n" > "$READONLY_GIT_DIR_MARKER"
+            git update-ref "$READONLY_GIT_DIR_REF" HEAD >/dev/null 2>&1 || true
+            printf "review only\n"
+        }
+        export GIT_DIR="$3"
+        readonly GIT_DIR
+        cd "$2" || exit 98
+        run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1
+    ' _ "$PROJECT_ROOT" "$SOURCE_ROOT" "$ambient_git_dir"
+); then
+    readonly_git_dir_rc=0
+else
+    readonly_git_dir_rc=$?
+fi
+if [[ "$readonly_git_dir_rc" -ne 0 && ! -e "$READONLY_GIT_DIR_MARKER" ]] &&
+   ! git -C "$SOURCE_ROOT" show-ref --verify --quiet "$READONLY_GIT_DIR_REF"; then
+    test_pass
+else
+    test_fail "expected readonly repository selectors to fail closed before dispatch: rc=$readonly_git_dir_rc dispatched=$(test -e "$READONLY_GIT_DIR_MARKER" && printf yes || printf no)"
+fi
+git -C "$SOURCE_ROOT" update-ref -d "$READONLY_GIT_DIR_REF" >/dev/null 2>&1 || true
 
 test_case "a repository subdirectory launch copies only eligible content in that subtree"
 workspace="$(_octopus_prepare_consultative_workspace "$SOURCE_ROOT/subdir")"
@@ -515,6 +548,39 @@ else
 fi
 rm -rf "$(dirname "$workspace")"
 
+test_case "a non-Git copy rejects a symlink that escapes the copied root"
+PLAIN_ESCAPE_ROOT="$TEST_TMP_DIR/plain-escape-source"
+PLAIN_ESCAPE_OUTSIDE="$TEST_TMP_DIR/plain-escape-outside"
+mkdir -p "$PLAIN_ESCAPE_ROOT" "$PLAIN_ESCAPE_OUTSIDE"
+printf 'outside secret\n' > "$PLAIN_ESCAPE_OUTSIDE/secret.txt"
+ln -s "../plain-escape-outside/secret.txt" "$PLAIN_ESCAPE_ROOT/external-link"
+workspace=""
+if workspace="$(_octopus_prepare_consultative_workspace "$PLAIN_ESCAPE_ROOT" 2>/dev/null)"; then
+    plain_escape_rc=0
+else
+    plain_escape_rc=$?
+fi
+if [[ "$plain_escape_rc" -ne 0 && -z "$workspace" ]]; then
+    test_pass
+else
+    test_fail "expected an external symlink in a non-Git source to fail closed: rc=$plain_escape_rc workspace=${workspace:-none}"
+fi
+[[ -z "$workspace" ]] || command rm -rf "$(dirname "$workspace")"
+
+test_case "a non-Git copy preserves a relative symlink confined to the copied root"
+PLAIN_LINK_ROOT="$TEST_TMP_DIR/plain-link-source"
+mkdir -p "$PLAIN_LINK_ROOT/files" "$PLAIN_LINK_ROOT/links"
+printf 'inside\n' > "$PLAIN_LINK_ROOT/files/inside.txt"
+ln -s "../files/inside.txt" "$PLAIN_LINK_ROOT/links/internal-link"
+workspace="$(_octopus_prepare_consultative_workspace "$PLAIN_LINK_ROOT")"
+if [[ -L "$workspace/links/internal-link" ]] &&
+   [[ "$(cat "$workspace/links/internal-link" 2>/dev/null)" == "inside" ]]; then
+    test_pass
+else
+    test_fail "expected a confined non-Git symlink to remain usable in the copy"
+fi
+command rm -rf "$(dirname "$workspace")"
+
 test_case "nested Git work trees recursively honor their own ignore rules without metadata"
 NESTED_ROOT="$TEST_TMP_DIR/nested-source"
 NESTED_CHILD_ROOT="$TEST_TMP_DIR/nested-child"
@@ -599,12 +665,12 @@ else
 fi
 rm -rf "$(dirname "$workspace_root")"
 
-test_case "an empty parent copy list skips tar and still copies nested work trees"
+test_case "an empty parent copy list skips leaf copies and still copies nested work trees"
 NESTED_ONLY_ROOT="$TEST_TMP_DIR/nested-only-source"
-NESTED_ONLY_TAR_BIN="$TEST_TMP_DIR/nested-only-tar-bin"
-NESTED_ONLY_TAR_MARKER="$TEST_TMP_DIR/nested-only-parent-tar-ran"
-REAL_TAR="$(command -v tar)"
-mkdir -p "$NESTED_ONLY_ROOT" "$NESTED_ONLY_TAR_BIN"
+NESTED_ONLY_CP_BIN="$TEST_TMP_DIR/nested-only-cp-bin"
+NESTED_ONLY_CP_MARKER="$TEST_TMP_DIR/nested-only-parent-cp-ran"
+REAL_CP="$(command -v cp)"
+mkdir -p "$NESTED_ONLY_ROOT" "$NESTED_ONLY_CP_BIN"
 git -C "$NESTED_ONLY_ROOT" init -q
 git -C "$NESTED_ONLY_ROOT" config user.email "test@example.com"
 git -C "$NESTED_ONLY_ROOT" config user.name "test"
@@ -614,87 +680,113 @@ git -C "$NESTED_ONLY_ROOT" update-index --add --cacheinfo 160000 "$nested_only_o
 git -C "$NESTED_ONLY_ROOT" commit -q -m "nested-only parent"
 printf 'nested-only working tree\n' > "$NESTED_ONLY_ROOT/nested-repo/nested.txt"
 NESTED_ONLY_ROOT="$(cd "$NESTED_ONLY_ROOT" && pwd -P)"
-cat > "$NESTED_ONLY_TAR_BIN/tar" <<'EOF'
+cat > "$NESTED_ONLY_CP_BIN/cp" <<'EOF'
 #!/usr/bin/env bash
 original_args=("$@")
-archive_root=""
-while [[ "$#" -gt 0 ]]; do
-    if [[ "$1" == "-C" ]]; then
-        archive_root="${2:-}"
-        shift
-    fi
-    shift
-done
-if [[ "$archive_root" == "$NESTED_ONLY_ROOT" ]]; then
-    printf 'parent tar ran\n' > "$NESTED_ONLY_TAR_MARKER"
+if [[ "$PWD" == "$NESTED_ONLY_ROOT" && "${1:-}" == "-pP" ]]; then
+    printf 'parent leaf copy ran\n' > "$NESTED_ONLY_CP_MARKER"
     exit 97
 fi
-exec "$REAL_TAR" "${original_args[@]}"
+exec "$REAL_CP" "${original_args[@]}"
 EOF
-chmod +x "$NESTED_ONLY_TAR_BIN/tar"
+chmod +x "$NESTED_ONLY_CP_BIN/cp"
 nested_only_rc=0
 if workspace="$(
-    export PATH="$NESTED_ONLY_TAR_BIN:$PATH"
-    export REAL_TAR NESTED_ONLY_ROOT NESTED_ONLY_TAR_MARKER
+    export PATH="$NESTED_ONLY_CP_BIN:$PATH"
+    export REAL_CP NESTED_ONLY_ROOT NESTED_ONLY_CP_MARKER
     _octopus_prepare_consultative_workspace "$NESTED_ONLY_ROOT"
 )"; then
     nested_only_rc=0
 else
     nested_only_rc=$?
 fi
-if [[ "$nested_only_rc" -eq 0 && ! -e "$NESTED_ONLY_TAR_MARKER" ]] &&
+if [[ "$nested_only_rc" -eq 0 && ! -e "$NESTED_ONLY_CP_MARKER" ]] &&
    [[ "$(cat "$workspace/nested-repo/nested.txt" 2>/dev/null)" == "nested-only working tree" ]] &&
    [[ ! -e "$workspace/nested-repo/.git" ]]; then
     test_pass
 else
-    test_fail "expected nested copy without invoking tar for an empty parent list: rc=$nested_only_rc"
+    test_fail "expected nested copy without invoking the parent leaf copier: rc=$nested_only_rc"
 fi
 [[ -z "${workspace:-}" ]] || rm -rf "$(dirname "$workspace")"
 
-test_case "nested repositories are excluded before the parent archive runs"
+test_case "nested repositories are excluded from the parent leaf copier"
 NESTED_ROOT="$(cd "$NESTED_ROOT" && pwd -P)"
-REAL_TAR="$(command -v tar)"
-TAR_GUARD_BIN="$TEST_TMP_DIR/tar-guard-bin"
-TAR_GUARD_MARKER="$TEST_TMP_DIR/tar-saw-nested-root"
-TAR_GUARD_EXECUTED="$TEST_TMP_DIR/tar-guard-executed"
-mkdir -p "$TAR_GUARD_BIN"
-cat > "$TAR_GUARD_BIN/tar" <<'EOF'
+REAL_CP="$(command -v cp)"
+CP_GUARD_BIN="$TEST_TMP_DIR/cp-guard-bin"
+CP_GUARD_MARKER="$TEST_TMP_DIR/cp-saw-nested-root"
+CP_GUARD_EXECUTED="$TEST_TMP_DIR/cp-guard-executed"
+mkdir -p "$CP_GUARD_BIN"
+cat > "$CP_GUARD_BIN/cp" <<'EOF'
 #!/usr/bin/env bash
 original_args=("$@")
-list_file=""
-archive_root=""
-while [[ "$#" -gt 0 ]]; do
-    case "$1" in
-        -C) archive_root="${2:-}"; shift ;;
-        -T|--files-from) list_file="${2:-}"; shift ;;
-        -T*) list_file="${1#-T}" ;;
-        --files-from=*) list_file="${1#--files-from=}" ;;
-    esac
-    shift
-done
-if [[ "$archive_root" == "$NESTED_ROOT" && -n "$list_file" && "$list_file" != "-" ]]; then
-    printf 'guard executed\n' > "$TAR_GUARD_EXECUTED"
-    while IFS= read -r -d '' entry; do
-        if [[ "${entry%/}" == "nested-repo" || "$entry" == nested-repo/* ]]; then
-            printf 'nested repository reached parent archive\n' > "$TAR_GUARD_MARKER"
-            exit 97
-        fi
-    done < "$list_file"
+if [[ "$PWD" == "$NESTED_ROOT" && "${1:-}" == "-pP" ]]; then
+    printf 'guard executed\n' > "$CP_GUARD_EXECUTED"
+    if [[ "${2:-}" == "./nested-repo" || "${2:-}" == ./nested-repo/* ]]; then
+        printf 'nested repository reached parent copier\n' > "$CP_GUARD_MARKER"
+        exit 97
+    fi
 fi
-exec "$REAL_TAR" "${original_args[@]}"
+exec "$REAL_CP" "${original_args[@]}"
 EOF
-chmod +x "$TAR_GUARD_BIN/tar"
+chmod +x "$CP_GUARD_BIN/cp"
 workspace="$(
-    export PATH="$TAR_GUARD_BIN:$PATH" REAL_TAR TAR_GUARD_MARKER TAR_GUARD_EXECUTED NESTED_ROOT
+    export PATH="$CP_GUARD_BIN:$PATH" REAL_CP CP_GUARD_MARKER CP_GUARD_EXECUTED NESTED_ROOT
     _octopus_prepare_consultative_workspace "$NESTED_ROOT"
 )"
-if [[ -f "$TAR_GUARD_EXECUTED" && ! -e "$TAR_GUARD_MARKER" ]] &&
+if [[ -f "$CP_GUARD_EXECUTED" && ! -e "$CP_GUARD_MARKER" ]] &&
    [[ -f "$workspace/nested-repo/nested.txt" && ! -e "$workspace/nested-repo/vendor" ]]; then
     test_pass
 else
-    test_fail "expected the parent archive to omit nested-repo before recursively copying it"
+    test_fail "expected the parent leaf copier to omit nested-repo before recursively copying it"
 fi
 rm -rf "$(dirname "$workspace")"
+
+test_case "an ancestor swap after validation cannot redirect the copied leaf"
+TOCTOU_ROOT="$TEST_TMP_DIR/toctou-source"
+TOCTOU_OUTSIDE="$TEST_TMP_DIR/toctou-outside"
+TOCTOU_BIN="$TEST_TMP_DIR/toctou-bin"
+TOCTOU_CP_MARKER="$TEST_TMP_DIR/toctou-cp-ran"
+REAL_CP="$(command -v cp)"
+mkdir -p "$TOCTOU_ROOT/safe" "$TOCTOU_OUTSIDE" "$TOCTOU_BIN"
+(
+    cd "$TOCTOU_ROOT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf 'safe bytes\n' > safe/payload.txt
+    git add safe/payload.txt
+    git commit -q -m init
+)
+printf 'outside secret\n' > "$TOCTOU_OUTSIDE/payload.txt"
+TOCTOU_ROOT="$(cd "$TOCTOU_ROOT" && pwd -P)"
+cat > "$TOCTOU_BIN/cp" <<'EOF'
+#!/usr/bin/env bash
+original_args=("$@")
+if [[ "$PWD" == "$TOCTOU_ROOT/safe" && "${1:-}" == "-pP" && ! -e "$TOCTOU_CP_MARKER" ]]; then
+    mv "$TOCTOU_ROOT/safe" "$TOCTOU_ROOT/safe-before-race"
+    ln -s "$TOCTOU_OUTSIDE" "$TOCTOU_ROOT/safe"
+    printf 'leaf copy ran\n' > "$TOCTOU_CP_MARKER"
+fi
+exec "$REAL_CP" "${original_args[@]}"
+EOF
+chmod +x "$TOCTOU_BIN/cp"
+workspace=""
+if workspace="$(
+    export PATH="$TOCTOU_BIN:$PATH"
+    export REAL_CP TOCTOU_ROOT TOCTOU_OUTSIDE TOCTOU_CP_MARKER
+    _octopus_prepare_consultative_workspace "$TOCTOU_ROOT"
+)"; then
+    toctou_rc=0
+else
+    toctou_rc=$?
+fi
+if [[ "$toctou_rc" -eq 0 && -f "$TOCTOU_CP_MARKER" ]] &&
+   [[ "$(cat "$workspace/safe/payload.txt" 2>/dev/null)" == "safe bytes" ]]; then
+    test_pass
+else
+    test_fail "expected the entered source directory to remain authoritative after an ancestor swap: rc=$toctou_rc cp_ran=$(test -e "$TOCTOU_CP_MARKER" && printf yes || printf no) copied=$(cat "$workspace/safe/payload.txt" 2>/dev/null || printf missing)"
+fi
+[[ -z "$workspace" ]] || command rm -rf "$(dirname "$workspace")"
 
 test_case "Git copy lists use one owned directory and clean it after success"
 COPY_LIST_TMPDIR="$TEST_TMP_DIR/copy-list-tmp"
@@ -771,20 +863,22 @@ else
     test_fail "expected append failures to propagate with no list residue: $append_failure_details"
 fi
 
-test_case "Git copy list directory is removed after archive failure"
+test_case "Git copy list directory is removed after leaf-copy failure"
 COPY_LIST_FAILURE_TMPDIR="$TEST_TMP_DIR/copy-list-failure-tmp"
 COPY_LIST_FAILURE_WORKSPACE="$TEST_TMP_DIR/copy-list-failure-workspace"
 COPY_LIST_FAILURE_BIN="$TEST_TMP_DIR/copy-list-failure-bin"
 mkdir -p "$COPY_LIST_FAILURE_TMPDIR" "$COPY_LIST_FAILURE_WORKSPACE" "$COPY_LIST_FAILURE_BIN"
-cat > "$COPY_LIST_FAILURE_BIN/tar" <<'EOF'
+cat > "$COPY_LIST_FAILURE_BIN/cp" <<'EOF'
 #!/usr/bin/env bash
+[[ "${1:-}" == "-pP" ]] || exec "$REAL_CP" "$@"
 exit 97
 EOF
-chmod +x "$COPY_LIST_FAILURE_BIN/tar"
+chmod +x "$COPY_LIST_FAILURE_BIN/cp"
 copy_list_failure_rc=0
 if (
     export TMPDIR="$COPY_LIST_FAILURE_TMPDIR"
     export PATH="$COPY_LIST_FAILURE_BIN:$PATH"
+    export REAL_CP
     _octopus_copy_git_tracked_tree "$SOURCE_ROOT" "$COPY_LIST_FAILURE_WORKSPACE"
 ); then
     copy_list_failure_rc=0
@@ -795,7 +889,7 @@ copy_list_failure_residue="$(find "$COPY_LIST_FAILURE_TMPDIR" -mindepth 1 -maxde
 if [[ "$copy_list_failure_rc" -ne 0 && -z "$copy_list_failure_residue" ]]; then
     test_pass
 else
-    test_fail "expected archive failure to remove its list directory: rc=$copy_list_failure_rc residue=$copy_list_failure_residue"
+    test_fail "expected leaf-copy failure to remove its list directory: rc=$copy_list_failure_rc residue=$copy_list_failure_residue"
 fi
 
 test_case "Git copy list directory is removed after INT and TERM"
@@ -1363,6 +1457,76 @@ else
     test_fail "expected exact signal status, full cleanup, restored environment, and unchanged caller traps: $dispatch_signal_failures"
 fi
 
+test_case "TERM cancels a running consultative provider without waiting for completion"
+DEFERRED_TERM_TMPDIR="$TEST_TMP_DIR/deferred-term-tmp"
+DEFERRED_TERM_STARTED="$TEST_TMP_DIR/deferred-term-started"
+DEFERRED_TERM_FINISHED="$TEST_TMP_DIR/deferred-term-finished"
+DEFERRED_TERM_CHILD_PID="$TEST_TMP_DIR/deferred-term-child.pid"
+mkdir -p "$DEFERRED_TERM_TMPDIR"
+TMPDIR="$DEFERRED_TERM_TMPDIR" \
+DEFERRED_TERM_STARTED="$DEFERRED_TERM_STARTED" \
+DEFERRED_TERM_FINISHED="$DEFERRED_TERM_FINISHED" \
+DEFERRED_TERM_CHILD_PID="$DEFERRED_TERM_CHILD_PID" \
+    /bin/bash -c '
+        source "$1/scripts/lib/agent-sync.sh"
+        log() { :; }
+        run_agent_sync() {
+            printf "started\n" > "$DEFERRED_TERM_STARTED"
+            /bin/sleep 5 &
+            provider_child=$!
+            printf "%s\n" "$provider_child" > "$DEFERRED_TERM_CHILD_PID"
+            wait "$provider_child"
+            printf "finished\n" > "$DEFERRED_TERM_FINISHED"
+            printf "review only\n"
+        }
+        cd "$2" || exit 98
+        run_agent_sync_consultative codex "review only" 120 reviewer ceremony >/dev/null 2>&1
+    ' _ "$PROJECT_ROOT" "$SOURCE_ROOT" &
+deferred_term_runner=$!
+deferred_term_started=false
+for _ in $(seq 1 100); do
+    if [[ -f "$DEFERRED_TERM_STARTED" && -f "$DEFERRED_TERM_CHILD_PID" ]]; then
+        deferred_term_started=true
+        break
+    fi
+    /bin/sleep 0.02
+done
+if [[ "$deferred_term_started" == "true" ]]; then
+    kill -TERM "$deferred_term_runner" 2>/dev/null || true
+fi
+deferred_term_stopped=false
+for _ in $(seq 1 100); do
+    if ! kill -0 "$deferred_term_runner" 2>/dev/null; then
+        deferred_term_stopped=true
+        break
+    fi
+    /bin/sleep 0.02
+done
+if [[ "$deferred_term_stopped" != "true" ]]; then
+    kill -KILL "$deferred_term_runner" 2>/dev/null || true
+fi
+set +e
+wait "$deferred_term_runner" 2>/dev/null
+deferred_term_rc=$?
+set -e
+deferred_term_child="$(cat "$DEFERRED_TERM_CHILD_PID" 2>/dev/null || true)"
+case "$deferred_term_child" in
+    ''|*[!0-9]*) ;;
+    *)
+        if kill -0 "$deferred_term_child" 2>/dev/null; then
+            kill -KILL "$deferred_term_child" 2>/dev/null || true
+        fi
+        ;;
+esac
+deferred_term_residue="$(find "$DEFERRED_TERM_TMPDIR" -mindepth 1 -maxdepth 1 -print)"
+if [[ "$deferred_term_started" == "true" && "$deferred_term_stopped" == "true" ]] &&
+   [[ "$deferred_term_rc" -eq 143 && ! -e "$DEFERRED_TERM_FINISHED" && -z "$deferred_term_residue" ]]; then
+    test_pass
+else
+    test_fail "expected TERM to interrupt provider capture promptly: started=$deferred_term_started stopped=$deferred_term_stopped rc=$deferred_term_rc finished=$(test -e "$DEFERRED_TERM_FINISHED" && printf yes || printf no) residue=${deferred_term_residue:-none}"
+fi
+command rm -rf "$DEFERRED_TERM_TMPDIR" "$DEFERRED_TERM_STARTED" "$DEFERRED_TERM_FINISHED" "$DEFERRED_TERM_CHILD_PID"
+
 test_case "cleanup removes only the allocated temp root when TMPDIR is inside another repository"
 CLEANUP_CONTAINER="$TEST_TMP_DIR/cleanup-container"
 CLEANUP_OUTER_REPO="$CLEANUP_CONTAINER/unrelated-repo"
@@ -1471,12 +1635,11 @@ COPY_GUARD_BIN="$TEST_TMP_DIR/copy-guard-bin"
 COPY_GUARD_MARKER="$TEST_TMP_DIR/whole-tree-copy-attempted"
 REAL_CP="$(command -v cp)"
 mkdir -p "$COPY_GUARD_BIN"
-cat > "$COPY_GUARD_BIN/tar" <<'EOF'
-#!/usr/bin/env bash
-exit 97
-EOF
 cat > "$COPY_GUARD_BIN/cp" <<'EOF'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "-pP" ]]; then
+    exit 97
+fi
 for arg in "$@"; do
     if [[ "$arg" == "$SOURCE_ROOT/." ]]; then
         printf 'whole-tree copy attempted\n' > "$COPY_GUARD_MARKER"
@@ -1484,7 +1647,7 @@ for arg in "$@"; do
 done
 exec "$REAL_CP" "$@"
 EOF
-chmod +x "$COPY_GUARD_BIN/tar" "$COPY_GUARD_BIN/cp"
+chmod +x "$COPY_GUARD_BIN/cp"
 if workspace="$(
     export PATH="$COPY_GUARD_BIN:$PATH" REAL_CP COPY_GUARD_MARKER SOURCE_ROOT
     _octopus_prepare_consultative_workspace "$SOURCE_ROOT"


### PR DESCRIPTION
## Description
`_octopus_prepare_consultative_workspace` in `scripts/lib/agent-sync.sh:139` copies the source directory with `cp -a --reflink=auto "${source_root}/." "${workspace}/"` for every advisory (council/consultative) seat, with no exclusion. On a repo with large gitignored vendor/build trees, an N-seat council needs N times the full repository size in `$TMPDIR`, which can exhaust a tmpfs (reported: 7 seats x 5.7 GB against a 7.8 GB tmpfs, where 4.7 GB was gitignored and never read by any seat).

Root cause: `source_root` (`scripts/lib/agent-sync.sh:176`, `$PWD` at call time) is copied whole via `cp -a`, which has no concept of `.gitignore`.

## Fix
Adds `_octopus_copy_git_tracked_tree` (`scripts/lib/agent-sync.sh`), which, when `source_root` is inside a git work tree, pipes `git ls-files -z --cached --others --exclude-standard` through `tar` to populate the workspace with only the tracked plus untracked-but-not-ignored files — the same set a human reviewer would see, and the set option (1) in the issue asked for. If `source_root` is not a git work tree, or the git/tar path fails for any reason, `_octopus_prepare_consultative_workspace` falls back unchanged to the original full `cp -a --reflink=auto` copy, so non-git callers are unaffected.

This is the smallest fix that removes the root cause (copying gitignored bytes nobody reads); it does not add a size-estimate preflight or an exclusion env var, which the issue listed as costlier alternatives.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check (ran `bash -n scripts/*.sh scripts/lib/*.sh`)
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (33/33)
- [ ] OpenClaw registry in sync — not applicable, no command/skill surface changed
- [ ] New skills/commands registered — not applicable
- [ ] Version bump — not applicable, patch-level fix only
- [ ] Documentation updated — not applicable, internal implementation detail
- [ ] CHANGELOG.md updated — left for the release step if/when this merges

## Testing
- New regression test: `tests/unit/test-consultative-workspace-gitignore.sh` — builds a git work tree with a tracked file, a gitignored file, and an untracked-but-not-ignored file, and asserts the workspace produced by `_octopus_prepare_consultative_workspace` contains the first two and excludes the gitignored one; also asserts a non-git source root still gets a full copy. 2/2 pass.
- Existing `tests/unit/test-consultative-agent-dispatch.sh` still passes (8/8) — it stubs this function directly so it does not exercise the new code path, but confirms the surrounding dispatch/cleanup contract is untouched.
- `bash -n` over every script in `scripts/` and `scripts/lib/` passes.
- The full `make test-unit` (292 files) was still executing in the sandboxed session environment at push time (each test spawns subshells and git operations, which is slow there); given the change is narrowly scoped to one function with direct test coverage above, I did not block the push on it. CI will run the full suite on this PR — I'll follow up on any failures there.

## Related Issues
Closes #980


---
_Generated by [Claude Code](https://claude.ai/code/session_01REbbzLaSUtYDV1cunhrp11)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consultative workspaces now exclude Git-ignored content while preserving tracked and other non-ignored files.
  * Nested Git work trees follow their own ignore rules.
  * Git discovery, validation, copy, and symlink safety failures now stop processing instead of falling back to a full copy.
  * Non-Git workspaces continue to use full copies.
  * Repository metadata and environment settings remain excluded from consultative sessions.
  * Interruptions and cancellation now clean up temporary workspace data reliably.

* **Tests**
  * Added coverage for ignored content, nested repositories, symlinks, cleanup, cancellation, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->