### PR TITLE
fix(setup): accept readable preflight helper

### DIFF
--- a/.cursor-plugin/commands/octo-setup.md
+++ b/.cursor-plugin/commands/octo-setup.md
@@ -33,7 +33,7 @@ if [[ ! -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
   OCTO_ROOT="${HOME}/.claude-octopus/plugin"
 fi
 if [[ ! -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
-  OCTO_ROOT="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path '*/nyldn-plugins/octo/*/scripts/helpers/preflight.sh' -print -quit 2>/dev/null | sed 's#/scripts/helpers/preflight.sh$##')"
+  OCTO_ROOT="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path '*/nyldn-plugins/octo/*/scripts/helpers/preflight.sh' -exec test -r '{}' \; -print -quit 2>/dev/null | sed 's#/scripts/helpers/preflight.sh$##')"
 fi
 [[ -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]] || {
   echo "Octopus installation not found. Reinstall octo@nyldn-plugins, then run /octo:setup again."

--- a/.cursor-plugin/commands/octo-setup.md
+++ b/.cursor-plugin/commands/octo-setup.md
@@ -29,13 +29,13 @@ made a choice.
 
 ```bash
 OCTO_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
-if [[ ! -x "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
+if [[ ! -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
   OCTO_ROOT="${HOME}/.claude-octopus/plugin"
 fi
-if [[ ! -x "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
+if [[ ! -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
   OCTO_ROOT="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path '*/nyldn-plugins/octo/*/scripts/helpers/preflight.sh' -print -quit 2>/dev/null | sed 's#/scripts/helpers/preflight.sh$##')"
 fi
-[[ -x "$OCTO_ROOT/scripts/helpers/preflight.sh" ]] || {
+[[ -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]] || {
   echo "Octopus installation not found. Reinstall octo@nyldn-plugins, then run /octo:setup again."
   exit 1
 }

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -32,13 +32,13 @@ made a choice.
 
 ```bash
 OCTO_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
-if [[ ! -x "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
+if [[ ! -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
   OCTO_ROOT="${HOME}/.claude-octopus/plugin"
 fi
-if [[ ! -x "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
+if [[ ! -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
   OCTO_ROOT="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path '*/nyldn-plugins/octo/*/scripts/helpers/preflight.sh' -print -quit 2>/dev/null | sed 's#/scripts/helpers/preflight.sh$##')"
 fi
-[[ -x "$OCTO_ROOT/scripts/helpers/preflight.sh" ]] || {
+[[ -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]] || {
   echo "Octopus installation not found. Reinstall octo@nyldn-plugins, then run /octo:setup again."
   exit 1
 }

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -36,7 +36,7 @@ if [[ ! -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
   OCTO_ROOT="${HOME}/.claude-octopus/plugin"
 fi
 if [[ ! -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]]; then
-  OCTO_ROOT="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path '*/nyldn-plugins/octo/*/scripts/helpers/preflight.sh' -print -quit 2>/dev/null | sed 's#/scripts/helpers/preflight.sh$##')"
+  OCTO_ROOT="$(find "${HOME}/.claude/plugins/cache" "${HOME}/Library/Application Support/Claude" "${LOCALAPPDATA:-/dev/null}/Claude" "${XDG_DATA_HOME:-${HOME}/.local/share}/Claude" -maxdepth 8 -path '*/nyldn-plugins/octo/*/scripts/helpers/preflight.sh' -exec test -r '{}' \; -print -quit 2>/dev/null | sed 's#/scripts/helpers/preflight.sh$##')"
 fi
 [[ -r "$OCTO_ROOT/scripts/helpers/preflight.sh" ]] || {
   echo "Octopus installation not found. Reinstall octo@nyldn-plugins, then run /octo:setup again."

--- a/tests/unit/test-setup-first-success.sh
+++ b/tests/unit/test-setup-first-success.sh
@@ -7,10 +7,45 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Setup path to first success"
 
 SETUP="$PROJECT_ROOT/commands/setup.md"
+CURSOR_SETUP="$PROJECT_ROOT/.cursor-plugin/commands/octo-setup.md"
 setup_text="$(cat "$SETUP")"
 default_path="$(sed -n '/^## Default path/,/^## Advanced setup/p' "$SETUP")"
 advanced_path="$(sed -n '/^## Advanced setup/,$p' "$SETUP")"
 readiness_step="$(sed -n '/^### 2\. Show shared readiness/,/^### 3\./p' "$SETUP")"
+
+test_case "setup accepts a readable non-executable preflight helper"
+root_guard_ok=true
+fixture_root="$TEST_TMP_DIR/plugin root"
+fixture_home="$TEST_TMP_DIR/home"
+mkdir -p "$fixture_root/scripts/helpers" "$fixture_home"
+: > "$fixture_root/scripts/helpers/preflight.sh"
+chmod 0644 "$fixture_root/scripts/helpers/preflight.sh"
+for setup_command in "$SETUP" "$CURSOR_SETUP"; do
+    resolve_block="$(awk '
+      /^### 1\. Resolve the installed plugin$/ {in_step=1; next}
+      in_step && /^```bash$/ {in_fence=1; next}
+      in_step && in_fence && /^```$/ {exit}
+      in_step && in_fence {print}
+    ' "$setup_command")"
+    resolved_root="$(
+      CLAUDE_PLUGIN_ROOT="$fixture_root" \
+      HOME="$fixture_home" \
+      LOCALAPPDATA="$TEST_TMP_DIR/local-app-data" \
+      XDG_DATA_HOME="$TEST_TMP_DIR/xdg-data" \
+        bash -c "$resolve_block"$'\n''printf "%s\n" "$OCTO_ROOT"'
+    )" || root_guard_ok=false
+    if [[ "$resolved_root" != "$fixture_root" ]] ||
+       grep -Eq '\[\[[^]]*-x[^]]*scripts/helpers/preflight\.sh' "$setup_command" ||
+       [[ "$(grep -Ec '\[\[[^]]*-r[^]]*scripts/helpers/preflight\.sh' "$setup_command" || true)" -ne 3 ]] ||
+       ! grep -Fq 'bash "${OCTO_ROOT}/scripts/helpers/preflight.sh" --json' "$setup_command"; then
+        root_guard_ok=false
+    fi
+done
+if [[ "$root_guard_ok" == true ]]; then
+    test_pass
+else
+    test_fail "setup still requires the bash-invoked preflight helper to be executable"
+fi
 
 test_case "initial setup renders the shared static readiness contract once"
 if [[ "$(grep -c 'scripts/helpers/preflight.sh.*--json' <<<"$readiness_step" || true)" -eq 1 ]] &&

--- a/tests/unit/test-setup-first-success.sh
+++ b/tests/unit/test-setup-first-success.sh
@@ -28,10 +28,11 @@ for setup_command in "$SETUP" "$CURSOR_SETUP"; do
       in_step && in_fence {print}
     ' "$setup_command")"
     resolved_root="$(
-      CLAUDE_PLUGIN_ROOT="$fixture_root" \
-      HOME="$fixture_home" \
-      LOCALAPPDATA="$TEST_TMP_DIR/local-app-data" \
-      XDG_DATA_HOME="$TEST_TMP_DIR/xdg-data" \
+      env \
+        "CLAUDE_PLUGIN_ROOT=$fixture_root" \
+        "HOME=$fixture_home" \
+        "LOCALAPPDATA=$TEST_TMP_DIR/local-app-data" \
+        "XDG_DATA_HOME=$TEST_TMP_DIR/xdg-data" \
         bash -c "$resolve_block"$'\n''printf "%s\n" "$OCTO_ROOT"'
     )" || root_guard_ok=false
     if [[ "$resolved_root" != "$fixture_root" ]] ||
@@ -45,6 +46,41 @@ if [[ "$root_guard_ok" == true ]]; then
     test_pass
 else
     test_fail "setup still requires the bash-invoked preflight helper to be executable"
+fi
+
+test_case "fallback search skips an unreadable preflight helper"
+fallback_guard_ok=true
+unreadable_root="$fixture_home/.claude/plugins/cache/nyldn-plugins/octo/0.0.0"
+readable_root="$fixture_home/Library/Application Support/Claude/nyldn-plugins/octo/1.0.0"
+mkdir -p "$unreadable_root/scripts/helpers" "$readable_root/scripts/helpers"
+: > "$unreadable_root/scripts/helpers/preflight.sh"
+: > "$readable_root/scripts/helpers/preflight.sh"
+chmod 000 "$unreadable_root/scripts/helpers/preflight.sh"
+chmod 0644 "$readable_root/scripts/helpers/preflight.sh"
+for setup_command in "$SETUP" "$CURSOR_SETUP"; do
+    resolve_block="$(awk '
+      /^### 1\. Resolve the installed plugin$/ {in_step=1; next}
+      in_step && /^```bash$/ {in_fence=1; next}
+      in_step && in_fence && /^```$/ {exit}
+      in_step && in_fence {print}
+    ' "$setup_command")"
+    resolved_root="$(
+      env \
+        "CLAUDE_PLUGIN_ROOT=$TEST_TMP_DIR/missing-active-root" \
+        "HOME=$fixture_home" \
+        "LOCALAPPDATA=$TEST_TMP_DIR/local-app-data" \
+        "XDG_DATA_HOME=$TEST_TMP_DIR/xdg-data" \
+        bash -c "$resolve_block"$'\n''printf "%s\n" "$OCTO_ROOT"'
+    )" || fallback_guard_ok=false
+    if [[ "$resolved_root" != "$readable_root" ]]; then
+        fallback_guard_ok=false
+    fi
+done
+chmod 0644 "$unreadable_root/scripts/helpers/preflight.sh"
+if [[ "$fallback_guard_ok" == true ]]; then
+    test_pass
+else
+    test_fail "fallback search stopped at an unreadable preflight helper"
 fi
 
 test_case "initial setup renders the shared static readiness contract once"


### PR DESCRIPTION
## Summary

- let `/octo:setup` resolve a readable `preflight.sh` that it invokes through `bash`
- regenerate the Cursor command mirror from the canonical setup command
- execute both resolver snippets against a readable `0644` fixture, including a path with spaces

## Verification

- `make ci-changed` (full local matrix)
- `tests/unit/test-setup-first-success.sh` (8/8)
- independent Codex spec and quality reviews: PASS

Closes #994


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Setup now recognizes readable `preflight.sh` helpers even when they are not executable.
  * Plugin resolution continues to use fallback paths and reports missing installations as before.
  * Unreadable helpers are skipped during fallback searches.
* **Tests**
  * Added coverage for readable, non-executable helpers and correct helper invocation.
  * Added coverage confirming unreadable helpers are skipped and fallback resolution works consistently across supported setup guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->