### PR TITLE
fix(heartbeat): stop run_with_timeout's watchdog from holding the caller's pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- Stop `run_with_timeout`'s in-process watchdog from holding the caller's
+  stdout: its orphaned `sleep` kept the pipe into `spawn_agent`'s `tee` open,
+  so a review could block for the full timeout after the command had already
+  produced output (worst on the shell-function provider path). ([#996](https://github.com/nyldn/claude-octopus/issues/996))
 - Store `/octo:plan` artifacts in unique, resolved run directories and share
   that location with plan-mode hooks and review skills, preventing writes into
   the global `~/.claude/` configuration directory and same-session overwrites.

--- a/scripts/lib/heartbeat.sh
+++ b/scripts/lib/heartbeat.sh
@@ -333,7 +333,13 @@ run_with_timeout() {
             done
 
             _octo_timeout_signal_snapshot KILL "$process_tree"
-        ) &
+        # Redirect the monitor's stdout away from the caller's: on the shell-
+        # function path this subshell inherits the pipe into spawn_agent's `tee`,
+        # and its `sleep` child is orphaned (reparented) when the monitor is
+        # killed on a normal completion — an orphan holding the pipe's write end
+        # keeps `tee` from ever seeing EOF, so the pipeline blocks for the full
+        # timeout even though the command already produced its output.
+        ) >/dev/null 2>&1 &
         monitor_pid=$!
 
         if wait "$cmd_pid" 2>/dev/null; then

--- a/tests/unit/test-issue-996-run-with-timeout-pipe-leak.sh
+++ b/tests/unit/test-issue-996-run-with-timeout-pipe-leak.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# tests/unit/test-issue-996-run-with-timeout-pipe-leak.sh
+# Regression test for #996: the in-process fallback of run_with_timeout must not
+# let its watchdog's orphaned `sleep` hold the caller's stdout. spawn_agent pipes
+# run_with_timeout into `tee`; a held pipe never sees EOF, so the whole review
+# blocks for the FULL timeout even though the command already produced output.
+# The shell-function path (perplexity_execute, openrouter_execute) always takes
+# this fallback, regardless of whether gtimeout/timeout is installed.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+log() { :; }
+source "$PROJECT_ROOT/scripts/lib/heartbeat.sh"
+
+test_suite "run_with_timeout pipe leak (#996)"
+
+test_case "shell-function dispatch does not leave a downstream pipe blocked"
+# A shell function forces the in-process fallback. The probe sleeps briefly so the
+# watchdog subshell has certainly spawned its own `sleep` child before the command
+# returns — that is the fault window; killing the watchdog then orphans that sleep.
+# Timeout is 6s: if the orphan is holding the caller's pipe, `tee` stays blocked
+# until 6s; the fix lets the pipeline finish about when the probe does (~1s). The
+# poll ceiling (3.5s) sits between the two, and any orphan self-terminates by 6s.
+outfile="$TEST_TMP_DIR/pipe-996.out"
+donefile="$TEST_TMP_DIR/pipe-996.done"
+rm -f "$outfile" "$donefile"
+_octo_996_probe() { sleep 1; printf 'PROBE_OUTPUT\n'; }
+( printf '' | run_with_timeout 6 _octo_996_probe | tee "$outfile" >/dev/null; echo done > "$donefile" ) &
+pipeline_pid=$!
+
+# Bounded poll (no fixed long wait): break the instant the pipeline completes, so
+# a slow runner cannot flake it. Ceiling (3s) sits between near-instant (fixed)
+# and the 5s block (bug), so the two outcomes are unambiguous.
+completed=false
+for _ in $(seq 1 35); do
+    if [[ -f "$donefile" ]]; then completed=true; break; fi
+    sleep 0.1
+done
+
+if [[ "$completed" == "true" ]] && [[ "$(cat "$outfile" 2>/dev/null)" == "PROBE_OUTPUT" ]]; then
+    test_pass
+else
+    test_fail "pipeline still blocked after 3.5s — watchdog sleep is holding the caller's stdout (#996)"
+fi
+
+# Best-effort cleanup of the pipeline; any orphaned watchdog sleep self-clears.
+kill "$pipeline_pid" 2>/dev/null || true
+wait "$pipeline_pid" 2>/dev/null || true
+
+test_summary


### PR DESCRIPTION
## Description

The in-process fallback of `run_with_timeout` backgrounds its watchdog as a subshell that `sleep`s for the timeout. On a normal completion the parent kills the subshell, but the subshell's `sleep` child is reparented rather than killed, and it keeps every file descriptor it inherited — including the caller's stdout.

`spawn_agent` pipes `run_with_timeout` into `tee`, so that orphaned `sleep` holds the write end of the pipe open. `tee` never sees EOF and the pipeline blocks for the **full timeout** even though the command has already finished and produced its output. The shell-function dispatch path (`perplexity_execute`, `openrouter_execute`) always takes this fallback regardless of whether `gtimeout`/`timeout` is installed, so those providers are the most exposed — a review can appear to hang for the whole `OCTOPUS_REVIEW_TIMEOUT` with no output. (In `review_run` Round 1, the `## Status:` marker poll only breaks when every agent's marker is present, so one held pipe stalls the whole round.)

The fix redirects the watchdog subshell's stdout to `/dev/null` so it never inherits the caller's pipe. The orphaned `sleep` still lingers until it elapses, but it no longer holds the pipe, so `tee` closes and the pipeline finishes as soon as the command does. It is deliberately minimal and does not touch the process-tree signalling added for #336/#738.

```diff
-        ) &
+        ) >/dev/null 2>&1 &
         monitor_pid=$!
```

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (33/33)
- [ ] OpenClaw registry in sync — n/a (no adapter/registry change)
- [ ] New skills/commands registered — n/a
- [ ] Version bump — deferred to a release commit
- [ ] Documentation updated — n/a
- [x] CHANGELOG.md updated (Unreleased → Fixed)

## Testing

Added `tests/unit/test-issue-996-run-with-timeout-pipe-leak.sh`, a behavioural regression test. It dispatches a shell function (which forces the in-process fallback) through `run_with_timeout` into a `tee` pipeline and asserts the pipeline completes. It uses a **bounded poll rather than a fixed wait**, so it cannot flake on a slow runner, and the timeout window (6s) sits well clear of the poll ceiling (3.5s) in both directions.

Verified it is a real regression test — **fails on the pre-fix code, passes after**:

```
# pre-fix:  FAIL — "pipeline still blocked after 3.5s — watchdog sleep is holding the caller's stdout (#996)"
# post-fix: PASS
```

I could not run the full `tests/run-all-tests.sh` locally to completion (it exceeds 10 min on my machine — that's CI's job), but ran every affected-area suite green:

```
test-issue-996-run-with-timeout-pipe-leak   1/1
test-heartbeat-timeout                      13/13
test-agent-timeout-budget                    7/7
test-bare-auth-probe-timeout                 9/9
test-stdin-timeout-guards                   12/12
test-preserve-caller-process-group           3/3
test-agent-lifecycle-events                 10/10
test-lifecycle-events-498                    7/7
```

Happy to adjust the CHANGELOG wording or the test's form to your preference.

## Related Issues
Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where timeout monitoring could keep output pipelines open after a command completed.
  - Command output now finishes promptly instead of potentially waiting for the full timeout period.

- **Tests**
  - Added regression coverage to verify timely pipeline completion and correct output capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->