### PR TITLE
fix: doctor agents check uses --json instead of TTY-only output

### DIFF
--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -1580,20 +1580,27 @@ doctor_check_agents() {
         if [[ $cli_rc -eq 0 && -n "$cli_output" ]]; then
             local cli_count
             if command -v jq >/dev/null 2>&1; then
-                if cli_count=$(printf '%s' "$cli_output" | jq 'length' 2>/dev/null); then
+                if cli_count=$(printf '%s' "$cli_output" | jq -e 'if type == "array" then length else error("expected array") end' 2>/dev/null); then
                     doctor_add "agents-cli" "agents" "pass" \
                         "Claude agents CLI: ${cli_count} agents registered" ""
                 else
                     doctor_add "agents-cli" "agents" "warn" \
                         "Claude agents CLI returned unparseable output" "Run 'claude agents --json' manually"
                 fi
-            elif [[ "$cli_output" == \[* ]]; then
-                cli_count=$(printf '%s' "$cli_output" | grep -o '"sessionId"' | wc -l | tr -d '[:space:]') || cli_count=0
-                doctor_add "agents-cli" "agents" "pass" \
-                    "Claude agents CLI: ${cli_count} agents registered" ""
             else
-                doctor_add "agents-cli" "agents" "warn" \
-                    "Claude agents CLI returned unparseable output" "Run 'claude agents --json' manually"
+                # Without jq, require a complete outer JSON array before using
+                # the conservative sessionId occurrence count. This avoids
+                # turning truncated or non-array CLI output into a false pass.
+                local cli_compact
+                cli_compact=$(printf '%s' "$cli_output" | tr -d '[:space:]')
+                if [[ "$cli_compact" == \[*\] ]]; then
+                    cli_count=$(printf '%s' "$cli_output" | awk '{ count += gsub(/"sessionId"/, "&") } END { print count + 0 }')
+                    doctor_add "agents-cli" "agents" "pass" \
+                        "Claude agents CLI: ${cli_count} agents registered" ""
+                else
+                    doctor_add "agents-cli" "agents" "warn" \
+                        "Claude agents CLI returned unparseable output" "Run 'claude agents --json' manually"
+                fi
             fi
         else
             doctor_add "agents-cli" "agents" "warn" \

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -1576,15 +1576,19 @@ doctor_check_agents() {
 
     if [[ "$SUPPORTS_AGENTS_CLI" == "true" ]]; then
         local cli_output
-        cli_output=$(claude agents 2>/dev/null | head -20 || echo "")
+        cli_output=$(claude agents --json 2>/dev/null || echo "")
         if [[ -n "$cli_output" ]]; then
             local cli_count
-            cli_count=$(echo "$cli_output" | grep -c "^") || cli_count=0
+            if command -v jq >/dev/null 2>&1; then
+                cli_count=$(printf '%s' "$cli_output" | jq 'length' 2>/dev/null) || cli_count=0
+            else
+                cli_count=$(printf '%s' "$cli_output" | grep -c '"sessionId"') || cli_count=0
+            fi
             doctor_add "agents-cli" "agents" "pass" \
                 "Claude agents CLI: ${cli_count} agents registered" ""
         else
             doctor_add "agents-cli" "agents" "warn" \
-                "Claude agents CLI returned no data" "Run 'claude agents' manually"
+                "Claude agents CLI returned no data" "Run 'claude agents --json' manually"
         fi
     else
         doctor_add "agents-cli" "agents" "info" \

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -1588,7 +1588,7 @@ doctor_check_agents() {
                         "Claude agents CLI returned unparseable output" "Run 'claude agents --json' manually"
                 fi
             elif [[ "$cli_output" == \[* ]]; then
-                cli_count=$(printf '%s' "$cli_output" | grep -o '"sessionId"' | wc -l | tr -d '[:space:]')
+                cli_count=$(printf '%s' "$cli_output" | grep -o '"sessionId"' | wc -l | tr -d '[:space:]') || cli_count=0
                 doctor_add "agents-cli" "agents" "pass" \
                     "Claude agents CLI: ${cli_count} agents registered" ""
             else

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -1580,12 +1580,18 @@ doctor_check_agents() {
         if [[ -n "$cli_output" ]]; then
             local cli_count
             if command -v jq >/dev/null 2>&1; then
-                cli_count=$(printf '%s' "$cli_output" | jq 'length' 2>/dev/null) || cli_count=0
+                if cli_count=$(printf '%s' "$cli_output" | jq 'length' 2>/dev/null); then
+                    doctor_add "agents-cli" "agents" "pass" \
+                        "Claude agents CLI: ${cli_count} agents registered" ""
+                else
+                    doctor_add "agents-cli" "agents" "warn" \
+                        "Claude agents CLI returned unparseable output" "Run 'claude agents --json' manually"
+                fi
             else
-                cli_count=$(printf '%s' "$cli_output" | grep -c '"sessionId"') || cli_count=0
+                cli_count=$(printf '%s' "$cli_output" | grep -o '"sessionId"' | wc -l | tr -d '[:space:]')
+                doctor_add "agents-cli" "agents" "pass" \
+                    "Claude agents CLI: ${cli_count} agents registered" ""
             fi
-            doctor_add "agents-cli" "agents" "pass" \
-                "Claude agents CLI: ${cli_count} agents registered" ""
         else
             doctor_add "agents-cli" "agents" "warn" \
                 "Claude agents CLI returned no data" "Run 'claude agents --json' manually"

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -1587,10 +1587,13 @@ doctor_check_agents() {
                     doctor_add "agents-cli" "agents" "warn" \
                         "Claude agents CLI returned unparseable output" "Run 'claude agents --json' manually"
                 fi
-            else
+            elif [[ "$cli_output" == \[* ]]; then
                 cli_count=$(printf '%s' "$cli_output" | grep -o '"sessionId"' | wc -l | tr -d '[:space:]')
                 doctor_add "agents-cli" "agents" "pass" \
                     "Claude agents CLI: ${cli_count} agents registered" ""
+            else
+                doctor_add "agents-cli" "agents" "warn" \
+                    "Claude agents CLI returned unparseable output" "Run 'claude agents --json' manually"
             fi
         else
             doctor_add "agents-cli" "agents" "warn" \

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -1575,9 +1575,9 @@ doctor_check_agents() {
         "${worktree_agents} agents with worktree isolation" ""
 
     if [[ "$SUPPORTS_AGENTS_CLI" == "true" ]]; then
-        local cli_output
-        cli_output=$(claude agents --json 2>/dev/null || echo "")
-        if [[ -n "$cli_output" ]]; then
+        local cli_output cli_rc=0
+        cli_output=$(claude agents --json 2>/dev/null) || cli_rc=$?
+        if [[ $cli_rc -eq 0 && -n "$cli_output" ]]; then
             local cli_count
             if command -v jq >/dev/null 2>&1; then
                 if cli_count=$(printf '%s' "$cli_output" | jq 'length' 2>/dev/null); then

--- a/tests/unit/test-doctor-v10.sh
+++ b/tests/unit/test-doctor-v10.sh
@@ -200,6 +200,7 @@ case "${DOCTOR_AGENTS_MODE:-compact}" in
     object) printf '%s\n' '{"agents":[]}' ;;
     truncated) printf '%s\n' '[{"sessionId":"one"}' ;;
     malformed) printf '%s\n' 'not-json' ;;
+    bracketed_malformed) printf '%s\n' '[not-json]' ;;
     failed) printf '%s\n' '[{"sessionId":"one"}]'; exit 7 ;;
 esac
 SH
@@ -306,6 +307,31 @@ if [[ "$malformed_nojq_result" == "warn|Claude agents CLI returned unparseable o
     test_pass
 else
     test_fail "malformed no-jq output was accepted: $malformed_nojq_result"
+fi
+
+test_case "agents CLI jq path rejects bracket-shaped but internally invalid JSON"
+run_agents_check bracketed_malformed
+bracketed_jq_result="$(agent_result_status agents-cli)"
+if [[ "$bracketed_jq_result" == "warn|Claude agents CLI returned unparseable output" ]]; then
+    test_pass
+else
+    test_fail "bracket-shaped invalid JSON was accepted by jq path: $bracketed_jq_result"
+fi
+
+test_case "agents CLI no-jq fallback reports 0 for bracket-shaped but internally invalid JSON (documented heuristic limit)"
+command() {
+    if [[ "${1:-}" == "-v" && "${2:-}" == "jq" ]]; then
+        return 1
+    fi
+    builtin command "$@"
+}
+run_agents_check bracketed_malformed
+bracketed_nojq_result="$(agent_result_status agents-cli)"
+unset -f command
+if [[ "$bracketed_nojq_result" == "pass|Claude agents CLI: 0 agents registered" ]]; then
+    test_pass
+else
+    test_fail "bracket-shaped invalid JSON no-jq result was unexpected: $bracketed_nojq_result"
 fi
 
 test_case "JSON escaping preserves UTF-8 and control characters"

--- a/tests/unit/test-doctor-v10.sh
+++ b/tests/unit/test-doctor-v10.sh
@@ -231,6 +231,15 @@ else
     test_fail "unexpected jq agents result: $agent_cli_result"
 fi
 
+test_case "agents CLI jq path reports 0 for an empty array (jq -e exit-status edge case)"
+run_agents_check empty
+agent_cli_result="$(agent_result_status agents-cli)"
+if [[ "$agent_cli_result" == "pass|Claude agents CLI: 0 agents registered" ]]; then
+    test_pass
+else
+    test_fail "unexpected jq empty-array result: $agent_cli_result"
+fi
+
 test_case "agents CLI rejects valid non-array JSON instead of passing a key count"
 run_agents_check object
 agent_cli_result="$(agent_result_status agents-cli)"

--- a/tests/unit/test-doctor-v10.sh
+++ b/tests/unit/test-doctor-v10.sh
@@ -187,6 +187,102 @@ else
     test_fail "elapsed=${elapsed}s result=${DOCTOR_RESULTS_STATUS[0]:-missing}"
 fi
 
+test_case "agents CLI accepts a JSON array and reports its exact jq count"
+agents_plugin_root="$TEST_TMP_DIR/agents-plugin"
+agents_bin="$TEST_TMP_DIR/agents-bin"
+mkdir -p "$agents_plugin_root/agents" "$agents_bin"
+printf '  sample-agent:\n    isolation: worktree\n' > "$agents_plugin_root/agents/config.yaml"
+cat > "$agents_bin/claude" <<'SH'
+#!/usr/bin/env bash
+case "${DOCTOR_AGENTS_MODE:-compact}" in
+    compact) printf '%s\n' '[{"sessionId":"one"},{"sessionId":"two"}]' ;;
+    empty) printf '%s\n' '[]' ;;
+    object) printf '%s\n' '{"agents":[]}' ;;
+    truncated) printf '%s\n' '[{"sessionId":"one"}' ;;
+    malformed) printf '%s\n' 'not-json' ;;
+    failed) printf '%s\n' '[{"sessionId":"one"}]'; exit 7 ;;
+esac
+SH
+chmod +x "$agents_bin/claude"
+
+run_agents_check() {
+    DOCTOR_RESULTS_NAME=() DOCTOR_RESULTS_CAT=() DOCTOR_RESULTS_STATUS=() DOCTOR_RESULTS_MSG=() DOCTOR_RESULTS_DETAIL=()
+    PLUGIN_DIR="$agents_plugin_root" SUPPORTS_AGENTS_CLI=true PATH="$agents_bin:$PATH" \
+        DOCTOR_AGENTS_MODE="$1" doctor_check_agents
+}
+
+agent_result_status() {
+    local result_name="$1"
+    local i
+    for i in "${!DOCTOR_RESULTS_NAME[@]}"; do
+        if [[ "${DOCTOR_RESULTS_NAME[$i]}" == "$result_name" ]]; then
+            printf '%s|%s\n' "${DOCTOR_RESULTS_STATUS[$i]}" "${DOCTOR_RESULTS_MSG[$i]}"
+            return
+        fi
+    done
+}
+
+run_agents_check compact
+agent_cli_result="$(agent_result_status agents-cli)"
+if [[ "$agent_cli_result" == "pass|Claude agents CLI: 2 agents registered" ]]; then
+    test_pass
+else
+    test_fail "unexpected jq agents result: $agent_cli_result"
+fi
+
+test_case "agents CLI rejects valid non-array JSON instead of passing a key count"
+run_agents_check object
+agent_cli_result="$(agent_result_status agents-cli)"
+if [[ "$agent_cli_result" == "warn|Claude agents CLI returned unparseable output" ]]; then
+    test_pass
+else
+    test_fail "non-array JSON was accepted: $agent_cli_result"
+fi
+
+test_case "agents CLI preserves command failures as warnings"
+run_agents_check failed
+agent_cli_result="$(agent_result_status agents-cli)"
+if [[ "$agent_cli_result" == "warn|Claude agents CLI returned no data" ]]; then
+    test_pass
+else
+    test_fail "command failure was accepted: $agent_cli_result"
+fi
+
+test_case "agents CLI no-jq fallback counts compact sessions and empty arrays"
+command() {
+    if [[ "${1:-}" == "-v" && "${2:-}" == "jq" ]]; then
+        return 1
+    fi
+    builtin command "$@"
+}
+run_agents_check compact
+compact_result="$(agent_result_status agents-cli)"
+run_agents_check empty
+empty_result="$(agent_result_status agents-cli)"
+unset -f command
+if [[ "$compact_result" == "pass|Claude agents CLI: 2 agents registered" &&
+      "$empty_result" == "pass|Claude agents CLI: 0 agents registered" ]]; then
+    test_pass
+else
+    test_fail "no-jq counts were incorrect: compact=$compact_result empty=$empty_result"
+fi
+
+test_case "agents CLI no-jq fallback rejects truncated arrays"
+command() {
+    if [[ "${1:-}" == "-v" && "${2:-}" == "jq" ]]; then
+        return 1
+    fi
+    builtin command "$@"
+}
+run_agents_check truncated
+truncated_result="$(agent_result_status agents-cli)"
+unset -f command
+if [[ "$truncated_result" == "warn|Claude agents CLI returned unparseable output" ]]; then
+    test_pass
+else
+    test_fail "truncated no-jq output was accepted: $truncated_result"
+fi
+
 test_case "JSON escaping preserves UTF-8 and control characters"
 escaped_unicode="$(doctor_json_escape $'snowman:☃ next:\u0085')"
 if jq -ne --arg expected $'snowman:☃ next:\u0085' --arg escaped "$escaped_unicode" \

--- a/tests/unit/test-doctor-v10.sh
+++ b/tests/unit/test-doctor-v10.sh
@@ -283,6 +283,31 @@ else
     test_fail "truncated no-jq output was accepted: $truncated_result"
 fi
 
+test_case "agents CLI jq path rejects genuinely malformed (non-JSON) output"
+run_agents_check malformed
+malformed_jq_result="$(agent_result_status agents-cli)"
+if [[ "$malformed_jq_result" == "warn|Claude agents CLI returned unparseable output" ]]; then
+    test_pass
+else
+    test_fail "malformed output was accepted by jq path: $malformed_jq_result"
+fi
+
+test_case "agents CLI no-jq fallback rejects genuinely malformed (non-JSON) output"
+command() {
+    if [[ "${1:-}" == "-v" && "${2:-}" == "jq" ]]; then
+        return 1
+    fi
+    builtin command "$@"
+}
+run_agents_check malformed
+malformed_nojq_result="$(agent_result_status agents-cli)"
+unset -f command
+if [[ "$malformed_nojq_result" == "warn|Claude agents CLI returned unparseable output" ]]; then
+    test_pass
+else
+    test_fail "malformed no-jq output was accepted: $malformed_nojq_result"
+fi
+
 test_case "JSON escaping preserves UTF-8 and control characters"
 escaped_unicode="$(doctor_json_escape $'snowman:☃ next:\u0085')"
 if jq -ne --arg expected $'snowman:☃ next:\u0085' --arg escaped "$escaped_unicode" \


### PR DESCRIPTION
## Description
The `agents` category in `octopus doctor` always reported a false-positive warning ("Claude agents CLI returned no data") and, even when working, miscounted agents.

Root cause in `scripts/lib/doctor.sh:1577-1592` (`doctor_check_agents`):
- `claude agents` requires an interactive terminal. Captured via `$(...)`, there is no TTY, so Claude Code writes its "requires an interactive terminal" notice to **stderr**, which the check discards with `2>/dev/null`. Stdout is empty, so the check always takes the warn branch.
- Even when `cli_output` was non-empty, `grep -c "^"` counted output *lines*, not agents — wrong by nature (and with `--json` a nested/multi-line array would inflate the count further).

## Type of Change
- [x] Bug fix

## Fix
Switch to the documented non-interactive interface `claude agents --json`, and count agents from the JSON itself (`jq 'length'`, falling back to `grep -c '"sessionId"'` when `jq` is unavailable, matching the file's existing `command -v jq` fallback convention used elsewhere in `doctor.sh`).

## Testing
- `bash -n scripts/lib/doctor.sh` — syntax OK
- Functional check with a stub `claude` binary returning a 2-element JSON array: the fixed logic reports `count=2` via both the `jq` and `grep` fallback paths (see PR diff commit message for detail)
- `make ci-changed` — 3/4 suites pass (`test-doctor-v10.sh` 19/19, `test-suite-reachability.sh` 14/14, `test-windows-doctor-compat.sh` 5/5). The 4th, `test-agy-provider.sh`, fails on a timing-sensitive "stalled agy catalog lookup" test that is unrelated to this change — confirmed by stashing this diff and re-running on unmodified `origin/main`, where it fails identically (pre-existing flake, not introduced by this PR).

```bash
bash -n scripts/lib/doctor.sh
bash tests/unit/test-doctor-v10.sh
bash tests/unit/test-suite-reachability.sh
bash tests/unit/test-windows-doctor-compat.sh
```

## Related Issues
Closes #1028

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTWQJXqrjJ7RsMFPovmEmx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTWQJXqrjJ7RsMFPovmEmx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent registration diagnostics by validating command success and structured output.
  - Added reliable agent counting for environments with or without JSON query support.
  - Malformed, incomplete, or unavailable agent data now produces a warning instead of an incorrect pass.
  - Updated warning guidance to show the command needed to inspect registered agents manually.
  - Checks now provide more accurate results across supported agent data formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->