### PR TITLE
fix: record the prompt actually dispatched to each seat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- Record the exact post-persona, post-budget prompt in each seat result, annotate
+  prompt compression with original and final sizes, and attribute oversize
+  events to the stable run, role, phase, and resolved budget. Compression
+  warnings now remain visible without entering captured review JSON. (#1005)
 - Fix `review_extract_output_text` discarding an entire `## Output` section
   when any other level-2 (`##`) header follows it before `## Status:`. Codex Round-1
   seat files routinely contain several intervening headers (e.g.

--- a/scripts/lib/agent-sync.sh
+++ b/scripts/lib/agent-sync.sh
@@ -381,7 +381,7 @@ ${provider_ctx}"
     fi
     local tokens_in
     tokens_in=$(( ${#enhanced_prompt} / 4 ))
-    enhanced_prompt=$(enforce_context_budget "$enhanced_prompt" "$role" "$agent_type")
+    enhanced_prompt=$(enforce_context_budget "$enhanced_prompt" "$role" "$agent_type" "$phase")
     local _budget_rc=$?
     if [[ $_budget_rc -ne 0 ]]; then
         run_contract_transition "$_sync_seat_id" failed \

--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -540,13 +540,52 @@ detect_image_type() {
 # Store failed tasks for retry (global array - bash 3.x compatible)
 FAILED_SUBTASKS=""  # Newline-separated list for compatibility
 
-# Extract a multiline prompt from a tangle result file.
-# Result files write "# Prompt: <first line>" followed by the dispatched prompt body
-# until "# Started:". Preserve that body so retries do not collapse to a useless
-# one-line prompt such as "Original task context:".
+# Print `<format-line>:<prompt-bytes>` for the current length-framed result
+# format. Stop at legacy prompt/output boundaries so legacy prompt content that
+# resembles frame metadata cannot be misclassified.
+tangle_result_prompt_frame() {
+    local result_file="$1"
+    awk '
+        /^# Prompt: / || /^# Started: / || /^## Output[[:space:]]*$/ { exit }
+        /^# Prompt-Format: octopus-length-v1$/ {
+            format_line=NR
+            if ((getline) > 0 && $0 ~ /^# Prompt-Bytes: [0-9]+$/) {
+                print format_line ":" $3
+            } else {
+                print format_line ":INVALID"
+            }
+            exit
+        }
+    ' "$result_file" 2>/dev/null || true
+}
+
+# Extract a multiline prompt from a tangle result file. Current result files
+# length-prefix the prompt so heading-shaped prompt content is unambiguous.
+# Retain the delimiter-based parser for pre-upgrade result files.
 extract_tangle_retry_prompt() {
     local result_file="$1"
-    local prompt result_dir task_id previous_task_id previous_result_file
+    local prompt prompt_frame prompt_line prompt_bytes actual_bytes first_prompt_line
+    local result_dir task_id previous_task_id previous_result_file
+    prompt_frame=$(tangle_result_prompt_frame "$result_file")
+    if [[ -n "$prompt_frame" ]]; then
+        prompt_line="${prompt_frame%%:*}"
+        prompt_bytes="${prompt_frame#*:}"
+        if [[ "$prompt_line" =~ ^[1-9][0-9]*$ && "$prompt_bytes" =~ ^[0-9]+$ ]]; then
+            first_prompt_line=$((prompt_line + 2))
+            # Append a non-newline sentinel inside the substitution so Bash
+            # does not strip legal trailing newline bytes from the frame.
+            prompt=$(tail -n "+${first_prompt_line}" "$result_file" 2>/dev/null \
+                | dd bs=1 count="$prompt_bytes" 2>/dev/null; printf '\034')
+            prompt="${prompt%$'\034'}"
+            actual_bytes=$(LC_ALL=C printf '%s' "$prompt" | wc -c | tr -d '[:space:]')
+            if [[ "$actual_bytes" == "$prompt_bytes" ]]; then
+                printf '%s\n' "$prompt"
+                return 0
+            fi
+        fi
+        return 1
+    fi
+
     prompt=$(awk '
         /^# Prompt: / {
             sub(/^# Prompt: /, "")
@@ -575,6 +614,40 @@ extract_tangle_retry_prompt() {
             extract_tangle_retry_prompt "$previous_result_file"
         fi
     fi
+}
+
+# Extract provider output without mistaking heading-shaped prompt content for
+# result metadata. Length-framed files skip the exact prompt byte count before
+# scanning for the real Started/Output headings; legacy files retain the old
+# delimiter parser.
+tangle_result_output_excerpt() {
+    local result_file="$1"
+    local prompt_frame prompt_line prompt_bytes first_prompt_line
+    prompt_frame=$(tangle_result_prompt_frame "$result_file")
+    if [[ -n "$prompt_frame" ]]; then
+        prompt_line="${prompt_frame%%:*}"
+        prompt_bytes="${prompt_frame#*:}"
+        if ! [[ "$prompt_line" =~ ^[1-9][0-9]*$ && "$prompt_bytes" =~ ^[0-9]+$ ]]; then
+            return 1
+        fi
+        first_prompt_line=$((prompt_line + 2))
+        tail -n "+${first_prompt_line}" "$result_file" 2>/dev/null \
+            | dd bs=1 skip="$prompt_bytes" 2>/dev/null \
+            | awk '
+                /^# Started:/ { after_started=1; next }
+                after_started && /^## Output$/ { in_output=1; next }
+                after_started && /^## Status:/ { in_output=0 }
+                in_output { print }
+            '
+        return ${PIPESTATUS[0]}
+    fi
+
+    awk '
+        /^# Started:/ { after_started=1; next }
+        after_started && /^## Output$/ { in_output=1; next }
+        after_started && /^## Status:/ { in_output=0 }
+        in_output { print }
+    ' "$result_file" 2>/dev/null || true
 }
 tangle_result_header_value() {
     local result_file="$1"
@@ -752,12 +825,7 @@ build_tangle_retry_feedback_prompt() {
     status=$(tangle_result_last_status "$result_file")
     role=$(tangle_result_header_value "$result_file" "# Role: ")
     agent=$(tangle_result_agent "$result_file")
-    output_excerpt=$(awk '
-        /^# Started:/ { after_started=1; next }
-        after_started && /^## Output$/ { in_output=1; next }
-        after_started && /^## Status:/ { in_output=0 }
-        in_output { print }
-    ' "$result_file" 2>/dev/null || true)
+    output_excerpt=$(tangle_result_output_excerpt "$result_file" || true)
     output_excerpt=$(printf '%s\n' "$output_excerpt" | tail -80 || true)
     diagnostics=$(tangle_retry_diagnostics "$result_file")
 

--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -541,7 +541,7 @@ detect_image_type() {
 FAILED_SUBTASKS=""  # Newline-separated list for compatibility
 
 # Extract a multiline prompt from a tangle result file.
-# Result files write "# Prompt: <first line>" followed by the original prompt body
+# Result files write "# Prompt: <first line>" followed by the dispatched prompt body
 # until "# Started:". Preserve that body so retries do not collapse to a useless
 # one-line prompt such as "Original task context:".
 extract_tangle_retry_prompt() {

--- a/scripts/lib/agent-utils.sh
+++ b/scripts/lib/agent-utils.sh
@@ -623,6 +623,7 @@ extract_tangle_retry_prompt() {
 tangle_result_output_excerpt() {
     local result_file="$1"
     local prompt_frame prompt_line prompt_bytes first_prompt_line
+    local -a pipeline_status
     prompt_frame=$(tangle_result_prompt_frame "$result_file")
     if [[ -n "$prompt_frame" ]]; then
         prompt_line="${prompt_frame%%:*}"
@@ -634,12 +635,17 @@ tangle_result_output_excerpt() {
         tail -n "+${first_prompt_line}" "$result_file" 2>/dev/null \
             | dd bs=1 skip="$prompt_bytes" 2>/dev/null \
             | awk '
-                /^# Started:/ { after_started=1; next }
-                after_started && /^## Output$/ { in_output=1; next }
+                /^# Started:/ { saw_started=1; after_started=1; next }
+                after_started && /^## Output$/ { saw_output=1; in_output=1; next }
                 after_started && /^## Status:/ { in_output=0 }
                 in_output { print }
+                END { exit(saw_started && saw_output ? 0 : 1) }
             '
-        return ${PIPESTATUS[0]}
+        pipeline_status=("${PIPESTATUS[@]}")
+        [[ "${pipeline_status[0]}" -eq 0 &&
+           "${pipeline_status[1]}" -eq 0 &&
+           "${pipeline_status[2]}" -eq 0 ]]
+        return
     fi
 
     awk '

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -715,10 +715,41 @@ ${summary_input}"
     return 1
 }
 
+octo_fit_prompt_to_char_budget() {
+    local prompt="$1"
+    local char_budget="$2"
+    local marker="$3"
+    local marker_chars prefix_chars
+
+    [[ "$char_budget" =~ ^[0-9]+$ ]] || return 1
+    if [[ ${#prompt} -le "$char_budget" ]]; then
+        printf '%s\n' "$prompt"
+        return 0
+    fi
+
+    marker_chars=${#marker}
+    if [[ "$marker_chars" -ge "$char_budget" ]]; then
+        printf '%s\n' "${prompt:0:$char_budget}"
+        return 0
+    fi
+    prefix_chars=$((char_budget - marker_chars))
+    printf '%s%s\n' "${prompt:0:$prefix_chars}" "$marker"
+}
+
+octo_context_budget_warning() {
+    local message="$1"
+    if type octo_notice_warn >/dev/null 2>&1; then
+        octo_notice_warn "$message"
+    else
+        log WARN "$message"
+    fi
+}
+
 enforce_context_budget() {
     local prompt="$1"
     local role="${2:-}"
     local agent_type="${3:-}"
+    local phase="${4:-}"
     local budget
     budget=$(get_provider_context_limit "$agent_type")
     [[ "$budget" =~ ^[0-9]+$ ]] || budget="${OCTOPUS_CONTEXT_BUDGET:-12000}"
@@ -741,36 +772,35 @@ enforce_context_budget() {
         case "$strategy" in
             fail)
                 log "ERROR" "Context budget: prompt for $target is ${original_chars} chars; limit is $char_budget chars (~$budget tokens)"
-                type record_oversize_event >/dev/null 2>&1 && record_oversize_event "$target" "$original_chars" "$original_chars" "failed" || true
+                type record_oversize_event >/dev/null 2>&1 && record_oversize_event "$target" "$original_chars" "$original_chars" "failed" "$role" "$phase" "$budget" || true
                 type write_agent_status >/dev/null 2>&1 && write_agent_status "$target" "failed" "$((original_chars / 4))" 0 "Prompt exceeded context budget" 0 "" "$role" || true
                 return 78
                 ;;
             summarize)
-                log "WARN" "Context budget: summarizing prompt for $target from ${original_chars} to <=$char_budget chars (~$budget tokens)"
                 local summarized
                 if summarized=$(summarize_then_dispatch "$prompt" "$role" "$target" "$budget") && [[ -n "$summarized" ]]; then
                     if [[ ${#summarized} -gt $char_budget ]]; then
-                        summarized="${summarized:0:$char_budget}
-
-[... summarized preflight output truncated to fit context budget of ~$budget tokens ...]"
+                        summarized=$(octo_fit_prompt_to_char_budget "$summarized" "$char_budget" $'\n\n[... summarized output truncated to fit context budget (~'"$budget"$' tokens) ...]')
                     fi
-                    type record_oversize_event >/dev/null 2>&1 && record_oversize_event "$target" "$original_chars" "${#summarized}" "summarized" || true
+                    type record_oversize_event >/dev/null 2>&1 && record_oversize_event "$target" "$original_chars" "${#summarized}" "summarized" "$role" "$phase" "$budget" || true
+                    octo_context_budget_warning "Context budget: summarized $target role=${role:-none} phase=${phase:-none} from ${original_chars} to ${#summarized} chars (budget=$budget tokens/$char_budget chars)"
                     printf '%s\n' "$summarized"
                     return 0
                 fi
-                log "WARN" "Context budget: summarizer unavailable; falling back to truncation for $target"
                 log "DEBUG" "Context budget: truncating prompt for $target from ${#prompt} to $char_budget chars (~$budget tokens)"
-                type record_oversize_event >/dev/null 2>&1 && record_oversize_event "$target" "$original_chars" "$char_budget" "truncated" || true
-                echo "${prompt:0:$char_budget}
-
-[... truncated to fit context budget of ~$budget tokens ...]"
+                local truncated
+                truncated=$(octo_fit_prompt_to_char_budget "$prompt" "$char_budget" $'\n\n[... truncated to fit context budget (~'"$budget"$' tokens) ...]')
+                type record_oversize_event >/dev/null 2>&1 && record_oversize_event "$target" "$original_chars" "${#truncated}" "truncated" "$role" "$phase" "$budget" || true
+                octo_context_budget_warning "Context budget: summarizer unavailable; truncated $target role=${role:-none} phase=${phase:-none} from ${original_chars} to ${#truncated} chars (budget=$budget tokens/$char_budget chars)"
+                printf '%s\n' "$truncated"
                 ;;
             truncate|*)
                 log "DEBUG" "Context budget: truncating prompt for $target from ${#prompt} to $char_budget chars (~$budget tokens)"
-                type record_oversize_event >/dev/null 2>&1 && record_oversize_event "$target" "$original_chars" "$char_budget" "truncated" || true
-                echo "${prompt:0:$char_budget}
-
-[... truncated to fit context budget of ~$budget tokens ...]"
+                local truncated
+                truncated=$(octo_fit_prompt_to_char_budget "$prompt" "$char_budget" $'\n\n[... truncated to fit context budget (~'"$budget"$' tokens) ...]')
+                type record_oversize_event >/dev/null 2>&1 && record_oversize_event "$target" "$original_chars" "${#truncated}" "truncated" "$role" "$phase" "$budget" || true
+                octo_context_budget_warning "Context budget: truncated $target role=${role:-none} phase=${phase:-none} from ${original_chars} to ${#truncated} chars (budget=$budget tokens/$char_budget chars)"
+                printf '%s\n' "$truncated"
                 ;;
         esac
     else

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -642,7 +642,7 @@ octo_normalize_context_budget() {
     done
     if [[ "$value" == "0" ]] ||
        [[ "${#value}" -gt "${#max_budget}" ]] ||
-       { [[ "${#value}" -eq "${#max_budget}" ]] && [[ "$value" > "$max_budget" ]]; }; then
+       { [[ "${#value}" -eq "${#max_budget}" ]] && [[ "$value" -gt "$max_budget" ]]; }; then
         log ERROR "Invalid $label '$1': expected 1..$max_budget"
         return 2
     fi

--- a/scripts/lib/dispatch.sh
+++ b/scripts/lib/dispatch.sh
@@ -626,11 +626,36 @@ get_provider_context_limit() {
     fi
 }
 
+# Normalize before Bash arithmetic. The maximum keeps a later four-character
+# token estimate inside a signed 32-bit shell integer on every supported host.
+octo_normalize_context_budget() {
+    local value="${1:-}" label="${2:-context budget}"
+    local max_budget=536870911
+    local LC_ALL=C
+
+    if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+        log ERROR "Invalid $label '$value': expected a positive decimal integer"
+        return 2
+    fi
+    while [[ "${#value}" -gt 1 && "${value:0:1}" == "0" ]]; do
+        value="${value:1}"
+    done
+    if [[ "$value" == "0" ]] ||
+       [[ "${#value}" -gt "${#max_budget}" ]] ||
+       { [[ "${#value}" -eq "${#max_budget}" ]] && [[ "$value" > "$max_budget" ]]; }; then
+        log ERROR "Invalid $label '$1': expected 1..$max_budget"
+        return 2
+    fi
+
+    printf '%s\n' "$value"
+}
+
 summarize_then_dispatch() {
     local prompt="$1"
     local role="${2:-}"
     local target_agent="${3:-unknown}"
     local budget="${4:-12000}"
+    budget=$(octo_normalize_context_budget "$budget" "summarizer context budget") || return 2
     local char_budget=$((budget * 4))
 
     # Keep the summarizer request itself bounded; preserve both task framing and
@@ -752,13 +777,19 @@ enforce_context_budget() {
     local phase="${4:-}"
     local budget
     budget=$(get_provider_context_limit "$agent_type")
-    [[ "$budget" =~ ^[0-9]+$ ]] || budget="${OCTOPUS_CONTEXT_BUDGET:-12000}"
+    budget=$(octo_normalize_context_budget "$budget" "provider context budget") || return 2
 
     # v9.3.0: Scale budget by role proportion
     if [[ -n "$role" ]]; then
-        local proportion
+        local proportion budget_whole budget_remainder
         proportion=$(get_role_budget_proportion "$role")
-        budget=$((budget * proportion / 100))
+        budget_whole=$((budget / 100))
+        budget_remainder=$((budget % 100))
+        budget=$((budget_whole * proportion + budget_remainder * proportion / 100))
+        if [[ "$budget" -lt 1 ]]; then
+            log ERROR "Invalid effective context budget for role '$role': value rounds to zero"
+            return 2
+        fi
     fi
 
     # Rough token estimate: ~4 chars per token

--- a/scripts/lib/error-tracking.sh
+++ b/scripts/lib/error-tracking.sh
@@ -182,53 +182,11 @@ octo_current_run_id() {
     printf '%s\n' "${OCTOPUS_RUN_ID:-${OCTOPUS_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-${CLAUDE_CODE_SESSION:-$OCTO_ERROR_TRACKING_FALLBACK_ID}}}}}"
 }
 
-# Warnings emitted below command substitutions would otherwise disappear into
-# PID handoff files or become part of captured provider JSON. Capture owners
-# allocate a private file, pass it through OCTOPUS_NOTICE_FILE, then replay it
-# once on their own stderr after the substitution boundary.
-octo_notice_channel_create() {
-    local root="${WORKSPACE_DIR:-${TMPDIR:-/tmp}}" notice_file=""
-    if mkdir -p "$root" 2>/dev/null; then
-        notice_file="$(mktemp "${root%/}/octo-notice.XXXXXX" 2>/dev/null || true)"
-    fi
-    if [[ -z "$notice_file" && "$root" != "${TMPDIR:-/tmp}" ]]; then
-        root="${TMPDIR:-/tmp}"
-        mkdir -p "$root" 2>/dev/null || return 1
-        notice_file="$(mktemp "${root%/}/octo-notice.XXXXXX" 2>/dev/null || true)"
-    fi
-    [[ -n "$notice_file" ]] || return 1
-    chmod 600 "$notice_file" 2>/dev/null || {
-        rm -f "$notice_file" 2>/dev/null || true
-        return 1
-    }
-    printf '%s\n' "$notice_file"
-}
-
-octo_notice_channel_is_valid() {
-    local notice_file="${1:-}" mode=""
-    [[ -n "$notice_file" && -f "$notice_file" && ! -L "$notice_file" ]] || return 1
-    mode=$(stat -f '%Lp' "$notice_file" 2>/dev/null || stat -c '%a' "$notice_file" 2>/dev/null || true)
-    [[ "$mode" == 600 ]]
-}
-
+# Capture owners keep provider stdout and stderr separate. Budget warnings can
+# therefore use the ordinary diagnostic stream without a pathname-based side
+# channel or an inherited bypass descriptor.
 octo_notice_warn() {
-    local message="$*" notice_file="${OCTOPUS_NOTICE_FILE:-}"
-    if octo_notice_channel_is_valid "$notice_file"; then
-        printf '%s\n' "$message" >> "$notice_file"
-    elif [[ "${OCTOPUS_NOTICE_FD:-}" == "8" ]] && { : >&8; } 2>/dev/null; then
-        log WARN "$message" 2>&8
-    else
-        log WARN "$message"
-    fi
-}
-
-octo_notice_channel_replay() {
-    local notice_file="${1:-}" message
-    octo_notice_channel_is_valid "$notice_file" || return 0
-    while IFS= read -r message || [[ -n "$message" ]]; do
-        [[ -n "$message" ]] && log WARN "$message"
-    done < "$notice_file"
-    rm -f "$notice_file" 2>/dev/null || true
+    log WARN "$*"
 }
 
 octo_run_dir() {
@@ -254,7 +212,7 @@ octo_json_quote() {
             $'\t') output="${output}\\t" ;;
             *)
                 printf -v code '%d' "'$char" 2>/dev/null || return 1
-                if [[ "$code" -lt 32 ]]; then
+                if [[ "$code" -ge 0 && "$code" -lt 32 ]]; then
                     printf -v encoded '\\u%04x' "$code"
                     output="${output}${encoded}"
                 else

--- a/scripts/lib/error-tracking.sh
+++ b/scripts/lib/error-tracking.sh
@@ -168,9 +168,65 @@ ERREOF
 # Resolve the current run id for multi-provider diagnostics. Prefer the explicit
 # run id when a workflow sets one, then host/session ids, then a stable fallback.
 octo_current_run_id() {
-    local fallback
-    fallback="run-$(date -u +%Y%m%dT%H%M%SZ)-$$"
-    printf '%s\n' "${OCTOPUS_RUN_ID:-${OCTOPUS_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-${CLAUDE_CODE_SESSION:-$fallback}}}}}"
+    if type octo_run_contract_id >/dev/null 2>&1; then
+        octo_run_contract_id
+        return
+    fi
+
+    # Standalone compatibility for unusually narrow source harnesses. Keep the
+    # fallback stable for the shell lifetime instead of minting a new run on
+    # every record.
+    if [[ -z "${OCTO_ERROR_TRACKING_FALLBACK_ID:-}" ]]; then
+        OCTO_ERROR_TRACKING_FALLBACK_ID="run-$(date -u +%Y%m%dT%H%M%SZ)-$$-${RANDOM:-0}"
+    fi
+    printf '%s\n' "${OCTOPUS_RUN_ID:-${OCTOPUS_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-${CLAUDE_CODE_SESSION:-$OCTO_ERROR_TRACKING_FALLBACK_ID}}}}}"
+}
+
+# Warnings emitted below command substitutions would otherwise disappear into
+# PID handoff files or become part of captured provider JSON. Capture owners
+# allocate a private file, pass it through OCTOPUS_NOTICE_FILE, then replay it
+# once on their own stderr after the substitution boundary.
+octo_notice_channel_create() {
+    local root="${WORKSPACE_DIR:-${TMPDIR:-/tmp}}" notice_file=""
+    if mkdir -p "$root" 2>/dev/null; then
+        notice_file="$(mktemp "${root%/}/octo-notice.XXXXXX" 2>/dev/null || true)"
+    fi
+    if [[ -z "$notice_file" && "$root" != "${TMPDIR:-/tmp}" ]]; then
+        root="${TMPDIR:-/tmp}"
+        mkdir -p "$root" 2>/dev/null || return 1
+        notice_file="$(mktemp "${root%/}/octo-notice.XXXXXX" 2>/dev/null || true)"
+    fi
+    [[ -n "$notice_file" ]] || return 1
+    chmod 600 "$notice_file" 2>/dev/null || {
+        rm -f "$notice_file" 2>/dev/null || true
+        return 1
+    }
+    printf '%s\n' "$notice_file"
+}
+
+octo_notice_channel_is_valid() {
+    local notice_file="${1:-}" mode=""
+    [[ -n "$notice_file" && -f "$notice_file" && ! -L "$notice_file" ]] || return 1
+    mode=$(stat -f '%Lp' "$notice_file" 2>/dev/null || stat -c '%a' "$notice_file" 2>/dev/null || true)
+    [[ "$mode" == 600 ]]
+}
+
+octo_notice_warn() {
+    local message="$*" notice_file="${OCTOPUS_NOTICE_FILE:-}"
+    if octo_notice_channel_is_valid "$notice_file"; then
+        printf '%s\n' "$message" >> "$notice_file"
+    else
+        log WARN "$message"
+    fi
+}
+
+octo_notice_channel_replay() {
+    local notice_file="${1:-}" message
+    octo_notice_channel_is_valid "$notice_file" || return 0
+    while IFS= read -r message || [[ -n "$message" ]]; do
+        [[ -n "$message" ]] && log WARN "$message"
+    done < "$notice_file"
+    rm -f "$notice_file" 2>/dev/null || true
 }
 
 octo_run_dir() {
@@ -372,23 +428,31 @@ record_oversize_event() {
     local original_chars="$2"
     local final_chars="$3"
     local outcome="$4"
+    local role="${5:-}"
+    local phase="${6:-}"
+    local budget="${7:-0}"
 
-    local dir
+    local dir run_id
+    run_id=$(octo_current_run_id)
     dir=$(octo_run_dir)
     mkdir -p "$dir"
 
     if command -v jq >/dev/null 2>&1; then
         jq -nc \
             --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg run_id "$run_id" \
             --arg agent "$agent" \
+            --arg role "$role" \
+            --arg phase "$phase" \
             --arg outcome "$outcome" \
+            --argjson budget "${budget:-0}" \
             --argjson original_chars "${original_chars:-0}" \
             --argjson final_chars "${final_chars:-0}" \
-            '{ts:$ts,agent:$agent,original_chars:$original_chars,final_chars:$final_chars,outcome:$outcome}' \
+            '{ts:$ts,run_id:$run_id,agent:$agent,role:$role,phase:$phase,budget:$budget,original_chars:$original_chars,final_chars:$final_chars,outcome:$outcome}' \
             >> "$dir/oversize.jsonl" 2>/dev/null || true
     else
-        printf '{"ts":"%s","agent":"%s","original_chars":%d,"final_chars":%d,"outcome":"%s"}\n' \
-            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$agent" "$original_chars" "$final_chars" "$outcome" \
+        printf '{"ts":"%s","run_id":"%s","agent":"%s","role":"%s","phase":"%s","budget":%d,"original_chars":%d,"final_chars":%d,"outcome":"%s"}\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$run_id" "$agent" "$role" "$phase" "$budget" "$original_chars" "$final_chars" "$outcome" \
             >> "$dir/oversize.jsonl"
     fi
 }

--- a/scripts/lib/error-tracking.sh
+++ b/scripts/lib/error-tracking.sh
@@ -12,6 +12,12 @@ if ! type _octo_run_output_usable_file >/dev/null 2>&1; then
     [[ -f "$_octo_run_contract_lib" ]] && source "$_octo_run_contract_lib"
 fi
 
+# Initialize this in the sourcing shell so command substitutions inherit one
+# stable fallback instead of creating a different run id in each subshell.
+if [[ -z "${OCTO_ERROR_TRACKING_FALLBACK_ID:-}" ]]; then
+    OCTO_ERROR_TRACKING_FALLBACK_ID="run-$(date -u +%Y%m%dT%H%M%SZ)-$$-${RANDOM:-0}"
+fi
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # UX ENHANCEMENTS: Feature 1 - Enhanced Spinner Verbs (v7.16.0)
 # Dynamic task progress updates with context-aware verbs
@@ -173,12 +179,7 @@ octo_current_run_id() {
         return
     fi
 
-    # Standalone compatibility for unusually narrow source harnesses. Keep the
-    # fallback stable for the shell lifetime instead of minting a new run on
-    # every record.
-    if [[ -z "${OCTO_ERROR_TRACKING_FALLBACK_ID:-}" ]]; then
-        OCTO_ERROR_TRACKING_FALLBACK_ID="run-$(date -u +%Y%m%dT%H%M%SZ)-$$-${RANDOM:-0}"
-    fi
+    # Standalone compatibility for unusually narrow source harnesses.
     printf '%s\n' "${OCTOPUS_RUN_ID:-${OCTOPUS_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-${CLAUDE_CODE_SESSION:-$OCTO_ERROR_TRACKING_FALLBACK_ID}}}}}"
 }
 

--- a/scripts/lib/error-tracking.sh
+++ b/scripts/lib/error-tracking.sh
@@ -215,6 +215,8 @@ octo_notice_warn() {
     local message="$*" notice_file="${OCTOPUS_NOTICE_FILE:-}"
     if octo_notice_channel_is_valid "$notice_file"; then
         printf '%s\n' "$message" >> "$notice_file"
+    elif [[ "${OCTOPUS_NOTICE_FD:-}" == "8" ]] && { : >&8; } 2>/dev/null; then
+        log WARN "$message" 2>&8
     else
         log WARN "$message"
     fi
@@ -233,6 +235,45 @@ octo_run_dir() {
     local run_id
     run_id=$(octo_current_run_id)
     printf '%s\n' "${WORKSPACE_DIR:-${HOME}/.claude-octopus}/runs/${run_id}"
+}
+
+octo_json_quote() {
+    local value="${1-}" char encoded="" output="" code
+    local LC_ALL=C
+
+    while [[ -n "$value" ]]; do
+        char="${value:0:1}"
+        value="${value:1}"
+        case "$char" in
+            '"') output="${output}\\\"" ;;
+            \\) output="${output}\\\\" ;;
+            $'\b') output="${output}\\b" ;;
+            $'\f') output="${output}\\f" ;;
+            $'\n') output="${output}\\n" ;;
+            $'\r') output="${output}\\r" ;;
+            $'\t') output="${output}\\t" ;;
+            *)
+                printf -v code '%d' "'$char" 2>/dev/null || return 1
+                if [[ "$code" -lt 32 ]]; then
+                    printf -v encoded '\\u%04x' "$code"
+                    output="${output}${encoded}"
+                else
+                    output="${output}${char}"
+                fi
+                ;;
+        esac
+    done
+
+    printf '"%s"' "$output"
+}
+
+octo_json_normalize_uint() {
+    local value="${1:-}"
+    [[ "$value" =~ ^[0-9]+$ ]] || return 1
+    while [[ "${#value}" -gt 1 && "${value:0:1}" == "0" ]]; do
+        value="${value:1}"
+    done
+    printf '%s\n' "$value"
 }
 
 octo_estimate_tokens_for_file() {
@@ -432,10 +473,14 @@ record_oversize_event() {
     local phase="${6:-}"
     local budget="${7:-0}"
 
-    local dir run_id
+    local dir run_id budget_json original_chars_json final_chars_json
     run_id=$(octo_current_run_id)
     dir=$(octo_run_dir)
     mkdir -p "$dir"
+
+    budget_json=$(octo_json_normalize_uint "$budget") || return 2
+    original_chars_json=$(octo_json_normalize_uint "$original_chars") || return 2
+    final_chars_json=$(octo_json_normalize_uint "$final_chars") || return 2
 
     if command -v jq >/dev/null 2>&1; then
         jq -nc \
@@ -445,14 +490,22 @@ record_oversize_event() {
             --arg role "$role" \
             --arg phase "$phase" \
             --arg outcome "$outcome" \
-            --argjson budget "${budget:-0}" \
-            --argjson original_chars "${original_chars:-0}" \
-            --argjson final_chars "${final_chars:-0}" \
+            --argjson budget "$budget_json" \
+            --argjson original_chars "$original_chars_json" \
+            --argjson final_chars "$final_chars_json" \
             '{ts:$ts,run_id:$run_id,agent:$agent,role:$role,phase:$phase,budget:$budget,original_chars:$original_chars,final_chars:$final_chars,outcome:$outcome}' \
             >> "$dir/oversize.jsonl" 2>/dev/null || true
     else
-        printf '{"ts":"%s","run_id":"%s","agent":"%s","role":"%s","phase":"%s","budget":%d,"original_chars":%d,"final_chars":%d,"outcome":"%s"}\n' \
-            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$run_id" "$agent" "$role" "$phase" "$budget" "$original_chars" "$final_chars" "$outcome" \
+        local ts_json run_id_json agent_json role_json phase_json outcome_json
+        ts_json=$(octo_json_quote "$(date -u +%Y-%m-%dT%H:%M:%SZ)") || return 2
+        run_id_json=$(octo_json_quote "$run_id") || return 2
+        agent_json=$(octo_json_quote "$agent") || return 2
+        role_json=$(octo_json_quote "$role") || return 2
+        phase_json=$(octo_json_quote "$phase") || return 2
+        outcome_json=$(octo_json_quote "$outcome") || return 2
+        printf '{"ts":%s,"run_id":%s,"agent":%s,"role":%s,"phase":%s,"budget":%s,"original_chars":%s,"final_chars":%s,"outcome":%s}\n' \
+            "$ts_json" "$run_id_json" "$agent_json" "$role_json" "$phase_json" \
+            "$budget_json" "$original_chars_json" "$final_chars_json" "$outcome_json" \
             >> "$dir/oversize.jsonl"
     fi
 }

--- a/scripts/lib/result-file.sh
+++ b/scripts/lib/result-file.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Shared result-file framing helpers.
+
+# Length-prefix the exact dispatched prompt so prompt content can contain any
+# Markdown heading, including the legacy `# Started:` delimiter.
+write_agent_result_prompt() {
+    local result_file="$1"
+    local prompt="$2"
+    local prompt_bytes
+    prompt_bytes=$(LC_ALL=C printf '%s' "$prompt" | wc -c | tr -d '[:space:]') || return 1
+    [[ "$prompt_bytes" =~ ^[0-9]+$ ]] || return 1
+    printf '# Prompt-Format: octopus-length-v1\n' >> "$result_file" || return 1
+    printf '# Prompt-Bytes: %s\n' "$prompt_bytes" >> "$result_file" || return 1
+    printf '%s\n' "$prompt" >> "$result_file"
+}

--- a/scripts/lib/result-file.sh
+++ b/scripts/lib/result-file.sh
@@ -7,7 +7,8 @@ write_agent_result_prompt() {
     local result_file="$1"
     local prompt="$2"
     local prompt_bytes
-    prompt_bytes=$(LC_ALL=C printf '%s' "$prompt" | wc -c | tr -d '[:space:]') || return 1
+    local LC_ALL=C
+    prompt_bytes=${#prompt}
     [[ "$prompt_bytes" =~ ^[0-9]+$ ]] || return 1
     printf '# Prompt-Format: octopus-length-v1\n' >> "$result_file" || return 1
     printf '# Prompt-Bytes: %s\n' "$prompt_bytes" >> "$result_file" || return 1

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -666,7 +666,9 @@ review_run_agent_sync_progress() {
 
     (
         OCTOPUS_NOTICE_FILE="$notice_file" \
-            run_agent_sync "$agent_type" "$prompt" 0 "$role" "$phase" > "$out_file" 2>&1
+            OCTOPUS_NOTICE_FD=8 \
+            run_agent_sync "$agent_type" "$prompt" 0 "$role" "$phase" \
+            8>&2 > "$out_file" 2>&1
         echo "$?" > "$rc_file"
     ) &
     pid=$!

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -639,7 +639,6 @@ review_run_agent_sync_progress() {
     local role="$3"
     local phase="$4"
     local label="${5:-sync}"
-    local notice_file="${OCTOPUS_NOTICE_FILE:-}" owns_notice_file=false
     local results_dir="${RESULTS_DIR:-${HOME}/.claude-octopus/results}"
     local stall_window="${OCTOPUS_REVIEW_STALL_WINDOW:-1800}"
     local poll_secs="${OCTOPUS_REVIEW_POLL_SECS:-30}"
@@ -650,26 +649,25 @@ review_run_agent_sync_progress() {
     [[ "$poll_secs" -lt 1 ]] && poll_secs=1
     mkdir -p "$results_dir" 2>/dev/null || true
 
-    local start_epoch out_file rc_file pid rc last_progress last_fp current_fp now
+    local start_epoch out_file err_file rc_file pid rc last_progress last_fp current_fp now
     start_epoch=$(date +%s)
     out_file="${results_dir}/.tmp-review-sync-${label}-$$-${RANDOM}.out"
+    err_file="${out_file}.err"
     rc_file="${out_file}.rc"
-    : > "$out_file"
+    if ! (umask 077; : > "$out_file" && : > "$err_file"); then
+        rm -f "$out_file" "$err_file" "$rc_file" 2>/dev/null || true
+        return 1
+    fi
     rm -f "$rc_file" 2>/dev/null || true
 
-    if type octo_notice_channel_is_valid >/dev/null 2>&1 &&
-       ! octo_notice_channel_is_valid "$notice_file" &&
-       type octo_notice_channel_create >/dev/null 2>&1; then
-        notice_file="$(octo_notice_channel_create 2>/dev/null || true)"
-        [[ -n "$notice_file" ]] && owns_notice_file=true
-    fi
-
     (
-        OCTOPUS_NOTICE_FILE="$notice_file" \
-            OCTOPUS_NOTICE_FD=8 \
-            run_agent_sync "$agent_type" "$prompt" 0 "$role" "$phase" \
-            8>&2 > "$out_file" 2>&1
-        echo "$?" > "$rc_file"
+        umask 077
+        set +e
+        run_agent_sync "$agent_type" "$prompt" 0 "$role" "$phase" \
+            8>&- > "$out_file" 2> "$err_file"
+        rc=$?
+        echo "$rc" > "$rc_file"
+        exit "$rc"
     ) &
     pid=$!
     last_progress=$(date +%s)
@@ -695,11 +693,9 @@ review_run_agent_sync_progress() {
     wait "$pid" 2>/dev/null || true
     rc=1
     [[ -f "$rc_file" ]] && rc=$(cat "$rc_file" 2>/dev/null || echo 1)
-    if [[ "$owns_notice_file" == true ]]; then
-        octo_notice_channel_replay "$notice_file"
-    fi
+    cat "$err_file" >&2 2>/dev/null || true
     cat "$out_file" 2>/dev/null || true
-    rm -f "$out_file" "$rc_file" 2>/dev/null || true
+    rm -f "$out_file" "$err_file" "$rc_file" 2>/dev/null || true
     return "$rc"
 }
 

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -639,6 +639,7 @@ review_run_agent_sync_progress() {
     local role="$3"
     local phase="$4"
     local label="${5:-sync}"
+    local notice_file="${OCTOPUS_NOTICE_FILE:-}" owns_notice_file=false
     local results_dir="${RESULTS_DIR:-${HOME}/.claude-octopus/results}"
     local stall_window="${OCTOPUS_REVIEW_STALL_WINDOW:-1800}"
     local poll_secs="${OCTOPUS_REVIEW_POLL_SECS:-30}"
@@ -656,8 +657,16 @@ review_run_agent_sync_progress() {
     : > "$out_file"
     rm -f "$rc_file" 2>/dev/null || true
 
+    if type octo_notice_channel_is_valid >/dev/null 2>&1 &&
+       ! octo_notice_channel_is_valid "$notice_file" &&
+       type octo_notice_channel_create >/dev/null 2>&1; then
+        notice_file="$(octo_notice_channel_create 2>/dev/null || true)"
+        [[ -n "$notice_file" ]] && owns_notice_file=true
+    fi
+
     (
-        run_agent_sync "$agent_type" "$prompt" 0 "$role" "$phase" > "$out_file" 2>&1
+        OCTOPUS_NOTICE_FILE="$notice_file" \
+            run_agent_sync "$agent_type" "$prompt" 0 "$role" "$phase" > "$out_file" 2>&1
         echo "$?" > "$rc_file"
     ) &
     pid=$!
@@ -684,6 +693,9 @@ review_run_agent_sync_progress() {
     wait "$pid" 2>/dev/null || true
     rc=1
     [[ -f "$rc_file" ]] && rc=$(cat "$rc_file" 2>/dev/null || echo 1)
+    if [[ "$owns_notice_file" == true ]]; then
+        octo_notice_channel_replay "$notice_file"
+    fi
     cat "$out_file" 2>/dev/null || true
     rm -f "$out_file" "$rc_file" 2>/dev/null || true
     return "$rc"

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -1538,7 +1538,9 @@ spawn_agent_capture_pid() {
     fi
 
     OCTOPUS_NOTICE_FILE="$notice_file" \
-        spawn_agent "$agent_type" "$prompt" "$task_id" "$role" "$phase" "$use_fork" >"$pid_file" 2>&1 &
+        OCTOPUS_NOTICE_FD=8 \
+        spawn_agent "$agent_type" "$prompt" "$task_id" "$role" "$phase" "$use_fork" \
+        8>&2 >"$pid_file" 2>&1 &
     local wrapper_pid=$!
     if [[ "${OCTOPUS_SPAWN_PID_HANDOFF_FD:-}" == "9" ]]; then
         printf 'wrapper:%s\n' "$wrapper_pid" >&9

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -609,9 +609,10 @@ ${heuristic_ctx}"
     if [[ "$agent_type" == codex* && "$agent_type" != "codex-review" ]]; then
         enhanced_prompt="${CODEX_SUBAGENT_PREAMBLE}${enhanced_prompt}"
     fi
-    local tokens_in
-    tokens_in=$(( ${#enhanced_prompt} / 4 ))
-    enhanced_prompt=$(enforce_context_budget "$enhanced_prompt" "${role:-}" "$agent_type")
+    local tokens_in _budget_original_chars _budget_final_chars _budget_compression
+    _budget_original_chars=${#enhanced_prompt}
+    tokens_in=$(( _budget_original_chars / 4 ))
+    enhanced_prompt=$(enforce_context_budget "$enhanced_prompt" "${role:-}" "$agent_type" "${phase:-}")
     local _budget_rc=$?
     if [[ $_budget_rc -ne 0 ]]; then
         octo_spawn_contract_finish "$_contract_seat_id" failed "" "" \
@@ -619,6 +620,9 @@ ${heuristic_ctx}"
         type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "failed" "$tokens_in" 0 "Prompt exceeded context budget" 0 "" "${role:-}" || true
         return "$_budget_rc"
     fi
+    _budget_final_chars=${#enhanced_prompt}
+    _budget_compression=none
+    [[ "$_budget_final_chars" -lt "$_budget_original_chars" ]] && _budget_compression=applied
 
     if declare -f octo_routing_policy >/dev/null 2>&1 &&
        [[ "$(octo_routing_policy 2>/dev/null || printf '%s' off)" == "eval" ]] &&
@@ -892,8 +896,11 @@ ${heuristic_ctx}"
                 "Failed to persist Agent Teams result header" 74 "" >/dev/null 2>&1 || true
             return 74
         fi
-        echo "# Dispatch: Agent Teams (native)" >> "$result_file"
+        printf '# Prompt metadata: original_chars=%s final_chars=%s compression=%s\n' \
+            "$_budget_original_chars" "$_budget_final_chars" "$_budget_compression" >> "$result_file"
+        printf '# Prompt: %s\n' "$enhanced_prompt" >> "$result_file"
         echo "# Started: $(date)" >> "$result_file"
+        echo "# Dispatch: Agent Teams (native)" >> "$result_file"
         if [[ "$SUPPORTS_HOOK_LAST_MESSAGE" == "true" ]]; then
             echo "# Result-capture: SubagentStop hook" >> "$result_file"
         fi
@@ -933,7 +940,9 @@ ${heuristic_ctx}"
         octo_capture_current_shell_pid || OCTO_CAPTURED_SHELL_PID="$$"
 
         write_agent_result_header "$result_file" "$agent_type" "${model:-unresolved}" "$task_id" "${role:-none}" "${phase:-none}" "legacy"
-        echo "# Prompt: $prompt" >> "$result_file"
+        printf '# Prompt metadata: original_chars=%s final_chars=%s compression=%s\n' \
+            "$_budget_original_chars" "$_budget_final_chars" "$_budget_compression" >> "$result_file"
+        printf '# Prompt: %s\n' "$enhanced_prompt" >> "$result_file"
         echo "# Started: $(date)" >> "$result_file"
         echo "" >> "$result_file"
         echo "## Output" >> "$result_file"
@@ -1510,14 +1519,26 @@ spawn_agent_capture_pid() {
     local role="${4:-}"
     local phase="${5:-}"
     local use_fork="${6:-false}"
+    local notice_file="${OCTOPUS_NOTICE_FILE:-}" owns_notice_file=false
+
+    if type octo_notice_channel_is_valid >/dev/null 2>&1 &&
+       ! octo_notice_channel_is_valid "$notice_file" &&
+       type octo_notice_channel_create >/dev/null 2>&1; then
+        notice_file="$(octo_notice_channel_create 2>/dev/null || true)"
+        [[ -n "$notice_file" ]] && owns_notice_file=true
+    fi
 
     local pid_file
-    pid_file=$(mktemp "${TMPDIR:-/tmp}/octo-spawn-pid.XXXXXX") || return 1
+    if ! pid_file=$(mktemp "${TMPDIR:-/tmp}/octo-spawn-pid.XXXXXX"); then
+        [[ "$owns_notice_file" == true ]] && rm -f "$notice_file" 2>/dev/null || true
+        return 1
+    fi
     if [[ "${OCTOPUS_SPAWN_PID_HANDOFF_FD:-}" == "9" ]]; then
         printf 'capture-file:%s\n' "$pid_file" >&9
     fi
 
-    spawn_agent "$agent_type" "$prompt" "$task_id" "$role" "$phase" "$use_fork" >"$pid_file" 2>&1 &
+    OCTOPUS_NOTICE_FILE="$notice_file" \
+        spawn_agent "$agent_type" "$prompt" "$task_id" "$role" "$phase" "$use_fork" >"$pid_file" 2>&1 &
     local wrapper_pid=$!
     if [[ "${OCTOPUS_SPAWN_PID_HANDOFF_FD:-}" == "9" ]]; then
         printf 'wrapper:%s\n' "$wrapper_pid" >&9
@@ -1567,6 +1588,9 @@ spawn_agent_capture_pid() {
         fi
         wait "$wrapper_pid" 2>/dev/null || true
         rm -f "$pid_file"
+        if [[ "$owns_notice_file" == true ]]; then
+            octo_notice_channel_replay "$notice_file"
+        fi
         return 1
     fi
 
@@ -1578,5 +1602,8 @@ spawn_agent_capture_pid() {
         printf 'provider:%s\n' "$pid" >&9
     fi
     rm -f "$pid_file"
+    if [[ "$owns_notice_file" == true ]]; then
+        octo_notice_channel_replay "$notice_file"
+    fi
     echo "$pid"
 }

--- a/scripts/lib/spawn.sh
+++ b/scripts/lib/spawn.sh
@@ -13,6 +13,9 @@ fi
 if ! type run_contract_transition >/dev/null 2>&1; then
     source "${_octopus_spawn_lib_dir}/run-contract.sh" 2>/dev/null || true
 fi
+if ! type write_agent_result_prompt >/dev/null 2>&1; then
+    source "${_octopus_spawn_lib_dir}/result-file.sh" 2>/dev/null || true
+fi
 
 quota_watcher_kill_spawn_children() {
     local spawn_pid="$1"
@@ -898,7 +901,11 @@ ${heuristic_ctx}"
         fi
         printf '# Prompt metadata: original_chars=%s final_chars=%s compression=%s\n' \
             "$_budget_original_chars" "$_budget_final_chars" "$_budget_compression" >> "$result_file"
-        printf '# Prompt: %s\n' "$enhanced_prompt" >> "$result_file"
+        if ! write_agent_result_prompt "$result_file" "$enhanced_prompt"; then
+            octo_spawn_contract_finish "$_contract_seat_id" failed "" "" \
+                "Failed to persist Agent Teams dispatched prompt" 74 "" >/dev/null 2>&1 || true
+            return 74
+        fi
         echo "# Started: $(date)" >> "$result_file"
         echo "# Dispatch: Agent Teams (native)" >> "$result_file"
         if [[ "$SUPPORTS_HOOK_LAST_MESSAGE" == "true" ]]; then
@@ -939,10 +946,18 @@ ${heuristic_ctx}"
         set -o pipefail  # v9.15.1: Pipeline exit code = first failure
         octo_capture_current_shell_pid || OCTO_CAPTURED_SHELL_PID="$$"
 
-        write_agent_result_header "$result_file" "$agent_type" "${model:-unresolved}" "$task_id" "${role:-none}" "${phase:-none}" "legacy"
+        if ! write_agent_result_header "$result_file" "$agent_type" "${model:-unresolved}" "$task_id" "${role:-none}" "${phase:-none}" "legacy"; then
+            octo_spawn_contract_finish "$_contract_seat_id" failed "" "" \
+                "Failed to persist background result header" 74 "" >/dev/null 2>&1 || true
+            exit 74
+        fi
         printf '# Prompt metadata: original_chars=%s final_chars=%s compression=%s\n' \
             "$_budget_original_chars" "$_budget_final_chars" "$_budget_compression" >> "$result_file"
-        printf '# Prompt: %s\n' "$enhanced_prompt" >> "$result_file"
+        if ! write_agent_result_prompt "$result_file" "$enhanced_prompt"; then
+            octo_spawn_contract_finish "$_contract_seat_id" failed "" "" \
+                "Failed to persist background dispatched prompt" 74 "" >/dev/null 2>&1 || true
+            exit 74
+        fi
         echo "# Started: $(date)" >> "$result_file"
         echo "" >> "$result_file"
         echo "## Output" >> "$result_file"
@@ -1519,28 +1534,20 @@ spawn_agent_capture_pid() {
     local role="${4:-}"
     local phase="${5:-}"
     local use_fork="${6:-false}"
-    local notice_file="${OCTOPUS_NOTICE_FILE:-}" owns_notice_file=false
-
-    if type octo_notice_channel_is_valid >/dev/null 2>&1 &&
-       ! octo_notice_channel_is_valid "$notice_file" &&
-       type octo_notice_channel_create >/dev/null 2>&1; then
-        notice_file="$(octo_notice_channel_create 2>/dev/null || true)"
-        [[ -n "$notice_file" ]] && owns_notice_file=true
-    fi
-
-    local pid_file
+    local pid_file err_file
     if ! pid_file=$(mktemp "${TMPDIR:-/tmp}/octo-spawn-pid.XXXXXX"); then
-        [[ "$owns_notice_file" == true ]] && rm -f "$notice_file" 2>/dev/null || true
+        return 1
+    fi
+    if ! err_file=$(mktemp "${TMPDIR:-/tmp}/octo-spawn-stderr.XXXXXX"); then
+        rm -f "$pid_file" 2>/dev/null || true
         return 1
     fi
     if [[ "${OCTOPUS_SPAWN_PID_HANDOFF_FD:-}" == "9" ]]; then
         printf 'capture-file:%s\n' "$pid_file" >&9
     fi
 
-    OCTOPUS_NOTICE_FILE="$notice_file" \
-        OCTOPUS_NOTICE_FD=8 \
-        spawn_agent "$agent_type" "$prompt" "$task_id" "$role" "$phase" "$use_fork" \
-        8>&2 >"$pid_file" 2>&1 &
+    spawn_agent "$agent_type" "$prompt" "$task_id" "$role" "$phase" "$use_fork" \
+        8>&- >"$pid_file" 2>"$err_file" &
     local wrapper_pid=$!
     if [[ "${OCTOPUS_SPAWN_PID_HANDOFF_FD:-}" == "9" ]]; then
         printf 'wrapper:%s\n' "$wrapper_pid" >&9
@@ -1571,6 +1578,7 @@ spawn_agent_capture_pid() {
     done
 
     if [[ -z "$pid" ]]; then
+        cat "$err_file" >&2 2>/dev/null || true
         log "ERROR" "spawn_agent produced no provider PID for $task_id; refusing to track wrapper PID $wrapper_pid" >&2
         if [[ -s "$pid_file" ]]; then
             tail -20 "$pid_file" >&2 || true
@@ -1589,10 +1597,7 @@ spawn_agent_capture_pid() {
             kill "$wrapper_pid" 2>/dev/null || true
         fi
         wait "$wrapper_pid" 2>/dev/null || true
-        rm -f "$pid_file"
-        if [[ "$owns_notice_file" == true ]]; then
-            octo_notice_channel_replay "$notice_file"
-        fi
+        rm -f "$pid_file" "$err_file"
         return 1
     fi
 
@@ -1603,9 +1608,8 @@ spawn_agent_capture_pid() {
     if [[ "${OCTOPUS_SPAWN_PID_HANDOFF_FD:-}" == "9" ]]; then
         printf 'provider:%s\n' "$pid" >&9
     fi
-    rm -f "$pid_file"
-    if [[ "$owns_notice_file" == true ]]; then
-        octo_notice_channel_replay "$notice_file"
-    fi
+    wait "$wrapper_pid" 2>/dev/null || true
+    cat "$err_file" >&2 2>/dev/null || true
+    rm -f "$pid_file" "$err_file"
     echo "$pid"
 }

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -22,6 +22,11 @@ if ! type review_kill_process_tree_frozen >/dev/null 2>&1; then
     fi
     unset _octo_review_lib
 fi
+if ! type write_agent_result_prompt >/dev/null 2>&1; then
+    _octo_result_file_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/result-file.sh"
+    [[ -f "$_octo_result_file_lib" ]] && source "$_octo_result_file_lib"
+    unset _octo_result_file_lib
+fi
 
 # v8.54.0: Single-agent probe for multi-agentic skill dispatch
 # Runs one probe perspective synchronously and writes result to RESULTS_DIR.
@@ -197,7 +202,7 @@ IMPORTANT: If you find yourself searching or grepping more than 3 times in a row
     echo "# Phase: $phase" >> "$result_file"
     printf '# Prompt metadata: original_chars=%s final_chars=%s compression=%s\n' \
         "$_budget_original_chars" "$_budget_final_chars" "$_budget_compression" >> "$result_file"
-    printf '# Prompt: %s\n' "$enhanced_prompt" >> "$result_file"
+    write_agent_result_prompt "$result_file" "$enhanced_prompt" || return 74
     echo "# Started: $(date)" >> "$result_file"
     echo "" >> "$result_file"
     echo "## Output" >> "$result_file"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -106,14 +106,18 @@ IMPORTANT: If you find yourself searching or grepping more than 3 times in a row
     # (probe dispatch has minimal variable content — context budget is the boundary)
 
     # v8.10.0: Enforce context budget AFTER all injections
-    local tokens_in
-    tokens_in=$(( ${#enhanced_prompt} / 4 ))
-    enhanced_prompt=$(enforce_context_budget "$enhanced_prompt" "$role" "$agent_type")
+    local tokens_in _budget_original_chars _budget_final_chars _budget_compression
+    _budget_original_chars=${#enhanced_prompt}
+    tokens_in=$(( _budget_original_chars / 4 ))
+    enhanced_prompt=$(enforce_context_budget "$enhanced_prompt" "$role" "$agent_type" "$phase")
     local _budget_rc=$?
     if [[ $_budget_rc -ne 0 ]]; then
         type write_agent_status >/dev/null 2>&1 && write_agent_status "$agent_type" "failed" "$tokens_in" 0 "Prompt exceeded context budget" 0 "" "$role" || true
         return "$_budget_rc"
     fi
+    _budget_final_chars=${#enhanced_prompt}
+    _budget_compression=none
+    [[ "$_budget_final_chars" -lt "$_budget_original_chars" ]] && _budget_compression=applied
 
     if declare -f octo_routing_policy >/dev/null 2>&1 &&
        [[ "$(octo_routing_policy 2>/dev/null || printf '%s' off)" == "eval" ]] &&
@@ -191,7 +195,9 @@ IMPORTANT: If you find yourself searching or grepping more than 3 times in a row
     echo "# Task ID: $task_id" >> "$result_file"
     echo "# Role: $role" >> "$result_file"
     echo "# Phase: $phase" >> "$result_file"
-    echo "# Prompt: ${perspective:0:200}" >> "$result_file"
+    printf '# Prompt metadata: original_chars=%s final_chars=%s compression=%s\n' \
+        "$_budget_original_chars" "$_budget_final_chars" "$_budget_compression" >> "$result_file"
+    printf '# Prompt: %s\n' "$enhanced_prompt" >> "$result_file"
     echo "# Started: $(date)" >> "$result_file"
     echo "" >> "$result_file"
     echo "## Output" >> "$result_file"

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -202,7 +202,13 @@ IMPORTANT: If you find yourself searching or grepping more than 3 times in a row
     echo "# Phase: $phase" >> "$result_file"
     printf '# Prompt metadata: original_chars=%s final_chars=%s compression=%s\n' \
         "$_budget_original_chars" "$_budget_final_chars" "$_budget_compression" >> "$result_file"
-    write_agent_result_prompt "$result_file" "$enhanced_prompt" || return 74
+    if ! write_agent_result_prompt "$result_file" "$enhanced_prompt"; then
+        update_agent_status "$agent_type" "failed" 0 "$estimated_cost" "$TIMEOUT" "$task_id" "$phase" "$result_file"
+        type write_agent_status >/dev/null 2>&1 && write_agent_status \
+            "$agent_type" "failed" "$tokens_in" 0 "Failed to persist dispatched prompt" \
+            0 "$result_file" "$role" || true
+        return 74
+    fi
     echo "# Started: $(date)" >> "$result_file"
     echo "" >> "$result_file"
     echo "## Output" >> "$result_file"

--- a/tests/unit/test-dispatch-oversize.sh
+++ b/tests/unit/test-dispatch-oversize.sh
@@ -9,48 +9,60 @@ source "$SCRIPT_DIR/../helpers/test-framework.sh"
 test_suite "Dispatch oversize preflight"
 
 log() { :; }
-record_oversize_event() { :; }
+octo_notice_warn() { printf '%s\n' "$*" > "$TEST_TMP_DIR/oversize-notice"; }
+record_oversize_event() { printf '%s\n' "$*" > "$TEST_TMP_DIR/oversize-event.args"; }
 write_agent_status() { :; }
 validate_agent_type() { return 0; }
 
 source "$PROJECT_ROOT/scripts/lib/dispatch.sh"
 
-long_prompt="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+long_prompt="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
-test_case "truncate strategy bounds oversized prompts"
-OCTOPUS_CONTEXT_BUDGET=4
+test_case "truncate strategy includes its marker inside the exact resolved boundary"
+OCTOPUS_CONTEXT_BUDGET=40
 OCTOPUS_OVERSIZE_STRATEGY=truncate
-output="$(enforce_context_budget "$long_prompt" "" "codex")"
-if [[ "$output" == abcdefghijklmnop* && "$output" == *"truncated to fit context budget"* ]]; then
+output="$(enforce_context_budget "$long_prompt" "reviewer" "codex" "review")"
+event_args="$(cat "$TEST_TMP_DIR/oversize-event.args")"
+notice="$(cat "$TEST_TMP_DIR/oversize-notice")"
+if [[ "${#output}" -eq 64 ]] &&
+   [[ "$output" == *"truncated to fit context budget"* ]] &&
+   [[ "$event_args" == "codex ${#long_prompt} 64 truncated reviewer review 16" ]] &&
+   [[ "$notice" == "Context budget: truncated codex role=reviewer phase=review from ${#long_prompt} to 64 chars (budget=16 tokens/64 chars)" ]]; then
     test_pass
 else
-    test_fail "expected truncated prompt, got: $output"
+    test_fail "boundary/accounting mismatch: output_chars=${#output} event='$event_args'"
 fi
 
 test_case "fail strategy returns context-budget status"
 set +e
-OCTOPUS_CONTEXT_BUDGET=4
+OCTOPUS_CONTEXT_BUDGET=40
 OCTOPUS_OVERSIZE_STRATEGY=fail
-enforce_context_budget "$long_prompt" "" "codex" >/tmp/octopus-oversize-fail.out
+enforce_context_budget "$long_prompt" "reviewer" "codex" "review" >"$TEST_TMP_DIR/oversize-fail.out"
 rc=$?
 set -e
-if [[ $rc -eq 78 ]]; then
+event_args="$(cat "$TEST_TMP_DIR/oversize-event.args")"
+if [[ $rc -eq 78 ]] &&
+   [[ "$event_args" == "codex ${#long_prompt} ${#long_prompt} failed reviewer review 16" ]]; then
     test_pass
 else
-    test_fail "expected exit 78 for oversize fail strategy, got: $rc"
+    test_fail "expected attributed exit 78, got rc=$rc event='$event_args'"
 fi
 
 test_case "summarize strategy dispatches through summarizer"
 run_agent_sync() {
     echo "condensed prompt"
 }
-OCTOPUS_CONTEXT_BUDGET=4
+OCTOPUS_CONTEXT_BUDGET=40
 OCTOPUS_OVERSIZE_STRATEGY=summarize
-output="$(enforce_context_budget "$long_prompt" "" "codex")"
-if [[ "$output" == "condensed prompt" ]]; then
+output="$(enforce_context_budget "$long_prompt" "reviewer" "codex" "review")"
+event_args="$(cat "$TEST_TMP_DIR/oversize-event.args")"
+notice="$(cat "$TEST_TMP_DIR/oversize-notice")"
+if [[ "$output" == "condensed prompt" ]] &&
+   [[ "$event_args" == "codex ${#long_prompt} 16 summarized reviewer review 16" ]] &&
+   [[ "$notice" == "Context budget: summarized codex role=reviewer phase=review from ${#long_prompt} to 16 chars (budget=16 tokens/64 chars)" ]]; then
     test_pass
 else
-    test_fail "expected summarized prompt, got: $output"
+    test_fail "expected attributed summarized prompt, got output='$output' event='$event_args'"
 fi
 
 test_summary

--- a/tests/unit/test-dispatch-oversize.sh
+++ b/tests/unit/test-dispatch-oversize.sh
@@ -65,4 +65,45 @@ else
     test_fail "expected attributed summarized prompt, got output='$output' event='$event_args'"
 fi
 
+test_case "leading-zero context budget is normalized as decimal before arithmetic"
+decimal_prompt="$(printf '%04000d' 0)"
+OCTOPUS_CONTEXT_BUDGET=0900
+OCTOPUS_OVERSIZE_STRATEGY=truncate
+set +e
+output="$(enforce_context_budget "$decimal_prompt" "reviewer" "codex" "review" \
+    2>"$TEST_TMP_DIR/decimal-budget.err")"
+decimal_rc=$?
+set -e
+event_args="$(cat "$TEST_TMP_DIR/oversize-event.args")"
+if [[ "$decimal_rc" -eq 0 ]] && [[ "${#output}" -eq 1440 ]] &&
+   [[ "$event_args" == "codex 4000 1440 truncated reviewer review 360" ]]; then
+    test_pass
+else
+    test_fail "0900 was not normalized safely: rc=$decimal_rc output_chars=${#output} event='$event_args' error='$(cat "$TEST_TMP_DIR/decimal-budget.err")'"
+fi
+
+test_case "invalid and overflowing context budgets fail before compression"
+invalid_budget_ok=true
+invalid_budget_failures=""
+for invalid_budget in 0 -1 18446744073709551616 9223372036854775807; do
+    rm -f "$TEST_TMP_DIR/oversize-event.args" "$TEST_TMP_DIR/oversize-notice"
+    set +e
+    OCTOPUS_CONTEXT_BUDGET="$invalid_budget" OCTOPUS_OVERSIZE_STRATEGY=truncate \
+        enforce_context_budget "$long_prompt" "reviewer" "codex" "review" \
+        >"$TEST_TMP_DIR/invalid-budget.out" 2>"$TEST_TMP_DIR/invalid-budget.err"
+    rc=$?
+    set -e
+    invalid_output="$(cat "$TEST_TMP_DIR/invalid-budget.out")"
+    if [[ "$rc" -ne 2 ]] || [[ -s "$TEST_TMP_DIR/invalid-budget.out" ]] ||
+       [[ -e "$TEST_TMP_DIR/oversize-event.args" ]] || [[ -e "$TEST_TMP_DIR/oversize-notice" ]]; then
+        invalid_budget_ok=false
+        invalid_budget_failures="${invalid_budget_failures}${invalid_budget}:rc=${rc}:chars=${#invalid_output};"
+    fi
+done
+if [[ "$invalid_budget_ok" == true ]]; then
+    test_pass
+else
+    test_fail "invalid budgets reached prompt processing: $invalid_budget_failures"
+fi
+
 test_summary

--- a/tests/unit/test-probe-single.sh
+++ b/tests/unit/test-probe-single.sh
@@ -48,10 +48,64 @@ assert_contains "$PROBE_SINGLE_SRC" \
   'write_agent_result_prompt.*result_file.*enhanced_prompt' "probe_single_agent: length-frames the dispatched prompt"
 
 assert_contains "$PROBE_SINGLE_SRC" \
-  'update_agent_status.*failed' "probe_single_agent: terminalizes prompt persistence failure"
-
-assert_contains "$PROBE_SINGLE_SRC" \
   'Failed to persist dispatched prompt' "probe_single_agent: records prompt persistence failure reason"
+
+test_case "probe_single_agent: prompt persistence failure is terminal"
+prompt_failure_dir="$TEST_TMP_DIR/probe-prompt-persistence"
+prompt_failure_status="$prompt_failure_dir/status.log"
+mkdir -p "$prompt_failure_dir"
+set +e
+(
+  trap - EXIT
+  # shellcheck disable=SC1090
+  source "$PROJECT_ROOT/scripts/lib/workflows.sh"
+  export RESULTS_DIR="$prompt_failure_dir/results"
+  export LOGS_DIR="$prompt_failure_dir/logs"
+  export PROJECT_ROOT="$prompt_failure_dir"
+  export SUPPORTS_AGENT_TYPE_ROUTING=false
+  export OCTOPUS_PERSONA_PACKS=off
+  export OCTOPUS_BACKEND=api
+  export SUPPORTS_STABLE_AUTH=true
+  export TIMEOUT=0
+  PROVIDER_ENV_ARRAY=()
+
+  log() { :; }
+  preflight_check() { return 0; }
+  classify_task() { printf '%s\n' research; }
+  match_routing_rule() { return 1; }
+  apply_persona() { printf '%s\n' "$2"; }
+  enforce_context_budget() { printf '%s\n' "$1"; }
+  octo_routing_policy() { printf '%s\n' off; }
+  get_agent_model() { printf '%s\n' test-model; }
+  get_agent_command() { printf '%s\n' true; }
+  validate_agent_command() { return 0; }
+  record_agent_call() { :; }
+  estimate_agent_call_cost() { printf '%s\n' 0; }
+  update_metrics() { :; }
+  bridge_register_task() { :; }
+  build_provider_env() { PROVIDER_ENV_ARRAY=(); }
+  write_agent_result_prompt() { return 1; }
+  update_agent_status() {
+    printf 'update:%s:%s:%s\n' "$1" "$2" "$6" >> "$prompt_failure_status"
+  }
+  write_agent_status() {
+    printf 'write:%s:%s:%s\n' "$1" "$2" "$5" >> "$prompt_failure_status"
+  }
+
+  mkdir -p "$RESULTS_DIR" "$LOGS_DIR"
+  probe_rc=0
+  probe_single_agent codex "Review the fixture" prompt-failure || probe_rc=$?
+  [[ "$probe_rc" -eq 74 ]] &&
+    grep -Fq 'update:codex:failed:prompt-failure' "$prompt_failure_status" &&
+    grep -Fq 'write:codex:failed:Failed to persist dispatched prompt' "$prompt_failure_status"
+)
+prompt_failure_rc=$?
+set -e
+if [[ "$prompt_failure_rc" -eq 0 ]]; then
+  test_pass
+else
+  test_fail "prompt persistence failure must return 74 and record both failed statuses"
+fi
 
 if ! grep -q "printf '# Prompt:" <<< "$PROBE_SINGLE_SRC"; then
   pass "probe_single_agent: does not use the ambiguous legacy prompt delimiter"

--- a/tests/unit/test-probe-single.sh
+++ b/tests/unit/test-probe-single.sh
@@ -44,6 +44,15 @@ assert_contains "$(grep -A40 'probe-single)' "$ALL_SRC" | head -45)" \
 assert_contains "$PROBE_SINGLE_SRC" \
   'RESULTS_DIR.*agent_type.*task_id.*\.md' "probe_single_agent: writes result file to RESULTS_DIR"
 
+assert_contains "$PROBE_SINGLE_SRC" \
+  'write_agent_result_prompt.*result_file.*enhanced_prompt' "probe_single_agent: length-frames the dispatched prompt"
+
+if ! grep -q "printf '# Prompt:" <<< "$PROBE_SINGLE_SRC"; then
+  pass "probe_single_agent: does not use the ambiguous legacy prompt delimiter"
+else
+  fail "probe_single_agent: does not use the ambiguous legacy prompt delimiter" "legacy prompt writer remains"
+fi
+
 # ── probe_single_agent calls apply_persona ───────────────────────────────────
 
 assert_contains "$PROBE_SINGLE_SRC" \

--- a/tests/unit/test-probe-single.sh
+++ b/tests/unit/test-probe-single.sh
@@ -47,6 +47,12 @@ assert_contains "$PROBE_SINGLE_SRC" \
 assert_contains "$PROBE_SINGLE_SRC" \
   'write_agent_result_prompt.*result_file.*enhanced_prompt' "probe_single_agent: length-frames the dispatched prompt"
 
+assert_contains "$PROBE_SINGLE_SRC" \
+  'update_agent_status.*failed' "probe_single_agent: terminalizes prompt persistence failure"
+
+assert_contains "$PROBE_SINGLE_SRC" \
+  'Failed to persist dispatched prompt' "probe_single_agent: records prompt persistence failure reason"
+
 if ! grep -q "printf '# Prompt:" <<< "$PROBE_SINGLE_SRC"; then
   pass "probe_single_agent: does not use the ambiguous legacy prompt delimiter"
 else

--- a/tests/unit/test-probe-single.sh
+++ b/tests/unit/test-probe-single.sh
@@ -14,6 +14,8 @@ ORCHESTRATE="$PROJECT_ROOT/scripts/orchestrate.sh"
 ALL_SRC=$(mktemp)
 trap 'rm -f "$ALL_SRC"' EXIT
 cat "$ORCHESTRATE" "$PROJECT_ROOT/scripts/lib/"*.sh > "$ALL_SRC" 2>/dev/null
+PROBE_SINGLE_SRC="$(sed -n '/^probe_single_agent() {/,/^probe_discover() {/p' \
+  "$PROJECT_ROOT/scripts/lib/workflows.sh" | sed '$d')"
 
 pass() { test_case "$1"; test_pass; }
 fail() { test_case "$1"; test_fail "${2:-$1}"; }
@@ -39,50 +41,50 @@ assert_contains "$(grep -A40 'probe-single)' "$ALL_SRC" | head -45)" \
 
 # ── probe_single_agent writes result files ───────────────────────────────────
 
-assert_contains "$(grep -A200 'probe_single_agent()' "$ALL_SRC" | head -220)" \
+assert_contains "$PROBE_SINGLE_SRC" \
   'RESULTS_DIR.*agent_type.*task_id.*\.md' "probe_single_agent: writes result file to RESULTS_DIR"
 
 # ── probe_single_agent calls apply_persona ───────────────────────────────────
 
-assert_contains "$(grep -A100 'probe_single_agent()' "$ALL_SRC" | head -120)" \
+assert_contains "$PROBE_SINGLE_SRC" \
   "apply_persona" "probe_single_agent: calls apply_persona()"
 
 # ── probe_single_agent calls enforce_context_budget ──────────────────────────
 
-assert_contains "$(grep -A100 'probe_single_agent()' "$ALL_SRC" | head -120)" \
+assert_contains "$PROBE_SINGLE_SRC" \
   "enforce_context_budget" "probe_single_agent: calls enforce_context_budget()"
 
 # ── probe_single_agent calls get_agent_command ───────────────────────────────
 
-assert_contains "$(grep -A120 'probe_single_agent()' "$ALL_SRC" | head -140)" \
+assert_contains "$PROBE_SINGLE_SRC" \
   "get_agent_command" "probe_single_agent: calls get_agent_command()"
 
 # ── probe_single_agent has auth retry logic ──────────────────────────────────
 
-assert_contains "$(grep -A200 'probe_single_agent()' "$ALL_SRC" | head -220)" \
+assert_contains "$PROBE_SINGLE_SRC" \
   "auth_attempt|max_auth_retries" "probe_single_agent: has auth retry logic"
 
 # ── probe_single_agent outputs result file path ──────────────────────────────
 
-assert_contains "$(grep -A300 'probe_single_agent()' "$ALL_SRC" | head -310)" \
+assert_contains "$PROBE_SINGLE_SRC" \
   'echo.*result_file' "probe_single_agent: outputs result file path on stdout"
 
 # ── probe_single_agent handles timeout status ────────────────────────────────
 
-assert_contains "$(grep -A300 'probe_single_agent()' "$ALL_SRC" | head -310)" \
+assert_contains "$PROBE_SINGLE_SRC" \
   "Status: TIMEOUT" "probe_single_agent: handles TIMEOUT status"
 
 # ── probe_single_agent handles failure status ────────────────────────────────
 
-assert_contains "$(grep -A300 'probe_single_agent()' "$ALL_SRC" | head -310)" \
+assert_contains "$PROBE_SINGLE_SRC" \
   "Status: FAILED" "probe_single_agent: handles FAILED status"
 
 # ── probe_single_agent preserves recovered Codex stderr transcript ───────────
 
-assert_contains "$(grep -A300 'probe_single_agent()' "$ALL_SRC" | head -310)" \
+assert_contains "$PROBE_SINGLE_SRC" \
   "Errors transcript below" "probe_single_agent: announces recovered Codex stderr transcript"
 
-assert_contains "$(grep -A300 'probe_single_agent()' "$ALL_SRC" | head -310)" \
+assert_contains "$PROBE_SINGLE_SRC" \
   'cat "\$temp_errors" >> "\$result_file"' "probe_single_agent: appends recovered Codex stderr transcript"
 
 # ── flow-discover.md references probe-single ─────────────────────────────────

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -38,6 +38,7 @@ if grep -q "review-round1-findings" "$REVIEW_SH"; then test_pass; else test_fail
 test_case "extractor prefers the last non-empty findings array"
 log() { :; }
 source "$REVIEW_SH" >/dev/null 2>&1 || true
+source "$PROJECT_ROOT/scripts/lib/error-tracking.sh" >/dev/null 2>&1 || true
 if out=$(review_extract_findings_array "$TMP_MD" 2>/dev/null); then
     if count=$(printf '%s' "$out" | jq 'length' 2>/dev/null) && title=$(printf '%s' "$out" | jq -r '.[0].title' 2>/dev/null); then
         if [[ "$count" == "1" && "$title" == "Broken regex" ]]; then
@@ -261,6 +262,35 @@ if OCTOPUS_REVIEW_STALL_WINDOW=08 OCTOPUS_REVIEW_POLL_SECS=08 \
     test_pass
 else
     test_fail "leading-zero timing knob triggered Bash octal parsing"
+fi
+
+test_case "Round 2 and Round 3 budget warnings replay once without contaminating JSON"
+original_log="$(declare -f log)"
+log() { printf '%s: %s\n' "$1" "$2" >&2; }
+run_agent_sync() {
+    octo_notice_warn "Context budget: compressed $4/$5"
+    printf '{"role":"%s","phase":"%s"}\n' "$4" "$5"
+}
+review_notice_err="$TEST_TMP_DIR/review-notices.err"
+: > "$review_notice_err"
+review_notice_ok=true
+for review_role in implementation-verifier implementation-debater implementation-synthesizer; do
+    review_json="$(review_run_agent_sync_progress codex prompt "$review_role" review "$review_role" 2>>"$review_notice_err")"
+    if ! jq -e --arg role "$review_role" \
+        '.role == $role and .phase == "review"' <<< "$review_json" >/dev/null 2>&1; then
+        review_notice_ok=false
+    fi
+done
+unset -f run_agent_sync
+eval "$original_log"
+if [[ "$review_notice_ok" == true ]] &&
+   [[ "$(grep -c '^WARN: Context budget: compressed ' "$review_notice_err" || true)" -eq 3 ]] &&
+   [[ "$(grep -c 'implementation-verifier/review' "$review_notice_err" || true)" -eq 1 ]] &&
+   [[ "$(grep -c 'implementation-debater/review' "$review_notice_err" || true)" -eq 1 ]] &&
+   [[ "$(grep -c 'implementation-synthesizer/review' "$review_notice_err" || true)" -eq 1 ]]; then
+    test_pass
+else
+    test_fail "review JSON was contaminated or notices were not replayed exactly once: $(cat "$review_notice_err")"
 fi
 
 test_case "retry wait stops when provider exits without terminal status"

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -293,12 +293,11 @@ else
     test_fail "review JSON was contaminated or notices were not replayed exactly once: $(cat "$review_notice_err")"
 fi
 
-test_case "review warning bypasses JSON capture when notice allocation and validation fail"
+test_case "review capture ignores untrusted notice paths and closes inherited descriptor 8"
 original_log="$(declare -f log)"
-original_notice_create="$(declare -f octo_notice_channel_create)"
 log() { printf '%s: %s\n' "$1" "$2" >&2; }
-octo_notice_channel_create() { return 1; }
 run_agent_sync() {
+    { printf 'descriptor bypass\n' >&8; } 2>/dev/null || true
     octo_notice_warn "Context budget: compressed $4/$5"
     printf '{"role":"%s","phase":"%s"}\n' "$4" "$5"
 }
@@ -310,28 +309,56 @@ chmod 644 "$invalid_notice"
 printf 'symlink sentinel\n' > "$symlink_target"
 ln -s "$symlink_target" "$symlink_notice"
 fallback_err="$TEST_TMP_DIR/review-fallback.err"
+review_fd8_target="$TEST_TMP_DIR/review-inherited-fd8"
 : > "$fallback_err"
+: > "$review_fd8_target"
 fallback_ok=true
 for notice_channel in "" "$invalid_notice" "$symlink_notice"; do
     review_json="$(OCTOPUS_NOTICE_FILE="$notice_channel" \
         review_run_agent_sync_progress codex prompt implementation-verifier review fallback \
-        2>>"$fallback_err")"
+        8>>"$review_fd8_target" 2>>"$fallback_err")"
     if ! jq -e '.role == "implementation-verifier" and .phase == "review"' \
         <<< "$review_json" >/dev/null 2>&1; then
         fallback_ok=false
     fi
 done
 unset -f run_agent_sync
-eval "$original_notice_create"
 eval "$original_log"
 if [[ "$fallback_ok" == true ]] &&
    [[ "$(grep -c '^WARN: Context budget: compressed implementation-verifier/review$' "$fallback_err" || true)" -eq 3 ]] &&
    [[ "$(cat "$invalid_notice")" == "invalid sentinel" ]] &&
    [[ "$(cat "$symlink_target")" == "symlink sentinel" ]] &&
-   ! find "$TEST_TMP_DIR" -name 'octo-notice.*' -o -name '.tmp-review-sync-fallback-*' | grep -q .; then
+   [[ ! -s "$review_fd8_target" ]] &&
+   ! find "$TEST_TMP_DIR" \( -name 'octo-notice.*' -o -name '.tmp-review-sync-fallback-*' \) | grep -q .; then
     test_pass
 else
-    test_fail "fallback warning contaminated JSON, was lost, or leaked resources: $(cat "$fallback_err")"
+    test_fail "review capture was contaminated, an untrusted path changed, descriptor 8 leaked, or a temp file remained"
+fi
+
+test_case "review capture preserves provider failure status and stderr exactly once"
+original_log="$(declare -f log)"
+log() { printf '%s: %s\n' "$1" "$2" >&2; }
+run_agent_sync() {
+    printf 'partial provider output\n'
+    printf 'provider diagnostic\n' >&2
+    return 23
+}
+failure_stdout="$TEST_TMP_DIR/review-failure.out"
+failure_stderr="$TEST_TMP_DIR/review-failure.err"
+set +e
+review_run_agent_sync_progress codex prompt implementation-verifier review failure-status \
+    >"$failure_stdout" 2>"$failure_stderr"
+failure_rc=$?
+set -e
+unset -f run_agent_sync
+eval "$original_log"
+if [[ "$failure_rc" -eq 23 ]] &&
+   [[ "$(grep -c '^partial provider output$' "$failure_stdout" || true)" -eq 1 ]] &&
+   [[ "$(grep -c '^provider diagnostic$' "$failure_stderr" || true)" -eq 1 ]] &&
+   ! find "$TEST_TMP_DIR" -name '.tmp-review-sync-failure-status-*' | grep -q .; then
+    test_pass
+else
+    test_fail "provider status/output/stderr was altered or review temp files remained"
 fi
 
 test_case "retry wait stops when provider exits without terminal status"

--- a/tests/unit/test-review-aggregation-robustness.sh
+++ b/tests/unit/test-review-aggregation-robustness.sh
@@ -293,6 +293,47 @@ else
     test_fail "review JSON was contaminated or notices were not replayed exactly once: $(cat "$review_notice_err")"
 fi
 
+test_case "review warning bypasses JSON capture when notice allocation and validation fail"
+original_log="$(declare -f log)"
+original_notice_create="$(declare -f octo_notice_channel_create)"
+log() { printf '%s: %s\n' "$1" "$2" >&2; }
+octo_notice_channel_create() { return 1; }
+run_agent_sync() {
+    octo_notice_warn "Context budget: compressed $4/$5"
+    printf '{"role":"%s","phase":"%s"}\n' "$4" "$5"
+}
+invalid_notice="$TEST_TMP_DIR/invalid-notice"
+symlink_notice="$TEST_TMP_DIR/symlink-notice"
+symlink_target="$TEST_TMP_DIR/symlink-target"
+printf 'invalid sentinel\n' > "$invalid_notice"
+chmod 644 "$invalid_notice"
+printf 'symlink sentinel\n' > "$symlink_target"
+ln -s "$symlink_target" "$symlink_notice"
+fallback_err="$TEST_TMP_DIR/review-fallback.err"
+: > "$fallback_err"
+fallback_ok=true
+for notice_channel in "" "$invalid_notice" "$symlink_notice"; do
+    review_json="$(OCTOPUS_NOTICE_FILE="$notice_channel" \
+        review_run_agent_sync_progress codex prompt implementation-verifier review fallback \
+        2>>"$fallback_err")"
+    if ! jq -e '.role == "implementation-verifier" and .phase == "review"' \
+        <<< "$review_json" >/dev/null 2>&1; then
+        fallback_ok=false
+    fi
+done
+unset -f run_agent_sync
+eval "$original_notice_create"
+eval "$original_log"
+if [[ "$fallback_ok" == true ]] &&
+   [[ "$(grep -c '^WARN: Context budget: compressed implementation-verifier/review$' "$fallback_err" || true)" -eq 3 ]] &&
+   [[ "$(cat "$invalid_notice")" == "invalid sentinel" ]] &&
+   [[ "$(cat "$symlink_target")" == "symlink sentinel" ]] &&
+   ! find "$TEST_TMP_DIR" -name 'octo-notice.*' -o -name '.tmp-review-sync-fallback-*' | grep -q .; then
+    test_pass
+else
+    test_fail "fallback warning contaminated JSON, was lost, or leaked resources: $(cat "$fallback_err")"
+fi
+
 test_case "retry wait stops when provider exits without terminal status"
 dead_result="$TEST_TMP_DIR/dead-result.md"
 sleep 1 &

--- a/tests/unit/test-run-observability-v10.sh
+++ b/tests/unit/test-run-observability-v10.sh
@@ -195,4 +195,37 @@ else
     test_fail "proof-disabled records diverged: $proof_disabled_result"
 fi
 
+test_case "no-jq oversize writer JSON-escapes arbitrary string fields"
+no_jq_run_id=$'run"id\\tail\nnext'
+no_jq_agent=$'codex"agent\\tail\nnext'
+no_jq_role=$'review"role\\tail\nnext'
+no_jq_phase=$'review"phase\\tail\nnext'
+no_jq_outcome=$'summarized"outcome\\tail\nnext'
+(
+    export OCTOPUS_RUN_ID="$no_jq_run_id"
+    command() {
+        if [[ "${1:-}" == "-v" && "${2:-}" == "jq" ]]; then
+            return 1
+        fi
+        builtin command "$@"
+    }
+    record_oversize_event "$no_jq_agent" 00100 00040 "$no_jq_outcome" \
+        "$no_jq_role" "$no_jq_phase" 00012
+)
+no_jq_record="$WORKSPACE_DIR/runs/$no_jq_run_id/oversize.jsonl"
+if jq -e \
+    --arg run_id "$no_jq_run_id" \
+    --arg agent "$no_jq_agent" \
+    --arg role "$no_jq_role" \
+    --arg phase "$no_jq_phase" \
+    --arg outcome "$no_jq_outcome" '
+      .run_id == $run_id and .agent == $agent and .role == $role and
+      .phase == $phase and .outcome == $outcome and
+      .budget == 12 and .original_chars == 100 and .final_chars == 40
+    ' "$no_jq_record" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "no-jq writer emitted invalid or lossy JSON: $(cat "$no_jq_record" 2>/dev/null || true)"
+fi
+
 test_summary

--- a/tests/unit/test-run-observability-v10.sh
+++ b/tests/unit/test-run-observability-v10.sh
@@ -195,6 +195,23 @@ else
     test_fail "proof-disabled records diverged: $proof_disabled_result"
 fi
 
+test_case "standalone fallback identity survives command substitutions"
+standalone_ids="$(
+    unset OCTOPUS_RUN_ID OCTOPUS_SESSION_ID CLAUDE_CODE_SESSION_ID \
+        CLAUDE_SESSION_ID CLAUDE_CODE_SESSION
+    unset -f octo_run_contract_id
+    first_standalone_id="$(octo_current_run_id)"
+    second_standalone_id="$(octo_current_run_id)"
+    printf '%s\n%s\n' "$first_standalone_id" "$second_standalone_id"
+)"
+first_standalone_id="$(printf '%s\n' "$standalone_ids" | sed -n '1p')"
+second_standalone_id="$(printf '%s\n' "$standalone_ids" | sed -n '2p')"
+if [[ -n "$first_standalone_id" && "$first_standalone_id" == "$second_standalone_id" ]]; then
+    test_pass
+else
+    test_fail "standalone fallback identity changed across command substitutions"
+fi
+
 test_case "no-jq oversize writer JSON-escapes arbitrary string fields"
 no_jq_run_id=$'run"id\\tail\nnext'
 no_jq_agent=$'codex"agent\\tail\nnext'

--- a/tests/unit/test-run-observability-v10.sh
+++ b/tests/unit/test-run-observability-v10.sh
@@ -162,4 +162,37 @@ else
     test_fail "status_rc=$cli_status_rc explain_rc=$cli_explain_rc ledger=$(<"$provider_ledger" 2>/dev/null || true)"
 fi
 
+test_case "proof-disabled compatibility records share the stable run-contract identity"
+proof_disabled_result="$(
+    unset OCTOPUS_RUN_ID OCTOPUS_SESSION_ID CLAUDE_CODE_SESSION_ID \
+        CLAUDE_SESSION_ID CLAUDE_CODE_SESSION OCTO_RUN_CONTRACT_FALLBACK_ID
+    export WORKSPACE_DIR="$TEST_TMP_DIR/proof-disabled-workspace"
+    export OCTOPUS_PROOF_PACKET=0
+    source "$PROJECT_ROOT/scripts/lib/run-contract.sh"
+    source "$PROJECT_ROOT/scripts/lib/error-tracking.sh"
+    first_id="$(octo_run_contract_id)"
+    second_id="$(octo_current_run_id)"
+    record_oversize_event codex 100 40 summarized implementation-verifier review 12
+    write_agent_status codex ok 25 10 "" 10 "$good_output" \
+        implementation-verifier verifier-seat contributed eligible
+    if [[ "$first_id" == "$second_id" ]] &&
+       [[ -s "$WORKSPACE_DIR/runs/$first_id/oversize.jsonl" ]] &&
+       [[ -s "$WORKSPACE_DIR/runs/$first_id/agents.jsonl" ]] &&
+       jq -e --arg run_id "$first_id" '
+           .run_id == $run_id and .agent == "codex" and
+           .role == "implementation-verifier" and .phase == "review" and
+           .budget == 12 and .original_chars == 100 and .final_chars == 40 and
+           (.ts | length) > 0
+       ' "$WORKSPACE_DIR/runs/$first_id/oversize.jsonl" >/dev/null 2>&1; then
+        printf 'pass\n'
+    else
+        printf 'fail:%s:%s\n' "$first_id" "$second_id"
+    fi
+)"
+if [[ "$proof_disabled_result" == pass ]]; then
+    test_pass
+else
+    test_fail "proof-disabled records diverged: $proof_disabled_result"
+fi
+
 test_summary

--- a/tests/unit/test-spawn-agent-capture-pid.sh
+++ b/tests/unit/test-spawn-agent-capture-pid.sh
@@ -16,6 +16,7 @@ eval "$(sed -n '/^spawn_agent_capture_pid() {/,/^}/p' "$PROJECT_ROOT/scripts/lib
 export WORKSPACE_DIR="$TEST_TMP_DIR"
 
 log() { printf '%s %s\n' "${1:-}" "${2:-}" >> "$TEST_TMP_DIR/log"; }
+source "$PROJECT_ROOT/scripts/lib/error-tracking.sh" >/dev/null 2>&1 || true
 
 # The wrapper does meaningful setup before it can print the provider PID.
 # Capture must wait for that PID rather than returning the wrapper PID.
@@ -30,6 +31,23 @@ if [[ "$pid" == "424242" ]]; then
     test_pass
 else
     test_fail "expected provider PID 424242, got: ${pid:-empty}"
+fi
+
+test_case "budget notice is replayed once without contaminating captured PID"
+original_log="$(declare -f log)"
+log() { printf '%s: %s\n' "$1" "$2" >&2; }
+spawn_agent() {
+    octo_notice_warn "Context budget: compressed reviewer/review"
+    printf '%s\n' 424242
+}
+capture_notice_err="$TEST_TMP_DIR/capture-notice.err"
+pid=$(spawn_agent_capture_pid codex prompt notice-task reviewer review 2>"$capture_notice_err")
+eval "$original_log"
+if [[ "$pid" == 424242 ]] &&
+   [[ "$(grep -c '^WARN: Context budget: compressed reviewer/review$' "$capture_notice_err" || true)" -eq 1 ]]; then
+    test_pass
+else
+    test_fail "PID was contaminated or notice count differed: pid='${pid:-empty}' notices='$(cat "$capture_notice_err")'"
 fi
 
 test_case "writes the provider PID to the opt-in signal handoff"

--- a/tests/unit/test-spawn-agent-capture-pid.sh
+++ b/tests/unit/test-spawn-agent-capture-pid.sh
@@ -50,12 +50,11 @@ else
     test_fail "PID was contaminated or notice count differed: pid='${pid:-empty}' notices='$(cat "$capture_notice_err")'"
 fi
 
-test_case "budget notice bypasses PID capture when notice allocation and validation fail"
+test_case "untrusted notice paths and inherited descriptor 8 cannot bypass stderr capture"
 original_log="$(declare -f log)"
-original_notice_create="$(declare -f octo_notice_channel_create)"
 log() { printf '%s: %s\n' "$1" "$2" >&2; }
-octo_notice_channel_create() { return 1; }
 spawn_agent() {
+    { printf 'descriptor bypass\n' >&8; } 2>/dev/null || true
     octo_notice_warn "Context budget: compressed reviewer/review"
     printf '%s\n' 424242
 }
@@ -67,24 +66,36 @@ chmod 644 "$invalid_notice"
 printf 'symlink sentinel\n' > "$symlink_target"
 ln -s "$symlink_target" "$symlink_notice"
 capture_fallback_err="$TEST_TMP_DIR/capture-fallback.err"
+fd8_target="$TEST_TMP_DIR/inherited-fd8"
 : > "$capture_fallback_err"
+: > "$fd8_target"
 capture_fallback_ok=true
 for notice_channel in "" "$invalid_notice" "$symlink_notice"; do
     pid="$(OCTOPUS_NOTICE_FILE="$notice_channel" \
         spawn_agent_capture_pid codex prompt notice-fallback reviewer review \
-        2>>"$capture_fallback_err")"
+        8>>"$fd8_target" 2>>"$capture_fallback_err")"
     [[ "$pid" == 424242 ]] || capture_fallback_ok=false
 done
-eval "$original_notice_create"
 eval "$original_log"
 if [[ "$capture_fallback_ok" == true ]] &&
    [[ "$(grep -c '^WARN: Context budget: compressed reviewer/review$' "$capture_fallback_err" || true)" -eq 3 ]] &&
    [[ "$(cat "$invalid_notice")" == "invalid sentinel" ]] &&
    [[ "$(cat "$symlink_target")" == "symlink sentinel" ]] &&
-   ! find "$TEST_TMP_DIR" -name 'octo-notice.*' -o -name 'octo-spawn-pid.*' | grep -q .; then
+   [[ ! -s "$fd8_target" ]] &&
+   ! find "$TEST_TMP_DIR" \( -name 'octo-notice.*' -o -name 'octo-spawn-pid.*' -o -name 'octo-spawn-stderr.*' \) | grep -q .; then
     test_pass
 else
-    test_fail "fallback warning contaminated PID, was lost, or leaked resources: pid='${pid:-empty}' notices='$(cat "$capture_fallback_err")'"
+    test_fail "captured PID or stderr was contaminated, an untrusted path changed, descriptor 8 leaked, or a temp file remained"
+fi
+
+test_case "fallback JSON quoting preserves UTF-8 and escapes controls"
+unicode_value=$'é-🐙\n\t\001'
+quoted_value="$(octo_json_quote "$unicode_value")"
+if jq -ne --arg expected "$unicode_value" --argjson actual "$quoted_value" \
+    '$actual == $expected' >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "fallback JSON encoder corrupted UTF-8 or controls: $quoted_value"
 fi
 
 test_case "writes the provider PID to the opt-in signal handoff"
@@ -109,10 +120,14 @@ spawn_agent() {
     return 1
 }
 export "OCTOPUS_SPAWN_PID_WAIT_ATTEMPTS=20"
-if pid=$(spawn_agent_capture_pid codex prompt failed-task implementer tangle 2>/dev/null); then
+failed_capture_err="$TEST_TMP_DIR/failed-capture.err"
+if pid=$(spawn_agent_capture_pid codex prompt failed-task implementer tangle 2>"$failed_capture_err"); then
     test_fail "expected failure, got wrapper/provider PID: ${pid:-empty}"
-else
+elif [[ "$(grep -c '^setup failed before provider launch$' "$failed_capture_err" || true)" -eq 1 ]] &&
+     ! find "$TEST_TMP_DIR" \( -name 'octo-spawn-pid.*' -o -name 'octo-spawn-stderr.*' \) | grep -q .; then
     test_pass
+else
+    test_fail "failed spawn stderr was altered or capture temp files remained"
 fi
 
 test_case "implementation has no wrapper PID fallback"

--- a/tests/unit/test-spawn-agent-capture-pid.sh
+++ b/tests/unit/test-spawn-agent-capture-pid.sh
@@ -50,6 +50,43 @@ else
     test_fail "PID was contaminated or notice count differed: pid='${pid:-empty}' notices='$(cat "$capture_notice_err")'"
 fi
 
+test_case "budget notice bypasses PID capture when notice allocation and validation fail"
+original_log="$(declare -f log)"
+original_notice_create="$(declare -f octo_notice_channel_create)"
+log() { printf '%s: %s\n' "$1" "$2" >&2; }
+octo_notice_channel_create() { return 1; }
+spawn_agent() {
+    octo_notice_warn "Context budget: compressed reviewer/review"
+    printf '%s\n' 424242
+}
+invalid_notice="$TEST_TMP_DIR/spawn-invalid-notice"
+symlink_notice="$TEST_TMP_DIR/spawn-symlink-notice"
+symlink_target="$TEST_TMP_DIR/spawn-symlink-target"
+printf 'invalid sentinel\n' > "$invalid_notice"
+chmod 644 "$invalid_notice"
+printf 'symlink sentinel\n' > "$symlink_target"
+ln -s "$symlink_target" "$symlink_notice"
+capture_fallback_err="$TEST_TMP_DIR/capture-fallback.err"
+: > "$capture_fallback_err"
+capture_fallback_ok=true
+for notice_channel in "" "$invalid_notice" "$symlink_notice"; do
+    pid="$(OCTOPUS_NOTICE_FILE="$notice_channel" \
+        spawn_agent_capture_pid codex prompt notice-fallback reviewer review \
+        2>>"$capture_fallback_err")"
+    [[ "$pid" == 424242 ]] || capture_fallback_ok=false
+done
+eval "$original_notice_create"
+eval "$original_log"
+if [[ "$capture_fallback_ok" == true ]] &&
+   [[ "$(grep -c '^WARN: Context budget: compressed reviewer/review$' "$capture_fallback_err" || true)" -eq 3 ]] &&
+   [[ "$(cat "$invalid_notice")" == "invalid sentinel" ]] &&
+   [[ "$(cat "$symlink_target")" == "symlink sentinel" ]] &&
+   ! find "$TEST_TMP_DIR" -name 'octo-notice.*' -o -name 'octo-spawn-pid.*' | grep -q .; then
+    test_pass
+else
+    test_fail "fallback warning contaminated PID, was lost, or leaked resources: pid='${pid:-empty}' notices='$(cat "$capture_fallback_err")'"
+fi
+
 test_case "writes the provider PID to the opt-in signal handoff"
 handoff_file="$TEST_TMP_DIR/provider-pid-handoff"
 pid=$(OCTOPUS_SPAWN_PID_HANDOFF_FD=9 \

--- a/tests/unit/test-spawn-run-contract.sh
+++ b/tests/unit/test-spawn-run-contract.sh
@@ -369,8 +369,10 @@ run_external_fixture() {
 test_case "Agent Teams prompt persistence failure terminalizes the seat"
 original_should_use_agent_teams="$(declare -f should_use_agent_teams)"
 original_write_agent_result_prompt="$(declare -f write_agent_result_prompt)"
+original_check_provider_health="$(declare -f check_provider_health)"
 should_use_agent_teams() { return 0; }
 write_agent_result_prompt() { return 1; }
+check_provider_health() { return 0; }
 saved_timeout="$TIMEOUT"
 TIMEOUT=0
 set +e
@@ -381,6 +383,7 @@ set -e
 TIMEOUT="$saved_timeout"
 eval "$original_should_use_agent_teams"
 eval "$original_write_agent_result_prompt"
+eval "$original_check_provider_health"
 native_prompt_transition="$(run_contract_latest_transition spawn-native-prompt-fail)"
 native_prompt_reason="$(jq -r --arg seat spawn-native-prompt-fail \
     'select(.seat_id == $seat and .transition == "failed") | .reason' "$ledger" | tail -n 1)"

--- a/tests/unit/test-spawn-run-contract.sh
+++ b/tests/unit/test-spawn-run-contract.sh
@@ -267,10 +267,16 @@ classify_task() { printf '%s\n' standard; }
 get_role_for_context() { printf '%s\n' reviewer; }
 match_routing_rule() { :; }
 load_agent_checkpoint() { :; }
-apply_persona() { printf '%s\n' "$2"; }
+apply_persona() { printf 'PERSONA[%s]\n%s\n' "$1" "$2"; }
 load_earned_skills() { :; }
 build_provider_context() { :; }
-enforce_context_budget() { printf '%s\n' "$1"; }
+enforce_context_budget() {
+    if [[ "${FAKE_COMPRESS_PROMPT:-false}" == true ]]; then
+        printf 'DISPATCHED role=%s phase=%s\n' "$2" "$4"
+    else
+        printf '%s\n' "$1"
+    fi
+}
 octo_prompt_byte_length() { LC_ALL=C printf '%s' "$1" | wc -c | tr -d '[:space:]'; }
 octo_dispatch_command_model() {
     printf '%s\n' "$1" | awk -v fallback="$2" '
@@ -341,6 +347,9 @@ octo_spawn_contract_finish() {
 octopus_capture_provider_output() {
     local prompt="$1" _timeout="$2" input="$3" output="$4" errors="$5"
     shift 5
+    if [[ -n "${CAPTURED_PROVIDER_PROMPT_FILE:-}" ]]; then
+        printf '%s' "$prompt" > "$CAPTURED_PROVIDER_PROMPT_FILE"
+    fi
     printf '%s' "$prompt" > "$input"
     "$@" < "$input" > "$output" 2> "$errors"
 }
@@ -403,6 +412,33 @@ if [[ "$external_success_transitions" == "planned,starting,authenticated,running
     test_pass
 else
     test_fail "supervised success contract mismatch (transitions=${external_success_transitions:-missing}, eligible=$external_success_eligible, model=${external_success_model:-missing}, reason=${external_success_reason:-none})"
+fi
+
+test_case "result prompt is exactly the enhanced and budgeted provider stdin"
+export FAKE_COMPRESS_PROMPT=true
+export CAPTURED_PROVIDER_PROMPT_FILE="$TEST_TMP_DIR/dispatched-provider-prompt"
+run_external_fixture success exact-prompt fake-api reviewer review
+unset FAKE_COMPRESS_PROMPT CAPTURED_PROVIDER_PROMPT_FILE
+prompt_result="$RESULTS_DIR/fake-api-exact-prompt.md"
+recorded_prompt="$(awk '
+    /^# Prompt: / {
+        sub(/^# Prompt: /, "")
+        print
+        in_prompt=1
+        next
+    }
+    in_prompt && /^# Started: / { exit }
+    in_prompt { print }
+' "$prompt_result")"
+dispatched_prompt="$(cat "$TEST_TMP_DIR/dispatched-provider-prompt")"
+expected_original=$'PERSONA[reviewer]\nExternal success fixture'
+if [[ "$recorded_prompt" == "$dispatched_prompt" ]] &&
+   [[ "$recorded_prompt" == "DISPATCHED role=reviewer phase=review" ]] &&
+   grep -Fqx "# Prompt metadata: original_chars=${#expected_original} final_chars=${#recorded_prompt} compression=applied" "$prompt_result" &&
+   ! grep -Fq 'External success fixture' "$prompt_result"; then
+    test_pass
+else
+    test_fail "recorded prompt did not match provider stdin (recorded='$recorded_prompt' dispatched='$dispatched_prompt')"
 fi
 
 test_case "exact background seat records canonical provider and literal model"

--- a/tests/unit/test-spawn-run-contract.sh
+++ b/tests/unit/test-spawn-run-contract.sh
@@ -272,7 +272,11 @@ load_earned_skills() { :; }
 build_provider_context() { :; }
 enforce_context_budget() {
     if [[ "${FAKE_COMPRESS_PROMPT:-false}" == true ]]; then
-        printf 'DISPATCHED role=%s phase=%s\n' "$2" "$4"
+        if [[ "${FAKE_PROMPT_MARKER:-false}" == true ]]; then
+            printf 'D\n# Started: x\n%s\n' "$4"
+        else
+            printf 'DISPATCHED role=%s phase=%s\n' "$2" "$4"
+        fi
     else
         printf '%s\n' "$1"
     fi
@@ -362,6 +366,56 @@ run_external_fixture() {
     wait "$pid" 2>/dev/null || true
 }
 
+test_case "Agent Teams prompt persistence failure terminalizes the seat"
+original_should_use_agent_teams="$(declare -f should_use_agent_teams)"
+original_write_agent_result_prompt="$(declare -f write_agent_result_prompt)"
+should_use_agent_teams() { return 0; }
+write_agent_result_prompt() { return 1; }
+saved_timeout="$TIMEOUT"
+TIMEOUT=0
+set +e
+spawn_agent claude-sonnet "Native prompt persistence fixture" native-prompt-fail reviewer review \
+    >"$TEST_TMP_DIR/native-prompt-fail.out" 2>"$TEST_TMP_DIR/native-prompt-fail.err"
+native_prompt_rc=$?
+set -e
+TIMEOUT="$saved_timeout"
+eval "$original_should_use_agent_teams"
+eval "$original_write_agent_result_prompt"
+native_prompt_transition="$(run_contract_latest_transition spawn-native-prompt-fail)"
+native_prompt_reason="$(jq -r --arg seat spawn-native-prompt-fail \
+    'select(.seat_id == $seat and .transition == "failed") | .reason' "$ledger" | tail -n 1)"
+if [[ "$native_prompt_rc" -eq 74 ]] &&
+   [[ "$native_prompt_transition" == failed ]] &&
+   [[ "$native_prompt_reason" == "Failed to persist Agent Teams dispatched prompt" ]]; then
+    test_pass
+else
+    test_fail "Agent Teams prompt-write failure remained nonterminal (rc=$native_prompt_rc transition=${native_prompt_transition:-missing} reason=${native_prompt_reason:-missing})"
+fi
+
+test_case "legacy prompt persistence failure terminalizes the seat"
+original_write_agent_result_prompt="$(declare -f write_agent_result_prompt)"
+write_agent_result_prompt() { return 1; }
+export FAKE_SCENARIO=success
+set +e
+legacy_prompt_pid="$(spawn_agent fake-api "Legacy prompt persistence fixture" legacy-prompt-fail reviewer review)"
+legacy_prompt_spawn_rc=$?
+set -e
+if [[ "$legacy_prompt_spawn_rc" -eq 0 && -n "$legacy_prompt_pid" ]]; then
+    wait "$legacy_prompt_pid" 2>/dev/null || true
+fi
+eval "$original_write_agent_result_prompt"
+unset FAKE_SCENARIO
+legacy_prompt_transition="$(run_contract_latest_transition spawn-legacy-prompt-fail)"
+legacy_prompt_reason="$(jq -r --arg seat spawn-legacy-prompt-fail \
+    'select(.seat_id == $seat and .transition == "failed") | .reason' "$ledger" | tail -n 1)"
+if [[ "$legacy_prompt_spawn_rc" -eq 0 ]] &&
+   [[ "$legacy_prompt_transition" == failed ]] &&
+   [[ "$legacy_prompt_reason" == "Failed to persist background dispatched prompt" ]]; then
+    test_pass
+else
+    test_fail "legacy prompt-write failure remained nonterminal (spawn_rc=$legacy_prompt_spawn_rc transition=${legacy_prompt_transition:-missing} reason=${legacy_prompt_reason:-missing})"
+fi
+
 claude_stub_dir="$TEST_TMP_DIR/claude-contract-bin"
 claude_argv_capture="$TEST_TMP_DIR/spawn-claude-argv"
 mkdir -p "$claude_stub_dir"
@@ -416,29 +470,40 @@ fi
 
 test_case "result prompt is exactly the enhanced and budgeted provider stdin"
 export FAKE_COMPRESS_PROMPT=true
+export FAKE_PROMPT_MARKER=true
 export CAPTURED_PROVIDER_PROMPT_FILE="$TEST_TMP_DIR/dispatched-provider-prompt"
 run_external_fixture success exact-prompt fake-api reviewer review
-unset FAKE_COMPRESS_PROMPT CAPTURED_PROVIDER_PROMPT_FILE
+unset FAKE_COMPRESS_PROMPT FAKE_PROMPT_MARKER CAPTURED_PROVIDER_PROMPT_FILE
 prompt_result="$RESULTS_DIR/fake-api-exact-prompt.md"
-recorded_prompt="$(awk '
-    /^# Prompt: / {
-        sub(/^# Prompt: /, "")
-        print
-        in_prompt=1
-        next
+prompt_frame="$(awk '
+    /^# Prompt-Format: octopus-length-v1$/ {
+        format_line=NR
+        getline
+        print format_line ":" $3
+        exit
     }
-    in_prompt && /^# Started: / { exit }
-    in_prompt { print }
 ' "$prompt_result")"
+prompt_line="${prompt_frame%%:*}"
+prompt_bytes="${prompt_frame#*:}"
+recorded_prompt="$(tail -n "+$((prompt_line + 2))" "$prompt_result" | dd bs=1 count="$prompt_bytes" 2>/dev/null)"
 dispatched_prompt="$(cat "$TEST_TMP_DIR/dispatched-provider-prompt")"
 expected_original=$'PERSONA[reviewer]\nExternal success fixture'
-if [[ "$recorded_prompt" == "$dispatched_prompt" ]] &&
-   [[ "$recorded_prompt" == "DISPATCHED role=reviewer phase=review" ]] &&
-   grep -Fqx "# Prompt metadata: original_chars=${#expected_original} final_chars=${#recorded_prompt} compression=applied" "$prompt_result" &&
-   ! grep -Fq 'External success fixture' "$prompt_result"; then
+expected_dispatched=$'D\n# Started: x\nreview'
+prompt_equal=false
+expected_equal=false
+byte_count_equal=false
+metadata_equal=false
+original_absent=false
+[[ "$recorded_prompt" == "$dispatched_prompt" ]] && prompt_equal=true
+[[ "$recorded_prompt" == "$expected_dispatched" ]] && expected_equal=true
+[[ "$(LC_ALL=C printf '%s' "$recorded_prompt" | wc -c | tr -d '[:space:]')" == "$prompt_bytes" ]] && byte_count_equal=true
+grep -Fqx "# Prompt metadata: original_chars=${#expected_original} final_chars=${#recorded_prompt} compression=applied" "$prompt_result" && metadata_equal=true
+! grep -Fq 'External success fixture' "$prompt_result" && original_absent=true
+if [[ "$prompt_equal" == true && "$expected_equal" == true && "$byte_count_equal" == true &&
+      "$metadata_equal" == true && "$original_absent" == true ]]; then
     test_pass
 else
-    test_fail "recorded prompt did not match provider stdin (recorded='$recorded_prompt' dispatched='$dispatched_prompt')"
+    test_fail "prompt frame mismatch (provider=$prompt_equal expected=$expected_equal bytes=$byte_count_equal metadata=$metadata_equal redaction=$original_absent)"
 fi
 
 test_case "exact background seat records canonical provider and literal model"

--- a/tests/unit/test-tangle-retry-feedback.sh
+++ b/tests/unit/test-tangle-retry-feedback.sh
@@ -165,6 +165,20 @@ else
     test_fail "length-framed output extraction used a prompt-local heading"
 fi
 
+test_case "length-framed output rejects an oversized prompt byte count"
+oversized_frame="$TEST_TMP_DIR/framed-oversized.md"
+printf '# Agent: codex\n# Prompt-Format: octopus-length-v1\n# Prompt-Bytes: 999999\nshort prompt\n' \
+    > "$oversized_frame"
+set +e
+oversized_output="$(tangle_result_output_excerpt "$oversized_frame")"
+oversized_rc=$?
+set -e
+if [[ "$oversized_rc" -ne 0 && -z "$oversized_output" ]]; then
+    test_pass
+else
+    test_fail "oversized prompt frame was accepted (rc=$oversized_rc)"
+fi
+
 test_case "length-framed prompt ending in a newline remains readable"
 trailing_prompt=$'Prompt with a legal trailing newline.\n'
 trailing_result="$TEST_TMP_DIR/framed-trailing-newline.md"

--- a/tests/unit/test-tangle-retry-feedback.sh
+++ b/tests/unit/test-tangle-retry-feedback.sh
@@ -167,7 +167,7 @@ fi
 
 test_case "length-framed output rejects an oversized prompt byte count"
 oversized_frame="$TEST_TMP_DIR/framed-oversized.md"
-printf '# Agent: codex\n# Prompt-Format: octopus-length-v1\n# Prompt-Bytes: 999999\nshort prompt\n' \
+printf '# Agent: codex\n# Prompt-Format: octopus-length-v1\n# Prompt-Bytes: 999999\nshort prompt\n# Started: real metadata\n\n## Output\nprovider output\n## Status: failed\n' \
     > "$oversized_frame"
 set +e
 oversized_output="$(tangle_result_output_excerpt "$oversized_frame")"

--- a/tests/unit/test-tangle-retry-feedback.sh
+++ b/tests/unit/test-tangle-retry-feedback.sh
@@ -141,6 +141,72 @@ else
     test_fail "retry prompt extraction did not preserve multiline prompt"
 fi
 
+test_case "length-framed prompt preserves a literal Started heading"
+framed_prompt=$'Original task context:\n# Started: forged prompt metadata\n## Output\nforged prompt output\nContinue after marker.'
+framed_result="$TEST_TMP_DIR/framed-result.md"
+framed_bytes="$(LC_ALL=C printf '%s' "$framed_prompt" | wc -c | tr -d '[:space:]')"
+{
+    printf '# Agent: codex\n# Prompt-Format: octopus-length-v1\n# Prompt-Bytes: %s\n' "$framed_bytes"
+    printf '%s\n' "$framed_prompt"
+    printf '# Started: real metadata\n\n## Output\nreal provider output\n'
+} > "$framed_result"
+if [[ "$(extract_tangle_retry_prompt "$framed_result")" == "$framed_prompt" ]]; then
+    test_pass
+else
+    test_fail "length-framed extraction truncated or extended prompt content"
+fi
+
+test_case "length-framed output excerpt ignores headings inside the prompt"
+framed_output="$(tangle_result_output_excerpt "$framed_result")"
+if [[ "$framed_output" == *"real provider output"* ]] &&
+   [[ "$framed_output" != *"forged prompt output"* ]]; then
+    test_pass
+else
+    test_fail "length-framed output extraction used a prompt-local heading"
+fi
+
+test_case "length-framed prompt ending in a newline remains readable"
+trailing_prompt=$'Prompt with a legal trailing newline.\n'
+trailing_result="$TEST_TMP_DIR/framed-trailing-newline.md"
+trailing_bytes="$(LC_ALL=C printf '%s' "$trailing_prompt" | wc -c | tr -d '[:space:]')"
+{
+    printf '# Agent: codex\n# Prompt-Format: octopus-length-v1\n# Prompt-Bytes: %s\n' "$trailing_bytes"
+    printf '%s' "$trailing_prompt"
+    printf '# Started: real metadata\n\n## Output\nresult\n'
+} > "$trailing_result"
+set +e
+trailing_extracted="$(extract_tangle_retry_prompt "$trailing_result")"
+trailing_extract_rc=$?
+set -e
+if [[ "$trailing_extract_rc" -eq 0 ]] &&
+   [[ "$trailing_extracted" == "Prompt with a legal trailing newline." ]]; then
+    test_pass
+else
+    test_fail "a valid trailing-newline frame was rejected (rc=$trailing_extract_rc)"
+fi
+
+test_case "legacy prompt content that resembles a length frame stays legacy-readable"
+legacy_collision="$TEST_TMP_DIR/legacy-frame-collision.md"
+cat > "$legacy_collision" <<'EOF'
+# Agent: codex
+# Prompt: Original task context:
+# Prompt-Format: octopus-length-v1
+# Prompt-Bytes: 1
+Keep this legacy prompt intact.
+# Started: real metadata
+
+## Output
+partial
+EOF
+legacy_collision_prompt="$(extract_tangle_retry_prompt "$legacy_collision")"
+if [[ "$legacy_collision_prompt" == *"# Prompt-Format: octopus-length-v1"* ]] &&
+   [[ "$legacy_collision_prompt" == *"# Prompt-Bytes: 1"* ]] &&
+   [[ "$legacy_collision_prompt" == *"Keep this legacy prompt intact."* ]]; then
+    test_pass
+else
+    test_fail "legacy prompt was misclassified as a length-framed artifact"
+fi
+
 test_case "retry artifacts without prompt headers fall back to previous artifact context"
 retry_prompt=$(extract_tangle_retry_prompt "$RETRY_RESULT")
 if [[ "$retry_prompt" == *"Implement the missing bounded POST route."* ]] &&    [[ "$retry_prompt" == *"Preserve existing GET compatibility."* ]]; then


### PR DESCRIPTION
Closes #1005.

The result artifact now records the exact prompt dispatched after context-budget enforcement. It also keeps explicit original/final character counts and compression metadata, emits a visible warning when compression occurs, and adds run, role, phase, and budget fields to oversize events.

Prompt content is length-framed so Markdown headings inside the prompt cannot be mistaken for result-file boundaries. Review capture keeps provider stderr separate from stdout so diagnostics do not corrupt the recorded response.

Verification:

- `make ci-changed` — passed (full local unit and integration matrix)
- Focused prompt framing, oversize, capture, retry, and observability suites — passed
- Fable review completed before the temporary review suspension — spec and quality pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prompt handling to preserve exact prompts, including trailing newlines and headings.
  - Fixed retry output extraction for prompts containing headings or special formatting.
  - Improved validation of context-budget limits, including decimal values and truncation boundaries.
  - Preserved provider error output and exit statuses more reliably.
  - Improved security and cleanup for temporary review and provider-output files.

- **Observability**
  - Added prompt size and compression details to result records.
  - Improved oversize-event attribution with stable run, role, phase, and budget information.
  - Kept budget warnings visible without contaminating captured review data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->