### PR TITLE
test: close remaining review debt

### DIFF
--- a/scripts/lib/intelligence.sh
+++ b/scripts/lib/intelligence.sh
@@ -13,7 +13,11 @@ if ! declare -f count_words >/dev/null 2>&1; then
 fi
 if ! declare -f octo_provider_canonical >/dev/null 2>&1; then
     source "${_INTELLIGENCE_LIB_DIR}/provider-registry.sh" || {
-        echo "intelligence: failed to load provider registry" >&2
+        if declare -f log >/dev/null 2>&1; then
+            log "ERROR" "intelligence: failed to load provider registry"
+        else
+            printf '%s\n' "intelligence: failed to load provider registry" >&2
+        fi
         return 1 2>/dev/null || exit 1
     }
 fi

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -43,7 +43,7 @@ cat >"$TMP_HOME/.claude-octopus/config/providers.json" <<'EOF'
 EOF
 
 export HOME="$TMP_HOME"
-export OCTOPUS_PROVIDERS_CONFIG="$TMP_HOME/.claude-octopus/config/providers.json"
+export "OCTOPUS_PROVIDERS_CONFIG=$TMP_HOME/.claude-octopus/config/providers.json"
 export OCTOPUS_PROVIDER_CHECKER="$CHECKER"
 export OCTO_ALLOWED_PROVIDERS="codex commandcode claude"
 export PLUGIN_DIR="$PROJECT_ROOT"

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -43,6 +43,7 @@ cat >"$TMP_HOME/.claude-octopus/config/providers.json" <<'EOF'
 EOF
 
 export HOME="$TMP_HOME"
+export OCTOPUS_PROVIDERS_CONFIG="$TMP_HOME/.claude-octopus/config/providers.json"
 export OCTOPUS_PROVIDER_CHECKER="$CHECKER"
 export OCTO_ALLOWED_PROVIDERS="codex commandcode claude"
 export PLUGIN_DIR="$PROJECT_ROOT"

--- a/tests/unit/test-provider-neutral-design-review.sh
+++ b/tests/unit/test-provider-neutral-design-review.sh
@@ -117,11 +117,12 @@ test_case "provider-local model keeps provider identity separate from role model
 log() { :; }
 export OCTOPUS_PLATFORM=Linux
 source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+expected_model="$(jq -r '.providers.commandcode.roles.researcher' "$TMP_HOME/.claude-octopus/config/providers.json")"
 model="$(resolve_octopus_model commandcode commandcode ceremony researcher)"
-if [[ "$model" == "minimaxai/minimax-m3" ]]; then
+if [[ "$model" == "$expected_model" ]]; then
   test_pass
 else
-  test_fail "expected provider-local MiniMax researcher model, got '$model'"
+  test_fail "expected provider-local researcher model '$expected_model', got '$model'"
 fi
 
 test_case "design review retries the same model before falling back"

--- a/tests/unit/test-tangle-overlap-consolidation.sh
+++ b/tests/unit/test-tangle-overlap-consolidation.sh
@@ -54,12 +54,12 @@ else
 fi
 
 test_case "consolidates transitive overlaps as one component"
-transitive='1. [CODING] Parent — Files: apps/web/ — Task: parent scope
-2. [CODING] Child — Files: apps/web/src/main.jsx — Task: child scope
-3. [CODING] Shared — Files: apps/web/package.json — Task: package scope'
+transitive='1. [CODING] Source — Files: apps/web/src/ — Task: source scope
+2. [CODING] Bridge — Files: apps/web/src/main.jsx, apps/web/package.json — Task: bridge scope
+3. [CODING] Package — Files: apps/web/package.json — Task: package scope'
 result=$(tangle_consolidate_overlapping_subtasks "$transitive")
 if [[ "$(tangle_parseable_coding_subtask_count "$result")" -eq 1 ]] &&
-   [[ "$result" == *"parent scope; child scope; package scope"* ]] &&
+   [[ "$result" == *"source scope; bridge scope; package scope"* ]] &&
    tangle_validate_parallel_write_scopes "$result" >/dev/null; then
     test_pass
 else


### PR DESCRIPTION
## Summary

Closes the remaining actionable review debt identified in historical merged PRs:

- use the project logger (with bootstrap-safe fallback) when intelligence provider-registry loading fails
- make the Tangle overlap test genuinely transitive (A↔B, B↔C, A∦C)
- derive the provider-neutral design-review expected model from the test fixture instead of hardcoding it

## Validation

- bash tests/unit/test-tangle-overlap-consolidation.sh — 5/5
- bash tests/unit/test-provider-neutral-design-review.sh — 21/21
- bash tests/unit/test-intelligence.sh — 47/47
- bash -n scripts/lib/intelligence.sh
- git diff --check

Follow-up to historical review comments on #784, #788, and #936.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when provider registry sources cannot be loaded, with structured logging where available and a clear fallback message.

- **Tests**
  - Updated provider model validation to use the configured fixture value dynamically.
  - Revised overlap consolidation coverage to reflect combined task text across source, bridge, and package scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->