### PR TITLE
fix(runtime): use BSD mv on macOS

### DIFF
--- a/scripts/lib/run-contract.sh
+++ b/scripts/lib/run-contract.sh
@@ -395,7 +395,8 @@ _octo_run_contract_snapshot_unlocked() {
     # -T for this operation; BSD/macOS mv uses -h.
     case "$(uname -s 2>/dev/null || true)" in
         Darwin|*BSD)
-            mv -fh "$latest_tmp" "$latest" 2>/dev/null || {
+            # Homebrew GNU coreutils may shadow BSD mv on macOS and rejects -h.
+            /bin/mv -fh "$latest_tmp" "$latest" 2>/dev/null || {
                 rm -f "$latest_tmp"
                 return 1
             }


### PR DESCRIPTION
## Problem

On macOS, Homebrew GNU coreutils can place GNU `mv` before `/bin/mv` in `PATH`.
Run-contract snapshot publication selects the BSD `-h` flag from `uname`, but invokes the PATH-resolved GNU binary. GNU `mv` rejects `-h`, causing provider launches to fail with exit 74.

## Fix

Invoke `/bin/mv` in the Darwin/BSD branch. Linux continues using GNU `mv -T`.

## Validation

- `bash tests/unit/test-spawn-run-contract.sh`
- `bash tests/unit/test-run-contract-v10.sh`
- 72 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replacement of the latest snapshot link on Darwin and BSD systems by using the system-provided move utility, reducing the risk of platform-specific failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->