### PR TITLE
fix(council): catch summary-paraphrase & prior-phase-deference blind seats (+ filename-dot access-failure miss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@
   proceeding") instead of reading the artifact. Both are gated on the response
   citing zero real `path.ext:line` locations, so a genuinely grounded review is
   never flagged; a bare "based on the provided summary" (as a plan/design review
-  legitimately uses) is deliberately not a trigger. Also fixes the existing
+  legitimately uses) is deliberately not a trigger, and code terms are matched as
+  whole tokens so a substring like `api` in "capital" is not read as a code
+  claim. Also fixes the existing
   first-person access-failure check missing an explicit admission whose sentence
   contained a dotted filename (e.g. `Foo.test.tsx`), whose periods split the
   sentence and severed the first-person clause from the access-failure clause.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@
 - Council blind-seat detection now catches two further "reviewed nothing"
   evasions that were counting toward `met: true`: (1) summary paraphrase — an
   APPROVE that leans on the task summary as confirmation of code-level facts
-  ("the summary confirms …", a reported-clean `tsc`/test run standing in for
-  reading the code); and (2) prior-phase deference — deferring to earlier rounds
+  ("the summary confirms …" or the reverse attribution "… as stated in / per the
+  summary", a reported-clean `tsc`/test run standing in for reading the code);
+  and (2) prior-phase deference — deferring to earlier rounds
   or gates ("given the rigorous validations in previous rounds … I recommend
   proceeding") instead of reading the artifact. Both are gated on the response
   citing zero real `path.ext:line` locations, so a genuinely grounded review is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,24 @@
   cannot break out and forge an authoritative block — safer than a caller
   inlining a diff into the authoritative task string.
 
+### Fixed
+
+- Council blind-seat detection now catches two further "reviewed nothing"
+  evasions that were counting toward `met: true`: (1) summary paraphrase — an
+  APPROVE that leans on the task summary as confirmation of code-level facts
+  ("the summary confirms …", a reported-clean `tsc`/test run standing in for
+  reading the code); and (2) prior-phase deference — deferring to earlier rounds
+  or gates ("given the rigorous validations in previous rounds … I recommend
+  proceeding") instead of reading the artifact. Both are gated on the response
+  citing zero real `path.ext:line` locations, so a genuinely grounded review is
+  never flagged; a bare "based on the provided summary" (as a plan/design review
+  legitimately uses) is deliberately not a trigger. Also fixes the existing
+  first-person access-failure check missing an explicit admission whose sentence
+  contained a dotted filename (e.g. `Foo.test.tsx`), whose periods split the
+  sentence and severed the first-person clause from the access-failure clause.
+  Flagged seats are excluded from the approving tally and recorded in
+  `summary.json` `quorum.blind_seats` like any other blind seat.
+
 ## [11.2.1] - 2026-09-07
 
 ### Fixed

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2000,6 +2000,15 @@ council_response_is_blind() {
         return 0
     fi
 
+    # A softer evasion: the seat never admits an access failure, but its verdict
+    # rests entirely on the task summary / prior rounds / a clean test suite
+    # rather than on reading the artifact, and it cites no real source location.
+    # Gated on zero file:line citations so a grounded review is never flagged
+    # (sail-cruisey #2570 paraphrase, #2463 prior-phase deference).
+    if council_response_defers_without_reading "$f"; then
+        return 0
+    fi
+
     local nlen
     nlen="$(tr -d '[:space:]' < "$f" | wc -c | tr -d '[:space:]')"
     (( nlen < 1600 )) || return 1
@@ -2022,13 +2031,18 @@ council_response_has_access_failure() {
 
     # Normalize wrapping, then evaluate one sentence/clause at a time. This
     # catches Markdown line wraps without letting a first-person sentence attach
-    # to a later third-person access report.
+    # to a later third-person access report. A period between two alphanumerics is
+    # part of a token (a filename like WatcherDashboard.test.tsx, a version like
+    # 1.0.4), NOT a sentence end — neutralize those to a space first, or the
+    # sentence split would sever "I am assuming ... <file>" from "... file access
+    # is restricted" and miss the admission (sail-cruisey #2459).
     local normalized_without_urls
     normalized_without_urls="$(tr '\n' ' ' < "$f" | tr -s '[:space:]' ' ' \
         | tr '[:upper:]' '[:lower:]' \
         | sed -E \
             -e 's#https?://[^[:space:]]*([.!?;])([[:space:]]|$)#\1\2#g' \
-            -e 's#https?://[^[:space:]]+##g')"
+            -e 's#https?://[^[:space:]]+##g' \
+            -e ':dot' -e 's#([[:alnum:]])\.([[:alnum:]])#\1 \2#g' -e 'tdot')"
     printf '%s\n' "$normalized_without_urls" | awk '
         BEGIN { RS="[.!?;]+"; found=0 }
         {
@@ -2037,6 +2051,52 @@ council_response_has_access_failure() {
             third_party_access = ($0 ~ /(^|[^[:alnum:]_])(another|other)[[:space:]]+(reviewer|seat|agent|provider|model)([^[:alnum:]_]|$)[^.!?;]{0,80}(cannot|could[[:space:]]*not|couldn.t|unable[[:space:]]+to|can.t|did[[:space:]]+not|lack(ed|s)?)/)
             first_person_access = ($0 ~ /(^|[^[:alnum:]_])(i|we)[[:space:]]+(cannot|could[[:space:]]*not|couldn.t|unable[[:space:]]+to|can.t|was[[:space:]]+not[[:space:]]+able[[:space:]]+to|were[[:space:]]+not[[:space:]]+able[[:space:]]+to)[[:space:]]+(open|read|access|view)/ || $0 ~ /(^|[^[:alnum:]_])(i|we)[[:space:]]+((did[[:space:]]+not|do[[:space:]]+not|don.t)[[:space:]]+have|lack(ed)?)[[:space:]]+(direct[[:space:]]+)?access/)
             if (first_person && access_failure && (!third_party_access || first_person_access)) found=1
+        }
+        END { exit(found ? 0 : 1) }
+    ' >/dev/null 2>&1
+}
+
+council_response_defers_without_reading() {
+    # A "soft blind" seat never states an access failure outright, but its verdict
+    # rests on the task summary, prior review rounds, or a clean test suite rather
+    # than on reading the artifact — it reviewed nothing. Two real agy evasions:
+    #   - summary paraphrase: "the ariaLabel field is correctly propagated, as
+    #     stated in the summary" (sail-cruisey #2570)
+    #   - prior-phase deference: "given the rigorous validations in previous
+    #     rounds ... I recommend proceeding" (#2463)
+    # This is length-independent (the evasions are long) but gated on ZERO
+    # `path.ext:line` citations: a genuinely grounded review carries a concrete
+    # file:line, so it is never flagged for merely mentioning a summary or a prior
+    # round. The colon citation form is deliberately the ONLY grounding signal
+    # here — prose "lines 251-263" or a bare filename can be copied from the
+    # plan/summary without reading it (#2463 does exactly that).
+    local f="$1"
+    [[ -f "$f" ]] || return 1
+
+    if grep -ciE '\.[[:alpha:]][[:alnum:]]{0,9}:[0-9]+' "$f" >/dev/null; then
+        return 1
+    fi
+
+    local normalized_without_urls
+    normalized_without_urls="$(tr '\n' ' ' < "$f" | tr -s '[:space:]' ' ' \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -E \
+            -e 's#https?://[^[:space:]]*([.!?;])([[:space:]]|$)#\1\2#g' \
+            -e 's#https?://[^[:space:]]+##g')"
+    printf '%s\n' "$normalized_without_urls" | awk '
+        {
+            # NOTE: a bare "based on the provided summary" is deliberately NOT a
+            # trigger — a legitimate plan/design review (no code to cite) uses that
+            # phrasing (sail-cruisey #2527). The blind signal is the summary being
+            # cited as CONFIRMATION of code-level facts ("the summary confirms …")
+            # or a reported-clean test/typecheck standing in for reading the code.
+            summary_reliance = ($0 ~ /the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|mitigat)/ \
+                || $0 ~ /(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
+                || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+(tsc|lint|test|ci|type)/)
+            prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \
+                || $0 ~ /(passed|cleared|survived)[^.!?;]{0,50}(phase[[:space:]]*[0-9]+|staged|rigorous)[^.!?;]{0,25}(reviews?|validations?|gates?|checks?)/ \
+                || $0 ~ /(test[[:space:]]+suite|tsc|lint|ci)[^.!?;]{0,40}(clean|passing|green)[^.!?;]{0,90}(recommend|proceed|approv|no[[:space:]]+(other[[:space:]]+)?(material[[:space:]]+)?(flaws?|issues?|concerns?))/)
+            if (summary_reliance || prior_deference) found=1
         }
         END { exit(found ? 0 : 1) }
     ' >/dev/null 2>&1

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2091,7 +2091,16 @@ council_response_defers_without_reading() {
         return 1
     fi
 
-    printf '%s\n' "$normalized_without_urls" | awk '
+    # Code-level verification token, wrapped in word boundaries so a code term is
+    # only matched as a whole token, never as a substring of an ordinary word
+    # ("api" inside "capital", "diff" inside "different", "test" inside "latest",
+    # "class" inside "classic" — CodeRabbit #1017). ERE has no \b, and macOS awk
+    # is BWK awk (no \<); the portable form guards both sides with
+    # (^|[^[:alnum:]]) ... ([^[:alnum:]]|$) and spells out the code-form
+    # inflections so common plural/tense forms still match.
+    local code_token='(^|[^[:alnum:]])(test(s|ed|ing|cases?)?|coverage|render(s|ed|ing)?|outputs?|type[- ]?check(s|ed|ing)?|tsc|lint(s|ed|ing|er)?|implement(s|ed|ing|ations?)?|propagat(e|es|ed|ing|ion)?|byte-identical|pass(es|ing|ed)?|regress(es|ed|ions?)?|contracts?|behaviou?r(s|al)?|diff(s|ed)?|assert(s|ed|ing|ions?)?|snapshots?|dom|css|class(es)?|components?|functions?|api(s)?|endpoints?|schema(s|ta)?|payloads?|fields?)([^[:alnum:]]|$)'
+
+    printf '%s\n' "$normalized_without_urls" | awk -v ct="$code_token" '
         {
             # NOTE: a bare "based on the provided summary" is deliberately NOT a
             # trigger — a legitimate plan/design review (no code to cite) uses that
@@ -2103,9 +2112,11 @@ council_response_defers_without_reading() {
             # word orders count: forward ("the summary confirms <code fact>") and
             # reverse ("<code fact> ... as stated in / according to / per the
             # summary") — the reverse attribution is the exact #2570 wording and
-            # carries no citation of its own (CodeRabbit #1017).
-            summary_reliance = ($0 ~ /the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|shows|verifies|mitigat[a-z]*)[^.!?;]{0,80}(test|coverage|render|output|type[- ]?check|tsc|lint|implement|propagat|byte-identical|pass(es|ing|ed)?|regression|contract|behaviou?r|diff|assertion|snapshot|dom|css|class|component|function|api|endpoint|schema|payload|field)/ \
-                || $0 ~ /(test|coverage|render|output|type[- ]?check|tsc|lint|implement|propagat|byte-identical|regression|contract|behaviou?r|diff|assertion|snapshot|dom|css|class|component|function|api|endpoint|schema|payload|field)[^.!?;]{0,80}(as[[:space:]]+stated[[:space:]]+in|according[[:space:]]+to|per)[[:space:]]+(the[[:space:]]+)?summary/ \
+            # carries no citation of its own (CodeRabbit #1017). The code fact is
+            # the token-bounded ct regex so "the capital plan, as stated in the
+            # summary" (api ⊂ capital) is not misread as a code claim.
+            summary_reliance = ($0 ~ ("the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|shows|verifies|mitigat[a-z]*)[^.!?;]{0,80}" ct) \
+                || $0 ~ (ct "[^.!?;]{0,80}(as[[:space:]]+stated[[:space:]]+in|according[[:space:]]+to|per)[[:space:]]+(the[[:space:]]+)?summary") \
                 || $0 ~ /(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
                 || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+(tsc|lint|test|ci|type)/)
             prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2099,8 +2099,13 @@ council_response_defers_without_reading() {
             # cited as CONFIRMATION of CODE-LEVEL facts ("the summary confirms the
             # tests pass / byte-identical output") — a bare "the summary states the
             # rollout is phased" (process, not code) is NOT a trigger — or a
-            # reported-clean test/typecheck standing in for reading the code.
+            # reported-clean test/typecheck standing in for reading the code. Both
+            # word orders count: forward ("the summary confirms <code fact>") and
+            # reverse ("<code fact> ... as stated in / according to / per the
+            # summary") — the reverse attribution is the exact #2570 wording and
+            # carries no citation of its own (CodeRabbit #1017).
             summary_reliance = ($0 ~ /the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|shows|verifies|mitigat[a-z]*)[^.!?;]{0,80}(test|coverage|render|output|type[- ]?check|tsc|lint|implement|propagat|byte-identical|pass(es|ing|ed)?|regression|contract|behaviou?r|diff|assertion|snapshot|dom|css|class|component|function|api|endpoint|schema|payload|field)/ \
+                || $0 ~ /(test|coverage|render|output|type[- ]?check|tsc|lint|implement|propagat|byte-identical|regression|contract|behaviou?r|diff|assertion|snapshot|dom|css|class|component|function|api|endpoint|schema|payload|field)[^.!?;]{0,80}(as[[:space:]]+stated[[:space:]]+in|according[[:space:]]+to|per)[[:space:]]+(the[[:space:]]+)?summary/ \
                 || $0 ~ /(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
                 || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+(tsc|lint|test|ci|type)/)
             prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2073,24 +2073,34 @@ council_response_defers_without_reading() {
     local f="$1"
     [[ -f "$f" ]] || return 1
 
-    if grep -ciE '\.[[:alpha:]][[:alnum:]]{0,9}:[0-9]+' "$f" >/dev/null; then
-        return 1
-    fi
-
     local normalized_without_urls
     normalized_without_urls="$(tr '\n' ' ' < "$f" | tr -s '[:space:]' ' ' \
         | tr '[:upper:]' '[:lower:]' \
         | sed -E \
             -e 's#https?://[^[:space:]]*([.!?;])([[:space:]]|$)#\1\2#g' \
             -e 's#https?://[^[:space:]]+##g')"
+
+    # A concrete SOURCE file:line citation is the grounding signal. Match only
+    # real source extensions, and only AFTER stripping URLs, so a URL port
+    # (https://example.com:443) or a doc/host token is never mistaken for
+    # evidence (CodeRabbit #1017). This is a prose signal, not a filesystem
+    # check — councils also review plans/PRDs that have no source tree, and the
+    # disposable workspace is gone by classification time, so a cited path cannot
+    # be resolved; the phrase gate below is the primary discriminator.
+    if grep -ciE '\.(tsx?|jsx?|mjs|cjs|css|scss|sass|less|html?|vue|svelte|py|go|rb|rs|java|kt|swift|cc?|cpp|cxx|hh?|hpp|sh|bash|zsh|sql|ya?ml|toml|jsonc?|mdx?|php|pl|lua|exs?|scala|dart|mm?|jl|tf|r)[[:space:]]*:[0-9]+' <<< "$normalized_without_urls" >/dev/null; then
+        return 1
+    fi
+
     printf '%s\n' "$normalized_without_urls" | awk '
         {
             # NOTE: a bare "based on the provided summary" is deliberately NOT a
             # trigger — a legitimate plan/design review (no code to cite) uses that
             # phrasing (sail-cruisey #2527). The blind signal is the summary being
-            # cited as CONFIRMATION of code-level facts ("the summary confirms …")
-            # or a reported-clean test/typecheck standing in for reading the code.
-            summary_reliance = ($0 ~ /the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|mitigat)/ \
+            # cited as CONFIRMATION of CODE-LEVEL facts ("the summary confirms the
+            # tests pass / byte-identical output") — a bare "the summary states the
+            # rollout is phased" (process, not code) is NOT a trigger — or a
+            # reported-clean test/typecheck standing in for reading the code.
+            summary_reliance = ($0 ~ /the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|shows|verifies|mitigat[a-z]*)[^.!?;]{0,80}(test|coverage|render|output|type[- ]?check|tsc|lint|implement|propagat|byte-identical|pass(es|ing|ed)?|regression|contract|behaviou?r|diff|assertion|snapshot|dom|css|class|component|function|api|endpoint|schema|payload|field)/ \
                 || $0 ~ /(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
                 || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+(tsc|lint|test|ci|type)/)
             prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2632,7 +2632,17 @@ test_council_blind_summary_deference() {
         echo "VERDICT: APPROVE"
     } > "$d/reverse-attr.md"
 
-    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n
+    # (h) Token-boundary control (CodeRabbit #1017): a NON-code plan sentence that
+    # happens to contain a code term as a SUBSTRING ("api" ⊂ "capital"), in the
+    # reverse-attribution word order. Must NOT be flagged — code terms match only
+    # as whole tokens, so "capital" is not a code fact.
+    {
+        echo "## Recommendation"
+        echo "The capital plan is sound and the phasing is prudent, as stated in the summary."
+        echo "VERDICT: APPROVE"
+    } > "$d/plan-capital.md"
+
+    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n capital_ok=n
     council_response_is_blind "$d/paraphrase.md" && para=y
     council_response_is_blind "$d/deference.md" && defer=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
@@ -2640,12 +2650,13 @@ test_council_blind_summary_deference() {
     council_response_is_blind "$d/url-port.md" && url_blind=y
     council_response_is_blind "$d/plan-states.md" || plan_states_ok=y
     council_response_is_blind "$d/reverse-attr.md" && reverse=y
+    council_response_is_blind "$d/plan-capital.md" || capital_ok=y
 
     if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
-          && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" ]]; then
+          && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" && "$capital_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2620,19 +2620,32 @@ test_council_blind_summary_deference() {
         echo "VERDICT: APPROVE"
     } > "$d/plan-states.md"
 
-    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n
+    # (g) Reverse-attribution ISOLATION (CodeRabbit #1017): the ONLY blind signal
+    # is a code fact deferred to the summary in reverse word order ("propagated
+    # ... as stated in the summary"). No forward "the summary confirms", no
+    # reported-clean-tsc, no prior-round deference, zero file:line. Must be blind
+    # solely via the reverse form — the paraphrase fixture (a) can't prove this
+    # because it also carries the forward and clean-tsc signals.
+    {
+        echo "## Review"
+        echo "APPROVE. The ariaLabel is correctly propagated to every icon button, as stated in the summary."
+        echo "VERDICT: APPROVE"
+    } > "$d/reverse-attr.md"
+
+    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n
     council_response_is_blind "$d/paraphrase.md" && para=y
     council_response_is_blind "$d/deference.md" && defer=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
     council_response_is_blind "$d/grounded-cited.md" || cited_ok=y
     council_response_is_blind "$d/url-port.md" && url_blind=y
     council_response_is_blind "$d/plan-states.md" || plan_states_ok=y
+    council_response_is_blind "$d/reverse-attr.md" && reverse=y
 
     if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
-          && "$url_blind" == "y" && "$plan_states_ok" == "y" ]]; then
+          && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2602,16 +2602,37 @@ test_council_blind_summary_deference() {
         echo "VERDICT: APPROVE"
     } > "$d/grounded-cited.md"
 
-    local para=n defer=n grounded_ok=n cited_ok=n
+    # (e) Deference lean but the only ":NN" is a URL port — must STILL be blind:
+    # URLs are stripped before the citation guard, so a link is not grounding
+    # (CodeRabbit #1017).
+    {
+        echo "## Review"
+        echo "Given the rigorous validations in previous rounds, I recommend proceeding; see the plan at https://example.com:443/plan for context."
+        echo "VERDICT: APPROVE"
+    } > "$d/url-port.md"
+
+    # (f) Plan/process review that says "the summary states" about a NON-code fact
+    # (rollout sequencing) with no citation — must NOT be flagged: summary
+    # reliance requires a code-level confirmation, not a process statement.
+    {
+        echo "## Recommendation"
+        echo "The summary states the rollout is phased across three releases, which is a sound sequencing decision for risk management."
+        echo "VERDICT: APPROVE"
+    } > "$d/plan-states.md"
+
+    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n
     council_response_is_blind "$d/paraphrase.md" && para=y
     council_response_is_blind "$d/deference.md" && defer=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
     council_response_is_blind "$d/grounded-cited.md" || cited_ok=y
+    council_response_is_blind "$d/url-port.md" && url_blind=y
+    council_response_is_blind "$d/plan-states.md" || plan_states_ok=y
 
-    if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" ]]; then
+    if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
+          && "$url_blind" == "y" && "$plan_states_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2558,6 +2558,64 @@ test_council_advice_marks_blind_seat() {
     fi
 }
 
+test_council_blind_summary_deference() {
+    test_case "a seat that rests on the summary or prior rounds with no file:line citation is blind; a grounded review (specific code, or a real file:line) is not (sail-cruisey #2570/#2463)"
+    load_council_lib || return 1
+
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-deference.XXXXXX")"
+
+    # (a) Summary paraphrase (#2570): APPROVE that rests on the summary, no
+    # access-failure admission, zero file:line citations.
+    {
+        echo "### Recommendation"
+        echo "APPROVE. The refactor is sound and backward compatible."
+        echo "### Assumptions"
+        echo "- The ariaLabel field is correctly propagated through all implementations, as stated in the summary."
+        echo "- The reported clean tsc output and 100% test pass rate are accurate representations of CI state."
+        echo "The summary confirms byte-identical rendered output, effectively mitigating regression risk."
+        echo "VERDICT: APPROVE"
+    } > "$d/paraphrase.md"
+
+    # (b) Prior-phase deference (#2463): defers to earlier rounds/gates instead of
+    # reading the artifact, no access-failure admission, zero file:line citations.
+    {
+        echo "## Architectural Review"
+        echo "The footer correction is architecturally sound and aligns the frontend with the backend data shape."
+        echo "Given the rigorous validations in previous rounds and the successful resolution of the final finding, it provides a solid, grounded foundation for Phase 6 implementation. I see no other material flaws, so I recommend proceeding."
+        echo "VERDICT: APPROVE"
+    } > "$d/deference.md"
+
+    # (c) Grounded review: analyzes specific code/behavior directly, with no
+    # summary/prior-round lean — must NOT be flagged even with zero file:line.
+    {
+        echo "## Review"
+        echo "The exclusive swap (const baseIconClass = bare ? styles.emptyIconShellBare : styles.emptyIconShell) prevents cascade races, and the additive emptyActionsBare class applies the 1rem margin without overriding emptyActions."
+        echo "The empty-state.test.tsx additions cover both the icon-shell swap and the actions spacing. I found no correctness issues or missed requirements."
+        echo "VERDICT: APPROVE"
+    } > "$d/grounded.md"
+
+    # (d) Uses a deference phrase BUT carries a real file:line citation — the
+    # colon-citation guard must keep it out of the blind set.
+    {
+        echo "## Review"
+        echo "Given the prior rounds, the guard added at src/SpendingTab.tsx:257 correctly classifies the single-amount footer."
+        echo "VERDICT: APPROVE"
+    } > "$d/grounded-cited.md"
+
+    local para=n defer=n grounded_ok=n cited_ok=n
+    council_response_is_blind "$d/paraphrase.md" && para=y
+    council_response_is_blind "$d/deference.md" && defer=y
+    council_response_is_blind "$d/grounded.md" || grounded_ok=y
+    council_response_is_blind "$d/grounded-cited.md" || cited_ok=y
+
+    if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" ]]; then
+        test_pass
+    else
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok"
+        return 1
+    fi
+}
+
 test_council_blind_fabricated_narrative() {
     test_case "a long first-person access failure is blind regardless of length or citation prose; grounded long reviews and plan reviews are not"
     load_council_lib || return 1
@@ -3304,6 +3362,7 @@ test_council_rc_is_timeout_requires_watchdog_provenance
 test_council_advice_marks_timed_out_seat
 test_council_advice_marks_blind_seat
 test_council_blind_fabricated_narrative
+test_council_blind_summary_deference
 test_council_permission_denied_finding_is_substantive
 test_council_advice_does_not_infer_timeout_from_provider_rc
 test_council_seat_timeout_rejects_zero_and_nonnumeric


### PR DESCRIPTION
## Problem

The blind-seat detector (from #978/#1000) catches an **explicit** access-failure admission, but agy evolved two evasions that cite zero `file:line` and were counting toward `met: true`:

1. **Summary paraphrase** (sail-cruisey #2570) — an APPROVE built from the task summary rather than the diff: *"the ariaLabel field is correctly propagated … as stated in the summary"*, *"the summary confirms byte-identical rendered output"*, *"the reported clean tsc output and 100% test pass rate…"*. No access-failure phrase.
2. **Prior-phase deference** (#2463) — *"Given the rigorous validations in previous rounds … I see no other material flaws, so I recommend proceeding."* Defers to earlier phases/gates instead of reading the artifact.

While validating, I also found the current `council_response_has_access_failure` **misses #2459's explicit admission** (which the task expected it to still catch): its sentence contains the dotted filename `WatcherDashboard.test.tsx`, and the sentence splitter treats every `.` as a boundary — severing *"I am assuming … WatcherDashboard"* from *"tsx … direct file access is restricted"*, so neither fragment has both the first-person and the access-failure clause.

## Change

- **`council_response_defers_without_reading`** — flags a seat when it leans on the **summary as confirmation of code facts** (`the summary confirms/states/…`, a reported-clean `tsc`/`lint`/`test`) **or** **prior-phase deference** (`given … previous rounds`, `passed … Phase N reviews`, `test suite … clean … recommend/proceed`), **AND** it cites **zero** real `path.ext:line` locations. Length-independent; runs after the authoritative first-person access-failure check.
- **Filename-dot fix** in `council_response_has_access_failure` — neutralize periods between alphanumerics (filenames, versions) to spaces before sentence-splitting, so an admission that names `Foo.test.tsx` isn't severed. (General fix — these reviews cite dotted filenames constantly.)

### Deliberate guardrails against false positives

- **Colon-citation is the only grounding signal** for the deference path. Prose `lines 251-263` or a bare filename can be copied from the plan without reading it — **#2463 does exactly that** (it cites `SpendingTab.tsx` "lines 251-263" yet reviewed nothing), so accepting prose citations would miss it.
- **A bare "based on the provided summary" is NOT a trigger** — a legitimate plan/design review (no code to cite) uses that phrasing (#2527). The signal is the summary being cited as *confirmation of code-level facts*, not mere reliance.

## Validation (real on-disk council responses)

| Seat | Expected | Result |
|---|---|---|
| #2570 paraphrase (`session-50e85d7c…`) | blind | ✅ |
| #2463 deference (`session-dc04e302…`) | blind | ✅ |
| #2459 explicit (`session-5f64198b…`) | blind | ✅ (via the filename-dot fix) |
| #2565 grounded (`session-963c3dcf…`) | not blind | ✅ |
| #2477 grounded, all CP2 rounds (`session-8d5f9450…`) | not blind | ✅ |
| #2469 grounded, all rounds (`session-9ae0ed0e…`) | not blind | ✅ |

All three MUST-flag cases are missed by pre-fix `origin/main`; all pass post-fix, with zero false positives across the 11 control rounds.

## Test

`test_council_blind_summary_deference` — paraphrase + deference bodies (flagged), a grounded body analyzing specific code (not flagged), and a deference body carrying a real `file:line` (not flagged, exercising the citation guard). Full suite: `tests/unit/test-council-command.sh` → 97 passed, 0 failed, 1 skipped (pre-existing pty skip); the maintainer's existing first-person / third-person / wrapped / URL access-failure fixtures all still pass, confirming the normalization change is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved review validation to identify responses relying only on summaries, prior rounds, restrictions, or clean test results without concrete source references.
  - Corrected access-failure detection for responses containing filenames and version-like dotted text.
  - Reviews identified as insufficiently grounded are now excluded from approval tallies and recorded in quorum reporting.

- **Tests**
  - Added coverage for summary-based deference, prior-review references, URL ports, and valid responses containing concrete source locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->