### PR TITLE
Prevent Codex updates from evicting active plugin cache

### DIFF
--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,46 +1,24 @@
 # AI Agent Handoff
 
-Last updated: 2026-08-31
-Status: the Codex updater now refuses to replace its versioned plugin cache
-from inside the Codex session using that cache. The fix is committed and
-pushed, and PR #986 is open. Focused tests pass locally and on a disposable
-Linux ARM64 host, and the complete local matrix is green.
-Branch: `fix/codex-update-cache-lifecycle`, based on public `main` at
-`368def22a832cf640bfc1a96811db6834e20c083` (v10.1.0).
-Delivery: PR [#986](https://github.com/nyldn/claude-octopus/pull/986) is open at
-`77df8ea57cfc8d756ae0ac11734dd2112120b825`. No patch release has been
-authorized for this follow-up.
-Current release: [v10.1.0](https://github.com/nyldn/claude-octopus/releases/tag/v10.1.0)
+Last updated: 2026-08-30
+Status: PR #984 contains the install, setup, readiness, dispatch, cost, and
+uninstall simplification. Two findings from the latest exact-head CodeRabbit
+round have verified fixes in the branch head, independent Fable 5 review
+returned PASS/PASS, and the complete local matrix is green. The final head
+still needs exact-head hosted review before merge.
+Branch: `feat/simplify-install-setup-use`, reconciled with `origin/main` at
+`f9b8c92aa228a4b3f6bc9132c6c0a06f3142b73e`.
+Delivery: PR [#984](https://github.com/nyldn/claude-octopus/pull/984) is open.
+Its branch head includes the final reviewed follow-up after
+`d412469ce7345496793849b88b1803a0b23c4d28`.
+Current release: [v10.0.0](https://github.com/nyldn/claude-octopus/releases/tag/v10.0.0)
 Tracking: `bd` is unavailable in this checkout, so no Beads issue was created or
-updated for this fix.
-Next action: wait for exact-head review and hosted checks, then merge. Release
-only with separate authorization.
-
-## Codex Plugin Cache Update Guard
-
-- Root cause: Codex binds hooks and skills to the versioned cache directory it
-  loaded at session start. Updating the plugin can delete that directory while
-  the session still refers to it, causing hook launch failures before the hook
-  script can run.
-- `update-plugin` now detects a Codex runtime environment or Codex process in
-  its parent chain and exits before invoking either cache-replacing Codex
-  command. The message tells the user to exit Codex, update from a separate
-  terminal, and restart Codex.
-- Regression coverage proves Codex ancestry and runtime detection, ordinary
-  terminal behavior, zero host-package-manager calls on refusal, and the
-  existing update sequence outside an active session. The focused suite passes
-  42/42.
-- Remote verification used a disposable clone of the exact v10.1.0 base plus
-  the current patch. The focused suite passed 42/42 on Linux ARM64; Bash syntax
-  and `git diff --check` also passed. No pre-existing remote checkout was
-  changed, and the disposable directory was removed after verification.
-- `CI=true GITHUB_ACTIONS=true make ci-changed` selected the complete matrix and
-  passed 16/16 smoke, 300/300 unit, and 8/8 integration suites, including the
-  CI-only checks. The existing Council macOS PTY and probe dry-run timeout cases
-  remained documented skips.
-- An attempted independent Codex review seat completed without a usable review
-  because stale handoff context polluted its output. It is not counted as an
-  approval. PR #986 remains subject to exact-head review and hosted checks.
+updated for this cleanup.
+Next action: commit and push the review follow-up, resolve the verified review
+threads, wait for exact-head checks and approval, then squash-merge PR #984 and
+run the guarded v10.1.0 release workflow. The user authorized merge, release,
+shared-marketplace publication, and cleanup of only the related worktrees
+proven safe to remove.
 
 ## Install, Setup, and Everyday-Use Simplification
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,24 +1,46 @@
 # AI Agent Handoff
 
-Last updated: 2026-08-30
-Status: PR #984 contains the install, setup, readiness, dispatch, cost, and
-uninstall simplification. Two findings from the latest exact-head CodeRabbit
-round have verified fixes in the branch head, independent Fable 5 review
-returned PASS/PASS, and the complete local matrix is green. The final head
-still needs exact-head hosted review before merge.
-Branch: `feat/simplify-install-setup-use`, reconciled with `origin/main` at
-`f9b8c92aa228a4b3f6bc9132c6c0a06f3142b73e`.
-Delivery: PR [#984](https://github.com/nyldn/claude-octopus/pull/984) is open.
-Its branch head includes the final reviewed follow-up after
-`d412469ce7345496793849b88b1803a0b23c4d28`.
-Current release: [v10.0.0](https://github.com/nyldn/claude-octopus/releases/tag/v10.0.0)
+Last updated: 2026-08-31
+Status: the Codex updater now refuses to replace its versioned plugin cache
+from inside the Codex session using that cache. The fix is committed and
+pushed, and PR #986 is open. Focused tests pass locally and on a disposable
+Linux ARM64 host, and the complete local matrix is green.
+Branch: `fix/codex-update-cache-lifecycle`, based on public `main` at
+`368def22a832cf640bfc1a96811db6834e20c083` (v10.1.0).
+Delivery: PR [#986](https://github.com/nyldn/claude-octopus/pull/986) is open at
+`77df8ea57cfc8d756ae0ac11734dd2112120b825`. No patch release has been
+authorized for this follow-up.
+Current release: [v10.1.0](https://github.com/nyldn/claude-octopus/releases/tag/v10.1.0)
 Tracking: `bd` is unavailable in this checkout, so no Beads issue was created or
-updated for this cleanup.
-Next action: commit and push the review follow-up, resolve the verified review
-threads, wait for exact-head checks and approval, then squash-merge PR #984 and
-run the guarded v10.1.0 release workflow. The user authorized merge, release,
-shared-marketplace publication, and cleanup of only the related worktrees
-proven safe to remove.
+updated for this fix.
+Next action: wait for exact-head review and hosted checks, then merge. Release
+only with separate authorization.
+
+## Codex Plugin Cache Update Guard
+
+- Root cause: Codex binds hooks and skills to the versioned cache directory it
+  loaded at session start. Updating the plugin can delete that directory while
+  the session still refers to it, causing hook launch failures before the hook
+  script can run.
+- `update-plugin` now detects a Codex runtime environment or Codex process in
+  its parent chain and exits before invoking either cache-replacing Codex
+  command. The message tells the user to exit Codex, update from a separate
+  terminal, and restart Codex.
+- Regression coverage proves Codex ancestry and runtime detection, ordinary
+  terminal behavior, zero host-package-manager calls on refusal, and the
+  existing update sequence outside an active session. The focused suite passes
+  42/42.
+- Remote verification used a disposable clone of the exact v10.1.0 base plus
+  the current patch. The focused suite passed 42/42 on Linux ARM64; Bash syntax
+  and `git diff --check` also passed. No pre-existing remote checkout was
+  changed, and the disposable directory was removed after verification.
+- `CI=true GITHUB_ACTIONS=true make ci-changed` selected the complete matrix and
+  passed 16/16 smoke, 300/300 unit, and 8/8 integration suites, including the
+  CI-only checks. The existing Council macOS PTY and probe dry-run timeout cases
+  remained documented skips.
+- An attempted independent Codex review seat completed without a usable review
+  because stale handoff context polluted its output. It is not counted as an
+  approval. PR #986 remains subject to exact-head review and hosted checks.
 
 ## Install, Setup, and Everyday-Use Simplification
 
@@ -1426,11 +1448,11 @@ record.
 - Real host verification upgraded and enabled both `octo@nyldn-plugins` and
   `claude-octopus@nyldn-plugins` at v9.61.3. The stable
   `~/.claude-octopus/plugin` link resolves to the v9.61.3 Claude cache.
-- **Post-release #865:** The Oracle `amy` E2E runner still asserted direct
+- **Post-release #865:** The Linux ARM64 E2E runner still asserted direct
   Gemini detection and probed Gemini after the provider was retired. Its
   durable source is the separate `nyldn/claude-octopus-dev` repository. PR #5
   there squash-merged as `218c3a7f` and the exact merged tree was deployed to
-  `~/.octopus-e2e/e2e-command-test.sh` on `amy`.
+  `~/.octopus-e2e/e2e-command-test.sh` on that runner.
 - The runner now asserts an `agy:*` registration with no executable `gemini:*`
   seat, probes AGY rather than Gemini, and classifies approval, weekly/session
   limit, quota, auth, and capacity responses as infrastructure skips. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   isolates normal sessions while treating fallback and checksum collisions as a
   best-effort edge case; an explicit `--output-dir` is honored unchanged. Set
   `OCTOPUS_COUNCIL_SHARED_POOL=1` to restore the flat shared pool.
+- Refuse Codex plugin updates from inside the Codex session using the loaded
+  version. This prevents cache replacement from deleting hook and skill paths
+  that remain bound to the running session.
 
 ## [10.1.0] - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -155,12 +155,16 @@ codex plugin add claude-octopus@nyldn-plugins
 Restart Codex. Skills appear automatically — invoke with `$skill-doctor`, `$skill-debug`, etc.
 
 Codex owns the versioned cache. To refresh an existing installation without
-editing cache files or symlinks directly:
+editing cache files or symlinks directly, exit Codex and run these commands in
+a separate terminal:
 
 ```bash
 codex plugin marketplace upgrade nyldn-plugins
 codex plugin add claude-octopus@nyldn-plugins
 ```
+
+Restart Codex after the update. Replacing the cache from the session that is
+using it can leave hooks and skills bound to a removed version directory.
 
 </details>
 

--- a/docs/PLUGIN-UPDATES.md
+++ b/docs/PLUGIN-UPDATES.md
@@ -51,6 +51,12 @@ session still has hooks and skills bound to that path. `update-plugin` detects
 this condition and exits before either Codex update command runs. Exit Codex,
 run the printed commands from a separate terminal, and then start Codex again.
 
+If the updater cannot inspect process ancestry from that separate terminal, it
+fails closed without changing the cache. After confirming the terminal is not
+owned by a running Codex session, set
+`OCTOPUS_CODEX_ACTIVE_SESSION=false` for that update command only. Definitive
+Codex runtime markers still block the update even when this override is set.
+
 On the next session, Octopus compares the stable
 `~/.claude-octopus/plugin` entrypoint with the version supplied by the host and
 repairs it when they differ. The check uses physical paths, so an older cache

--- a/docs/PLUGIN-UPDATES.md
+++ b/docs/PLUGIN-UPDATES.md
@@ -29,7 +29,8 @@ fingerprint can be reported immediately.
 - Claude Code refreshes `nyldn-plugins`, then updates
   `octo@nyldn-plugins`.
 - Codex upgrades `nyldn-plugins`, then refreshes
-  `claude-octopus@nyldn-plugins`.
+  `claude-octopus@nyldn-plugins`, but only when the command is run outside an
+  active Codex session.
 - Factory and standalone installs receive host-specific/manual guidance instead
   of an assumed command.
 
@@ -43,6 +44,12 @@ Claude Code may download an update in the background, but the current process
 continues using the plugin version it loaded at session start. Run
 `/reload-plugins` or restart Claude Code after an update; restart Codex after a
 Codex plugin update.
+
+Do not replace the installed plugin from a terminal owned by the Codex session
+that is using it. Codex can remove the old versioned cache directory while the
+session still has hooks and skills bound to that path. `update-plugin` detects
+this condition and exits before either Codex update command runs. Exit Codex,
+run the printed commands from a separate terminal, and then start Codex again.
 
 On the next session, Octopus compares the stable
 `~/.claude-octopus/plugin` entrypoint with the version supplied by the host and

--- a/scripts/lib/plugin-update.sh
+++ b/scripts/lib/plugin-update.sh
@@ -96,10 +96,11 @@ octo_plugin_running_inside_codex() {
 
     command -v ps >/dev/null 2>&1 || return 2
     [[ "$process_pid" =~ ^[0-9]+$ ]] || return 2
+    [[ "$process_pid" -gt 1 ]] || return 2
     while [[ "$process_pid" -gt 1 ]]; do
         [[ "$depth" -lt 12 ]] || return 2
         process_name="$(ps -o comm= -p "$process_pid" 2>/dev/null)" || return 2
-        process_name="${process_name//[[:space:]]/}"
+        process_name="$(printf '%s' "$process_name" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
         [[ -n "$process_name" ]] || return 2
         process_name="${process_name##*/}"
         case "$process_name" in

--- a/scripts/lib/plugin-update.sh
+++ b/scripts/lib/plugin-update.sh
@@ -86,17 +86,21 @@ octo_plugin_running_inside_codex() {
 
     case "$override" in
         true|1|yes) return 0 ;;
-        false|0|no) return 1 ;;
     esac
 
     [[ -n "${CODEX_SANDBOX:-}" || -n "${CODEX_PLUGIN_ROOT:-}" ]] && return 0
+
+    case "$override" in
+        false|0|no) return 1 ;;
+    esac
 
     command -v ps >/dev/null 2>&1 || return 2
     [[ "$process_pid" =~ ^[0-9]+$ ]] || return 2
     while [[ "$process_pid" -gt 1 ]]; do
         [[ "$depth" -lt 12 ]] || return 2
         process_name="$(ps -o comm= -p "$process_pid" 2>/dev/null)" || return 2
-        [[ -n "${process_name//[[:space:]]/}" ]] || return 2
+        process_name="${process_name//[[:space:]]/}"
+        [[ -n "$process_name" ]] || return 2
         process_name="${process_name##*/}"
         case "$process_name" in
             codex|codex.exe) return 0 ;;

--- a/scripts/lib/plugin-update.sh
+++ b/scripts/lib/plugin-update.sh
@@ -91,17 +91,21 @@ octo_plugin_running_inside_codex() {
 
     [[ -n "${CODEX_SANDBOX:-}" || -n "${CODEX_PLUGIN_ROOT:-}" ]] && return 0
 
-    command -v ps >/dev/null 2>&1 || return 1
-    while [[ "$process_pid" =~ ^[0-9]+$ && "$process_pid" -gt 1 && "$depth" -lt 12 ]]; do
-        process_name="$(ps -o comm= -p "$process_pid" 2>/dev/null || true)"
+    command -v ps >/dev/null 2>&1 || return 2
+    [[ "$process_pid" =~ ^[0-9]+$ ]] || return 2
+    while [[ "$process_pid" -gt 1 ]]; do
+        [[ "$depth" -lt 12 ]] || return 2
+        process_name="$(ps -o comm= -p "$process_pid" 2>/dev/null)" || return 2
+        [[ -n "${process_name//[[:space:]]/}" ]] || return 2
         process_name="${process_name##*/}"
         case "$process_name" in
             codex|codex.exe) return 0 ;;
         esac
 
-        parent_pid="$(ps -o ppid= -p "$process_pid" 2>/dev/null || true)"
+        parent_pid="$(ps -o ppid= -p "$process_pid" 2>/dev/null)" || return 2
         parent_pid="${parent_pid//[[:space:]]/}"
-        [[ "$parent_pid" =~ ^[0-9]+$ && "$parent_pid" != "$process_pid" ]] || break
+        [[ "$parent_pid" =~ ^[0-9]+$ ]] || return 2
+        [[ "$parent_pid" != "$process_pid" ]] || return 2
         process_pid="$parent_pid"
         depth=$((depth + 1))
     done
@@ -203,7 +207,7 @@ ${OCTO_PLUGIN_CACHE_VERSION}")"
 octo_plugin_update_run() {
     local plugin_root="${1:-${CLAUDE_PLUGIN_ROOT:-}}"
     local host="${2:-$(octo_plugin_detect_host "$plugin_root")}"
-    local expected_before="unknown" expected_after="unknown"
+    local expected_before="unknown" expected_after="unknown" codex_session_rc=0
 
     octo_plugin_update_load "$plugin_root" "$host"
     expected_before="$OCTO_PLUGIN_NEWEST_VERSION"
@@ -227,12 +231,19 @@ ${OCTO_PLUGIN_CATALOG_VERSION}")"
             printf 'Run /reload-plugins or restart Claude Code before continuing.\n'
             ;;
         codex)
-            if octo_plugin_running_inside_codex ""; then
+            octo_plugin_running_inside_codex "" || codex_session_rc=$?
+            if [[ "$codex_session_rc" -eq 0 ]]; then
                 printf '%s\n' \
                     'Claude Octopus will not replace its plugin cache from inside the running Codex session.' \
                     'Exit Codex, run the update outside the running Codex session, then start Codex again:' \
                     '  codex plugin marketplace upgrade nyldn-plugins' \
                     '  codex plugin add claude-octopus@nyldn-plugins' >&2
+                return 2
+            fi
+            if [[ "$codex_session_rc" -ne 1 ]]; then
+                printf '%s\n' \
+                    'Claude Octopus could not safely determine whether this terminal belongs to a running Codex session.' \
+                    'No update was attempted. Run the update from a separate terminal, or set OCTOPUS_CODEX_ACTIVE_SESSION=false there.' >&2
                 return 2
             fi
             if ! command -v codex >/dev/null 2>&1; then

--- a/scripts/lib/plugin-update.sh
+++ b/scripts/lib/plugin-update.sh
@@ -80,6 +80,35 @@ octo_plugin_detect_host() {
     fi
 }
 
+octo_plugin_running_inside_codex() {
+    local override="${OCTOPUS_CODEX_ACTIVE_SESSION:-auto}"
+    local process_pid="${1:-${PPID:-}}" process_name="" parent_pid="" depth=0
+
+    case "$override" in
+        true|1|yes) return 0 ;;
+        false|0|no) return 1 ;;
+    esac
+
+    [[ -n "${CODEX_SANDBOX:-}" || -n "${CODEX_PLUGIN_ROOT:-}" ]] && return 0
+
+    command -v ps >/dev/null 2>&1 || return 1
+    while [[ "$process_pid" =~ ^[0-9]+$ && "$process_pid" -gt 1 && "$depth" -lt 12 ]]; do
+        process_name="$(ps -o comm= -p "$process_pid" 2>/dev/null || true)"
+        process_name="${process_name##*/}"
+        case "$process_name" in
+            codex|codex.exe) return 0 ;;
+        esac
+
+        parent_pid="$(ps -o ppid= -p "$process_pid" 2>/dev/null || true)"
+        parent_pid="${parent_pid//[[:space:]]/}"
+        [[ "$parent_pid" =~ ^[0-9]+$ && "$parent_pid" != "$process_pid" ]] || break
+        process_pid="$parent_pid"
+        depth=$((depth + 1))
+    done
+
+    return 1
+}
+
 octo_plugin_update_load() {
     local plugin_root="${1:-${CLAUDE_PLUGIN_ROOT:-}}"
     local requested_host="${2:-}"
@@ -198,6 +227,14 @@ ${OCTO_PLUGIN_CATALOG_VERSION}")"
             printf 'Run /reload-plugins or restart Claude Code before continuing.\n'
             ;;
         codex)
+            if octo_plugin_running_inside_codex ""; then
+                printf '%s\n' \
+                    'Claude Octopus will not replace its plugin cache from inside the running Codex session.' \
+                    'Exit Codex, run the update outside the running Codex session, then start Codex again:' \
+                    '  codex plugin marketplace upgrade nyldn-plugins' \
+                    '  codex plugin add claude-octopus@nyldn-plugins' >&2
+                return 2
+            fi
             if ! command -v codex >/dev/null 2>&1; then
                 printf 'Codex CLI is not available; update through the Codex plugin manager instead.\n' >&2
                 return 1

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -170,8 +170,9 @@ plugin manager. This command performs network and package-manager work, so it
 only runs when explicitly requested; SessionStart hooks and doctor diagnostics
 never invoke it.
 
-After Claude Code updates, run /reload-plugins or restart. After Codex updates,
-restart Codex. A stale process cannot replace the plugin code it already loaded.
+After Claude Code updates, run /reload-plugins or restart. For Codex, exit the
+active session first, run this command from a separate terminal, and then start
+Codex again. The updater refuses to replace files used by its own Codex session.
 EOF
             ;;
         embrace)

--- a/tests/unit/fixtures/env-var-effects.tsv
+++ b/tests/unit/fixtures/env-var-effects.tsv
@@ -21,6 +21,7 @@ OCTOPUS_AGY_MODEL	covered-by	test-agy-provider.sh
 OCTOPUS_AUTO_TITLE	skip	sets the Claude Code session title; observable only in the host UI
 OCTOPUS_AUTO_ROUTER_MODE	covered-by	test-explicit-activation.sh
 OCTOPUS_CLAUDE_SDK_MODEL	covered-by	test-claude-sdk-provider.sh
+OCTOPUS_CODEX_ACTIVE_SESSION	covered-by	test-plugin-update-health.sh
 OCTOPUS_CODEX_MODEL	covered-by	test-role-mapping-v929.sh
 OCTOPUS_COMMANDCODE_ALLOWED_MODELS	skip	allowlist for a provider with no CLI on CI runners
 OCTOPUS_COMMANDCODE_BIN	covered-by	test-commandcode-harness.sh

--- a/tests/unit/test-plugin-update-health.sh
+++ b/tests/unit/test-plugin-update-health.sh
@@ -155,6 +155,8 @@ case "${OCTO_TEST_PS_MODE:-}:$pid:$format" in
     terminal-tree:420:comm=) printf '/usr/sbin/sshd\n' ;;
     terminal-tree:420:ppid=) printf '1\n' ;;
     empty-comm:410:comm=) printf '   \n' ;;
+    internal-space:410:comm=) printf '/tmp/code x\n' ;;
+    internal-space:410:ppid=) printf '1\n' ;;
     terminal-any:*:comm=) printf '/bin/zsh\n' ;;
     terminal-any:*:ppid=) printf '1\n' ;;
     *) exit 1 ;;
@@ -194,13 +196,28 @@ octo_plugin_running_inside_codex 410 || process_rc=$?
 if [[ "$process_rc" -eq 2 ]]; then test_pass; else test_fail "expected inspection rc=2, got $process_rc"; fi
 unset -f ps
 
+EMPTY_PROCESS_PATH="$PATH"
+PATH="$FAKE_BIN:$PATH"
 OCTO_TEST_PS_MODE=empty-comm
 export OCTO_TEST_PS_MODE
 empty_process_rc=0
 octo_plugin_running_inside_codex 410 || empty_process_rc=$?
 test_case "empty process inspection is reported as unknown"
 if [[ "$empty_process_rc" -eq 2 ]]; then test_pass; else test_fail "expected empty-process rc=2, got $empty_process_rc"; fi
+
+OCTO_TEST_PS_MODE=internal-space
+export OCTO_TEST_PS_MODE
+internal_space_rc=0
+octo_plugin_running_inside_codex 410 || internal_space_rc=$?
+test_case "internal process-name whitespace does not impersonate Codex"
+if [[ "$internal_space_rc" -eq 1 ]]; then test_pass; else test_fail "expected ordinary-process rc=1, got $internal_space_rc"; fi
 unset OCTO_TEST_PS_MODE
+PATH="$EMPTY_PROCESS_PATH"
+
+initial_pid_rc=0
+octo_plugin_running_inside_codex 1 || initial_pid_rc=$?
+test_case "uninspectable initial parent pid is reported as unknown"
+if [[ "$initial_pid_rc" -eq 2 ]]; then test_pass; else test_fail "expected initial-pid rc=2, got $initial_pid_rc"; fi
 
 CODEX_SANDBOX=workspace-write
 export CODEX_SANDBOX

--- a/tests/unit/test-plugin-update-health.sh
+++ b/tests/unit/test-plugin-update-health.sh
@@ -148,7 +148,7 @@ pid="$4"
 case "${OCTO_TEST_PS_MODE:-}:$pid:$format" in
     codex-tree:410:comm=) printf '/bin/zsh\n' ;;
     codex-tree:410:ppid=) printf '420\n' ;;
-    codex-tree:420:comm=) printf '/usr/local/bin/codex\n' ;;
+    codex-tree:420:comm=) printf '  /usr/local/bin/codex  \n' ;;
     codex-tree:420:ppid=) printf '1\n' ;;
     terminal-tree:410:comm=) printf '/bin/zsh\n' ;;
     terminal-tree:410:ppid=) printf '420\n' ;;
@@ -168,7 +168,7 @@ export OCTO_TEST_PS_MODE
 test_case "process ancestry detects a running Codex session"
 if octo_plugin_running_inside_codex 410; then test_pass; else test_fail "Codex ancestor was not detected"; fi
 
-OCTO_TEST_PS_MODE=terminal-any
+OCTO_TEST_PS_MODE=terminal-tree
 export OCTO_TEST_PS_MODE
 test_case "ordinary terminal ancestry is not a Codex session"
 terminal_rc=0
@@ -293,11 +293,30 @@ fi
 unset OCTOPUS_CODEX_ACTIVE_SESSION
 
 : > "$CALL_LOG"
+OCTOPUS_CODEX_ACTIVE_SESSION=false
+CODEX_SANDBOX=workspace-write
+export OCTOPUS_CODEX_ACTIVE_SESSION CODEX_SANDBOX
+CODEX_MARKER_OUTPUT=""
+test_case "active Codex runtime marker overrides a false session override"
+if CODEX_MARKER_OUTPUT="$(octo_plugin_update_run "$PLUGIN_ROOT" codex 2>&1)"; then
+    test_fail "false override bypassed a definitive Codex runtime marker"
+elif [[ -s "$CALL_LOG" ]]; then
+    test_fail "marker-proven Codex session invoked the host package manager"
+elif assert_contains "$CODEX_MARKER_OUTPUT" "outside the running Codex session"; then
+    test_pass
+fi
+unset OCTOPUS_CODEX_ACTIVE_SESSION CODEX_SANDBOX
+
+: > "$CALL_LOG"
 ps() { return 127; }
 CODEX_INSPECTION_OUTPUT=""
+CODEX_INSPECTION_RC=0
 test_case "unknown Codex ancestry refuses cache-replacing update"
-if CODEX_INSPECTION_OUTPUT="$(octo_plugin_update_run "$PLUGIN_ROOT" codex 2>&1)"; then
+CODEX_INSPECTION_OUTPUT="$(octo_plugin_update_run "$PLUGIN_ROOT" codex 2>&1)" || CODEX_INSPECTION_RC=$?
+if [[ "$CODEX_INSPECTION_RC" -eq 0 ]]; then
     test_fail "update proceeded without a reliable Codex ancestry check"
+elif [[ "$CODEX_INSPECTION_RC" -ne 2 ]]; then
+    test_fail "unknown Codex ancestry returned $CODEX_INSPECTION_RC instead of 2"
 elif [[ -s "$CALL_LOG" ]]; then
     test_fail "unknown Codex ancestry invoked the host package manager"
 elif assert_contains "$CODEX_INSPECTION_OUTPUT" "could not safely determine"; then

--- a/tests/unit/test-plugin-update-health.sh
+++ b/tests/unit/test-plugin-update-health.sh
@@ -154,6 +154,8 @@ case "${OCTO_TEST_PS_MODE:-}:$pid:$format" in
     terminal-tree:410:ppid=) printf '420\n' ;;
     terminal-tree:420:comm=) printf '/usr/sbin/sshd\n' ;;
     terminal-tree:420:ppid=) printf '1\n' ;;
+    terminal-any:*:comm=) printf '/bin/zsh\n' ;;
+    terminal-any:*:ppid=) printf '1\n' ;;
     *) exit 1 ;;
 esac
 EOF
@@ -166,12 +168,30 @@ export OCTO_TEST_PS_MODE
 test_case "process ancestry detects a running Codex session"
 if octo_plugin_running_inside_codex 410; then test_pass; else test_fail "Codex ancestor was not detected"; fi
 
-OCTO_TEST_PS_MODE=terminal-tree
+OCTO_TEST_PS_MODE=terminal-any
 export OCTO_TEST_PS_MODE
 test_case "ordinary terminal ancestry is not a Codex session"
-if octo_plugin_running_inside_codex 410; then test_fail "ordinary terminal was mistaken for Codex"; else test_pass; fi
+terminal_rc=0
+octo_plugin_running_inside_codex 410 || terminal_rc=$?
+if [[ "$terminal_rc" -eq 1 ]]; then test_pass; else test_fail "expected outside-session rc=1, got $terminal_rc"; fi
 unset OCTO_TEST_PS_MODE
 PATH="$PROCESS_TEST_PATH"
+
+NO_PS_PATH="$TEST_TMP_DIR/no-ps-bin"
+mkdir -p "$NO_PS_PATH"
+PATH="$NO_PS_PATH"
+missing_ps_rc=0
+octo_plugin_running_inside_codex 410 || missing_ps_rc=$?
+PATH="$PROCESS_TEST_PATH"
+test_case "missing process inspector is reported as unknown"
+if [[ "$missing_ps_rc" -eq 2 ]]; then test_pass; else test_fail "expected missing-ps rc=2, got $missing_ps_rc"; fi
+
+ps() { return 127; }
+test_case "failed process inspection is reported as unknown"
+process_rc=0
+octo_plugin_running_inside_codex 410 || process_rc=$?
+if [[ "$process_rc" -eq 2 ]]; then test_pass; else test_fail "expected inspection rc=2, got $process_rc"; fi
+unset -f ps
 
 CODEX_SANDBOX=workspace-write
 export CODEX_SANDBOX
@@ -272,6 +292,35 @@ elif assert_contains "$CODEX_ACTIVE_OUTPUT" "outside the running Codex session";
 fi
 unset OCTOPUS_CODEX_ACTIVE_SESSION
 
+: > "$CALL_LOG"
+ps() { return 127; }
+CODEX_INSPECTION_OUTPUT=""
+test_case "unknown Codex ancestry refuses cache-replacing update"
+if CODEX_INSPECTION_OUTPUT="$(octo_plugin_update_run "$PLUGIN_ROOT" codex 2>&1)"; then
+    test_fail "update proceeded without a reliable Codex ancestry check"
+elif [[ -s "$CALL_LOG" ]]; then
+    test_fail "unknown Codex ancestry invoked the host package manager"
+elif assert_contains "$CODEX_INSPECTION_OUTPUT" "could not safely determine"; then
+    test_pass
+fi
+unset -f ps
+
+: > "$CALL_LOG"
+AUTOMATIC_UPDATE_PATH="$PATH"
+PATH="$FAKE_BIN:$PATH"
+OCTO_TEST_PS_MODE=terminal-any
+export OCTO_TEST_PS_MODE
+unset CODEX_SANDBOX CODEX_PLUGIN_ROOT OCTOPUS_CODEX_ACTIVE_SESSION
+test_case "automatic ancestry check permits an ordinary terminal update"
+if octo_plugin_update_run "$PLUGIN_ROOT" codex >/dev/null && [[ -s "$CALL_LOG" ]]; then
+    test_pass
+else
+    test_fail "ordinary terminal update did not reach the host package manager"
+fi
+unset OCTO_TEST_PS_MODE
+PATH="$AUTOMATIC_UPDATE_PATH"
+
+: > "$CALL_LOG"
 OCTOPUS_CODEX_ACTIVE_SESSION=false
 export OCTOPUS_CODEX_ACTIVE_SESSION
 octo_plugin_update_run "$PLUGIN_ROOT" codex >/dev/null

--- a/tests/unit/test-plugin-update-health.sh
+++ b/tests/unit/test-plugin-update-health.sh
@@ -141,6 +141,44 @@ EOF
     chmod +x "$FAKE_BIN/$command_name"
 done
 
+cat > "$FAKE_BIN/ps" <<'EOF'
+#!/usr/bin/env bash
+format="$2"
+pid="$4"
+case "${OCTO_TEST_PS_MODE:-}:$pid:$format" in
+    codex-tree:410:comm=) printf '/bin/zsh\n' ;;
+    codex-tree:410:ppid=) printf '420\n' ;;
+    codex-tree:420:comm=) printf '/usr/local/bin/codex\n' ;;
+    codex-tree:420:ppid=) printf '1\n' ;;
+    terminal-tree:410:comm=) printf '/bin/zsh\n' ;;
+    terminal-tree:410:ppid=) printf '420\n' ;;
+    terminal-tree:420:comm=) printf '/usr/sbin/sshd\n' ;;
+    terminal-tree:420:ppid=) printf '1\n' ;;
+    *) exit 1 ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/ps"
+
+PROCESS_TEST_PATH="$PATH"
+PATH="$FAKE_BIN:$PATH"
+OCTO_TEST_PS_MODE=codex-tree
+export OCTO_TEST_PS_MODE
+test_case "process ancestry detects a running Codex session"
+if octo_plugin_running_inside_codex 410; then test_pass; else test_fail "Codex ancestor was not detected"; fi
+
+OCTO_TEST_PS_MODE=terminal-tree
+export OCTO_TEST_PS_MODE
+test_case "ordinary terminal ancestry is not a Codex session"
+if octo_plugin_running_inside_codex 410; then test_fail "ordinary terminal was mistaken for Codex"; else test_pass; fi
+unset OCTO_TEST_PS_MODE
+PATH="$PROCESS_TEST_PATH"
+
+CODEX_SANDBOX=workspace-write
+export CODEX_SANDBOX
+test_case "Codex runtime environment identifies an active session"
+if octo_plugin_running_inside_codex 410; then test_pass; else test_fail "CODEX_SANDBOX was not detected"; fi
+unset CODEX_SANDBOX
+
 write_marketplace_state '{"nyldn-plugins":{"autoUpdate":false}}'
 touch "$STATE_DIR/.setup-complete"
 HOOK_OUTPUT=$(env \
@@ -221,7 +259,23 @@ octo_plugin_update_load "$PLUGIN_ROOT" claude
 if assert_equals "1.2.0" "$OCTO_PLUGIN_INSTALLED_VERSION"; then test_pass; fi
 
 : > "$CALL_LOG"
+OCTOPUS_CODEX_ACTIVE_SESSION=true
+export OCTOPUS_CODEX_ACTIVE_SESSION
+CODEX_ACTIVE_OUTPUT=""
+test_case "active Codex session refuses cache-replacing update"
+if CODEX_ACTIVE_OUTPUT="$(octo_plugin_update_run "$PLUGIN_ROOT" codex 2>&1)"; then
+    test_fail "active Codex session unexpectedly replaced its loaded plugin"
+elif [[ -s "$CALL_LOG" ]]; then
+    test_fail "active Codex session invoked the host package manager"
+elif assert_contains "$CODEX_ACTIVE_OUTPUT" "outside the running Codex session"; then
+    test_pass
+fi
+unset OCTOPUS_CODEX_ACTIVE_SESSION
+
+OCTOPUS_CODEX_ACTIVE_SESSION=false
+export OCTOPUS_CODEX_ACTIVE_SESSION
 octo_plugin_update_run "$PLUGIN_ROOT" codex >/dev/null
+unset OCTOPUS_CODEX_ACTIVE_SESSION
 CODEX_CALLS="$(cat "$CALL_LOG")"
 test_case "explicit Codex update refreshes marketplace"
 if assert_contains "$CODEX_CALLS" "plugin marketplace upgrade nyldn-plugins"; then test_pass; fi

--- a/tests/unit/test-plugin-update-health.sh
+++ b/tests/unit/test-plugin-update-health.sh
@@ -154,6 +154,7 @@ case "${OCTO_TEST_PS_MODE:-}:$pid:$format" in
     terminal-tree:410:ppid=) printf '420\n' ;;
     terminal-tree:420:comm=) printf '/usr/sbin/sshd\n' ;;
     terminal-tree:420:ppid=) printf '1\n' ;;
+    empty-comm:410:comm=) printf '   \n' ;;
     terminal-any:*:comm=) printf '/bin/zsh\n' ;;
     terminal-any:*:ppid=) printf '1\n' ;;
     *) exit 1 ;;
@@ -192,6 +193,14 @@ process_rc=0
 octo_plugin_running_inside_codex 410 || process_rc=$?
 if [[ "$process_rc" -eq 2 ]]; then test_pass; else test_fail "expected inspection rc=2, got $process_rc"; fi
 unset -f ps
+
+OCTO_TEST_PS_MODE=empty-comm
+export OCTO_TEST_PS_MODE
+empty_process_rc=0
+octo_plugin_running_inside_codex 410 || empty_process_rc=$?
+test_case "empty process inspection is reported as unknown"
+if [[ "$empty_process_rc" -eq 2 ]]; then test_pass; else test_fail "expected empty-process rc=2, got $empty_process_rc"; fi
+unset OCTO_TEST_PS_MODE
 
 CODEX_SANDBOX=workspace-write
 export CODEX_SANDBOX


### PR DESCRIPTION
## Summary

- stop `update-plugin` before it replaces the versioned cache used by its own Codex session
- detect Codex through runtime markers or process ancestry while preserving updates from ordinary terminals
- explain the required exit, update, and restart sequence in user guidance
- remove machine-specific names from the public handoff

## Verification

- `bash tests/unit/test-plugin-update-health.sh` (42/42)
- disposable Linux ARM64 checkout: focused suite 42/42, Bash syntax, and `git diff --check`
- `CI=true GITHUB_ACTIONS=true make ci-changed` (16/16 smoke, 300/300 unit, 8/8 integration)
- `make sync-check`
- `git diff --check`

The two documented platform and dry-run skips remain unchanged. No release is included in this pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented plugin updates from replacing files during an active Codex session.
  - Updates now fail safely when the session status cannot be determined.

- **Documentation**
  - Clarified that users must exit Codex, run updates from a separate terminal, and restart Codex afterward.
  - Added guidance for safely overriding session detection when appropriate.
  - Corrected the documented E2E runner for the v9.61.3 post-release note.

- **Tests**
  - Added coverage for active-session detection, safe blocking, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->