### PR TITLE
fix(review): fail closed on incomplete diff snapshots

### DIFF
--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -1205,6 +1205,29 @@ review_local_synthesis_json() {
     fi
 }
 
+# review_collect_scratchpad_dir: choose the process scratchpad without placing
+# temporary collection files in the repository or its Git metadata.
+review_collect_scratchpad_dir() {
+    local repo_root="$1"
+    local scratch_dir="${OCTOPUS_TMP_DIR:-${TMPDIR:-/tmp}}"
+    local repo_root_physical=""
+    local scratch_dir_physical=""
+
+    repo_root_physical=$(cd "$repo_root" 2>/dev/null && pwd -P) || repo_root_physical=""
+    scratch_dir_physical=$(cd "$scratch_dir" 2>/dev/null && pwd -P) || scratch_dir_physical=""
+    if [[ -n "$repo_root_physical" && -n "$scratch_dir_physical" ]]; then
+        case "$scratch_dir_physical" in
+            "$repo_root_physical"|"$repo_root_physical"/*) scratch_dir="/tmp" ;;
+        esac
+    fi
+    printf '%s\n' "${scratch_dir%/}"
+}
+
+review_collect_path_list_cleanup() {
+    local path_list="$1"
+    [[ -z "$path_list" ]] || rm -f "$path_list" 2>/dev/null || true
+}
+
 # review_collect_no_index_file_diff: normalize git diff --no-index so rc=1
 # means "differences found" while real Git failures (>1) remain errors.
 review_collect_no_index_file_diff() {
@@ -1223,14 +1246,14 @@ review_collect_no_index_file_diff() {
 }
 
 # review_collect_untracked_diff: collects untracked, non-ignored files as unified diffs.
-review_collect_untracked_diff() {
+review_collect_untracked_diff() (
     local exclude_path="${1:-}"
     local diff_content=""
     local path=""
     local file_diff=""
     local repo_root=""
     local path_list=""
-    local git_dir=""
+    local scratch_dir=""
     local rc=0
     local -a ls_args=(--full-name --others --exclude-standard -z -- ":(top)")
 
@@ -1243,19 +1266,15 @@ review_collect_untracked_diff() {
     if [[ -n "$exclude_path" ]]; then
         ls_args+=(":(top,exclude,literal)${exclude_path}")
     fi
-    if git_dir=$(git -C "$repo_root" rev-parse --git-dir 2>/dev/null); then
-        :
-    else
-        rc=$?
-        return "$rc"
-    fi
-    [[ "$git_dir" == /* ]] || git_dir="$repo_root/$git_dir"
-    path_list=$(mktemp "${git_dir%/}/octopus-review-untracked.XXXXXX") || return 1
+    scratch_dir=$(review_collect_scratchpad_dir "$repo_root") || return 1
+    path_list=$(mktemp "${scratch_dir}/octopus-review-untracked.XXXXXX") || return 1
+    trap 'review_collect_path_list_cleanup "$path_list"' EXIT
+    trap 'review_collect_path_list_cleanup "$path_list"; exit 130' INT
+    trap 'review_collect_path_list_cleanup "$path_list"; exit 143' TERM
     if git -C "$repo_root" ls-files "${ls_args[@]}" > "$path_list" 2>/dev/null; then
         :
     else
         rc=$?
-        rm -f "$path_list" 2>/dev/null || true
         return "$rc"
     fi
     while IFS= read -r -d '' path; do
@@ -1263,7 +1282,6 @@ review_collect_untracked_diff() {
             :
         else
             rc=$?
-            rm -f "$path_list" 2>/dev/null || true
             return "$rc"
         fi
         if [[ -n "$file_diff" ]]; then
@@ -1271,9 +1289,8 @@ review_collect_untracked_diff() {
             diff_content+="$file_diff"
         fi
     done < "$path_list"
-    rm -f "$path_list" 2>/dev/null || true
     printf '%s' "$diff_content"
-}
+)
 
 # review_collect_working_tree_diff: collects unstaged tracked changes plus untracked files.
 review_collect_working_tree_diff() {
@@ -1303,14 +1320,14 @@ review_collect_working_tree_diff() {
 # review_collect_unborn_worktree_diff: collects the effective worktree of a repository
 # with no commits yet. Every tracked or untracked non-ignored file is an addition relative
 # to the empty repository, and current worktree content wins over transient index state.
-review_collect_unborn_worktree_diff() {
+review_collect_unborn_worktree_diff() (
     local exclude_path="${1:-}"
     local diff_content=""
     local path=""
     local file_diff=""
     local repo_root=""
     local path_list=""
-    local git_dir=""
+    local scratch_dir=""
     local rc=0
     local -a ls_args=(--full-name --cached --others --exclude-standard -z -- ":(top)")
 
@@ -1323,19 +1340,15 @@ review_collect_unborn_worktree_diff() {
     if [[ -n "$exclude_path" ]]; then
         ls_args+=(":(top,exclude,literal)${exclude_path}")
     fi
-    if git_dir=$(git -C "$repo_root" rev-parse --git-dir 2>/dev/null); then
-        :
-    else
-        rc=$?
-        return "$rc"
-    fi
-    [[ "$git_dir" == /* ]] || git_dir="$repo_root/$git_dir"
-    path_list=$(mktemp "${git_dir%/}/octopus-review-unborn.XXXXXX") || return 1
+    scratch_dir=$(review_collect_scratchpad_dir "$repo_root") || return 1
+    path_list=$(mktemp "${scratch_dir}/octopus-review-unborn.XXXXXX") || return 1
+    trap 'review_collect_path_list_cleanup "$path_list"' EXIT
+    trap 'review_collect_path_list_cleanup "$path_list"; exit 130' INT
+    trap 'review_collect_path_list_cleanup "$path_list"; exit 143' TERM
     if git -C "$repo_root" ls-files "${ls_args[@]}" > "$path_list" 2>/dev/null; then
         :
     else
         rc=$?
-        rm -f "$path_list" 2>/dev/null || true
         return "$rc"
     fi
     while IFS= read -r -d '' path; do
@@ -1344,7 +1357,6 @@ review_collect_unborn_worktree_diff() {
             :
         else
             rc=$?
-            rm -f "$path_list" 2>/dev/null || true
             return "$rc"
         fi
         if [[ -n "$file_diff" ]]; then
@@ -1352,9 +1364,8 @@ review_collect_unborn_worktree_diff() {
             diff_content+="$file_diff"
         fi
     done < "$path_list"
-    rm -f "$path_list" 2>/dev/null || true
     printf '%s' "$diff_content"
-}
+)
 
 # review_collect_all_changes_diff: collects the effective tracked worktree against HEAD
 # plus untracked files. Unlike working-tree, this includes staged-only changes too.
@@ -1364,6 +1375,8 @@ review_collect_all_changes_diff() {
     local diff_content=""
     local untracked_content=""
     local rc=0
+    local head_rc=0
+    local all_refs=""
 
     if git rev-parse --verify HEAD >/dev/null 2>&1; then
         if [[ -n "$exclude_path" ]]; then
@@ -1392,6 +1405,17 @@ review_collect_all_changes_diff() {
             diff_content+="$untracked_content"
         fi
     else
+        head_rc=$?
+        if ! git symbolic-ref -q HEAD >/dev/null 2>&1; then
+            return "$head_rc"
+        fi
+        if ! all_refs=$(git for-each-ref --format='%(refname)' 2>/dev/null); then
+            return "$head_rc"
+        fi
+        # An unborn repository has no refs at all. A symbolic HEAD with a
+        # missing target in a repository that already has refs is corruption,
+        # not a reason to fall back to a no-index diff.
+        [[ -z "$all_refs" ]] || return "$head_rc"
         if diff_content=$(review_collect_unborn_worktree_diff "$exclude_path"); then
             :
         else

--- a/scripts/lib/review.sh
+++ b/scripts/lib/review.sh
@@ -1205,6 +1205,23 @@ review_local_synthesis_json() {
     fi
 }
 
+# review_collect_no_index_file_diff: normalize git diff --no-index so rc=1
+# means "differences found" while real Git failures (>1) remain errors.
+review_collect_no_index_file_diff() {
+    local repo_root="$1"
+    local path="$2"
+    local file_diff=""
+    local rc=0
+
+    if file_diff=$(git -C "$repo_root" diff --no-index -- /dev/null "$path" 2>/dev/null); then
+        :
+    else
+        rc=$?
+        [[ "$rc" -eq 1 ]] || return "$rc"
+    fi
+    printf '%s' "$file_diff"
+}
+
 # review_collect_untracked_diff: collects untracked, non-ignored files as unified diffs.
 review_collect_untracked_diff() {
     local exclude_path="${1:-}"
@@ -1212,19 +1229,49 @@ review_collect_untracked_diff() {
     local path=""
     local file_diff=""
     local repo_root=""
+    local path_list=""
+    local git_dir=""
+    local rc=0
     local -a ls_args=(--full-name --others --exclude-standard -z -- ":(top)")
-    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-    [[ -n "$repo_root" ]] || return 0
+
+    if repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+        :
+    else
+        rc=$?
+        return "$rc"
+    fi
     if [[ -n "$exclude_path" ]]; then
         ls_args+=(":(top,exclude,literal)${exclude_path}")
     fi
+    if git_dir=$(git -C "$repo_root" rev-parse --git-dir 2>/dev/null); then
+        :
+    else
+        rc=$?
+        return "$rc"
+    fi
+    [[ "$git_dir" == /* ]] || git_dir="$repo_root/$git_dir"
+    path_list=$(mktemp "${git_dir%/}/octopus-review-untracked.XXXXXX") || return 1
+    if git -C "$repo_root" ls-files "${ls_args[@]}" > "$path_list" 2>/dev/null; then
+        :
+    else
+        rc=$?
+        rm -f "$path_list" 2>/dev/null || true
+        return "$rc"
+    fi
     while IFS= read -r -d '' path; do
-        file_diff=$(git -C "$repo_root" diff --no-index -- /dev/null "$path" 2>/dev/null || true)
+        if file_diff=$(review_collect_no_index_file_diff "$repo_root" "$path"); then
+            :
+        else
+            rc=$?
+            rm -f "$path_list" 2>/dev/null || true
+            return "$rc"
+        fi
         if [[ -n "$file_diff" ]]; then
             [[ -n "$diff_content" ]] && diff_content+=$'\n'
             diff_content+="$file_diff"
         fi
-    done < <(git -C "$repo_root" ls-files "${ls_args[@]}" 2>/dev/null)
+    done < "$path_list"
+    rm -f "$path_list" 2>/dev/null || true
     printf '%s' "$diff_content"
 }
 
@@ -1232,8 +1279,20 @@ review_collect_untracked_diff() {
 review_collect_working_tree_diff() {
     local diff_content=""
     local untracked_content=""
-    diff_content=$(git diff 2>/dev/null || true)
-    untracked_content=$(review_collect_untracked_diff)
+    local rc=0
+
+    if diff_content=$(git diff 2>/dev/null); then
+        :
+    else
+        rc=$?
+        return "$rc"
+    fi
+    if untracked_content=$(review_collect_untracked_diff); then
+        :
+    else
+        rc=$?
+        return "$rc"
+    fi
     if [[ -n "$untracked_content" ]]; then
         [[ -n "$diff_content" ]] && diff_content+=$'\n'
         diff_content+="$untracked_content"
@@ -1250,20 +1309,50 @@ review_collect_unborn_worktree_diff() {
     local path=""
     local file_diff=""
     local repo_root=""
+    local path_list=""
+    local git_dir=""
+    local rc=0
     local -a ls_args=(--full-name --cached --others --exclude-standard -z -- ":(top)")
-    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-    [[ -n "$repo_root" ]] || return 0
+
+    if repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+        :
+    else
+        rc=$?
+        return "$rc"
+    fi
     if [[ -n "$exclude_path" ]]; then
         ls_args+=(":(top,exclude,literal)${exclude_path}")
     fi
+    if git_dir=$(git -C "$repo_root" rev-parse --git-dir 2>/dev/null); then
+        :
+    else
+        rc=$?
+        return "$rc"
+    fi
+    [[ "$git_dir" == /* ]] || git_dir="$repo_root/$git_dir"
+    path_list=$(mktemp "${git_dir%/}/octopus-review-unborn.XXXXXX") || return 1
+    if git -C "$repo_root" ls-files "${ls_args[@]}" > "$path_list" 2>/dev/null; then
+        :
+    else
+        rc=$?
+        rm -f "$path_list" 2>/dev/null || true
+        return "$rc"
+    fi
     while IFS= read -r -d '' path; do
         [[ -f "$repo_root/$path" || -L "$repo_root/$path" ]] || continue
-        file_diff=$(git -C "$repo_root" diff --no-index -- /dev/null "$path" 2>/dev/null || true)
+        if file_diff=$(review_collect_no_index_file_diff "$repo_root" "$path"); then
+            :
+        else
+            rc=$?
+            rm -f "$path_list" 2>/dev/null || true
+            return "$rc"
+        fi
         if [[ -n "$file_diff" ]]; then
             [[ -n "$diff_content" ]] && diff_content+=$'\n'
             diff_content+="$file_diff"
         fi
-    done < <(git -C "$repo_root" ls-files "${ls_args[@]}" 2>/dev/null)
+    done < "$path_list"
+    rm -f "$path_list" 2>/dev/null || true
     printf '%s' "$diff_content"
 }
 
@@ -1274,19 +1363,41 @@ review_collect_all_changes_diff() {
     local exclude_path="${1:-}"
     local diff_content=""
     local untracked_content=""
+    local rc=0
+
     if git rev-parse --verify HEAD >/dev/null 2>&1; then
         if [[ -n "$exclude_path" ]]; then
-            diff_content=$(git diff HEAD -- ":(top)" ":(top,exclude,literal)${exclude_path}" 2>/dev/null || true)
+            if diff_content=$(git diff HEAD -- ":(top)" ":(top,exclude,literal)${exclude_path}" 2>/dev/null); then
+                :
+            else
+                rc=$?
+                return "$rc"
+            fi
         else
-            diff_content=$(git diff HEAD 2>/dev/null || true)
+            if diff_content=$(git diff HEAD 2>/dev/null); then
+                :
+            else
+                rc=$?
+                return "$rc"
+            fi
         fi
-        untracked_content=$(review_collect_untracked_diff "$exclude_path")
+        if untracked_content=$(review_collect_untracked_diff "$exclude_path"); then
+            :
+        else
+            rc=$?
+            return "$rc"
+        fi
         if [[ -n "$untracked_content" ]]; then
             [[ -n "$diff_content" ]] && diff_content+=$'\n'
             diff_content+="$untracked_content"
         fi
     else
-        diff_content=$(review_collect_unborn_worktree_diff "$exclude_path")
+        if diff_content=$(review_collect_unborn_worktree_diff "$exclude_path"); then
+            :
+        else
+            rc=$?
+            return "$rc"
+        fi
     fi
     printf '%s' "$diff_content"
 }
@@ -1298,17 +1409,26 @@ review_collect_diff() {
     local target="$1"
     local exclude_path="${2:-}"
     local diff_content=""
+    local rc=0
 
     case "$target" in
-        staged)       diff_content=$(git diff --cached 2>/dev/null || true) ;;
-        working-tree) diff_content=$(review_collect_working_tree_diff) ;;
-        all-changes)  diff_content=$(review_collect_all_changes_diff "$exclude_path") ;;
-        [0-9]*)       diff_content=$(gh pr diff "$target" 2>/dev/null || true) ;;
+        staged)
+            if diff_content=$(git diff --cached 2>/dev/null); then :; else rc=$?; return "$rc"; fi
+            ;;
+        working-tree)
+            if diff_content=$(review_collect_working_tree_diff); then :; else rc=$?; return "$rc"; fi
+            ;;
+        all-changes)
+            if diff_content=$(review_collect_all_changes_diff "$exclude_path"); then :; else rc=$?; return "$rc"; fi
+            ;;
+        [0-9]*)
+            if diff_content=$(gh pr diff "$target" 2>/dev/null); then :; else rc=$?; return "$rc"; fi
+            ;;
         *)
             if [[ -f "$target" ]] && [[ -r "$target" ]] && head -n 20 "$target" 2>/dev/null | grep -Ec "^(diff --git|--- |\+\+\+ |@@ )" >/dev/null; then
-                diff_content=$(cat "$target" 2>/dev/null || true)
+                if diff_content=$(cat "$target" 2>/dev/null); then :; else rc=$?; return "$rc"; fi
             else
-                diff_content=$(git diff HEAD -- "$target" 2>/dev/null || true)
+                if diff_content=$(git diff HEAD -- "$target" 2>/dev/null); then :; else rc=$?; return "$rc"; fi
             fi
             ;;
     esac

--- a/scripts/lib/workflows.sh
+++ b/scripts/lib/workflows.sh
@@ -3049,17 +3049,27 @@ tangle_build_review_diff_snapshot() {
         trap 'rm -f "$snapshot_tmp" 2>/dev/null || true' EXIT INT TERM
 
         if ! review_collect_diff all-changes "$exclude_path" > "$snapshot_tmp"; then
+            log ERROR "unable to collect complete all-changes diff for tangle review snapshot"
             return 1
         fi
         if [[ -n "$exclude_path" ]]; then
-            status_text=$(git status --porcelain --untracked-files=all -- ":(top)" ":(top,exclude,literal)${exclude_path}" 2>/dev/null || true)
+            if ! status_text=$(git status --porcelain --untracked-files=all -- ":(top)" ":(top,exclude,literal)${exclude_path}" 2>/dev/null); then
+                log ERROR "unable to inspect git status for tangle review snapshot"
+                return 1
+            fi
         else
-            status_text=$(git status --porcelain --untracked-files=all 2>/dev/null || true)
+            if ! status_text=$(git status --porcelain --untracked-files=all 2>/dev/null); then
+                log ERROR "unable to inspect git status for tangle review snapshot"
+                return 1
+            fi
         fi
         if [[ ! -s "$snapshot_tmp" && -n "$status_text" ]]; then
             # One bounded regeneration handles transient index/worktree races. If the
             # invariant still fails, stop instead of asking reviewers to inspect nothing.
-            review_collect_diff all-changes "$exclude_path" > "$snapshot_tmp" 2>/dev/null || true
+            if ! review_collect_diff all-changes "$exclude_path" > "$snapshot_tmp" 2>/dev/null; then
+                log ERROR "unable to regenerate complete all-changes diff for tangle review snapshot"
+                return 1
+            fi
             if [[ ! -s "$snapshot_tmp" ]]; then
                 log ERROR "tangle review snapshot invariant failed: git status is dirty but all-changes diff is empty"
                 return 1
@@ -3083,7 +3093,7 @@ tangle_build_review_diff_snapshot() {
         fi
 
         mv -f "$snapshot_tmp" "$snapshot_path" || return 1
-        if ! chmod 0444 "$snapshot_path" 2>/dev/null; then
+        if ! chmod 0400 "$snapshot_path" 2>/dev/null; then
             rm -f "$snapshot_path" 2>/dev/null || true
             log ERROR "unable to make tangle review snapshot immutable"
             return 1

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -262,11 +262,29 @@ else
     snapshot=""
     snapshot_mode=""
 fi
-if [[ -f "$snapshot" ]] && [[ ! -w "$snapshot" ]] && [[ "$snapshot_mode" == "400" ]] &&
+if [[ -f "$snapshot" ]] && [[ "$snapshot_mode" == "400" ]] &&
    grep -q 'a.txt' "$snapshot" && grep -q 'b.txt' "$snapshot" && grep -q 'c.txt' "$snapshot"; then
     test_pass
 else
     test_fail "review snapshot must be owner-only and cover staged, unstaged, and untracked changes"
+fi
+
+test_case "review collection rejects a missing symbolic HEAD in a non-empty repository"
+workspace=$(make_test_dir workspace-missing-symbolic-head)
+git -C "$workspace" init -q
+git -C "$workspace" config user.email test@example.com
+git -C "$workspace" config user.name "Octopus Test"
+printf 'committed\n' > "$workspace/committed.txt"
+git -C "$workspace" add committed.txt
+git -C "$workspace" commit -q -m init
+printf 'ref: refs/heads/missing\n' > "$workspace/.git/HEAD"
+if (
+    cd "$workspace" || exit 1
+    ! review_collect_all_changes_diff >/dev/null
+); then
+    test_pass
+else
+    test_fail "a symbolic HEAD with a missing target must not be treated as an unborn repository"
 fi
 
 test_case "untracked collection propagates git ls-files failures"

--- a/tests/unit/test-tangle-context-review-loop.sh
+++ b/tests/unit/test-tangle-context-review-loop.sh
@@ -256,12 +256,113 @@ git -C "$workspace" add a.txt
 printf 'unstaged-b\n' > "$workspace/b.txt"
 printf 'untracked-c\n' > "$workspace/c.txt"
 snapshot_results=$(make_test_dir snapshot-results)
-if snapshot=$(cd "$workspace" && RESULTS_DIR="$snapshot_results" tangle_build_review_diff_snapshot "test" "initial") &&
-   [[ -f "$snapshot" ]] && [[ ! -w "$snapshot" ]] &&
+if snapshot=$(cd "$workspace" && RESULTS_DIR="$snapshot_results" tangle_build_review_diff_snapshot "test" "initial"); then
+    snapshot_mode=$(stat -c '%a' "$snapshot" 2>/dev/null || stat -f '%Lp' "$snapshot" 2>/dev/null || true)
+else
+    snapshot=""
+    snapshot_mode=""
+fi
+if [[ -f "$snapshot" ]] && [[ ! -w "$snapshot" ]] && [[ "$snapshot_mode" == "400" ]] &&
    grep -q 'a.txt' "$snapshot" && grep -q 'b.txt' "$snapshot" && grep -q 'c.txt' "$snapshot"; then
     test_pass
 else
-    test_fail "review snapshot must immutably cover staged, unstaged, and untracked changes"
+    test_fail "review snapshot must be owner-only and cover staged, unstaged, and untracked changes"
+fi
+
+test_case "untracked collection propagates git ls-files failures"
+workspace=$(make_test_dir workspace-ls-files-failure)
+git -C "$workspace" init -q
+printf 'untracked\n' > "$workspace/untracked.txt"
+if (
+    cd "$workspace" || exit 1
+    git() {
+        if [[ "${1:-}" == "-C" && "${3:-}" == "ls-files" ]]; then
+            return 2
+        fi
+        command git "$@"
+    }
+    ! review_collect_untracked_diff >/dev/null
+); then
+    test_pass
+else
+    test_fail "untracked collection swallowed a git ls-files failure"
+fi
+
+test_case "repo-local TMPDIR does not contaminate review collection"
+workspace=$(make_test_dir workspace-local-tmpdir)
+git -C "$workspace" init -q
+git -C "$workspace" config user.email test@example.com
+git -C "$workspace" config user.name "Octopus Test"
+printf 'base\n' > "$workspace/tracked.txt"
+git -C "$workspace" add tracked.txt
+git -C "$workspace" commit -q -m init
+printf 'untracked\n' > "$workspace/untracked.txt"
+mkdir -p "$workspace/tmp"
+if collected=$(cd "$workspace" && TMPDIR="$workspace/tmp" review_collect_all_changes_diff) &&
+   grep -q 'untracked.txt' <<< "$collected" &&
+   ! grep -q 'octopus-review-untracked' <<< "$collected"; then
+    test_pass
+else
+    test_fail "review collection scratch files leaked into the worktree diff"
+fi
+
+test_case "review snapshot rejects an initial partial diff when collection errors"
+workspace=$(make_test_dir workspace-partial-initial)
+git -C "$workspace" init -q
+git -C "$workspace" config user.email test@example.com
+git -C "$workspace" config user.name "Octopus Test"
+printf 'base\n' > "$workspace/tracked.txt"
+git -C "$workspace" add tracked.txt
+git -C "$workspace" commit -q -m init
+printf 'changed\n' > "$workspace/tracked.txt"
+partial_results=$(make_test_dir partial-initial-results)
+if (
+    cd "$workspace" || exit 1
+    git() {
+        if [[ "${1:-}" == "diff" && "${2:-}" == "HEAD" ]]; then
+            printf '%s\n' 'diff --git a/tracked.txt b/tracked.txt' '@@ -1 +1 @@' '-base' '+partial'
+            return 2
+        fi
+        command git "$@"
+    }
+    ! RESULTS_DIR="$partial_results" tangle_build_review_diff_snapshot test partial-initial >/dev/null 2>&1
+) && ! find "$partial_results" -type f -name 'tangle-review-input-*.diff' -print -quit | grep -q .; then
+    test_pass
+else
+    test_fail "initial snapshot collection must reject partial diff output from a failing git command"
+fi
+
+test_case "review snapshot rejects partial output from the bounded regeneration"
+workspace=$(make_test_dir workspace-partial-retry)
+git -C "$workspace" init -q
+git -C "$workspace" config user.email test@example.com
+git -C "$workspace" config user.name "Octopus Test"
+printf 'base\n' > "$workspace/tracked.txt"
+git -C "$workspace" add tracked.txt
+git -C "$workspace" commit -q -m init
+printf 'changed\n' > "$workspace/tracked.txt"
+retry_results=$(make_test_dir partial-retry-results)
+retry_count="$retry_results/collect-count"
+printf '0\n' > "$retry_count"
+if (
+    cd "$workspace" || exit 1
+    review_collect_diff() {
+        local calls
+        calls=$(<"$retry_count")
+        calls=$((calls + 1))
+        printf '%s\n' "$calls" > "$retry_count"
+        if [[ "$calls" -eq 1 ]]; then
+            return 0
+        fi
+        printf '%s\n' 'diff --git a/tracked.txt b/tracked.txt' '@@ -1 +1 @@' '-base' '+partial'
+        return 2
+    }
+    ! RESULTS_DIR="$retry_results" tangle_build_review_diff_snapshot test partial-retry >/dev/null 2>&1
+) && [[ "$(<"$retry_count")" -eq 2 ]] &&
+   ! find "$retry_results" -type f -name 'tangle-review-input-*.diff' -print -quit | grep -q .; then
+    test_pass
+else
+    test_fail "snapshot regeneration must reject partial diff output when the retry command fails"
 fi
 
 test_case "repository-local results do not contaminate review snapshots"


### PR DESCRIPTION
## Summary

- make contextual-review diff collection fail closed when Git or helper collection fails
- preserve `git diff --no-index` exit code 1 as the normal differences-found case while propagating real errors
- keep NUL-safe untracked/unborn enumeration without allowing scratch files to contaminate the worktree diff
- reject partial initial or retry snapshots and fail closed when `git status` cannot be inspected
- restrict persisted review snapshots to owner-only mode `0400`

## Why

Follow-up hardening after #1002. A failed diff command could previously be normalized to success by `|| true`, allowing a partial or empty review snapshot to be accepted. This makes the review input integrity invariant explicit: incomplete collection is an error, not an empty diff.

## Tests

- `./tests/unit/test-tangle-context-review-loop.sh` — 99/99
- `./tests/unit/test-review-run.sh` — 43/43
- `./tests/unit/test-command-staged-review.sh` — 9/9
- `./tests/unit/test-review-aggregation-robustness.sh`
- `./tests/unit/test-review-round1-spawn-failure.sh`
- `./tests/unit/test-cross-model-review.sh`
- `./tests/unit/test-contextual-review-fleet-cli.sh`
- `LC_ALL=C.UTF-8 ./scripts/build-codex-skills.sh --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Git and review snapshot errors are now surfaced instead of being silently ignored.
  - Review snapshots reject incomplete or partial diff data, including failures during retry attempts.
  - Temporary repository artifacts are excluded from collected review changes and cleaned up reliably.
  - Review snapshots are now restricted to owner-only access.
  - Repositories without an initial commit are handled more reliably when collecting review changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->