### PR TITLE
fix(council): a degenerate chair no longer corrupts the quorum tally (real APPROVE recorded as met:false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@
   `summary.json` under `quorum.blind_seats`, and trigger an end-of-run warning
   naming the provider — so the seat's mode/model can be switched after the first
   blind round. (The default per-seat dispatch mode is unchanged.)
+- Council quorum no longer records a real, passed cross-vendor vote as
+  `quorum.met: false` when the chair synthesis fully degenerates. A chair that
+  was dispatched but returned a degenerate response (all chair seats degenerate,
+  host not the chair) previously forced `met=false` even when both independent
+  vendors cleanly APPROVED with distinct model families — silently, since the
+  family-shortage warning did not apply. `quorum.met` now reflects the
+  independent vote (as the host-native-chair carve-out already intended); the
+  missing synthesis is surfaced via a new `summary.json quorum.chair_synthesis_available`
+  flag and an end-of-run warning, and the run stops before synthesis with a clear
+  message directing the operator to the per-seat verdicts in `responses/`.
 
 ## [10.1.0] - 2026-08-30
 

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -3033,6 +3033,13 @@ council_write_summary_json() {
     council_scan_veto_artifacts
     received_non_chair="$(council_received_non_chair)"
 
+    # Only advertise synthesis.md when it was actually written. The stop-before-
+    # synthesis paths (quorum not met, or vote passed but no chair to synthesize)
+    # return before council_write_synthesis, so a hardcoded path would point a
+    # consumer at a file that does not exist.
+    local synthesis_written="false"
+    [[ -f "${COUNCIL_RUN_DIR}/synthesis.md" ]] && synthesis_written="true"
+
     jq -n \
         --arg run_id "$COUNCIL_RUN_ID" \
         --arg status "$status" \
@@ -3083,6 +3090,7 @@ council_write_summary_json() {
         --arg chair_fallback_used "$COUNCIL_CHAIR_FALLBACK_USED" \
         --arg chair_fallback_persona "$COUNCIL_CHAIR_FALLBACK_PERSONA" \
         --arg implementation_plan_written "$COUNCIL_IMPLEMENTATION_PLAN_WRITTEN" \
+        --arg synthesis_written "$synthesis_written" \
         --arg gate_a_approved "$COUNCIL_GATE_A_APPROVED" \
         --arg gate_b_approved "$COUNCIL_GATE_B_APPROVED" \
         --argjson handoff "$COUNCIL_IMPLEMENTATION_HANDOFF_JSON" \
@@ -3165,7 +3173,7 @@ council_write_summary_json() {
             overridden: false
           },
           artifacts: {
-            synthesis: "synthesis.md",
+            synthesis: (if $synthesis_written == "true" then "synthesis.md" else null end),
             responses_dir: "responses",
             critiques_dir: "critiques",
             revisions_dir: "revisions",

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -47,6 +47,7 @@ COUNCIL_RESPONSES_RECEIVED=""
 COUNCIL_QUORUM_MET=""
 COUNCIL_CHAIR_RESPONSE_RECEIVED=""
 COUNCIL_CHAIR_HOST_NATIVE=""
+COUNCIL_CHAIR_SYNTHESIS_AVAILABLE=""
 COUNCIL_CHAIR_FALLBACK_USED=""
 COUNCIL_CHAIR_FALLBACK_PERSONA=""
 COUNCIL_IMPLEMENTATION_PLAN_WRITTEN=""
@@ -2083,6 +2084,7 @@ council_run_advice_phase() {
     COUNCIL_RESPONSES_RECEIVED="0"
     COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
     COUNCIL_CHAIR_HOST_NATIVE="false"
+    COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="false"
     COUNCIL_RESPONDING_PROVIDERS=""
     COUNCIL_RESPONDING_MODEL_FAMILIES=""
     COUNCIL_SEAT_RECORDS_JSON="[]"
@@ -2246,8 +2248,24 @@ council_run_advice_phase() {
     if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" == "true" || "$COUNCIL_CHAIR_HOST_NATIVE" == "true" ]]; then
         chair_present="true"
     fi
+    # A present, synthesis-capable chair is what makes a synthesized recommendation
+    # possible. Track it separately from the vote: the chair is the synthesizer, not
+    # an independent cross-lab reviewer (see the seats[] note above), so its absence
+    # must not flip a passed vote to met=false.
+    COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="$chair_present"
 
-    if [[ "$chair_present" == "true" ]] && (( received_non_chair >= required )) \
+    # The independent cross-lab VOTE, from the non-chair seats' verdicts alone:
+    # >= `required` responders AND, for standard/deep, >= `required` DISTINCT
+    # APPROVING model families. quorum.met reflects THIS vote. A missing or fully
+    # degenerate chair synthesis no longer forces met=false — the host-native
+    # carve-out above already establishes that a run with two cleanly-approving
+    # vendors must not be reported met=false purely because a chair response file
+    # never materialized; a dispatched-but-degenerate chair is the same principle.
+    # When the vote passes but no chair synthesis is present, met stays true and the
+    # missing synthesis is surfaced loudly (council_print_run_warnings +
+    # summary.json quorum.chair_synthesis_available) so the operator reads the raw
+    # per-seat verdicts instead of trusting a silently corrupted met=false.
+    if (( received_non_chair >= required )) \
         && { (( required < 2 )) || (( COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES >= required )); }; then
         COUNCIL_QUORUM_MET="true"
     else
@@ -3061,6 +3079,7 @@ council_write_summary_json() {
         --arg approving_model_families "${COUNCIL_APPROVING_MODEL_FAMILIES:-}" \
         --arg chair_received "$COUNCIL_CHAIR_RESPONSE_RECEIVED" \
         --arg chair_host_native "${COUNCIL_CHAIR_HOST_NATIVE:-false}" \
+        --arg chair_synthesis_available "${COUNCIL_CHAIR_SYNTHESIS_AVAILABLE:-false}" \
         --arg chair_fallback_used "$COUNCIL_CHAIR_FALLBACK_USED" \
         --arg chair_fallback_persona "$COUNCIL_CHAIR_FALLBACK_PERSONA" \
         --arg implementation_plan_written "$COUNCIL_IMPLEMENTATION_PLAN_WRITTEN" \
@@ -3100,6 +3119,7 @@ council_write_summary_json() {
             received_non_chair: ($received_non_chair | tonumber),
             chair_received: ($chair_received == "true"),
             chair_host_native: ($chair_host_native == "true"),
+            chair_synthesis_available: ($chair_synthesis_available == "true"),
             distinct_providers: ($distinct_providers | tonumber),
             responding_providers: $responding_providers,
             distinct_approving_providers: ($distinct_approving_providers | tonumber),
@@ -3196,6 +3216,10 @@ council_print_run_warnings() {
     if [[ -n "${COUNCIL_BLIND_SEATS:-}" ]]; then
         echo "Council warning: blind seat(s) returned a verdict without reading the artifact and were excluded from quorum: ${COUNCIL_BLIND_SEATS} — switch that provider's mode/model (e.g. give it file-read tools) or inline the artifact into the prompt. See summary.json quorum.blind_seats."
     fi
+
+    if [[ "$COUNCIL_QUORUM_MET" == "true" && "${COUNCIL_CHAIR_SYNTHESIS_AVAILABLE:-}" != "true" ]]; then
+        echo "Council warning: quorum met on independent vendor approvals, but chair synthesis was unavailable (no chair response / all chair seats degenerate). No synthesized recommendation was produced — read responses/*.md for the per-seat verdicts. See summary.json quorum.chair_synthesis_available."
+    fi
 }
 
 # Body of the council run. Wrapped by council_run() below so that a summary.json
@@ -3242,11 +3266,25 @@ _council_run_impl() {
 
     council_run_advice_phase
 
+    # Two distinct stop-before-synthesis conditions:
+    #   1. The vote failed (quorum.met=false) — nothing was approved.
+    #   2. The vote PASSED (quorum.met=true) but no synthesis-capable chair is
+    #      present (all chair seats degenerate, host not the chair), so there is no
+    #      one to synthesize. met stays true — the vote stands and is recorded — but
+    #      the run cannot produce synthesis.md this round. This must be surfaced, not
+    #      silently reported as a failed quorum (the corrupted-tally failure mode).
     if [[ "$COUNCIL_QUORUM_MET" != "true" ]]; then
         council_append_corpus_artifacts || return 1
         council_write_summary_json "partial" || return 1
         council_print_run_warnings
         echo "Council stopped before synthesis: quorum was not met. See ${COUNCIL_RUN_DIR}/summary.json"
+        return 1
+    fi
+    if [[ "$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE" != "true" ]]; then
+        council_append_corpus_artifacts || return 1
+        council_write_summary_json "partial" || return 1
+        council_print_run_warnings
+        echo "Council quorum met on independent vendor approvals, but chair synthesis was unavailable — no synthesized recommendation was produced this round. Read the per-seat verdicts in ${COUNCIL_RUN_DIR}/responses/ (summary.json quorum.met=true, chair_synthesis_available=false)."
         return 1
     fi
 

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -149,6 +149,7 @@ council_reset_defaults() {
     COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
     COUNCIL_CHAIR_HOST_NATIVE="false"
     COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="false"
+    COUNCIL_BLIND_SEATS=""
     COUNCIL_CHAIR_FALLBACK_USED="false"
     COUNCIL_CHAIR_FALLBACK_PERSONA=""
     COUNCIL_IMPLEMENTATION_PLAN_WRITTEN="false"
@@ -2247,7 +2248,8 @@ council_run_advice_phase() {
         COUNCIL_CHAIR_HOST_NATIVE="true"
     fi
     # Chair response and host-native state identify a synthesis candidate.
-    # COUNCIL_CHAIR_SYNTHESIS_AVAILABLE stays false until synthesis succeeds.
+    # Availability stays false until dispatched synthesis succeeds or the
+    # expected host-native in-context placeholder has been written.
 
     # The independent cross-lab VOTE, from the non-chair seats' verdicts alone:
     # >= `required` responders AND, for standard/deep, >= `required` DISTINCT
@@ -3320,6 +3322,11 @@ _council_run_impl() {
     fi
     COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="false"
     if council_write_synthesis; then
+        COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="true"
+    elif [[ "$COUNCIL_CHAIR_HOST_NATIVE" == "true" \
+          && -s "${COUNCIL_RUN_DIR}/synthesis.md" ]]; then
+        # A host-native chair cannot dispatch itself. Its expected fallback file
+        # keeps the in-context synthesis contract available to the host run.
         COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="true"
     else
         council_append_corpus_artifacts || return 1

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -3296,7 +3296,7 @@ _council_run_impl() {
         council_append_corpus_artifacts || return 1
         council_write_summary_json "partial" || return 1
         council_print_run_warnings
-        echo "Council quorum met on independent vendor approvals, but chair synthesis was unavailable — no synthesized recommendation was produced this round. Read the per-seat verdicts in ${COUNCIL_RUN_DIR}/responses/ (summary.json quorum.met=true, chair_synthesis_available=false)."
+        _council_warn "Council quorum met on independent vendor approvals, but chair synthesis was unavailable — no synthesized recommendation was produced this round. Read the per-seat verdicts in ${COUNCIL_RUN_DIR}/responses/ (summary.json quorum.met=true, chair_synthesis_available=false)."
         return 1
     fi
 
@@ -3332,7 +3332,7 @@ _council_run_impl() {
         council_append_corpus_artifacts || return 1
         council_write_summary_json "partial" || return 1
         council_print_run_warnings
-        echo "Council quorum met on independent vendor approvals, but chair synthesis was unavailable — no synthesized recommendation was produced this round. Read the per-seat verdicts in ${COUNCIL_RUN_DIR}/responses/ (summary.json quorum.met=true, chair_synthesis_available=false)."
+        _council_warn "Council quorum met on independent vendor approvals, but chair synthesis was unavailable — no synthesized recommendation was produced this round. Read the per-seat verdicts in ${COUNCIL_RUN_DIR}/responses/ (summary.json quorum.met=true, chair_synthesis_available=false)."
         return 1
     fi
     if council_check_cost_cap "implementation" "implementation planning"; then

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -147,6 +147,8 @@ council_reset_defaults() {
     COUNCIL_RESPONSES_RECEIVED="0"
     COUNCIL_QUORUM_MET="false"
     COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
+    COUNCIL_CHAIR_HOST_NATIVE="false"
+    COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="false"
     COUNCIL_CHAIR_FALLBACK_USED="false"
     COUNCIL_CHAIR_FALLBACK_PERSONA=""
     COUNCIL_IMPLEMENTATION_PLAN_WRITTEN="false"
@@ -2244,15 +2246,8 @@ council_run_advice_phase() {
     if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" != "true" ]] && council_chair_is_host_native; then
         COUNCIL_CHAIR_HOST_NATIVE="true"
     fi
-    local chair_present="false"
-    if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" == "true" || "$COUNCIL_CHAIR_HOST_NATIVE" == "true" ]]; then
-        chair_present="true"
-    fi
-    # A present, synthesis-capable chair is what makes a synthesized recommendation
-    # possible. Track it separately from the vote: the chair is the synthesizer, not
-    # an independent cross-lab reviewer (see the seats[] note above), so its absence
-    # must not flip a passed vote to met=false.
-    COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="$chair_present"
+    # Chair response and host-native state identify a synthesis candidate.
+    # COUNCIL_CHAIR_SYNTHESIS_AVAILABLE stays false until synthesis succeeds.
 
     # The independent cross-lab VOTE, from the non-chair seats' verdicts alone:
     # >= `required` responders AND, for standard/deep, >= `required` DISTINCT
@@ -2503,6 +2498,7 @@ Medium
 
 Review \`summary.json\` and approve, revise, debate, or stop.
 EOF
+    return 1
 }
 
 council_needs_implementation_plan() {
@@ -3226,7 +3222,12 @@ council_print_run_warnings() {
     fi
 
     if [[ "$COUNCIL_QUORUM_MET" == "true" && "${COUNCIL_CHAIR_SYNTHESIS_AVAILABLE:-}" != "true" ]]; then
-        echo "Council warning: quorum met on independent vendor approvals, but chair synthesis was unavailable (no chair response / all chair seats degenerate). No synthesized recommendation was produced — read responses/*.md for the per-seat verdicts. See summary.json quorum.chair_synthesis_available."
+        local _chair_synthesis_warning="Council warning: quorum met on independent vendor approvals, but chair synthesis was unavailable (no chair response / all chair seats degenerate). No synthesized recommendation was produced — read responses/*.md for the per-seat verdicts. See summary.json quorum.chair_synthesis_available."
+        if declare -F log >/dev/null 2>&1; then
+            log WARN "$_chair_synthesis_warning" 2>&1
+        else
+            printf '%s\n' "$_chair_synthesis_warning"
+        fi
     fi
 }
 
@@ -3288,7 +3289,8 @@ _council_run_impl() {
         echo "Council stopped before synthesis: quorum was not met. See ${COUNCIL_RUN_DIR}/summary.json"
         return 1
     fi
-    if [[ "$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE" != "true" ]]; then
+    if [[ "$COUNCIL_CHAIR_RESPONSE_RECEIVED" != "true" \
+          && "$COUNCIL_CHAIR_HOST_NATIVE" != "true" ]]; then
         council_append_corpus_artifacts || return 1
         council_write_summary_json "partial" || return 1
         council_print_run_warnings
@@ -3316,7 +3318,16 @@ _council_run_impl() {
         [[ "$COUNCIL_ABORTED_FOR_COST" == "true" ]] && return 0
         return 1
     fi
-    council_write_synthesis
+    COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="false"
+    if council_write_synthesis; then
+        COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="true"
+    else
+        council_append_corpus_artifacts || return 1
+        council_write_summary_json "partial" || return 1
+        council_print_run_warnings
+        echo "Council quorum met on independent vendor approvals, but chair synthesis was unavailable — no synthesized recommendation was produced this round. Read the per-seat verdicts in ${COUNCIL_RUN_DIR}/responses/ (summary.json quorum.met=true, chair_synthesis_available=false)."
+        return 1
+    fi
     if council_check_cost_cap "implementation" "implementation planning"; then
         :
     else

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1953,10 +1953,12 @@ test_council_split_double_seat_fails_quorum() {
     OCTOPUS_COUNCIL_FIXTURE_REVISE_PERSONAS='code-reviewer' \
         council_run --depth standard --output-dir "$tmp_dir" "Review X" >/dev/null 2>&1 || true
     rd="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
-    if jq -e '.quorum.met == false and .quorum.distinct_approving_providers == 1 and .quorum.approving_providers == "agy"' "$rd/summary.json" >/dev/null; then
+    # This run stops before synthesis (quorum not met), so synthesis.md is never
+    # written — summary.json must NOT advertise it (artifacts.synthesis == null).
+    if jq -e '.quorum.met == false and .quorum.distinct_approving_providers == 1 and .quorum.approving_providers == "agy" and .artifacts.synthesis == null' "$rd/summary.json" >/dev/null; then
         test_pass
     else
-        test_fail "split double-seat did not fail quorum: $(jq -c .quorum "$rd/summary.json" 2>/dev/null)"
+        test_fail "split double-seat did not fail quorum or advertised a missing synthesis.md: quorum=$(jq -c .quorum "$rd/summary.json" 2>/dev/null) synthesis=$(jq -c .artifacts.synthesis "$rd/summary.json" 2>/dev/null)"
         return 1
     fi
 }
@@ -1966,10 +1968,11 @@ test_council_all_approve_meets_quorum() {
     load_council_lib || return 1
     prepare_cached_all_approve_run || { test_fail "cached all-approve run failed"; return 1; }
     local rd="$CACHED_COUNCIL_ALL_APPROVE_RUN_DIR"
-    if jq -e '.quorum.met == true and .quorum.distinct_approving_providers >= 2' "$rd/summary.json" >/dev/null; then
+    # This run completes through synthesis, so summary.json advertises synthesis.md.
+    if jq -e '.quorum.met == true and .quorum.distinct_approving_providers >= 2 and .artifacts.synthesis == "synthesis.md"' "$rd/summary.json" >/dev/null; then
         test_pass
     else
-        test_fail "clean all-approve did not meet quorum: $(jq -c .quorum "$rd/summary.json" 2>/dev/null)"
+        test_fail "clean all-approve did not meet quorum or failed to advertise synthesis.md: quorum=$(jq -c .quorum "$rd/summary.json" 2>/dev/null) synthesis=$(jq -c .artifacts.synthesis "$rd/summary.json" 2>/dev/null)"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1624,24 +1624,46 @@ test_council_quorum_met_with_host_native_chair() {
 }
 
 test_council_reset_defaults_clears_chair_state() {
-    test_case "council_reset_defaults clears host-native and synthesis state from a prior run"
+    test_case "council_reset_defaults clears chair and blind-seat state from a prior run"
     load_council_lib || return 1
 
     COUNCIL_CHAIR_HOST_NATIVE="true"
     COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="true"
+    COUNCIL_BLIND_SEATS="codex agy"
     council_reset_defaults
 
     if [[ "$COUNCIL_CHAIR_HOST_NATIVE" == "false" \
-          && "$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE" == "false" ]]; then
+          && "$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE" == "false" \
+          && -z "$COUNCIL_BLIND_SEATS" ]]; then
         test_pass
     else
-        test_fail "chair state survived reset: host_native=$COUNCIL_CHAIR_HOST_NATIVE synthesis=$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE"
+        test_fail "per-run state survived reset: host_native=$COUNCIL_CHAIR_HOST_NATIVE synthesis=$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE blind=[$COUNCIL_BLIND_SEATS]"
         return 1
     fi
 }
 
-test_council_failed_host_native_synthesis_is_partial() {
-    test_case "failed host-native synthesis records a partial run and leaves synthesis unavailable"
+test_council_dry_run_does_not_reuse_blind_seats() {
+    test_case "a dry run does not report blind seats retained from a prior run"
+    load_council_lib || return 1
+    local d summary
+    d="$(mktemp -d "$TEST_TMP_DIR/council-blind-reset.XXXXXX")"
+
+    COUNCIL_BLIND_SEATS="codex agy"
+    council_run --dry-run --goal advice --depth quick --benchmark off \
+        --output-dir "$d" "Review the change" >/dev/null
+    summary="$(find "$d" -name summary.json -type f -print -quit)"
+
+    if [[ -f "$summary" ]] && jq -e \
+        '.status == "dry-run" and .quorum.blind_seats == []' "$summary" >/dev/null; then
+        test_pass
+    else
+        test_fail "dry-run retained blind seats: $(jq -c '.quorum.blind_seats' "$summary" 2>/dev/null || printf missing)"
+        return 1
+    fi
+}
+
+test_council_host_native_placeholder_completes_in_context() {
+    test_case "host-native synthesis placeholder remains completed and available in context"
     load_council_lib || return 1
     local d; d="$(mktemp -d "$TEST_TMP_DIR/council-hnsynth.XXXXXX")"
     mkdir -p "$d/responses" "$d/critiques" "$d/revisions"
@@ -1659,7 +1681,54 @@ test_council_failed_host_native_synthesis_is_partial() {
         COUNCIL_QUORUM_MET="true"
         COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
         COUNCIL_CHAIR_HOST_NATIVE="true"
-        COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="true"
+        COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="false"
+    }
+    council_run_critique_phase() { :; }
+    council_run_revision_phase() { :; }
+    council_dispatch_member() { return 1; }
+    council_append_corpus_artifacts() { :; }
+    council_write_summary_json() { printf '%s' "$1" > "$d/summary-status"; }
+    council_print_run_warnings() { :; }
+    council_write_implementation_plan() { :; }
+    council_scan_veto_artifacts() { :; }
+    council_needs_implementation_plan() { return 1; }
+    council_process_implementation_gates() { :; }
+
+    local rc=0
+    _council_run_impl "Review the change" >/dev/null 2>&1 || rc=$?
+    local status=""
+    status="$(cat "$d/summary-status" 2>/dev/null)"
+
+    if [[ "$rc" -eq 0 && "$status" == "completed" \
+          && "$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE" == "true" \
+          && -s "$d/synthesis.md" ]]; then
+        test_pass
+    else
+        test_fail "host-native placeholder contract wrong: rc=$rc status=$status synthesis=$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE artifact=$([[ -s "$d/synthesis.md" ]] && printf yes || printf no)"
+        return 1
+    fi
+}
+
+test_council_failed_dispatched_synthesis_is_partial() {
+    test_case "a failed dispatched chair synthesis remains partial and unavailable"
+    load_council_lib || return 1
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-dispatched-synth.XXXXXX")"
+    mkdir -p "$d/responses" "$d/critiques" "$d/revisions"
+
+    council_parse_args() { council_reset_defaults; COUNCIL_TASK="Review the change"; }
+    council_create_run_dir() { COUNCIL_RUN_DIR="$d"; COUNCIL_RUN_ID="test-dispatched-synthesis"; }
+    council_build_roster() {
+        COUNCIL_RESOLVED_MEMBERS="strategy-analyst,backend-architect,security-auditor"
+        COUNCIL_ROSTER_JSON='[{"persona":"strategy-analyst","seat":"chair","provider":"codex"}]'
+    }
+    council_write_config_json() { :; }
+    council_write_research_artifact() { :; }
+    council_check_cost_cap() { return 0; }
+    council_run_advice_phase() {
+        COUNCIL_QUORUM_MET="true"
+        COUNCIL_CHAIR_RESPONSE_RECEIVED="true"
+        COUNCIL_CHAIR_HOST_NATIVE="false"
+        COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="false"
     }
     council_run_critique_phase() { :; }
     council_run_revision_phase() { :; }
@@ -1678,11 +1747,10 @@ test_council_failed_host_native_synthesis_is_partial() {
     status="$(cat "$d/summary-status" 2>/dev/null)"
 
     if [[ "$rc" -ne 0 && "$status" == "partial" \
-          && "$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE" == "false" \
-          && -s "$d/synthesis.md" ]]; then
+          && "$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE" == "false" ]]; then
         test_pass
     else
-        test_fail "failed synthesis was not partial: rc=$rc status=$status synthesis=$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE artifact=$([[ -s "$d/synthesis.md" ]] && printf yes || printf no)"
+        test_fail "failed dispatched synthesis contract wrong: rc=$rc status=$status synthesis=$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE"
         return 1
     fi
 }
@@ -1877,7 +1945,9 @@ test_council_per_session_pool_isolation
 test_council_benchmark_routing_lib_is_extracted
 test_council_chair_is_host_native_detects_status
 test_council_reset_defaults_clears_chair_state
-test_council_failed_host_native_synthesis_is_partial
+test_council_dry_run_does_not_reuse_blind_seats
+test_council_host_native_placeholder_completes_in_context
+test_council_failed_dispatched_synthesis_is_partial
 test_council_synthesis_warning_uses_logger_and_stays_capturable
 test_council_quorum_met_with_host_native_chair
 test_council_degenerate_chair_keeps_vote_and_flags_synthesis

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1574,7 +1574,7 @@ test_council_run_status_beacon_lifecycle() {
 }
 
 test_council_quorum_met_with_host_native_chair() {
-    test_case "quorum.met reflects the vote: host-native chair (synthesis available) and chair-absent (met stays true, synthesis flagged unavailable) both keep two vendor approvals"
+    test_case "quorum.met reflects the vote before synthesis: host-native and absent chairs keep two vendor approvals without claiming synthesis"
     load_council_lib || return 1
     local d; d="$(mktemp -d "$TEST_TMP_DIR/council-hnchair.XXXXXX")"; mkdir -p "$d/responses"
     COUNCIL_RUN_DIR="$d"
@@ -1614,11 +1614,102 @@ test_council_quorum_met_with_host_native_chair() {
 
     unset -f council_dispatch_member_detached council_run_chair_fallback
 
-    if [[ "$met_hn" == "true" && "$chair_recv_hn" == "false" && "$hostnative_hn" == "true" && "$synth_hn" == "true" \
+    if [[ "$met_hn" == "true" && "$chair_recv_hn" == "false" && "$hostnative_hn" == "true" && "$synth_hn" == "false" \
           && "$met_absent" == "true" && "$synth_absent" == "false" ]]; then
         test_pass
     else
         test_fail "host-native chair quorum wrong: met=$met_hn chair_received=$chair_recv_hn host_native=$hostnative_hn synth=$synth_hn ; absent-chair met=$met_absent synth=$synth_absent"
+        return 1
+    fi
+}
+
+test_council_reset_defaults_clears_chair_state() {
+    test_case "council_reset_defaults clears host-native and synthesis state from a prior run"
+    load_council_lib || return 1
+
+    COUNCIL_CHAIR_HOST_NATIVE="true"
+    COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="true"
+    council_reset_defaults
+
+    if [[ "$COUNCIL_CHAIR_HOST_NATIVE" == "false" \
+          && "$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE" == "false" ]]; then
+        test_pass
+    else
+        test_fail "chair state survived reset: host_native=$COUNCIL_CHAIR_HOST_NATIVE synthesis=$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE"
+        return 1
+    fi
+}
+
+test_council_failed_host_native_synthesis_is_partial() {
+    test_case "failed host-native synthesis records a partial run and leaves synthesis unavailable"
+    load_council_lib || return 1
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-hnsynth.XXXXXX")"
+    mkdir -p "$d/responses" "$d/critiques" "$d/revisions"
+
+    council_parse_args() { council_reset_defaults; COUNCIL_TASK="Review the change"; }
+    council_create_run_dir() { COUNCIL_RUN_DIR="$d"; COUNCIL_RUN_ID="test-host-native-synthesis"; }
+    council_build_roster() {
+        COUNCIL_RESOLVED_MEMBERS="strategy-analyst,backend-architect,security-auditor"
+        COUNCIL_ROSTER_JSON='[{"persona":"strategy-analyst","seat":"chair","provider":"claude"}]'
+    }
+    council_write_config_json() { :; }
+    council_write_research_artifact() { :; }
+    council_check_cost_cap() { return 0; }
+    council_run_advice_phase() {
+        COUNCIL_QUORUM_MET="true"
+        COUNCIL_CHAIR_RESPONSE_RECEIVED="false"
+        COUNCIL_CHAIR_HOST_NATIVE="true"
+        COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="true"
+    }
+    council_run_critique_phase() { :; }
+    council_run_revision_phase() { :; }
+    council_dispatch_member() { return 1; }
+    council_append_corpus_artifacts() { :; }
+    council_write_summary_json() { printf '%s' "$1" > "$d/summary-status"; }
+    council_print_run_warnings() { :; }
+    council_write_implementation_plan() { :; }
+    council_scan_veto_artifacts() { :; }
+    council_needs_implementation_plan() { return 1; }
+    council_process_implementation_gates() { :; }
+
+    local rc=0
+    _council_run_impl "Review the change" >/dev/null 2>&1 || rc=$?
+    local status=""
+    status="$(cat "$d/summary-status" 2>/dev/null)"
+
+    if [[ "$rc" -ne 0 && "$status" == "partial" \
+          && "$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE" == "false" \
+          && -s "$d/synthesis.md" ]]; then
+        test_pass
+    else
+        test_fail "failed synthesis was not partial: rc=$rc status=$status synthesis=$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE artifact=$([[ -s "$d/synthesis.md" ]] && printf yes || printf no)"
+        return 1
+    fi
+}
+
+test_council_synthesis_warning_uses_logger_and_stays_capturable() {
+    test_case "chair synthesis warning uses the project logger and remains capturable on stdout"
+    load_council_lib || return 1
+    local logged="$TEST_TMP_DIR/council-warning-log.txt"
+    local stderr="$TEST_TMP_DIR/council-warning-stderr.txt"
+    local message="Council warning: quorum met on independent vendor approvals, but chair synthesis was unavailable (no chair response / all chair seats degenerate). No synthesized recommendation was produced — read responses/*.md for the per-seat verdicts. See summary.json quorum.chair_synthesis_available."
+
+    log() {
+        printf '%s|%s\n' "$1" "$2" > "$logged"
+        printf 'LOGGER: %s\n' "$2" >&2
+    }
+    COUNCIL_QUORUM_MET="true"
+    COUNCIL_CHAIR_SYNTHESIS_AVAILABLE="false"
+
+    local output
+    output="$(council_print_run_warnings 2> "$stderr")"
+    unset -f log
+
+    if [[ "$(cat "$logged" 2>/dev/null)" == "WARN|$message" \
+          && "$output" == *"$message"* && ! -s "$stderr" ]]; then
+        test_pass
+    else
+        test_fail "warning logger contract wrong: logged=[$(cat "$logged" 2>/dev/null)] output=[$output] stderr=[$(cat "$stderr" 2>/dev/null)]"
         return 1
     fi
 }
@@ -1785,6 +1876,9 @@ test_council_run_status_beacon_lifecycle
 test_council_per_session_pool_isolation
 test_council_benchmark_routing_lib_is_extracted
 test_council_chair_is_host_native_detects_status
+test_council_reset_defaults_clears_chair_state
+test_council_failed_host_native_synthesis_is_partial
+test_council_synthesis_warning_uses_logger_and_stays_capturable
 test_council_quorum_met_with_host_native_chair
 test_council_degenerate_chair_keeps_vote_and_flags_synthesis
 test_council_one_vote_per_vendor_opt_in

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -1574,7 +1574,7 @@ test_council_run_status_beacon_lifecycle() {
 }
 
 test_council_quorum_met_with_host_native_chair() {
-    test_case "quorum.met is true when a host-native chair + two vendors approve (chair_received stays false)"
+    test_case "quorum.met reflects the vote: host-native chair (synthesis available) and chair-absent (met stays true, synthesis flagged unavailable) both keep two vendor approvals"
     load_council_lib || return 1
     local d; d="$(mktemp -d "$TEST_TMP_DIR/council-hnchair.XXXXXX")"; mkdir -p "$d/responses"
     COUNCIL_RUN_DIR="$d"
@@ -1600,21 +1600,75 @@ test_council_quorum_met_with_host_native_chair() {
 
     COUNCIL_PROVIDER_STATUS_JSON='{"claude":"host-native","codex":"available","agy":"available"}' \
         council_run_advice_phase >/dev/null 2>&1 || true
-    local met_hn chair_recv_hn hostnative_hn
-    met_hn="$COUNCIL_QUORUM_MET"; chair_recv_hn="$COUNCIL_CHAIR_RESPONSE_RECEIVED"; hostnative_hn="$COUNCIL_CHAIR_HOST_NATIVE"
+    local met_hn chair_recv_hn hostnative_hn synth_hn
+    met_hn="$COUNCIL_QUORUM_MET"; chair_recv_hn="$COUNCIL_CHAIR_RESPONSE_RECEIVED"
+    hostnative_hn="$COUNCIL_CHAIR_HOST_NATIVE"; synth_hn="$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE"
 
-    # Negative control: same two approvals but the chair provider is merely
-    # "available" and never responded — chair is genuinely absent, met must be false.
+    # Chair genuinely absent (provider merely "available", never responded, no
+    # fallback): the two vendor approvals still carry the VOTE, so met stays true
+    # (Finding 4 — a missing/degenerate chair must not corrupt the tally to
+    # met=false), but the missing synthesis is flagged chair_synthesis_available=false.
     COUNCIL_PROVIDER_STATUS_JSON='{"claude":"available","codex":"available","agy":"available"}' \
         council_run_advice_phase >/dev/null 2>&1 || true
-    local met_absent="$COUNCIL_QUORUM_MET"
+    local met_absent="$COUNCIL_QUORUM_MET" synth_absent="$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE"
 
     unset -f council_dispatch_member_detached council_run_chair_fallback
 
-    if [[ "$met_hn" == "true" && "$chair_recv_hn" == "false" && "$hostnative_hn" == "true" && "$met_absent" == "false" ]]; then
+    if [[ "$met_hn" == "true" && "$chair_recv_hn" == "false" && "$hostnative_hn" == "true" && "$synth_hn" == "true" \
+          && "$met_absent" == "true" && "$synth_absent" == "false" ]]; then
         test_pass
     else
-        test_fail "host-native chair quorum wrong: met=$met_hn chair_received=$chair_recv_hn host_native=$hostnative_hn ; absent-chair met=$met_absent"
+        test_fail "host-native chair quorum wrong: met=$met_hn chair_received=$chair_recv_hn host_native=$hostnative_hn synth=$synth_hn ; absent-chair met=$met_absent synth=$synth_absent"
+        return 1
+    fi
+}
+
+test_council_degenerate_chair_keeps_vote_and_flags_synthesis() {
+    test_case "a dispatched chair that returns a degenerate response keeps quorum.met=true on the two vendor approvals, flags chair_synthesis_available=false, and warns (Finding 4)"
+    load_council_lib || return 1
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-degchair.XXXXXX")"; mkdir -p "$d/responses"
+    COUNCIL_RUN_DIR="$d"
+    COUNCIL_DEPTH="standard"   # required_non_chair = 2
+    COUNCIL_FIXTURE=""
+    COUNCIL_CHAIR_FALLBACK_USED="false"; COUNCIL_CHAIR_FALLBACK_PERSONA=""
+    COUNCIL_ROSTER_JSON='[
+      {"persona":"strategy-analyst","seat":"chair","provider":"codex","provider_org":"openai","model":"gpt"},
+      {"persona":"backend-architect","seat":"member","provider":"codex","provider_org":"openai","model":"gpt"},
+      {"persona":"security-auditor","seat":"member","provider":"agy","provider_org":"google","model":"gemini"}
+    ]'
+    # The two non-chair vendors cleanly APPROVE with grounded evidence; the chair
+    # seat is DISPATCHED but returns the host self-dispatch stub (non-substantive →
+    # degenerate). The chair provider is NOT host-native, and no fallback recovers
+    # it, so the chair synthesis is genuinely absent — but the vote still carries.
+    council_dispatch_member_detached() {
+        local mj="$1" out="$3" seat
+        seat="$(jq -r '.seat // "member"' <<< "$mj")"
+        if [[ "$seat" == "chair" ]]; then
+            printf 'Subprocess dispatch is unavailable in this environment.\n' > "$out"
+            return 0
+        fi
+        printf '## Review\n\nsrc/app.ts:42 correctly guards the nil case; tests cover it.\n\nVERDICT: APPROVE\n' > "$out"
+        return 0
+    }
+    council_run_chair_fallback() { :; }   # no dispatched fallback available
+
+    COUNCIL_PROVIDER_STATUS_JSON='{"codex":"available","agy":"available"}' \
+        council_run_advice_phase >/dev/null 2>&1 || true
+
+    local met synth chair_status approving warn
+    met="$COUNCIL_QUORUM_MET"
+    synth="$COUNCIL_CHAIR_SYNTHESIS_AVAILABLE"
+    chair_status="$(jq -r 'map(select(.seat == "chair"))[0].status // "none"' <<< "$COUNCIL_SEAT_RECORDS_JSON" 2>/dev/null)"
+    approving="$COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES"
+    warn="$(council_print_run_warnings)"
+
+    unset -f council_dispatch_member_detached council_run_chair_fallback
+
+    if [[ "$met" == "true" && "$synth" == "false" && "$chair_status" == "degenerate" \
+          && "$approving" == "2" && "$warn" == *"chair synthesis was unavailable"* ]]; then
+        test_pass
+    else
+        test_fail "degenerate-chair quorum wrong: met=$met synth=$synth chair_status=$chair_status approving_families=$approving warn=[$warn]"
         return 1
     fi
 }
@@ -1732,6 +1786,7 @@ test_council_per_session_pool_isolation
 test_council_benchmark_routing_lib_is_extracted
 test_council_chair_is_host_native_detects_status
 test_council_quorum_met_with_host_native_chair
+test_council_degenerate_chair_keeps_vote_and_flags_synthesis
 test_council_one_vote_per_vendor_opt_in
 test_council_defaults_are_depth_aware
 test_council_rejects_non_usd_budget


### PR DESCRIPTION
## Problem (octo-dev Finding 4)

A council seat's headline verdict lives in `summary.json` at `quorum.met`. On a real governed run (#2346 CP2), **both** non-chair vendors (`agy`, `codex`) ended their `responses/*.md` with `VERDICT: APPROVE` — grounded, citing real `file:line` — yet `summary.json` recorded `quorum.met: false`. All three `chair`-labeled seats had `status: "degenerate"`. The operator only rescued the valid quorum by hex-dumping the response tails (`tail -c 200 | xxd`).

### Root cause

`COUNCIL_QUORUM_MET` required `chair_present` — a chair *response* OR a *host-native* chair:

```sh
if [[ "$chair_present" == "true" ]] && (( received_non_chair >= required )) \
    && { (( required < 2 )) || (( DISTINCT_APPROVING_MODEL_FAMILIES >= required )); }; then
    COUNCIL_QUORUM_MET="true"
else
    COUNCIL_QUORUM_MET="false"
    ...
fi
```

When every dispatched chair seat comes back degenerate and the host is **not** the chair, `chair_present=false` → `met=false`, **even with two cleanly-approving distinct-family vendors**. And it's silent: the distinct-approving-family guard warning only fires when families are *insufficient* (they weren't here), so nothing is logged.

The chair is the **synthesizer, not an independent cross-lab vote** — the `seats[]` tally already encodes that (`.seat != "chair"`). So a failed synthesis must not flip a passed vote. The code even says so: the host-native carve-out at `council.sh:2018` was added precisely so "a run with two cleanly-approving vendors is [not] falsely reported quorum.met=false purely because chair_received never flipped true." Finding 4 is the same principle violated via a different path — a dispatched-but-degenerate chair.

## Change

- **Separate the vote from the chair.** `quorum.met` now reflects the independent approving-family vote alone. Chair presence moves to a new `COUNCIL_CHAIR_SYNTHESIS_AVAILABLE`.
- **Never silent.** `summary.json` gains `quorum.chair_synthesis_available`; `council_print_run_warnings` emits a warning; and when the vote passed but no chair can synthesize, the run stops before synthesis with a message pointing at `responses/`.

This matches the scope confirmed with the maintainer-side operator: `met` reflects the vote (not the synthesis), and the missing synthesis is surfaced loudly rather than corrupting the tally.

```
quorum.met = true                       # 2 distinct approving families, required=2
quorum.chair_synthesis_available = false
WARNING: quorum met on independent vendor approvals, but chair synthesis was
unavailable (all chair seats degenerate). No synthesized recommendation was
produced — read responses/*.md for the per-seat verdicts.
```

**Scope, deliberately narrow:** this does not change *why* a chair degenerates (that's Finding 1 / #973 territory — cross-session seat reaping) nor the per-seat dispatch mode (Finding 2 / #978). It only stops a failed synthesis from corrupting an otherwise-passed vote.

## Test

- `test_council_degenerate_chair_keeps_vote_and_flags_synthesis` — the exact Finding-4 repro: a dispatched chair returns the host self-dispatch stub (→ degenerate), two vendors APPROVE, host not native → asserts `met=true`, `chair_synthesis_available=false`, chair seat `status=degenerate`, two approving families, and the warning text.
- Updates the host-native-chair test's negative control to the new contract (absent chair + passing vote → `met=true`, synthesis flagged unavailable).

Both new assertions are coupled to the new global and cannot pass against pre-fix code (verified: pre-fix run aborts on `COUNCIL_CHAIR_SYNTHESIS_AVAILABLE: unbound variable`). Full suite: `tests/unit/test-council-command.sh` → 87 passed, 0 failed, 1 skipped (pre-existing pty skip).

## Relationship to the other council PRs

Independent of #973 (per-session pool, Finding 1) and #978 (blind-seat surfacing, Finding 2); all three touch `scripts/lib/council.sh` but in disjoint regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Council quorum remains met when independent vendor approvals pass, even if chair synthesis is unavailable.
  * Runs preserve partial results, identify unavailable chair synthesis, and direct operators to per-seat verdicts.
  * Summary output distinguishes quorum status from chair synthesis availability.
  * Synthesis artifacts are reported only when synthesis completes successfully.
  * End-of-run warnings clarify when synthesis cannot be completed.

* **Tests**
  * Added coverage for missing, failed, host-native, and degenerate chair responses while retaining valid quorum results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->