### PR TITLE
fix: fail closed when provider allowlist is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Make review-fleet construction fail closed when the provider allowlist library cannot be loaded, and remove the unused optional cursor-agent library load.
+
 ## [10.1.0] - 2026-08-30
 
 ### Removed

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -19,8 +19,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-source "${SCRIPT_DIR}/../lib/cursor-agent.sh" 2>/dev/null || true
-source "${SCRIPT_DIR}/../lib/provider-allowlist.sh" 2>/dev/null || true
+PROVIDER_ALLOWLIST_LIB="${SCRIPT_DIR}/../lib/provider-allowlist.sh"
+if [[ ! -r "$PROVIDER_ALLOWLIST_LIB" ]]; then
+    printf 'ERROR: required provider allowlist library is not readable: %s\n' "$PROVIDER_ALLOWLIST_LIB" >&2
+    exit 1
+fi
+if ! source "$PROVIDER_ALLOWLIST_LIB"; then
+    printf 'ERROR: failed to load required provider allowlist library: %s\n' "$PROVIDER_ALLOWLIST_LIB" >&2
+    exit 1
+fi
 source "${SCRIPT_DIR}/../lib/provider-registry.sh"
 source "${SCRIPT_DIR}/../lib/provider-policy.sh"
 source "${SCRIPT_DIR}/../lib/agent-spec.sh"

--- a/tests/unit/test-provider-allowlist.sh
+++ b/tests/unit/test-provider-allowlist.sh
@@ -116,6 +116,20 @@ if assert_contains "$output" "agy:available" "legacy gemini token should authori
     test_pass
 fi
 
+test_case "build-fleet fails closed when provider allowlist library is missing"
+missing_root="$TEST_TMP_DIR/build-fleet-missing-allowlist"
+mkdir -p "$missing_root/helpers" "$missing_root/lib"
+cp "$BUILD_FLEET" "$missing_root/helpers/build-fleet.sh"
+set +e
+missing_output=$(bash "$missing_root/helpers/build-fleet.sh" review standard "review target" 2>&1)
+missing_rc=$?
+set -e
+if [[ "$missing_rc" -ne 0 ]] && [[ "$missing_output" == *"required provider allowlist library"* ]]; then
+    test_pass
+else
+    test_fail "build-fleet did not fail closed without provider-allowlist.sh: rc=$missing_rc output=$missing_output"
+fi
+
 test_case "build-fleet excludes disallowed providers"
 fleet=$(PATH="$mock_bin:/usr/bin:/bin" OCTO_ALLOWED_PROVIDERS="claude gemini" "$BUILD_FLEET" review standard "review target" 2>/dev/null)
 if assert_contains "$fleet" "agy|" "legacy gemini token should make AGY eligible" &&


### PR DESCRIPTION
## Description
Resolve a historical CodeRabbit Major finding left behind in merged PR #934. Review-fleet construction now fails closed if the required provider allowlist library cannot be loaded, and the unused optional cursor-agent library load is removed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh`
- [x] OpenClaw registry in sync: `scripts/build-openclaw.sh --check`
- [ ] New skills/commands registered in `.claude-plugin/plugin.json` (not applicable)
- [ ] Version bump (if releasing) (not applicable)
- [x] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (for features/fixes)

## Testing

```bash
bash tests/unit/test-provider-allowlist.sh
bash tests/unit/test-provider-neutral-council.sh
bash tests/unit/test-openclaw-compat.sh
bash -n scripts/orchestrate.sh
scripts/build-openclaw.sh --check
```

Focused results: provider allowlist 14/14, provider-neutral council 6/6, OpenClaw compatibility 33/33.

## Related Issues
Follow-up to a historical CodeRabbit Major finding in merged PR #934.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Review-fleet construction now stops safely with a clear error when the required provider allowlist cannot be loaded.
  - Removed an unused optional component load, reducing unnecessary setup during fleet construction.

- **Reliability**
  - Added validation to prevent fleet creation from continuing with incomplete provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->