### PR TITLE
fix: harden provider routing and reasoning edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
   missing synthesis is surfaced via a new `summary.json quorum.chair_synthesis_available`
   flag and an end-of-run warning, and the run stops before synthesis with a clear
   message directing the operator to the per-seat verdicts in `responses/`.
+- Harden provider/model routing and OpenAI-compatible reasoning handling: canonicalize route-provider aliases, let cross-provider legacy role routes fall through to matching phase routes, preserve Bash 3.2-compatible execution-profile overrides, normalize `xhigh`/`max` reasoning to `high`, and only drop `reasoning_effort` when the API specifically rejects that field.
 
 ## [10.1.0] - 2026-08-30
 

--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import argparse, json, os, subprocess, sys, time, urllib.parse, urllib.request, urllib.error
+import argparse, json, os, re, subprocess, sys, time, urllib.parse, urllib.request, urllib.error
 from pathlib import Path
 
 PROVIDERS = {
@@ -127,6 +127,19 @@ def normalize_reasoning_effort(value):
     return value
 
 
+def rejects_reasoning_effort(body_text):
+    text = body_text.lower()
+    field = r"reasoning(?:_effort| effort|-effort)"
+    kind = r"(?:field|parameter|argument|property)"
+    rejection = r"(?:unsupported|not supported|unrecognized|unknown|unexpected|not allowed|not permitted)"
+    patterns = (
+        rf"{rejection}\s+{kind}\s*:?\s*[\"'`]?{field}",
+        rf"{kind}\s+[\"'`]?{field}[\"'`]?\s+(?:is\s+)?{rejection}",
+        rf"{field}[\"'`]?\s+(?:{kind}\s+)?(?:is\s+)?{rejection}",
+    )
+    return any(re.search(pattern, text) for pattern in patterns)
+
+
 def api_call(base_url, key, model, headers_extra, messages, max_tokens=0, request_timeout=60.0, max_retries=3, reasoning_effort=None, reasoning_policy="best_effort", tool_policy="auto"):
     payload = {"model": model, "messages": messages, "temperature": 0}
     if tool_policy == "auto":
@@ -159,7 +172,7 @@ def api_call(base_url, key, model, headers_extra, messages, max_tokens=0, reques
                 reasoning_effort
                 and reasoning_policy == "best_effort"
                 and e.code in {400, 422}
-                and any(token in body_text.lower() for token in ("reasoning_effort", "reasoning effort", "reasoning-effort"))
+                and rejects_reasoning_effort(body_text)
             ):
                 print("chat_reasoning_fallback unsupported reasoning_effort; retrying without it", file=sys.stderr)
                 return api_call(

--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -120,6 +120,13 @@ def tool_exec(cwd: Path, name: str, args: dict) -> str:
     except Exception as e:
         return f"ERROR: {type(e).__name__}: {e}"
 
+
+def normalize_reasoning_effort(value):
+    if value in {"xhigh", "max"}:
+        return "high"
+    return value
+
+
 def api_call(base_url, key, model, headers_extra, messages, max_tokens=0, request_timeout=60.0, max_retries=3, reasoning_effort=None, reasoning_policy="best_effort", tool_policy="auto"):
     payload = {"model": model, "messages": messages, "temperature": 0}
     if tool_policy == "auto":
@@ -152,7 +159,7 @@ def api_call(base_url, key, model, headers_extra, messages, max_tokens=0, reques
                 reasoning_effort
                 and reasoning_policy == "best_effort"
                 and e.code in {400, 422}
-                and any(token in body_text.lower() for token in ("reasoning_effort", "reasoning effort", "reasoning"))
+                and any(token in body_text.lower() for token in ("reasoning_effort", "reasoning effort", "reasoning-effort"))
             ):
                 print("chat_reasoning_fallback unsupported reasoning_effort; retrying without it", file=sys.stderr)
                 return api_call(
@@ -214,11 +221,13 @@ def main() -> int:
     ]
     print(f"provider={args.provider} base_url={base_url} model={model} cwd={cwd}", file=sys.stderr)
     requested_reasoning = args.reasoning_effort or "none"
-    print(f"chat_reasoning requested={requested_reasoning} policy={args.reasoning_policy}", file=sys.stderr)
+    effective_reasoning = normalize_reasoning_effort(args.reasoning_effort)
+    effective_label = effective_reasoning or "none"
+    print(f"chat_reasoning requested={requested_reasoning} effective={effective_label} policy={args.reasoning_policy}", file=sys.stderr)
     turn = 0
     while True:
         turn += 1
-        d = api_call(base_url, key, model, cfg.get("headers", {}), messages, max_tokens=max_tokens, request_timeout=request_timeout, max_retries=max_retries, reasoning_effort=args.reasoning_effort, reasoning_policy=args.reasoning_policy, tool_policy=args.tool_policy)
+        d = api_call(base_url, key, model, cfg.get("headers", {}), messages, max_tokens=max_tokens, request_timeout=request_timeout, max_retries=max_retries, reasoning_effort=effective_reasoning, reasoning_policy=args.reasoning_policy, tool_policy=args.tool_policy)
         ch = d.get("choices", [{}])[0]; msg = ch.get("message", {})
         finish = ch.get("finish_reason")
         raw_content = msg.get("content")

--- a/scripts/helpers/openai-compatible-agent.py
+++ b/scripts/helpers/openai-compatible-agent.py
@@ -129,7 +129,7 @@ def normalize_reasoning_effort(value):
 
 def rejects_reasoning_effort(body_text):
     text = body_text.lower()
-    field = r"reasoning(?:_effort| effort|-effort)"
+    field = r"(?<![A-Za-z0-9_-])reasoning(?:_effort| effort|-effort)(?![A-Za-z0-9_-])"
     kind = r"(?:field|parameter|argument|property)"
     rejection = r"(?:unsupported|not supported|unrecognized|unknown|unexpected|not allowed|not permitted)"
     patterns = (

--- a/scripts/lib/execution-profile.sh
+++ b/scripts/lib/execution-profile.sh
@@ -190,6 +190,14 @@ _octopus_profile_env_key() {
   printf '%s' "${1:-}" | tr '[:lower:]-' '[:upper:]_' | sed -E 's/[^A-Z0-9_]+/_/g; s/^_+//; s/_+$//'
 }
 
+_octopus_profile_env_value() {
+  local env_name="${1:-}" value=""
+  [[ -n "$env_name" && "$env_name" != *[!A-Z0-9_]* ]] || return 1
+  eval "value=\${${env_name}-}"
+  printf '%s
+' "$value"
+}
+
 octopus_explicit_provider_override() {
   local phase="$1" operation="$2" phase_key operation_key env_name value
   phase_key="$(_octopus_profile_env_key "$phase")"
@@ -197,17 +205,17 @@ octopus_explicit_provider_override() {
 
   if [[ -n "$phase_key" && -n "$operation_key" ]]; then
     env_name="OCTOPUS_${phase_key}_${operation_key}_AGENT"
-    value="${!env_name:-}"
+    value="$(_octopus_profile_env_value "$env_name" 2>/dev/null || true)"
     [[ -n "$value" ]] && { printf '%s\n' "$value"; return 0; }
   fi
   if [[ -n "$phase_key" ]]; then
     env_name="OCTOPUS_${phase_key}_AGENT"
-    value="${!env_name:-}"
+    value="$(_octopus_profile_env_value "$env_name" 2>/dev/null || true)"
     [[ -n "$value" ]] && { printf '%s\n' "$value"; return 0; }
   fi
   if [[ -n "$operation_key" ]]; then
     env_name="OCTOPUS_${operation_key}_AGENT"
-    value="${!env_name:-}"
+    value="$(_octopus_profile_env_value "$env_name" 2>/dev/null || true)"
     [[ -n "$value" ]] && { printf '%s\n' "$value"; return 0; }
   fi
   return 1

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -15,6 +15,9 @@ source "${_model_resolver_lib_dir}/provider-registry.sh" || { echo "model-resolv
 if ! declare -f octo_model_cache_file >/dev/null 2>&1; then
     source "${_model_resolver_lib_dir}/model-cache-path.sh" 2>/dev/null || true
 fi
+if ! declare -f get_model_catalog >/dev/null 2>&1; then
+    source "${_model_resolver_lib_dir}/models.sh" || { echo "model-resolver: failed to load models.sh" >&2; return 1 2>/dev/null || exit 1; }
+fi
 if ! declare -f _is_cursor_agent_binary >/dev/null 2>&1; then
     source "${_model_resolver_lib_dir}/cursor-agent.sh" 2>/dev/null || true
 fi
@@ -250,6 +253,31 @@ _octo_is_known_provider_name() {
     _octo_canonical_known_provider_name "${1:-}" >/dev/null 2>&1
 }
 
+_octo_route_value_model_family() {
+    local model="${1:-}" target_provider="${2:-}" catalog_provider=""
+    if [[ "$model" == "default" && -n "$target_provider" ]]; then
+        octo_provider_org "$target_provider" 2>/dev/null || printf '%s\n' unknown
+        return 0
+    fi
+    if is_known_model "$model"; then
+        catalog_provider="$(get_model_capability "$model" provider 2>/dev/null || true)"
+        if [[ -n "$catalog_provider" && "$catalog_provider" != "unknown" ]]; then
+            octo_provider_org "$catalog_provider" 2>/dev/null || printf '%s\n' unknown
+            return 0
+        fi
+    fi
+    case "${1:-}" in
+        claude-*|anthropic/*) printf '%s\n' anthropic ;;
+        gpt-*|o[134]-*|codex*|openai/*) printf '%s\n' openai ;;
+        gemini-*|agy-*|google/*) printf '%s\n' google ;;
+        qwen*|qwen/*|alibaba/*) printf '%s\n' alibaba ;;
+        grok-*|xai/*|x-ai/*) printf '%s\n' xai ;;
+        mistral-*|mistral/*|mistralai/*) printf '%s\n' mistral ;;
+        sonar*|perplexity/*) printf '%s\n' perplexity ;;
+        *) printf '%s\n' unknown ;;
+    esac
+}
+
 _octo_effective_cost_mode() {
     local config_file="${1:-}"
     local mode="${OCTOPUS_COST_MODE:-}"
@@ -433,6 +461,8 @@ resolve_octopus_model() {
             local phase_route_provider=""
             local phase_route_model=""
             local role_route_blocks_phase="false"
+            local role_route_model_family=""
+            local role_route_provider_org=""
 
             if [[ -n "$role" ]]; then
                 role_route_json=$(echo "$config_data" | jq -c --arg role "$role" '.routing.roles[$role] // empty' 2>/dev/null)
@@ -463,7 +493,14 @@ resolve_octopus_model() {
                             role_route_provider="$(octo_provider_canonical "$role_route_value" 2>/dev/null || printf '%s' "$role_route_value")"
                             [[ "$role_route_provider" == "$canonical_provider" ]] && role_route_blocks_phase="true"
                         else
+                            role_route_model_family="$(_octo_route_value_model_family "$role_route_value" "$canonical_provider")"
+                            role_route_provider_org="$(octo_provider_org "$canonical_provider" 2>/dev/null || true)"
                             role_route_blocks_phase="true"
+                            if ! octo_provider_has_capability "$canonical_provider" model-gateway &&
+                               [[ "$role_route_model_family" != "unknown" &&
+                                  "$role_route_model_family" != "$role_route_provider_org" ]]; then
+                                role_route_blocks_phase="false"
+                            fi
                         fi
                     fi
                 fi
@@ -514,13 +551,13 @@ resolve_octopus_model() {
                     if [[ -n "$role_route_provider" && "$role_route_provider" != "$canonical_provider" ]]; then
                         [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (role routing): SKIP (role route $routed targets $role_route_provider, resolving for $provider); checking phase route" >&2
                         routed=""
-                    elif [[ -z "$role_route_provider" && -n "$phase_routed" && "$phase_routed" != "null" ]]; then
+                    elif [[ -z "$role_route_provider" && "$role_route_blocks_phase" != "true" && -n "$phase_routed" && "$phase_routed" != "null" ]]; then
                         [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (role routing): SKIP (bare role route $routed is unscoped and phase route exists); checking phase route" >&2
                         routed=""
                     fi
                 fi
             fi
-            if [[ -z "$routed" || "$routed" == "null" ]] && [[ -n "$phase_routed" && "$phase_routed" != "null" ]]; then
+            if [[ -z "$routed" || "$routed" == "null" ]] && [[ "$role_route_blocks_phase" != "true" ]] && [[ -n "$phase_routed" && "$phase_routed" != "null" ]]; then
                 routed="$phase_routed"
             fi
 

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -387,6 +387,7 @@ resolve_octopus_model() {
             local role_route_type=""
             local role_route_provider=""
             local role_route_model=""
+            local role_route_value=""
             local phase_route_provider=""
             local phase_route_model=""
             local role_route_blocks_phase="false"
@@ -398,6 +399,9 @@ resolve_octopus_model() {
                     if [[ "$role_route_type" == "object" ]]; then
                         role_route_provider=$(echo "$role_route_json" | jq -r '.provider // empty' 2>/dev/null)
                         role_route_model=$(echo "$role_route_json" | jq -r '.model // empty' 2>/dev/null)
+                        if [[ -n "$role_route_provider" ]]; then
+                            role_route_provider="$(octo_provider_canonical "$role_route_provider" 2>/dev/null || printf '%s' "$role_route_provider")"
+                        fi
                         if [[ -z "$role_route_provider" || "$role_route_provider" == "$canonical_provider" ]]; then
                             role_route_blocks_phase="true"
                             if [[ -n "$role_route_model" ]]; then
@@ -406,8 +410,19 @@ resolve_octopus_model() {
                             fi
                         fi
                     else
-                        # Legacy string routes retain their existing alias/provider semantics.
-                        role_route_blocks_phase="true"
+                        # A legacy role route only blocks the phase route when it
+                        # applies to the provider currently being resolved.
+                        role_route_value=$(echo "$role_route_json" | jq -r '.' 2>/dev/null)
+                        if [[ "$role_route_value" == *:* ]]; then
+                            role_route_provider="${role_route_value%%:*}"
+                            role_route_provider="$(octo_provider_canonical "$role_route_provider" 2>/dev/null || printf '%s' "$role_route_provider")"
+                            [[ "$role_route_provider" == "$canonical_provider" ]] && role_route_blocks_phase="true"
+                        elif _octo_is_known_provider_name "$role_route_value"; then
+                            role_route_provider="$(octo_provider_canonical "$role_route_value" 2>/dev/null || printf '%s' "$role_route_value")"
+                            [[ "$role_route_provider" == "$canonical_provider" ]] && role_route_blocks_phase="true"
+                        else
+                            role_route_blocks_phase="true"
+                        fi
                     fi
                 fi
             fi
@@ -417,6 +432,9 @@ resolve_octopus_model() {
                 if [[ -n "$phase_route_json" && "$phase_route_json" != "null" ]] && [[ "$(echo "$phase_route_json" | jq -r 'type' 2>/dev/null)" == "object" ]]; then
                     phase_route_provider=$(echo "$phase_route_json" | jq -r '.provider // empty' 2>/dev/null)
                     phase_route_model=$(echo "$phase_route_json" | jq -r '.model // empty' 2>/dev/null)
+                    if [[ -n "$phase_route_provider" ]]; then
+                        phase_route_provider="$(octo_provider_canonical "$phase_route_provider" 2>/dev/null || printf '%s' "$phase_route_provider")"
+                    fi
                     if [[ ( -z "$phase_route_provider" || "$phase_route_provider" == "$canonical_provider" ) && -n "$phase_route_model" ]]; then
                         resolved_model="$phase_route_model"
                         [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (literal phase route): $resolved_model ← SELECTED" >&2
@@ -448,7 +466,10 @@ resolve_octopus_model() {
                     elif _octo_is_known_provider_name "$routed"; then
                         role_route_provider="$routed"
                     fi
-                    if [[ -n "$role_route_provider" && "$role_route_provider" != "$provider" ]]; then
+                    if [[ -n "$role_route_provider" ]]; then
+                        role_route_provider="$(octo_provider_canonical "$role_route_provider" 2>/dev/null || printf '%s' "$role_route_provider")"
+                    fi
+                    if [[ -n "$role_route_provider" && "$role_route_provider" != "$canonical_provider" ]]; then
                         [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (role routing): SKIP (role route $routed targets $role_route_provider, resolving for $provider); checking phase route" >&2
                         routed=""
                     elif [[ -z "$role_route_provider" && -n "$phase_routed" && "$phase_routed" != "null" ]]; then
@@ -468,7 +489,9 @@ resolve_octopus_model() {
                 if [[ "$routed" == *:* ]]; then
                     local ref_provider="${routed%%:*}"
                     local ref_type="${routed#*:}"
-                    if [[ "$ref_provider" != "$provider" ]]; then
+                    local canonical_ref_provider
+                    canonical_ref_provider="$(octo_provider_canonical "$ref_provider" 2>/dev/null || printf '%s' "$ref_provider")"
+                    if [[ "$canonical_ref_provider" != "$canonical_provider" ]]; then
                         # Route targets a different provider — skip for this resolution
                         [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): SKIP (route $routed targets $ref_provider, resolving for $provider)" >&2
                         routed=""

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -199,13 +199,54 @@ validate_model_name_for_provider() {
     esac
 }
 
+_octo_canonical_known_provider_name() {
+    local requested normalized id aliases command org caps alias alias_base old_ifs
+    requested="${1:-}"
+    normalized="$(octo_provider_normalize "$requested")"
+    [[ -n "$normalized" ]] || return 1
+
+    # Routing values are ambiguous: a bare string can be either a provider or
+    # a model. Accept canonical IDs and exact aliases (plus the exact base of a
+    # wildcard alias), but do not let wildcard aliases such as gpt* classify a
+    # concrete model like gpt-5.5 as a provider route.
+    while IFS='|' read -r id aliases command org caps; do
+        if [[ "$normalized" == "$id" ]]; then
+            printf '%s\n' "$id"
+            return 0
+        fi
+        old_ifs="$IFS"
+        IFS=','
+        for alias in $aliases; do
+            IFS="$old_ifs"
+            [[ -n "$alias" ]] || continue
+            case "$alias" in
+                *'*')
+                    alias_base="${alias%\*}"
+                    [[ "$normalized" == "$alias_base" ]] || continue
+                    ;;
+                *)
+                    [[ "$normalized" == "$alias" ]] || continue
+                    ;;
+            esac
+            printf '%s\n' "$id"
+            return 0
+        done
+        IFS="$old_ifs"
+    done <<EOF
+$(octo_provider_registry_rows)
+EOF
+
+    # Preserve the legacy provider variant accepted before registry-backed
+    # classification was introduced.
+    if [[ "$normalized" == "agy-research" ]]; then
+        printf '%s\n' "agy"
+        return 0
+    fi
+    return 1
+}
+
 _octo_is_known_provider_name() {
-    case "$1" in
-        codex|claude|perplexity|qwen|copilot|opencode|ollama|openrouter|orcarouter|cursor-agent|commandcode|vibe|agy|agy-research|antigravity)
-            return 0 ;;
-        *)
-            return 1 ;;
-    esac
+    _octo_canonical_known_provider_name "${1:-}" >/dev/null 2>&1
 }
 
 _octo_effective_cost_mode() {

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -537,7 +537,7 @@ resolve_octopus_model() {
                         [[ -n "$_trace" ]] && echo "[model-trace] Tier 3 (phase/role routing): SKIP (route $routed targets $ref_provider, resolving for $provider)" >&2
                         routed=""
                     else
-                        if ! resolved_model=$(resolve_octopus_model "$ref_provider" "$ref_type" "" ""); then
+                        if ! resolved_model=$(resolve_octopus_model "$canonical_ref_provider" "$ref_type" "" ""); then
                             return 1
                         fi
                     fi

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -11,12 +11,20 @@ fi
 # ═══════════════════════════════════════════════════════════════════════════════
 
 _model_resolver_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${_model_resolver_lib_dir}/provider-registry.sh" || { echo "model-resolver: failed to load provider-registry.sh" >&2; return 1 2>/dev/null || exit 1; }
+_model_resolver_load_error() {
+    local message="$1"
+    if declare -f log >/dev/null 2>&1; then
+        log ERROR "$message" || printf 'model-resolver: %s\n' "$message" >&2
+    else
+        printf 'model-resolver: %s\n' "$message" >&2
+    fi
+}
+source "${_model_resolver_lib_dir}/provider-registry.sh" || { _model_resolver_load_error "failed to load provider-registry.sh"; return 1 2>/dev/null || exit 1; }
 if ! declare -f octo_model_cache_file >/dev/null 2>&1; then
     source "${_model_resolver_lib_dir}/model-cache-path.sh" 2>/dev/null || true
 fi
 if ! declare -f get_model_catalog >/dev/null 2>&1; then
-    source "${_model_resolver_lib_dir}/models.sh" || { echo "model-resolver: failed to load models.sh" >&2; return 1 2>/dev/null || exit 1; }
+    source "${_model_resolver_lib_dir}/models.sh" || { _model_resolver_load_error "failed to load models.sh"; return 1 2>/dev/null || exit 1; }
 fi
 if ! declare -f _is_cursor_agent_binary >/dev/null 2>&1; then
     source "${_model_resolver_lib_dir}/cursor-agent.sh" 2>/dev/null || true
@@ -270,7 +278,7 @@ _octo_route_value_model_family() {
         claude-*|anthropic/*) printf '%s\n' anthropic ;;
         gpt-*|o[134]-*|codex*|openai/*) printf '%s\n' openai ;;
         gemini-*|agy-*|google/*) printf '%s\n' google ;;
-        qwen*|qwen/*|alibaba/*) printf '%s\n' alibaba ;;
+        qwen*|alibaba/*) printf '%s\n' alibaba ;;
         grok-*|xai/*|x-ai/*) printf '%s\n' xai ;;
         mistral-*|mistral/*|mistralai/*) printf '%s\n' mistral ;;
         sonar*|perplexity/*) printf '%s\n' perplexity ;;

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -200,7 +200,8 @@ validate_model_name_for_provider() {
 }
 
 _octo_canonical_known_provider_name() {
-    local requested normalized id aliases command org caps alias alias_base old_ifs
+    local requested normalized id aliases command org caps alias alias_base
+    local -a aliases_list
     requested="${1:-}"
     normalized="$(octo_provider_normalize "$requested")"
     [[ -n "$normalized" ]] || return 1
@@ -214,24 +215,24 @@ _octo_canonical_known_provider_name() {
             printf '%s\n' "$id"
             return 0
         fi
-        old_ifs="$IFS"
-        IFS=','
-        for alias in $aliases; do
-            IFS="$old_ifs"
-            [[ -n "$alias" ]] || continue
-            case "$alias" in
-                *'*')
-                    alias_base="${alias%\*}"
-                    [[ "$normalized" == "$alias_base" ]] || continue
-                    ;;
-                *)
-                    [[ "$normalized" == "$alias" ]] || continue
-                    ;;
-            esac
-            printf '%s\n' "$id"
-            return 0
-        done
-        IFS="$old_ifs"
+        aliases_list=()
+        if [[ -n "$aliases" ]]; then
+            IFS=',' read -r -a aliases_list <<< "$aliases"
+            for alias in "${aliases_list[@]}"; do
+                [[ -n "$alias" ]] || continue
+                case "$alias" in
+                    *'*')
+                        alias_base="${alias%\*}"
+                        [[ "$normalized" == "$alias_base" ]] || continue
+                        ;;
+                    *)
+                        [[ "$normalized" == "$alias" ]] || continue
+                        ;;
+                esac
+                printf '%s\n' "$id"
+                return 0
+            done
+        fi
     done <<EOF
 $(octo_provider_registry_rows)
 EOF

--- a/scripts/lib/provider-registry.sh
+++ b/scripts/lib/provider-registry.sh
@@ -3,7 +3,8 @@
 # Source-safe and Bash 3.2 compatible: no associative arrays, no shell options.
 #
 # Columns: id|aliases|command|organization|capabilities
-# Capabilities describe which shared interfaces should expose the provider.
+# Capabilities describe which shared interfaces should expose the provider and
+# stable routing traits such as whether it accepts cross-vendor model IDs.
 # Every provider must implement the universal baseline below. Optional capability
 # omissions must be documented in octo_provider_limitations_rows().
 
@@ -13,23 +14,23 @@ OCTO_PROVIDER_OPTIONAL_CAPABILITIES="council health detect"
 octo_provider_registry_rows() {
     cat <<'EOF'
 codex|openai,gpt*|codex|openai|model-config,council,health,detect,dispatch,env
-commandcode|command-code*|command-code|commandcode|model-config,council,health,detect,dispatch,env
+commandcode|command-code*|command-code|commandcode|model-config,council,health,detect,dispatch,env,model-gateway
 claude|anthropic,sonnet*,opus*|claude|anthropic|model-config,council,health,detect,dispatch,env
 claude-sdk|claude-agent*|claude-agent|anthropic|model-config,health,detect,dispatch,env
 agy|antigravity*,gemini,gemini-*|agy|google|model-config,council,health,detect,dispatch,env
 perplexity||perplexity|perplexity|model-config,health,detect,dispatch,env
-opencode||opencode|opencode|model-config,council,detect,dispatch,env
-openrouter||openrouter|openrouter|model-config,council,health,detect,dispatch,env
-orcarouter||orcarouter|orcarouter|model-config,council,health,detect,dispatch,env
-atlascloud|atlas,atlas-cloud|atlascloud|atlascloud|model-config,health,detect,dispatch,env
-openai-compatible||openai-compatible|openai-compatible|model-config,council,detect,dispatch,env
-openai-tools||openai-compatible|openai-compatible|model-config,council,dispatch,env
-openai-compatible-agent||openai-compatible|openai-compatible|model-config,dispatch,env
-cursor-agent|cursor|cursor-agent|cursor|model-config,health,detect,dispatch,env
+opencode||opencode|opencode|model-config,council,detect,dispatch,env,model-gateway
+openrouter||openrouter|openrouter|model-config,council,health,detect,dispatch,env,model-gateway
+orcarouter||orcarouter|orcarouter|model-config,council,health,detect,dispatch,env,model-gateway
+atlascloud|atlas,atlas-cloud|atlascloud|atlascloud|model-config,health,detect,dispatch,env,model-gateway
+openai-compatible||openai-compatible|openai-compatible|model-config,council,detect,dispatch,env,model-gateway
+openai-tools||openai-compatible|openai-compatible|model-config,council,dispatch,env,model-gateway
+openai-compatible-agent||openai-compatible|openai-compatible|model-config,dispatch,env,model-gateway
+cursor-agent|cursor|cursor-agent|cursor|model-config,health,detect,dispatch,env,model-gateway
 grok|xai|grok|xai|model-config,health,detect,dispatch,env
 qwen||qwen|alibaba|model-config,council,health,detect,dispatch,env
-ollama|local|ollama|local|model-config,health,detect,dispatch,env
-copilot|github-copilot|copilot|github|model-config,health,detect,dispatch,env
+ollama|local|ollama|local|model-config,health,detect,dispatch,env,model-gateway
+copilot|github-copilot|copilot|github|model-config,health,detect,dispatch,env,model-gateway
 vibe||vibe|mistral|model-config,health,detect,dispatch,env
 EOF
 }

--- a/tests/test-execution-profile.sh
+++ b/tests/test-execution-profile.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "$ROOT/tests/helpers/test-framework.sh"
+test_suite "execution profile"
 source "$ROOT/scripts/lib/execution-profile.sh"
-TMP=$(mktemp -d)
-trap "rm -rf $TMP" EXIT
+TMP="$TEST_TMP_DIR/execution-profile"
+mkdir -p "$TMP"
 CFG="$TMP/providers.json"
 cat > "$CFG" <<JSON
 {
@@ -26,7 +28,16 @@ cat > "$CFG" <<JSON
 }
 JSON
 export OCTOPUS_PROVIDERS_CONFIG="$CFG"
-assert_eq(){ [[ "$1" == "$2" ]] || { echo "FAIL expected=$2 got=$1" >&2; exit 1; }; }
+assert_eq() {
+  local actual="$1" expected="$2" desc="${3:-expected $2}"
+  test_case "$desc"
+  if [[ "$actual" == "$expected" ]]; then
+    test_pass
+  else
+    test_fail "expected=[$expected] got=[$actual]"
+    return 1
+  fi
+}
 assert_eq "$(octopus_profile_provider council logic-reviewer fallback)" codex
 assert_eq "$(octopus_profile_model council logic-reviewer)" gpt-5.6
 assert_eq "$(octopus_profile_provider council quick-checker fallback)" codex
@@ -49,10 +60,13 @@ rc=$?
 set -e
 assert_eq "$rc" 2
 assert_eq "$(octopus_reasoning_cli_fragment gemini high best_effort)" ""
+OCTOPUS_COUNCIL_LOGIC_REVIEWER_AGENT=codex:local-shell-override
+assert_eq "$(octopus_explicit_provider_override council logic-reviewer)" codex:local-shell-override "unexported shell override remains visible"
+unset OCTOPUS_COUNCIL_LOGIC_REVIEWER_AGENT
 export OCTOPUS_LOGIC_REVIEWER_REASONING=high
 assert_eq "$(octopus_resolve_reasoning_level codex council logic-reviewer)" high
 unset OCTOPUS_LOGIC_REVIEWER_REASONING
 export OCTOPUS_COUNCIL_LOGIC_REVIEWER_REASONING=low
 assert_eq "$(octopus_resolve_reasoning_level codex council logic-reviewer)" low
 unset OCTOPUS_COUNCIL_LOGIC_REVIEWER_REASONING
-printf "PASS test-execution-profile\n"
+test_summary

--- a/tests/test-execution-profile.sh
+++ b/tests/test-execution-profile.sh
@@ -35,7 +35,7 @@ assert_eq() {
     test_pass
   else
     test_fail "expected=[$expected] got=[$actual]"
-    return 1
+    return 0
   fi
 }
 assert_eq "$(octopus_profile_provider council logic-reviewer fallback)" codex

--- a/tests/unit/test-execution-profile-dispatch.sh
+++ b/tests/unit/test-execution-profile-dispatch.sh
@@ -20,12 +20,12 @@ validate_model_name(){ return 0; }
 assert_contains() {
   local haystack="$1" needle="$2"
   test_case "contains: $needle"
-  if [[ "$haystack" == *"$needle"* ]]; then test_pass; else test_fail "missing [$needle] in [$haystack]"; return 1; fi
+  if [[ "$haystack" == *"$needle"* ]]; then test_pass; else test_fail "missing [$needle] in [$haystack]"; return 0; fi
 }
 assert_not_contains() {
   local haystack="$1" needle="$2"
   test_case "does not contain: $needle"
-  if [[ "$haystack" != *"$needle"* ]]; then test_pass; else test_fail "unexpected [$needle] in [$haystack]"; return 1; fi
+  if [[ "$haystack" != *"$needle"* ]]; then test_pass; else test_fail "unexpected [$needle] in [$haystack]"; return 0; fi
 }
 export OCTOPUS_REASONING_POLICY=strict
 export OCTOPUS_CODEX_REASONING=medium

--- a/tests/unit/test-execution-profile-dispatch.sh
+++ b/tests/unit/test-execution-profile-dispatch.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$ROOT/tests/helpers/test-framework.sh"
+test_suite "execution profile dispatch"
 export PLUGIN_DIR="$ROOT"
 export OCTOPUS_PLATFORM=Linux
 export OPENAI_COMPAT_BASE_URL=https://example.invalid/v1
@@ -15,8 +17,16 @@ source "$ROOT/scripts/lib/execution-profile.sh"
 source "$ROOT/scripts/lib/dispatch.sh"
 get_agent_model(){ case "$1" in codex*) echo gpt-5.6;; claude*) echo sonnet;; openai-*) echo deepseek-ai/DeepSeek-V4-Pro;; *) echo model;; esac; }
 validate_model_name(){ return 0; }
-assert_contains(){ [[ "$1" == *"$2"* ]] || { echo "FAIL missing [$2] in [$1]" >&2; exit 1; }; }
-assert_not_contains(){ [[ "$1" != *"$2"* ]] || { echo "FAIL unexpected [$2] in [$1]" >&2; exit 1; }; }
+assert_contains() {
+  local haystack="$1" needle="$2"
+  test_case "contains: $needle"
+  if [[ "$haystack" == *"$needle"* ]]; then test_pass; else test_fail "missing [$needle] in [$haystack]"; return 1; fi
+}
+assert_not_contains() {
+  local haystack="$1" needle="$2"
+  test_case "does not contain: $needle"
+  if [[ "$haystack" != *"$needle"* ]]; then test_pass; else test_fail "unexpected [$needle] in [$haystack]"; return 1; fi
+}
 export OCTOPUS_REASONING_POLICY=strict
 export OCTOPUS_CODEX_REASONING=medium
 cmd=$(get_agent_command codex council logic-reviewer)
@@ -51,4 +61,4 @@ export OCTOPUS_PROBE_TECHNICAL_IMPLEMENTATION_ANALYSIS_REASONING=medium
 cmd=$(get_agent_command codex probe "Technical implementation analysis")
 assert_contains "$cmd" 'model_reasoning_effort="medium"'
 unset OCTOPUS_PROBE_TECHNICAL_IMPLEMENTATION_ANALYSIS_REASONING
-printf "PASS test-execution-profile-dispatch\n"
+test_summary

--- a/tests/unit/test-openai-reasoning-payload.py
+++ b/tests/unit/test-openai-reasoning-payload.py
@@ -81,4 +81,42 @@ with patch.object(mod.urllib.request, "urlopen", side_effect=error) as mocked:
         raise AssertionError("generic reasoning error unexpectedly triggered fallback")
 assert mocked.call_count == 1, mocked.call_count
 
+# A 400 response that explicitly rejects the reasoning_effort field retries
+# once without that field when best-effort reasoning is enabled.
+field_error = urllib.error.HTTPError(
+    "https://example.test/chat/completions",
+    400,
+    "bad request",
+    {},
+    io.BytesIO(b'{"error":"unsupported field: reasoning_effort"}'),
+)
+fallback_seen = []
+
+
+def fake_reasoning_fallback(req, timeout=None):
+    del timeout
+    fallback_seen.append(json.loads(req.data.decode()))
+    if len(fallback_seen) == 1:
+        raise field_error
+    return Resp()
+
+
+with patch.object(
+    mod.urllib.request, "urlopen", side_effect=fake_reasoning_fallback
+) as mocked:
+    result = mod.api_call(
+        "https://example.test",
+        "k",
+        "m",
+        {},
+        [{"role": "user", "content": "x"}],
+        reasoning_effort="medium",
+        reasoning_policy="best_effort",
+    )
+
+assert result["choices"][0]["message"]["content"] == "ok", result
+assert mocked.call_count == 2, mocked.call_count
+assert fallback_seen[0]["reasoning_effort"] == "medium", fallback_seen
+assert "reasoning_effort" not in fallback_seen[1], fallback_seen
+
 print("PASS test-openai-reasoning-payload")

--- a/tests/unit/test-openai-reasoning-payload.py
+++ b/tests/unit/test-openai-reasoning-payload.py
@@ -60,6 +60,7 @@ assert mod.normalize_reasoning_effort("medium") == "medium"
 for generic_body in (
     b'{"error":"invalid reasoning_effort value"}',
     b'{"error":"unsupported value for reasoning_effort"}',
+    b'{"error":"unsupported field: reasoning_effort_mode"}',
 ):
     error = urllib.error.HTTPError(
         "https://example.test/chat/completions",

--- a/tests/unit/test-openai-reasoning-payload.py
+++ b/tests/unit/test-openai-reasoning-payload.py
@@ -55,31 +55,35 @@ assert mod.normalize_reasoning_effort("xhigh") == "high"
 assert mod.normalize_reasoning_effort("max") == "high"
 assert mod.normalize_reasoning_effort("medium") == "medium"
 
-# A generic reasoning validation error must not be mistaken for rejection of
-# the reasoning_effort field and retried without that field.
-error = urllib.error.HTTPError(
-    "https://example.test/chat/completions",
-    400,
-    "bad request",
-    {},
-    io.BytesIO(b'{"error":"reasoning trace is invalid"}'),
-)
-with patch.object(mod.urllib.request, "urlopen", side_effect=error) as mocked:
-    try:
-        mod.api_call(
-            "https://example.test",
-            "k",
-            "m",
-            {},
-            [{"role": "user", "content": "x"}],
-            reasoning_effort="medium",
-            reasoning_policy="best_effort",
-        )
-    except RuntimeError:
-        pass
-    else:
-        raise AssertionError("generic reasoning error unexpectedly triggered fallback")
-assert mocked.call_count == 1, mocked.call_count
+# A field-named value error must not be mistaken for rejection of the field and
+# retried without it.
+for generic_body in (
+    b'{"error":"invalid reasoning_effort value"}',
+    b'{"error":"unsupported value for reasoning_effort"}',
+):
+    error = urllib.error.HTTPError(
+        "https://example.test/chat/completions",
+        400,
+        "bad request",
+        {},
+        io.BytesIO(generic_body),
+    )
+    with patch.object(mod.urllib.request, "urlopen", side_effect=error) as mocked:
+        try:
+            mod.api_call(
+                "https://example.test",
+                "k",
+                "m",
+                {},
+                [{"role": "user", "content": "x"}],
+                reasoning_effort="medium",
+                reasoning_policy="best_effort",
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("generic reasoning error unexpectedly triggered fallback")
+    assert mocked.call_count == 1, (generic_body, mocked.call_count)
 
 # A 400 response that explicitly rejects the reasoning_effort field retries
 # once without that field when best-effort reasoning is enabled.

--- a/tests/unit/test-openai-reasoning-payload.py
+++ b/tests/unit/test-openai-reasoning-payload.py
@@ -1,20 +1,84 @@
-import importlib.util, json
-from unittest.mock import patch
+#!/usr/bin/env python3
+import importlib.util
+import io
+import json
+import urllib.error
 from pathlib import Path
-path=Path(__file__).resolve().parents[2]/"scripts/helpers/openai-compatible-agent.py"
-spec=importlib.util.spec_from_file_location("agent",path)
-mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+from unittest.mock import patch
+
+path = Path(__file__).resolve().parents[2] / "scripts/helpers/openai-compatible-agent.py"
+spec = importlib.util.spec_from_file_location("agent", path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
 class Resp:
-    def __enter__(self): return self
-    def __exit__(self,*a): return False
-    def read(self): return b'{"choices":[{"message":{"content":"ok"}}]}'
-seen=[]
-def fake(req,timeout=None):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return b'{"choices":[{"message":{"content":"ok"}}]}'
+
+
+seen = []
+
+
+def fake(req, timeout=None):
+    del timeout
     seen.append(json.loads(req.data.decode()))
     return Resp()
-with patch.object(mod.urllib.request,"urlopen",side_effect=fake):
-    mod.api_call("https://example.test","k","m",{},[{"role":"user","content":"x"}],reasoning_effort="medium")
-    mod.api_call("https://example.test","k","m",{},[{"role":"user","content":"x"}])
-assert seen[0]["reasoning_effort"]=="medium",seen
-assert "reasoning_effort" not in seen[1],seen
+
+
+with patch.object(mod.urllib.request, "urlopen", side_effect=fake):
+    mod.api_call(
+        "https://example.test",
+        "k",
+        "m",
+        {},
+        [{"role": "user", "content": "x"}],
+        reasoning_effort="medium",
+    )
+    mod.api_call(
+        "https://example.test",
+        "k",
+        "m",
+        {},
+        [{"role": "user", "content": "x"}],
+    )
+
+assert seen[0]["reasoning_effort"] == "medium", seen
+assert "reasoning_effort" not in seen[1], seen
+assert mod.normalize_reasoning_effort("xhigh") == "high"
+assert mod.normalize_reasoning_effort("max") == "high"
+assert mod.normalize_reasoning_effort("medium") == "medium"
+
+# A generic reasoning validation error must not be mistaken for rejection of
+# the reasoning_effort field and retried without that field.
+error = urllib.error.HTTPError(
+    "https://example.test/chat/completions",
+    400,
+    "bad request",
+    {},
+    io.BytesIO(b'{"error":"reasoning trace is invalid"}'),
+)
+with patch.object(mod.urllib.request, "urlopen", side_effect=error) as mocked:
+    try:
+        mod.api_call(
+            "https://example.test",
+            "k",
+            "m",
+            {},
+            [{"role": "user", "content": "x"}],
+            reasoning_effort="medium",
+            reasoning_policy="best_effort",
+        )
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("generic reasoning error unexpectedly triggered fallback")
+assert mocked.call_count == 1, mocked.call_count
+
 print("PASS test-openai-reasoning-payload")

--- a/tests/unit/test-provider-registry-contracts.sh
+++ b/tests/unit/test-provider-registry-contracts.sh
@@ -116,6 +116,11 @@ expected="codex commandcode claude claude-sdk agy perplexity opencode openrouter
 actual="$(octo_provider_ids)"
 if [[ "$actual" == "$expected" ]]; then test_pass; else test_fail "canonical provider inventory drift: $actual"; fi
 
+test_case "cross-vendor model gateways are explicit registry metadata"
+expected="commandcode opencode openrouter orcarouter atlascloud openai-compatible openai-tools openai-compatible-agent cursor-agent ollama copilot"
+actual="$(octo_provider_ids model-gateway)"
+if [[ "$actual" == "$expected" ]]; then test_pass; else test_fail "model gateway inventory drift: $actual"; fi
+
 test_case "registry self-validation enforces baseline and documented omissions"
 if octo_provider_validate_contracts; then test_pass; else test_fail "registry governance contract failed"; fi
 

--- a/tests/unit/test-resolve-model.sh
+++ b/tests/unit/test-resolve-model.sh
@@ -46,7 +46,7 @@ assert_eq() {
         test_pass
     else
         test_fail "expected=[$expected] got=[$actual]"
-        return 1
+        return 0
     fi
 }
 
@@ -255,10 +255,111 @@ cat > "$CONFIG_FILE" << EOF
 {
   "version": "3.0",
   "providers": { "codex": { "default": "gpt-default" } },
-  "routing": { "roles": { "logic-reviewer": "gpt-5.5" } }
+  "routing": {
+    "roles": { "logic-reviewer": "gpt-5.5" },
+    "phases": { "review": "gpt-phase-model" }
+  }
 }
 EOF
-assert_eq "$(resolve_octopus_model "codex" "codex" "review" "logic-reviewer")" "gpt-5.5" "Bare gpt model remains a model route, not a provider alias"
+assert_eq "$(resolve_octopus_model "codex" "codex" "review" "logic-reviewer")" "gpt-5.5" "Bare gpt model keeps role precedence over a phase route"
+
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": { "commandcode": { "default": "deepseek/deepseek-v4-pro" } },
+  "routing": {
+    "roles": { "logic-reviewer": "deepseek/deepseek-v4-pro" },
+    "phases": { "review": "minimaxai/minimax-m3" }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "commandcode" "commandcode" "review" "logic-reviewer")" "deepseek/deepseek-v4-pro" "Command Code gateway keeps a vendor-qualified bare role over its phase route"
+
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": { "openrouter": { "default": "openai/gpt-5.5" } },
+  "routing": {
+    "roles": { "logic-reviewer": "anthropic/claude-sonnet-4" },
+    "phases": { "review": "openai/gpt-5.5" }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "openrouter" "openrouter" "review" "logic-reviewer")" "anthropic/claude-sonnet-4" "OpenRouter gateway keeps a cross-vendor bare role over its phase route"
+
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": { "qwen": { "default": "qwen3-coder" } },
+  "routing": {
+    "roles": { "logic-reviewer": "qwen3-coder" },
+    "phases": { "review": "qwen3-max" }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "qwen" "qwen" "review" "logic-reviewer")" "qwen3-coder" "Qwen keeps its native bare role over a phase route"
+
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": { "perplexity": { "default": "sonar-pro" } },
+  "routing": {
+    "roles": { "researcher": "sonar-pro" },
+    "phases": { "research": "sonar" }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "perplexity" "perplexity" "research" "researcher")" "sonar-pro" "Perplexity keeps its native bare role over a phase route"
+
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": { "perplexity": { "default": "sonar-pro" } },
+  "routing": {
+    "roles": { "researcher": "gpt-5.5" },
+    "phases": { "research": "sonar-pro" }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "perplexity" "perplexity" "research" "researcher")" "sonar-pro" "Perplexity rejects a known cross-vendor bare role in favor of its phase route"
+
+for default_provider in grok vibe; do
+    clear_model_cache
+    cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": { "$default_provider": { "default": "default" } },
+  "routing": {
+    "roles": { "logic-reviewer": "default" },
+    "phases": { "review": "${default_provider}-phase" }
+  }
+}
+EOF
+    assert_eq "$(resolve_octopus_model "$default_provider" "$default_provider" "review" "logic-reviewer")" "default" "$default_provider keeps its provider-local default role sentinel over a phase route"
+done
+
+test_case "catalogued native models resolve to their registry organization"
+catalog_family_mismatches=""
+while IFS= read -r catalog_model; do
+    [[ -n "$catalog_model" ]] || continue
+    catalog_provider="$(get_model_capability "$catalog_model" provider)"
+    octo_provider_has_capability "$catalog_provider" model-gateway && continue
+    catalog_org="$(octo_provider_org "$catalog_provider")"
+    route_family="$(_octo_route_value_model_family "$catalog_model")"
+    if [[ "$route_family" != "$catalog_org" ]]; then
+        catalog_family_mismatches="${catalog_family_mismatches}${catalog_model}:${route_family}->${catalog_org} "
+    fi
+done < <(octo_model_ids)
+if [[ -z "$catalog_family_mismatches" ]]; then
+    test_pass
+else
+    test_fail "model catalog family drift: $catalog_family_mismatches"
+fi
 
 # Registry wildcard aliases are data, not shell globs. A matching filesystem
 # entry must not replace the literal gpt* alias before its base is compared.

--- a/tests/unit/test-resolve-model.sh
+++ b/tests/unit/test-resolve-model.sh
@@ -260,6 +260,17 @@ cat > "$CONFIG_FILE" << EOF
 EOF
 assert_eq "$(resolve_octopus_model "codex" "codex" "review" "logic-reviewer")" "gpt-5.5" "Bare gpt model remains a model route, not a provider alias"
 
+# Registry wildcard aliases are data, not shell globs. A matching filesystem
+# entry must not replace the literal gpt* alias before its base is compared.
+alias_glob_dir="$TEST_TMP_DIR/provider-alias-glob"
+mkdir -p "$alias_glob_dir"
+: > "$alias_glob_dir/gpt-collision"
+previous_pwd="$PWD"
+cd "$alias_glob_dir"
+alias_glob_result="$(_octo_canonical_known_provider_name "gpt")"
+cd "$previous_pwd"
+assert_eq "$alias_glob_result" "codex" "Provider wildcard aliases ignore matching filesystem entries"
+
 # Test 6: Recursive reference (codex:spark)
 clear_model_cache
 cat > "$CONFIG_FILE" << EOF

--- a/tests/unit/test-resolve-model.sh
+++ b/tests/unit/test-resolve-model.sh
@@ -50,6 +50,16 @@ assert_eq() {
     fi
 }
 
+logged_load_error=""
+log() { logged_load_error="$1:$2"; }
+_model_resolver_load_error "catalog unavailable"
+assert_eq "$logged_load_error" "ERROR:catalog unavailable" "Load failures use the project logger when available"
+unset -f log
+fallback_load_error="$(_model_resolver_load_error "catalog unavailable" 2>&1)"
+assert_eq "$fallback_load_error" "model-resolver: catalog unavailable" "Load failures retain a bootstrap stderr fallback"
+log() { :; }
+export -f log
+
 # Clear model resolution caches (in-memory + persistent file)
 # Must be called between tests that change env vars or config files
 clear_model_cache() {

--- a/tests/unit/test-resolve-model.sh
+++ b/tests/unit/test-resolve-model.sh
@@ -275,6 +275,22 @@ cat > "$CONFIG_FILE" << EOF
 EOF
 assert_eq "$(resolve_octopus_model "codex" "codex" "deliver")" "config-spark" "Recursive reference"
 
+# Recursive provider references must use the canonical provider for the lookup,
+# not only for the cross-provider comparison.
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": {
+    "codex": { "default": "config-default", "spark": "config-spark" }
+  },
+  "routing": {
+    "phases": { "deliver": "openai:spark" }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "codex" "codex" "deliver")" "config-spark" "Recursive provider alias uses canonical model namespace"
+
 # Test 7: Tier mapping
 clear_model_cache
 cat > "$CONFIG_FILE" << EOF

--- a/tests/unit/test-resolve-model.sh
+++ b/tests/unit/test-resolve-model.sh
@@ -235,6 +235,31 @@ cat > "$CONFIG_FILE" << EOF
 EOF
 assert_eq "$(resolve_octopus_model "commandcode" "commandcode-research" "research" "researcher")" "minimaxai/minimax-m3" "Cross-provider legacy role falls through to matching object phase"
 
+# Regression: a bare provider alias keeps role-provider precedence over a
+# legacy phase model route, while model-like gpt-* values remain model routes.
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": { "agy": { "default": "agy-default" } },
+  "routing": {
+    "roles": { "researcher": "gemini" },
+    "phases": { "research": "agy-phase-model" }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "agy" "agy-research" "research" "researcher")" "agy-default" "Bare gemini alias preserves matching role-provider precedence"
+
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": { "codex": { "default": "gpt-default" } },
+  "routing": { "roles": { "logic-reviewer": "gpt-5.5" } }
+}
+EOF
+assert_eq "$(resolve_octopus_model "codex" "codex" "review" "logic-reviewer")" "gpt-5.5" "Bare gpt model remains a model route, not a provider alias"
+
 # Test 6: Recursive reference (codex:spark)
 clear_model_cache
 cat > "$CONFIG_FILE" << EOF

--- a/tests/unit/test-resolve-model.sh
+++ b/tests/unit/test-resolve-model.sh
@@ -37,20 +37,16 @@ export CLAUDE_CODE_SESSION=""
 export SUPPORTS_OPUS_4_7="${SUPPORTS_OPUS_4_7:-false}"
 source "${PLUGIN_DIR}/scripts/lib/model-resolver.sh"
 
-TESTS_RUN=0
-TESTS_PASSED=0
-
 assert_eq() {
-    TESTS_RUN=$((TESTS_RUN + 1))
     local actual="$1"
     local expected="$2"
     local desc="$3"
+    test_case "$desc"
     if [[ "$actual" == "$expected" ]]; then
-        echo -e "${GREEN}✓${NC} $desc (got: $actual)"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
+        test_pass
     else
-        echo -e "${RED}✗${NC} $desc (expected: $expected, got: $actual)"
-        exit 1
+        test_fail "expected=[$expected] got=[$actual]"
+        return 1
     fi
 }
 
@@ -206,6 +202,38 @@ cat > "$CONFIG_FILE" << EOF
 }
 EOF
 assert_eq "$(resolve_octopus_model "commandcode" "commandcode-research" "research" "researcher")" "minimaxai/minimax-m3" "Cross-provider literal role falls through to matching phase"
+
+# Regression: object-route provider aliases are canonicalized before comparison.
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": { "agy": { "default": "agy-default" } },
+  "routing": {
+    "phases": {
+      "research": { "provider": "antigravity", "model": "agy-alias-phase" }
+    }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "agy" "agy" "research" "")" "agy-alias-phase" "Literal object phase routing canonicalizes provider aliases"
+
+# Regression: a cross-provider legacy role route must not mask a matching
+# literal object phase route for the provider being resolved.
+clear_model_cache
+cat > "$CONFIG_FILE" << EOF
+{
+  "version": "3.0",
+  "providers": { "commandcode": { "default": "deepseek/deepseek-v4-pro" } },
+  "routing": {
+    "roles": { "researcher": "claude:sonnet" },
+    "phases": {
+      "research": { "provider": "commandcode", "model": "minimaxai/minimax-m3" }
+    }
+  }
+}
+EOF
+assert_eq "$(resolve_octopus_model "commandcode" "commandcode-research" "research" "researcher")" "minimaxai/minimax-m3" "Cross-provider legacy role falls through to matching object phase"
 
 # Test 6: Recursive reference (codex:spark)
 clear_model_cache


### PR DESCRIPTION
## Description
Resolve historical CodeRabbit Major findings left behind across merged PRs #616, #625, and #734. This hardens provider/model routing, OpenAI-compatible reasoning fallback behavior, Bash 3.2-compatible execution-profile overrides, and the affected test-framework coverage.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [x] OpenClaw registry in sync: `scripts/build-openclaw.sh --check`
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` (not applicable)
- [ ] Version bump (if releasing) (not applicable)
- [x] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (for features/fixes)

## Testing

```bash
bash tests/test-execution-profile.sh
bash tests/unit/test-execution-profile-dispatch.sh
python3 tests/unit/test-openai-reasoning-payload.py
bash tests/unit/test-resolve-model.sh
bash tests/unit/test-openclaw-compat.sh
bash -n scripts/orchestrate.sh
scripts/build-openclaw.sh --check
```

Focused results: execution profile 21/21, dispatch 10/10, reasoning payload PASS, resolver 21/21, OpenClaw compatibility 33/33.

## Related Issues
Follow-up to historical CodeRabbit Major findings in merged PRs #616, #625, and #734.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider and model routing across aliases, legacy routes, recursive references, and cross-provider configurations.
  - Preserved execution-profile provider overrides across supported shell environments.
  - Normalized `xhigh` and `max` reasoning requests to `high`.
  - Improved handling of APIs that reject `reasoning_effort`, avoiding unnecessary fallback retries.
  - Improved compatibility with model gateways that accept cross-provider model IDs.

- **Tests**
  - Added regression coverage for routing, shell overrides, provider capabilities, and reasoning-effort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->