### PR TITLE
fix(council): validate citations against evidence root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   sentence and severed the first-person clause from the access-failure clause.
   Flagged seats are excluded from the approving tally and recorded in
   `summary.json` `quorum.blind_seats` like any other blind seat.
+- Harden evidence-aware grounding against substring and markdown-boundary false
+  positives, recognize common source/configuration extensions and flexible
+  citation spacing, and validate citation ranges before a seat can count toward
+  quorum.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
   proceeding") instead of reading the artifact. Both are gated on the response
   citing zero real `path.ext:line` locations, so a genuinely grounded review is
   never flagged; a bare "based on the provided summary" (as a plan/design review
-  legitimately uses) is deliberately not a trigger. Also fixes the existing
+  legitimately uses) is deliberately not a trigger, and code terms are matched as
+  whole tokens so a substring like `api` in "capital" is not read as a code
+  claim. Also fixes the existing
   first-person access-failure check missing an explicit admission whose sentence
   contained a dotted filename (e.g. `Foo.test.tsx`), whose periods split the
   sentence and severed the first-person clause from the access-failure clause.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Council blind-seat detection now catches two further "reviewed nothing"
+  evasions that were counting toward `met: true`: (1) summary paraphrase — an
+  APPROVE that leans on the task summary as confirmation of code-level facts
+  ("the summary confirms …", a reported-clean `tsc`/test run standing in for
+  reading the code); and (2) prior-phase deference — deferring to earlier rounds
+  or gates ("given the rigorous validations in previous rounds … I recommend
+  proceeding") instead of reading the artifact. Both are gated on the response
+  citing zero real `path.ext:line` locations, so a genuinely grounded review is
+  never flagged; a bare "based on the provided summary" (as a plan/design review
+  legitimately uses) is deliberately not a trigger. Also fixes the existing
+  first-person access-failure check missing an explicit admission whose sentence
+  contained a dotted filename (e.g. `Foo.test.tsx`), whose periods split the
+  sentence and severed the first-person clause from the access-failure clause.
+  Flagged seats are excluded from the approving tally and recorded in
+  `summary.json` `quorum.blind_seats` like any other blind seat.
+
 ## [11.2.1] - 2026-09-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 - Council blind-seat detection now catches two further "reviewed nothing"
   evasions that were counting toward `met: true`: (1) summary paraphrase — an
   APPROVE that leans on the task summary as confirmation of code-level facts
-  ("the summary confirms …", a reported-clean `tsc`/test run standing in for
-  reading the code); and (2) prior-phase deference — deferring to earlier rounds
+  ("the summary confirms …" or the reverse attribution "… as stated in / per the
+  summary", a reported-clean `tsc`/test run standing in for reading the code);
+  and (2) prior-phase deference — deferring to earlier rounds
   or gates ("given the rigorous validations in previous rounds … I recommend
   proceeding") instead of reading the artifact. Both are gated on the response
   citing zero real `path.ext:line` locations, so a genuinely grounded review is

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2210,11 +2210,11 @@ from pathlib import Path
 
 response = Path(sys.argv[1])
 root = Path(sys.argv[2]).resolve()
-pattern = re.compile(r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*):([0-9]+)(?![0-9])")
+pattern = re.compile(r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*):([0-9]+)(?:-([0-9]+))?(?![0-9-])")
 validated = []
 seen = set()
 file_facts = {}
-for raw_path, raw_line in pattern.findall(response.read_text(encoding="utf-8", errors="replace")):
+for raw_path, raw_start, raw_end in pattern.findall(response.read_text(encoding="utf-8", errors="replace")):
     relative = Path(raw_path)
     if relative.is_absolute() or ".." in relative.parts:
         continue
@@ -2225,8 +2225,9 @@ for raw_path, raw_line in pattern.findall(response.read_text(encoding="utf-8", e
         continue
     if not candidate.is_file():
         continue
-    line = int(raw_line)
-    if line < 1:
+    start_line = int(raw_start)
+    end_line = int(raw_end or raw_start)
+    if start_line < 1 or end_line < start_line:
         continue
     if candidate not in file_facts:
         content = hashlib.sha256()
@@ -2237,10 +2238,10 @@ for raw_path, raw_line in pattern.findall(response.read_text(encoding="utf-8", e
                 line_count += 1
         file_facts[candidate] = (line_count, "sha256:" + content.hexdigest())
     line_count, content_digest = file_facts[candidate]
-    key = (relative.as_posix(), line)
-    if line <= line_count and key not in seen:
+    key = (relative.as_posix(), start_line)
+    if end_line <= line_count and key not in seen:
         seen.add(key)
-        validated.append({"path": key[0], "line": line, "content_digest": content_digest})
+        validated.append({"path": key[0], "line": start_line, "content_digest": content_digest})
 print(json.dumps(validated, separators=(",", ":")))
 PY
 }

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2036,8 +2036,13 @@ council_response_defers_without_reading() {
             # cited as CONFIRMATION of CODE-LEVEL facts ("the summary confirms the
             # tests pass / byte-identical output") — a bare "the summary states the
             # rollout is phased" (process, not code) is NOT a trigger — or a
-            # reported-clean test/typecheck standing in for reading the code.
+            # reported-clean test/typecheck standing in for reading the code. Both
+            # word orders count: forward ("the summary confirms <code fact>") and
+            # reverse ("<code fact> ... as stated in / according to / per the
+            # summary") — the reverse attribution is the exact #2570 wording and
+            # carries no citation of its own (CodeRabbit #1017).
             summary_reliance = ($0 ~ /the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|shows|verifies|mitigat[a-z]*)[^.!?;]{0,80}(test|coverage|render|output|type[- ]?check|tsc|lint|implement|propagat|byte-identical|pass(es|ing|ed)?|regression|contract|behaviou?r|diff|assertion|snapshot|dom|css|class|component|function|api|endpoint|schema|payload|field)/ \
+                || $0 ~ /(test|coverage|render|output|type[- ]?check|tsc|lint|implement|propagat|byte-identical|regression|contract|behaviou?r|diff|assertion|snapshot|dom|css|class|component|function|api|endpoint|schema|payload|field)[^.!?;]{0,80}(as[[:space:]]+stated[[:space:]]+in|according[[:space:]]+to|per)[[:space:]]+(the[[:space:]]+)?summary/ \
                 || $0 ~ /(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
                 || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+(tsc|lint|test|ci|type)/)
             prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2104,7 +2104,7 @@ council_response_defers_without_reading() {
         local validated_evidence
         validated_evidence="$(council_response_evidence_paths_json "$f" "$evidence_root")" || validated_evidence='[]'
         local validated_source_evidence
-        validated_source_evidence="$(jq --arg ext "\\.(${source_extension_pattern})$" '[.[] | select(.path | test($ext))]' <<< "$validated_evidence" 2>/dev/null || printf '[]')"
+        validated_source_evidence="$(jq --arg ext "\\.(${source_extension_pattern})$" '[.[] | select(.path | test($ext; "i"))]' <<< "$validated_evidence" 2>/dev/null || printf '[]')"
         if [[ "$(jq 'length' <<< "$validated_source_evidence" 2>/dev/null || printf 0)" -gt 0 ]]; then
             return 1
         fi
@@ -2137,7 +2137,7 @@ council_response_defers_without_reading() {
             summary_reliance = ($0 ~ ("the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|shows|verifies|mitigat[a-z]*)[^.!?;]{0,80}" ct) \
                 || $0 ~ (ct "[^.!?;]{0,80}(as[[:space:]]+stated[[:space:]]+in|according[[:space:]]+to|per)[[:space:]]+(the[[:space:]]+)?summary") \
                 || $0 ~ /(^|[^[:alnum:]_])(i|we|my|our)[^.!?;]{0,40}(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
-                || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+((tsc|lint|test)([^[:alnum:]]|$)|ci([^[:alnum:]]|$)|type([^[:alnum:]]|$)))/)
+                || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+((tsc|lint|test)([^[:alnum:]_]|$)|ci([^[:alnum:]_]|$)|type([^[:alnum:]_]|$)))/)
             prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \
                 || $0 ~ /(passed|cleared|survived)[^.!?;]{0,50}(phase[[:space:]]*[0-9]+|staged|rigorous)[^.!?;]{0,25}(reviews?|validations?|gates?|checks?)/ \
                 || $0 ~ /((test[[:space:]]+suite|tsc|lint)([^[:alnum:]]|$)|ci([^[:alnum:]]|$))[^.!?;]{0,40}(clean|passing|green)[^.!?;]{0,90}(recommend|proceed|approv|no[[:space:]]+(other[[:space:]]+)?(material[[:space:]]+)?(flaws?|issues?|concerns?))/)
@@ -2210,7 +2210,7 @@ from pathlib import Path
 
 response = Path(sys.argv[1])
 root = Path(sys.argv[2]).resolve()
-pattern = re.compile(r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*):([0-9]+)(?:-([0-9]+))?(?![0-9-])")
+pattern = re.compile(r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*):([0-9]+)(?:-([0-9]+))?(?![A-Za-z0-9_/-])")
 validated = []
 seen = set()
 file_facts = {}

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2137,7 +2137,7 @@ council_response_defers_without_reading() {
             summary_reliance = ($0 ~ ("the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|shows|verifies|mitigat[a-z]*)[^.!?;]{0,80}" ct) \
                 || $0 ~ (ct "[^.!?;]{0,80}(as[[:space:]]+stated[[:space:]]+in|according[[:space:]]+to|per)[[:space:]]+(the[[:space:]]+)?summary") \
                 || $0 ~ /(^|[^[:alnum:]_])(i|we|my|our)[^.!?;]{0,40}(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
-                || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+((tsc|lint|test)([^[:alnum:]]|$)|ci([^[:alnum:]]|$)|type)/)
+                || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+((tsc|lint|test)([^[:alnum:]]|$)|ci([^[:alnum:]]|$)|type([^[:alnum:]]|$)))/)
             prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \
                 || $0 ~ /(passed|cleared|survived)[^.!?;]{0,50}(phase[[:space:]]*[0-9]+|staged|rigorous)[^.!?;]{0,25}(reviews?|validations?|gates?|checks?)/ \
                 || $0 ~ /((test[[:space:]]+suite|tsc|lint)([^[:alnum:]]|$)|ci([^[:alnum:]]|$))[^.!?;]{0,40}(clean|passing|green)[^.!?;]{0,90}(recommend|proceed|approv|no[[:space:]]+(other[[:space:]]+)?(material[[:space:]]+)?(flaws?|issues?|concerns?))/)

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2218,7 +2218,7 @@ from pathlib import Path
 
 response = Path(sys.argv[1])
 root = Path(sys.argv[2]).resolve()
-pattern = re.compile(r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*)\s*:\s*([0-9]+)(?:-([0-9]+))?(?![A-Za-z0-9_/-]|\.[A-Za-z0-9])")
+pattern = re.compile(r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*)\s*:\s*([0-9]+)(?:-([0-9]+))?(?![A-Za-z0-9_/-]|\.(?:[A-Za-z0-9_/-]|\.))")
 validated = []
 seen = set()
 file_facts = {}

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2034,18 +2034,22 @@ council_response_has_access_failure() {
 
     # Normalize wrapping, then evaluate one sentence/clause at a time. This
     # catches Markdown line wraps without letting a first-person sentence attach
-    # to a later third-person access report. A period between two alphanumerics is
-    # part of a token (a filename like WatcherDashboard.test.tsx, a version like
-    # 1.0.4), NOT a sentence end — neutralize those to a space first, or the
-    # sentence split would sever "I am assuming ... <file>" from "... file access
-    # is restricted" and miss the admission (sail-cruisey #2459).
+    # to a later third-party access report. Neutralize dots only inside known
+    # source filenames and numeric versions; a genuine sentence boundary such as
+    # "file.However" must remain a boundary even when whitespace is missing.
     local normalized_without_urls
     normalized_without_urls="$(tr '\n' ' ' < "$f" | tr -s '[:space:]' ' ' \
         | tr '[:upper:]' '[:lower:]' \
         | sed -E \
             -e 's#https?://[^[:space:]]*([.!?;])([[:space:]]|$)#\1\2#g' \
             -e 's#https?://[^[:space:]]+##g' \
-            -e ':dot' -e 's#([[:alnum:]])\.([[:alnum:]])#\1 \2#g' -e 'tdot')"
+            -e ':filename' \
+            -e 's#([[:alnum:]_/-]+)\.([[:alnum:]_-]+\.(tsx?|jsx?|mjs|cjs|css|scss|sass|less|html?|vue|svelte|py|go|rb|rs|java|kt|swift|cc?|cpp|cxx|hh?|hpp|sh|bash|zsh|sql|ya?ml|toml|jsonc?|mdx?|php|pl|lua|exs?|scala|dart|mm?|jl|tf|r))#\1__OCTO_DOT__\2#g' \
+            -e 'tfilename' \
+            -e 's#([[:alnum:]_/-]+)\.(tsx?|jsx?|mjs|cjs|css|scss|sass|less|html?|vue|svelte|py|go|rb|rs|java|kt|swift|cc?|cpp|cxx|hh?|hpp|sh|bash|zsh|sql|ya?ml|toml|jsonc?|mdx?|php|pl|lua|exs?|scala|dart|mm?|jl|tf|r)([^[:alnum:]_]|$)#\1__OCTO_DOT__\2\3#g' \
+            -e ':version' \
+            -e 's#([0-9]+)\.([0-9]+)#\1__OCTO_DOT__\2#g' \
+            -e 'tversion')"
     printf '%s\n' "$normalized_without_urls" | awk '
         BEGIN { RS="[.!?;]+"; found=0 }
         {
@@ -2132,11 +2136,11 @@ council_response_defers_without_reading() {
             # summary" (api ⊂ capital) is not misread as a code claim.
             summary_reliance = ($0 ~ ("the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|shows|verifies|mitigat[a-z]*)[^.!?;]{0,80}" ct) \
                 || $0 ~ (ct "[^.!?;]{0,80}(as[[:space:]]+stated[[:space:]]+in|according[[:space:]]+to|per)[[:space:]]+(the[[:space:]]+)?summary") \
-                || $0 ~ /(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
-                || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+(tsc|lint|test|ci|type)/)
+                || $0 ~ /(^|[^[:alnum:]_])(i|we|my|our)[^.!?;]{0,40}(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
+                || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+((tsc|lint|test)([^[:alnum:]]|$)|ci([^[:alnum:]]|$)|type)/)
             prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \
                 || $0 ~ /(passed|cleared|survived)[^.!?;]{0,50}(phase[[:space:]]*[0-9]+|staged|rigorous)[^.!?;]{0,25}(reviews?|validations?|gates?|checks?)/ \
-                || $0 ~ /(test[[:space:]]+suite|tsc|lint|ci)[^.!?;]{0,40}(clean|passing|green)[^.!?;]{0,90}(recommend|proceed|approv|no[[:space:]]+(other[[:space:]]+)?(material[[:space:]]+)?(flaws?|issues?|concerns?))/)
+                || $0 ~ /((test[[:space:]]+suite|tsc|lint)([^[:alnum:]]|$)|ci([^[:alnum:]]|$))[^.!?;]{0,40}(clean|passing|green)[^.!?;]{0,90}(recommend|proceed|approv|no[[:space:]]+(other[[:space:]]+)?(material[[:space:]]+)?(flaws?|issues?|concerns?))/)
             if (summary_reliance || prior_deference) found=1
         }
         END { exit(found ? 0 : 1) }

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2218,7 +2218,7 @@ from pathlib import Path
 
 response = Path(sys.argv[1])
 root = Path(sys.argv[2]).resolve()
-pattern = re.compile(r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*)\s*:\s*([0-9]+)(?:-([0-9]+))?(?![A-Za-z0-9_/-])")
+pattern = re.compile(r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*)\s*:\s*([0-9]+)(?:-([0-9]+))?(?![A-Za-z0-9_/-]|\.[A-Za-z0-9])")
 validated = []
 seen = set()
 file_facts = {}

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2087,17 +2087,21 @@ council_response_defers_without_reading() {
     # A concrete SOURCE file:line citation is the grounding signal. Match only
     # real source extensions, and only AFTER stripping URLs, so a URL port
     # (https://example.com:443) or a doc/host token is never mistaken for
-    # evidence (CodeRabbit #1017). This is a prose signal, not a filesystem
-    # check — councils also review plans/PRDs that have no source tree, and the
-    # disposable workspace is gone by classification time, so a cited path cannot
-    # be resolved; the phrase gate below is the primary discriminator.
-    if grep -ciE '\.(tsx?|jsx?|mjs|cjs|css|scss|sass|less|html?|vue|svelte|py|go|rb|rs|java|kt|swift|cc?|cpp|cxx|hh?|hpp|sh|bash|zsh|sql|ya?ml|toml|jsonc?|mdx?|php|pl|lua|exs?|scala|dart|mm?|jl|tf|r)[[:space:]]*:[0-9]+' <<< "$normalized_without_urls" >/dev/null; then
-        if [[ -z "$evidence_root" ]]; then
+    # evidence (CodeRabbit #1017). A live source tree turns this prose signal
+    # into an evidence check. Keep the extension allowlist aligned with the
+    # citations eligible for this blind-seat gate. If the live validator is
+    # unavailable, preserve the prose-only exemption rather than treating its
+    # empty result as proof that the citation is fabricated.
+    local source_extension_pattern='tsx?|jsx?|mjs|cjs|css|scss|sass|less|html?|vue|svelte|py|go|rb|rs|java|kt|swift|cc?|cpp|cxx|hh?|hpp|sh|bash|zsh|sql|ya?ml|toml|jsonc?|mdx?|php|pl|lua|exs?|scala|dart|mm?|jl|tf|r'
+    if grep -ciE "\\.(${source_extension_pattern})[[:space:]]*:[0-9]+" <<< "$normalized_without_urls" >/dev/null; then
+        if [[ -z "$evidence_root" || ! -d "$evidence_root" ]] || ! command -v python3 >/dev/null 2>&1; then
             return 1
         fi
         local validated_evidence
         validated_evidence="$(council_response_evidence_paths_json "$f" "$evidence_root")" || validated_evidence='[]'
-        if [[ "$(jq 'length' <<< "$validated_evidence" 2>/dev/null || printf 0)" -gt 0 ]]; then
+        local validated_source_evidence
+        validated_source_evidence="$(jq --arg ext "\\.(${source_extension_pattern})$" '[.[] | select(.path | test($ext))]' <<< "$validated_evidence" 2>/dev/null || printf '[]')"
+        if [[ "$(jq 'length' <<< "$validated_source_evidence" 2>/dev/null || printf 0)" -gt 0 ]]; then
             return 1
         fi
     fi

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1885,7 +1885,10 @@ council_response_is_substantive() {
     #      merely quotes such a phrase is never rejected.
     # (RATIONALE: sail-cruisey #1839 — agy's "I cannot access the implementation
     # plan, PRD, or security audit files" REVISE was counted as the 2nd provider.)
-    local f="$1"
+    # A live evidence root lets the detector distinguish a real citation from
+    # a fabricated file:line token. Standalone callers may omit it for plan or
+    # PRD reviews that have no source tree.
+    local f="$1" evidence_root="${2:-}"
     [[ -f "$f" ]] || return 1
 
     # 1) Host self-dispatch stub — runner-emitted, exact match. (grep -c … >/dev/null,
@@ -1910,7 +1913,7 @@ council_response_is_substantive() {
     #    be scored as a substantive responder. Fold it in here so the single
     #    substantive gate the quorum tally keys on and the advice-phase `blind` label
     #    agree; the advice phase still re-tests is_blind to label it distinctly.
-    if council_response_is_blind "$f"; then
+    if council_response_is_blind "$f" "$evidence_root"; then
         return 1
     fi
 
@@ -1927,7 +1930,7 @@ council_response_is_blind() {
     # round instead of eating several. First-person access failure is checked
     # independently of length; less-specific refusal and permission shapes remain
     # brevity-gated to protect genuine reviews that discuss those failures.
-    local f="$1"
+    local f="$1" evidence_root="${2:-}"
     [[ -f "$f" ]] || return 1
 
     # A first-person access failure is authoritative. Citation-shaped prose is not
@@ -1942,7 +1945,7 @@ council_response_is_blind() {
     # rather than on reading the artifact, and it cites no real source location.
     # Gated on zero file:line citations so a grounded review is never flagged
     # (sail-cruisey #2570 paraphrase, #2463 prior-phase deference).
-    if council_response_defers_without_reading "$f"; then
+    if council_response_defers_without_reading "$f" "$evidence_root"; then
         return 0
     fi
 
@@ -2006,8 +2009,9 @@ council_response_defers_without_reading() {
     # file:line, so it is never flagged for merely mentioning a summary or a prior
     # round. The colon citation form is deliberately the ONLY grounding signal
     # here — prose "lines 251-263" or a bare filename can be copied from the
-    # plan/summary without reading it (#2463 does exactly that).
-    local f="$1"
+    # plan/summary without reading it (#2463 does exactly that). When an
+    # evidence root is available, the cited path must also resolve beneath it.
+    local f="$1" evidence_root="${2:-}"
     [[ -f "$f" ]] || return 1
 
     local normalized_without_urls
@@ -2025,7 +2029,14 @@ council_response_defers_without_reading() {
     # disposable workspace is gone by classification time, so a cited path cannot
     # be resolved; the phrase gate below is the primary discriminator.
     if grep -ciE '\.(tsx?|jsx?|mjs|cjs|css|scss|sass|less|html?|vue|svelte|py|go|rb|rs|java|kt|swift|cc?|cpp|cxx|hh?|hpp|sh|bash|zsh|sql|ya?ml|toml|jsonc?|mdx?|php|pl|lua|exs?|scala|dart|mm?|jl|tf|r)[[:space:]]*:[0-9]+' <<< "$normalized_without_urls" >/dev/null; then
-        return 1
+        if [[ -z "$evidence_root" ]]; then
+            return 1
+        fi
+        local validated_evidence
+        validated_evidence="$(council_response_evidence_paths_json "$f" "$evidence_root")" || validated_evidence='[]'
+        if [[ "$(jq 'length' <<< "$validated_evidence" 2>/dev/null || printf 0)" -gt 0 ]]; then
+            return 1
+        fi
     fi
 
     # Code-level verification token, wrapped in word boundaries so a code term is
@@ -2243,7 +2254,7 @@ council_contribution_record_json() {
     local verdict="" evidence='[]' access_state="unverified" validation_result="invalid-empty"
     if council_response_nonempty "$response_path"; then
         verdict="$(council_response_verdict "$response_path")"
-        if council_response_is_blind "$response_path"; then
+        if council_response_is_blind "$response_path" "$evidence_root"; then
             access_state="failed"
             validation_result="invalid-access"
         elif ! council_response_has_verdict "$response_path"; then
@@ -2430,7 +2441,7 @@ council_run_advice_phase() {
         # the seat finished writing right at the boundary. Salvage that instead of
         # discarding a usable verdict as a provider shortage (sail-cruisey #2077).
         if council_response_nonempty "$output_path" \
-                && council_response_is_substantive "$output_path" \
+                && council_response_is_substantive "$output_path" "$evidence_root" \
                 && { (( dispatch_rc == 0 )) || council_response_has_verdict "$output_path"; }; then
             COUNCIL_RESPONSES_RECEIVED=$((COUNCIL_RESPONSES_RECEIVED + 1))
             resp_bytes="$(wc -c < "$output_path" 2>/dev/null | tr -d '[:space:]')"; [[ -z "$resp_bytes" ]] && resp_bytes=0
@@ -2464,11 +2475,11 @@ council_run_advice_phase() {
             fi
         elif council_response_nonempty "$output_path"; then
             resp_bytes="$(wc -c < "$output_path" 2>/dev/null | tr -d '[:space:]')"; [[ -z "$resp_bytes" ]] && resp_bytes=0
-            if council_response_is_substantive "$output_path"; then
+            if council_response_is_substantive "$output_path" "$evidence_root"; then
                 # A timed-out/truncated review without a final verdict is preserved
                 # for diagnosis, but cannot count as a response or approver.
                 seat_status="no-response"
-            elif council_response_is_blind "$output_path"; then
+            elif council_response_is_blind "$output_path" "$evidence_root"; then
                 # Returned a verdict without reading the artifact (no file tools /
                 # permission). Label it distinctly and surface which provider, so
                 # the operator can switch its mode after ROUND ONE, not round six.
@@ -2631,7 +2642,7 @@ council_run_chair_fallback() {
         # diagnosis, but must not masquerade as a recovered chair response.
         if [[ -n "$existing_response" ]] \
                 && council_response_nonempty "$existing_response" \
-                && council_response_is_substantive "$existing_response" \
+                && council_response_is_substantive "$existing_response" "$evidence_root" \
                 && jq -e --arg persona "$persona" \
                     'any(.[]; .persona == $persona and .status == "responded")' \
                     <<< "${COUNCIL_SEAT_RECORDS_JSON:-[]}" >/dev/null; then
@@ -2654,7 +2665,7 @@ council_run_chair_fallback() {
         council_dispatch_member_detached "$member_json" "independent-advice" "$output_path" || dispatch_rc=$?
         dispatch_timeout_provenance="$COUNCIL_LAST_DISPATCH_TIMEOUT_PROVENANCE"
         if council_response_nonempty "$output_path" \
-                && council_response_is_substantive "$output_path" \
+                && council_response_is_substantive "$output_path" "$evidence_root" \
                 && { (( dispatch_rc == 0 )) || council_response_has_verdict "$output_path"; }; then
             COUNCIL_RESPONSES_RECEIVED=$((COUNCIL_RESPONSES_RECEIVED + 1))
             COUNCIL_CHAIR_RESPONSE_RECEIVED="true"

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -1937,6 +1937,15 @@ council_response_is_blind() {
         return 0
     fi
 
+    # A softer evasion: the seat never admits an access failure, but its verdict
+    # rests entirely on the task summary / prior rounds / a clean test suite
+    # rather than on reading the artifact, and it cites no real source location.
+    # Gated on zero file:line citations so a grounded review is never flagged
+    # (sail-cruisey #2570 paraphrase, #2463 prior-phase deference).
+    if council_response_defers_without_reading "$f"; then
+        return 0
+    fi
+
     local nlen
     nlen="$(tr -d '[:space:]' < "$f" | wc -c | tr -d '[:space:]')"
     (( nlen < 1600 )) || return 1
@@ -1959,13 +1968,18 @@ council_response_has_access_failure() {
 
     # Normalize wrapping, then evaluate one sentence/clause at a time. This
     # catches Markdown line wraps without letting a first-person sentence attach
-    # to a later third-person access report.
+    # to a later third-person access report. A period between two alphanumerics is
+    # part of a token (a filename like WatcherDashboard.test.tsx, a version like
+    # 1.0.4), NOT a sentence end — neutralize those to a space first, or the
+    # sentence split would sever "I am assuming ... <file>" from "... file access
+    # is restricted" and miss the admission (sail-cruisey #2459).
     local normalized_without_urls
     normalized_without_urls="$(tr '\n' ' ' < "$f" | tr -s '[:space:]' ' ' \
         | tr '[:upper:]' '[:lower:]' \
         | sed -E \
             -e 's#https?://[^[:space:]]*([.!?;])([[:space:]]|$)#\1\2#g' \
-            -e 's#https?://[^[:space:]]+##g')"
+            -e 's#https?://[^[:space:]]+##g' \
+            -e ':dot' -e 's#([[:alnum:]])\.([[:alnum:]])#\1 \2#g' -e 'tdot')"
     printf '%s\n' "$normalized_without_urls" | awk '
         BEGIN { RS="[.!?;]+"; found=0 }
         {
@@ -1974,6 +1988,52 @@ council_response_has_access_failure() {
             third_party_access = ($0 ~ /(^|[^[:alnum:]_])(another|other)[[:space:]]+(reviewer|seat|agent|provider|model)([^[:alnum:]_]|$)[^.!?;]{0,80}(cannot|could[[:space:]]*not|couldn.t|unable[[:space:]]+to|can.t|did[[:space:]]+not|lack(ed|s)?)/)
             first_person_access = ($0 ~ /(^|[^[:alnum:]_])(i|we)[[:space:]]+(cannot|could[[:space:]]*not|couldn.t|unable[[:space:]]+to|can.t|was[[:space:]]+not[[:space:]]+able[[:space:]]+to|were[[:space:]]+not[[:space:]]+able[[:space:]]+to)[[:space:]]+(open|read|access|view)/ || $0 ~ /(^|[^[:alnum:]_])(i|we)[[:space:]]+((did[[:space:]]+not|do[[:space:]]+not|don.t)[[:space:]]+have|lack(ed)?)[[:space:]]+(direct[[:space:]]+)?access/)
             if (first_person && access_failure && (!third_party_access || first_person_access)) found=1
+        }
+        END { exit(found ? 0 : 1) }
+    ' >/dev/null 2>&1
+}
+
+council_response_defers_without_reading() {
+    # A "soft blind" seat never states an access failure outright, but its verdict
+    # rests on the task summary, prior review rounds, or a clean test suite rather
+    # than on reading the artifact — it reviewed nothing. Two real agy evasions:
+    #   - summary paraphrase: "the ariaLabel field is correctly propagated, as
+    #     stated in the summary" (sail-cruisey #2570)
+    #   - prior-phase deference: "given the rigorous validations in previous
+    #     rounds ... I recommend proceeding" (#2463)
+    # This is length-independent (the evasions are long) but gated on ZERO
+    # `path.ext:line` citations: a genuinely grounded review carries a concrete
+    # file:line, so it is never flagged for merely mentioning a summary or a prior
+    # round. The colon citation form is deliberately the ONLY grounding signal
+    # here — prose "lines 251-263" or a bare filename can be copied from the
+    # plan/summary without reading it (#2463 does exactly that).
+    local f="$1"
+    [[ -f "$f" ]] || return 1
+
+    if grep -ciE '\.[[:alpha:]][[:alnum:]]{0,9}:[0-9]+' "$f" >/dev/null; then
+        return 1
+    fi
+
+    local normalized_without_urls
+    normalized_without_urls="$(tr '\n' ' ' < "$f" | tr -s '[:space:]' ' ' \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -E \
+            -e 's#https?://[^[:space:]]*([.!?;])([[:space:]]|$)#\1\2#g' \
+            -e 's#https?://[^[:space:]]+##g')"
+    printf '%s\n' "$normalized_without_urls" | awk '
+        {
+            # NOTE: a bare "based on the provided summary" is deliberately NOT a
+            # trigger — a legitimate plan/design review (no code to cite) uses that
+            # phrasing (sail-cruisey #2527). The blind signal is the summary being
+            # cited as CONFIRMATION of code-level facts ("the summary confirms …")
+            # or a reported-clean test/typecheck standing in for reading the code.
+            summary_reliance = ($0 ~ /the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|mitigat)/ \
+                || $0 ~ /(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
+                || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+(tsc|lint|test|ci|type)/)
+            prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \
+                || $0 ~ /(passed|cleared|survived)[^.!?;]{0,50}(phase[[:space:]]*[0-9]+|staged|rigorous)[^.!?;]{0,25}(reviews?|validations?|gates?|checks?)/ \
+                || $0 ~ /(test[[:space:]]+suite|tsc|lint|ci)[^.!?;]{0,40}(clean|passing|green)[^.!?;]{0,90}(recommend|proceed|approv|no[[:space:]]+(other[[:space:]]+)?(material[[:space:]]+)?(flaws?|issues?|concerns?))/)
+            if (summary_reliance || prior_deference) found=1
         }
         END { exit(found ? 0 : 1) }
     ' >/dev/null 2>&1

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2010,24 +2010,34 @@ council_response_defers_without_reading() {
     local f="$1"
     [[ -f "$f" ]] || return 1
 
-    if grep -ciE '\.[[:alpha:]][[:alnum:]]{0,9}:[0-9]+' "$f" >/dev/null; then
-        return 1
-    fi
-
     local normalized_without_urls
     normalized_without_urls="$(tr '\n' ' ' < "$f" | tr -s '[:space:]' ' ' \
         | tr '[:upper:]' '[:lower:]' \
         | sed -E \
             -e 's#https?://[^[:space:]]*([.!?;])([[:space:]]|$)#\1\2#g' \
             -e 's#https?://[^[:space:]]+##g')"
+
+    # A concrete SOURCE file:line citation is the grounding signal. Match only
+    # real source extensions, and only AFTER stripping URLs, so a URL port
+    # (https://example.com:443) or a doc/host token is never mistaken for
+    # evidence (CodeRabbit #1017). This is a prose signal, not a filesystem
+    # check — councils also review plans/PRDs that have no source tree, and the
+    # disposable workspace is gone by classification time, so a cited path cannot
+    # be resolved; the phrase gate below is the primary discriminator.
+    if grep -ciE '\.(tsx?|jsx?|mjs|cjs|css|scss|sass|less|html?|vue|svelte|py|go|rb|rs|java|kt|swift|cc?|cpp|cxx|hh?|hpp|sh|bash|zsh|sql|ya?ml|toml|jsonc?|mdx?|php|pl|lua|exs?|scala|dart|mm?|jl|tf|r)[[:space:]]*:[0-9]+' <<< "$normalized_without_urls" >/dev/null; then
+        return 1
+    fi
+
     printf '%s\n' "$normalized_without_urls" | awk '
         {
             # NOTE: a bare "based on the provided summary" is deliberately NOT a
             # trigger — a legitimate plan/design review (no code to cite) uses that
             # phrasing (sail-cruisey #2527). The blind signal is the summary being
-            # cited as CONFIRMATION of code-level facts ("the summary confirms …")
-            # or a reported-clean test/typecheck standing in for reading the code.
-            summary_reliance = ($0 ~ /the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|mitigat)/ \
+            # cited as CONFIRMATION of CODE-LEVEL facts ("the summary confirms the
+            # tests pass / byte-identical output") — a bare "the summary states the
+            # rollout is phased" (process, not code) is NOT a trigger — or a
+            # reported-clean test/typecheck standing in for reading the code.
+            summary_reliance = ($0 ~ /the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|shows|verifies|mitigat[a-z]*)[^.!?;]{0,80}(test|coverage|render|output|type[- ]?check|tsc|lint|implement|propagat|byte-identical|pass(es|ing|ed)?|regression|contract|behaviou?r|diff|assertion|snapshot|dom|css|class|component|function|api|endpoint|schema|payload|field)/ \
                 || $0 ~ /(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
                 || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+(tsc|lint|test|ci|type)/)
             prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2233,8 +2233,11 @@ for raw_path, raw_start, raw_end in pattern.findall(response.read_text(encoding=
         continue
     if not candidate.is_file():
         continue
-    start_line = int(raw_start)
-    end_line = int(raw_end or raw_start)
+    try:
+        start_line = int(raw_start)
+        end_line = int(raw_end or raw_start)
+    except ValueError:
+        continue
     if start_line < 1 or end_line < start_line:
         continue
     if candidate not in file_facts:

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2038,7 +2038,15 @@ council_response_has_access_failure() {
     # source filenames and numeric versions; a genuine sentence boundary such as
     # "file.However" must remain a boundary even when whitespace is missing.
     local normalized_without_urls
-    normalized_without_urls="$(tr '\n' ' ' < "$f" | tr -s '[:space:]' ' ' \
+    normalized_without_urls="$(awk '
+        NR == 1 { previous = $0; next }
+        {
+            separator = ($0 ~ /^[[:space:]]*([-*][[:space:]]+|[0-9]+[.)][[:space:]]+)/) ? "; " : " "
+            printf "%s%s", previous, separator
+            previous = $0
+        }
+        END { print previous }
+    ' "$f" | tr -s '[:space:]' ' ' \
         | tr '[:upper:]' '[:lower:]' \
         | sed -E \
             -e 's#https?://[^[:space:]]*([.!?;])([[:space:]]|$)#\1\2#g' \
@@ -2096,8 +2104,8 @@ council_response_defers_without_reading() {
     # citations eligible for this blind-seat gate. If the live validator is
     # unavailable, preserve the prose-only exemption rather than treating its
     # empty result as proof that the citation is fabricated.
-    local source_extension_pattern='tsx?|jsx?|mjs|cjs|css|scss|sass|less|html?|vue|svelte|py|go|rb|rs|java|kt|swift|cc?|cpp|cxx|hh?|hpp|sh|bash|zsh|sql|ya?ml|toml|jsonc?|mdx?|php|pl|lua|exs?|scala|dart|mm?|jl|tf|r'
-    if grep -ciE "\\.(${source_extension_pattern})[[:space:]]*:[0-9]+" <<< "$normalized_without_urls" >/dev/null; then
+    local source_extension_pattern='tsx?|jsx?|mjs|cjs|css|scss|sass|less|html?|vue|svelte|py|go|rb|rs|java|kt|swift|cs|cc?|cpp|cxx|hh?|hpp|sh|bash|zsh|ps1|sql|ya?ml|toml|jsonc?|xml|proto|graphql|gql|ini|cfg|conf|env|gradle|mdx?|php|pl|lua|exs?|scala|dart|mm?|jl|tf|r'
+    if grep -ciE "\\.(${source_extension_pattern})[[:space:]]*:[[:space:]]*[0-9]+" <<< "$normalized_without_urls" >/dev/null; then
         if [[ -z "$evidence_root" || ! -d "$evidence_root" ]] || ! command -v python3 >/dev/null 2>&1; then
             return 1
         fi
@@ -2140,7 +2148,7 @@ council_response_defers_without_reading() {
                 || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+((tsc|lint|test)([^[:alnum:]_]|$)|ci([^[:alnum:]_]|$)|type([^[:alnum:]_]|$)))/)
             prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \
                 || $0 ~ /(passed|cleared|survived)[^.!?;]{0,50}(phase[[:space:]]*[0-9]+|staged|rigorous)[^.!?;]{0,25}(reviews?|validations?|gates?|checks?)/ \
-                || $0 ~ /((test[[:space:]]+suite|tsc|lint)([^[:alnum:]]|$)|ci([^[:alnum:]]|$))[^.!?;]{0,40}(clean|passing|green)[^.!?;]{0,90}(recommend|proceed|approv|no[[:space:]]+(other[[:space:]]+)?(material[[:space:]]+)?(flaws?|issues?|concerns?))/)
+                || $0 ~ /((^|[^[:alnum:]_])test[[:space:]]+suite([^[:alnum:]_]|$)|(^|[^[:alnum:]_])(tsc|lint|ci)([^[:alnum:]_]|$))[^.!?;]{0,40}(clean|passing|green)[^.!?;]{0,90}(recommend|proceed|approv|no[[:space:]]+(other[[:space:]]+)?(material[[:space:]]+)?(flaws?|issues?|concerns?))/)
             if (summary_reliance || prior_deference) found=1
         }
         END { exit(found ? 0 : 1) }
@@ -2210,12 +2218,12 @@ from pathlib import Path
 
 response = Path(sys.argv[1])
 root = Path(sys.argv[2]).resolve()
-pattern = re.compile(r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*):([0-9]+)(?:-([0-9]+))?(?![A-Za-z0-9_/-])")
+pattern = re.compile(r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*)\s*:\s*([0-9]+)(?:-([0-9]+))?(?![A-Za-z0-9_/-])")
 validated = []
 seen = set()
 file_facts = {}
 for raw_path, raw_start, raw_end in pattern.findall(response.read_text(encoding="utf-8", errors="replace")):
-    relative = Path(raw_path)
+    relative = Path(raw_path.strip())
     if relative.is_absolute() or ".." in relative.parts:
         continue
     try:

--- a/scripts/lib/council.sh
+++ b/scripts/lib/council.sh
@@ -2028,7 +2028,16 @@ council_response_defers_without_reading() {
         return 1
     fi
 
-    printf '%s\n' "$normalized_without_urls" | awk '
+    # Code-level verification token, wrapped in word boundaries so a code term is
+    # only matched as a whole token, never as a substring of an ordinary word
+    # ("api" inside "capital", "diff" inside "different", "test" inside "latest",
+    # "class" inside "classic" — CodeRabbit #1017). ERE has no \b, and macOS awk
+    # is BWK awk (no \<); the portable form guards both sides with
+    # (^|[^[:alnum:]]) ... ([^[:alnum:]]|$) and spells out the code-form
+    # inflections so common plural/tense forms still match.
+    local code_token='(^|[^[:alnum:]])(test(s|ed|ing|cases?)?|coverage|render(s|ed|ing)?|outputs?|type[- ]?check(s|ed|ing)?|tsc|lint(s|ed|ing|er)?|implement(s|ed|ing|ations?)?|propagat(e|es|ed|ing|ion)?|byte-identical|pass(es|ing|ed)?|regress(es|ed|ions?)?|contracts?|behaviou?r(s|al)?|diff(s|ed)?|assert(s|ed|ing|ions?)?|snapshots?|dom|css|class(es)?|components?|functions?|api(s)?|endpoints?|schema(s|ta)?|payloads?|fields?)([^[:alnum:]]|$)'
+
+    printf '%s\n' "$normalized_without_urls" | awk -v ct="$code_token" '
         {
             # NOTE: a bare "based on the provided summary" is deliberately NOT a
             # trigger — a legitimate plan/design review (no code to cite) uses that
@@ -2040,9 +2049,11 @@ council_response_defers_without_reading() {
             # word orders count: forward ("the summary confirms <code fact>") and
             # reverse ("<code fact> ... as stated in / according to / per the
             # summary") — the reverse attribution is the exact #2570 wording and
-            # carries no citation of its own (CodeRabbit #1017).
-            summary_reliance = ($0 ~ /the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|shows|verifies|mitigat[a-z]*)[^.!?;]{0,80}(test|coverage|render|output|type[- ]?check|tsc|lint|implement|propagat|byte-identical|pass(es|ing|ed)?|regression|contract|behaviou?r|diff|assertion|snapshot|dom|css|class|component|function|api|endpoint|schema|payload|field)/ \
-                || $0 ~ /(test|coverage|render|output|type[- ]?check|tsc|lint|implement|propagat|byte-identical|regression|contract|behaviou?r|diff|assertion|snapshot|dom|css|class|component|function|api|endpoint|schema|payload|field)[^.!?;]{0,80}(as[[:space:]]+stated[[:space:]]+in|according[[:space:]]+to|per)[[:space:]]+(the[[:space:]]+)?summary/ \
+            # carries no citation of its own (CodeRabbit #1017). The code fact is
+            # the token-bounded ct regex so "the capital plan, as stated in the
+            # summary" (api ⊂ capital) is not misread as a code claim.
+            summary_reliance = ($0 ~ ("the[[:space:]]+summary[[:space:]]+(confirms|states|indicates|reports|notes|says|claims|shows|verifies|mitigat[a-z]*)[^.!?;]{0,80}" ct) \
+                || $0 ~ (ct "[^.!?;]{0,80}(as[[:space:]]+stated[[:space:]]+in|according[[:space:]]+to|per)[[:space:]]+(the[[:space:]]+)?summary") \
                 || $0 ~ /(constraints?|restrictions?|rules|permissions?|sandbox)[[:space:]]+(prevent|restrict|prohibit|preclude|block)[a-z]*[^.!?;]{0,50}(verif|read|access|inspect|examin|confirm|review)/ \
                 || $0 ~ /(reported|stated|claimed)[[:space:]]+(clean|passing)[[:space:]]+(tsc|lint|test|ci|type)/)
             prior_deference = ($0 ~ /(given|based on|relying on|because of|considering)[^.!?;]{0,70}(previous|prior|earlier)[[:space:]]+(rounds?|reviews?|validations?|phases?)/ \

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2501,7 +2501,17 @@ test_council_blind_summary_deference() {
         echo "VERDICT: APPROVE"
     } > "$d/reverse-attr.md"
 
-    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n
+    # (h) Token-boundary control (CodeRabbit #1017): a NON-code plan sentence that
+    # happens to contain a code term as a SUBSTRING ("api" ⊂ "capital"), in the
+    # reverse-attribution word order. Must NOT be flagged — code terms match only
+    # as whole tokens, so "capital" is not a code fact.
+    {
+        echo "## Recommendation"
+        echo "The capital plan is sound and the phasing is prudent, as stated in the summary."
+        echo "VERDICT: APPROVE"
+    } > "$d/plan-capital.md"
+
+    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n capital_ok=n
     council_response_is_blind "$d/paraphrase.md" && para=y
     council_response_is_blind "$d/deference.md" && defer=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
@@ -2509,12 +2519,13 @@ test_council_blind_summary_deference() {
     council_response_is_blind "$d/url-port.md" && url_blind=y
     council_response_is_blind "$d/plan-states.md" || plan_states_ok=y
     council_response_is_blind "$d/reverse-attr.md" && reverse=y
+    council_response_is_blind "$d/plan-capital.md" || capital_ok=y
 
     if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
-          && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" ]]; then
+          && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" && "$capital_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2668,8 +2668,10 @@ test_council_blind_summary_deference() {
     # A citation-shaped token is not grounding when it does not resolve beneath
     # the evidence root. A real source file and in-range line remains grounding.
     local evidence_root="$d/evidence" fabricated_citation=n valid_citation=n out_of_range_citation=n
+    local valid_range_citation=n out_of_range_range_citation=n reversed_range_citation=n
     mkdir -p "$evidence_root/src"
     printf 'const value = 1;\n' > "$evidence_root/src/real.tsx"
+    printf 'const first = 1;\nconst second = 2;\n' > "$evidence_root/src/range.tsx"
     printf '%s\n' \
         'The summary confirms the implementation is correct at made-up.ts:1.' \
         'VERDICT: APPROVE' > "$d/fabricated-citation.md"
@@ -2679,17 +2681,30 @@ test_council_blind_summary_deference() {
     printf '%s\n' \
         'The summary confirms the implementation is correct at src/real.tsx:2.' \
         'VERDICT: APPROVE' > "$d/out-of-range-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/range.tsx:1-2.' \
+        'VERDICT: APPROVE' > "$d/valid-range-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/range.tsx:1-3.' \
+        'VERDICT: APPROVE' > "$d/out-of-range-range-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/range.tsx:2-1.' \
+        'VERDICT: APPROVE' > "$d/reversed-range-citation.md"
     council_response_is_blind "$d/fabricated-citation.md" "$evidence_root" && fabricated_citation=y
     council_response_is_blind "$d/valid-citation.md" "$evidence_root" || valid_citation=y
     council_response_is_blind "$d/out-of-range-citation.md" "$evidence_root" && out_of_range_citation=y
+    council_response_is_blind "$d/valid-range-citation.md" "$evidence_root" || valid_range_citation=y
+    council_response_is_blind "$d/out-of-range-range-citation.md" "$evidence_root" && out_of_range_range_citation=y
+    council_response_is_blind "$d/reversed-range-citation.md" "$evidence_root" && reversed_range_citation=y
 
     if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
           && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" && "$capital_ok" == "y" \
           && "$fabricated_citation" == "y" && "$valid_citation" == "y" && "$out_of_range_citation" == "y" \
+          && "$valid_range_citation" == "y" && "$out_of_range_range_citation" == "y" && "$reversed_range_citation" == "y" \
           && "$ci_substring_ok" == "y" && "$type_substring_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation valid_range_citation=$valid_range_citation out_of_range_range_citation=$out_of_range_range_citation reversed_range_citation=$reversed_range_citation ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2471,16 +2471,37 @@ test_council_blind_summary_deference() {
         echo "VERDICT: APPROVE"
     } > "$d/grounded-cited.md"
 
-    local para=n defer=n grounded_ok=n cited_ok=n
+    # (e) Deference lean but the only ":NN" is a URL port — must STILL be blind:
+    # URLs are stripped before the citation guard, so a link is not grounding
+    # (CodeRabbit #1017).
+    {
+        echo "## Review"
+        echo "Given the rigorous validations in previous rounds, I recommend proceeding; see the plan at https://example.com:443/plan for context."
+        echo "VERDICT: APPROVE"
+    } > "$d/url-port.md"
+
+    # (f) Plan/process review that says "the summary states" about a NON-code fact
+    # (rollout sequencing) with no citation — must NOT be flagged: summary
+    # reliance requires a code-level confirmation, not a process statement.
+    {
+        echo "## Recommendation"
+        echo "The summary states the rollout is phased across three releases, which is a sound sequencing decision for risk management."
+        echo "VERDICT: APPROVE"
+    } > "$d/plan-states.md"
+
+    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n
     council_response_is_blind "$d/paraphrase.md" && para=y
     council_response_is_blind "$d/deference.md" && defer=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
     council_response_is_blind "$d/grounded-cited.md" || cited_ok=y
+    council_response_is_blind "$d/url-port.md" && url_blind=y
+    council_response_is_blind "$d/plan-states.md" || plan_states_ok=y
 
-    if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" ]]; then
+    if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
+          && "$url_blind" == "y" && "$plan_states_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2427,6 +2427,64 @@ test_council_advice_marks_blind_seat() {
     fi
 }
 
+test_council_blind_summary_deference() {
+    test_case "a seat that rests on the summary or prior rounds with no file:line citation is blind; a grounded review (specific code, or a real file:line) is not (sail-cruisey #2570/#2463)"
+    load_council_lib || return 1
+
+    local d; d="$(mktemp -d "$TEST_TMP_DIR/council-deference.XXXXXX")"
+
+    # (a) Summary paraphrase (#2570): APPROVE that rests on the summary, no
+    # access-failure admission, zero file:line citations.
+    {
+        echo "### Recommendation"
+        echo "APPROVE. The refactor is sound and backward compatible."
+        echo "### Assumptions"
+        echo "- The ariaLabel field is correctly propagated through all implementations, as stated in the summary."
+        echo "- The reported clean tsc output and 100% test pass rate are accurate representations of CI state."
+        echo "The summary confirms byte-identical rendered output, effectively mitigating regression risk."
+        echo "VERDICT: APPROVE"
+    } > "$d/paraphrase.md"
+
+    # (b) Prior-phase deference (#2463): defers to earlier rounds/gates instead of
+    # reading the artifact, no access-failure admission, zero file:line citations.
+    {
+        echo "## Architectural Review"
+        echo "The footer correction is architecturally sound and aligns the frontend with the backend data shape."
+        echo "Given the rigorous validations in previous rounds and the successful resolution of the final finding, it provides a solid, grounded foundation for Phase 6 implementation. I see no other material flaws, so I recommend proceeding."
+        echo "VERDICT: APPROVE"
+    } > "$d/deference.md"
+
+    # (c) Grounded review: analyzes specific code/behavior directly, with no
+    # summary/prior-round lean — must NOT be flagged even with zero file:line.
+    {
+        echo "## Review"
+        echo "The exclusive swap (const baseIconClass = bare ? styles.emptyIconShellBare : styles.emptyIconShell) prevents cascade races, and the additive emptyActionsBare class applies the 1rem margin without overriding emptyActions."
+        echo "The empty-state.test.tsx additions cover both the icon-shell swap and the actions spacing. I found no correctness issues or missed requirements."
+        echo "VERDICT: APPROVE"
+    } > "$d/grounded.md"
+
+    # (d) Uses a deference phrase BUT carries a real file:line citation — the
+    # colon-citation guard must keep it out of the blind set.
+    {
+        echo "## Review"
+        echo "Given the prior rounds, the guard added at src/SpendingTab.tsx:257 correctly classifies the single-amount footer."
+        echo "VERDICT: APPROVE"
+    } > "$d/grounded-cited.md"
+
+    local para=n defer=n grounded_ok=n cited_ok=n
+    council_response_is_blind "$d/paraphrase.md" && para=y
+    council_response_is_blind "$d/deference.md" && defer=y
+    council_response_is_blind "$d/grounded.md" || grounded_ok=y
+    council_response_is_blind "$d/grounded-cited.md" || cited_ok=y
+
+    if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" ]]; then
+        test_pass
+    else
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok"
+        return 1
+    fi
+}
+
 test_council_blind_fabricated_narrative() {
     test_case "a long first-person access failure is blind regardless of length or citation prose; grounded long reviews and plan reviews are not"
     load_council_lib || return 1
@@ -3173,6 +3231,7 @@ test_council_rc_is_timeout_requires_watchdog_provenance
 test_council_advice_marks_timed_out_seat
 test_council_advice_marks_blind_seat
 test_council_blind_fabricated_narrative
+test_council_blind_summary_deference
 test_council_permission_denied_finding_is_substantive
 test_council_advice_does_not_infer_timeout_from_provider_rc
 test_council_seat_timeout_rejects_zero_and_nonnumeric

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2690,7 +2690,7 @@ test_council_blind_summary_deference() {
     # the evidence root. A real source file and in-range line remains grounding.
     local evidence_root="$d/evidence" fabricated_citation=n valid_citation=n out_of_range_citation=n
     local valid_range_citation=n out_of_range_range_citation=n reversed_range_citation=n
-    local malformed_suffix_citation=n malformed_range_citation=n dotted_numeric_citation=n dotted_text_citation=n sentence_final_citation_ok=n uppercase_extension_ok=n config_extension_ok=n spaced_citation_ok=n
+    local malformed_suffix_citation=n malformed_range_citation=n dotted_numeric_citation=n dotted_text_citation=n dotted_identifier_citation=n dotted_run_citation=n sentence_final_citation_ok=n uppercase_extension_ok=n config_extension_ok=n spaced_citation_ok=n
     mkdir -p "$evidence_root/src"
     printf 'const value = 1;\n' > "$evidence_root/src/real.tsx"
     printf 'const first = 1;\nconst second = 2;\n' > "$evidence_root/src/range.tsx"
@@ -2728,6 +2728,12 @@ test_council_blind_summary_deference() {
         'The summary confirms the implementation is correct at src/range.tsx:1.foo.' \
         'VERDICT: APPROVE' > "$d/dotted-text-citation.md"
     printf '%s\n' \
+        'The summary confirms the implementation is correct at src/range.tsx:1._foo.' \
+        'VERDICT: APPROVE' > "$d/dotted-identifier-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/range.tsx:1..foo.' \
+        'VERDICT: APPROVE' > "$d/dotted-run-citation.md"
+    printf '%s\n' \
         'The summary confirms the implementation is correct at src/range.tsx:1.' \
         'VERDICT: APPROVE' > "$d/sentence-final-citation.md"
     printf '%s\n' \
@@ -2749,6 +2755,8 @@ test_council_blind_summary_deference() {
     council_response_is_blind "$d/malformed-range-citation.md" "$evidence_root" && malformed_range_citation=y
     council_response_is_blind "$d/dotted-numeric-citation.md" "$evidence_root" && dotted_numeric_citation=y
     council_response_is_blind "$d/dotted-text-citation.md" "$evidence_root" && dotted_text_citation=y
+    council_response_is_blind "$d/dotted-identifier-citation.md" "$evidence_root" && dotted_identifier_citation=y
+    council_response_is_blind "$d/dotted-run-citation.md" "$evidence_root" && dotted_run_citation=y
     council_response_is_blind "$d/sentence-final-citation.md" "$evidence_root" || sentence_final_citation_ok=y
     council_response_is_blind "$d/uppercase-extension-citation.md" "$evidence_root" || uppercase_extension_ok=y
     council_response_is_blind "$d/config-extension-citation.md" "$evidence_root" || config_extension_ok=y
@@ -2763,12 +2771,13 @@ test_council_blind_summary_deference() {
           && "$ci_prior_substring_ok" == "y" && "$adjacent_bullets_ok" == "y" \
           && "$malformed_suffix_citation" == "y" && "$malformed_range_citation" == "y" \
           && "$dotted_numeric_citation" == "y" && "$dotted_text_citation" == "y" \
+          && "$dotted_identifier_citation" == "y" && "$dotted_run_citation" == "y" \
           && "$sentence_final_citation_ok" == "y" \
           && "$uppercase_extension_ok" == "y" && "$config_extension_ok" == "y" \
           && "$spaced_citation_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para defer=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation valid_range_citation=$valid_range_citation out_of_range_range_citation=$out_of_range_range_citation reversed_range_citation=$reversed_range_citation malformed_suffix_citation=$malformed_suffix_citation malformed_range_citation=$malformed_range_citation dotted_numeric_citation=$dotted_numeric_citation dotted_text_citation=$dotted_text_citation sentence_final_citation_ok=$sentence_final_citation_ok uppercase_extension_ok=$uppercase_extension_ok config_extension_ok=$config_extension_ok spaced_citation_ok=$spaced_citation_ok ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok ci_identifier_ok=$ci_identifier_ok type_identifier_ok=$type_identifier_ok ci_prior_substring_ok=$ci_prior_substring_ok adjacent_bullets_ok=$adjacent_bullets_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para defer=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation valid_range_citation=$valid_range_citation out_of_range_range_citation=$out_of_range_range_citation reversed_range_citation=$reversed_range_citation malformed_suffix_citation=$malformed_suffix_citation malformed_range_citation=$malformed_range_citation dotted_numeric_citation=$dotted_numeric_citation dotted_text_citation=$dotted_text_citation dotted_identifier_citation=$dotted_identifier_citation dotted_run_citation=$dotted_run_citation sentence_final_citation_ok=$sentence_final_citation_ok uppercase_extension_ok=$uppercase_extension_ok config_extension_ok=$config_extension_ok spaced_citation_ok=$spaced_citation_ok ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok ci_identifier_ok=$ci_identifier_ok type_identifier_ok=$type_identifier_ok ci_prior_substring_ok=$ci_prior_substring_ok adjacent_bullets_ok=$adjacent_bullets_ok"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2648,8 +2648,12 @@ test_council_blind_summary_deference() {
         echo "The reported clean citation is efficient and sufficient, and I recommend proceeding."
         echo "VERDICT: APPROVE"
     } > "$d/ci-substring.md"
+    {
+        echo "The reported clean TypeScript compilation succeeded, and the new hook wiring looks correct."
+        echo "VERDICT: APPROVE"
+    } > "$d/type-substring.md"
 
-    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n capital_ok=n ci_substring_ok=n
+    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n capital_ok=n ci_substring_ok=n type_substring_ok=n
     council_response_is_blind "$d/paraphrase.md" && para=y
     council_response_is_blind "$d/deference.md" && defer=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
@@ -2659,6 +2663,7 @@ test_council_blind_summary_deference() {
     council_response_is_blind "$d/reverse-attr.md" && reverse=y
     council_response_is_blind "$d/plan-capital.md" || capital_ok=y
     council_response_is_blind "$d/ci-substring.md" || ci_substring_ok=y
+    council_response_is_blind "$d/type-substring.md" || type_substring_ok=y
 
     # A citation-shaped token is not grounding when it does not resolve beneath
     # the evidence root. A real source file and in-range line remains grounding.
@@ -2681,10 +2686,10 @@ test_council_blind_summary_deference() {
     if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
           && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" && "$capital_ok" == "y" \
           && "$fabricated_citation" == "y" && "$valid_citation" == "y" && "$out_of_range_citation" == "y" \
-          && "$ci_substring_ok" == "y" ]]; then
+          && "$ci_substring_ok" == "y" && "$type_substring_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation ci_substring_ok=$ci_substring_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2652,8 +2652,16 @@ test_council_blind_summary_deference() {
         echo "The reported clean TypeScript compilation succeeded, and the new hook wiring looks correct."
         echo "VERDICT: APPROVE"
     } > "$d/type-substring.md"
+    {
+        echo "The reported clean ci_config is efficient and sufficient, and I recommend proceeding."
+        echo "VERDICT: APPROVE"
+    } > "$d/ci-identifier.md"
+    {
+        echo "The reported passing type_name check succeeded, and I recommend proceeding."
+        echo "VERDICT: APPROVE"
+    } > "$d/type-identifier.md"
 
-    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n capital_ok=n ci_substring_ok=n type_substring_ok=n
+    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n capital_ok=n ci_substring_ok=n type_substring_ok=n ci_identifier_ok=n type_identifier_ok=n
     council_response_is_blind "$d/paraphrase.md" && para=y
     council_response_is_blind "$d/deference.md" && defer=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
@@ -2664,14 +2672,18 @@ test_council_blind_summary_deference() {
     council_response_is_blind "$d/plan-capital.md" || capital_ok=y
     council_response_is_blind "$d/ci-substring.md" || ci_substring_ok=y
     council_response_is_blind "$d/type-substring.md" || type_substring_ok=y
+    council_response_is_blind "$d/ci-identifier.md" || ci_identifier_ok=y
+    council_response_is_blind "$d/type-identifier.md" || type_identifier_ok=y
 
     # A citation-shaped token is not grounding when it does not resolve beneath
     # the evidence root. A real source file and in-range line remains grounding.
     local evidence_root="$d/evidence" fabricated_citation=n valid_citation=n out_of_range_citation=n
     local valid_range_citation=n out_of_range_range_citation=n reversed_range_citation=n
+    local malformed_suffix_citation=n malformed_range_citation=n uppercase_extension_ok=n
     mkdir -p "$evidence_root/src"
     printf 'const value = 1;\n' > "$evidence_root/src/real.tsx"
     printf 'const first = 1;\nconst second = 2;\n' > "$evidence_root/src/range.tsx"
+    printf 'const first = 1;\n' > "$evidence_root/src/upper.TSX"
     printf '%s\n' \
         'The summary confirms the implementation is correct at made-up.ts:1.' \
         'VERDICT: APPROVE' > "$d/fabricated-citation.md"
@@ -2690,21 +2702,36 @@ test_council_blind_summary_deference() {
     printf '%s\n' \
         'The summary confirms the implementation is correct at src/range.tsx:2-1.' \
         'VERDICT: APPROVE' > "$d/reversed-range-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/range.tsx:1-2/extra.' \
+        'VERDICT: APPROVE' > "$d/malformed-suffix-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/range.tsx:1-2-extra.' \
+        'VERDICT: APPROVE' > "$d/malformed-range-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/upper.TSX:1.' \
+        'VERDICT: APPROVE' > "$d/uppercase-extension-citation.md"
     council_response_is_blind "$d/fabricated-citation.md" "$evidence_root" && fabricated_citation=y
     council_response_is_blind "$d/valid-citation.md" "$evidence_root" || valid_citation=y
     council_response_is_blind "$d/out-of-range-citation.md" "$evidence_root" && out_of_range_citation=y
     council_response_is_blind "$d/valid-range-citation.md" "$evidence_root" || valid_range_citation=y
     council_response_is_blind "$d/out-of-range-range-citation.md" "$evidence_root" && out_of_range_range_citation=y
     council_response_is_blind "$d/reversed-range-citation.md" "$evidence_root" && reversed_range_citation=y
+    council_response_is_blind "$d/malformed-suffix-citation.md" "$evidence_root" && malformed_suffix_citation=y
+    council_response_is_blind "$d/malformed-range-citation.md" "$evidence_root" && malformed_range_citation=y
+    council_response_is_blind "$d/uppercase-extension-citation.md" "$evidence_root" || uppercase_extension_ok=y
 
     if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
           && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" && "$capital_ok" == "y" \
           && "$fabricated_citation" == "y" && "$valid_citation" == "y" && "$out_of_range_citation" == "y" \
           && "$valid_range_citation" == "y" && "$out_of_range_range_citation" == "y" && "$reversed_range_citation" == "y" \
-          && "$ci_substring_ok" == "y" && "$type_substring_ok" == "y" ]]; then
+          && "$ci_substring_ok" == "y" && "$type_substring_ok" == "y" \
+          && "$ci_identifier_ok" == "y" && "$type_identifier_ok" == "y" \
+          && "$malformed_suffix_citation" == "y" && "$malformed_range_citation" == "y" \
+          && "$uppercase_extension_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation valid_range_citation=$valid_range_citation out_of_range_range_citation=$out_of_range_range_citation reversed_range_citation=$reversed_range_citation ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para defer=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation valid_range_citation=$valid_range_citation out_of_range_range_citation=$out_of_range_range_citation reversed_range_citation=$reversed_range_citation malformed_suffix_citation=$malformed_suffix_citation malformed_range_citation=$malformed_range_citation uppercase_extension_ok=$uppercase_extension_ok ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok ci_identifier_ok=$ci_identifier_ok type_identifier_ok=$type_identifier_ok"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2642,7 +2642,14 @@ test_council_blind_summary_deference() {
         echo "VERDICT: APPROVE"
     } > "$d/plan-capital.md"
 
-    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n capital_ok=n
+    # "ci" appears inside ordinary words such as citation and sufficient; it
+    # must not satisfy the clean-CI deference branch without token boundaries.
+    {
+        echo "The reported clean citation is efficient and sufficient, and I recommend proceeding."
+        echo "VERDICT: APPROVE"
+    } > "$d/ci-substring.md"
+
+    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n capital_ok=n ci_substring_ok=n
     council_response_is_blind "$d/paraphrase.md" && para=y
     council_response_is_blind "$d/deference.md" && defer=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
@@ -2651,6 +2658,7 @@ test_council_blind_summary_deference() {
     council_response_is_blind "$d/plan-states.md" || plan_states_ok=y
     council_response_is_blind "$d/reverse-attr.md" && reverse=y
     council_response_is_blind "$d/plan-capital.md" || capital_ok=y
+    council_response_is_blind "$d/ci-substring.md" || ci_substring_ok=y
 
     # A citation-shaped token is not grounding when it does not resolve beneath
     # the evidence root. A real source file and in-range line remains grounding.
@@ -2672,10 +2680,11 @@ test_council_blind_summary_deference() {
 
     if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
           && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" && "$capital_ok" == "y" \
-          && "$fabricated_citation" == "y" && "$valid_citation" == "y" && "$out_of_range_citation" == "y" ]]; then
+          && "$fabricated_citation" == "y" && "$valid_citation" == "y" && "$out_of_range_citation" == "y" \
+          && "$ci_substring_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation ci_substring_ok=$ci_substring_ok"
         return 1
     fi
 }
@@ -2743,6 +2752,13 @@ test_council_blind_fabricated_narrative() {
         echo "VERDICT: APPROVE"
     } > "$d/third-person-restriction.md"
 
+    # An access-control statement is implementation prose, not the reviewer
+    # admitting that their own permissions prevented verification.
+    {
+        echo "The access permissions restrict access to the admin panel, and the review should confirm that the authorization boundary is preserved."
+        echo "VERDICT: APPROVE"
+    } > "$d/access-control-prose.md"
+
     # First-person prose in one clause must not attach to another reviewer's
     # access failure in a later semicolon-delimited clause.
     {
@@ -2770,6 +2786,16 @@ test_council_blind_fabricated_narrative() {
         done
         echo "VERDICT: APPROVE"
     } > "$d/same-clause-self-and-third-party.md"
+
+    # A missing space after a sentence period must not merge a first-person
+    # assessment with a later third-party access report.
+    {
+        for _i in $(seq 1 24); do
+            echo "The implementation preserves the documented workflow contract and the proposed change is internally coherent."
+        done
+        echo "I completed an independent assessment.However another reviewer could not access the files."
+        echo "VERDICT: APPROVE"
+    } > "$d/no-space-boundary.md"
 
     # Ordinary Markdown wrapping must not hide the reviewer's own admission.
     {
@@ -2869,6 +2895,7 @@ test_council_blind_fabricated_narrative() {
     local same_clause_third_party_ok=n same_clause_self_and_third_party=n
     local wrapped=n did_not_have=n was_not_able=n lack_access=n url_port=n
     local url_period_ok=n url_semicolon_ok=n assuming_ok=n shellcite_blind=n cantdiff=n
+    local access_control_ok=n no_space_boundary_ok=n ci_substring_ok=n
     council_response_is_blind "$d/cantdiff.md" && cantdiff=y
     council_response_is_blind "$d/wrapped-admission.md" && wrapped=y
     council_response_is_blind "$d/did-not-have-access.md" && did_not_have=y
@@ -2884,9 +2911,11 @@ test_council_blind_fabricated_narrative() {
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
     council_response_is_blind "$d/planreview.md" || plan_ok=y
     council_response_is_blind "$d/third-person-restriction.md" || third_person_ok=y
+    council_response_is_blind "$d/access-control-prose.md" || access_control_ok=y
     council_response_is_blind "$d/mixed-person.md" || mixed_person_ok=y
     council_response_is_blind "$d/same-clause-third-party.md" || same_clause_third_party_ok=y
     council_response_is_blind "$d/same-clause-self-and-third-party.md" && same_clause_self_and_third_party=y
+    council_response_is_blind "$d/no-space-boundary.md" || no_space_boundary_ok=y
 
     # Integration: a fabricated-narrative agy seat alongside a grounded codex seat
     # in a standard (required=2) council. agy must be classified blind and dropped
@@ -2927,6 +2956,7 @@ test_council_blind_fabricated_narrative() {
 
     if [[ "$fab" == "y" && "$fab_len" -gt 1600 && "$grounded_ok" == "y" && "$plan_ok" == "y" \
           && "$third_person_ok" == "y" && "$mixed_person_ok" == "y" \
+          && "$access_control_ok" == "y" && "$no_space_boundary_ok" == "y" \
           && "$same_clause_third_party_ok" == "y" \
           && "$same_clause_self_and_third_party" == "y" \
           && "$wrapped" == "y" && "$did_not_have" == "y" \
@@ -2938,7 +2968,7 @@ test_council_blind_fabricated_narrative() {
           && "$approving_fams" == "1" && "$met" == "false" ]]; then
         test_pass
     else
-        test_fail "fabricated-narrative blind detection wrong: fab=$fab fab_len=$fab_len grounded_ok=$grounded_ok plan_ok=$plan_ok third_person_ok=$third_person_ok mixed_person_ok=$mixed_person_ok wrapped=$wrapped did_not_have=$did_not_have was_not_able=$was_not_able lack_access=$lack_access url_port=$url_port url_period_ok=$url_period_ok url_semicolon_ok=$url_semicolon_ok assuming_ok=$assuming_ok shellcite_blind=$shellcite_blind cantdiff=$cantdiff agy_status='$agy_status' blind=[$blind] responders=[$codex_prov] approving_families=$approving_fams met=$met"
+        test_fail "fabricated-narrative blind detection wrong: fab=$fab fab_len=$fab_len grounded_ok=$grounded_ok plan_ok=$plan_ok third_person_ok=$third_person_ok access_control_ok=$access_control_ok no_space_boundary_ok=$no_space_boundary_ok mixed_person_ok=$mixed_person_ok wrapped=$wrapped did_not_have=$did_not_have was_not_able=$was_not_able lack_access=$lack_access url_port=$url_port url_period_ok=$url_period_ok url_semicolon_ok=$url_semicolon_ok assuming_ok=$assuming_ok shellcite_blind=$shellcite_blind cantdiff=$cantdiff agy_status='$agy_status' blind=[$blind] responders=[$codex_prov] approving_families=$approving_fams met=$met"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2489,19 +2489,32 @@ test_council_blind_summary_deference() {
         echo "VERDICT: APPROVE"
     } > "$d/plan-states.md"
 
-    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n
+    # (g) Reverse-attribution ISOLATION (CodeRabbit #1017): the ONLY blind signal
+    # is a code fact deferred to the summary in reverse word order ("propagated
+    # ... as stated in the summary"). No forward "the summary confirms", no
+    # reported-clean-tsc, no prior-round deference, zero file:line. Must be blind
+    # solely via the reverse form — the paraphrase fixture (a) can't prove this
+    # because it also carries the forward and clean-tsc signals.
+    {
+        echo "## Review"
+        echo "APPROVE. The ariaLabel is correctly propagated to every icon button, as stated in the summary."
+        echo "VERDICT: APPROVE"
+    } > "$d/reverse-attr.md"
+
+    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n
     council_response_is_blind "$d/paraphrase.md" && para=y
     council_response_is_blind "$d/deference.md" && defer=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
     council_response_is_blind "$d/grounded-cited.md" || cited_ok=y
     council_response_is_blind "$d/url-port.md" && url_blind=y
     council_response_is_blind "$d/plan-states.md" || plan_states_ok=y
+    council_response_is_blind "$d/reverse-attr.md" && reverse=y
 
     if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
-          && "$url_blind" == "y" && "$plan_states_ok" == "y" ]]; then
+          && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2521,11 +2521,26 @@ test_council_blind_summary_deference() {
     council_response_is_blind "$d/reverse-attr.md" && reverse=y
     council_response_is_blind "$d/plan-capital.md" || capital_ok=y
 
+    # A citation-shaped token is not grounding when it does not resolve beneath
+    # the evidence root. A real source file and in-range line remains grounding.
+    local evidence_root="$d/evidence" fabricated_citation=n valid_citation=n
+    mkdir -p "$evidence_root/src"
+    printf 'const value = 1;\n' > "$evidence_root/src/real.tsx"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at made-up.ts:1.' \
+        'VERDICT: APPROVE' > "$d/fabricated-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/real.tsx:1.' \
+        'VERDICT: APPROVE' > "$d/valid-citation.md"
+    council_response_is_blind "$d/fabricated-citation.md" "$evidence_root" && fabricated_citation=y
+    council_response_is_blind "$d/valid-citation.md" "$evidence_root" || valid_citation=y
+
     if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
-          && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" && "$capital_ok" == "y" ]]; then
+          && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" && "$capital_ok" == "y" \
+          && "$fabricated_citation" == "y" && "$valid_citation" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2660,8 +2660,17 @@ test_council_blind_summary_deference() {
         echo "The reported passing type_name check succeeded, and I recommend proceeding."
         echo "VERDICT: APPROVE"
     } > "$d/type-identifier.md"
+    {
+        echo "The implementation is efficient and the tests are clean, and I recommend approval."
+        echo "VERDICT: APPROVE"
+    } > "$d/ci-prior-substring.md"
+    {
+        echo "- The previous rounds recorded the rollout context."
+        echo "- The implementation is efficient and the tests are clean, and I recommend approval."
+        echo "VERDICT: APPROVE"
+    } > "$d/adjacent-bullets.md"
 
-    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n capital_ok=n ci_substring_ok=n type_substring_ok=n ci_identifier_ok=n type_identifier_ok=n
+    local para=n defer=n grounded_ok=n cited_ok=n url_blind=n plan_states_ok=n reverse=n capital_ok=n ci_substring_ok=n type_substring_ok=n ci_identifier_ok=n type_identifier_ok=n ci_prior_substring_ok=n adjacent_bullets_ok=n
     council_response_is_blind "$d/paraphrase.md" && para=y
     council_response_is_blind "$d/deference.md" && defer=y
     council_response_is_blind "$d/grounded.md" || grounded_ok=y
@@ -2674,16 +2683,20 @@ test_council_blind_summary_deference() {
     council_response_is_blind "$d/type-substring.md" || type_substring_ok=y
     council_response_is_blind "$d/ci-identifier.md" || ci_identifier_ok=y
     council_response_is_blind "$d/type-identifier.md" || type_identifier_ok=y
+    council_response_is_blind "$d/ci-prior-substring.md" || ci_prior_substring_ok=y
+    council_response_is_blind "$d/adjacent-bullets.md" || adjacent_bullets_ok=y
 
     # A citation-shaped token is not grounding when it does not resolve beneath
     # the evidence root. A real source file and in-range line remains grounding.
     local evidence_root="$d/evidence" fabricated_citation=n valid_citation=n out_of_range_citation=n
     local valid_range_citation=n out_of_range_range_citation=n reversed_range_citation=n
-    local malformed_suffix_citation=n malformed_range_citation=n uppercase_extension_ok=n
+    local malformed_suffix_citation=n malformed_range_citation=n uppercase_extension_ok=n config_extension_ok=n spaced_citation_ok=n
     mkdir -p "$evidence_root/src"
     printf 'const value = 1;\n' > "$evidence_root/src/real.tsx"
     printf 'const first = 1;\nconst second = 2;\n' > "$evidence_root/src/range.tsx"
     printf 'const first = 1;\n' > "$evidence_root/src/upper.TSX"
+    printf 'public class Program {}\n' > "$evidence_root/src/Program.cs"
+    printf '<config />\n' > "$evidence_root/src/config.xml"
     printf '%s\n' \
         'The summary confirms the implementation is correct at made-up.ts:1.' \
         'VERDICT: APPROVE' > "$d/fabricated-citation.md"
@@ -2711,6 +2724,12 @@ test_council_blind_summary_deference() {
     printf '%s\n' \
         'The summary confirms the implementation is correct at src/upper.TSX:1.' \
         'VERDICT: APPROVE' > "$d/uppercase-extension-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/Program.cs:1.' \
+        'VERDICT: APPROVE' > "$d/config-extension-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/config.xml : 1.' \
+        'VERDICT: APPROVE' > "$d/spaced-citation.md"
     council_response_is_blind "$d/fabricated-citation.md" "$evidence_root" && fabricated_citation=y
     council_response_is_blind "$d/valid-citation.md" "$evidence_root" || valid_citation=y
     council_response_is_blind "$d/out-of-range-citation.md" "$evidence_root" && out_of_range_citation=y
@@ -2720,6 +2739,8 @@ test_council_blind_summary_deference() {
     council_response_is_blind "$d/malformed-suffix-citation.md" "$evidence_root" && malformed_suffix_citation=y
     council_response_is_blind "$d/malformed-range-citation.md" "$evidence_root" && malformed_range_citation=y
     council_response_is_blind "$d/uppercase-extension-citation.md" "$evidence_root" || uppercase_extension_ok=y
+    council_response_is_blind "$d/config-extension-citation.md" "$evidence_root" || config_extension_ok=y
+    council_response_is_blind "$d/spaced-citation.md" "$evidence_root" || spaced_citation_ok=y
 
     if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
           && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" && "$capital_ok" == "y" \
@@ -2727,11 +2748,13 @@ test_council_blind_summary_deference() {
           && "$valid_range_citation" == "y" && "$out_of_range_range_citation" == "y" && "$reversed_range_citation" == "y" \
           && "$ci_substring_ok" == "y" && "$type_substring_ok" == "y" \
           && "$ci_identifier_ok" == "y" && "$type_identifier_ok" == "y" \
+          && "$ci_prior_substring_ok" == "y" && "$adjacent_bullets_ok" == "y" \
           && "$malformed_suffix_citation" == "y" && "$malformed_range_citation" == "y" \
-          && "$uppercase_extension_ok" == "y" ]]; then
+          && "$uppercase_extension_ok" == "y" && "$config_extension_ok" == "y" \
+          && "$spaced_citation_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para defer=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation valid_range_citation=$valid_range_citation out_of_range_range_citation=$out_of_range_range_citation reversed_range_citation=$reversed_range_citation malformed_suffix_citation=$malformed_suffix_citation malformed_range_citation=$malformed_range_citation uppercase_extension_ok=$uppercase_extension_ok ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok ci_identifier_ok=$ci_identifier_ok type_identifier_ok=$type_identifier_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para defer=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation valid_range_citation=$valid_range_citation out_of_range_range_citation=$out_of_range_range_citation reversed_range_citation=$reversed_range_citation malformed_suffix_citation=$malformed_suffix_citation malformed_range_citation=$malformed_range_citation uppercase_extension_ok=$uppercase_extension_ok config_extension_ok=$config_extension_ok spaced_citation_ok=$spaced_citation_ok ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok ci_identifier_ok=$ci_identifier_ok type_identifier_ok=$type_identifier_ok ci_prior_substring_ok=$ci_prior_substring_ok adjacent_bullets_ok=$adjacent_bullets_ok"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2654,7 +2654,7 @@ test_council_blind_summary_deference() {
 
     # A citation-shaped token is not grounding when it does not resolve beneath
     # the evidence root. A real source file and in-range line remains grounding.
-    local evidence_root="$d/evidence" fabricated_citation=n valid_citation=n
+    local evidence_root="$d/evidence" fabricated_citation=n valid_citation=n out_of_range_citation=n
     mkdir -p "$evidence_root/src"
     printf 'const value = 1;\n' > "$evidence_root/src/real.tsx"
     printf '%s\n' \
@@ -2663,15 +2663,19 @@ test_council_blind_summary_deference() {
     printf '%s\n' \
         'The summary confirms the implementation is correct at src/real.tsx:1.' \
         'VERDICT: APPROVE' > "$d/valid-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/real.tsx:2.' \
+        'VERDICT: APPROVE' > "$d/out-of-range-citation.md"
     council_response_is_blind "$d/fabricated-citation.md" "$evidence_root" && fabricated_citation=y
     council_response_is_blind "$d/valid-citation.md" "$evidence_root" || valid_citation=y
+    council_response_is_blind "$d/out-of-range-citation.md" "$evidence_root" && out_of_range_citation=y
 
     if [[ "$para" == "y" && "$defer" == "y" && "$grounded_ok" == "y" && "$cited_ok" == "y" \
           && "$url_blind" == "y" && "$plan_states_ok" == "y" && "$reverse" == "y" && "$capital_ok" == "y" \
-          && "$fabricated_citation" == "y" && "$valid_citation" == "y" ]]; then
+          && "$fabricated_citation" == "y" && "$valid_citation" == "y" && "$out_of_range_citation" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para deference=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2690,7 +2690,7 @@ test_council_blind_summary_deference() {
     # the evidence root. A real source file and in-range line remains grounding.
     local evidence_root="$d/evidence" fabricated_citation=n valid_citation=n out_of_range_citation=n
     local valid_range_citation=n out_of_range_range_citation=n reversed_range_citation=n
-    local malformed_suffix_citation=n malformed_range_citation=n dotted_numeric_citation=n dotted_text_citation=n dotted_identifier_citation=n dotted_run_citation=n sentence_final_citation_ok=n uppercase_extension_ok=n config_extension_ok=n spaced_citation_ok=n
+    local malformed_suffix_citation=n malformed_range_citation=n dotted_numeric_citation=n dotted_text_citation=n dotted_identifier_citation=n dotted_run_citation=n oversized_citation=n sentence_final_citation_ok=n uppercase_extension_ok=n config_extension_ok=n spaced_citation_ok=n
     mkdir -p "$evidence_root/src"
     printf 'const value = 1;\n' > "$evidence_root/src/real.tsx"
     printf 'const first = 1;\nconst second = 2;\n' > "$evidence_root/src/range.tsx"
@@ -2733,6 +2733,10 @@ test_council_blind_summary_deference() {
     printf '%s\n' \
         'The summary confirms the implementation is correct at src/range.tsx:1..foo.' \
         'VERDICT: APPROVE' > "$d/dotted-run-citation.md"
+    local oversized_line; oversized_line="$(awk 'BEGIN { for (i = 1; i <= 5000; i++) printf "9" }')"
+    printf '%s\n' \
+        "The summary confirms the implementation is correct at src/range.tsx:${oversized_line}." \
+        'VERDICT: APPROVE' > "$d/oversized-citation.md"
     printf '%s\n' \
         'The summary confirms the implementation is correct at src/range.tsx:1.' \
         'VERDICT: APPROVE' > "$d/sentence-final-citation.md"
@@ -2757,6 +2761,7 @@ test_council_blind_summary_deference() {
     council_response_is_blind "$d/dotted-text-citation.md" "$evidence_root" && dotted_text_citation=y
     council_response_is_blind "$d/dotted-identifier-citation.md" "$evidence_root" && dotted_identifier_citation=y
     council_response_is_blind "$d/dotted-run-citation.md" "$evidence_root" && dotted_run_citation=y
+    council_response_is_blind "$d/oversized-citation.md" "$evidence_root" && oversized_citation=y
     council_response_is_blind "$d/sentence-final-citation.md" "$evidence_root" || sentence_final_citation_ok=y
     council_response_is_blind "$d/uppercase-extension-citation.md" "$evidence_root" || uppercase_extension_ok=y
     council_response_is_blind "$d/config-extension-citation.md" "$evidence_root" || config_extension_ok=y
@@ -2772,12 +2777,13 @@ test_council_blind_summary_deference() {
           && "$malformed_suffix_citation" == "y" && "$malformed_range_citation" == "y" \
           && "$dotted_numeric_citation" == "y" && "$dotted_text_citation" == "y" \
           && "$dotted_identifier_citation" == "y" && "$dotted_run_citation" == "y" \
+          && "$oversized_citation" == "y" \
           && "$sentence_final_citation_ok" == "y" \
           && "$uppercase_extension_ok" == "y" && "$config_extension_ok" == "y" \
           && "$spaced_citation_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para defer=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation valid_range_citation=$valid_range_citation out_of_range_range_citation=$out_of_range_range_citation reversed_range_citation=$reversed_range_citation malformed_suffix_citation=$malformed_suffix_citation malformed_range_citation=$malformed_range_citation dotted_numeric_citation=$dotted_numeric_citation dotted_text_citation=$dotted_text_citation dotted_identifier_citation=$dotted_identifier_citation dotted_run_citation=$dotted_run_citation sentence_final_citation_ok=$sentence_final_citation_ok uppercase_extension_ok=$uppercase_extension_ok config_extension_ok=$config_extension_ok spaced_citation_ok=$spaced_citation_ok ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok ci_identifier_ok=$ci_identifier_ok type_identifier_ok=$type_identifier_ok ci_prior_substring_ok=$ci_prior_substring_ok adjacent_bullets_ok=$adjacent_bullets_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para defer=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation valid_range_citation=$valid_range_citation out_of_range_range_citation=$out_of_range_range_citation reversed_range_citation=$reversed_range_citation malformed_suffix_citation=$malformed_suffix_citation malformed_range_citation=$malformed_range_citation dotted_numeric_citation=$dotted_numeric_citation dotted_text_citation=$dotted_text_citation dotted_identifier_citation=$dotted_identifier_citation dotted_run_citation=$dotted_run_citation oversized_citation=$oversized_citation sentence_final_citation_ok=$sentence_final_citation_ok uppercase_extension_ok=$uppercase_extension_ok config_extension_ok=$config_extension_ok spaced_citation_ok=$spaced_citation_ok ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok ci_identifier_ok=$ci_identifier_ok type_identifier_ok=$type_identifier_ok ci_prior_substring_ok=$ci_prior_substring_ok adjacent_bullets_ok=$adjacent_bullets_ok"
         return 1
     fi
 }

--- a/tests/unit/test-council-command.sh
+++ b/tests/unit/test-council-command.sh
@@ -2690,7 +2690,7 @@ test_council_blind_summary_deference() {
     # the evidence root. A real source file and in-range line remains grounding.
     local evidence_root="$d/evidence" fabricated_citation=n valid_citation=n out_of_range_citation=n
     local valid_range_citation=n out_of_range_range_citation=n reversed_range_citation=n
-    local malformed_suffix_citation=n malformed_range_citation=n uppercase_extension_ok=n config_extension_ok=n spaced_citation_ok=n
+    local malformed_suffix_citation=n malformed_range_citation=n dotted_numeric_citation=n dotted_text_citation=n sentence_final_citation_ok=n uppercase_extension_ok=n config_extension_ok=n spaced_citation_ok=n
     mkdir -p "$evidence_root/src"
     printf 'const value = 1;\n' > "$evidence_root/src/real.tsx"
     printf 'const first = 1;\nconst second = 2;\n' > "$evidence_root/src/range.tsx"
@@ -2722,6 +2722,15 @@ test_council_blind_summary_deference() {
         'The summary confirms the implementation is correct at src/range.tsx:1-2-extra.' \
         'VERDICT: APPROVE' > "$d/malformed-range-citation.md"
     printf '%s\n' \
+        'The summary confirms the implementation is correct at src/range.tsx:1.2.' \
+        'VERDICT: APPROVE' > "$d/dotted-numeric-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/range.tsx:1.foo.' \
+        'VERDICT: APPROVE' > "$d/dotted-text-citation.md"
+    printf '%s\n' \
+        'The summary confirms the implementation is correct at src/range.tsx:1.' \
+        'VERDICT: APPROVE' > "$d/sentence-final-citation.md"
+    printf '%s\n' \
         'The summary confirms the implementation is correct at src/upper.TSX:1.' \
         'VERDICT: APPROVE' > "$d/uppercase-extension-citation.md"
     printf '%s\n' \
@@ -2738,6 +2747,9 @@ test_council_blind_summary_deference() {
     council_response_is_blind "$d/reversed-range-citation.md" "$evidence_root" && reversed_range_citation=y
     council_response_is_blind "$d/malformed-suffix-citation.md" "$evidence_root" && malformed_suffix_citation=y
     council_response_is_blind "$d/malformed-range-citation.md" "$evidence_root" && malformed_range_citation=y
+    council_response_is_blind "$d/dotted-numeric-citation.md" "$evidence_root" && dotted_numeric_citation=y
+    council_response_is_blind "$d/dotted-text-citation.md" "$evidence_root" && dotted_text_citation=y
+    council_response_is_blind "$d/sentence-final-citation.md" "$evidence_root" || sentence_final_citation_ok=y
     council_response_is_blind "$d/uppercase-extension-citation.md" "$evidence_root" || uppercase_extension_ok=y
     council_response_is_blind "$d/config-extension-citation.md" "$evidence_root" || config_extension_ok=y
     council_response_is_blind "$d/spaced-citation.md" "$evidence_root" || spaced_citation_ok=y
@@ -2750,11 +2762,13 @@ test_council_blind_summary_deference() {
           && "$ci_identifier_ok" == "y" && "$type_identifier_ok" == "y" \
           && "$ci_prior_substring_ok" == "y" && "$adjacent_bullets_ok" == "y" \
           && "$malformed_suffix_citation" == "y" && "$malformed_range_citation" == "y" \
+          && "$dotted_numeric_citation" == "y" && "$dotted_text_citation" == "y" \
+          && "$sentence_final_citation_ok" == "y" \
           && "$uppercase_extension_ok" == "y" && "$config_extension_ok" == "y" \
           && "$spaced_citation_ok" == "y" ]]; then
         test_pass
     else
-        test_fail "summary/deference blind detection wrong: paraphrase=$para defer=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation valid_range_citation=$valid_range_citation out_of_range_range_citation=$out_of_range_range_citation reversed_range_citation=$reversed_range_citation malformed_suffix_citation=$malformed_suffix_citation malformed_range_citation=$malformed_range_citation uppercase_extension_ok=$uppercase_extension_ok config_extension_ok=$config_extension_ok spaced_citation_ok=$spaced_citation_ok ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok ci_identifier_ok=$ci_identifier_ok type_identifier_ok=$type_identifier_ok ci_prior_substring_ok=$ci_prior_substring_ok adjacent_bullets_ok=$adjacent_bullets_ok"
+        test_fail "summary/deference blind detection wrong: paraphrase=$para defer=$defer grounded_ok=$grounded_ok cited_ok=$cited_ok url_blind=$url_blind plan_states_ok=$plan_states_ok reverse=$reverse capital_ok=$capital_ok fabricated_citation=$fabricated_citation valid_citation=$valid_citation out_of_range_citation=$out_of_range_citation valid_range_citation=$valid_range_citation out_of_range_range_citation=$out_of_range_range_citation reversed_range_citation=$reversed_range_citation malformed_suffix_citation=$malformed_suffix_citation malformed_range_citation=$malformed_range_citation dotted_numeric_citation=$dotted_numeric_citation dotted_text_citation=$dotted_text_citation sentence_final_citation_ok=$sentence_final_citation_ok uppercase_extension_ok=$uppercase_extension_ok config_extension_ok=$config_extension_ok spaced_citation_ok=$spaced_citation_ok ci_substring_ok=$ci_substring_ok type_substring_ok=$type_substring_ok ci_identifier_ok=$ci_identifier_ok type_identifier_ok=$type_identifier_ok ci_prior_substring_ok=$ci_prior_substring_ok adjacent_bullets_ok=$adjacent_bullets_ok"
         return 1
     fi
 }


### PR DESCRIPTION
## Summary

- carry the council grounding hardening from #1017 onto current `main`
- validate source-style `file:line` citations against the live evidence root during advice and chair-fallback classification
- preserve plan/PRD reviews that have no source tree by keeping the standalone detector behavior unchanged when no evidence root is supplied
- add regression coverage for fabricated and real citations

## Evidence

- `bash -n scripts/lib/council.sh tests/unit/test-council-command.sh`
- `bash tests/unit/test-council-command.sh` — 97 passed, 0 failed, 1 existing macOS PTY skip
- `git diff --check`

This branch includes the merged `main` context-file change from #1024 and supersedes the current #1017 head because the original PR is owned by a fork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved council review validation for approvals based only on summaries, prior review rounds, or clean-check claims without source evidence.
  * Improved citation verification for valid, fabricated, unresolved, and incidental references, including line ranges, URL ports, spacing, and token boundaries.
  * Fixed access-failure detection when filenames or version numbers contain periods.
  * Reduced false positives at sentence and Markdown boundaries.
  * Blind seats remain excluded from approval tallies and recorded in quorum results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->