### PR TITLE
fix: remove dead get_provider_context_limit shadow in smoke.sh

### DIFF
--- a/scripts/lib/smoke.sh
+++ b/scripts/lib/smoke.sh
@@ -87,51 +87,6 @@ get_provider_capabilities() {
     esac
 }
 
-# Get context limit for provider:tier combination
-get_provider_context_limit() {
-    local provider="$1"
-    local tier="$2"
-
-    case "$provider:$tier" in
-        agy:*)
-            echo "200000"  # Varies by selected Antigravity backend model
-            ;;
-        claude:max-20x|claude:max-5x)
-            echo "200000"
-            ;;
-        claude:*)
-            echo "100000"
-            ;;
-        codex:pro|codex:api-only)
-            echo "128000"
-            ;;
-        codex:*)
-            echo "64000"
-            ;;
-        opencode:*)
-            echo "128000"  # Varies by backend model (generic)
-            ;;
-        openrouter:*)
-            echo "128000"  # Varies by model (generic)
-            ;;
-        orcarouter:*)
-            echo "128000"  # Varies by model (generic)
-            ;;
-        openrouter-glm5:*)
-            echo "203000"  # GLM-5: 203K context
-            ;;
-        openrouter-kimi:*)
-            echo "262000"  # Kimi K2.5: 262K context
-            ;;
-        openrouter-deepseek:*)
-            echo "164000"  # DeepSeek R1: 164K context
-            ;;
-        *)
-            echo "32000"
-            ;;
-    esac
-}
-
 # Load provider configuration from file
 # Performance optimized: Single-pass parsing (saves ~200-500ms vs grep|sed chains)
 load_providers_config() {

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -1385,7 +1385,7 @@ USER_HAS_AGY="false"
 USER_OPUS_BUDGET="balanced"
 KNOWLEDGE_WORK_MODE="false"
 
-# [EXTRACTED to lib/smoke.sh] get_provider_capabilities, get_provider_context_limit
+# [EXTRACTED to lib/smoke.sh] get_provider_capabilities
 
 
 # [EXTRACTED to lib/cost.sh] get_cost_tier_value()

--- a/tests/unit/test-provider-registry.sh
+++ b/tests/unit/test-provider-registry.sh
@@ -67,6 +67,19 @@ else
     test_fail "unexpected context routing: default=$default_context override=$override_context sdk=$sdk_context"
 fi
 
+test_case "smoke source order preserves Claude context override"
+source_order_context=$(env -u OCTOPUS_CONTEXT_BUDGET "OCTOPUS_CLAUDE_CONTEXT_BUDGET=200000" \
+    bash -c '
+        source "$1/scripts/lib/dispatch.sh"
+        source "$1/scripts/lib/smoke.sh"
+        get_provider_context_limit claude-opus
+    ' _ "$PROJECT_ROOT")
+if [[ "$source_order_context" == "200000" ]]; then
+    test_pass
+else
+    test_fail "smoke source order changed Claude context override: $source_order_context"
+fi
+
 test_case "registry cost classes preserve dynamic authentication billing"
 bundled_costs=$(env -u OPENAI_API_KEY -u COMMAND_CODE_API_KEY -u QWEN_API_KEY -u OPENAI_BASE_URL bash -c '
     source "$1/scripts/lib/provider-routing.sh"


### PR DESCRIPTION
## Description

`orchestrate.sh` sources `lib/dispatch.sh` (line 166) and then `lib/smoke.sh` (line 219). Both defined a function named `get_provider_context_limit`, so smoke.sh's definition won for the whole run.

The two were not interchangeable:

- `lib/dispatch.sh:604` takes a single `agent_type` and honors the documented env vars — `OCTOPUS_CONTEXT_BUDGET`, `OCTOPUS_CLAUDE_CONTEXT_BUDGET`, etc.
- `lib/smoke.sh:91` took `(provider, tier)`, read no env var at all, and had no case arm matching an agent type: `claude-opus` fell through to `*) echo "32000"`.

`enforce_context_budget` (`lib/dispatch.sh:723`) calls the function with one argument, so under the real source order it always received smoke.sh's env-blind value — silently ignoring every `OCTOPUS_*_CONTEXT_BUDGET` override and truncating `claude-*` review seats' prompts to a fraction of their actual size on large diffs.

I confirmed `get_provider_context_limit` in `smoke.sh` had zero callers anywhere in the codebase (only its own definition), so it's removed outright rather than renamed — it was pure shadowing dead code. Also fixed the now-stale `# [EXTRACTED to lib/smoke.sh] get_provider_capabilities, get_provider_context_limit` comment in `orchestrate.sh` that referenced it.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code passes `bash -n scripts/orchestrate.sh`
- [x] Shell scripts pass `bash -n` syntax check
- [x] Tests pass: `bash tests/unit/test-openclaw-compat.sh` (33/33)
- [ ] OpenClaw registry in sync — n/a, no adapter/registry surface touched
- [ ] New skills/commands registered — n/a
- [ ] Version bump — deferred to a release commit
- [ ] Documentation updated — n/a, internal implementation detail
- [ ] CHANGELOG.md updated — deferred to the release step

## Testing

Reproduced the issue's own repro with the real source order, before and after the fix:

```
# before (matches the issue report)
$ OCTOPUS_CONTEXT_BUDGET=200000 OCTOPUS_CLAUDE_CONTEXT_BUDGET=200000 bash -c '
    source ./lib/dispatch.sh; source ./lib/smoke.sh
    echo "claude-opus -> $(get_provider_context_limit claude-opus)"'
claude-opus -> 32000

# after this fix
$ OCTOPUS_CONTEXT_BUDGET=200000 OCTOPUS_CLAUDE_CONTEXT_BUDGET=200000 bash -c '
    source ./lib/dispatch.sh; source ./lib/smoke.sh
    echo "claude-opus -> $(get_provider_context_limit claude-opus)"'
claude-opus -> 200000
```

Ran every suite that directly exercises this function or `smoke.sh`:

```
bash tests/unit/test-provider-registry.sh          # 12/12
bash tests/unit/test-provider-registry-parity.sh   # 16/16
bash tests/unit/test-model-aware-seats.sh          # 16/16
bash tests/unit/test-smoke-test-dispatch-exclusion.sh  # 9/9
bash tests/unit/test-openclaw-compat.sh            # 33/33
```

`git diff origin/main...HEAD --summary | grep "mode change"` — empty (no mode changes).

I did not run the full `make test-unit`/`make test-integration` matrix given the change is a two-line net diff (delete a dead, shadowing function definition + fix one stale comment) with direct coverage above; CI will run the full suite on this PR.

## Related Issues
Closes #1003

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHoirC2kTE6fCXkZJ4hX7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHoirC2kTE6fCXkZJ4hX7y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed provider-specific context-window lookup behavior from smoke testing.
  * Updated internal extraction documentation to reflect the revised smoke-test utilities.

* **Tests**
  * Added coverage to verify that Claude context-budget overrides remain available when smoke-test components are loaded in sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->