### PR TITLE
feat(providers): promote Cursor CLI to a first-class peer provider

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -2,7 +2,7 @@
 
 # Claude Octopus
 
-**One prompt. Up to eleven external AI integrations checking each other's work.** Claude Octopus turns Claude Code into a multi-LLM orchestration engine — Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, Grok, and Kimi Code all contribute perspectives, then a 75% consensus gate catches disagreements before they ship.
+**One prompt. Up to twelve external AI integrations checking each other's work.** Claude Octopus turns Claude Code into a multi-LLM orchestration engine — Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, Cursor CLI, Grok, and Kimi Code all contribute perspectives, then a 75% consensus gate catches disagreements before they ship.
 
 **Claude-native first, Octopus for escalation.** Use Claude-native `/init`, `/review`, and `/security-review` when Claude is enough. Use Octopus when you want multiple model opinions, adversarial review, or stricter multi-LLM workflows.
 
@@ -81,7 +81,7 @@ Upgrading from v9? Read the [v10 migration guide](../docs/V10-MIGRATION.md).
 
 - Claude Code v2.1.14+
 - Zero external providers needed (Claude is built in)
-- Optional: Codex CLI, Antigravity CLI (`agy`), Copilot, Qwen, Ollama, Perplexity API key, OpenRouter API key, OrcaRouter API key, OpenCode CLI, xAI API key (Grok), and Kimi Code CLI
+- Optional: Codex CLI, Antigravity CLI (`agy`), Copilot, Qwen, Ollama, Perplexity API key, OpenRouter API key, OrcaRouter API key, OpenCode CLI, Cursor CLI (`agent`), xAI API key (Grok), and Kimi Code CLI
 - Five external integrations cost nothing extra when you already have the relevant subscriptions or local runtime (OAuth or local)
 
 ## One Limitation

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-octopus",
   "version": "10.1.0",
-  "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Antigravity, Grok, Copilot, Qwen, Perplexity, OpenRouter, OrcaRouter, Ollama, OpenCode, and Kimi Code from a single plugin.",
+  "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Antigravity, Cursor CLI, Grok, Copilot, Qwen, Perplexity, OpenRouter, OrcaRouter, Ollama, OpenCode, and Kimi Code from a single plugin.",
   "author": {
     "name": "nyldn"
   },
@@ -17,6 +17,7 @@
     "antigravity",
     "agy",
     "grok",
+    "cursor",
     "copilot",
     "qwen",
     "ollama",
@@ -35,8 +36,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Claude Octopus",
-    "shortDescription": "Multi-LLM orchestration \u2014 dispatch to 11 providers from one plugin.",
-    "longDescription": "Claude Octopus orchestrates eleven external AI providers (Codex, Antigravity, Grok, Copilot, Qwen, Perplexity, OpenRouter, OrcaRouter, Ollama, OpenCode, and Kimi Code) through structured Double Diamond workflows. 31 personas, 53 commands, 62 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch includes prompt-size preflight, agent summary tables, circuit breakers, cost tracking, and model routing.",
+    "shortDescription": "Multi-LLM orchestration \u2014 dispatch to 12 providers from one plugin.",
+    "longDescription": "Claude Octopus orchestrates twelve external AI providers (Codex, Antigravity, Cursor CLI, Grok, Copilot, Qwen, Perplexity, OpenRouter, OrcaRouter, Ollama, OpenCode, and Kimi Code) through structured Double Diamond workflows. 31 personas, 53 commands, 62 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch includes prompt-size preflight, agent summary tables, circuit breakers, cost tracking, and model routing.",
     "composerIcon": "./assets/octopus-icon.svg",
     "developerName": "nyldn",
     "category": "Orchestration",

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -35,8 +35,10 @@ proven safe to remove.
   `scripts/lib/cursor-agent.sh` now owns one
   bounded `agent status --format json` probe (network-bound, 3-12s observed;
   `OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT` default 15s) whose verdict is cached
-  per process and on disk (`.cursor-agent-auth-cache`, TTL 600s, negative
-  60s; legacy `authInfo` still short-circuits); providers, preflight, smoke, model
+  per process and in the user cache directory
+  (`~/.cache/claude-octopus/cursor-agent-auth-verdict`, TTL 600s, negative
+  60s, never in the workspace, symlinks refused, atomic replace; the
+  `authInfo` file check still short-circuits); providers, preflight, smoke, model
   resolver, and Embrace call the helper instead of grepping the file. The
   fallback watchdog in `_cursor_agent_run_with_timeout` detaches its stdio so
   fast probes no longer stall a caller's command substitution.
@@ -70,6 +72,30 @@ proven safe to remove.
   Expectations updated in registry-contracts, model-metadata-parity,
   usage-report, readme-release-sync, shared-marketplace-sync, and
   agy-provider suites.
+- Verified (2026-09-04, this branch head): `CI=true GITHUB_ACTIONS=true make
+  ci-changed` selected the full matrix and passed 16/16 smoke, 305/305 unit,
+  and 8/8 integration suites (5629 cases, 0 failures); `make sync-check`,
+  `git diff --check`, and `git diff origin/main...HEAD --summary | grep "mode
+  change"` (empty) passed. Focused suites, all passing:
+  `bash tests/unit/test-cursor-agent-provider.sh` (33/33),
+  `test-provider-registry-contracts.sh` (15/15), `test-provider-registry-parity.sh`
+  (16/16), `test-provider-neutral-council.sh` (6/6), `test-model-metadata-parity.sh`
+  (6/6), `test-readme-release-sync.sh` (11/11), `test-shared-marketplace-sync.sh`
+  (17/17), `test-env-var-effects.sh` (9/9), `test-agy-provider.sh` (52/52; one
+  earlier run hit a transient 1s mock timeout under concurrent load and passed
+  twice on rerun), `tests/test-fleet-diversity.sh` (42/42). Live, read-only:
+  `scripts/helpers/check-providers.sh` reports `cursor-agent:available` with
+  and without `CURSOR_API_KEY`; `bash scripts/helpers/build-fleet.sh review
+  standard test` seats cursor-agent; one real dispatch through the exact
+  command string (`agent --trust --output-format text --mode ask --model auto
+  -p ""`, prompt on stdin) returned `ok`.
+- CodeRabbit round 1 (7 threads) is addressed: per-slot debate fallback that
+  also replaces both unavailable defaults, verdict cache moved to the user
+  cache directory with symlink refusal and atomic replace, canonical-ID
+  matching for configured review participants, PATH-restricted watchdog test,
+  OrcaRouter in the README comparison row, and this verification record. The
+  docstring-coverage pre-merge warning is advisory (bash helpers) and was not
+  acted on.
 - Delivery: PR [#1001](https://github.com/nyldn/claude-octopus/pull/1001)
   from fork branch `dnachavez:add-cursor-cli-provider` (remote `fork`,
   `git@github.com:dnachavez/claude-octopus.git`); `origin` is read-only for

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,6 +1,6 @@
 # AI Agent Handoff
 
-Last updated: 2026-08-30
+Last updated: 2026-09-04
 Status: PR #984 contains the install, setup, readiness, dispatch, cost, and
 uninstall simplification. Two findings from the latest exact-head CodeRabbit
 round have verified fixes in the branch head, independent Fable 5 review
@@ -19,6 +19,59 @@ threads, wait for exact-head checks and approval, then squash-merge PR #984 and
 run the guarded v10.1.0 release workflow. The user authorized merge, release,
 shared-marketplace publication, and cleanup of only the related worktrees
 proven safe to remove.
+
+## Cursor CLI First-Class Provider (branch `add-cursor-cli-provider`, 2026-09-04)
+
+- Scope: promote the existing `cursor-agent` seat (Cursor CLI, binary `agent`)
+  from a stale "Grok 4.20 via Cursor" side seat to a peer provider for a
+  Claude Code + Codex (ChatGPT OAuth) + Cursor CLI setup. Decisions confirmed
+  by the user: default model `auto`; council capability plus review/debate
+  cascades; `OCTOPUS_CURSOR_AGENT_MODE=ask|plan|agent` with read-only default;
+  Cursor promoted to the eleventh documented public provider.
+- Auth: on build 2026.06.24 the `authInfo` block was absent from
+  `~/.cursor/cli-config.json` at session start while `agent status` reported
+  authenticated; the CLI wrote the block later in the session. The file grep
+  is therefore a cheap first check, not a reliable one.
+  `scripts/lib/cursor-agent.sh` now owns one
+  bounded `agent status --format json` probe (network-bound, 3-12s observed;
+  `OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT` default 15s) whose verdict is cached
+  per process and on disk (`.cursor-agent-auth-cache`, TTL 600s, negative
+  60s; legacy `authInfo` still short-circuits); providers, preflight, smoke, model
+  resolver, and Embrace call the helper instead of grepping the file. The
+  fallback watchdog in `_cursor_agent_run_with_timeout` detaches its stdio so
+  fast probes no longer stall a caller's command substitution.
+- Dispatch: `agent --trust --output-format text [--mode ask|plan] --model <m>`;
+  role table in `cursor_agent_mode_for_role`, override in
+  `cursor_agent_resolve_mode`. `provider-routing.sh` isolates Cursor under
+  `env -i` (PATH, HOME, TERM, TMPDIR, CURSOR_API_KEY, `OCTOPUS_CURSOR_AGENT_*`)
+  with `OCTOPUS_ALLOW_FULL_CURSOR_AGENT_ENV=true` opt-out.
+- Catalog: `models.sh`, `config/model-pricing.tsv`, and the dispatch fallback
+  list use live `agent models` IDs (composer-2.5, cursor-grok-4.6-*,
+  gpt-5.6-sol/luna-high, claude-sonnet/opus-5-thinking-high,
+  gemini-3.7-flash-high). Bracket overrides are rejected by
+  `validate_model_name`; flat IDs only. Vendor family (`agent-spec.sh`,
+  `execution-profile.sh`) maps composer/cursor-agent to `cursor` and
+  cursor-grok to `xai`.
+- Fleet: registry row gains `council`; the limitation row is removed.
+  `review.sh` cascades seat Cursor after Copilot (logic, security, CVE) and
+  the config-participants case accepts `cursor-agent`; `debate.sh` seats
+  Cursor when Antigravity or Codex is unusable; `build-fleet.sh` labels the
+  seat "Cursor Perspective". `OCTOPUS_COUNCIL_DEFAULT_PROVIDERS_DEFAULT` is
+  unchanged because `build_council_order` appends every admitted
+  council-capable provider.
+- Docs: `scripts/sync-readme.py` lists Cursor CLI as a public provider
+  (counts regenerate to eleven); README, ARCHITECTURE, TROUBLESHOOTING,
+  DEVELOPER, PROVIDERS, `.codex-plugin/plugin.json`, CHANGELOG, and the new
+  `config/providers/cursor-agent/CLAUDE.md` describe Cursor directly and the
+  standalone `grok` CLI separately.
+- Tests: `tests/unit/test-cursor-agent-provider.sh` grew from 7 to 27 cases
+  (status-probe auth, bounded probe, cache, legacy authInfo, role modes,
+  dispatch strings, env isolation, registry, family, cascades, docs guards).
+  Expectations updated in registry-contracts, model-metadata-parity,
+  usage-report, readme-release-sync, shared-marketplace-sync, and
+  agy-provider suites.
+- Tracking: `bd` is not installed in this worktree, so no Beads issue was
+  created; this section is the record.
 
 ## Install, Setup, and Everyday-Use Simplification
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -35,9 +35,10 @@ proven safe to remove.
   `scripts/lib/cursor-agent.sh` now owns one
   bounded `agent status --format json` probe (network-bound, 3-12s observed;
   `OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT` default 15s) whose verdict is cached
-  per process and in the user cache directory
-  (`~/.cache/claude-octopus/cursor-agent-auth-verdict`, TTL 600s, negative
-  60s, never in the workspace, symlinks refused, atomic replace; the
+  per process and on disk at `OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE` when set,
+  otherwise `${XDG_CACHE_HOME:-$HOME/.cache}/claude-octopus/cursor-agent-auth-verdict`
+  (TTL 600s, negative 60s, never in the workspace, symlinks refused, atomic
+  replace; the
   `authInfo` file check still short-circuits); providers, preflight, smoke, model
   resolver, and Embrace call the helper instead of grepping the file. The
   fallback watchdog in `_cursor_agent_run_with_timeout` detaches its stdio so
@@ -78,12 +79,16 @@ proven safe to remove.
   `git diff --check`, and `git diff origin/main...HEAD --summary | grep "mode
   change"` (empty) passed. Focused suites, all passing:
   `bash tests/unit/test-cursor-agent-provider.sh` (33/33),
-  `test-provider-registry-contracts.sh` (15/15), `test-provider-registry-parity.sh`
-  (16/16), `test-provider-neutral-council.sh` (6/6), `test-model-metadata-parity.sh`
-  (6/6), `test-readme-release-sync.sh` (11/11), `test-shared-marketplace-sync.sh`
-  (17/17), `test-env-var-effects.sh` (9/9), `test-agy-provider.sh` (52/52; one
-  earlier run hit a transient 1s mock timeout under concurrent load and passed
-  twice on rerun), `tests/test-fleet-diversity.sh` (42/42). Live, read-only:
+  `bash tests/unit/test-provider-registry-contracts.sh` (15/15),
+  `bash tests/unit/test-provider-registry-parity.sh` (16/16),
+  `bash tests/unit/test-provider-neutral-council.sh` (6/6),
+  `bash tests/unit/test-model-metadata-parity.sh` (6/6),
+  `bash tests/unit/test-readme-release-sync.sh` (11/11),
+  `bash tests/unit/test-shared-marketplace-sync.sh` (17/17),
+  `bash tests/unit/test-env-var-effects.sh` (9/9),
+  `bash tests/unit/test-agy-provider.sh` (52/52; one earlier run hit a
+  transient 1s mock timeout under concurrent load and passed twice on rerun),
+  `bash tests/test-fleet-diversity.sh` (42/42). Live, read-only:
   `scripts/helpers/check-providers.sh` reports `cursor-agent:available` with
   and without `CURSOR_API_KEY`; `bash scripts/helpers/build-fleet.sh review
   standard test` seats cursor-agent; one real dispatch through the exact

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -1,6 +1,6 @@
 # AI Agent Handoff
 
-Last updated: 2026-09-04
+Last updated: 2026-08-30
 Status: PR #984 contains the install, setup, readiness, dispatch, cost, and
 uninstall simplification. Two findings from the latest exact-head CodeRabbit
 round have verified fixes in the branch head, independent Fable 5 review
@@ -19,95 +19,6 @@ threads, wait for exact-head checks and approval, then squash-merge PR #984 and
 run the guarded v10.1.0 release workflow. The user authorized merge, release,
 shared-marketplace publication, and cleanup of only the related worktrees
 proven safe to remove.
-
-## Cursor CLI First-Class Provider (branch `add-cursor-cli-provider`, 2026-09-04)
-
-- Scope: promote the existing `cursor-agent` seat (Cursor CLI, binary `agent`)
-  from a stale "Grok 4.20 via Cursor" side seat to a peer provider for a
-  Claude Code + Codex (ChatGPT OAuth) + Cursor CLI setup. Decisions confirmed
-  by the user: default model `auto`; council capability plus review/debate
-  cascades; `OCTOPUS_CURSOR_AGENT_MODE=ask|plan|agent` with read-only default;
-  Cursor promoted to the eleventh documented public provider.
-- Auth: on build 2026.06.24 the `authInfo` block was absent from
-  `~/.cursor/cli-config.json` at session start while `agent status` reported
-  authenticated; the CLI wrote the block later in the session. The file grep
-  is therefore a cheap first check, not a reliable one.
-  `scripts/lib/cursor-agent.sh` now owns one
-  bounded `agent status --format json` probe (network-bound, 3-12s observed;
-  `OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT` default 15s) whose verdict is cached
-  per process and on disk at `OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE` when set,
-  otherwise `${XDG_CACHE_HOME:-$HOME/.cache}/claude-octopus/cursor-agent-auth-verdict`
-  (TTL 600s, negative 60s, never in the workspace, symlinks refused, atomic
-  replace; the
-  `authInfo` file check still short-circuits); providers, preflight, smoke, model
-  resolver, and Embrace call the helper instead of grepping the file. The
-  fallback watchdog in `_cursor_agent_run_with_timeout` detaches its stdio so
-  fast probes no longer stall a caller's command substitution.
-- Dispatch: `agent --trust --output-format text [--mode ask|plan] --model <m>`;
-  role table in `cursor_agent_mode_for_role`, override in
-  `cursor_agent_resolve_mode`. `provider-routing.sh` isolates Cursor under
-  `env -i` (PATH, HOME, TERM, TMPDIR, CURSOR_API_KEY, `OCTOPUS_CURSOR_AGENT_*`)
-  with `OCTOPUS_ALLOW_FULL_CURSOR_AGENT_ENV=true` opt-out.
-- Catalog: `models.sh`, `config/model-pricing.tsv`, and the dispatch fallback
-  list use live `agent models` IDs (composer-2.5, cursor-grok-4.6-*,
-  gpt-5.6-sol/luna-high, claude-sonnet/opus-5-thinking-high,
-  gemini-3.7-flash-high). Bracket overrides are rejected by
-  `validate_model_name`; flat IDs only. Vendor family (`agent-spec.sh`,
-  `execution-profile.sh`) maps composer/cursor-agent to `cursor` and
-  cursor-grok to `xai`.
-- Fleet: registry row gains `council`; the limitation row is removed.
-  `review.sh` cascades seat Cursor after Copilot (logic, security, CVE) and
-  the config-participants case accepts `cursor-agent`; `debate.sh` seats
-  Cursor when Antigravity or Codex is unusable; `build-fleet.sh` labels the
-  seat "Cursor Perspective". `OCTOPUS_COUNCIL_DEFAULT_PROVIDERS_DEFAULT` is
-  unchanged because `build_council_order` appends every admitted
-  council-capable provider.
-- Docs: `scripts/sync-readme.py` lists Cursor CLI as a public provider
-  (counts regenerate to eleven); README, ARCHITECTURE, TROUBLESHOOTING,
-  DEVELOPER, PROVIDERS, `.codex-plugin/plugin.json`, CHANGELOG, and the new
-  `config/providers/cursor-agent/CLAUDE.md` describe Cursor directly and the
-  standalone `grok` CLI separately.
-- Tests: `tests/unit/test-cursor-agent-provider.sh` grew from 7 to 27 cases
-  (status-probe auth, bounded probe, cache, legacy authInfo, role modes,
-  dispatch strings, env isolation, registry, family, cascades, docs guards).
-  Expectations updated in registry-contracts, model-metadata-parity,
-  usage-report, readme-release-sync, shared-marketplace-sync, and
-  agy-provider suites.
-- Verified (2026-09-04, this branch head): `CI=true GITHUB_ACTIONS=true make
-  ci-changed` selected the full matrix and passed 16/16 smoke, 305/305 unit,
-  and 8/8 integration suites (5629 cases, 0 failures); `make sync-check`,
-  `git diff --check`, and `git diff origin/main...HEAD --summary | grep "mode
-  change"` (empty) passed. Focused suites, all passing:
-  `bash tests/unit/test-cursor-agent-provider.sh` (33/33),
-  `bash tests/unit/test-provider-registry-contracts.sh` (15/15),
-  `bash tests/unit/test-provider-registry-parity.sh` (16/16),
-  `bash tests/unit/test-provider-neutral-council.sh` (6/6),
-  `bash tests/unit/test-model-metadata-parity.sh` (6/6),
-  `bash tests/unit/test-readme-release-sync.sh` (11/11),
-  `bash tests/unit/test-shared-marketplace-sync.sh` (17/17),
-  `bash tests/unit/test-env-var-effects.sh` (9/9),
-  `bash tests/unit/test-agy-provider.sh` (52/52; one earlier run hit a
-  transient 1s mock timeout under concurrent load and passed twice on rerun),
-  `bash tests/test-fleet-diversity.sh` (42/42). Live, read-only:
-  `scripts/helpers/check-providers.sh` reports `cursor-agent:available` with
-  and without `CURSOR_API_KEY`; `bash scripts/helpers/build-fleet.sh review
-  standard test` seats cursor-agent; one real dispatch through the exact
-  command string (`agent --trust --output-format text --mode ask --model auto
-  -p ""`, prompt on stdin) returned `ok`.
-- CodeRabbit round 1 (7 threads) is addressed: per-slot debate fallback that
-  also replaces both unavailable defaults, verdict cache moved to the user
-  cache directory with symlink refusal and atomic replace, canonical-ID
-  matching for configured review participants, PATH-restricted watchdog test,
-  OrcaRouter in the README comparison row, and this verification record. The
-  docstring-coverage pre-merge warning is advisory (bash helpers) and was not
-  acted on.
-- Delivery: PR [#1001](https://github.com/nyldn/claude-octopus/pull/1001)
-  from fork branch `dnachavez:add-cursor-cli-provider` (remote `fork`,
-  `git@github.com:dnachavez/claude-octopus.git`); `origin` is read-only for
-  this account. Fork PRs stall at `action_required` after every push and
-  need maintainer approval of the workflow run.
-- Tracking: `bd` is not installed in this worktree, so no Beads issue was
-  created; this section is the record.
 
 ## Install, Setup, and Everyday-Use Simplification
 

--- a/AI_AGENT_HANDOFF.md
+++ b/AI_AGENT_HANDOFF.md
@@ -70,6 +70,11 @@ proven safe to remove.
   Expectations updated in registry-contracts, model-metadata-parity,
   usage-report, readme-release-sync, shared-marketplace-sync, and
   agy-provider suites.
+- Delivery: PR [#1001](https://github.com/nyldn/claude-octopus/pull/1001)
+  from fork branch `dnachavez:add-cursor-cli-provider` (remote `fork`,
+  `git@github.com:dnachavez/claude-octopus.git`); `origin` is read-only for
+  this account. Fork PRs stall at `action_required` after every push and
+  need maintainer approval of the workflow run.
 - Tracking: `bd` is not installed in this worktree, so no Beads issue was
   created; this section is the record.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,9 @@
   persisted an `authInfo` block in `~/.cursor/cli-config.json` (observed on
   build 2026.06.24 at session start). One bounded `agent status --format json`
   probe in `scripts/lib/cursor-agent.sh`
-  (own 15s timeout, verdict cached per process and on disk for 10 minutes;
-  negative verdicts for 60s) replaces seven duplicated file greps across
+  (own 15s timeout, verdict cached per process and in the user cache
+  directory for 10 minutes, negative verdicts for 60s, symlinks refused and
+  atomic replace) replaces seven duplicated file greps across
   detection, health, preflight, smoke, model resolution, and Embrace fleet
   construction; account details from the probe are never echoed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,33 @@
   readiness. A pin with no matching alias fails closed. Config errors exit 1,
   so the existing exit-code gate in `spawn.sh` handles them.
 
+- Cursor CLI (`agent`) is a first-class peer provider: registry `council`
+  capability, review-fleet and debate availability cascades, `env -i`
+  credential isolation with `OCTOPUS_ALLOW_FULL_CURSOR_AGENT_ENV` opt-out, a
+  curated catalog of current `agent models` IDs, and a
+  `config/providers/cursor-agent/CLAUDE.md` module. Public documentation now
+  lists eleven external providers.
+- `OCTOPUS_CURSOR_AGENT_MODE=ask|plan|agent` controls Cursor tool access.
+  `agent -p` otherwise has write and shell access, so dispatch is read-only
+  (`--mode ask`) by default, `--mode plan` for planner roles, and full agent
+  mode only for implementer roles or an explicit override.
+
+### Changed
+
+- The unpinned Cursor model is `auto` (Cursor's service-side selection)
+  instead of the retired `grok-4-20`; fallback candidates and pricing rows
+  follow the live catalog.
+
 ### Fixed
+
+- Cursor session authentication is detected even when the CLI has not yet
+  persisted an `authInfo` block in `~/.cursor/cli-config.json` (observed on
+  build 2026.06.24 at session start). One bounded `agent status --format json`
+  probe in `scripts/lib/cursor-agent.sh`
+  (own 15s timeout, verdict cached per process and on disk for 10 minutes;
+  negative verdicts for 60s) replaces seven duplicated file greps across
+  detection, health, preflight, smoke, model resolution, and Embrace fleet
+  construction; account details from the probe are never echoed.
 
 - Record the exact post-persona, post-budget prompt in each seat result, annotate
   prompt compression with original and final sizes, and attribute oversize

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,11 @@
   credential isolation with `OCTOPUS_ALLOW_FULL_CURSOR_AGENT_ENV` opt-out, a
   curated catalog of current `agent models` IDs, and a
   `config/providers/cursor-agent/CLAUDE.md` module. Public documentation now
-  lists eleven external providers.
+  lists twelve external providers.
 - `OCTOPUS_CURSOR_AGENT_MODE=ask|plan|agent` controls Cursor tool access.
   `agent -p` otherwise has write and shell access, so dispatch is read-only
-  (`--mode ask`) by default, `--mode plan` for planner roles, and full agent
-  mode only for implementer roles or an explicit override.
+  (`--mode ask`) by default, `--mode plan` for planner roles, and `--force`
+  only for implementer roles or an explicit override.
 
 ### Changed
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -8,7 +8,7 @@ last_reviewed: 2026-08-30
 
 ## Mission
 
-Make up to 11 external AI integrations available for explicit escalation, so blind spots surface on the work that warrants multi-model scrutiny without taxing every ordinary task.
+Make up to 12 external AI integrations available for explicit escalation, so blind spots surface on the work that warrants multi-model scrutiny without taxing every ordinary task.
 
 ## Vision
 
@@ -37,7 +37,7 @@ Claude Octopus is a **multi-runtime orchestration plugin** with three architectu
 
 | Layer | What it does | Gap it closes |
 |-------|-------------|---------------|
-| **Provider adapters** (`scripts/orchestrate.sh`, `bin/check-providers.sh`) | Detects, authenticates, and dispatches to up to 11 external AI integrations | Eliminates manual per-provider boilerplate |
+| **Provider adapters** (`scripts/orchestrate.sh`, `bin/check-providers.sh`) | Detects, authenticates, and dispatches to up to 12 external AI integrations | Eliminates manual per-provider boilerplate |
 | **Workflow engine** (`skills/`) | Structures every task into Discover → Define → Develop → Deliver with quality gates | Stops ad-hoc "just ask Claude" from shipping low-confidence output |
 | **Consensus layer** | 75% gate: flags disagreements across providers before code is finalized | The actual blind-spot catcher — surfaces the 1-in-5 case where Claude was wrong |
 
@@ -45,9 +45,9 @@ Claude Octopus is a **multi-runtime orchestration plugin** with three architectu
 
 ## Core Value Propositions
 
-- **Blind spot elimination:** Any model can be wrong; 11 external integrations rarely agree on the same wrong answer
+- **Blind spot elimination:** Any model can be wrong; 12 external integrations rarely agree on the same wrong answer
 - **Zero-friction escalation:** Claude-native for ordinary tasks, Octopus for anything that deserves a second opinion
-- **Four providers can cost nothing extra when you already have access:** Codex (OAuth), Antigravity CLI, Copilot (GitHub subscription), and Ollama (local) — Qwen now requires API-key or Coding-Plan auth, while Perplexity and OpenRouter are metered
+- **Five providers can cost nothing extra when you already have access:** Codex (OAuth), Antigravity CLI, Copilot (GitHub subscription), Cursor CLI (Cursor subscription), and Ollama (local) — Qwen now requires API-key or Coding-Plan auth, while Perplexity and OpenRouter are metered
 - **Dark Factory autonomy:** Spec in, software out — full Discover→Define→Develop→Deliver pipeline without step-by-step prompting
 - **Opinionated four-phase methodology:** Infrastructure plus the workflow that uses it correctly
 

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Or type `/octo:auto <what you want>` and the smart router picks for you. Plain-p
 
 | | Claude Code alone | [Superpowers](https://github.com/obra/superpowers) | Claude Octopus |
 |---|---|---|---|
-| **Core idea** | One model, your prompts | Structured methodology for one agent | Built-in Claude plus up to 11 external integrations cross-checking each other |
+| **Core idea** | One model, your prompts | Structured methodology for one agent | Built-in Claude plus up to 12 external integrations cross-checking each other |
 | **Providers** | Claude only | Claude only | Claude host; Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, Cursor CLI, Grok, and Kimi Code |
 | **Workflow** | Ad-hoc | Spec → plan → subagent-driven dev | Discover → Define → Develop → Deliver (Double Diamond) |
 | **Strength** | Simple, no setup | Long autonomous runs with discipline | Multiple perspectives catching blind spots |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐙 Claude Octopus
 
-Every AI model has blind spots. Claude Octopus supports eleven external provider integrations — Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, Grok, and Kimi Code — alongside the built-in Claude Code host, with consensus gates that flag disagreements before you ship.
+Every AI model has blind spots. Claude Octopus supports twelve external provider integrations — Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, Cursor CLI, Grok, and Kimi Code — alongside the built-in Claude Code host, with consensus gates that flag disagreements before you ship.
 
 **Claude-native first, Octopus for escalation.** Use Claude-native `/init`, `/review`, and `/security-review` when Claude is enough. Use Octopus when you want multiple model opinions, adversarial review, or stricter multi-LLM workflows.
 
@@ -60,7 +60,7 @@ Every AI model has blind spots. Claude Octopus supports eleven external provider
 | **v10.1.0** (new) | Simplify setup, provider readiness, dispatch controls, cost reporting, and uninstall guidance. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
-| **v9** | Up to 10 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Explicit-only activation by default, with an optional smart router. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Opt-in discipline gates and token compression. Two-stage review. Circuit breakers with automatic provider recovery inside active workflows. Cursor + OpenCode + Codex cross-compatibility. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |
+| **v9** | Up to 11 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, Cursor CLI, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Explicit-only activation by default, with an optional smart router. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Opt-in discipline gates and token compression. Two-stage review. Circuit breakers with automatic provider recovery inside active workflows. Cursor + OpenCode + Codex cross-compatibility. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |
 | **v8** | Multi-LLM code review with inline PR comments. Parallel workstreams in isolated git worktrees. Reaction engine — auto-responds to CI failures. 32 specialized personas. Dark Factory autonomous pipeline. |
 | **v7** | Double Diamond workflow. Multi-provider dispatch. Quality gates and consensus scoring. Configurable sandbox modes. |
 
@@ -406,7 +406,7 @@ Or type `/octo:auto <what you want>` and the smart router picks for you. Plain-p
 | | Claude Code alone | [Superpowers](https://github.com/obra/superpowers) | Claude Octopus |
 |---|---|---|---|
 | **Core idea** | One model, your prompts | Structured methodology for one agent | Built-in Claude plus up to 11 external integrations cross-checking each other |
-| **Providers** | Claude only | Claude only | Claude host; Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, Grok, and Kimi Code |
+| **Providers** | Claude only | Claude only | Claude host; Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, Cursor CLI, Grok, and Kimi Code |
 | **Workflow** | Ad-hoc | Spec → plan → subagent-driven dev | Discover → Define → Develop → Deliver (Double Diamond) |
 | **Strength** | Simple, no setup | Long autonomous runs with discipline | Multiple perspectives catching blind spots |
 | **Consensus gates** | No | No | Yes — 75% agreement threshold |
@@ -436,7 +436,8 @@ Claude Octopus coordinates eleven external provider integrations alongside the b
 | 🟤 Qwen (Alibaba) | Qwen3-Coder research via API-key or Coding-Plan auth |
 | ⚫ Ollama (Local) | Zero-cost local LLM — offline, privacy-sensitive, fallback |
 | 🟠 OpenCode | Alternate coding-agent integration and cross-checking seat |
-| ⚡ Grok (xAI, via cursor-agent) | Frontier-model second opinion — added as a first-class seat in v9.48 |
+| 🟪 Cursor CLI (`agent`) | Cursor-subscription models (Composer, GPT-5.6, Claude, Gemini, Grok) as a council, review, and debate seat — read-only by default, `auto` model unless pinned |
+| ⚡ Grok (xAI, standalone `grok` CLI) | Frontier-model second opinion via `XAI_API_KEY` — added as a first-class seat in v9.48 |
 | 🌙 Kimi Code | Standalone coding-agent seat using provider credentials and model aliases from `config.toml` |
 | 🔵 Claude (Anthropic, Opus 5 + Sonnet 5) | Architecture, strategy, security review, orchestration, consensus, final synthesis |
 | 🔵 Claude Agent SDK seat (`claude-sdk`) | Optional second Anthropic seat: Opus 5 with the 1M-token context window, independent of the host session (set `CLAUDE_SDK_API_KEY`) |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Every AI model has blind spots. Claude Octopus supports twelve external provider
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
 
-🐙 **Research, build, review, and ship — with eleven external providers checking the host's work.** Claude-native handles the ordinary path. Octopus remains dormant until you explicitly run `/octo:*`, then handles the escalated path. A 75% consensus gate catches disagreements before they reach production.
+🐙 **Research, build, review, and ship — with twelve external providers checking the host's work.** Claude-native handles the ordinary path. Octopus remains dormant until you explicitly run `/octo:*`, then handles the escalated path. A 75% consensus gate catches disagreements before they reach production.
 
 🧠 **Remembers across sessions.** Integrates with [claude-mem](https://github.com/thedotmack/claude-mem) and [agentmemory](https://github.com/rohitg00/agentmemory) for persistent memory — past decisions, research, and context survive session boundaries.
 
@@ -28,9 +28,9 @@ Every AI model has blind spots. Claude Octopus supports twelve external provider
 
 🐙 **31 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **53 commands** (slash commands you type), **62 skills** (reusable workflow modules). Explicit workflows select the experts they need; ordinary Claude requests do not activate Octopus.
 
-🐙 **Works with just Claude. Adds up to eleven external provider integrations.** Zero external providers are needed to start. Add them one at a time — each becomes available when detected and runs only inside an explicit workflow.
+🐙 **Works with just Claude. Adds up to twelve external provider integrations.** Zero external providers are needed to start. Add them one at a time — each becomes available when detected and runs only inside an explicit workflow.
 
-💰 **Four providers cost nothing extra when you already have access.** Codex, Antigravity CLI, and Copilot use existing subscriptions or local auth. Ollama runs locally for free. Qwen now requires API-key or Coding-Plan auth; its free OAuth tier ended on 2026-04-15.
+💰 **Five providers cost nothing extra when you already have access.** Codex, Antigravity CLI, Copilot, and Cursor CLI use existing subscriptions or local auth. Ollama runs locally for free. Qwen now requires API-key or Coding-Plan auth; its free OAuth tier ended on 2026-04-15.
 
 ---
 
@@ -60,7 +60,7 @@ Every AI model has blind spots. Claude Octopus supports twelve external provider
 | **v10.1.0** (new) | Simplify setup, provider readiness, dispatch controls, cost reporting, and uninstall guidance. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
-| **v9** | Up to 11 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, Cursor CLI, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Explicit-only activation by default, with an optional smart router. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Opt-in discipline gates and token compression. Two-stage review. Circuit breakers with automatic provider recovery inside active workflows. Cursor + OpenCode + Codex cross-compatibility. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |
+| **v9** | Up to 10 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Explicit-only activation by default, with an optional smart router. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Opt-in discipline gates and token compression. Two-stage review. Circuit breakers with automatic provider recovery inside active workflows. Cursor + OpenCode + Codex cross-compatibility. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |
 | **v8** | Multi-LLM code review with inline PR comments. Parallel workstreams in isolated git worktrees. Reaction engine — auto-responds to CI failures. 32 specialized personas. Dark Factory autonomous pipeline. |
 | **v7** | Double Diamond workflow. Multi-provider dispatch. Quality gates and consensus scoring. Configurable sandbox modes. |
 
@@ -421,9 +421,9 @@ Or type `/octo:auto <what you want>` and the smart router picks for you. Plain-p
 
 ## How It Works
 
-### How 11 External Providers Work Together
+### How 12 External Providers Work Together
 
-Claude Octopus coordinates eleven external provider integrations alongside the built-in Claude Code host. The optional `claude-sdk` route is a second Anthropic seat, so it is shown below but is not counted as a separate provider family.
+Claude Octopus coordinates twelve external provider integrations alongside the built-in Claude Code host. The optional `claude-sdk` route is a second Anthropic seat, so it is shown below but is not counted as a separate provider family.
 
 | Provider | Role |
 |----------|------|

--- a/config/model-pricing.tsv
+++ b/config/model-pricing.tsv
@@ -37,10 +37,15 @@ model	claude-opus-4.8-fast	10.00	50.00	Anthropic fast
 model	claude-opus-4.7	5.00	25.00	Anthropic legacy
 model	claude-opus-4.6	5.00	25.00	Anthropic legacy
 model	claude-opus-4.6-fast	30.00	150.00	Anthropic legacy fast
-model	grok-4-20	0.00	0.00	Cursor subscription route
-model	grok-4-20-thinking	0.00	0.00	Cursor subscription route
-model	composer-2-fast	0.00	0.00	Cursor subscription route
-model	composer-2	0.00	0.00	Cursor subscription route
+model	composer-2.5	0.00	0.00	Cursor subscription route
+model	composer-2.5-fast	0.00	0.00	Cursor subscription route
+model	cursor-grok-4.6-high	0.00	0.00	Cursor subscription route
+model	cursor-grok-4.6-xhigh	0.00	0.00	Cursor subscription route
+model	gpt-5.6-sol-high	0.00	0.00	Cursor subscription route
+model	gpt-5.6-luna-high	0.00	0.00	Cursor subscription route
+model	claude-sonnet-5-thinking-high	0.00	0.00	Cursor subscription route
+model	claude-opus-5-thinking-high	0.00	0.00	Cursor subscription route
+model	gemini-3.7-flash-high	0.00	0.00	Cursor subscription route
 model	z-ai/glm-5	0.80	2.56	OpenRouter
 model	moonshotai/kimi-k2.5	0.45	2.25	OpenRouter
 model	deepseek/deepseek-v4-pro	0.435	0.87	OpenRouter current DeepSeek route

--- a/config/providers/cursor-agent/CLAUDE.md
+++ b/config/providers/cursor-agent/CLAUDE.md
@@ -63,7 +63,7 @@ Octopus opts down by role. `OCTOPUS_CURSOR_AGENT_MODE` overrides the table.
 |------|------|------|
 | research, review, council, verifier, synthesizer, anything else | `ask` | `--mode ask` (read-only Q&A) |
 | `planner`, `architect`, `strategist` | `plan` | `--mode plan` (read-only planning) |
-| `implementer`, `developer`, `implementer-heavy` | `agent` | none (full tool access) |
+| `implementer`, `developer`, `implementer-heavy` | `agent` | `--force` (full unattended tool access) |
 
 An invalid override logs an error and keeps the role default.
 

--- a/config/providers/cursor-agent/CLAUDE.md
+++ b/config/providers/cursor-agent/CLAUDE.md
@@ -97,7 +97,7 @@ Cursor serves as:
   logic, security, or diversity review seats and the debate slot when
   Antigravity or Codex is unavailable
 - **Research perspective** — "Cursor Perspective" in dynamic research fleets
-- **Implementer** — only when the role is implementer/developer (full agent mode)
+- **Implementer** — only when the role is implementer/developer (`--force`)
 
 ## Timeouts
 

--- a/config/providers/cursor-agent/CLAUDE.md
+++ b/config/providers/cursor-agent/CLAUDE.md
@@ -1,0 +1,104 @@
+# Cursor CLI Provider Configuration
+
+This file contains Cursor-specific instructions for Claude Octopus workflows.
+
+## Provider Information
+
+- **Provider**: Cursor CLI (optional) — binary `agent`, registry ID `cursor-agent`, alias `cursor`
+- **Emoji**: 🟪
+- **API Key**: Optional — `CURSOR_API_KEY`; otherwise the `agent login` session
+- **CLI Command**: `agent -p` (headless print mode, prompt on stdin)
+- **Agent Types**: `cursor-agent`, `cursor-agent:<model>`
+- **Cost**: Included in the Cursor subscription (pricing rows are `0.00`); each prompt consumes Cursor plan usage
+
+## Detection
+
+- Binary identity: `agent --version` must print a CalVer string (`2026.06.24-…`).
+  `agent` is a generic name, so a semver-style output is rejected. The probe is
+  bounded by `OCTOPUS_CURSOR_AGENT_PROBE_TIMEOUT` (default 3s).
+- Auth check (precedence order), owned by `scripts/lib/cursor-agent.sh`:
+  1. `CURSOR_API_KEY` env var
+  2. An `authInfo` block in `~/.cursor/cli-config.json` (cheap, offline)
+  3. That block can be missing while the CLI is still logged in (seen on build
+     2026.06.24 until the CLI persisted its session); `agent status --format json`
+     must then report `"isAuthenticated": true`. The call is network-bound (3–12s),
+     so it is bounded by `OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT` (default 15s)
+     and its yes/no verdict is cached per process and on disk
+     (`${WORKSPACE_DIR:-~/.claude-octopus}/.cursor-agent-auth-cache`,
+     `OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL` default 600s, negative verdicts
+     `OCTOPUS_CURSOR_AGENT_AUTH_NEGATIVE_TTL` default 60s, TTL `0` disables).
+     The JSON carries the account email and is never echoed or cached.
+
+If the CLI is not installed or not authenticated, silently skip — no errors, no warnings.
+
+## Authentication Setup
+
+### Option 1: Interactive Login (recommended)
+```bash
+agent login
+```
+
+### Option 2: API Key (CI/automation)
+```bash
+export CURSOR_API_KEY="..."
+```
+
+## Dispatch Pattern
+
+```bash
+agent --trust --output-format text --mode ask --model auto -p ""   # prompt arrives on stdin
+```
+
+`--trust` skips the workspace-trust prompt. `-p ""` is appended by
+spawn/workflows/agent-sync so the prompt travels on stdin (no ARG_MAX limit).
+
+### Execution mode (safety)
+
+`agent -p` has full tool access (write + shell) in the working directory, so
+Octopus opts down by role. `OCTOPUS_CURSOR_AGENT_MODE` overrides the table.
+
+| Role | Mode | Flag |
+|------|------|------|
+| research, review, council, verifier, synthesizer, anything else | `ask` | `--mode ask` (read-only Q&A) |
+| `planner`, `architect`, `strategist` | `plan` | `--mode plan` (read-only planning) |
+| `implementer`, `developer`, `implementer-heavy` | `agent` | none (full tool access) |
+
+An invalid override logs an error and keeps the role default.
+
+## Model Selection
+
+Default is `auto` (Cursor's service-side pick; always valid). Pin with
+`OCTOPUS_CURSOR_AGENT_MODEL`, `providers.json` (`providers.cursor-agent.default`),
+or a model-qualified seat such as `cursor-agent:composer-2.5`.
+
+Use flat IDs exactly as printed by `agent models` (for example
+`composer-2.5`, `cursor-grok-4.6-high`, `gpt-5.6-sol-high`,
+`claude-sonnet-5-thinking-high`, `gemini-3.7-flash-high`). Cursor's bracket
+override syntax (`claude-opus-4-8[context=1m,effort=high]`) is rejected by the
+model-name validator.
+
+Vendor family for independence checks follows the pinned model
+(`claude-*` → Anthropic, `gpt-*` → OpenAI, `cursor-grok-*` → xAI,
+`composer-*`/`auto` → Cursor).
+
+## Environment Isolation
+
+Dispatch runs under `env -i` with `PATH`, `HOME` (session state lives in
+`~/.cursor`), `TERM`, `TMPDIR`, `CURSOR_API_KEY` when set, and the
+`OCTOPUS_CURSOR_AGENT_*` controls. Set `OCTOPUS_ALLOW_FULL_CURSOR_AGENT_ENV=true`
+to inherit the full parent environment.
+
+## Role Assignment
+
+Cursor serves as:
+- **Council / review / debate seat** — registry `council` capability; fills
+  logic, security, or diversity review seats and the debate slot when
+  Antigravity or Codex is unavailable
+- **Research perspective** — "Cursor Perspective" in dynamic research fleets
+- **Implementer** — only when the role is implementer/developer (full agent mode)
+
+## Timeouts
+
+- `OCTOPUS_CURSOR_AGENT_TIMEOUT` — per-dispatch wall clock (default 120s)
+- `OCTOPUS_CURSOR_AGENT_PROBE_TIMEOUT` — `agent --version` identity probe (default 3s)
+- `OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT` — `agent status` session probe (default 15s)

--- a/config/providers/cursor-agent/CLAUDE.md
+++ b/config/providers/cursor-agent/CLAUDE.md
@@ -23,10 +23,12 @@ This file contains Cursor-specific instructions for Claude Octopus workflows.
      2026.06.24 until the CLI persisted its session); `agent status --format json`
      must then report `"isAuthenticated": true`. The call is network-bound (3–12s),
      so it is bounded by `OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT` (default 15s)
-     and its yes/no verdict is cached per process and on disk
-     (`${WORKSPACE_DIR:-~/.claude-octopus}/.cursor-agent-auth-cache`,
-     `OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL` default 600s, negative verdicts
-     `OCTOPUS_CURSOR_AGENT_AUTH_NEGATIVE_TTL` default 60s, TTL `0` disables).
+     and its yes/no verdict is cached per process and on disk in the user
+     cache directory (`${XDG_CACHE_HOME:-~/.cache}/claude-octopus/cursor-agent-auth-verdict`,
+     never inside the workspace; symlinks are refused and the file is replaced
+     atomically; `OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL` default 600s, negative
+     verdicts `OCTOPUS_CURSOR_AGENT_AUTH_NEGATIVE_TTL` default 60s, TTL `0`
+     disables, `OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE` overrides the path).
      The JSON carries the account email and is never echoed or cached.
 
 If the CLI is not installed or not authenticated, silently skip — no errors, no warnings.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,7 +42,8 @@ Claude Octopus coordinates **eleven external AI integrations** alongside its bui
 | **Copilot** *(optional)* | `copilot -p` | GitHub models (Claude/GPT/Google models) | GitHub Copilot subscription |
 | **Qwen** *(optional)* | `qwen -p` | Qwen3-Coder | `QWEN_API_KEY` or Coding-Plan auth |
 | **OpenCode** *(optional)* | `opencode run` | Multi-provider router | Your OpenCode auth |
-| **Grok** *(optional)* | OpenAI-compatible API | Grok models | Your `XAI_API_KEY` |
+| **Cursor CLI** *(optional)* | `agent -p --mode ask\|plan` | `auto` (Cursor's pick) or any flat ID from `agent models` (Composer, GPT-5.6, Claude, Gemini, Grok) | Cursor subscription (`agent login`) or `CURSOR_API_KEY` |
+| **Grok** *(optional)* | `grok -p` (standalone xAI CLI) | Grok models | Your `XAI_API_KEY` or `grok login` |
 | **Kimi Code** *(optional)* | `kimi -p` | Model alias selected from Kimi Code `config.toml` | Provider credential or OAuth login configured in Kimi Code |
 
 > **Note:** Models are as of July 2026. The orchestrate.sh script uses the latest supported models. Only Claude is required — all others are optional and auto-detected.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,7 +42,7 @@ Claude Octopus coordinates **eleven external AI integrations** alongside its bui
 | **Copilot** *(optional)* | `copilot -p` | GitHub models (Claude/GPT/Google models) | GitHub Copilot subscription |
 | **Qwen** *(optional)* | `qwen -p` | Qwen3-Coder | `QWEN_API_KEY` or Coding-Plan auth |
 | **OpenCode** *(optional)* | `opencode run` | Multi-provider router | Your OpenCode auth |
-| **Cursor CLI** *(optional)* | `agent -p --mode ask\|plan` | `auto` (Cursor's pick) or any flat ID from `agent models` (Composer, GPT-5.6, Claude, Gemini, Grok) | Cursor subscription (`agent login`) or `CURSOR_API_KEY` |
+| **Cursor CLI** *(optional)* | `agent -p --mode ask\|plan` for read-only roles; `agent -p --force` for implementers | `auto` (Cursor's pick) or any flat ID from `agent models` (Composer, GPT-5.6, Claude, Gemini, Grok) | Cursor subscription (`agent login`) or `CURSOR_API_KEY` |
 | **Grok** *(optional)* | `grok -p` (standalone xAI CLI) | Grok models | Your `XAI_API_KEY` or `grok login` |
 | **Kimi Code** *(optional)* | `kimi -p` | Model alias selected from Kimi Code `config.toml` | Provider credential or OAuth login configured in Kimi Code |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This document explains how Claude Octopus orchestrates multiple AI providers and
 
 ## Overview
 
-Claude Octopus coordinates **eleven external AI integrations** alongside its built-in Claude host to give you multi-perspective analysis. The diagram shows the representative execution path; the full roster follows it.
+Claude Octopus coordinates **twelve external AI integrations** alongside its built-in Claude host to give you multi-perspective analysis. The diagram shows the representative execution path; the full roster follows it.
 
 ```
     +------------------+

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -82,7 +82,8 @@ claude-octopus/
 │   │   ├── codex/CLAUDE.md     # Codex-specific
 │   │   ├── claude/CLAUDE.md    # Claude orchestrator
 │   │   ├── ollama/CLAUDE.md    # Ollama local LLM
-│   │   └── copilot/CLAUDE.md   # GitHub Copilot CLI
+│   │   ├── copilot/CLAUDE.md   # GitHub Copilot CLI
+│   │   └── cursor-agent/CLAUDE.md  # Cursor CLI (`agent`)
 │   └── workflows/CLAUDE.md      # Double Diamond methodology
 ```
 
@@ -99,6 +100,7 @@ claude --add-dir=config/workflows          # Double Diamond
 | `providers/claude` | Understanding Claude's orchestrator role |
 | `providers/ollama` | Working with Ollama local LLM |
 | `providers/copilot` | Working with GitHub Copilot CLI |
+| `providers/cursor-agent` | Working with Cursor CLI (`agent`) |
 | `workflows` | Learning about Double Diamond methodology |
 
 ---

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -104,7 +104,8 @@ probe lives in `scripts/lib/cursor-agent.sh` (`cursor_agent_is_available`):
 `CURSOR_API_KEY`, else an `authInfo` block in `~/.cursor/cli-config.json`
 (cheap but not always present), else a bounded (`OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT`, 15s) `agent status
 --format json` probe whose yes/no verdict is cached per process and on disk
-(`.cursor-agent-auth-cache`, TTL 600s). Do not re-implement that check in
+under the user cache directory (`~/.cache/claude-octopus/cursor-agent-auth-verdict`,
+TTL 600s; never in the workspace, symlinks refused, atomic replace). Do not re-implement that check in
 consumers. Dispatch is read-only by default
 (`--mode ask`; `--mode plan` for planner roles; full agent mode only for
 implementer roles or `OCTOPUS_CURSOR_AGENT_MODE=agent`).

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -108,8 +108,8 @@ The cache path resolves to `OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE` when set,
 otherwise `${XDG_CACHE_HOME:-$HOME/.cache}/claude-octopus/cursor-agent-auth-verdict`
 (TTL 600s; never in the workspace, symlinks refused, atomic replace). Do not re-implement that check in
 consumers. Dispatch is read-only by default
-(`--mode ask`; `--mode plan` for planner roles; full agent mode only for
-implementer roles or `OCTOPUS_CURSOR_AGENT_MODE=agent`).
+(`--mode ask`; `--mode plan` for planner roles; `--force` only for implementer
+roles or `OCTOPUS_CURSOR_AGENT_MODE=agent`).
 
 Retired `gemini` and `gemini-*` IDs are accepted only as compatibility aliases and canonicalize to `agy`. They are not executable providers, are never probed, and are not written to new configuration.
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -99,6 +99,16 @@ Google seat), perplexity, opencode, openrouter, orcarouter, atlascloud,
 openai-compatible, openai-tools, openai-compatible-agent, cursor-agent, grok,
 qwen, ollama, copilot, vibe, and kimi.
 
+`cursor-agent` is the Cursor CLI (`agent` binary, `cursor` alias). Its auth
+probe lives in `scripts/lib/cursor-agent.sh` (`cursor_agent_is_available`):
+`CURSOR_API_KEY`, else an `authInfo` block in `~/.cursor/cli-config.json`
+(cheap but not always present), else a bounded (`OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT`, 15s) `agent status
+--format json` probe whose yes/no verdict is cached per process and on disk
+(`.cursor-agent-auth-cache`, TTL 600s). Do not re-implement that check in
+consumers. Dispatch is read-only by default
+(`--mode ask`; `--mode plan` for planner roles; full agent mode only for
+implementer roles or `OCTOPUS_CURSOR_AGENT_MODE=agent`).
+
 Retired `gemini` and `gemini-*` IDs are accepted only as compatibility aliases and canonicalize to `agy`. They are not executable providers, are never probed, and are not written to new configuration.
 
 ## Remaining adapter work

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -103,9 +103,10 @@ qwen, ollama, copilot, vibe, and kimi.
 probe lives in `scripts/lib/cursor-agent.sh` (`cursor_agent_is_available`):
 `CURSOR_API_KEY`, else an `authInfo` block in `~/.cursor/cli-config.json`
 (cheap but not always present), else a bounded (`OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT`, 15s) `agent status
---format json` probe whose yes/no verdict is cached per process and on disk
-under the user cache directory (`~/.cache/claude-octopus/cursor-agent-auth-verdict`,
-TTL 600s; never in the workspace, symlinks refused, atomic replace). Do not re-implement that check in
+--format json` probe whose yes/no verdict is cached per process and on disk.
+The cache path resolves to `OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE` when set,
+otherwise `${XDG_CACHE_HOME:-$HOME/.cache}/claude-octopus/cursor-agent-auth-verdict`
+(TTL 600s; never in the workspace, symlinks refused, atomic replace). Do not re-implement that check in
 consumers. Dispatch is read-only by default
 (`--mode ask`; `--mode plan` for planner roles; full agent mode only for
 implementer roles or `OCTOPUS_CURSOR_AGENT_MODE=agent`).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -27,7 +27,8 @@ A provider is used only when its CLI is installed AND its auth check passes. If 
 | 🟣 Perplexity | `PERPLEXITY_API_KEY` set | Export the key; no CLI needed |
 | 🌐 OpenRouter | Enabled in config AND `OPENROUTER_API_KEY` set | Export the key |
 | 🟤 OpenCode | `opencode` on PATH, `opencode auth list` succeeds | `opencode auth login` |
-| ⚡ Grok | `cursor-agent` binary present plus `CURSOR_API_KEY` or authenticated `~/.cursor/cli-config.json` | Sign in to the Cursor CLI or export `CURSOR_API_KEY` |
+| 🟪 Cursor CLI | `agent` on PATH reporting a CalVer version, plus `CURSOR_API_KEY` or an authenticated session (`agent status` says authenticated; older builds also persist `authInfo` in `~/.cursor/cli-config.json`) | `agent login` or export `CURSOR_API_KEY`; pin models with flat IDs from `agent models` (bracket overrides are rejected) |
+| ⚡ Grok | `grok` on PATH plus `XAI_API_KEY` or `~/.grok/auth.json` | `grok login` or export `XAI_API_KEY` |
 | 🔵 claude-sdk seat | `CLAUDE_SDK_API_KEY` set | Export an Anthropic API key; the shim exits with code 78 and "CLAUDE_SDK_API_KEY is not set" without it |
 
 ## Common non-auth failures

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -280,7 +280,7 @@ build_research_fleet() {
                     qwen)
                         emit "qwen" "Contrarian Analysis" "Play devil's advocate on: $PROMPT. What are the strongest arguments AGAINST the obvious approach? What risks are being systematically underestimated?" ;;
                     cursor-agent)
-                        emit "cursor-agent" "XAI Perspective" "Provide an independent analysis of: $PROMPT. Focus on alternative implementation choices, practical trade-offs, and assumptions that deserve re-examination." ;;
+                        emit "cursor-agent" "Cursor Perspective" "Provide an independent analysis of: $PROMPT. Focus on alternative implementation choices, practical trade-offs, and assumptions that deserve re-examination." ;;
                     opencode)
                         emit "opencode" "Implementation Patterns" "Research concrete implementation patterns for: $PROMPT. Focus on production-grade examples, common pitfalls, and battle-tested approaches. Cite specific repos or documentation." ;;
                     ollama)

--- a/scripts/helpers/build-fleet.sh
+++ b/scripts/helpers/build-fleet.sh
@@ -78,11 +78,15 @@ for _provider in codex commandcode grok agy copilot qwen cursor-agent opencode \
     # auto-approves tools and cannot enforce that boundary, so it remains an
     # implementation provider but is not eligible for these fleets.
     [[ "$_provider" == "kimi" ]] && continue
-    provider_status_is_available "$_provider" && AVAILABLE_CLI+=("$_provider")
+    provider_status_is_available "$_provider" && \
+        octo_provider_allowed "$_provider" && \
+        AVAILABLE_CLI+=("$_provider")
 done
 # Atlas Cloud's canonical provider status is `atlascloud`, while its executable
 # agent type is `atlascloud-agent` (the Python tool-loop dispatch shim).
-provider_status_is_available atlascloud && AVAILABLE_CLI+=("atlascloud-agent")
+provider_status_is_available atlascloud && \
+    octo_provider_allowed atlascloud-agent && \
+    AVAILABLE_CLI+=("atlascloud-agent")
 
 CLI_COUNT=0
 if [[ -n "${AVAILABLE_CLI[*]:-}" ]]; then

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -106,7 +106,7 @@ check_deps() {
         warnings+=("kimi:Kimi Code CLI not installed (optional) — install: curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash; then run kimi and enter /login")
     fi
 
-    # Cursor Agent CLI (optional — Grok 4.20 via Cursor subscription)
+    # Cursor CLI (optional — Cursor subscription models via the `agent` binary)
     if declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
         ok+=("cursor-agent:Cursor Agent CLI installed")
     else

--- a/scripts/lib/agent-spec.sh
+++ b/scripts/lib/agent-spec.sh
@@ -216,6 +216,7 @@ octo_model_family() {
         openai/*|gpt-*|o[0-9]*|*chatgpt*) echo openai; return ;;
         google/*|*gemini*) echo google; return ;;
         qwen/*|alibaba/*|*qwen*) echo alibaba; return ;;
+        composer*) echo cursor; return ;;
         x-ai/*|xai/*|*grok*) echo xai; return ;;
         mistralai/*|*mistral*) echo mistral; return ;;
         stealth/*) echo stealth; return ;;
@@ -230,7 +231,8 @@ octo_model_family() {
         claude|claude-*) echo anthropic ;;
         gemini|gemini-*|agy|agy-*|antigravity) echo google ;;
         qwen|qwen-*) echo alibaba ;;
-        grok|grok-*|cursor-agent|cursor-agent-*) echo xai ;;
+        grok|grok-*|cursor-grok-*) echo xai ;;
+        cursor-agent|cursor-agent-*|composer|composer-*) echo cursor ;;
         vibe|vibe-*) echo mistral ;;
         kimi|kimi-*) echo moonshot ;;
         perplexity|perplexity-*) echo perplexity ;;

--- a/scripts/lib/cursor-agent.sh
+++ b/scripts/lib/cursor-agent.sh
@@ -116,8 +116,12 @@ _cursor_agent_config_has_auth_info() {
 }
 
 # On-disk verdict cache: two lines (epoch seconds, yes|no). Never credentials.
+# Kept in the user's cache directory, never in the workspace: a workspace may be
+# a repository checkout, where a committed symlink could redirect the write.
+# Reads refuse symlinks and writes replace the file atomically via rename, which
+# never follows a link that appears between the check and the replace.
 _cursor_agent_auth_cache_file() {
-    printf '%s\n' "${OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE:-${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.cursor-agent-auth-cache}"
+    printf '%s\n' "${OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE:-${XDG_CACHE_HOME:-${HOME}/.cache}/claude-octopus/cursor-agent-auth-verdict}"
 }
 
 _cursor_agent_auth_cache_ttl() {
@@ -132,6 +136,7 @@ _cursor_agent_auth_cache_read() {
     ttl="$(_cursor_agent_auth_cache_ttl)"
     [[ "$ttl" -gt 0 ]] || return 1
     file="$(_cursor_agent_auth_cache_file)"
+    [[ -L "$file" ]] && return 1
     [[ -f "$file" ]] || return 1
     { read -r stamp && read -r state; } < "$file" 2>/dev/null || return 1
     [[ "$stamp" =~ ^[0-9]+$ ]] || return 1
@@ -148,11 +153,23 @@ _cursor_agent_auth_cache_read() {
 }
 
 _cursor_agent_auth_cache_write() {
-    local file
+    local file dir tmp
     [[ "$(_cursor_agent_auth_cache_ttl)" -gt 0 ]] || return 0
     file="$(_cursor_agent_auth_cache_file)"
-    mkdir -p "$(dirname "$file")" 2>/dev/null || return 0
-    printf '%s\n%s\n' "$(date +%s)" "$1" > "$file" 2>/dev/null || true
+    if [[ -L "$file" ]]; then
+        _cursor_log WARN "cursor-agent: refusing to write the auth verdict through a symlink: $file"
+        return 0
+    fi
+    dir="$(dirname "$file")"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    tmp="$(mktemp "${dir}/.cursor-agent-auth-verdict.XXXXXX" 2>/dev/null)" || return 0
+    if printf '%s\n%s\n' "$(date +%s)" "$1" > "$tmp" 2>/dev/null \
+        && chmod 600 "$tmp" 2>/dev/null \
+        && mv -f "$tmp" "$file" 2>/dev/null; then
+        return 0
+    fi
+    /bin/rm -f "$tmp" 2>/dev/null || true
+    return 0
 }
 
 _cursor_agent_session_probe() {

--- a/scripts/lib/cursor-agent.sh
+++ b/scripts/lib/cursor-agent.sh
@@ -267,10 +267,12 @@ cursor_agent_resolve_mode() {
     echo "$mode"
 }
 
-# Emit the argv fragment for a resolved mode ("" for full agent mode).
+# Emit the argv fragment for a resolved mode. Agent mode uses --force so
+# unattended implementers may run tools without stopping for approval.
 cursor_agent_mode_flag() {
     case "${1:-ask}" in
         ask|plan) printf -- '--mode %s' "$1" ;;
+        agent) printf '%s' '--force' ;;
         *) printf '' ;;
     esac
 }
@@ -303,6 +305,7 @@ cursor_agent_execute() {
     cursor_mode="$(cursor_agent_resolve_mode "$role")"
     case "$cursor_mode" in
         ask|plan) mode_args=(--mode "$cursor_mode") ;;
+        agent) mode_args=(--force) ;;
     esac
     local response exit_code
     response=$(printf '%s' "$prompt" | _cursor_agent_run_with_timeout "$timeout" agent -p "" --trust --output-format text "${mode_args[@]+"${mode_args[@]}"}" 2>&1) && exit_code=0 || exit_code=$?

--- a/scripts/lib/cursor-agent.sh
+++ b/scripts/lib/cursor-agent.sh
@@ -240,7 +240,7 @@ cursor_agent_auth_method() {
 # Every seat that only reads must opt down explicitly:
 #   ask   → --mode ask   (Q&A, read-only)                  default for research/review/council
 #   plan  → --mode plan  (read-only planning, no edits)    planners and architects
-#   agent → no --mode    (full tool access)                implementer roles only
+#   agent → --force      (unattended full tool access)     implementer roles only
 # Mirrors OCTOPUS_CODEX_SANDBOX / OCTOPUS_COMMANDCODE_PERMISSION_MODE.
 cursor_agent_mode_for_role() {
     case "${1:-}" in

--- a/scripts/lib/cursor-agent.sh
+++ b/scripts/lib/cursor-agent.sh
@@ -20,6 +20,12 @@ _cursor_log() {
 # Source-safe: no main execution block.
 # ═══════════════════════════════════════════════════════════════════════════════
 
+_cursor_agent_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+if ! declare -f run_with_timeout >/dev/null 2>&1; then
+    # shellcheck source=/dev/null
+    source "${_cursor_agent_lib_dir}/heartbeat.sh" 2>/dev/null || true
+fi
+
 # Cursor Agent CLI binary identity check
 #
 # Version format: CalVer (YYYY.MM.DD-hash), e.g. "2026.04.14-ee4b43a"
@@ -36,42 +42,14 @@ _cursor_agent_run_with_timeout() {
     local timeout_secs="$1"
     shift
 
-    if command -v gtimeout &>/dev/null; then
-        gtimeout "$timeout_secs" "$@"
-        return $?
+    if ! declare -f run_with_timeout >/dev/null 2>&1; then
+        _cursor_log ERROR "cursor-agent: shared timeout supervisor unavailable"
+        return 1
     fi
-    if command -v timeout &>/dev/null; then
-        timeout "$timeout_secs" "$@"
-        return $?
-    fi
-
-    local output_file="${TMPDIR:-/tmp}/cursor-agent-timeout.$$.$RANDOM.out"
-    local cmd_pid monitor_pid exit_code
-    : > "$output_file" || return 1
-
-    "$@" >"$output_file" 2>&1 <&0 &
-    cmd_pid=$!
-    # The watchdog must not inherit our stdio: a caller's command substitution
-    # would otherwise stay open until the monitor's sleeps finish, even after a
-    # fast command has already returned (same fix as the agy helper).
-    ( /bin/sleep "$timeout_secs"; kill -TERM "$cmd_pid" 2>/dev/null; /bin/sleep 1; kill -KILL "$cmd_pid" 2>/dev/null ) >/dev/null 2>&1 </dev/null &
-    monitor_pid=$!
-
-    exit_code=0
-    wait "$cmd_pid" 2>/dev/null || exit_code=$?
-
-    kill "$monitor_pid" 2>/dev/null || true
-    wait "$monitor_pid" 2>/dev/null || true
-
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        printf '%s\n' "$line"
-    done < "$output_file"
-    /bin/rm -f "$output_file" 2>/dev/null || true
-
-    if [[ $exit_code -eq 137 || $exit_code -eq 143 ]]; then
-        return 124
-    fi
-    return "$exit_code"
+    # Always use the shared private-process-group path. A short-lived Cursor
+    # command can leave descendants holding stdout after its main PID exits;
+    # the portable supervisor contains and reaps that complete process group.
+    run_with_timeout --portable-supervisor "$timeout_secs" "$@"
 }
 
 _is_cursor_agent_binary() {

--- a/scripts/lib/cursor-agent.sh
+++ b/scripts/lib/cursor-agent.sh
@@ -165,7 +165,7 @@ _cursor_agent_session_probe() {
     # Keep whatever was printed even on a non-zero exit; the verdict is the
     # boolean, not the exit status.
     status_output=$(_cursor_agent_run_with_timeout "$status_timeout" agent status --format json </dev/null 2>/dev/null) || true
-    if printf '%s' "$status_output" | grep -Eq '"isAuthenticated"[[:space:]]*:[[:space:]]*true'; then
+    if grep -Ec '"isAuthenticated"[[:space:]]*:[[:space:]]*true' >/dev/null <<< "$status_output"; then
         _CURSOR_AGENT_SESSION_AUTH_CACHE="yes"
         _cursor_agent_auth_cache_write yes
         return 0

--- a/scripts/lib/cursor-agent.sh
+++ b/scripts/lib/cursor-agent.sh
@@ -13,8 +13,10 @@ _cursor_log() {
     fi
 }
 # Uses `agent -p` headless mode with --trust to skip workspace prompts.
-# Auth: Cursor OAuth session (via `agent login`), stored in ~/.cursor/
-# Unique models: grok-4-20, grok-4-20-thinking, composer-2-fast, composer-2
+# Auth: CURSOR_API_KEY or a Cursor session (`agent login`).
+# Models: Cursor's service-owned catalog (`agent models`); default `auto`.
+# Execution mode: read-only (`--mode ask`) unless the role writes code — see
+# cursor_agent_mode_for_role / OCTOPUS_CURSOR_AGENT_MODE below.
 # Source-safe: no main execution block.
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -49,7 +51,10 @@ _cursor_agent_run_with_timeout() {
 
     "$@" >"$output_file" 2>&1 <&0 &
     cmd_pid=$!
-    ( /bin/sleep "$timeout_secs"; kill -TERM "$cmd_pid" 2>/dev/null; /bin/sleep 1; kill -KILL "$cmd_pid" 2>/dev/null ) &
+    # The watchdog must not inherit our stdio: a caller's command substitution
+    # would otherwise stay open until the monitor's sleeps finish, even after a
+    # fast command has already returned (same fix as the agy helper).
+    ( /bin/sleep "$timeout_secs"; kill -TERM "$cmd_pid" 2>/dev/null; /bin/sleep 1; kill -KILL "$cmd_pid" 2>/dev/null ) >/dev/null 2>&1 </dev/null &
     monitor_pid=$!
 
     exit_code=0
@@ -82,28 +87,123 @@ _is_cursor_agent_binary() {
     return 1
 }
 
+# ── Authentication ────────────────────────────────────────────────────────────
+# Precedence:
+#   1. CURSOR_API_KEY in the environment                     → "env:CURSOR_API_KEY"
+#   2. Cursor session created by `agent login`               → "cursor-session"
+#      a. an "authInfo" block in ~/.cursor/cli-config.json (cheap, offline)
+#      b. the block can be absent while the CLI is still authenticated
+#         (observed on build 2026.06.24 until the CLI persisted its session);
+#         `agent status --format json` → {"isAuthenticated":true} is then the
+#         only reliable signal
+# `agent status` is network-bound (3-12s observed), so it gets its own bound
+# (OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT, default 15s) and its yes/no verdict is
+# cached per process and on disk (OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL, default
+# 600s; negative results expire after OCTOPUS_CURSOR_AGENT_AUTH_NEGATIVE_TTL,
+# default 60s, so a fresh `agent login` shows up quickly; TTL 0 disables the
+# file cache). Doctor, preflight, smoke, and fleet builders therefore pay the
+# probe once per window instead of once per process. The JSON carries account
+# identity (email, userId) and is never echoed or cached; only the boolean is.
+#
+# NOTE: ~/.cursor/agent-cli-state.json is a statsig migration flag
+# ({"hasClearedLegacyStatsigFields":true}), NOT auth state — verified on
+# Cursor Agent CLI build 2026.04.17-787b533.
+
+_CURSOR_AGENT_SESSION_AUTH_CACHE=""
+
+_cursor_agent_config_has_auth_info() {
+    grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null
+}
+
+# On-disk verdict cache: two lines (epoch seconds, yes|no). Never credentials.
+_cursor_agent_auth_cache_file() {
+    printf '%s\n' "${OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE:-${WORKSPACE_DIR:-${HOME}/.claude-octopus}/.cursor-agent-auth-cache}"
+}
+
+_cursor_agent_auth_cache_ttl() {
+    local ttl="${OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL:-600}"
+    [[ "$ttl" =~ ^[0-9]+$ ]] || ttl=600
+    printf '%s\n' "$ttl"
+}
+
+# Prints a fresh cached verdict (yes|no) or returns 1.
+_cursor_agent_auth_cache_read() {
+    local ttl file stamp state now age max_age
+    ttl="$(_cursor_agent_auth_cache_ttl)"
+    [[ "$ttl" -gt 0 ]] || return 1
+    file="$(_cursor_agent_auth_cache_file)"
+    [[ -f "$file" ]] || return 1
+    { read -r stamp && read -r state; } < "$file" 2>/dev/null || return 1
+    [[ "$stamp" =~ ^[0-9]+$ ]] || return 1
+    case "$state" in
+        yes) max_age="$ttl" ;;
+        no)  max_age="${OCTOPUS_CURSOR_AGENT_AUTH_NEGATIVE_TTL:-60}"
+             [[ "$max_age" =~ ^[0-9]+$ ]] || max_age=60 ;;
+        *)   return 1 ;;
+    esac
+    now="$(date +%s)"
+    age=$((now - stamp))
+    (( age >= 0 && age < max_age )) || return 1
+    printf '%s\n' "$state"
+}
+
+_cursor_agent_auth_cache_write() {
+    local file
+    [[ "$(_cursor_agent_auth_cache_ttl)" -gt 0 ]] || return 0
+    file="$(_cursor_agent_auth_cache_file)"
+    mkdir -p "$(dirname "$file")" 2>/dev/null || return 0
+    printf '%s\n%s\n' "$(date +%s)" "$1" > "$file" 2>/dev/null || true
+}
+
+_cursor_agent_session_probe() {
+    local status_timeout status_output cached
+    if [[ -n "$_CURSOR_AGENT_SESSION_AUTH_CACHE" ]]; then
+        [[ "$_CURSOR_AGENT_SESSION_AUTH_CACHE" == "yes" ]]
+        return $?
+    fi
+    if cached="$(_cursor_agent_auth_cache_read)"; then
+        _CURSOR_AGENT_SESSION_AUTH_CACHE="$cached"
+        [[ "$cached" == "yes" ]]
+        return $?
+    fi
+    status_timeout="${OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT:-15}"
+    # Keep whatever was printed even on a non-zero exit; the verdict is the
+    # boolean, not the exit status.
+    status_output=$(_cursor_agent_run_with_timeout "$status_timeout" agent status --format json </dev/null 2>/dev/null) || true
+    if printf '%s' "$status_output" | grep -Eq '"isAuthenticated"[[:space:]]*:[[:space:]]*true'; then
+        _CURSOR_AGENT_SESSION_AUTH_CACHE="yes"
+        _cursor_agent_auth_cache_write yes
+        return 0
+    fi
+    _CURSOR_AGENT_SESSION_AUTH_CACHE="no"
+    _cursor_agent_auth_cache_write no
+    return 1
+}
+
+# Session auth only (ignores CURSOR_API_KEY). Cheap file check first, then the
+# bounded status probe. Requires a verified Cursor binary before probing; pass
+# "verified" as $1 when the caller has already run _is_cursor_agent_binary.
+cursor_agent_session_authenticated() {
+    _cursor_agent_config_has_auth_info && return 0
+    if [[ "${1:-}" != "verified" ]]; then
+        _is_cursor_agent_binary || return 1
+    fi
+    _cursor_agent_session_probe
+}
+
+# Any accepted credential: env key or session.
+cursor_agent_is_authenticated() {
+    [[ -n "${CURSOR_API_KEY:-}" ]] && return 0
+    cursor_agent_session_authenticated "${1:-}"
+}
+
 # Check if Cursor Agent CLI is available and authenticated
 # Returns 0 if ready, 1 if not
 cursor_agent_is_available() {
-    if ! command -v agent &>/dev/null; then
-        return 1
-    fi
+    command -v agent &>/dev/null || return 1
     # Verify binary identity — `agent` is a generic name
-    if ! _is_cursor_agent_binary; then
-        return 1
-    fi
-    # Check auth: env var first (fast), then Cursor config file
-    if [[ -n "${CURSOR_API_KEY:-}" ]]; then
-        return 0
-    fi
-    # Session auth lives in ~/.cursor/cli-config.json's authInfo block.
-    # NOTE: ~/.cursor/agent-cli-state.json is a statsig migration flag
-    # ({"hasClearedLegacyStatsigFields":true}), NOT auth state — verified
-    # on Cursor Agent CLI build 2026.04.17-787b533.
-    if grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; then
-        return 0
-    fi
-    return 1
+    _is_cursor_agent_binary || return 1
+    cursor_agent_is_authenticated verified
 }
 
 # Get the auth method currently in use (for doctor/setup reporting)
@@ -111,19 +211,61 @@ cursor_agent_is_available() {
 cursor_agent_auth_method() {
     if [[ -n "${CURSOR_API_KEY:-}" ]]; then
         echo "env:CURSOR_API_KEY"
-    elif grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; then
+    elif cursor_agent_session_authenticated; then
         echo "cursor-session"
     else
         echo "none"
     fi
 }
 
+# ── Execution mode ────────────────────────────────────────────────────────────
+# `agent -p` has full tool access (write + shell) in the working directory.
+# Every seat that only reads must opt down explicitly:
+#   ask   → --mode ask   (Q&A, read-only)                  default for research/review/council
+#   plan  → --mode plan  (read-only planning, no edits)    planners and architects
+#   agent → no --mode    (full tool access)                implementer roles only
+# Mirrors OCTOPUS_CODEX_SANDBOX / OCTOPUS_COMMANDCODE_PERMISSION_MODE.
+cursor_agent_mode_for_role() {
+    case "${1:-}" in
+        implementer|developer|implementer-heavy) echo "agent" ;;
+        planner|architect|strategist) echo "plan" ;;
+        *) echo "ask" ;;
+    esac
+}
+
+# Apply the OCTOPUS_CURSOR_AGENT_MODE override to the role-derived default.
+# An invalid value logs an error and keeps the role default (fails safe).
+cursor_agent_resolve_mode() {
+    local role="${1:-}" mode
+    mode="$(cursor_agent_mode_for_role "$role")"
+    if [[ -n "${OCTOPUS_CURSOR_AGENT_MODE:-}" ]]; then
+        case "$OCTOPUS_CURSOR_AGENT_MODE" in
+            ask|plan|agent) mode="$OCTOPUS_CURSOR_AGENT_MODE" ;;
+            *)
+                _cursor_log ERROR "Invalid OCTOPUS_CURSOR_AGENT_MODE value: '${OCTOPUS_CURSOR_AGENT_MODE}'. Allowed: ask, plan, agent"
+                _cursor_log ERROR "Falling back to role-derived default (${mode})."
+                ;;
+        esac
+    fi
+    echo "$mode"
+}
+
+# Emit the argv fragment for a resolved mode ("" for full agent mode).
+cursor_agent_mode_flag() {
+    case "${1:-ask}" in
+        ask|plan) printf -- '--mode %s' "$1" ;;
+        *) printf '' ;;
+    esac
+}
+
 # Execute a prompt via Cursor Agent CLI headless mode
-# Args: $1=agent_type (e.g. cursor-agent), $2=prompt, $3=output_file (optional)
+# Args: $1=agent_type (e.g. cursor-agent), $2=prompt, $3=output_file (optional),
+#       $4=role (optional; drives the read-only/plan/agent mode contract)
 cursor_agent_execute() {
     local agent_type="$1"
     local prompt="$2"
     local output_file="${3:-}"
+    local role="${4:-}"
 
     if ! command -v agent &>/dev/null; then
         _cursor_log ERROR "cursor-agent: CLI not found — install: curl -fsSL https://cursor.com/install | bash"
@@ -139,8 +281,14 @@ cursor_agent_execute() {
     [[ "${VERBOSE:-}" == "true" ]] && _cursor_log DEBUG "cursor_agent_execute: type=$agent_type, timeout=${timeout}s, auth=$(cursor_agent_auth_method)" || true
 
     # Note: --model is set by dispatch.sh via get_agent_command(), not here
+    local -a mode_args=()
+    local cursor_mode
+    cursor_mode="$(cursor_agent_resolve_mode "$role")"
+    case "$cursor_mode" in
+        ask|plan) mode_args=(--mode "$cursor_mode") ;;
+    esac
     local response exit_code
-    response=$(printf '%s' "$prompt" | _cursor_agent_run_with_timeout "$timeout" agent -p "" --trust --output-format text 2>&1) && exit_code=0 || exit_code=$?
+    response=$(printf '%s' "$prompt" | _cursor_agent_run_with_timeout "$timeout" agent -p "" --trust --output-format text "${mode_args[@]+"${mode_args[@]}"}" 2>&1) && exit_code=0 || exit_code=$?
 
     # Handle errors
     if [[ $exit_code -ne 0 ]]; then

--- a/scripts/lib/debate.sh
+++ b/scripts/lib/debate.sh
@@ -6,6 +6,22 @@ debate_label_upper() {
     printf '%s\n' "$1" | tr '[:lower:]' '[:upper:]'
 }
 
+# First ready provider for a release-default debate seat, skipping agents that
+# already hold a slot. Cursor CLI leads (Cursor-only setups), then the other
+# external CLIs; a Claude Opus seat is the last resort so the debate can still
+# run with distinct participants.
+_debate_pick_available_seat() {
+    local candidate
+    for candidate in cursor-agent codex agy copilot qwen opencode claude-opus; do
+        case " $* " in *" $candidate "*) continue ;; esac
+        if is_agent_available_v2 "$candidate" 2>/dev/null; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
 debate_labels_match() {
     local label="$1"
     local label_upper="$2"
@@ -52,7 +68,7 @@ grapple_debate() {
     local agent_b="agy" label_b="Antigravity" label_b_upper="ANTIGRAVITY"
     local agent_c="claude-sonnet" label_c="Sonnet" label_c_upper="SONNET"
 
-    local _debate_config_seats=false
+    local _debate_cfg_a=false _debate_cfg_b=false _debate_cfg_c=false
     local _debate_config_file="${HOME}/.claude-octopus/config/providers.json"
     if [[ -f "$_debate_config_file" ]] && command -v jq >/dev/null 2>&1; then
         local _participants _participant_count
@@ -78,15 +94,14 @@ grapple_debate() {
                 _label=$(agent_display_label "$_agent") || continue
                 _label_upper=$(agent_display_label_upper "$_agent") || continue
                 case "$_slot_idx" in
-                    0) agent_a="$_agent"; label_a="$_label"; label_a_upper="$_label_upper" ;;
-                    1) agent_b="$_agent"; label_b="$_label"; label_b_upper="$_label_upper" ;;
-                    2) agent_c="$_agent"; label_c="$_label"; label_c_upper="$_label_upper"; break ;;
+                    0) agent_a="$_agent"; label_a="$_label"; label_a_upper="$_label_upper"; _debate_cfg_a=true ;;
+                    1) agent_b="$_agent"; label_b="$_label"; label_b_upper="$_label_upper"; _debate_cfg_b=true ;;
+                    2) agent_c="$_agent"; label_c="$_label"; label_c_upper="$_label_upper"; _debate_cfg_c=true; break ;;
                 esac
                 _resolved_count=$((_resolved_count + 1))
                 _slot_idx=$((_slot_idx + 1))
             done <<< "$_participants"
             if [[ "$_resolved_count" -gt 0 ]]; then
-                _debate_config_seats=true
                 log INFO "Debate participants (from config): $label_a ($agent_a) vs $label_b ($agent_b) vs $label_c ($agent_c)"
             else
                 log INFO "Debate config had no valid participants; using defaults: $label_a ($agent_a) vs $label_b ($agent_b) vs $label_c ($agent_c)"
@@ -94,23 +109,35 @@ grapple_debate() {
         fi
     fi
 
-    # Availability fallback for the release-default seats only (config-selected
-    # participants are never overridden): when Antigravity (slot B) or Codex
-    # (slot A) is not usable but Cursor CLI is, seat Cursor instead of dispatching
-    # to a provider that is guaranteed to fail.
-    if [[ "$_debate_config_seats" != true ]] && declare -f is_agent_available_v2 >/dev/null 2>&1 \
-        && is_agent_available_v2 cursor-agent 2>/dev/null; then
-        if [[ "$agent_b" == "agy" ]] && ! is_agent_available_v2 agy 2>/dev/null; then
-            agent_b="cursor-agent"
-            label_b=$(agent_display_label cursor-agent)
-            label_b_upper=$(agent_display_label_upper cursor-agent)
-            log INFO "Debate: Antigravity unavailable, seating Cursor CLI as participant B"
-        elif [[ "$agent_a" == "codex" ]] && ! is_agent_available_v2 codex 2>/dev/null; then
-            agent_a="cursor-agent"
-            label_a=$(agent_display_label cursor-agent)
-            label_a_upper=$(agent_display_label_upper cursor-agent)
-            log INFO "Debate: Codex unavailable, seating Cursor CLI as participant A"
-        fi
+    # Availability fallback for release-default external seats. Slots taken from
+    # configuration are never overridden; every unconfigured slot is evaluated
+    # on its own, so a config naming only one participant still gets usable
+    # defaults, and both defaults are replaced when both are unavailable.
+    if declare -f is_agent_available_v2 >/dev/null 2>&1; then
+        local _slot_name _slot_agent _slot_cfg _replacement
+        for _slot_name in A B; do
+            if [[ "$_slot_name" == "A" ]]; then
+                _slot_agent="$agent_a"; _slot_cfg="$_debate_cfg_a"
+            else
+                _slot_agent="$agent_b"; _slot_cfg="$_debate_cfg_b"
+            fi
+            [[ "$_slot_cfg" == true ]] && continue
+            is_agent_available_v2 "$_slot_agent" 2>/dev/null && continue
+            if ! _replacement="$(_debate_pick_available_seat "$agent_a" "$agent_b" "$agent_c")"; then
+                log WARN "Debate: default participant '$_slot_agent' (slot ${_slot_name}) is unavailable and no replacement provider is ready"
+                continue
+            fi
+            log INFO "Debate: default participant '$_slot_agent' unavailable, seating $_replacement as participant ${_slot_name}"
+            if [[ "$_slot_name" == "A" ]]; then
+                agent_a="$_replacement"
+                label_a=$(agent_display_label "$_replacement")
+                label_a_upper=$(agent_display_label_upper "$_replacement")
+            else
+                agent_b="$_replacement"
+                label_b=$(agent_display_label "$_replacement")
+                label_b_upper=$(agent_display_label_upper "$_replacement")
+            fi
+        done
     fi
 
     # Keep debate attribution labels unique even when multiple configured

--- a/scripts/lib/debate.sh
+++ b/scripts/lib/debate.sh
@@ -52,6 +52,7 @@ grapple_debate() {
     local agent_b="agy" label_b="Antigravity" label_b_upper="ANTIGRAVITY"
     local agent_c="claude-sonnet" label_c="Sonnet" label_c_upper="SONNET"
 
+    local _debate_config_seats=false
     local _debate_config_file="${HOME}/.claude-octopus/config/providers.json"
     if [[ -f "$_debate_config_file" ]] && command -v jq >/dev/null 2>&1; then
         local _participants _participant_count
@@ -85,10 +86,30 @@ grapple_debate() {
                 _slot_idx=$((_slot_idx + 1))
             done <<< "$_participants"
             if [[ "$_resolved_count" -gt 0 ]]; then
+                _debate_config_seats=true
                 log INFO "Debate participants (from config): $label_a ($agent_a) vs $label_b ($agent_b) vs $label_c ($agent_c)"
             else
                 log INFO "Debate config had no valid participants; using defaults: $label_a ($agent_a) vs $label_b ($agent_b) vs $label_c ($agent_c)"
             fi
+        fi
+    fi
+
+    # Availability fallback for the release-default seats only (config-selected
+    # participants are never overridden): when Antigravity (slot B) or Codex
+    # (slot A) is not usable but Cursor CLI is, seat Cursor instead of dispatching
+    # to a provider that is guaranteed to fail.
+    if [[ "$_debate_config_seats" != true ]] && declare -f is_agent_available_v2 >/dev/null 2>&1 \
+        && is_agent_available_v2 cursor-agent 2>/dev/null; then
+        if [[ "$agent_b" == "agy" ]] && ! is_agent_available_v2 agy 2>/dev/null; then
+            agent_b="cursor-agent"
+            label_b=$(agent_display_label cursor-agent)
+            label_b_upper=$(agent_display_label_upper cursor-agent)
+            log INFO "Debate: Antigravity unavailable, seating Cursor CLI as participant B"
+        elif [[ "$agent_a" == "codex" ]] && ! is_agent_available_v2 codex 2>/dev/null; then
+            agent_a="cursor-agent"
+            label_a=$(agent_display_label cursor-agent)
+            label_a_upper=$(agent_display_label_upper cursor-agent)
+            log INFO "Debate: Codex unavailable, seating Cursor CLI as participant A"
         fi
     fi
 

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -5,6 +5,9 @@ source "${_profile_lib_dir}/provider-registry.sh" || { echo "dispatch: failed to
 if ! declare -f octopus_resolve_reasoning_level >/dev/null 2>&1; then
     source "${_profile_lib_dir}/execution-profile.sh" 2>/dev/null || true
 fi
+if ! declare -f cursor_agent_resolve_mode >/dev/null 2>&1; then
+    source "${_profile_lib_dir}/cursor-agent.sh" 2>/dev/null || true
+fi
 # Claude Octopus — Agent Dispatch & Model Resolution
 # ═══════════════════════════════════════════════════════════════════════════════
 # Extracted from orchestrate.sh in v9.7.7 monolith decomposition.
@@ -609,13 +612,21 @@ get_agent_command() {
             fi
             echo "${PLUGIN_DIR}/scripts/helpers/commandcode-exec.sh ${model} ${commandcode_mode}"
             ;;
-        cursor-agent)  # v9.23.0: Cursor Agent CLI — Grok 4.20 via Cursor subscription
+        cursor-agent)  # Cursor CLI (`agent`) — Cursor subscription models, default `auto`
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
                 return 1
             fi
+            # `agent -p` has write+shell access, so seats are read-only unless
+            # the role writes code: --mode ask (default) / --mode plan / none.
+            # Role table + OCTOPUS_CURSOR_AGENT_MODE override live in
+            # lib/cursor-agent.sh (cursor_agent_resolve_mode), matching the
+            # OCTOPUS_CODEX_SANDBOX / OCTOPUS_COMMANDCODE_PERMISSION_MODE precedent.
+            local cursor_mode cursor_mode_flag
+            cursor_mode="$(cursor_agent_resolve_mode "$role")"
+            cursor_mode_flag="$(cursor_agent_mode_flag "$cursor_mode")"
             # NOTE: bare ${model} (no quotes) — downstream uses `read -ra` which
             # does NOT interpret quotes; literal " would be passed to --model.
-            echo "agent --trust --output-format text --model ${model}"
+            echo "agent --trust --output-format text${cursor_mode_flag:+ ${cursor_mode_flag}} --model ${model}"
             ;;
         vibe|vibe-research)  # Mistral Vibe — interactive CLI (model in ~/.vibe/config.toml)
             # Routed through helpers/vibe-exec.sh: vibe's -p only accepts the
@@ -1167,7 +1178,7 @@ find_capable_fallback() {
         perplexity)
             candidates=(sonar sonar-pro) ;;
         cursor-agent)
-            candidates=(composer-2-fast composer-2 grok-4-20 grok-4-20-thinking) ;;
+            candidates=(auto composer-2.5-fast composer-2.5 gpt-5.6-sol-high claude-sonnet-5-thinking-high) ;;
     esac
 
     for candidate in "${candidates[@]}"; do

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -616,8 +616,8 @@ get_agent_command() {
             if ! model=$(get_agent_model "$agent_type" "$phase" "$role"); then
                 return 1
             fi
-            # `agent -p` has write+shell access, so seats are read-only unless
-            # the role writes code: --mode ask (default) / --mode plan / none.
+            # `agent -p` has write and shell access, so seats are read-only
+            # unless the role writes code: --mode ask, --mode plan, or --force.
             # Role table + OCTOPUS_CURSOR_AGENT_MODE override live in
             # lib/cursor-agent.sh (cursor_agent_resolve_mode), matching the
             # OCTOPUS_CODEX_SANDBOX / OCTOPUS_COMMANDCODE_PERMISSION_MODE precedent.

--- a/scripts/lib/embrace.sh
+++ b/scripts/lib/embrace.sh
@@ -89,12 +89,9 @@ get_dispatch_strategy() {
     fi
     _gds_provider_allowed ollama && _gds_not_quota_dead ollama && command -v ollama >/dev/null 2>&1 && curl -sf http://localhost:11434/api/tags &>/dev/null && has_ollama=true
     if _gds_provider_allowed cursor-agent && _gds_not_quota_dead cursor-agent; then
-        if declare -f cursor_agent_is_available >/dev/null 2>&1; then
-            cursor_agent_is_available && has_cursor_agent=true
-        elif declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
-            if [[ -n "${CURSOR_API_KEY:-}" ]] || grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; then
-                has_cursor_agent=true
-            fi
+        # lib/cursor-agent.sh owns binary identity and auth (env key or session).
+        if declare -f cursor_agent_is_available >/dev/null 2>&1 && cursor_agent_is_available; then
+            has_cursor_agent=true
         fi
     fi
 

--- a/scripts/lib/execution-profile.sh
+++ b/scripts/lib/execution-profile.sh
@@ -57,6 +57,10 @@ octo_route_task_class() {
 }
 
 _octo_route_provider_for_model() {
+  case "${1:-}" in
+    composer-*|cursor-agent*|cursor-grok-*) printf '%s\n' cursor-agent; return 0 ;;
+    grok-*) printf '%s\n' grok; return 0 ;;
+  esac
   case "$(octo_model_family "${1:-}")" in
     anthropic)
       case "${1:-}" in

--- a/scripts/lib/execution-profile.sh
+++ b/scripts/lib/execution-profile.sh
@@ -12,8 +12,9 @@ octo_model_family() {
     gpt-*|o[134]-*|codex*|openai/*) printf '%s\n' openai ;;
     gemini-*|agy-*|google/*) printf '%s\n' google ;;
     qwen-*|qwen/*) printf '%s\n' alibaba ;;
-    grok-*|xai/*) printf '%s\n' xai ;;
+    grok-*|xai/*|cursor-grok-*) printf '%s\n' xai ;;
     kimi-*|moonshot/*) printf '%s\n' moonshot ;;
+    composer-*|cursor-agent*) printf '%s\n' cursor ;;
     *) printf '%s\n' unknown ;;
   esac
 }

--- a/scripts/lib/grok.sh
+++ b/scripts/lib/grok.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# xAI Grok CLI provider (standalone `grok` binary — NOT cursor-agent's grok-4-20).
+# xAI Grok CLI provider (standalone `grok` binary — NOT the cursor-agent seat's cursor-grok-* models).
 # Added by octo-grok-patch.sh. No top-level set -e*: sourced libs must not alter
 # parent shell options (orchestrate.sh already sets `set -eo pipefail`).
 # Auth: $XAI_API_KEY or ~/.grok/auth.json (grok login session).

--- a/scripts/lib/model-resolver.sh
+++ b/scripts/lib/model-resolver.sh
@@ -729,7 +729,7 @@ resolve_octopus_model() {
                 ;;
             copilot*)        resolved_model="auto" ;; # Let the current Copilot CLI choose its supported default.
             qwen*)           resolved_model="qwen3-coder" ;;
-            cursor-agent*)   resolved_model="grok-4-20" ;;
+            cursor-agent*)   resolved_model="auto" ;; # Cursor's service-side pick; pin any `agent models` ID via OCTOPUS_CURSOR_AGENT_MODEL
             opencode-research*) resolved_model="opencode/glm-5.1" ;;
             opencode-fast*)  resolved_model="opencode/deepseek-v4-flash-free" ;;
             opencode*)       resolved_model="opencode/deepseek-v4-flash-free" ;;
@@ -860,10 +860,7 @@ is_agent_available_v2() {
             [[ "$PROVIDER_OPENCODE_INSTALLED" == "true" && "$PROVIDER_OPENCODE_AUTH_METHOD" != "none" ]]
             ;;
         cursor-agent|cursor-agent-*)
-            declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary && {
-                [[ -n "${CURSOR_API_KEY:-}" ]] || \
-                grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null
-            }
+            declare -f cursor_agent_is_available >/dev/null 2>&1 && cursor_agent_is_available
             ;;
         grok|grok-*)
             declare -f grok_is_available >/dev/null 2>&1 && grok_is_available

--- a/scripts/lib/models.sh
+++ b/scripts/lib/models.sh
@@ -36,7 +36,9 @@ get_model_catalog() {
         o3-mini)                echo "200|yes|no|yes|codex|budget|active" ;;
         # Antigravity CLI (agy routes to the user's configured Antigravity default)
         agy/default|default)       echo "1000|yes|yes|no|agy|standard|active" ;;
-        # GitHub Copilot CLI service-owned automatic model selection
+        # GitHub Copilot CLI service-owned automatic model selection. Cursor CLI
+        # shares the bare `auto` ID (its own service-side pick); pricing is
+        # provider-aware so the cursor-agent route still bills as subscription.
         auto)                      echo "128|yes|no|no|copilot|standard|active" ;;
         # Claude
         claude-haiku-4.5)      echo "200|yes|yes|yes|claude|budget|active" ;;
@@ -50,11 +52,17 @@ get_model_catalog() {
         claude-opus-4.6)        echo "200|yes|yes|yes|claude|premium|legacy" ;;
         claude-opus-4.8-fast)   echo "1000|yes|yes|yes|claude|premium|active" ;;
         claude-opus-4.6-fast)   echo "200|yes|yes|yes|claude|premium|legacy" ;;
-        # Cursor Agent (Grok via Cursor subscription)
-        grok-4-20)              echo "200|yes|no|no|cursor-agent|standard|active" ;;
-        grok-4-20-thinking)     echo "200|yes|no|yes|cursor-agent|premium|active" ;;
-        composer-2-fast)        echo "200|yes|no|no|cursor-agent|standard|active" ;;
-        composer-2)             echo "200|yes|no|no|cursor-agent|premium|active" ;;
+        # Cursor CLI (`agent`) — Cursor subscription catalog. Curated subset of
+        # `agent models`; any other flat ID from that list is accepted as a pin.
+        composer-2.5)                    echo "200|yes|no|no|cursor-agent|standard|active" ;;
+        composer-2.5-fast)               echo "200|yes|no|no|cursor-agent|standard|active" ;;
+        cursor-grok-4.6-high)            echo "200|yes|no|yes|cursor-agent|standard|active" ;;
+        cursor-grok-4.6-xhigh)           echo "200|yes|no|yes|cursor-agent|premium|active" ;;
+        gpt-5.6-sol-high)                echo "1000|yes|yes|yes|cursor-agent|premium|active" ;;
+        gpt-5.6-luna-high)               echo "1000|yes|yes|yes|cursor-agent|budget|active" ;;
+        claude-sonnet-5-thinking-high)   echo "1000|yes|yes|yes|cursor-agent|standard|active" ;;
+        claude-opus-5-thinking-high)     echo "1000|yes|yes|yes|cursor-agent|premium|active" ;;
+        gemini-3.7-flash-high)           echo "1000|yes|yes|yes|cursor-agent|budget|active" ;;
         # OpenRouter
         z-ai/glm-5)             echo "203|yes|no|no|openrouter|standard|active" ;;
         moonshotai/kimi-k2.5)   echo "262|yes|yes|no|openrouter|standard|active" ;;
@@ -138,10 +146,15 @@ claude-opus-4.8-fast
 claude-opus-4.7
 claude-opus-4.6
 claude-opus-4.6-fast
-grok-4-20
-grok-4-20-thinking
-composer-2-fast
-composer-2
+composer-2.5
+composer-2.5-fast
+cursor-grok-4.6-high
+cursor-grok-4.6-xhigh
+gpt-5.6-sol-high
+gpt-5.6-luna-high
+claude-sonnet-5-thinking-high
+claude-opus-5-thinking-high
+gemini-3.7-flash-high
 z-ai/glm-5
 moonshotai/kimi-k2.5
 deepseek/deepseek-v4-pro

--- a/scripts/lib/preflight.sh
+++ b/scripts/lib/preflight.sh
@@ -222,7 +222,7 @@ _octo_provider_static_readiness() {
             remediation="Install Cursor Agent, then run: agent login"
             if declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
                 if _octo_value_has_nonwhitespace "${CURSOR_API_KEY:-}" ||
-                   grep -Ec '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" >/dev/null 2>&1; then
+                   { declare -f cursor_agent_session_authenticated >/dev/null 2>&1 && cursor_agent_session_authenticated; }; then
                     status="available"; reason_code="ready"; remediation=""
                 else
                     status="degraded"; reason_code="auth-missing"; remediation="Run: agent login, or set CURSOR_API_KEY."

--- a/scripts/lib/provider-registry.sh
+++ b/scripts/lib/provider-registry.sh
@@ -26,7 +26,7 @@ atlascloud|atlas,atlas-cloud|atlascloud|atlascloud|model-config,health,detect,di
 openai-compatible||openai-compatible|openai-compatible|model-config,council,detect,dispatch,env,model-gateway
 openai-tools||openai-compatible|openai-compatible|model-config,council,dispatch,env,model-gateway
 openai-compatible-agent||openai-compatible|openai-compatible|model-config,dispatch,env,model-gateway
-cursor-agent|cursor|cursor-agent|cursor|model-config,health,detect,dispatch,env,model-gateway
+cursor-agent|cursor|cursor-agent|cursor|model-config,council,health,detect,dispatch,env,model-gateway
 grok|xai|grok|xai|model-config,health,detect,dispatch,env
 qwen||qwen|alibaba|model-config,council,health,detect,dispatch,env
 ollama|local|ollama|local|model-config,health,detect,dispatch,env,model-gateway
@@ -291,7 +291,6 @@ openai-tools|detect|api-configured-runtime-has-no-local-cli-detection
 openai-compatible-agent|council|agent-runtime-is-not-a-supported-council-seat
 openai-compatible-agent|health|generic-agent-runtime-has-no-provider-specific-health-probe
 openai-compatible-agent|detect|api-configured-runtime-has-no-local-cli-detection
-cursor-agent|council|interactive-agent-cli-is-not-a-supported-council-seat
 grok|council|grok-runtime-is-not-a-supported-council-seat
 ollama|council|local-runtime-is-not-a-supported-council-seat
 copilot|council|copilot-runtime-is-not-a-supported-council-seat

--- a/scripts/lib/provider-routing.sh
+++ b/scripts/lib/provider-routing.sh
@@ -240,6 +240,39 @@ _octo_build_provider_env_impl() {
                 fi
             fi
             ;;
+        cursor-agent*)
+            # Cursor CLI defaults to a minimal environment (parity with codex/agy/grok).
+            # HOME must cross the boundary: `agent login` session state lives under
+            # ~/.cursor. Users needing full desktop/session inheritance can opt out.
+            if [[ "${OCTOPUS_ALLOW_FULL_CURSOR_AGENT_ENV:-false}" == "true" ]]; then
+                if [[ "${OCTOPUS_SECURITY_V870:-true}" == "true" ]] && declare -f log_warn >/dev/null 2>&1; then
+                    log_warn "Cursor CLI inherits the parent shell environment because OCTOPUS_ALLOW_FULL_CURSOR_AGENT_ENV=true."
+                fi
+                PROVIDER_ENV_ARRAY=()
+            else
+                if [[ -z "${CURSOR_API_KEY:-}" ]] && declare -f resolve_provider_env >/dev/null 2>&1; then
+                    resolve_provider_env "CURSOR_API_KEY" 2>/dev/null || true
+                fi
+                PROVIDER_ENV_ARRAY=(env -i "PATH=$PATH" "HOME=$HOME" "TERM=${TERM:-dumb}" "TMPDIR=${TMPDIR:-/tmp}")
+                if [[ -n "${CURSOR_API_KEY:-}" ]]; then
+                    PROVIDER_ENV_ARRAY+=("CURSOR_API_KEY=${CURSOR_API_KEY}")
+                fi
+                # Cursor adapter controls are configuration, never credentials.
+                local _cursor_adapter_var
+                for _cursor_adapter_var in \
+                    OCTOPUS_CURSOR_AGENT_MODEL \
+                    OCTOPUS_CURSOR_AGENT_MODE \
+                    OCTOPUS_CURSOR_AGENT_TIMEOUT \
+                    OCTOPUS_CURSOR_AGENT_PROBE_TIMEOUT; do
+                    if [[ -n "${!_cursor_adapter_var:-}" ]]; then
+                        PROVIDER_ENV_ARRAY+=("${_cursor_adapter_var}=${!_cursor_adapter_var}")
+                    fi
+                done
+                if [[ ${#_trace_env[@]} -gt 0 ]]; then
+                    PROVIDER_ENV_ARRAY+=("${_trace_env[@]}")
+                fi
+            fi
+            ;;
         perplexity*)
             # perplexity_execute is a shell function — env -i cannot exec it (#300)
             if [[ -z "${PERPLEXITY_API_KEY:-}" ]]; then

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -1004,9 +1004,8 @@ check_provider_health() {
                 echo "cursor-agent: 'agent' binary is not Cursor Agent CLI" >&2
                 return 1
             fi
-            # Check auth: env var or Cursor session (authInfo in cli-config.json)
-            if [[ -z "${CURSOR_API_KEY:-}" ]] && \
-               ! grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; then
+            # Check auth: env var or Cursor session (lib/cursor-agent.sh owns the probe)
+            if ! cursor_agent_is_authenticated; then
                 echo "cursor-agent: not authenticated (run: agent login or set CURSOR_API_KEY)" >&2
                 return 1
             fi
@@ -1339,13 +1338,11 @@ detect_providers() {
         result="${result}qwen:${qwen_auth} "
     fi
 
-    # Detect Cursor Agent CLI (Grok via Cursor subscription)
+    # Detect Cursor CLI (`agent`; Cursor subscription models)
     if { ! declare -f octo_provider_allowed >/dev/null 2>&1 || octo_provider_allowed cursor-agent; } && declare -f _is_cursor_agent_binary >/dev/null 2>&1 && _is_cursor_agent_binary; then
         local cursor_auth="none"
-        if [[ -n "${CURSOR_API_KEY:-}" ]]; then
-            cursor_auth="env:CURSOR_API_KEY"
-        elif grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; then
-            cursor_auth="cursor-session"
+        if declare -f cursor_agent_auth_method >/dev/null 2>&1; then
+            cursor_auth="$(cursor_agent_auth_method)"
         fi
         result="${result}cursor-agent:${cursor_auth} "
     fi

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -127,6 +127,18 @@ _review_fleet_from_config() {
                     has_diversity=true
                 fi
                 ;;
+            cursor-agent|cursor-agent-*)
+                if [[ "$has_security" == "false" ]]; then
+                    fleet+="${provider}:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+                    has_security=true
+                elif [[ "$has_logic" == "false" ]]; then
+                    fleet+="${provider}:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+                    has_logic=true
+                elif [[ "$has_diversity" == "false" ]]; then
+                    fleet+="${provider}:implementation-diversity-reviewer:cross-family perspective on logic and assumptions"$'\n'
+                    has_diversity=true
+                fi
+                ;;
             copilot|copilot-*)
                 if [[ "$has_cve" == "false" ]]; then
                     fleet+="${provider}:implementation-cve-reviewer:known CVEs via web search, library advisories"$'\n'
@@ -382,18 +394,27 @@ build_review_fleet() {
 
     # ── Cascade fallback (original behavior — no config or empty config) ──
 
-    # logic-reviewer: Codex (OpenAI) → OpenCode → Copilot → claude-sonnet fallback
+    # Cursor CLI: `agent` is a generic binary name, so gate on the provider
+    # helper (identity + auth) rather than `command -v agent`.
+    local cursor_agent_ready=false
+    if declare -f cursor_agent_is_available >/dev/null 2>&1 && cursor_agent_is_available; then
+        cursor_agent_ready=true
+    fi
+
+    # logic-reviewer: Codex (OpenAI) → OpenCode → Copilot → Cursor → claude-sonnet fallback
     if command -v codex >/dev/null 2>&1; then
         fleet+="codex:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
     elif command -v opencode >/dev/null 2>&1; then
         fleet+="opencode:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
     elif command -v copilot >/dev/null 2>&1; then
         fleet+="copilot:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
+    elif [[ "$cursor_agent_ready" == true ]]; then
+        fleet+="cursor-agent:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
     else
         fleet+="claude-sonnet:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'
     fi
 
-    # security-reviewer: AGY (Google) → Qwen → Copilot → claude-sonnet fallback
+    # security-reviewer: AGY (Google) → Qwen → Copilot → Cursor → claude-sonnet fallback
     # Prefer different family from logic-reviewer for diversity
     if command -v agy >/dev/null 2>&1; then
         fleet+="agy:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
@@ -401,6 +422,8 @@ build_review_fleet() {
         fleet+="qwen:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
     elif command -v copilot >/dev/null 2>&1; then
         fleet+="copilot:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
+    elif [[ "$cursor_agent_ready" == true ]]; then
+        fleet+="cursor-agent:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
     else
         fleet+="claude-sonnet:implementation-security-reviewer:OWASP vulnerabilities, injection, auth flaws, data exposure"$'\n'
     fi
@@ -420,6 +443,9 @@ build_review_fleet() {
     elif command -v qwen >/dev/null 2>&1; then
         fleet+="qwen:implementation-cve-reviewer:known CVEs via web search, library advisories"$'\n'
         log INFO "CVE lookup: Perplexity+AGY unavailable, using Qwen"
+    elif [[ "$cursor_agent_ready" == true ]]; then
+        fleet+="cursor-agent:implementation-cve-reviewer:known CVEs and library advisories from model knowledge"$'\n'
+        log INFO "CVE lookup: no web-search provider, using Cursor CLI"
     else
         fleet+="claude-sonnet:implementation-cve-reviewer:known CVEs via WebSearch tool, library advisories"$'\n'
         log WARN "CVE lookup: no dedicated web-search provider, using Claude WebSearch (degraded)"

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -68,9 +68,19 @@ _review_fleet_from_config() {
     local fleet=""
     local has_logic=false has_security=false has_arch=false has_cve=false has_diversity=false
 
+    local raw_executor canonical
     while IFS= read -r provider; do
         [[ -z "$provider" ]] && continue
-        case "$provider" in
+        # Match on the canonical registry ID so registered aliases (cursor,
+        # gemini-*, antigravity, openai, ...) select a seat. Executor variants
+        # such as codex-review keep their own name; pure aliases are rewritten
+        # to the executable provider ID, preserving any :model suffix.
+        raw_executor="${provider%%:*}"
+        canonical="$(octo_provider_canonical "$raw_executor" 2>/dev/null || printf '%s' "$raw_executor")"
+        if [[ "$canonical" != "$raw_executor" && "$raw_executor" != "${canonical}-"* ]]; then
+            provider="${canonical}${provider#"$raw_executor"}"
+        fi
+        case "$canonical" in
             codex|codex-*)
                 if [[ "$has_logic" == "false" ]]; then
                     fleet+="${provider}:implementation-logic-reviewer:correctness and logic bugs, edge cases, regressions"$'\n'

--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -828,11 +828,11 @@ SMOKE_TEST_CACHE_FILE="${WORKSPACE_DIR:-$HOME/.claude-octopus}/.smoke-test-cache
 smoke_test_cache_key() {
     local codex_model cursor_agent_model cursor_agent_state codex_sandbox
     codex_model=$(get_agent_model "codex" 2>/dev/null || echo "default")
-    cursor_agent_model=$(get_agent_model "cursor-agent" 2>/dev/null || echo "${OCTOPUS_CURSOR_AGENT_MODEL:-grok-4-20}")
-    if [[ -n "${CURSOR_API_KEY:-}" ]]; then
+    cursor_agent_model=$(get_agent_model "cursor-agent" 2>/dev/null || echo "${OCTOPUS_CURSOR_AGENT_MODEL:-auto}")
+    if declare -f cursor_agent_auth_method >/dev/null 2>&1; then
+        cursor_agent_state="$(cursor_agent_auth_method)"
+    elif [[ -n "${CURSOR_API_KEY:-}" ]]; then
         cursor_agent_state="env:CURSOR_API_KEY"
-    elif grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; then
-        cursor_agent_state="${HOME}/.cursor/cli-config.json"
     else
         cursor_agent_state="none"
     fi
@@ -909,7 +909,7 @@ _display_smoke_test_error() {
             if [[ "$provider" == "codex" ]]; then
                 echo -e "    ${DIM}Fix: export OCTOPUS_CODEX_MODEL=gpt-5.6-sol${NC}"
             elif [[ "$provider" == "cursor" || "$provider" == "cursor-agent" || "$provider" == "Cursor Agent" ]]; then
-                echo -e "    ${DIM}Fix: export OCTOPUS_CURSOR_AGENT_MODEL=grok-4-20${NC}"
+                echo -e "    ${DIM}Fix: export OCTOPUS_CURSOR_AGENT_MODEL=auto  (or any ID from: agent models)${NC}"
             elif [[ "$provider" == "agy" || "$provider" == "Antigravity" ]]; then
                 echo -e "    ${DIM}Fix: agy models  (pick a valid label)  OR  unset OCTOPUS_AGY_MODEL to use agy's default${NC}"
             else
@@ -1003,9 +1003,10 @@ _smoke_test_provider() {
         popd >/dev/null 2>&1 || cd "$OLDPWD" 2>/dev/null || true
         rm -rf "$smoke_dir" 2>/dev/null
     elif [[ "$provider" == "cursor-agent" ]]; then
-        # --trust required for untrusted workspaces; matches cursor-agent.sh:143 dispatch path
+        # cmd_str already carries --trust, --output-format text, --mode and
+        # --model from dispatch; only the stdin headless trigger is appended.
         echo "Reply with exactly: ok" | run_with_timeout "$smoke_timeout" \
-            $cmd_str -p "" --trust --output-format text \
+            $cmd_str -p "" \
             >/dev/null 2>"$stderr_file" || smoke_exit=$?
     elif [[ "$provider" == "agy" ]]; then
         # agy-exec.sh is a stdin adapter that builds its own argv and execs agy
@@ -1089,8 +1090,7 @@ provider_smoke_test() {
     # Determine which providers are available (from preflight state)
     local has_codex=false has_cursor_agent=false has_agy=false
     command -v codex &>/dev/null && has_codex=true
-    if command -v agent &>/dev/null && _is_cursor_agent_binary && \
-       { [[ -n "${CURSOR_API_KEY:-}" ]] || grep -Eq '"authInfo"[[:space:]]*:[[:space:]]*\{' "${HOME}/.cursor/cli-config.json" 2>/dev/null; }; then
+    if declare -f cursor_agent_is_available >/dev/null 2>&1 && cursor_agent_is_available; then
         has_cursor_agent=true
     fi
     command -v agy &>/dev/null && has_agy=true

--- a/scripts/sync-readme.py
+++ b/scripts/sync-readme.py
@@ -30,6 +30,7 @@ PUBLIC_EXTERNAL_PROVIDERS = (
     ("OpenRouter", "OpenRouter API key"),
     ("OrcaRouter", "OrcaRouter API key"),
     ("OpenCode", "OpenCode CLI"),
+    ("Cursor CLI", "Cursor CLI (`agent`)"),
     ("Grok", "xAI API key (Grok)"),
     ("Kimi Code", "Kimi Code CLI"),
 )

--- a/tests/unit/fixtures/env-var-effects.tsv
+++ b/tests/unit/fixtures/env-var-effects.tsv
@@ -75,3 +75,4 @@ OCTOPUS_WORKSPACE	covered-by	test-subagent-stop-gate.sh
 OCTOPUS_X_MODEL	placeholder	doc template fragment, not a real variable
 OCTOPUS_CURSOR_AGENT_MODE	covered-by	test-cursor-agent-provider.sh
 OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT	covered-by	test-cursor-agent-provider.sh
+OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE	covered-by	test-cursor-agent-provider.sh

--- a/tests/unit/fixtures/env-var-effects.tsv
+++ b/tests/unit/fixtures/env-var-effects.tsv
@@ -73,3 +73,5 @@ OCTOPUS_TRACE_MODELS	skip	emits trace lines to stderr; covered indirectly by mod
 OCTOPUS_WORKFLOW_STATE_DIR	covered-by	test-probe-cancellation-cleanup.sh
 OCTOPUS_WORKSPACE	covered-by	test-subagent-stop-gate.sh
 OCTOPUS_X_MODEL	placeholder	doc template fragment, not a real variable
+OCTOPUS_CURSOR_AGENT_MODE	covered-by	test-cursor-agent-provider.sh
+OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT	covered-by	test-cursor-agent-provider.sh

--- a/tests/unit/test-agy-provider.sh
+++ b/tests/unit/test-agy-provider.sh
@@ -1403,7 +1403,7 @@ test_agy_docs_cost_and_marker() {
     test_case "docs show agy cost controls and distinct provider marker"
 
     if grep -q 'OCTOPUS_AGY_MODEL' "$PROJECT_ROOT/CLAUDE.md" && \
-       grep -q 'Four providers cost nothing extra' "$PROJECT_ROOT/README.md" && \
+       grep -q 'Antigravity CLI.*existing subscriptions' "$PROJECT_ROOT/README.md" && \
        grep -q '🧭 Antigravity CLI (`agy`)' "$PROJECT_ROOT/README.md" && \
        ! grep -q '🟢 Antigravity CLI (`agy`)' "$PROJECT_ROOT/README.md"; then
         test_pass
@@ -1433,8 +1433,7 @@ test_agy_slash_command_visibility() {
        grep -q 'Antigravity CLI' "$PROJECT_ROOT/.claude/skills/skill-debate/SKILL.md" && \
        grep -q 'Antigravity CLI' "$PROJECT_ROOT/docs/COMMAND-REFERENCE.md" && \
        grep -q 'Antigravity CLI' "$PROJECT_ROOT/SECURITY.md" && \
-       grep -q 'up to 11 external AI integrations' "$PROJECT_ROOT/PRODUCT.md" && \
-       grep -q 'Four providers can cost nothing extra' "$PROJECT_ROOT/PRODUCT.md" && \
+       grep -q 'providers can cost nothing extra.*Antigravity CLI' "$PROJECT_ROOT/PRODUCT.md" && \
        grep -q 'codex agy' "$PROJECT_ROOT/tests/test-fleet-diversity.sh" && \
        grep -q 'codex, agy' "$PROJECT_ROOT/tests/unit/test-research-fanout-static.sh"; then
         test_pass

--- a/tests/unit/test-codex-manifest.sh
+++ b/tests/unit/test-codex-manifest.sh
@@ -15,16 +15,18 @@ else
     test_fail "Codex supports at most three interface.defaultPrompt entries"
 fi
 
-test_case "Codex metadata names all eleven external providers"
+test_case "Codex metadata names all twelve external providers"
 if jq -e '
+    (.description | contains("Cursor CLI")) and
     (.description | contains("Kimi Code")) and
-    (.interface.shortDescription | contains("11 providers")) and
-    (.interface.longDescription | contains("eleven external AI providers")) and
+    (.interface.shortDescription | contains("12 providers")) and
+    (.interface.longDescription | contains("twelve external AI providers")) and
+    (.interface.longDescription | contains("Cursor CLI")) and
     (.interface.longDescription | contains("Kimi Code"))
 ' "$PROJECT_ROOT/.codex-plugin/plugin.json" >/dev/null; then
     test_pass
 else
-    test_fail "Codex metadata must count eleven providers and include Kimi Code"
+    test_fail "Codex metadata must count twelve providers and include Cursor CLI and Kimi Code"
 fi
 
 test_summary

--- a/tests/unit/test-cursor-agent-provider.sh
+++ b/tests/unit/test-cursor-agent-provider.sh
@@ -199,7 +199,7 @@ reset_mocks; write_cursor_status_mock
 CALLS_FILE="$TEST_TMP_DIR/status-calls-1.txt"; : > "$CALLS_FILE"
 probe_output=$(
     unset CURSOR_API_KEY
-    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
+    export "HOME=${EMPTY_CURSOR_HOME}" "PATH=${CURSOR_PROBE_PATH}" "CURSOR_STATUS_CALLS=${CALLS_FILE}"
     export CURSOR_MOCK_STATUS_JSON='{"status":"authenticated","isAuthenticated":true,"userInfo":{"email":"secret@example.test"}}'
     _CURSOR_AGENT_SESSION_AUTH_CACHE=""
     if cursor_agent_is_available; then
@@ -218,7 +218,7 @@ test_case "unauthenticated agent status leaves Cursor unavailable"
 reset_mocks; write_cursor_status_mock
 probe_output=$(
     unset CURSOR_API_KEY
-    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH"
+    export "HOME=${EMPTY_CURSOR_HOME}" "PATH=${CURSOR_PROBE_PATH}"
     export CURSOR_MOCK_STATUS_JSON='{"status":"unauthenticated","isAuthenticated":false}'
     _CURSOR_AGENT_SESSION_AUTH_CACHE=""
     cursor_agent_is_available && echo "available" || echo "unavailable:$(cursor_agent_auth_method)"
@@ -238,7 +238,7 @@ printf '#!/bin/bash\nexec /usr/bin/grep "$@"\n' > "$MOCK_BIN_DIR/grep"; chmod +x
 SECONDS=0
 probe_output=$(
     unset CURSOR_API_KEY
-    export HOME="$EMPTY_CURSOR_HOME" PATH="$MOCK_BIN_DIR"
+    export "HOME=${EMPTY_CURSOR_HOME}" "PATH=${MOCK_BIN_DIR}"
     export CURSOR_MOCK_STATUS_SLEEP=5 OCTOPUS_CURSOR_AGENT_PROBE_TIMEOUT=1 OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT=1
     export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true}'
     _CURSOR_AGENT_SESSION_AUTH_CACHE=""
@@ -255,7 +255,7 @@ reset_mocks; write_cursor_status_mock
 CALLS_FILE="$TEST_TMP_DIR/status-calls-2.txt"; : > "$CALLS_FILE"
 probe_output=$(
     unset CURSOR_API_KEY
-    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
+    export "HOME=${EMPTY_CURSOR_HOME}" "PATH=${CURSOR_PROBE_PATH}" "CURSOR_STATUS_CALLS=${CALLS_FILE}"
     export CURSOR_MOCK_VERSION="1.4.2" CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true}'
     _CURSOR_AGENT_SESSION_AUTH_CACHE=""
     cursor_agent_session_authenticated && echo "authenticated" || echo "rejected"
@@ -271,7 +271,7 @@ reset_mocks; write_cursor_status_mock
 CALLS_FILE="$TEST_TMP_DIR/status-calls-3.txt"; : > "$CALLS_FILE"
 probe_output=$(
     unset CURSOR_API_KEY
-    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
+    export "HOME=${EMPTY_CURSOR_HOME}" "PATH=${CURSOR_PROBE_PATH}" "CURSOR_STATUS_CALLS=${CALLS_FILE}"
     export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true}'
     _CURSOR_AGENT_SESSION_AUTH_CACHE=""
     cursor_agent_is_available && cursor_agent_is_available && cursor_agent_auth_method
@@ -290,7 +290,7 @@ printf '{"authInfo": {"accessToken":"redacted"}}\n' > "$LEGACY_HOME/.cursor/cli-
 CALLS_FILE="$TEST_TMP_DIR/status-calls-4.txt"; : > "$CALLS_FILE"
 probe_output=$(
     unset CURSOR_API_KEY
-    export HOME="$LEGACY_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
+    export "HOME=${LEGACY_HOME}" "PATH=${CURSOR_PROBE_PATH}" "CURSOR_STATUS_CALLS=${CALLS_FILE}"
     export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":false}'
     _CURSOR_AGENT_SESSION_AUTH_CACHE=""
     cursor_agent_auth_method
@@ -307,8 +307,8 @@ CALLS_FILE="$TEST_TMP_DIR/status-calls-5.txt"; : > "$CALLS_FILE"
 AUTH_CACHE="$TEST_TMP_DIR/auth-cache/verdict"
 probe_output=$(
     unset CURSOR_API_KEY
-    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
-    export OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL=600 OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE="$AUTH_CACHE"
+    export "HOME=${EMPTY_CURSOR_HOME}" "PATH=${CURSOR_PROBE_PATH}" "CURSOR_STATUS_CALLS=${CALLS_FILE}"
+    export OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL=600 "OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE=${AUTH_CACHE}"
     export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true,"userInfo":{"email":"secret@example.test"}}'
     first=$(bash -c 'source "'"$CURSOR_LIB"'"; cursor_agent_auth_method')
     second=$(bash -c 'source "'"$CURSOR_LIB"'"; cursor_agent_auth_method')
@@ -330,8 +330,8 @@ mkdir -p "$(dirname "$AUTH_CACHE")"
 printf '%s\nyes\n' "$(( $(date +%s) - 7200 ))" > "$AUTH_CACHE"
 probe_output=$(
     unset CURSOR_API_KEY
-    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
-    export OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL=600 OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE="$AUTH_CACHE"
+    export "HOME=${EMPTY_CURSOR_HOME}" "PATH=${CURSOR_PROBE_PATH}" "CURSOR_STATUS_CALLS=${CALLS_FILE}"
+    export OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL=600 "OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE=${AUTH_CACHE}"
     export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":false}'
     bash -c 'source "'"$CURSOR_LIB"'"; cursor_agent_auth_method'
 )
@@ -349,8 +349,8 @@ TARGET_FILE="$SYMLINK_DIR/victim"; printf 'untouched\n' > "$TARGET_FILE"
 ln -sf "$TARGET_FILE" "$SYMLINK_DIR/verdict"
 probe_output=$(
     unset CURSOR_API_KEY
-    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH"
-    export OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL=600 OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE="$SYMLINK_DIR/verdict"
+    export "HOME=${EMPTY_CURSOR_HOME}" "PATH=${CURSOR_PROBE_PATH}"
+    export OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL=600 "OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE=${SYMLINK_DIR}/verdict"
     export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true}'
     bash -c 'source "'"$CURSOR_LIB"'"; cursor_agent_auth_method' 2>/dev/null
 )
@@ -361,7 +361,7 @@ else
 fi
 
 test_case "verdict cache defaults to the user cache directory, not the workspace"
-default_cache=$(HOME="$EMPTY_CURSOR_HOME" WORKSPACE_DIR="$TEST_TMP_DIR/some-checkout" env -u XDG_CACHE_HOME -u OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE bash -c 'source "'"$CURSOR_LIB"'"; _cursor_agent_auth_cache_file')
+default_cache=$(env -u XDG_CACHE_HOME -u OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE "HOME=${EMPTY_CURSOR_HOME}" "WORKSPACE_DIR=${TEST_TMP_DIR}/some-checkout" bash -c 'source "'"$CURSOR_LIB"'"; _cursor_agent_auth_cache_file')
 if [[ "$default_cache" == "$EMPTY_CURSOR_HOME/.cache/claude-octopus/cursor-agent-auth-verdict" ]]; then
     test_pass
 else
@@ -425,10 +425,10 @@ cat >/dev/null
 echo "cursor response"
 EOF
 chmod +x "$MOCK_BIN_DIR/timeout" "$MOCK_BIN_DIR/agent"
-if PATH="$MOCK_BIN_DIR:/usr/bin:/bin" CURSOR_API_KEY=test ARGV_FILE="$ARGV_FILE" \
+if PATH="${MOCK_BIN_DIR}:/usr/bin:/bin" CURSOR_API_KEY=test ARGV_FILE="${ARGV_FILE}" \
     cursor_agent_execute cursor-agent "prompt" "" researcher >/dev/null 2>&1 &&
    grep -q -- '--mode ask' "$ARGV_FILE" &&
-   PATH="$MOCK_BIN_DIR:/usr/bin:/bin" CURSOR_API_KEY=test ARGV_FILE="$ARGV_FILE" \
+   PATH="${MOCK_BIN_DIR}:/usr/bin:/bin" CURSOR_API_KEY=test ARGV_FILE="${ARGV_FILE}" \
     cursor_agent_execute cursor-agent "prompt" "" implementer >/dev/null 2>&1 &&
    ! grep -q -- '--mode' "$ARGV_FILE"; then
     test_pass

--- a/tests/unit/test-cursor-agent-provider.sh
+++ b/tests/unit/test-cursor-agent-provider.sh
@@ -229,13 +229,16 @@ else
     test_fail "expected unavailable:none, got '$probe_output'"
 fi
 
-test_case "session status probe stays bounded by OCTOPUS_CURSOR_AGENT_PROBE_TIMEOUT"
+test_case "session status probe stays bounded by OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT"
 reset_mocks; write_cursor_status_mock
-rm -f "$MOCK_BIN_DIR/timeout"   # force the portable fallback watchdog on hosts without coreutils timeout
+# Force the portable fallback watchdog: PATH holds only the mock dir (no
+# coreutils timeout/gtimeout on any host) plus a grep shim for the verdict parse.
+rm -f "$MOCK_BIN_DIR/timeout"
+printf '#!/bin/bash\nexec /usr/bin/grep "$@"\n' > "$MOCK_BIN_DIR/grep"; chmod +x "$MOCK_BIN_DIR/grep"
 SECONDS=0
 probe_output=$(
     unset CURSOR_API_KEY
-    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH"
+    export HOME="$EMPTY_CURSOR_HOME" PATH="$MOCK_BIN_DIR"
     export CURSOR_MOCK_STATUS_SLEEP=5 OCTOPUS_CURSOR_AGENT_PROBE_TIMEOUT=1 OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT=1
     export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true}'
     _CURSOR_AGENT_SESSION_AUTH_CACHE=""
@@ -337,6 +340,32 @@ if [[ "$probe_output" == "none" && "${call_count:-0}" -eq 1 && "$(sed -n '2p' "$
     test_pass
 else
     test_fail "stale cache should re-probe (calls=${call_count:-0} result=$probe_output cache=$(cat "$AUTH_CACHE" 2>/dev/null | tr '\n' ' '))"
+fi
+
+test_case "verdict cache refuses a symlinked cache file and never follows it"
+reset_mocks; write_cursor_status_mock
+SYMLINK_DIR="$TEST_TMP_DIR/auth-cache/symlinked"; mkdir -p "$SYMLINK_DIR"
+TARGET_FILE="$SYMLINK_DIR/victim"; printf 'untouched\n' > "$TARGET_FILE"
+ln -sf "$TARGET_FILE" "$SYMLINK_DIR/verdict"
+probe_output=$(
+    unset CURSOR_API_KEY
+    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH"
+    export OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL=600 OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE="$SYMLINK_DIR/verdict"
+    export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true}'
+    bash -c 'source "'"$CURSOR_LIB"'"; cursor_agent_auth_method' 2>/dev/null
+)
+if [[ "$probe_output" == "cursor-session" && "$(cat "$TARGET_FILE")" == "untouched" && -L "$SYMLINK_DIR/verdict" ]]; then
+    test_pass
+else
+    test_fail "symlinked cache must not be followed (result=$probe_output target=$(cat "$TARGET_FILE" 2>/dev/null))"
+fi
+
+test_case "verdict cache defaults to the user cache directory, not the workspace"
+default_cache=$(HOME="$EMPTY_CURSOR_HOME" WORKSPACE_DIR="$TEST_TMP_DIR/some-checkout" env -u XDG_CACHE_HOME -u OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE bash -c 'source "'"$CURSOR_LIB"'"; _cursor_agent_auth_cache_file')
+if [[ "$default_cache" == "$EMPTY_CURSOR_HOME/.cache/claude-octopus/cursor-agent-auth-verdict" ]]; then
+    test_pass
+else
+    test_fail "unexpected default cache path: $default_cache"
 fi
 
 test_case "no consumer re-implements the Cursor auth probe"
@@ -488,12 +517,40 @@ else
     test_fail "octo_model_family: composer=$(octo_model_family composer-2.5) grok=$(octo_model_family cursor-grok-4.6-high) cursor-agent=$(octo_model_family cursor-agent)"
 fi
 
+test_case "configured review participants accept the cursor alias and keep executor variants"
+review_fleet_fn="$(sed -n '/^_review_fleet_from_config() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/review.sh")"
+REVIEW_HOME="$TEST_TMP_DIR/review-alias-home"; mkdir -p "$REVIEW_HOME/.claude-octopus/config"
+# Order matters: agy takes the security seat first, codex-review the logic seat,
+# so the cursor alias must land on the diversity seat under its canonical ID.
+printf '{"routing":{"features":{"review":["gemini-fast","codex-review","cursor"]}}}\n' > "$REVIEW_HOME/.claude-octopus/config/providers.json"
+review_output=$(HOME="$REVIEW_HOME" bash -c 'log(){ :; }; source "'"$PROJECT_ROOT"'/scripts/lib/provider-registry.sh"; '"$review_fleet_fn"'; _review_fleet_from_config' 2>/dev/null)
+if grep -q '^agy:implementation-security-reviewer' <<< "$review_output" &&
+   grep -q '^codex-review:implementation-logic-reviewer' <<< "$review_output" &&
+   grep -q '^cursor-agent:implementation-diversity-reviewer' <<< "$review_output" &&
+   ! grep -qE '^(cursor|gemini-fast):' <<< "$review_output"; then
+    test_pass
+else
+    test_fail "alias handling in _review_fleet_from_config drifted: $(printf '%s' "$review_output" | tr '\n' ' ')"
+fi
+
+test_case "debate seat fallback skips seated agents and evaluates each default slot"
+pick_fn="$(sed -n '/^_debate_pick_available_seat() {/,/^}/p' "$PROJECT_ROOT/scripts/lib/debate.sh")"
+picked=$(bash -c 'is_agent_available_v2(){ case "$1" in cursor-agent|claude-opus) return 0;; *) return 1;; esac; }; '"$pick_fn"'; a=$(_debate_pick_available_seat codex agy claude-sonnet); b=$(_debate_pick_available_seat codex cursor-agent claude-sonnet); echo "$a/$b"')
+if [[ "$picked" == "cursor-agent/claude-opus" ]] &&
+   grep -q '_debate_cfg_a=true' "$PROJECT_ROOT/scripts/lib/debate.sh" &&
+   grep -q 'for _slot_name in A B' "$PROJECT_ROOT/scripts/lib/debate.sh" &&
+   ! grep -q '_debate_config_seats' "$PROJECT_ROOT/scripts/lib/debate.sh"; then
+    test_pass
+else
+    test_fail "debate fallback drifted (picked=$picked)"
+fi
+
 test_case "review and debate cascades seat Cursor when preferred providers are absent"
 if grep -q 'cursor-agent:implementation-logic-reviewer' "$PROJECT_ROOT/scripts/lib/review.sh" &&
    grep -q 'cursor-agent:implementation-security-reviewer' "$PROJECT_ROOT/scripts/lib/review.sh" &&
    grep -q 'cursor-agent:implementation-cve-reviewer' "$PROJECT_ROOT/scripts/lib/review.sh" &&
    grep -q 'cursor_agent_is_available' "$PROJECT_ROOT/scripts/lib/review.sh" &&
-   grep -q 'is_agent_available_v2 cursor-agent' "$PROJECT_ROOT/scripts/lib/debate.sh" &&
+   grep -q '_debate_pick_available_seat' "$PROJECT_ROOT/scripts/lib/debate.sh" &&
    grep -q '"Cursor Perspective"' "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" &&
    ! grep -q '"XAI Perspective"' "$PROJECT_ROOT/scripts/helpers/build-fleet.sh"; then
     test_pass

--- a/tests/unit/test-cursor-agent-provider.sh
+++ b/tests/unit/test-cursor-agent-provider.sh
@@ -158,4 +158,358 @@ else
     test_pass
 fi
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# Session auth via `agent status` — 2026.06+ builds keep no authInfo marker in
+# ~/.cursor/cli-config.json; the bounded, cached status probe is the only signal.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+write_cursor_status_mock() {
+    cat > "$MOCK_BIN_DIR/agent" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--version" ]]; then
+    echo "${CURSOR_MOCK_VERSION:-2026.06.24-test}"
+    exit 0
+fi
+if [[ "$1" == "status" ]]; then
+    [[ -n "${CURSOR_STATUS_CALLS:-}" ]] && echo "status $*" >> "$CURSOR_STATUS_CALLS"
+    [[ -n "${CURSOR_MOCK_STATUS_SLEEP:-}" ]] && /bin/sleep "$CURSOR_MOCK_STATUS_SLEEP"
+    printf '%s\n' "${CURSOR_MOCK_STATUS_JSON:-{\"isAuthenticated\":false}}"
+    exit 0
+fi
+exit 2
+EOF
+    cat > "$MOCK_BIN_DIR/timeout" <<'EOF'
+#!/bin/bash
+shift
+exec "$@"
+EOF
+    chmod +x "$MOCK_BIN_DIR/agent" "$MOCK_BIN_DIR/timeout"
+}
+
+EMPTY_CURSOR_HOME="$TEST_TMP_DIR/cursor-home-empty"
+mkdir -p "$EMPTY_CURSOR_HOME/.cursor"
+printf '{"version":1,"sandbox":{}}\n' > "$EMPTY_CURSOR_HOME/.cursor/cli-config.json"
+CURSOR_PROBE_PATH="$MOCK_BIN_DIR:/usr/bin:/bin"
+# Probe cases exercise the live status path; the on-disk verdict cache gets its
+# own case below.
+export OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL=0
+
+test_case "session auth is accepted from agent status when cli-config.json has no authInfo"
+reset_mocks; write_cursor_status_mock
+CALLS_FILE="$TEST_TMP_DIR/status-calls-1.txt"; : > "$CALLS_FILE"
+probe_output=$(
+    unset CURSOR_API_KEY
+    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
+    export CURSOR_MOCK_STATUS_JSON='{"status":"authenticated","isAuthenticated":true,"userInfo":{"email":"secret@example.test"}}'
+    _CURSOR_AGENT_SESSION_AUTH_CACHE=""
+    if cursor_agent_is_available; then
+        echo "available:$(cursor_agent_auth_method)"
+    else
+        echo "unavailable:$(cursor_agent_auth_method)"
+    fi
+)
+if [[ "$probe_output" == "available:cursor-session" ]] && ! grep -q "secret@example.test" <<< "$probe_output" && grep -q "status --format json" "$CALLS_FILE"; then
+    test_pass
+else
+    test_fail "expected available:cursor-session via status probe, got '$probe_output' (calls: $(cat "$CALLS_FILE" 2>/dev/null))"
+fi
+
+test_case "unauthenticated agent status leaves Cursor unavailable"
+reset_mocks; write_cursor_status_mock
+probe_output=$(
+    unset CURSOR_API_KEY
+    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH"
+    export CURSOR_MOCK_STATUS_JSON='{"status":"unauthenticated","isAuthenticated":false}'
+    _CURSOR_AGENT_SESSION_AUTH_CACHE=""
+    cursor_agent_is_available && echo "available" || echo "unavailable:$(cursor_agent_auth_method)"
+)
+if [[ "$probe_output" == "unavailable:none" ]]; then
+    test_pass
+else
+    test_fail "expected unavailable:none, got '$probe_output'"
+fi
+
+test_case "session status probe stays bounded by OCTOPUS_CURSOR_AGENT_PROBE_TIMEOUT"
+reset_mocks; write_cursor_status_mock
+rm -f "$MOCK_BIN_DIR/timeout"   # force the portable fallback watchdog on hosts without coreutils timeout
+SECONDS=0
+probe_output=$(
+    unset CURSOR_API_KEY
+    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH"
+    export CURSOR_MOCK_STATUS_SLEEP=5 OCTOPUS_CURSOR_AGENT_PROBE_TIMEOUT=1 OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT=1
+    export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true}'
+    _CURSOR_AGENT_SESSION_AUTH_CACHE=""
+    cursor_agent_is_available && echo "available" || echo "unavailable"
+)
+if [[ "$probe_output" == "unavailable" && $SECONDS -le 3 ]]; then
+    test_pass
+else
+    test_fail "status probe was not bounded (result=$probe_output elapsed=${SECONDS}s)"
+fi
+
+test_case "a non-Cursor 'agent' binary short-circuits before the status probe"
+reset_mocks; write_cursor_status_mock
+CALLS_FILE="$TEST_TMP_DIR/status-calls-2.txt"; : > "$CALLS_FILE"
+probe_output=$(
+    unset CURSOR_API_KEY
+    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
+    export CURSOR_MOCK_VERSION="1.4.2" CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true}'
+    _CURSOR_AGENT_SESSION_AUTH_CACHE=""
+    cursor_agent_session_authenticated && echo "authenticated" || echo "rejected"
+)
+if [[ "$probe_output" == "rejected" && ! -s "$CALLS_FILE" ]]; then
+    test_pass
+else
+    test_fail "semver 'agent' should be rejected without probing status (result=$probe_output calls=$(cat "$CALLS_FILE"))"
+fi
+
+test_case "status probe result is cached for the process"
+reset_mocks; write_cursor_status_mock
+CALLS_FILE="$TEST_TMP_DIR/status-calls-3.txt"; : > "$CALLS_FILE"
+probe_output=$(
+    unset CURSOR_API_KEY
+    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
+    export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true}'
+    _CURSOR_AGENT_SESSION_AUTH_CACHE=""
+    cursor_agent_is_available && cursor_agent_is_available && cursor_agent_auth_method
+)
+call_count=$(grep -c "status" "$CALLS_FILE" 2>/dev/null || true)
+if [[ "$probe_output" == "cursor-session" && "${call_count:-0}" -eq 1 ]]; then
+    test_pass
+else
+    test_fail "expected one cached status probe, got ${call_count:-0} (result=$probe_output)"
+fi
+
+test_case "legacy authInfo block still authenticates without probing status"
+reset_mocks; write_cursor_status_mock
+LEGACY_HOME="$TEST_TMP_DIR/cursor-home-legacy"; mkdir -p "$LEGACY_HOME/.cursor"
+printf '{"authInfo": {"accessToken":"redacted"}}\n' > "$LEGACY_HOME/.cursor/cli-config.json"
+CALLS_FILE="$TEST_TMP_DIR/status-calls-4.txt"; : > "$CALLS_FILE"
+probe_output=$(
+    unset CURSOR_API_KEY
+    export HOME="$LEGACY_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
+    export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":false}'
+    _CURSOR_AGENT_SESSION_AUTH_CACHE=""
+    cursor_agent_auth_method
+)
+if [[ "$probe_output" == "cursor-session" && ! -s "$CALLS_FILE" ]]; then
+    test_pass
+else
+    test_fail "legacy authInfo should short-circuit (result=$probe_output calls=$(cat "$CALLS_FILE"))"
+fi
+
+test_case "status verdict is cached on disk across processes and holds no credentials"
+reset_mocks; write_cursor_status_mock
+CALLS_FILE="$TEST_TMP_DIR/status-calls-5.txt"; : > "$CALLS_FILE"
+AUTH_CACHE="$TEST_TMP_DIR/auth-cache/verdict"
+probe_output=$(
+    unset CURSOR_API_KEY
+    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
+    export OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL=600 OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE="$AUTH_CACHE"
+    export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true,"userInfo":{"email":"secret@example.test"}}'
+    first=$(bash -c 'source "'"$CURSOR_LIB"'"; cursor_agent_auth_method')
+    second=$(bash -c 'source "'"$CURSOR_LIB"'"; cursor_agent_auth_method')
+    echo "${first}/${second}"
+)
+call_count=$(grep -c "status" "$CALLS_FILE" 2>/dev/null || true)
+if [[ "$probe_output" == "cursor-session/cursor-session" && "${call_count:-0}" -eq 1 ]] &&
+   [[ "$(sed -n '2p' "$AUTH_CACHE")" == "yes" ]] && ! grep -q "secret" "$AUTH_CACHE"; then
+    test_pass
+else
+    test_fail "expected one probe shared via the verdict cache, got calls=${call_count:-0} result=$probe_output cache=$(cat "$AUTH_CACHE" 2>/dev/null | tr '\n' ' ')"
+fi
+
+test_case "a stale or negative cached verdict re-probes"
+reset_mocks; write_cursor_status_mock
+CALLS_FILE="$TEST_TMP_DIR/status-calls-6.txt"; : > "$CALLS_FILE"
+AUTH_CACHE="$TEST_TMP_DIR/auth-cache/stale"
+mkdir -p "$(dirname "$AUTH_CACHE")"
+printf '%s\nyes\n' "$(( $(date +%s) - 7200 ))" > "$AUTH_CACHE"
+probe_output=$(
+    unset CURSOR_API_KEY
+    export HOME="$EMPTY_CURSOR_HOME" PATH="$CURSOR_PROBE_PATH" CURSOR_STATUS_CALLS="$CALLS_FILE"
+    export OCTOPUS_CURSOR_AGENT_AUTH_CACHE_TTL=600 OCTOPUS_CURSOR_AGENT_AUTH_CACHE_FILE="$AUTH_CACHE"
+    export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":false}'
+    bash -c 'source "'"$CURSOR_LIB"'"; cursor_agent_auth_method'
+)
+call_count=$(grep -c "status" "$CALLS_FILE" 2>/dev/null || true)
+if [[ "$probe_output" == "none" && "${call_count:-0}" -eq 1 && "$(sed -n '2p' "$AUTH_CACHE")" == "no" ]]; then
+    test_pass
+else
+    test_fail "stale cache should re-probe (calls=${call_count:-0} result=$probe_output cache=$(cat "$AUTH_CACHE" 2>/dev/null | tr '\n' ' '))"
+fi
+
+test_case "no consumer re-implements the Cursor auth probe"
+offenders=$(grep -RnE 'authInfo|agent[[:space:]]+status[[:space:]]+--format' "$PROJECT_ROOT/scripts" --include='*.sh' 2>/dev/null | grep -v 'scripts/lib/cursor-agent.sh' || true)
+if [[ -z "$offenders" ]]; then
+    test_pass
+else
+    test_fail "auth probe duplicated outside lib/cursor-agent.sh: $offenders"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Execution mode contract — `agent -p` has write+shell access; seats opt down.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+test_case "role table defaults to read-only ask, plan for planners, agent for implementers"
+if [[ "$(cursor_agent_mode_for_role researcher)" == "ask" ]] &&
+   [[ "$(cursor_agent_mode_for_role "")" == "ask" ]] &&
+   [[ "$(cursor_agent_mode_for_role implementation-security-reviewer)" == "ask" ]] &&
+   [[ "$(cursor_agent_mode_for_role backend-architect)" == "ask" ]] &&
+   [[ "$(cursor_agent_mode_for_role planner)" == "plan" ]] &&
+   [[ "$(cursor_agent_mode_for_role architect)" == "plan" ]] &&
+   [[ "$(cursor_agent_mode_for_role implementer)" == "agent" ]] &&
+   [[ "$(cursor_agent_mode_for_role developer)" == "agent" ]]; then
+    test_pass
+else
+    test_fail "role→mode table drifted"
+fi
+
+test_case "OCTOPUS_CURSOR_AGENT_MODE overrides the role default and rejects unknown values"
+if [[ "$(OCTOPUS_CURSOR_AGENT_MODE=agent cursor_agent_resolve_mode researcher 2>/dev/null)" == "agent" ]] &&
+   [[ "$(OCTOPUS_CURSOR_AGENT_MODE=plan cursor_agent_resolve_mode implementer 2>/dev/null)" == "plan" ]] &&
+   [[ "$(OCTOPUS_CURSOR_AGENT_MODE=yolo cursor_agent_resolve_mode implementer 2>/dev/null)" == "agent" ]] &&
+   [[ "$(OCTOPUS_CURSOR_AGENT_MODE=yolo cursor_agent_resolve_mode researcher 2>/dev/null)" == "ask" ]] &&
+   [[ "$(cursor_agent_mode_flag ask)" == "--mode ask" ]] &&
+   [[ -z "$(cursor_agent_mode_flag agent)" ]]; then
+    test_pass
+else
+    test_fail "mode override handling drifted"
+fi
+
+test_case "cursor_agent_execute applies the read-only mode for non-implementer roles"
+reset_mocks
+ARGV_FILE="$TEST_TMP_DIR/cursor-argv-mode.txt"
+cat > "$MOCK_BIN_DIR/timeout" <<'EOF'
+#!/bin/bash
+shift
+exec "$@"
+EOF
+cat > "$MOCK_BIN_DIR/agent" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--version" ]]; then
+    echo "2026.06.24-test"
+    exit 0
+fi
+printf '%s\n' "$*" > "$ARGV_FILE"
+cat >/dev/null
+echo "cursor response"
+EOF
+chmod +x "$MOCK_BIN_DIR/timeout" "$MOCK_BIN_DIR/agent"
+if PATH="$MOCK_BIN_DIR:/usr/bin:/bin" CURSOR_API_KEY=test ARGV_FILE="$ARGV_FILE" \
+    cursor_agent_execute cursor-agent "prompt" "" researcher >/dev/null 2>&1 &&
+   grep -q -- '--mode ask' "$ARGV_FILE" &&
+   PATH="$MOCK_BIN_DIR:/usr/bin:/bin" CURSOR_API_KEY=test ARGV_FILE="$ARGV_FILE" \
+    cursor_agent_execute cursor-agent "prompt" "" implementer >/dev/null 2>&1 &&
+   ! grep -q -- '--mode' "$ARGV_FILE"; then
+    test_pass
+else
+    test_fail "cursor_agent_execute did not honour the role mode contract: $(cat "$ARGV_FILE" 2>/dev/null)"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dispatch, environment isolation, registry, and fleet wiring
+# ═══════════════════════════════════════════════════════════════════════════════
+
+log() { :; }
+PLUGIN_DIR="$PROJECT_ROOT"
+export "TMPDIR=${TEST_TMP_DIR}/runtime"; mkdir -p "$TMPDIR"
+source "$PROJECT_ROOT/scripts/lib/provider-registry.sh"
+source "$PROJECT_ROOT/scripts/lib/utils.sh"
+source "$PROJECT_ROOT/scripts/lib/models.sh"
+source "$PROJECT_ROOT/scripts/lib/model-resolver.sh"
+source "$PROJECT_ROOT/scripts/lib/provider-routing.sh"
+source "$PROJECT_ROOT/scripts/lib/dispatch.sh"
+
+test_case "dispatch defaults to --mode ask --model auto and validates the command"
+cmd=$(HOME="$EMPTY_CURSOR_HOME" get_agent_command cursor-agent probe researcher 2>/dev/null || true)
+if [[ "$cmd" == "agent --trust --output-format text --mode ask --model auto" ]] && validate_agent_command "$cmd" 2>/dev/null; then
+    test_pass
+else
+    test_fail "unexpected researcher dispatch: '$cmd'"
+fi
+
+test_case "dispatch omits --mode for implementer roles and uses --mode plan for planners"
+impl_cmd=$(HOME="$EMPTY_CURSOR_HOME" get_agent_command cursor-agent tangle implementer 2>/dev/null || true)
+plan_cmd=$(HOME="$EMPTY_CURSOR_HOME" get_agent_command cursor-agent grasp planner 2>/dev/null || true)
+if [[ "$impl_cmd" == "agent --trust --output-format text --model auto" ]] &&
+   [[ "$plan_cmd" == "agent --trust --output-format text --mode plan --model auto" ]]; then
+    test_pass
+else
+    test_fail "implementer='$impl_cmd' planner='$plan_cmd'"
+fi
+
+test_case "OCTOPUS_CURSOR_AGENT_MODE reaches dispatch and explicit seats keep their model"
+override_cmd=$(HOME="$EMPTY_CURSOR_HOME" OCTOPUS_CURSOR_AGENT_MODE=plan get_agent_command cursor-agent tangle implementer 2>/dev/null || true)
+seat_cmd=$(HOME="$EMPTY_CURSOR_HOME" get_agent_command cursor-agent:composer-2.5 probe researcher 2>/dev/null || true)
+if [[ "$override_cmd" == *"--mode plan"* ]] && [[ "$seat_cmd" == *"--mode ask --model composer-2.5" ]]; then
+    test_pass
+else
+    test_fail "override='$override_cmd' seat='$seat_cmd'"
+fi
+
+test_case "cursor-agent dispatch runs under env -i with CURSOR_API_KEY and HOME only"
+(
+    export CURSOR_API_KEY=test-key OPENAI_API_KEY=leak OCTOPUS_CURSOR_AGENT_MODE=ask
+    build_provider_env cursor-agent
+    joined=" ${PROVIDER_ENV_ARRAY[*]} "
+    [[ "${PROVIDER_ENV_ARRAY[0]}" == "env" && "${PROVIDER_ENV_ARRAY[1]}" == "-i" ]] &&
+    [[ "$joined" == *" CURSOR_API_KEY=test-key "* ]] &&
+    [[ "$joined" == *" HOME=$HOME "* ]] &&
+    [[ "$joined" == *" OCTOPUS_CURSOR_AGENT_MODE=ask "* ]] &&
+    [[ "$joined" != *"OPENAI_API_KEY"* ]]
+) && test_pass || test_fail "cursor-agent env isolation drifted"
+
+test_case "OCTOPUS_ALLOW_FULL_CURSOR_AGENT_ENV=true inherits the parent environment"
+(
+    export OCTOPUS_ALLOW_FULL_CURSOR_AGENT_ENV=true
+    build_provider_env cursor-agent
+    [[ ${#PROVIDER_ENV_ARRAY[@]} -eq 0 ]]
+) && test_pass || test_fail "full-env opt-out should yield an empty env prefix"
+
+test_case "cursor-agent is a council-capable registry provider with a live default model"
+if octo_provider_has_capability cursor-agent council &&
+   ! octo_provider_limitation_reason cursor-agent council >/dev/null 2>&1 &&
+   [[ "$(HOME="$EMPTY_CURSOR_HOME" resolve_octopus_model cursor-agent cursor-agent "" "")" == "auto" ]] &&
+   [[ "$(get_model_capability composer-2.5 provider)" == "cursor-agent" ]] &&
+   ! is_known_model grok-4-20 2>/dev/null; then
+    test_pass
+else
+    test_fail "registry/catalog wiring for cursor-agent drifted"
+fi
+
+test_case "vendor family separates Cursor seats from the standalone grok CLI"
+if [[ "$(octo_model_family composer-2.5)" == "cursor" ]] &&
+   [[ "$(octo_model_family cursor-grok-4.6-high)" == "xai" ]] &&
+   [[ "$(octo_model_family claude-sonnet-5-thinking-high)" == "anthropic" ]] &&
+   [[ "$(octo_model_family cursor-agent)" == "cursor" ]]; then
+    test_pass
+else
+    test_fail "octo_model_family: composer=$(octo_model_family composer-2.5) grok=$(octo_model_family cursor-grok-4.6-high) cursor-agent=$(octo_model_family cursor-agent)"
+fi
+
+test_case "review and debate cascades seat Cursor when preferred providers are absent"
+if grep -q 'cursor-agent:implementation-logic-reviewer' "$PROJECT_ROOT/scripts/lib/review.sh" &&
+   grep -q 'cursor-agent:implementation-security-reviewer' "$PROJECT_ROOT/scripts/lib/review.sh" &&
+   grep -q 'cursor-agent:implementation-cve-reviewer' "$PROJECT_ROOT/scripts/lib/review.sh" &&
+   grep -q 'cursor_agent_is_available' "$PROJECT_ROOT/scripts/lib/review.sh" &&
+   grep -q 'is_agent_available_v2 cursor-agent' "$PROJECT_ROOT/scripts/lib/debate.sh" &&
+   grep -q '"Cursor Perspective"' "$PROJECT_ROOT/scripts/helpers/build-fleet.sh" &&
+   ! grep -q '"XAI Perspective"' "$PROJECT_ROOT/scripts/helpers/build-fleet.sh"; then
+    test_pass
+else
+    test_fail "fleet cascades do not seat cursor-agent"
+fi
+
+test_case "provider module and public docs describe Cursor CLI, not Grok-via-Cursor"
+if [[ -f "$PROJECT_ROOT/config/providers/cursor-agent/CLAUDE.md" ]] &&
+   grep -q 'OCTOPUS_CURSOR_AGENT_MODE' "$PROJECT_ROOT/config/providers/cursor-agent/CLAUDE.md" &&
+   grep -q 'Cursor CLI' "$PROJECT_ROOT/docs/TROUBLESHOOTING.md" &&
+   ! grep -q 'via cursor-agent' "$PROJECT_ROOT/README.md" &&
+   ! grep -rq 'grok-4-20' "$PROJECT_ROOT/scripts" "$PROJECT_ROOT/config"; then
+    test_pass
+else
+    test_fail "public Cursor documentation drifted"
+fi
+
 test_summary

--- a/tests/unit/test-cursor-agent-provider.sh
+++ b/tests/unit/test-cursor-agent-provider.sh
@@ -400,7 +400,7 @@ if [[ "$(OCTOPUS_CURSOR_AGENT_MODE=agent cursor_agent_resolve_mode researcher 2>
    [[ "$(OCTOPUS_CURSOR_AGENT_MODE=yolo cursor_agent_resolve_mode implementer 2>/dev/null)" == "agent" ]] &&
    [[ "$(OCTOPUS_CURSOR_AGENT_MODE=yolo cursor_agent_resolve_mode researcher 2>/dev/null)" == "ask" ]] &&
    [[ "$(cursor_agent_mode_flag ask)" == "--mode ask" ]] &&
-   [[ -z "$(cursor_agent_mode_flag agent)" ]]; then
+   [[ "$(cursor_agent_mode_flag agent)" == "--force" ]]; then
     test_pass
 else
     test_fail "mode override handling drifted"
@@ -428,9 +428,11 @@ chmod +x "$MOCK_BIN_DIR/timeout" "$MOCK_BIN_DIR/agent"
 if PATH="${MOCK_BIN_DIR}:/usr/bin:/bin" CURSOR_API_KEY=test ARGV_FILE="${ARGV_FILE}" \
     cursor_agent_execute cursor-agent "prompt" "" researcher >/dev/null 2>&1 &&
    grep -q -- '--mode ask' "$ARGV_FILE" &&
+   ! grep -q -- '--force' "$ARGV_FILE" &&
    PATH="${MOCK_BIN_DIR}:/usr/bin:/bin" CURSOR_API_KEY=test ARGV_FILE="${ARGV_FILE}" \
     cursor_agent_execute cursor-agent "prompt" "" implementer >/dev/null 2>&1 &&
-   ! grep -q -- '--mode' "$ARGV_FILE"; then
+   ! grep -q -- '--mode' "$ARGV_FILE" &&
+   grep -q -- '--force' "$ARGV_FILE"; then
     test_pass
 else
     test_fail "cursor_agent_execute did not honour the role mode contract: $(cat "$ARGV_FILE" 2>/dev/null)"
@@ -458,10 +460,10 @@ else
     test_fail "unexpected researcher dispatch: '$cmd'"
 fi
 
-test_case "dispatch omits --mode for implementer roles and uses --mode plan for planners"
+test_case "dispatch force-allows implementers and uses --mode plan for planners"
 impl_cmd=$(HOME="$EMPTY_CURSOR_HOME" get_agent_command cursor-agent tangle implementer 2>/dev/null || true)
 plan_cmd=$(HOME="$EMPTY_CURSOR_HOME" get_agent_command cursor-agent grasp planner 2>/dev/null || true)
-if [[ "$impl_cmd" == "agent --trust --output-format text --model auto" ]] &&
+if [[ "$impl_cmd" == "agent --trust --output-format text --force --model auto" ]] &&
    [[ "$plan_cmd" == "agent --trust --output-format text --mode plan --model auto" ]]; then
     test_pass
 else

--- a/tests/unit/test-cursor-agent-provider.sh
+++ b/tests/unit/test-cursor-agent-provider.sh
@@ -200,7 +200,7 @@ CALLS_FILE="$TEST_TMP_DIR/status-calls-1.txt"; : > "$CALLS_FILE"
 probe_output=$(
     unset CURSOR_API_KEY
     export "HOME=${EMPTY_CURSOR_HOME}" "PATH=${CURSOR_PROBE_PATH}" "CURSOR_STATUS_CALLS=${CALLS_FILE}"
-    export CURSOR_MOCK_STATUS_JSON='{"status":"authenticated","isAuthenticated":true,"userInfo":{"email":"secret@example.test"}}'
+    export 'CURSOR_MOCK_STATUS_JSON={"status":"authenticated","isAuthenticated":true,"userInfo":{"email":"secret@example.test"}}'
     _CURSOR_AGENT_SESSION_AUTH_CACHE=""
     if cursor_agent_is_available; then
         echo "available:$(cursor_agent_auth_method)"
@@ -231,6 +231,7 @@ fi
 
 test_case "session status probe stays bounded by OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT"
 reset_mocks; write_cursor_status_mock
+CALLS_FILE="$TEST_TMP_DIR/status-calls-bounded.txt"; : > "$CALLS_FILE"
 # Force the portable fallback watchdog: PATH holds only the mock dir (no
 # coreutils timeout/gtimeout on any host) plus a grep shim for the verdict parse.
 rm -f "$MOCK_BIN_DIR/timeout"
@@ -238,16 +239,16 @@ printf '#!/bin/bash\nexec /usr/bin/grep "$@"\n' > "$MOCK_BIN_DIR/grep"; chmod +x
 SECONDS=0
 probe_output=$(
     unset CURSOR_API_KEY
-    export "HOME=${EMPTY_CURSOR_HOME}" "PATH=${MOCK_BIN_DIR}"
-    export CURSOR_MOCK_STATUS_SLEEP=5 OCTOPUS_CURSOR_AGENT_PROBE_TIMEOUT=1 OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT=1
-    export CURSOR_MOCK_STATUS_JSON='{"isAuthenticated":true}'
+    export "HOME=${EMPTY_CURSOR_HOME}" "PATH=${MOCK_BIN_DIR}" "CURSOR_STATUS_CALLS=${CALLS_FILE}"
+    export "CURSOR_MOCK_STATUS_SLEEP=5" "OCTOPUS_CURSOR_AGENT_PROBE_TIMEOUT=1" "OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT=1"
+    export 'CURSOR_MOCK_STATUS_JSON={"isAuthenticated":true}'
     _CURSOR_AGENT_SESSION_AUTH_CACHE=""
     cursor_agent_is_available && echo "available" || echo "unavailable"
 )
-if [[ "$probe_output" == "unavailable" && $SECONDS -le 3 ]]; then
+if [[ "$probe_output" == "unavailable" && $SECONDS -le 3 ]] && grep -q "status --format json" "$CALLS_FILE"; then
     test_pass
 else
-    test_fail "status probe was not bounded (result=$probe_output elapsed=${SECONDS}s)"
+    test_fail "status probe was not exercised and bounded (result=$probe_output elapsed=${SECONDS}s calls=$(cat "$CALLS_FILE" 2>/dev/null))"
 fi
 
 test_case "a non-Cursor 'agent' binary short-circuits before the status probe"

--- a/tests/unit/test-model-metadata-parity.sh
+++ b/tests/unit/test-model-metadata-parity.sh
@@ -52,8 +52,8 @@ fi
 test_case "subscription Cursor Grok and metered standalone Grok stay distinct"
 export "WORKSPACE_DIR=${TEST_TMP_DIR}"
 source "$PROJECT_ROOT/scripts/lib/cost.sh"
-cursor_price="$(get_model_pricing grok-4-20 cursor-agent)"
-standalone_price="$(get_model_pricing grok-4-20 grok)"
+cursor_price="$(get_model_pricing cursor-grok-4.6-high cursor-agent)"
+standalone_price="$(get_model_pricing cursor-grok-4.6-high grok)"
 if [[ "$cursor_price" == "0.00:0.00" && "$standalone_price" == "3.00:15.00" ]]; then
     test_pass
 else

--- a/tests/unit/test-provider-allowlist.sh
+++ b/tests/unit/test-provider-allowlist.sh
@@ -140,6 +140,24 @@ if assert_contains "$fleet" "agy|" "legacy gemini token should make AGY eligible
     test_pass
 fi
 
+test_case "build-fleet rejects an available-but-denied candidate set"
+denied_checker="$TEST_TMP_DIR/denied-provider-checker.sh"
+cat > "$denied_checker" <<'SH'
+#!/bin/bash
+printf '%s\n' 'codex:available'
+SH
+chmod +x "$denied_checker"
+set +e
+fleet=$(OCTOPUS_PROVIDER_CHECKER="$denied_checker" OCTO_ALLOWED_PROVIDERS=agy \
+    "$BUILD_FLEET" research quick fixture 2>/dev/null)
+fleet_rc=$?
+set -e
+if [[ "$fleet_rc" -ne 0 && -z "$fleet" ]]; then
+    test_pass
+else
+    test_fail "denied candidates must produce a failed empty fleet: rc=$fleet_rc fleet='$fleet'"
+fi
+
 test_case "quick research never emits a disallowed Claude fallback"
 codex_only_checker="$TEST_TMP_DIR/codex-only-checker.sh"
 cat > "$codex_only_checker" <<'SH'

--- a/tests/unit/test-provider-registry-contracts.sh
+++ b/tests/unit/test-provider-registry-contracts.sh
@@ -13,7 +13,7 @@ actual="$(octo_provider_ids health)"
 if [[ "$actual" == "$expected" ]]; then test_pass; else test_fail "health set drift: $actual"; fi
 
 test_case "Council capability preserves current providers and adds commandcode"
-expected="codex commandcode claude agy opencode openrouter orcarouter openai-compatible openai-tools qwen"
+expected="codex commandcode claude agy opencode openrouter orcarouter openai-compatible openai-tools cursor-agent qwen"
 actual="$(octo_provider_ids council)"
 if [[ "$actual" == "$expected" ]]; then test_pass; else test_fail "Council set drift: $actual"; fi
 

--- a/tests/unit/test-readme-release-sync.sh
+++ b/tests/unit/test-readme-release-sync.sh
@@ -126,7 +126,7 @@ plugin_readme.write_text(plugin_text)
 product = root / "PRODUCT.md"
 product_text = product.read_text()
 product_text = product_text.replace(
-    "up to 10 external AI integrations",
+    "up to 11 external AI integrations",
     "up to 8 AI CLIs",
 )
 # Any historical count line must normalise back to the stable phrase, so an
@@ -294,18 +294,18 @@ if "$SYNC_SCRIPT" --root "$fixture" >/tmp/octo-readme-sync-update.out 2>&1 &&
    "$SYNC_SCRIPT" --root "$fixture" --check >/tmp/octo-readme-sync-recheck.out 2>&1 &&
    grep -q "Version-${CURRENT_VERSION}-blue" "$fixture/README.md" &&
    grep -q "v${CURRENT_VERSION}.*(new)" "$fixture/README.md" &&
-   grep -q 'supports eleven external provider integrations.*Kimi Code' "$fixture/README.md" &&
+   grep -q 'supports twelve external provider integrations.*Cursor CLI.*Kimi Code' "$fixture/README.md" &&
    grep -qF '| **v9** | Up to 10 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, and Grok)' "$fixture/README.md" &&
    grep -q 'OrcaRouter' "$fixture/README.md" &&
    grep -q 'GPT-5.6 Sol' "$fixture/README.md" &&
    grep -q 'Claude Opus 5' "$fixture/README.md" &&
    grep -q 'Claude Sonnet 5' "$fixture/README.md" &&
    grep -qE '[0-9]+ Claude Code capability flags through.*v[0-9]+\.[0-9]+\.[0-9]+' "$fixture/README.md" &&
-   grep -q 'xAI API key (Grok), and Kimi Code CLI' "$fixture/.claude-plugin/README.md" &&
+   grep -q 'OpenCode CLI, Cursor CLI (`agent`), xAI API key (Grok), and Kimi Code CLI' "$fixture/.claude-plugin/README.md" &&
    grep -q 'OrcaRouter' "$fixture/.claude-plugin/README.md" &&
    grep -q "all ${CURRENT_COMMAND_COUNT} commands" "$fixture/.claude-plugin/README.md" &&
    grep -q "${CURRENT_PERSONA_COUNT} specialized agents" "$fixture/.claude-plugin/README.md" &&
-   grep -q 'up to 11 external AI integrations' "$fixture/PRODUCT.md" &&
+   grep -q 'up to 12 external AI integrations' "$fixture/PRODUCT.md" &&
    grep -q "${CURRENT_COMMAND_COUNT} slash commands, ${CURRENT_SKILL_COUNT} skills, and ${CURRENT_PERSONA_COUNT} specialized personas" "$fixture/PRODUCT.md" &&
    grep -q "Complete reference for all ${CURRENT_COMMAND_COUNT} Claude Octopus slash commands" "$fixture/docs/COMMAND-REFERENCE.md" &&
    grep -q "All ${CURRENT_COMMAND_COUNT} slash commands" "$fixture/docs/README.md" &&
@@ -422,16 +422,19 @@ else
     test_fail "model-config command still presents pre-GPT-5.6 defaults"
 fi
 
-test_case "public documentation names all eleven external integrations"
-if grep -q 'eleven external provider integrations' "$PROJECT_ROOT/README.md" &&
+test_case "public documentation names all twelve external integrations"
+if grep -q 'twelve external provider integrations' "$PROJECT_ROOT/README.md" &&
    grep -q '| .*OrcaRouter' "$PROJECT_ROOT/README.md" &&
    grep -q '| .*Kimi Code' "$PROJECT_ROOT/README.md" &&
-   grep -q 'Up to eleven external AI integrations' "$PROJECT_ROOT/.claude-plugin/README.md" &&
+   grep -q '| .*Cursor CLI' "$PROJECT_ROOT/README.md" &&
+   grep -q 'Up to twelve external AI integrations' "$PROJECT_ROOT/.claude-plugin/README.md" &&
    grep -q 'OrcaRouter' "$PROJECT_ROOT/.claude-plugin/README.md" &&
+   grep -q 'Cursor CLI' "$PROJECT_ROOT/.claude-plugin/README.md" &&
    grep -q 'Grok' "$PROJECT_ROOT/.claude-plugin/README.md" &&
    grep -q 'Kimi Code' "$PROJECT_ROOT/.claude-plugin/README.md" &&
-   grep -q 'eleven external AI integrations' "$PROJECT_ROOT/docs/ARCHITECTURE.md" &&
+   grep -q 'twelve external AI integrations' "$PROJECT_ROOT/docs/ARCHITECTURE.md" &&
    grep -q '| .*OrcaRouter' "$PROJECT_ROOT/docs/ARCHITECTURE.md" &&
+   grep -q '| .*Cursor CLI' "$PROJECT_ROOT/docs/ARCHITECTURE.md" &&
    grep -q '| .*Kimi Code' "$PROJECT_ROOT/docs/ARCHITECTURE.md"; then
     test_pass
 else

--- a/tests/unit/test-readme-release-sync.sh
+++ b/tests/unit/test-readme-release-sync.sh
@@ -95,7 +95,7 @@ text = readme.read_text()
 text = re.sub(r"Version-\d+\.\d+\.\d+-blue", "Version-0.0.0-blue", text)
 text = re.sub(r"Version \d+\.\d+\.\d+", "Version 0.0.0", text)
 text = text.replace(
-    "supports eleven external provider integrations",
+    "supports twelve external provider integrations",
     "supports eight external provider integrations",
     1,
 )
@@ -126,7 +126,7 @@ plugin_readme.write_text(plugin_text)
 product = root / "PRODUCT.md"
 product_text = product.read_text()
 product_text = product_text.replace(
-    "up to 11 external AI integrations",
+    "up to 12 external AI integrations",
     "up to 8 AI CLIs",
 )
 # Any historical count line must normalise back to the stable phrase, so an

--- a/tests/unit/test-routing-evals-v10.sh
+++ b/tests/unit/test-routing-evals-v10.sh
@@ -107,6 +107,23 @@ else
     test_fail "unresolved verifier claimed coverage: $retain_decision"
 fi
 
+for route_case in \
+    'composer-2.5|cursor-agent' \
+    'cursor-agent-auto|cursor-agent' \
+    'cursor-grok-4.6-high|cursor-agent' \
+    'grok-4-fast|grok'; do
+    route_model="${route_case%%|*}"
+    expected_provider="${route_case#*|}"
+    test_case "model route: $route_model uses $expected_provider"
+    route_decision="$(bash -c 'source "$1"; octo_route_decision balanced off "$2" "" false "" ""' _ "$PROFILE_LIB" "$route_model")"
+    if jq -e --arg provider "$expected_provider" --arg model "$route_model" \
+        '.provider == $provider and .model == $model' <<< "$route_decision" >/dev/null; then
+        test_pass
+    else
+        test_fail "expected $route_model to use $expected_provider, got $route_decision"
+    fi
+done
+
 test_case "both synchronous and background dispatch pass byte counts to command routing"
 if grep -q 'octo_prompt_byte_length.*enhanced_prompt' "$PROJECT_ROOT/scripts/lib/agent-sync.sh" &&
    grep -q 'octo_prompt_byte_length.*enhanced_prompt' "$PROJECT_ROOT/scripts/lib/spawn.sh"; then

--- a/tests/unit/test-seteleak-kill-wait-751.sh
+++ b/tests/unit/test-seteleak-kill-wait-751.sh
@@ -121,28 +121,23 @@ test_heartbeat_kill_lines_guarded() {
     fi
 }
 
-# cursor-agent.sh:55-56 — _cursor_agent_run_with_timeout()'s fallback path.
-# Unlike the other four sites, `wait "$cmd_pid"` here feeds `exit_code=$?`:
-# a blind `|| true` would silently zero out the real exit code, so the fix
-# uses `exit_code=0; wait ... || exit_code=$?` instead. Assert both halves:
-# no abort under set -e, and the captured code is still correct.
-test_cursor_agent_preserves_exit_code_and_survives_sete() {
-    test_case "cursor-agent.sh: fallback wait preserves the wrapped command's exit code without aborting under set -e"
+# Cursor delegates timeout ownership to heartbeat.sh instead of maintaining a
+# second watchdog. The adapter must preserve the shared helper's arguments and
+# exit status under the repository's set -e execution mode.
+test_cursor_agent_delegates_timeout_and_survives_sete() {
+    test_case "cursor-agent.sh: timeout adapter delegates to the shared portable supervisor"
 
     local out
     out=$(
         bash -c '
             set -eo pipefail
             source "'"$PROJECT_ROOT"'/scripts/lib/cursor-agent.sh"
-            fails_with_7() { return 7; }
-            # Force the in-process fallback (skip gtimeout/timeout) by
-            # emptying PATH so neither resolves; everything the fallback
-            # itself needs is a builtin, a shell function, or an absolute
-            # path (/bin/sleep, /bin/rm), matching the code path the fix targets.
-            # Capture via `|| rc=$?` so this test harness does not itself
-            # trip set -e on the (expected, non-zero) return value.
+            run_with_timeout() {
+                printf "SHARED_ARGS=%s\n" "$*"
+                return 7
+            }
             rc=0
-            PATH="" _cursor_agent_run_with_timeout 0.2 fails_with_7 </dev/null || rc=$?
+            _cursor_agent_run_with_timeout 9 agent --version </dev/null || rc=$?
             echo "RC=$rc"
             echo REACHED-END
         ' 2>&1
@@ -150,8 +145,10 @@ test_cursor_agent_preserves_exit_code_and_survives_sete() {
 
     assert_contains "$out" "REACHED-END" \
         "_cursor_agent_run_with_timeout must not abort under set -e" || return
+    assert_contains "$out" "SHARED_ARGS=--portable-supervisor 9 agent --version" \
+        "_cursor_agent_run_with_timeout must delegate to the shared supervisor" || return
     assert_contains "$out" "RC=7" \
-        "_cursor_agent_run_with_timeout must still return the wrapped command's real exit code (7), not silently become 0 (proves exit_code=0; wait ... || exit_code=\$? preserves the value, unlike a blind || true)" || return
+        "_cursor_agent_run_with_timeout must preserve the shared helper's exit status" || return
     test_pass
 }
 
@@ -160,6 +157,6 @@ test_guarded_kill_wait_survives_sete
 test_workflows_synthesis_monitor_guarded
 test_heartbeat_run_with_timeout_survives_early_exit_race
 test_heartbeat_kill_lines_guarded
-test_cursor_agent_preserves_exit_code_and_survives_sete
+test_cursor_agent_delegates_timeout_and_survives_sete
 
 test_summary

--- a/tests/unit/test-shared-marketplace-sync.sh
+++ b/tests/unit/test-shared-marketplace-sync.sh
@@ -188,7 +188,7 @@ test_release_description_uses_current_summary() {
 test_readme_provider_and_cost_contract() {
     test_case "README defines provider counting and auditable cost assumptions"
 
-    if grep -q 'eleven external provider integrations' "$PROJECT_ROOT/README.md" &&
+    if grep -q 'twelve external provider integrations' "$PROJECT_ROOT/README.md" &&
        ! grep -q 'Up to 9 providers' "$PROJECT_ROOT/README.md" &&
        grep -q 'developers.openai.com/api/docs/models/gpt-5.6-sol' "$PROJECT_ROOT/README.md" &&
        grep -q 'docs.perplexity.ai/docs/getting-started/pricing' "$PROJECT_ROOT/README.md" &&

--- a/tests/unit/test-usage-report.sh
+++ b/tests/unit/test-usage-report.sh
@@ -18,7 +18,7 @@ cat > "$TMP_DIR/usage/subagent-usage.jsonl" <<'EOF'
 {"provider":"codex","model":"gpt-5.6-terra","skill":"flow-develop","est_tokens_in":5000,"est_tokens_out":1000,"quality":70}
 {"provider":"claude","model":"claude-sonnet-5","skill":"flow-discover","mcp_server":"perplexity-mcp","est_tokens_in":20000,"est_tokens_out":4000,"quality":90}
 {"provider":"agy","skill":"flow-discover","est_tokens_in":8000,"est_tokens_out":3000,"quality":60}
-{"provider":"cursor-agent","model":"grok-4-20","skill":"flow-review","est_tokens_in":1000000,"est_tokens_out":0,"quality":75}
+{"provider":"cursor-agent","model":"composer-2.5","skill":"flow-review","est_tokens_in":1000000,"est_tokens_out":0,"quality":75}
 {"provider":"cursor-agent-preview","model":"gpt-5.4","skill":"flow-review","est_tokens_in":1000000,"est_tokens_out":0,"quality":75}
 {"provider":"grok","model":"default","skill":"flow-review","est_tokens_in":1000000,"est_tokens_out":0,"quality":75}
 {"provider":"copilot","model":"gpt-5.4","skill":"flow-review","est_tokens_in":1000000,"est_tokens_out":0,"quality":75}


### PR DESCRIPTION
## Summary

`cursor-agent` (Cursor CLI, binary `agent`) was a stale "Grok 4.20 via Cursor subscription" side seat: its default model no longer exists, session auth was only detected through an `authInfo` block that current CLI builds may not have persisted yet, it was excluded from councils and fleet cascades, ran with full write+shell access, and inherited the whole shell environment. This promotes it to a first-class peer provider for setups whose only external CLIs are Codex and Cursor.

- **Auth**: one bounded `agent status --format json` probe in `scripts/lib/cursor-agent.sh` (`OCTOPUS_CURSOR_AGENT_STATUS_TIMEOUT`, verdict cached per process and on disk) replaces seven duplicated `authInfo` greps across detection, health, preflight, smoke, model resolution, and Embrace. The fallback watchdog no longer holds a caller's command-substitution pipe open.
- **Safety**: `OCTOPUS_CURSOR_AGENT_MODE=ask|plan|agent`; dispatch is read-only (`--mode ask`) by default, `--mode plan` for planner roles, full agent mode only for implementer roles.
- **Isolation**: `env -i` arm in `provider-routing.sh` with `OCTOPUS_ALLOW_FULL_CURSOR_AGENT_ENV` opt-out.
- **Models**: default `auto`; catalog, pricing rows, and fallback candidates use live `agent models` IDs; vendor family maps composer/cursor-agent → `cursor`, cursor-grok → `xai`.
- **Fleet**: registry `council` capability, review-fleet and debate availability cascades, "Cursor Perspective" research seat.
- **Docs**: Cursor CLI becomes the eleventh public provider (`sync-readme.py`), Grok rows now describe the standalone `grok` CLI, new `config/providers/cursor-agent/CLAUDE.md`.

## Verification

- `CI=true GITHUB_ACTIONS=true make ci-changed` failed closed to the full matrix: 16 smoke, 305 unit, 8 integration suites green (5625 cases, 0 failures); `make sync-check`, `git diff --check`, and the executable-mode check pass.
- `tests/unit/test-cursor-agent-provider.sh` grew from 7 to 29 cases (status-probe auth, bounded probe, disk cache, legacy `authInfo`, role modes, dispatch strings, env isolation, registry, vendor family, cascades, docs guards).
- Live: `check-providers.sh` reports `cursor-agent:available` on both the API-key and session-only paths; `build-fleet.sh review` seats Cursor; one real dispatch through the exact command string (`agent --trust --output-format text --mode ask --model auto -p ""`) returned `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Cursor CLI (`agent`) as a supported AI provider.
  - Cursor CLI can participate in council, review, debate, and fleet workflows.
  - Added support for Cursor subscription models, API-key or session authentication, and role-based execution modes.
  - Added isolated environment handling with an opt-out for full environment access.
  - Updated model selection to use Cursor’s service-selected default and current model catalog.
  - Improved provider fallback and availability detection.

- **Documentation**
  - Updated product, provider, architecture, troubleshooting, and README content to reflect twelve integrations and Cursor CLI setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->