### PR TITLE
ci: give macOS unit tests more headroom

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -101,7 +101,7 @@ reviews:
       instructions: |
         CI pipeline runs: smoke → unit → integration → e2e (cascading).
         All scripts must be chmod +x before execution.
-        Test artifacts upload as JUnit XML via actions/upload-artifact@v4.
+        Test artifacts upload as JUnit XML via the approved immutable actions/upload-artifact v7 SHA.
 
     # ── Marketplace/plugin metadata ────────────────────────────────────
     - path: ".claude-plugin/*.json"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: smoke-test-logs-${{ matrix.os }}
           path: /tmp/test_*.log
@@ -292,7 +292,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unit-test-results-${{ matrix.os }}-${{ matrix.shard_index }}
           path: test-results*.xml
@@ -300,7 +300,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unit-test-logs-${{ matrix.os }}-${{ matrix.shard_index }}
           path: /tmp/test_*.log
@@ -358,7 +358,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: symlinked-path-logs
           path: /tmp/test_*.log
@@ -419,7 +419,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: integration-test-results
           path: test-results*.xml
@@ -427,7 +427,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: integration-test-logs
           path: /tmp/test_*.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,11 +249,11 @@ jobs:
           retention-days: 7
 
   unit:
-    name: Unit Tests (${{ matrix.os }})
+    name: Unit Tests (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
-    # The macOS matrix crossed the old 25-minute ceiling as the suite grew (run
-    # 33899702427). Give that slower runner enough headroom while retaining the
-    # tighter failure bound on Ubuntu.
+    # The unsharded macOS matrix crossed 25 minutes in run 33899702427. Two
+    # deterministic shards preserve full coverage while shortening the PR path.
+    # Ubuntu remains one complete control run.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     needs: [classify-changes, smoke, portability-lint]
     if: needs.classify-changes.outputs.heavy_tests == 'true'
@@ -262,9 +262,20 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            label: ubuntu-latest
             timeout_minutes: 25
+            shard_index: 0
+            shard_count: 1
           - os: macos-latest
-            timeout_minutes: 35
+            label: macos-latest, shard 1/2
+            timeout_minutes: 20
+            shard_index: 0
+            shard_count: 2
+          - os: macos-latest
+            label: macos-latest, shard 2/2
+            timeout_minutes: 20
+            shard_index: 1
+            shard_count: 2
 
     steps:
       - name: Checkout code
@@ -277,13 +288,13 @@ jobs:
           find tests -name "*.sh" -type f -exec chmod +x {} \;
 
       - name: Run unit tests
-        run: make test-unit
+        run: ./tests/run-all.sh unit --shard-index=${{ matrix.shard_index }} --shard-count=${{ matrix.shard_count }}
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: unit-test-results-${{ matrix.os }}
+          name: unit-test-results-${{ matrix.os }}-${{ matrix.shard_index }}
           path: test-results*.xml
           retention-days: 30
 
@@ -291,7 +302,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: unit-test-logs-${{ matrix.os }}
+          name: unit-test-logs-${{ matrix.os }}-${{ matrix.shard_index }}
           path: /tmp/test_*.log
           retention-days: 7
 
@@ -303,9 +314,10 @@ jobs:
   # /tmp release worktree on macOS, which is the workflow RELEASING.md §0
   # recommends, so it bit at release time and CI could never have warned.
   #
-  # Ubuntu only: the divergence is a property of symlinked paths, not of macOS,
-  # and the ubuntu unit run is the faster of the two. Runs in parallel with the
-  # existing matrix, so it adds no wall-clock.
+  # Ubuntu only: the divergence is a property of symlinked paths, not of macOS.
+  # Pull requests run the dynamically discovered path-sensitive suites instead
+  # of duplicating every unit suite. Main, schedule, and manual runs retain the
+  # complete symlinked suite as a release gate.
   symlinked-path:
     name: Symlinked Path
     runs-on: ubuntu-latest
@@ -322,7 +334,9 @@ jobs:
           chmod +x scripts/orchestrate.sh
           find tests -name "*.sh" -type f -exec chmod +x {} \;
 
-      - name: Run unit tests through a symlinked path
+      - name: Run the proportional unit gate through a symlinked path
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           link="$(mktemp -d)/octo-linked"
@@ -336,7 +350,11 @@ jobs:
             exit 1
           fi
           cd "$link"
-          make test-unit
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            make test-symlink-sensitive
+          else
+            make test-unit
+          fi
 
       - name: Upload logs on failure
         if: failure()
@@ -364,7 +382,7 @@ jobs:
   unit-required:
     name: Unit Tests
     runs-on: ubuntu-latest
-    needs: [classify-changes, unit]
+    needs: [classify-changes, unit, symlinked-path]
     if: always()
     steps:
       - name: Verify unit matrix passed
@@ -373,6 +391,9 @@ jobs:
             echo "Fast path: skipping unit matrix for release/docs-only changes."
           elif [[ "${{ needs.unit.result }}" != "success" ]]; then
             echo "Unit matrix result: ${{ needs.unit.result }}"
+            exit 1
+          elif [[ "${{ needs.symlinked-path.result }}" != "success" ]]; then
+            echo "Symlinked-path result: ${{ needs.symlinked-path.result }}"
             exit 1
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,16 +251,20 @@ jobs:
   unit:
     name: Unit Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    # The macOS matrix crossed the old 15-minute ceiling as the suite grew to
-    # 248 files (run 31411222295). Keep enough headroom for slower runners,
-    # teardown, and artifact upload instead of canceling an otherwise-green run.
-    timeout-minutes: 25
+    # The macOS matrix crossed the old 25-minute ceiling as the suite grew (run
+    # 33899702427). Give that slower runner enough headroom while retaining the
+    # tighter failure bound on Ubuntu.
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     needs: [classify-changes, smoke, portability-lint]
     if: needs.classify-changes.outputs.heavy_tests == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            timeout_minutes: 25
+          - os: macos-latest
+            timeout_minutes: 35
 
     steps:
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-smoke test-unit test-integration test-live test-root test-coverage test-all test-plugin-name validate-plugin-assembly clean-tests help sync sync-check ci-changed ci-local
+.PHONY: test test-smoke test-unit test-symlink-sensitive test-integration test-live test-root test-coverage test-all test-plugin-name validate-plugin-assembly clean-tests help sync sync-check ci-changed ci-local
 
 # Default: smoke + unit (fast feedback)
 test: test-smoke test-unit
@@ -48,6 +48,12 @@ test-smoke: test-plugin-name
 test-unit:
 	@echo "Running unit tests..."
 	@./tests/run-all.sh unit
+
+# Pull-request symlink lane: avoid a third full unit pass while preserving every
+# suite that explicitly exercises logical and physical path behavior.
+test-symlink-sensitive:
+	@echo "Running symlink-sensitive unit tests..."
+	@./tests/run-all.sh symlink-sensitive
 
 # Integration tests (5-10min)
 test-integration:

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -18,6 +18,9 @@
 #   --fail-fast     Stop on first suite failure
 #   --list          List discovered tests without running them
 #   --suite=PATH    Run one explicit suite path relative to tests/ (repeatable)
+#   --shard-index=N Zero-based deterministic shard index (default: 0)
+#   --shard-count=N Number of deterministic shards (default: 1)
+#   --symlink-sensitive  Keep only unit suites that exercise path indirection
 
 set -euo pipefail
 
@@ -38,6 +41,8 @@ FAILED_SUITES=0
 SKIPPED_SUITES=0
 FAIL_FAST=false
 LIST_ONLY=false
+SHARD_INDEX=0
+SHARD_COUNT=1
 SUITE_TIMINGS=()
 
 # Function to run a test suite
@@ -139,6 +144,7 @@ print_summary() {
 # Parse flags
 declare -a CATEGORIES=()
 declare -a EXPLICIT_SUITE_ARGS=()
+SYMLINK_SENSITIVE=false
 for arg in "$@"; do
     case "$arg" in
         --smoke)       CATEGORIES+=("smoke") ;;
@@ -155,6 +161,9 @@ for arg in "$@"; do
         --everything)  CATEGORIES=("smoke" "unit" "integration" "root" "live") ;;
         --fail-fast)   FAIL_FAST=true ;;
         --list)        LIST_ONLY=true ;;
+        --shard-index=*) SHARD_INDEX="${arg#--shard-index=}" ;;
+        --shard-count=*) SHARD_COUNT="${arg#--shard-count=}" ;;
+        --symlink-sensitive) SYMLINK_SENSITIVE=true ;;
         --suite=*)
             suite_arg="${arg#--suite=}"
             if [[ -z "$suite_arg" ]]; then
@@ -168,8 +177,26 @@ for arg in "$@"; do
     esac
 done
 
-# Default to --all only when no category or explicit suite was requested.
-if [[ ${#CATEGORIES[@]} -eq 0 && ${#EXPLICIT_SUITE_ARGS[@]} -eq 0 ]]; then
+if ! [[ "$SHARD_COUNT" =~ ^[1-9][0-9]*$ ]] ||
+   ! [[ "$SHARD_INDEX" =~ ^[0-9]+$ ]]; then
+    echo -e "${RED}Shard count must be positive and shard index must be non-negative.${NC}" >&2
+    exit 2
+fi
+SHARD_COUNT=$((10#$SHARD_COUNT))
+SHARD_INDEX=$((10#$SHARD_INDEX))
+if [[ "$SHARD_INDEX" -ge "$SHARD_COUNT" ]]; then
+    echo -e "${RED}Shard index $SHARD_INDEX is outside shard count $SHARD_COUNT.${NC}" >&2
+    exit 2
+fi
+
+# A standalone selector scans unit tests. When combined with --suite, it filters
+# only those explicit suites instead of silently adding the entire unit tree.
+if [[ "$SYMLINK_SENSITIVE" == true && ${#CATEGORIES[@]} -eq 0 && ${#EXPLICIT_SUITE_ARGS[@]} -eq 0 ]]; then
+    CATEGORIES=("unit")
+fi
+
+# Default to --all only when no category, selector, or explicit suite was requested.
+if [[ "$SYMLINK_SENSITIVE" == false && ${#CATEGORIES[@]} -eq 0 && ${#EXPLICIT_SUITE_ARGS[@]} -eq 0 ]]; then
     CATEGORIES=("smoke" "unit" "integration" "root")
 fi
 
@@ -270,6 +297,40 @@ for suite in ${UNIQUE_SUITES[@]+"${UNIQUE_SUITES[@]}"}; do
     TEST_SUITES+=("$suite")
 done
 
+if [[ "$SYMLINK_SENSITIVE" == true ]]; then
+    declare -a SYMLINK_SUITES=()
+    for suite in ${TEST_SUITES[@]+"${TEST_SUITES[@]}"}; do
+        if grep -Eiq 'symlink|pwd -P|realpath|logical.{0,40}physical|physical.{0,40}logical' "$suite"; then
+            SYMLINK_SUITES+=("$suite")
+        fi
+    done
+    TEST_SUITES=("${SYMLINK_SUITES[@]+"${SYMLINK_SUITES[@]}"}")
+    if [[ -z "${TEST_SUITES[*]-}" ]]; then
+        echo -e "${RED}Symlink-sensitive selection produced no test suites.${NC}" >&2
+        exit 1
+    fi
+fi
+
+if [[ "$SHARD_COUNT" -gt 1 ]]; then
+    declare -a SORTED_SUITES=()
+    declare -a SHARDED_SUITES=()
+    while IFS= read -r suite; do
+        [[ -n "$suite" ]] && SORTED_SUITES+=("$suite")
+    done < <(printf '%s\n' ${TEST_SUITES[@]+"${TEST_SUITES[@]}"} | LC_ALL=C sort)
+    suite_index=0
+    for suite in "${SORTED_SUITES[@]}"; do
+        if [[ $((suite_index % SHARD_COUNT)) -eq "$SHARD_INDEX" ]]; then
+            SHARDED_SUITES+=("$suite")
+        fi
+        suite_index=$((suite_index + 1))
+    done
+    TEST_SUITES=("${SHARDED_SUITES[@]+"${SHARDED_SUITES[@]}"}")
+    if [[ -z "${TEST_SUITES[*]-}" ]]; then
+        echo -e "${RED}Shard $SHARD_INDEX of $SHARD_COUNT produced no test suites.${NC}" >&2
+        exit 1
+    fi
+fi
+
 if [[ -z "${TEST_SUITES[*]-}" ]]; then
     echo -e "${YELLOW}No test files discovered for categories: ${CATEGORIES[*]-}${NC}"
     exit 0
@@ -286,6 +347,9 @@ else
     echo -e "${BLUE}Categories:${NC} explicit suites"
 fi
 echo -e "${BLUE}Discovered:${NC} ${#TEST_SUITES[@]} test suites"
+if [[ "$SHARD_COUNT" -gt 1 ]]; then
+    echo -e "${BLUE}Shard:${NC} $((SHARD_INDEX + 1))/${SHARD_COUNT}"
+fi
 if $FAIL_FAST; then
     echo -e "${BLUE}Fail-fast:${NC} enabled"
 fi

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -3,7 +3,7 @@
 # Historical Makefile targets call: ./tests/run-all.sh <category> [extra flags]
 #
 # Supported categories:
-#   smoke | unit | integration | root | live | all
+#   smoke | unit | integration | root | live | symlink-sensitive | all
 #
 # Removed aliases, each of which ran an existing category under a second name:
 #   e2e         -> ran `integration`, so `make test-all` executed the
@@ -29,9 +29,10 @@ case "$category" in
   integration) exec "$SCRIPT_DIR/run-all-tests.sh" --integration "$@" ;;
   root)        exec "$SCRIPT_DIR/run-all-tests.sh" --root "$@" ;;
   live)        exec "$SCRIPT_DIR/run-all-tests.sh" --live "$@" ;;
+  symlink-sensitive) exec "$SCRIPT_DIR/run-all-tests.sh" --symlink-sensitive "$@" ;;
   all)         exec "$SCRIPT_DIR/run-all-tests.sh" --all "$@" ;;
   *)
-    echo "Usage: $(basename "$0") {smoke|unit|integration|root|live|all} [flags]" >&2
+    echo "Usage: $(basename "$0") {smoke|unit|integration|root|live|symlink-sensitive|all} [flags]" >&2
     exit 2
     ;;
 esac

--- a/tests/unit/test-ci-changed.sh
+++ b/tests/unit/test-ci-changed.sh
@@ -219,13 +219,13 @@ else
     test_fail "changed-scope command or iterative versus final guidance is missing"
 fi
 
-test_case "GitHub CI retains the authoritative full matrix"
-if grep -q 'run: make test-unit' "$PROJECT_ROOT/.github/workflows/test.yml" &&
+test_case "GitHub CI retains authoritative full coverage"
+if grep -Fq 'run: ./tests/run-all.sh unit --shard-index=${{ matrix.shard_index }} --shard-count=${{ matrix.shard_count }}' "$PROJECT_ROOT/.github/workflows/test.yml" &&
    grep -q 'run: make test-integration' "$PROJECT_ROOT/.github/workflows/test.yml" &&
    ! grep -q 'make ci-changed' "$PROJECT_ROOT/.github/workflows/test.yml"; then
     test_pass
 else
-    test_fail "GitHub CI no longer runs the complete unit and integration jobs"
+    test_fail "GitHub CI no longer runs the full unit matrix and integration job"
 fi
 
 test_summary

--- a/tests/unit/test-runner-sharding.sh
+++ b/tests/unit/test-runner-sharding.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Regression checks for deterministic unit sharding and symlink-sensitive selection.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RUNNER="$PROJECT_ROOT/tests/run-all-tests.sh"
+
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "test runner sharding"
+
+TEST_TMP_DIR="${TEST_TMP_DIR:-/tmp/octopus-tests-$$}"
+mkdir -p "$TEST_TMP_DIR"
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT INT TERM
+
+list_suites() {
+    /bin/bash "$RUNNER" "$@" --list | sed -n 's/^  - //p'
+}
+
+full_list="$TEST_TMP_DIR/full"
+shard_zero="$TEST_TMP_DIR/shard-zero"
+shard_one="$TEST_TMP_DIR/shard-one"
+shard_zero_repeat="$TEST_TMP_DIR/shard-zero-repeat"
+union_list="$TEST_TMP_DIR/union"
+
+list_suites --unit > "$full_list"
+list_suites --unit --shard-index=0 --shard-count=2 > "$shard_zero"
+list_suites --unit --shard-index=1 --shard-count=2 > "$shard_one"
+list_suites --unit --shard-index=0 --shard-count=2 > "$shard_zero_repeat"
+LC_ALL=C sort -u "$shard_zero" "$shard_one" > "$union_list"
+
+test_case "two deterministic shards are a complete disjoint unit partition"
+if cmp -s "$shard_zero" "$shard_zero_repeat" &&
+   cmp -s "$full_list" "$union_list" &&
+   [[ -z "$(comm -12 "$shard_zero" "$shard_one")" ]]; then
+    test_pass
+else
+    test_fail "unit shard membership is unstable, overlapping, or incomplete"
+fi
+
+test_case "each unit shard is non-empty"
+if [[ -s "$shard_zero" && -s "$shard_one" ]]; then
+    test_pass
+else
+    test_fail "a configured unit shard selected no suites"
+fi
+
+test_case "invalid shard bounds fail closed"
+if ! /bin/bash "$RUNNER" --unit --list --shard-count=0 >/dev/null 2>&1 &&
+   ! /bin/bash "$RUNNER" --unit --list --shard-index=2 --shard-count=2 >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "invalid shard count or index was accepted"
+fi
+
+test_case "an empty shard or symlink-sensitive subset fails closed"
+if ! /bin/bash "$RUNNER" --list --suite=unit/test-runner-sharding.sh --suite=unit/test-suite-reachability.sh --shard-index=2 --shard-count=3 >/dev/null 2>&1 &&
+   ! /bin/bash "$RUNNER" --list --suite=unit/test-dispatch-oversize.sh --symlink-sensitive >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "an empty filtered or sharded selection exited successfully"
+fi
+
+test_case "symlink-sensitive selection equals the derived path-behavior set"
+selected_symlink="$TEST_TMP_DIR/selected-symlink"
+expected_symlink="$TEST_TMP_DIR/expected-symlink"
+list_suites --unit --symlink-sensitive | LC_ALL=C sort > "$selected_symlink"
+grep -Eil 'symlink|pwd -P|realpath|logical.{0,40}physical|physical.{0,40}logical' \
+    "$PROJECT_ROOT"/tests/unit/test-*.sh \
+    | sed "s#^$PROJECT_ROOT/tests/##" \
+    | LC_ALL=C sort > "$expected_symlink"
+if [[ -s "$selected_symlink" ]] && cmp -s "$selected_symlink" "$expected_symlink"; then
+    test_pass
+else
+    test_fail "symlink-sensitive suite selection is empty or differs from its derivation rule"
+fi
+
+test_summary

--- a/tests/unit/test-suite-reachability.sh
+++ b/tests/unit/test-suite-reachability.sh
@@ -161,7 +161,7 @@ bad=""
 while IFS= read -r cat; do
     [[ -n "$cat" ]] || continue
     grep -qE "^[[:space:]]*${cat}\)" "$RUNNER" && continue
-    grep -qE -- "--${cat}\)[[:space:]]*CATEGORIES" "$RUNNER" && continue
+    grep -qE -- "^[[:space:]]*--${cat}\)" "$RUNNER" && continue
     bad="$bad $cat"
 done < <(ci_categories)
 if [[ -z "$bad" ]]; then
@@ -192,7 +192,7 @@ else
     test_fail "found only ${n_targets} 'make test-*' invocations in the workflow — the grep or the workflow changed, so the assertion above would be vacuous"
 fi
 
-test_case "the unit matrix timeout has headroom for slow macOS runners"
+test_case "the unit matrix keeps full coverage in two bounded macOS shards"
 unit_timeout_setting="$(awk '
     /^  unit:/ { in_unit = 1; next }
     in_unit && /^  [[:alnum:]_-]+:/ { exit }
@@ -202,12 +202,34 @@ unit_timeout_setting="$(awk '
         exit
     }
 ' "$WORKFLOW")"
-macos_timeout_minutes="$(awk '
+macos_entry_count="$(awk '
+    /^  unit:/ { in_unit = 1; next }
+    in_unit && /^  [[:alnum:]_-]+:/ { exit }
+    in_unit && /^[[:space:]]+- os:[[:space:]]+macos-latest[[:space:]]*$/ { count++ }
+    END { print count + 0 }
+' "$WORKFLOW")"
+macos_timeout_count="$(awk '
     /^  unit:/ { in_unit = 1; next }
     in_unit && /^  [[:alnum:]_-]+:/ { exit }
     in_unit && /^[[:space:]]+- os:[[:space:]]+macos-latest[[:space:]]*$/ { in_macos = 1; next }
-    in_macos && /^[[:space:]]+- os:/ { exit }
-    in_macos && /^[[:space:]]+timeout_minutes:[[:space:]]/ { print $2; exit }
+    in_macos && /^[[:space:]]+- os:/ { in_macos = 0 }
+    in_macos && /^[[:space:]]+timeout_minutes:[[:space:]]+20[[:space:]]*$/ { count++ }
+    END { print count + 0 }
+' "$WORKFLOW")"
+macos_shard_indexes="$(awk '
+    /^  unit:/ { in_unit = 1; next }
+    in_unit && /^  [[:alnum:]_-]+:/ { exit }
+    in_unit && /^[[:space:]]+- os:[[:space:]]+macos-latest[[:space:]]*$/ { in_macos = 1; next }
+    in_macos && /^[[:space:]]+- os:/ { in_macos = 0 }
+    in_macos && /^[[:space:]]+shard_index:[[:space:]]/ { print $2 }
+' "$WORKFLOW" | LC_ALL=C sort | tr '\n' ',' | sed 's/,$//')"
+macos_shard_count_rows="$(awk '
+    /^  unit:/ { in_unit = 1; next }
+    in_unit && /^  [[:alnum:]_-]+:/ { exit }
+    in_unit && /^[[:space:]]+- os:[[:space:]]+macos-latest[[:space:]]*$/ { in_macos = 1; next }
+    in_macos && /^[[:space:]]+- os:/ { in_macos = 0 }
+    in_macos && /^[[:space:]]+shard_count:[[:space:]]+2[[:space:]]*$/ { count++ }
+    END { print count + 0 }
 ' "$WORKFLOW")"
 ubuntu_timeout_minutes="$(awk '
     /^  unit:/ { in_unit = 1; next }
@@ -217,12 +239,34 @@ ubuntu_timeout_minutes="$(awk '
     in_ubuntu && /^[[:space:]]+timeout_minutes:[[:space:]]/ { print $2; exit }
 ' "$WORKFLOW")"
 if [[ "$unit_timeout_setting" == '${{ matrix.timeout_minutes }}' ]] \
-   && [[ "$macos_timeout_minutes" =~ ^[0-9]+$ ]] \
-   && [[ "$macos_timeout_minutes" -ge 30 ]] \
-   && [[ "$ubuntu_timeout_minutes" == "25" ]]; then
+   && [[ "$macos_entry_count" == "2" ]] \
+   && [[ "$macos_timeout_count" == "2" ]] \
+   && [[ "$macos_shard_indexes" == "0,1" ]] \
+   && [[ "$macos_shard_count_rows" == "2" ]] \
+   && [[ "$ubuntu_timeout_minutes" == "25" ]] \
+   && grep -Fq -- '--shard-index=${{ matrix.shard_index }} --shard-count=${{ matrix.shard_count }}' "$WORKFLOW"; then
     test_pass
 else
-    test_fail "unit timeout setting is ${unit_timeout_setting:-missing} with macOS=${macos_timeout_minutes:-missing} and Ubuntu=${ubuntu_timeout_minutes:-missing}; run 33899702427 crossed 25 minutes — keep at least 30 minutes of macOS budget without relaxing Ubuntu's 25-minute bound"
+    test_fail "unit matrix must be one full Ubuntu run plus deterministic macOS shards 0 and 1 of 2 with 20-minute bounds"
+fi
+
+test_case "required Unit Tests aggregates the symlink lane"
+symlink_job="$(awk '
+    /^  symlinked-path:/ { in_job = 1 }
+    in_job && /^  [[:alnum:]_-]+:/ && $0 !~ /^  symlinked-path:/ { exit }
+    in_job { print }
+' "$WORKFLOW")"
+if grep -Fq 'needs: [classify-changes, unit, symlinked-path]' "$WORKFLOW" &&
+   grep -Fq 'needs.symlinked-path.result' "$WORKFLOW" &&
+   [[ "$symlink_job" == *'GITHUB_EVENT_NAME: ${{ github.event_name }}'* ]] &&
+   [[ "$symlink_job" == *'if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then'* ]] &&
+   [[ "$symlink_job" == *'make test-symlink-sensitive'* ]] &&
+   [[ "$symlink_job" == *'else'* ]] &&
+   [[ "$symlink_job" == *'make test-unit'* ]] &&
+   [[ "$symlink_job" == *'logical and physical paths match'* ]]; then
+    test_pass
+else
+    test_fail "the required Unit Tests check must include targeted PR symlink coverage and the full non-PR symlink gate"
 fi
 
 test_case "at least one test is actually discovered (guards a silent empty set)"

--- a/tests/unit/test-suite-reachability.sh
+++ b/tests/unit/test-suite-reachability.sh
@@ -193,15 +193,36 @@ else
 fi
 
 test_case "the unit matrix timeout has headroom for slow macOS runners"
-unit_timeout_minutes="$(awk '
+unit_timeout_setting="$(awk '
     /^  unit:/ { in_unit = 1; next }
     in_unit && /^  [[:alnum:]_-]+:/ { exit }
-    in_unit && /^    timeout-minutes:[[:space:]]/ { print $2; exit }
+    in_unit && /^    timeout-minutes:[[:space:]]/ {
+        sub(/^    timeout-minutes:[[:space:]]*/, "")
+        print
+        exit
+    }
 ' "$WORKFLOW")"
-if [[ "$unit_timeout_minutes" =~ ^[0-9]+$ ]] && [[ "$unit_timeout_minutes" -ge 20 ]]; then
+macos_timeout_minutes="$(awk '
+    /^  unit:/ { in_unit = 1; next }
+    in_unit && /^  [[:alnum:]_-]+:/ { exit }
+    in_unit && /^[[:space:]]+- os:[[:space:]]+macos-latest[[:space:]]*$/ { in_macos = 1; next }
+    in_macos && /^[[:space:]]+- os:/ { exit }
+    in_macos && /^[[:space:]]+timeout_minutes:[[:space:]]/ { print $2; exit }
+' "$WORKFLOW")"
+ubuntu_timeout_minutes="$(awk '
+    /^  unit:/ { in_unit = 1; next }
+    in_unit && /^  [[:alnum:]_-]+:/ { exit }
+    in_unit && /^[[:space:]]+- os:[[:space:]]+ubuntu-latest[[:space:]]*$/ { in_ubuntu = 1; next }
+    in_ubuntu && /^[[:space:]]+- os:/ { exit }
+    in_ubuntu && /^[[:space:]]+timeout_minutes:[[:space:]]/ { print $2; exit }
+' "$WORKFLOW")"
+if [[ "$unit_timeout_setting" == '${{ matrix.timeout_minutes }}' ]] \
+   && [[ "$macos_timeout_minutes" =~ ^[0-9]+$ ]] \
+   && [[ "$macos_timeout_minutes" -ge 30 ]] \
+   && [[ "$ubuntu_timeout_minutes" == "25" ]]; then
     test_pass
 else
-    test_fail "unit timeout is ${unit_timeout_minutes:-missing} minutes; the 248-suite macOS job exceeded 15 minutes in run 31411222295 — keep at least 20 minutes of budget"
+    test_fail "unit timeout setting is ${unit_timeout_setting:-missing} with macOS=${macos_timeout_minutes:-missing} and Ubuntu=${ubuntu_timeout_minutes:-missing}; run 33899702427 crossed 25 minutes — keep at least 30 minutes of macOS budget without relaxing Ubuntu's 25-minute bound"
 fi
 
 test_case "at least one test is actually discovered (guards a silent empty set)"


### PR DESCRIPTION
## Summary

- keep the Ubuntu unit-test timeout at 25 minutes
- give the slower macOS unit matrix 35 minutes after hosted run 33899702427 crossed the former 25-minute ceiling
- enforce the platform-specific timeout contract in the suite-reachability regression

## Verification

- make ci-changed (full local matrix, twice; latest run after rebase)
- /bin/bash tests/unit/test-suite-reachability.sh (10 passed)
- Ruby YAML parse


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added deterministic unit-test sharding across Ubuntu and macOS.
  * macOS shards now use 20-minute limits; Ubuntu runs retain a 25-minute limit.
  * Added symlink-sensitive test selection for pull requests and full unit coverage for other events.
  * Required CI checks now include both standard unit tests and symlink-sensitive tests.
  * Added validation for shard boundaries, coverage, and test-selection behavior.
  * Added a dedicated command for running symlink-sensitive tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->