### PR TITLE
fix(council): detect long "fabricated narrative" blind seats (met:true from an unread artifact)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@
   `"severity":` signal in a seat's output — from a `WARN` to a hard `ERROR`
   naming the affected seat file, instead of a silent drop.
   (#1004)
+- Council blind-seat detection now catches a "fabricated narrative" seat: a
+  reviewer dispatched without file-read tools that returns a long, plausible
+  `VERDICT: APPROVE` written entirely from the prose task summary, never having
+  read the artifact. The prior check was brevity-gated (skipped responses over
+  ~1600 chars), so these long fabrications slipped through and a single-vendor
+  council was recorded as `met: true`. A new length-independent signature flags a
+  seat only when it BOTH admits it could not reach the artifact (file access
+  restricted / prohibited from file-or-terminal tools / "assuming the described
+  changes" / cannot-read-files) AND cites zero real source references
+  (`path.ext:line`); such seats are excluded from quorum and recorded in
+  `summary.json` `quorum.blind_seats` like any other blind seat. A bare "based on
+  the provided summary" is intentionally not a trigger, so a legitimate plan or
+  design review (which has no code to cite) is never flagged.
 - Store `/octo:plan` artifacts in unique, resolved run directories and share
   that location with plan-mode hooks and review skills, preventing writes into
   the global `~/.claude/` configuration directory and same-session overwrites.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,14 @@
   read the artifact. The prior check was brevity-gated (skipped responses over
   ~1600 chars), so these long fabrications slipped through and a single-vendor
   council was recorded as `met: true`. A new length-independent signature flags a
-  seat only when it BOTH admits it could not reach the artifact (file access
-  restricted / prohibited from file-or-terminal tools / "assuming the described
-  changes" / cannot-read-files) AND cites zero real source references
+  seat only when it BOTH admits in the first person that it could not reach the
+  artifact (file access restricted / prohibited from file-or-terminal tools /
+  cannot-read-files) AND cites zero real source references
   (`path.ext:line`); such seats are excluded from quorum and recorded in
   `summary.json` `quorum.blind_seats` like any other blind seat. A bare "based on
-  the provided summary" is intentionally not a trigger, so a legitimate plan or
-  design review (which has no code to cite) is never flagged.
+  the provided summary" or "assuming the described changes" is intentionally not
+  a trigger, so a legitimate plan or design review (which has no code to cite) is
+  never flagged.
 - Store `/octo:plan` artifacts in unique, resolved run directories and share
   that location with plan-mode hooks and review skills, preventing writes into
   the global `~/.claude/` configuration directory and same-session overwrites.

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1935,16 +1935,20 @@ council_response_is_blind() {
     # a reviewer dispatched without file-read tools that writes a long, plausible
     # VERDICT entirely from the prose task-summary. It slips past the brevity gate
     # below (these fabrications run well over 1600 chars). Flag it only when it
-    # BOTH (a) admits it could not reach the artifact — file access restricted /
-    # prohibited from file-or-terminal tools / "assuming the described changes" /
-    # cannot-read-files — AND (b) cites zero real source references (path.ext:line).
+    # BOTH (a) explicitly admits it could not reach the artifact — file access
+    # restricted / prohibited from file-or-terminal tools / cannot-read-files —
+    # AND (b) cites zero real source references (extension-neutral path.ext:line).
     # Both are required so a genuine review is never flagged for merely mentioning
-    # a summary. NOTE: a bare "based on the provided summary" is deliberately NOT a
-    # trigger — a legitimate plan/design review (which has no code to cite) uses
-    # that phrasing, so it would false-positive; the (a) set is limited to explicit
-    # could-not-read-the-artifact admissions.
-    if grep -ciE "(direct[[:space:]]+)?file[[:space:]]+access[[:space:]]+is[[:space:]]+restricted|restricted[[:space:]]+by[[:space:]]+the[[:space:]]+output[[:space:]]+rules|prohibited[[:space:]]+from[[:space:]]+using[[:space:]]+any[[:space:]]+(file|terminal|command)|assuming[[:space:]]+the[[:space:]]+described[[:space:]]+changes|(cannot|could[[:space:]]*not|couldn'?t|unable[[:space:]]+to|can'?t)[[:space:]]+(open|read|access|view)[^.]{0,40}files?" "$f" >/dev/null \
-        && ! grep -ciE '\.(tsx?|jsx?|css|mjs|cjs):[0-9]+' "$f" >/dev/null; then
+    # a summary. NOTES:
+    #  - a bare "based on the provided summary" is deliberately NOT a trigger — a
+    #    legitimate plan/design review (no code to cite) uses that phrasing.
+    #  - "assuming the described changes" is likewise NOT a standalone trigger: it
+    #    is a normal conditional a plan review can use. #2459 is still caught by its
+    #    explicit "file access is restricted" admission.
+    #  - (b) matches any letter-first extension (.sh/.py/.go/.tsx/…), so a grounded
+    #    non-frontend review that cites e.g. council.sh:1946 is never flagged.
+    if grep -ciE "(direct[[:space:]]+)?file[[:space:]]+access[[:space:]]+is[[:space:]]+restricted|restricted[[:space:]]+by[[:space:]]+the[[:space:]]+output[[:space:]]+rules|prohibited[[:space:]]+from[[:space:]]+using[[:space:]]+any[[:space:]]+(file|terminal|command)|(cannot|could[[:space:]]*not|couldn'?t|unable[[:space:]]+to|can'?t)[[:space:]]+(open|read|access|view)[^.]{0,40}files?" "$f" >/dev/null \
+        && ! grep -ciE '[[:alnum:]_./-]+\.[[:alpha:]][[:alnum:]]*:[0-9]+' "$f" >/dev/null; then
         return 0
     fi
 

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1924,10 +1924,30 @@ council_response_is_blind() {
     # provider explicitly reports it could not reach the file/permission, rather
     # than a host self-dispatch stub. Surfacing it (vs a generic "degenerate")
     # lets the operator switch that provider's mode/model after the FIRST blind
-    # round instead of eating several. Brevity-gated so a long real review that
-    # merely quotes such a phrase is never flagged.
+    # round instead of eating several. The explicit-refusal checks below are
+    # brevity-gated so a long real review that merely quotes such a phrase is
+    # never flagged; the fabricated-narrative check just above is length-
+    # independent because that failure mode is, by construction, long.
     local f="$1"
     [[ -f "$f" ]] || return 1
+
+    # Length-INDEPENDENT "fabricated narrative" blind seat (sail-cruisey #2459):
+    # a reviewer dispatched without file-read tools that writes a long, plausible
+    # VERDICT entirely from the prose task-summary. It slips past the brevity gate
+    # below (these fabrications run well over 1600 chars). Flag it only when it
+    # BOTH (a) admits it could not reach the artifact — file access restricted /
+    # prohibited from file-or-terminal tools / "assuming the described changes" /
+    # cannot-read-files — AND (b) cites zero real source references (path.ext:line).
+    # Both are required so a genuine review is never flagged for merely mentioning
+    # a summary. NOTE: a bare "based on the provided summary" is deliberately NOT a
+    # trigger — a legitimate plan/design review (which has no code to cite) uses
+    # that phrasing, so it would false-positive; the (a) set is limited to explicit
+    # could-not-read-the-artifact admissions.
+    if grep -ciE "(direct[[:space:]]+)?file[[:space:]]+access[[:space:]]+is[[:space:]]+restricted|restricted[[:space:]]+by[[:space:]]+the[[:space:]]+output[[:space:]]+rules|prohibited[[:space:]]+from[[:space:]]+using[[:space:]]+any[[:space:]]+(file|terminal|command)|assuming[[:space:]]+the[[:space:]]+described[[:space:]]+changes|(cannot|could[[:space:]]*not|couldn'?t|unable[[:space:]]+to|can'?t)[[:space:]]+(open|read|access|view)[^.]{0,40}files?" "$f" >/dev/null \
+        && ! grep -ciE '\.(tsx?|jsx?|css|mjs|cjs):[0-9]+' "$f" >/dev/null; then
+        return 0
+    fi
+
     local nlen
     nlen="$(tr -d '[:space:]' < "$f" | wc -c | tr -d '[:space:]')"
     (( nlen < 1600 )) || return 1

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1962,7 +1962,9 @@ council_response_is_blind() {
         {
             first_person = ($0 ~ /(^|[^[:alnum:]_])(i|we|my|our)([^[:alnum:]_]|$)/)
             access_failure = ($0 ~ /((direct[[:space:]]+)?file[[:space:]]+access[[:space:]]+is[[:space:]]+restricted|restricted[[:space:]]+by[[:space:]]+the[[:space:]]+output[[:space:]]+rules|prohibited[[:space:]]+from[[:space:]]+using[[:space:]]+any[[:space:]]+(file|terminal|command)|(cannot|could[[:space:]]*not|couldn.t|unable[[:space:]]+to|can.t|was[[:space:]]+not[[:space:]]+able[[:space:]]+to|were[[:space:]]+not[[:space:]]+able[[:space:]]+to)[[:space:]]+(open|read|access|view)[^.!?;]{0,40}(files?|plan|prd|diff|patch|artifact|document|spec)|(did[[:space:]]+not|do[[:space:]]+not|don.t)[[:space:]]+have[[:space:]]+(direct[[:space:]]+)?access[^.!?;]{0,40}(files?|plan|prd|diff|patch|artifact|document|spec)|lack(ed|s)?[[:space:]]+(direct[[:space:]]+)?access[^.!?;]{0,40}(files?|plan|prd|diff|patch|artifact|document|spec))/)
-            if (first_person && access_failure) found=1
+            third_party_access = ($0 ~ /(^|[^[:alnum:]_])(another|other)[[:space:]]+(reviewer|seat|agent|provider|model)([^[:alnum:]_]|$)[^.!?;]{0,80}(cannot|could[[:space:]]*not|couldn.t|unable[[:space:]]+to|can.t|did[[:space:]]+not|lack(ed|s)?)/)
+            first_person_access = ($0 ~ /(^|[^[:alnum:]_])(i|we)[[:space:]]+(cannot|could[[:space:]]*not|couldn.t|unable[[:space:]]+to|can.t|was[[:space:]]+not[[:space:]]+able[[:space:]]+to|were[[:space:]]+not[[:space:]]+able[[:space:]]+to)[[:space:]]+(open|read|access|view)/ || $0 ~ /(^|[^[:alnum:]_])(i|we)[[:space:]]+((did[[:space:]]+not|do[[:space:]]+not|don.t)[[:space:]]+have|lack(ed)?)[[:space:]]+(direct[[:space:]]+)?access/)
+            if (first_person && access_failure && (!third_party_access || first_person_access)) found=1
         }
         END { exit(found ? 0 : 1) }
     ' >/dev/null 2>&1 \

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1948,8 +1948,26 @@ council_response_is_blind() {
     #    explicit "file access is restricted" admission.
     #  - (b) matches any letter-first extension (.sh/.py/.go/.tsx/…), so a grounded
     #    non-frontend review that cites e.g. council.sh:1946 is never flagged.
-    if grep -ciE "(^|[^[:alnum:]_])(i|we|my|our)([^[:alnum:]_]|$)[^.]{0,200}((direct[[:space:]]+)?file[[:space:]]+access[[:space:]]+is[[:space:]]+restricted|restricted[[:space:]]+by[[:space:]]+the[[:space:]]+output[[:space:]]+rules|prohibited[[:space:]]+from[[:space:]]+using[[:space:]]+any[[:space:]]+(file|terminal|command)|(cannot|could[[:space:]]*not|couldn'?t|unable[[:space:]]+to|can'?t)[[:space:]]+(open|read|access|view)[^.]{0,40}(files?|plan|prd|diff|patch|artifact|document|spec))" "$f" >/dev/null \
-        && ! grep -ciE '[[:alnum:]_./-]+\.[[:alpha:]][[:alnum:]]*:[0-9]+' "$f" >/dev/null; then
+    # Normalize wrapping, then evaluate one sentence/clause at a time. This
+    # catches Markdown line wraps without letting an unrelated first-person
+    # sentence turn a later third-person access report into an admission.
+    local normalized_without_urls
+    normalized_without_urls="$(tr '\n' ' ' < "$f" | tr -s '[:space:]' ' ' \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -E \
+            -e 's#https?://[^[:space:]]*([.!?;])([[:space:]]|$)#\1\2#g' \
+            -e 's#https?://[^[:space:]]+##g')"
+    if printf '%s\n' "$normalized_without_urls" | awk '
+        BEGIN { RS="[.!?;]+"; found=0 }
+        {
+            first_person = ($0 ~ /(^|[^[:alnum:]_])(i|we|my|our)([^[:alnum:]_]|$)/)
+            access_failure = ($0 ~ /((direct[[:space:]]+)?file[[:space:]]+access[[:space:]]+is[[:space:]]+restricted|restricted[[:space:]]+by[[:space:]]+the[[:space:]]+output[[:space:]]+rules|prohibited[[:space:]]+from[[:space:]]+using[[:space:]]+any[[:space:]]+(file|terminal|command)|(cannot|could[[:space:]]*not|couldn.t|unable[[:space:]]+to|can.t|was[[:space:]]+not[[:space:]]+able[[:space:]]+to|were[[:space:]]+not[[:space:]]+able[[:space:]]+to)[[:space:]]+(open|read|access|view)[^.!?;]{0,40}(files?|plan|prd|diff|patch|artifact|document|spec)|(did[[:space:]]+not|do[[:space:]]+not|don.t)[[:space:]]+have[[:space:]]+(direct[[:space:]]+)?access[^.!?;]{0,40}(files?|plan|prd|diff|patch|artifact|document|spec)|lack(ed|s)?[[:space:]]+(direct[[:space:]]+)?access[^.!?;]{0,40}(files?|plan|prd|diff|patch|artifact|document|spec))/)
+            if (first_person && access_failure) found=1
+        }
+        END { exit(found ? 0 : 1) }
+    ' >/dev/null 2>&1 \
+        && ! printf '%s\n' "$normalized_without_urls" \
+            | grep -ciE '(^|[^[:alnum:]_./-])[[:alnum:]_./-]+\.[[:alpha:]][[:alnum:]]*:[0-9]+([^0-9]|$)' >/dev/null; then
         return 0
     fi
 

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1947,7 +1947,7 @@ council_response_is_blind() {
     #    explicit "file access is restricted" admission.
     #  - (b) matches any letter-first extension (.sh/.py/.go/.tsx/…), so a grounded
     #    non-frontend review that cites e.g. council.sh:1946 is never flagged.
-    if grep -ciE "(direct[[:space:]]+)?file[[:space:]]+access[[:space:]]+is[[:space:]]+restricted|restricted[[:space:]]+by[[:space:]]+the[[:space:]]+output[[:space:]]+rules|prohibited[[:space:]]+from[[:space:]]+using[[:space:]]+any[[:space:]]+(file|terminal|command)|(cannot|could[[:space:]]*not|couldn'?t|unable[[:space:]]+to|can'?t)[[:space:]]+(open|read|access|view)[^.]{0,40}files?" "$f" >/dev/null \
+    if grep -ciE "(direct[[:space:]]+)?file[[:space:]]+access[[:space:]]+is[[:space:]]+restricted|restricted[[:space:]]+by[[:space:]]+the[[:space:]]+output[[:space:]]+rules|prohibited[[:space:]]+from[[:space:]]+using[[:space:]]+any[[:space:]]+(file|terminal|command)|(cannot|could[[:space:]]*not|couldn'?t|unable[[:space:]]+to|can'?t)[[:space:]]+(open|read|access|view)[^.]{0,40}(files?|plan|prd|diff|patch|artifact|document|spec)" "$f" >/dev/null \
         && ! grep -ciE '[[:alnum:]_./-]+\.[[:alpha:]][[:alnum:]]*:[0-9]+' "$f" >/dev/null; then
         return 0
     fi

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1935,8 +1935,9 @@ council_response_is_blind() {
     # a reviewer dispatched without file-read tools that writes a long, plausible
     # VERDICT entirely from the prose task-summary. It slips past the brevity gate
     # below (these fabrications run well over 1600 chars). Flag it only when it
-    # BOTH (a) explicitly admits it could not reach the artifact — file access
-    # restricted / prohibited from file-or-terminal tools / cannot-read-files —
+    # BOTH (a) explicitly admits in the first person that it could not reach the
+    # artifact — file access restricted / prohibited from file-or-terminal tools /
+    # cannot-read-files —
     # AND (b) cites zero real source references (extension-neutral path.ext:line).
     # Both are required so a genuine review is never flagged for merely mentioning
     # a summary. NOTES:
@@ -1947,7 +1948,7 @@ council_response_is_blind() {
     #    explicit "file access is restricted" admission.
     #  - (b) matches any letter-first extension (.sh/.py/.go/.tsx/…), so a grounded
     #    non-frontend review that cites e.g. council.sh:1946 is never flagged.
-    if grep -ciE "(direct[[:space:]]+)?file[[:space:]]+access[[:space:]]+is[[:space:]]+restricted|restricted[[:space:]]+by[[:space:]]+the[[:space:]]+output[[:space:]]+rules|prohibited[[:space:]]+from[[:space:]]+using[[:space:]]+any[[:space:]]+(file|terminal|command)|(cannot|could[[:space:]]*not|couldn'?t|unable[[:space:]]+to|can'?t)[[:space:]]+(open|read|access|view)[^.]{0,40}(files?|plan|prd|diff|patch|artifact|document|spec)" "$f" >/dev/null \
+    if grep -ciE "(^|[^[:alnum:]_])(i|we|my|our)([^[:alnum:]_]|$)[^.]{0,200}((direct[[:space:]]+)?file[[:space:]]+access[[:space:]]+is[[:space:]]+restricted|restricted[[:space:]]+by[[:space:]]+the[[:space:]]+output[[:space:]]+rules|prohibited[[:space:]]+from[[:space:]]+using[[:space:]]+any[[:space:]]+(file|terminal|command)|(cannot|could[[:space:]]*not|couldn'?t|unable[[:space:]]+to|can'?t)[[:space:]]+(open|read|access|view)[^.]{0,40}(files?|plan|prd|diff|patch|artifact|document|spec))" "$f" >/dev/null \
         && ! grep -ciE '[[:alnum:]_./-]+\.[[:alpha:]][[:alnum:]]*:[0-9]+' "$f" >/dev/null; then
         return 0
     fi

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2438,6 +2438,72 @@ test_council_blind_fabricated_narrative() {
         echo "VERDICT: APPROVE"
     } > "$d/third-person-restriction.md"
 
+    # First-person prose in one clause must not attach to another reviewer's
+    # access failure in a later semicolon-delimited clause.
+    {
+        for _i in $(seq 1 24); do
+            echo "I completed an independent assessment; another reviewer could not access the files. The implementation remains sound."
+        done
+        echo "VERDICT: APPROVE"
+    } > "$d/mixed-person.md"
+
+    # Ordinary Markdown wrapping must not hide the reviewer's own admission.
+    {
+        for _i in $(seq 1 24); do
+            echo "The proposed implementation appears internally consistent and preserves the documented workflow contract."
+        done
+        printf '%s\n' "I cannot" "access the files in this environment."
+        echo "VERDICT: APPROVE"
+    } > "$d/wrapped-admission.md"
+
+    # Equivalent explicit first-person admissions must not evade the long-form
+    # check merely by avoiding the words "cannot" and "unable".
+    {
+        for _i in $(seq 1 24); do
+            echo "The proposed implementation appears internally consistent and preserves the documented workflow contract."
+        done
+        echo "I did not have access to the repository files in this environment."
+        echo "VERDICT: APPROVE"
+    } > "$d/did-not-have-access.md"
+    {
+        for _i in $(seq 1 24); do
+            echo "The proposed implementation appears internally consistent and preserves the documented workflow contract."
+        done
+        echo "I was not able to read the diff in this environment."
+        echo "VERDICT: APPROVE"
+    } > "$d/was-not-able.md"
+    {
+        for _i in $(seq 1 24); do
+            echo "The proposed implementation appears internally consistent and preserves the documented workflow contract."
+        done
+        echo "I lack direct access to the source files in this environment."
+        echo "VERDICT: APPROVE"
+    } > "$d/lack-access.md"
+
+    # A URL port is not a repository source citation.
+    {
+        for _i in $(seq 1 24); do
+            echo "The service health endpoint is documented at https://example.com:443/status and the overall approach appears sound."
+        done
+        echo "I cannot access the files in this environment."
+        echo "VERDICT: APPROVE"
+    } > "$d/url-port.md"
+
+    # Removing a URL must preserve a following sentence/clause boundary so a
+    # first-person assessment does not attach to a third-person access report.
+    {
+        for _i in $(seq 1 24); do
+            echo "I completed an independent assessment at https://example.com/status. Another reviewer could not access the files."
+        done
+        echo "VERDICT: APPROVE"
+    } > "$d/url-period-boundary.md"
+    {
+        for _i in $(seq 1 24); do
+            echo "I completed an independent assessment at https://example.com/status; another reviewer could not access the files."
+        done
+        echo "VERDICT: APPROVE"
+    } > "$d/url-semicolon-boundary.md"
+
     # (e) Plan review that uses the conditional "assuming the described changes"
     # with no code cites and NO access-failure admission — must NOT be flagged.
     # "assuming the described changes" is a normal conditional, not an admission
@@ -2454,7 +2520,10 @@ test_council_blind_fabricated_narrative() {
     # #1000: shell/py/go citations, not just the frontend allowlist).
     {
         echo "## Review"
-        echo "Even with file access restricted in this sandbox, the guard added at scripts/lib/council.sh:1946 correctly bounds the case; helpers/run.py:12 is consistent."
+        for _i in $(seq 1 24); do
+            echo "The implementation follows the documented control flow and preserves the existing safety boundary."
+        done
+        echo "I cannot access files in this sandbox, but the guard at [scripts/lib/council.sh:1946] correctly bounds the case; helpers/run.py:12 is consistent."
         echo "VERDICT: APPROVE"
     } > "$d/shellcite.md"
 
@@ -2474,8 +2543,17 @@ test_council_blind_fabricated_narrative() {
         echo "VERDICT: APPROVE"
     } > "$d/cantdiff.md"
 
-    local fab_len fab=n grounded_ok=n plan_ok=n third_person_ok=n assuming_ok=n shellcite_ok=n cantdiff=n
+    local fab_len fab=n grounded_ok=n plan_ok=n third_person_ok=n mixed_person_ok=n
+    local wrapped=n did_not_have=n was_not_able=n lack_access=n url_port=n
+    local url_period_ok=n url_semicolon_ok=n assuming_ok=n shellcite_ok=n cantdiff=n
     council_response_is_blind "$d/cantdiff.md" && cantdiff=y
+    council_response_is_blind "$d/wrapped-admission.md" && wrapped=y
+    council_response_is_blind "$d/did-not-have-access.md" && did_not_have=y
+    council_response_is_blind "$d/was-not-able.md" && was_not_able=y
+    council_response_is_blind "$d/lack-access.md" && lack_access=y
+    council_response_is_blind "$d/url-port.md" && url_port=y
+    council_response_is_blind "$d/url-period-boundary.md" || url_period_ok=y
+    council_response_is_blind "$d/url-semicolon-boundary.md" || url_semicolon_ok=y
     fab_len="$(tr -d '[:space:]' < "$d/fabricated.md" | wc -c | tr -d '[:space:]')"
     council_response_is_blind "$d/assuming.md" || assuming_ok=y
     council_response_is_blind "$d/shellcite.md" || shellcite_ok=y
@@ -2483,6 +2561,7 @@ test_council_blind_fabricated_narrative() {
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
     council_response_is_blind "$d/planreview.md" || plan_ok=y
     council_response_is_blind "$d/third-person-restriction.md" || third_person_ok=y
+    council_response_is_blind "$d/mixed-person.md" || mixed_person_ok=y
 
     # Integration: a fabricated-narrative agy seat alongside a grounded codex seat
     # in a standard (required=2) council. agy must be classified blind and dropped
@@ -2520,14 +2599,17 @@ test_council_blind_fabricated_narrative() {
     codex_prov="$COUNCIL_RESPONDING_PROVIDERS"
 
     if [[ "$fab" == "y" && "$fab_len" -gt 1600 && "$grounded_ok" == "y" && "$plan_ok" == "y" \
-          && "$third_person_ok" == "y" \
+          && "$third_person_ok" == "y" && "$mixed_person_ok" == "y" \
+          && "$wrapped" == "y" && "$did_not_have" == "y" \
+          && "$was_not_able" == "y" && "$lack_access" == "y" && "$url_port" == "y" \
+          && "$url_period_ok" == "y" && "$url_semicolon_ok" == "y" \
           && "$assuming_ok" == "y" && "$shellcite_ok" == "y" && "$cantdiff" == "y" \
           && "$agy_status" == "blind" && "$blind" == *"agy"* \
           && "$codex_prov" == *"codex"* && "$codex_prov" != *"agy"* \
           && "$approving_fams" == "1" && "$met" == "false" ]]; then
         test_pass
     else
-        test_fail "fabricated-narrative blind detection wrong: fab=$fab fab_len=$fab_len grounded_ok=$grounded_ok plan_ok=$plan_ok third_person_ok=$third_person_ok assuming_ok=$assuming_ok shellcite_ok=$shellcite_ok cantdiff=$cantdiff agy_status='$agy_status' blind=[$blind] responders=[$codex_prov] approving_families=$approving_fams met=$met"
+        test_fail "fabricated-narrative blind detection wrong: fab=$fab fab_len=$fab_len grounded_ok=$grounded_ok plan_ok=$plan_ok third_person_ok=$third_person_ok mixed_person_ok=$mixed_person_ok wrapped=$wrapped did_not_have=$did_not_have was_not_able=$was_not_able lack_access=$lack_access url_port=$url_port url_period_ok=$url_period_ok url_semicolon_ok=$url_semicolon_ok assuming_ok=$assuming_ok shellcite_ok=$shellcite_ok cantdiff=$cantdiff agy_status='$agy_status' blind=[$blind] responders=[$codex_prov] approving_families=$approving_fams met=$met"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2447,6 +2447,25 @@ test_council_blind_fabricated_narrative() {
         echo "VERDICT: APPROVE"
     } > "$d/mixed-person.md"
 
+    # First-person analysis and another reviewer's access failure can also share
+    # one clause; the explicit third-party subject keeps it from becoming a
+    # personal admission.
+    {
+        for _i in $(seq 1 24); do
+            echo "I confirmed that another reviewer could not access the files, but their limitation does not change my substantive assessment."
+        done
+        echo "VERDICT: APPROVE"
+    } > "$d/same-clause-third-party.md"
+
+    # A third-party report must not mask an explicit first-person admission in
+    # that same clause.
+    {
+        for _i in $(seq 1 24); do
+            echo "I cannot access the files, and another reviewer could not access them either."
+        done
+        echo "VERDICT: APPROVE"
+    } > "$d/same-clause-self-and-third-party.md"
+
     # Ordinary Markdown wrapping must not hide the reviewer's own admission.
     {
         for _i in $(seq 1 24); do
@@ -2544,6 +2563,7 @@ test_council_blind_fabricated_narrative() {
     } > "$d/cantdiff.md"
 
     local fab_len fab=n grounded_ok=n plan_ok=n third_person_ok=n mixed_person_ok=n
+    local same_clause_third_party_ok=n same_clause_self_and_third_party=n
     local wrapped=n did_not_have=n was_not_able=n lack_access=n url_port=n
     local url_period_ok=n url_semicolon_ok=n assuming_ok=n shellcite_ok=n cantdiff=n
     council_response_is_blind "$d/cantdiff.md" && cantdiff=y
@@ -2562,6 +2582,8 @@ test_council_blind_fabricated_narrative() {
     council_response_is_blind "$d/planreview.md" || plan_ok=y
     council_response_is_blind "$d/third-person-restriction.md" || third_person_ok=y
     council_response_is_blind "$d/mixed-person.md" || mixed_person_ok=y
+    council_response_is_blind "$d/same-clause-third-party.md" || same_clause_third_party_ok=y
+    council_response_is_blind "$d/same-clause-self-and-third-party.md" && same_clause_self_and_third_party=y
 
     # Integration: a fabricated-narrative agy seat alongside a grounded codex seat
     # in a standard (required=2) council. agy must be classified blind and dropped
@@ -2587,6 +2609,8 @@ test_council_blind_fabricated_narrative() {
         return 0
     }
     council_run_chair_fallback() { :; }
+    # This is an assignment word before a function call. Quote the value, not
+    # the complete KEY=value token, which the shell would treat as a command.
     COUNCIL_PROVIDER_STATUS_JSON='{"agy":"available","codex":"available"}' \
         council_run_advice_phase >/dev/null 2>&1 || true
     unset -f council_dispatch_member_detached council_run_chair_fallback
@@ -2600,6 +2624,8 @@ test_council_blind_fabricated_narrative() {
 
     if [[ "$fab" == "y" && "$fab_len" -gt 1600 && "$grounded_ok" == "y" && "$plan_ok" == "y" \
           && "$third_person_ok" == "y" && "$mixed_person_ok" == "y" \
+          && "$same_clause_third_party_ok" == "y" \
+          && "$same_clause_self_and_third_party" == "y" \
           && "$wrapped" == "y" && "$did_not_have" == "y" \
           && "$was_not_able" == "y" && "$lack_access" == "y" && "$url_port" == "y" \
           && "$url_period_ok" == "y" && "$url_semicolon_ok" == "y" \

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2375,6 +2375,110 @@ test_council_advice_marks_blind_seat() {
     fi
 }
 
+test_council_blind_fabricated_narrative() {
+    test_case "a long fabricated-narrative seat (admits no file access, zero source cites) is blind regardless of length; grounded long reviews and plan reviews are not (sail-cruisey #2459)"
+    load_council_lib || return 1
+
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-fabricated.XXXXXX")"
+
+    # (a) Fabricated narrative: LONG (>1600 non-ws chars, clears the brevity gate),
+    # admits "direct file access is restricted by the output rules", cites zero
+    # path.ext:line references, still emits VERDICT: APPROVE. This is the exact
+    # shape of the agy seat in the #2459 council that recorded met:true wrongly.
+    {
+        echo "## Review"
+        echo
+        for _i in $(seq 1 24); do
+            echo "Based on the provided summary of the changes, the approach is architecturally sound and the described refactor preserves the existing data contract between the frontend and the backend API surface while keeping the component boundaries intact."
+        done
+        echo
+        echo "I am assuming the described changes accurately reflect the contents of the diff, as direct file access is restricted by the output rules."
+        echo
+        echo "VERDICT: APPROVE"
+    } > "$d/fabricated.md"
+
+    # (b) Grounded long review: same length class, but carries real file:line
+    # evidence — must NOT be flagged even though it also references "the summary".
+    {
+        echo "## Review"
+        echo
+        for _i in $(seq 1 24); do
+            echo "Based on the provided summary and the diff, the guard added in src/WatcherDashboard.tsx:142 correctly handles the nil price point and the fixture wiring is consistent across the affected suite."
+        done
+        echo
+        echo "src/WatcherDashboard.test.tsx:88 asserts the success case; src/api/types.ts:53 defines the contract."
+        echo
+        echo "VERDICT: APPROVE"
+    } > "$d/grounded.md"
+
+    # (c) Plan/design review control: LONG, references "based on the provided
+    # summary", cites zero code lines (there is no code to cite in a plan review),
+    # but makes NO could-not-read-the-artifact admission. Must NOT be flagged —
+    # this is the #2527 false-positive guard.
+    {
+        echo "## Recommendation"
+        echo
+        for _i in $(seq 1 24); do
+            echo "Approve the plan. Solving the contrast issue at the design-token architecture level and enforcing it with an automated end-to-end assertion is aligned with robust, systemic engineering practice and prevents future regressions."
+        done
+        echo
+        echo "Confidence: High (based on the provided summary of the plan's methodology)."
+        echo
+        echo "VERDICT: APPROVE"
+    } > "$d/planreview.md"
+
+    local fab_len fab=n grounded_ok=n plan_ok=n
+    fab_len="$(tr -d '[:space:]' < "$d/fabricated.md" | wc -c | tr -d '[:space:]')"
+    council_response_is_blind "$d/fabricated.md" && fab=y
+    council_response_is_blind "$d/grounded.md" || grounded_ok=y
+    council_response_is_blind "$d/planreview.md" || plan_ok=y
+
+    # Integration: a fabricated-narrative agy seat alongside a grounded codex seat
+    # in a standard (required=2) council. agy must be classified blind and dropped
+    # from the approving set, leaving a single grounded model family (openai) — so
+    # the vote fails and quorum.met recomputes to false (the #2459 miss).
+    local r; r="$(mktemp -d "$TEST_TMP_DIR/council-fab-int.XXXXXX")"; mkdir -p "$r/responses"
+    COUNCIL_RUN_DIR="$r"
+    COUNCIL_DEPTH="standard"
+    COUNCIL_FIXTURE=""
+    COUNCIL_BLIND_SEATS=""
+    COUNCIL_ROSTER_JSON='[
+      {"persona":"backend-architect","seat":"member","provider":"agy","provider_org":"google","model":"gemini"},
+      {"persona":"security-auditor","seat":"member","provider":"codex","provider_org":"openai","model":"gpt"}
+    ]'
+    council_dispatch_member_detached() {
+        local mj="$1" out="$3" prov
+        prov="$(jq -r '.provider' <<< "$mj")"
+        if [[ "$prov" == "agy" ]]; then
+            cp "$d/fabricated.md" "$out"
+        else
+            printf '## Review\n\nsrc/app.tsx:42 guards the nil case; src/api/types.ts:9 matches.\n\nVERDICT: APPROVE\n' > "$out"
+        fi
+        return 0
+    }
+    council_run_chair_fallback() { :; }
+    COUNCIL_PROVIDER_STATUS_JSON='{"agy":"available","codex":"available"}' \
+        council_run_advice_phase >/dev/null 2>&1 || true
+    unset -f council_dispatch_member_detached council_run_chair_fallback
+
+    local agy_status codex_prov blind met approving_fams
+    agy_status="$(jq -r 'map(select(.provider=="agy"))[0].status // "none"' <<< "$COUNCIL_SEAT_RECORDS_JSON" 2>/dev/null)"
+    blind="$COUNCIL_BLIND_SEATS"
+    met="$COUNCIL_QUORUM_MET"
+    approving_fams="$COUNCIL_DISTINCT_APPROVING_MODEL_FAMILIES"
+    codex_prov="$COUNCIL_RESPONDING_PROVIDERS"
+
+    if [[ "$fab" == "y" && "$fab_len" -gt 1600 && "$grounded_ok" == "y" && "$plan_ok" == "y" \
+          && "$agy_status" == "blind" && "$blind" == *"agy"* \
+          && "$codex_prov" == *"codex"* && "$codex_prov" != *"agy"* \
+          && "$approving_fams" == "1" && "$met" == "false" ]]; then
+        test_pass
+    else
+        test_fail "fabricated-narrative blind detection wrong: fab=$fab fab_len=$fab_len grounded_ok=$grounded_ok plan_ok=$plan_ok agy_status='$agy_status' blind=[$blind] responders=[$codex_prov] approving_families=$approving_fams met=$met"
+        return 1
+    fi
+}
+
 test_council_permission_denied_finding_is_substantive() {
     test_case "a short grounded review may mention permission denied without being blind"
     load_council_lib || return 1
@@ -2850,6 +2954,7 @@ test_council_live_response_uses_synthesis_timeout_for_chair
 test_council_rc_is_timeout_requires_watchdog_provenance
 test_council_advice_marks_timed_out_seat
 test_council_advice_marks_blind_seat
+test_council_blind_fabricated_narrative
 test_council_permission_denied_finding_is_substantive
 test_council_advice_does_not_infer_timeout_from_provider_rc
 test_council_seat_timeout_rejects_zero_and_nonnumeric

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2427,7 +2427,18 @@ test_council_blind_fabricated_narrative() {
         echo "VERDICT: APPROVE"
     } > "$d/planreview.md"
 
-    # (d) Plan review that uses the conditional "assuming the described changes"
+    # (d) Substantive third-person review that discusses an access restriction as
+    # implementation behavior. The phrase alone is not a personal admission that
+    # the reviewer could not inspect the artifact, even without source citations.
+    {
+        echo "## Review"
+        for _i in $(seq 1 24); do
+            echo "The implementation correctly documents that file access is restricted by the output rules while preserving the review workflow and its existing operator-facing behavior."
+        done
+        echo "VERDICT: APPROVE"
+    } > "$d/third-person-restriction.md"
+
+    # (e) Plan review that uses the conditional "assuming the described changes"
     # with no code cites and NO access-failure admission — must NOT be flagged.
     # "assuming the described changes" is a normal conditional, not an admission
     # of blindness, so it is not a standalone trigger (CodeRabbit #1000).
@@ -2437,7 +2448,7 @@ test_council_blind_fabricated_narrative() {
         echo "VERDICT: APPROVE"
     } > "$d/assuming.md"
 
-    # (e) Grounded review that DOES admit restricted access but cites a real
+    # (f) Grounded review that DOES admit restricted access but cites a real
     # non-frontend source reference (path.ext:line). The extension-neutral cite
     # check must recognize it and keep the seat OUT of the blind set (CodeRabbit
     # #1000: shell/py/go citations, not just the frontend allowlist).
@@ -2447,7 +2458,7 @@ test_council_blind_fabricated_narrative() {
         echo "VERDICT: APPROVE"
     } > "$d/shellcite.md"
 
-    # (f) Long, citation-free response whose access admission names a NON-"file"
+    # (g) Long, citation-free response whose access admission names a NON-"file"
     # artifact noun ("cannot access the diff") — must still be flagged. The access
     # clause uses the same artifact nouns as the short-response branch, not just
     # file/files (CodeRabbit #1000).
@@ -2463,7 +2474,7 @@ test_council_blind_fabricated_narrative() {
         echo "VERDICT: APPROVE"
     } > "$d/cantdiff.md"
 
-    local fab_len fab=n grounded_ok=n plan_ok=n assuming_ok=n shellcite_ok=n cantdiff=n
+    local fab_len fab=n grounded_ok=n plan_ok=n third_person_ok=n assuming_ok=n shellcite_ok=n cantdiff=n
     council_response_is_blind "$d/cantdiff.md" && cantdiff=y
     fab_len="$(tr -d '[:space:]' < "$d/fabricated.md" | wc -c | tr -d '[:space:]')"
     council_response_is_blind "$d/assuming.md" || assuming_ok=y
@@ -2471,6 +2482,7 @@ test_council_blind_fabricated_narrative() {
     council_response_is_blind "$d/fabricated.md" && fab=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
     council_response_is_blind "$d/planreview.md" || plan_ok=y
+    council_response_is_blind "$d/third-person-restriction.md" || third_person_ok=y
 
     # Integration: a fabricated-narrative agy seat alongside a grounded codex seat
     # in a standard (required=2) council. agy must be classified blind and dropped
@@ -2508,13 +2520,14 @@ test_council_blind_fabricated_narrative() {
     codex_prov="$COUNCIL_RESPONDING_PROVIDERS"
 
     if [[ "$fab" == "y" && "$fab_len" -gt 1600 && "$grounded_ok" == "y" && "$plan_ok" == "y" \
+          && "$third_person_ok" == "y" \
           && "$assuming_ok" == "y" && "$shellcite_ok" == "y" && "$cantdiff" == "y" \
           && "$agy_status" == "blind" && "$blind" == *"agy"* \
           && "$codex_prov" == *"codex"* && "$codex_prov" != *"agy"* \
           && "$approving_fams" == "1" && "$met" == "false" ]]; then
         test_pass
     else
-        test_fail "fabricated-narrative blind detection wrong: fab=$fab fab_len=$fab_len grounded_ok=$grounded_ok plan_ok=$plan_ok assuming_ok=$assuming_ok shellcite_ok=$shellcite_ok cantdiff=$cantdiff agy_status='$agy_status' blind=[$blind] responders=[$codex_prov] approving_families=$approving_fams met=$met"
+        test_fail "fabricated-narrative blind detection wrong: fab=$fab fab_len=$fab_len grounded_ok=$grounded_ok plan_ok=$plan_ok third_person_ok=$third_person_ok assuming_ok=$assuming_ok shellcite_ok=$shellcite_ok cantdiff=$cantdiff agy_status='$agy_status' blind=[$blind] responders=[$codex_prov] approving_families=$approving_fams met=$met"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2427,8 +2427,30 @@ test_council_blind_fabricated_narrative() {
         echo "VERDICT: APPROVE"
     } > "$d/planreview.md"
 
-    local fab_len fab=n grounded_ok=n plan_ok=n
+    # (d) Plan review that uses the conditional "assuming the described changes"
+    # with no code cites and NO access-failure admission — must NOT be flagged.
+    # "assuming the described changes" is a normal conditional, not an admission
+    # of blindness, so it is not a standalone trigger (CodeRabbit #1000).
+    {
+        echo "## Recommendation"
+        echo "Approve. Assuming the described changes land as specified, the token architecture is sound and the rollout sequencing is reasonable."
+        echo "VERDICT: APPROVE"
+    } > "$d/assuming.md"
+
+    # (e) Grounded review that DOES admit restricted access but cites a real
+    # non-frontend source reference (path.ext:line). The extension-neutral cite
+    # check must recognize it and keep the seat OUT of the blind set (CodeRabbit
+    # #1000: shell/py/go citations, not just the frontend allowlist).
+    {
+        echo "## Review"
+        echo "Even with file access restricted in this sandbox, the guard added at scripts/lib/council.sh:1946 correctly bounds the case; helpers/run.py:12 is consistent."
+        echo "VERDICT: APPROVE"
+    } > "$d/shellcite.md"
+
+    local fab_len fab=n grounded_ok=n plan_ok=n assuming_ok=n shellcite_ok=n
     fab_len="$(tr -d '[:space:]' < "$d/fabricated.md" | wc -c | tr -d '[:space:]')"
+    council_response_is_blind "$d/assuming.md" || assuming_ok=y
+    council_response_is_blind "$d/shellcite.md" || shellcite_ok=y
     council_response_is_blind "$d/fabricated.md" && fab=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
     council_response_is_blind "$d/planreview.md" || plan_ok=y
@@ -2469,12 +2491,13 @@ test_council_blind_fabricated_narrative() {
     codex_prov="$COUNCIL_RESPONDING_PROVIDERS"
 
     if [[ "$fab" == "y" && "$fab_len" -gt 1600 && "$grounded_ok" == "y" && "$plan_ok" == "y" \
+          && "$assuming_ok" == "y" && "$shellcite_ok" == "y" \
           && "$agy_status" == "blind" && "$blind" == *"agy"* \
           && "$codex_prov" == *"codex"* && "$codex_prov" != *"agy"* \
           && "$approving_fams" == "1" && "$met" == "false" ]]; then
         test_pass
     else
-        test_fail "fabricated-narrative blind detection wrong: fab=$fab fab_len=$fab_len grounded_ok=$grounded_ok plan_ok=$plan_ok agy_status='$agy_status' blind=[$blind] responders=[$codex_prov] approving_families=$approving_fams met=$met"
+        test_fail "fabricated-narrative blind detection wrong: fab=$fab fab_len=$fab_len grounded_ok=$grounded_ok plan_ok=$plan_ok assuming_ok=$assuming_ok shellcite_ok=$shellcite_ok agy_status='$agy_status' blind=[$blind] responders=[$codex_prov] approving_families=$approving_fams met=$met"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2447,7 +2447,24 @@ test_council_blind_fabricated_narrative() {
         echo "VERDICT: APPROVE"
     } > "$d/shellcite.md"
 
-    local fab_len fab=n grounded_ok=n plan_ok=n assuming_ok=n shellcite_ok=n
+    # (f) Long, citation-free response whose access admission names a NON-"file"
+    # artifact noun ("cannot access the diff") — must still be flagged. The access
+    # clause uses the same artifact nouns as the short-response branch, not just
+    # file/files (CodeRabbit #1000).
+    {
+        echo "## Review"
+        echo
+        for _i in $(seq 1 24); do
+            echo "The refactor keeps the data contract intact and the component boundaries look reasonable given the described behavior of the affected modules and their call sites."
+        done
+        echo
+        echo "I cannot access the diff directly, so this is based on the described behavior."
+        echo
+        echo "VERDICT: APPROVE"
+    } > "$d/cantdiff.md"
+
+    local fab_len fab=n grounded_ok=n plan_ok=n assuming_ok=n shellcite_ok=n cantdiff=n
+    council_response_is_blind "$d/cantdiff.md" && cantdiff=y
     fab_len="$(tr -d '[:space:]' < "$d/fabricated.md" | wc -c | tr -d '[:space:]')"
     council_response_is_blind "$d/assuming.md" || assuming_ok=y
     council_response_is_blind "$d/shellcite.md" || shellcite_ok=y
@@ -2491,13 +2508,13 @@ test_council_blind_fabricated_narrative() {
     codex_prov="$COUNCIL_RESPONDING_PROVIDERS"
 
     if [[ "$fab" == "y" && "$fab_len" -gt 1600 && "$grounded_ok" == "y" && "$plan_ok" == "y" \
-          && "$assuming_ok" == "y" && "$shellcite_ok" == "y" \
+          && "$assuming_ok" == "y" && "$shellcite_ok" == "y" && "$cantdiff" == "y" \
           && "$agy_status" == "blind" && "$blind" == *"agy"* \
           && "$codex_prov" == *"codex"* && "$codex_prov" != *"agy"* \
           && "$approving_fams" == "1" && "$met" == "false" ]]; then
         test_pass
     else
-        test_fail "fabricated-narrative blind detection wrong: fab=$fab fab_len=$fab_len grounded_ok=$grounded_ok plan_ok=$plan_ok assuming_ok=$assuming_ok shellcite_ok=$shellcite_ok agy_status='$agy_status' blind=[$blind] responders=[$codex_prov] approving_families=$approving_fams met=$met"
+        test_fail "fabricated-narrative blind detection wrong: fab=$fab fab_len=$fab_len grounded_ok=$grounded_ok plan_ok=$plan_ok assuming_ok=$assuming_ok shellcite_ok=$shellcite_ok cantdiff=$cantdiff agy_status='$agy_status' blind=[$blind] responders=[$codex_prov] approving_families=$approving_fams met=$met"
         return 1
     fi
 }


### PR DESCRIPTION
## Problem (octo-dev #2459)

`council_response_is_blind()` misses a **fabricated-narrative** blind seat: a reviewer dispatched without file-read tools (agy in `permission_mode: "plan"`) that returns a *long, plausible* `VERDICT: APPROVE` written entirely from the prose task summary, never having read the artifact.

Two reasons it slipped through:
1. The whole function is **brevity-gated** — `(( nlen < 1600 )) || return 1` — and these fabrications run well past 1600 chars.
2. The existing regexes only match short "cannot access the file" phrasing or a bare permission-error-only body.

Real failure — council session `20260903-165551-0103d3`, seat `responses/01-backend-architect.md` (provider **agy**, 2191 non-ws chars): emitted `VERDICT: APPROVE` while the body said *"direct file access is restricted by the output rules"* and *"assuming the described changes ... reflect the contents of the diff"*, with **zero** `file:line` citations. The runner recorded `blind_seats: []`, `met: true`, `distinct_approving_model_families: 2`. It should have counted agy blind → single grounded vendor (codex) → `met: false`.

## Change

Add a **length-independent** signature that runs *before* the brevity gate. Flag a seat blind only when it **both**:
- **(a)** admits it could not reach the artifact — `file access is restricted` / `restricted by the output rules` / `prohibited from using any (file|terminal|command)` / `assuming the described changes` / `cannot|could not|unable to (open|read|access|view) … files`, **and**
- **(b)** cites **zero** real source references (`\.(tsx?|jsx?|css|mjs|cjs):[0-9]+`).

Both are required so a genuine review is never flagged for merely mentioning a summary. Newly-flagged seats flow through the existing blind handling (excluded from `council_compute_approving_providers()`/quorum, recorded via `council_note_blind_seat()`), so `summary.json`'s `blind_seats`/`met`/`distinct_approving_*` recompute correctly.

### Deliberate deviation from the spec's phrase list

The request listed **"based on the provided summary"** as an (a) trigger. I **excluded** it, because the "clean control" session #2527 (`session-56475c8e-…`) contains a legitimate **plan/design** review (agy `01-backend-architect.md`) that says *"based on the provided summary of the plan's methodology"* with zero code cites — a plan review has no code to cite. Triggering on that bare phrase would **false-positive**, violating the "no seat newly flagged" acceptance criterion. The reliable signal is the explicit *could-not-read-the-artifact* admission, which #2459 has and #2527 lacks.

## Validation (real on-disk data)

| Seat | Expected | Result |
|---|---|---|
| #2459 `01-backend-architect.md` (agy, 0 cites, "file access is restricted") | blind | ✅ flagged |
| #2459 `02-security-auditor.md` (codex, 5 `file:line`) | not blind | ✅ not flagged |
| control #2527 `session-56475c8e-…` (all seats, incl. the plan review) | no new flags | ✅ none |
| control #2518 `session-61fb3b42-…` (all seats) | no new flags | ✅ none |

Verified by sourcing the modified `council.sh` and calling `council_response_is_blind` on the actual files.

## Test

`test_council_blind_fabricated_narrative` covers the fabricated (long, blind), grounded-long (with `file:line`), and plan-review (bare "summary", no admission) cases, plus an integration run where the fabricated agy seat + a grounded codex seat recompute to `quorum.met: false` (one grounded family). It fails against pre-fix code (the 1600-char gate lets the 4002-char fabrication through). Full suite: 96 passed, 0 failed, 1 skipped (pre-existing pty skip).

This mirrors the detection already shipped + tested downstream in sail-cruisey #2550 (the commit-gate backstop); this moves it to the source so `summary.json` stops mis-reporting `met`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved council review validation to detect lengthy approval responses that acknowledge they could not access the artifact and provide no source references.
  * Blind reviews are now excluded from quorum calculations, preventing unsupported approvals from incorrectly satisfying council quorum.
  * Blind-seat results are recorded for clearer review and quorum reporting.
  * Legitimate plan and design reviews remain unaffected when they do not cite source files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->