### PR TITLE
feat: installation health and command discovery (v11.5.0)

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -23,7 +23,7 @@ You get:    A structured comparison with three independent viewpoints,
             scored for agreement. Disagreements are flagged, not hidden.
 ```
 
-Octopus includes research, escalated code review, debugging, TDD, security audits, UI design, PRDs, and full build-to-ship workflows: 53 commands, 63 skills, 31 specialized personas.
+Octopus includes research, escalated code review, debugging, TDD, security audits, UI design, PRDs, and full build-to-ship workflows: 54 commands, 63 skills, 31 specialized personas.
 
 ### Engineering methods
 
@@ -105,7 +105,7 @@ Octopus orchestrates — it doesn't replace domain knowledge. If three models co
 ## Learn More
 
 - [**Full README**](../README.md) — feature deep-dive, provider grid, architecture, star history
-- [**Command Reference**](../docs/COMMAND-REFERENCE.md) — all 53 commands with triggers
+- [**Command Reference**](../docs/COMMAND-REFERENCE.md) — all 54 commands with triggers
 - [**Persona Guide**](../docs/AGENTS.md) — 31 specialized agents
 - [**Changelog**](../CHANGELOG.md) — release history
 - [**Issues**](https://github.com/nyldn/claude-octopus/issues) — bugs and feature requests

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "nyldn plugins for Claude Code workflows.",
-    "version": "11.4.2"
+    "version": "11.5.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "url",
         "url": "https://github.com/nyldn/claude-octopus.git"
       },
-      "description": "v11.4.2 - Keep private development material out of public plugin releases. 31 personas, 53 commands, 63 skills. Run /octo:setup.",
-      "version": "11.4.2",
+      "description": "v11.5.0 - Find the right command, check your installation, and repair broken plugin links safely. 31 personas, 54 commands, 63 skills. Run /octo:setup.",
+      "version": "11.5.0",
       "author": {
         "name": "nyldn",
         "url": "https://github.com/nyldn"

--- a/.claude-plugin/plugin-manifest.json
+++ b/.claude-plugin/plugin-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": "2026-06",
   "name": "octo",
   "displayName": "Claude Octopus",
-  "version": "11.4.2",
+  "version": "11.5.0",
   "description": "Multi-AI orchestration for Claude Code: up to 8 model seats in parallel across research, design, coding, and review, with council verdicts, adversarial debate, and per-provider cost attribution.",
   "author": {
     "name": "nyldn",
@@ -23,7 +23,7 @@
   },
   "components": {
     "commands": {
-      "count": 53,
+      "count": 54,
       "highlights": [
         "/octo:embrace",
         "/octo:discover",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "11.4.2",
-  "description": "v11.4.2 \u2014 Keep private development material out of public plugin releases. Run /octo:setup.",
+  "version": "11.5.0",
+  "description": "v11.5.0 - Find the right command, check your installation, and repair broken plugin links safely. Run /octo:setup.",
   "author": {
     "name": "nyldn",
     "url": "https://github.com/nyldn"
@@ -141,6 +141,7 @@
     "./commands/history.md",
     "./commands/discipline.md",
     "./commands/usage.md",
-    "./commands/whats-new.md"
+    "./commands/whats-new.md",
+    "./commands/guide.md"
   ]
 }

--- a/.claude-plugin/routines.json
+++ b/.claude-plugin/routines.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Claude Octopus routine manifest (v11.4.2). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
+  "$comment": "Claude Octopus routine manifest (v11.5.0). Saved automation configs for Claude Code routines: schedule triggers map to cron-style saved automations, github triggers map to repository event automations. All routines ship disabled; enable per-project after reviewing provider cost implications (external CLI seats bill to the user's API keys).",
   "schemaVersion": 1,
   "routines": [
     {

--- a/.claude/skills/skill-doctor/SKILL.md
+++ b/.claude/skills/skill-doctor/SKILL.md
@@ -62,7 +62,25 @@ if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" 
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]] && command -v octopus >/dev/null 2>&1; then
   OCTO_BIN="$(command -v octopus)"
-  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd -P)"
+  OCTO_LINK_HOPS=0
+  while [[ -L "$OCTO_BIN" ]]; do
+    OCTO_LINK_HOPS=$((OCTO_LINK_HOPS + 1))
+    if [[ "$OCTO_LINK_HOPS" -le 40 ]]; then
+      OCTO_BIN_DIR="$(cd -P "$(dirname "$OCTO_BIN")" 2>/dev/null && pwd -P)" || { OCTO_BIN=""; break; }
+      OCTO_LINK_TARGET="$(readlink "$OCTO_BIN")" || { OCTO_BIN=""; break; }
+      case "$OCTO_LINK_TARGET" in
+        /*) OCTO_BIN="$OCTO_LINK_TARGET" ;;
+        *) OCTO_BIN="$OCTO_BIN_DIR/$OCTO_LINK_TARGET" ;;
+      esac
+    else
+      OCTO_BIN=""
+      break
+    fi
+  done
+  if [[ -n "$OCTO_BIN" ]]; then
+    OCTO_BIN_DIR="$(cd -P "$(dirname "$OCTO_BIN")" 2>/dev/null && pwd -P)" || OCTO_BIN_DIR=""
+    [[ -z "$OCTO_BIN_DIR" ]] || OCTO_PLUGIN_ROOT="$(cd "$OCTO_BIN_DIR/.." 2>/dev/null && pwd -P)"
+  fi
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
   OCTO_PLUGIN_ROOT="$(

--- a/.claude/skills/skill-doctor/SKILL.md
+++ b/.claude/skills/skill-doctor/SKILL.md
@@ -21,7 +21,7 @@ trigger: |
 
 ## Overview
 
-Run environment diagnostics across 14 check categories. Doctor 2.0 identifies
+Run environment diagnostics across 15 check categories. Doctor 2.0 identifies
 misconfigured providers, stale loaded or cached plugin versions, invalid plugin
 assembly, unwritable state, non-terminal run records, orphan process evidence,
 broken hooks, and other issues that prevent Claude Octopus from working
@@ -51,18 +51,18 @@ correctly.
 
 ### Step 1: Resolve Plugin Root and Run Full Diagnostics
 
-Use this resolver before running Octopus scripts. Do not assume
-`~/.claude-octopus/plugin` exists; Windows Git Bash installs may not support the
-stable symlink. Run this as a single Bash call.
+Use this resolver before running Octopus scripts. Prefer the active host root,
+then the stable root or the installed CLI. Do not create or replace a stable
+link while collecting diagnostics. Run this as a single Bash call.
 
 ```bash
-OCTO_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+OCTO_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-}}"
 if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
   OCTO_PLUGIN_ROOT="${HOME}/.claude-octopus/plugin"
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]] && command -v octopus >/dev/null 2>&1; then
   OCTO_BIN="$(command -v octopus)"
-  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd)"
+  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd -P)"
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
   OCTO_PLUGIN_ROOT="$(
@@ -77,18 +77,13 @@ if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" 
   echo "Claude Octopus plugin root not found. Reinstall the octo plugin, then retry doctor diagnostics."
   exit 1
 fi
-mkdir -p "${HOME}/.claude-octopus"
-_octo_stable="${HOME}/.claude-octopus/plugin"
-if [[ ! -L "$_octo_stable" ]] || [[ "$(cd "$OCTO_PLUGIN_ROOT" 2>/dev/null && pwd -P)" != "$(cd "$_octo_stable" 2>/dev/null && pwd -P)" ]]; then
-  [[ -L "$_octo_stable" || -f "$_octo_stable" ]] && rm -f "$_octo_stable" 2>/dev/null || true
-  ln -s "$OCTO_PLUGIN_ROOT" "$_octo_stable" 2>/dev/null || true
-fi
-unset _octo_stable
 export OCTO_PLUGIN_ROOT
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --verbose
 ```
 
-This runs all 14 check categories and displays a formatted report.
+This runs all 15 check categories and displays a formatted report. The
+installation category reports a missing or mismatched stable root; it does not
+repair it.
 
 ### Step 2: Filter by Category (Optional)
 
@@ -113,6 +108,7 @@ bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor conflicts
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor agents
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor recurrence
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor cache
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor installation
 ```
 
 ### Step 3: Check & Install Dependencies
@@ -172,7 +168,26 @@ Access, the Antigravity CLI item, and its Access Control settings.
 
 ### Step 5: Interactive Remediation (MANDATORY for fixable issues)
 
-After running diagnostics, if ANY fixable issues are found, you MUST use AskUserQuestion to offer fixes. Do NOT just print instructions — offer to execute them.
+After running diagnostics, if ANY fixable issues are found, you MUST use
+AskUserQuestion to offer fixes. Do not just print instructions. Offer to
+execute them.
+
+Stable-root repair is bounded and requires explicit authorization. First show
+the proposed change with:
+
+```bash
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" repair --dry-run
+```
+
+Only after the user authorizes that exact repair may you run:
+
+```bash
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" repair --apply
+```
+
+Never recreate the stable link in the resolver or as an automatic doctor
+follow-up. Cache cleanup, stale PID cleanup, login flows, package installation,
+and plugin updates also require explicit confirmation.
 
 Before each accepted repair, restate the exact target and action. Configuration
 repairs must use a validated sibling temporary file and atomic rename; if any
@@ -261,6 +276,7 @@ Offer to run the login command for the expired provider.
 | `agents` | Agent definitions, worktree isolation, CLI registration, version compatibility |
 | `recurrence` | Failure pattern detection — flags repeated quality gate failures, source hotspots, 48h trends |
 | `cache` | Cache size, freshness, and hygiene |
+| `installation` | Loaded plugin root, stable root, host-scoped install metadata, and context profile |
 
 Software dependency installation is checked separately by
 `scripts/install-deps.sh check` in Step 3, including Node.js, jq, provider CLIs,
@@ -303,41 +319,55 @@ All checks pass — no action needed.
 
 ---
 
-## Hook Profile
+## Context and intensity profiles
 
-Claude Octopus hooks can run in different profiles to balance cost and coverage.
+The installation report exposes two optional context settings:
 
-Current profile: `$OCTO_HOOK_PROFILE` (default: standard)
+- `OCTOPUS_CONTEXT_PROFILE` selects `core`, `orchestration`, or `full` context
+  behavior. The `octopus profile` command reads and writes this setting.
+- `OCTOPUS_HOOK_PROFILE` can override the optional context-hook profile with
+  `core`, `orchestration`, or `full`.
 
-Available profiles:
-- **minimal** — Only session lifecycle and cost tracking hooks (lowest overhead)
-- **standard** — All hooks except expensive review/security gates (default)
-- **strict** — All hooks enabled including quality and security gates
+These settings control optional context work only. They never disable safety or
+lifecycle hooks. A missing or invalid hook-profile registry fails closed.
 
-Override: Set `OCTO_PROFILE=budget|balanced|quality` or `OCTO_DISABLED_HOOKS=hook1,hook2` to fine-tune. Legacy `OCTO_HOOK_PROFILE` still works (minimal→budget, standard→balanced, strict→quality).
+`OCTO_PROFILE` is a separate legacy intensity setting with `budget`,
+`balanced`, and `quality` values. It is not an alias for either context
+setting, and it must not be used to claim that safety hooks are disabled.
 
 ---
 
-## Intensity Profile
+## Legacy intensity profile
 
-The doctor reports the active intensity profile — a single knob controlling hook gating, model selection, phase skipping, and context verbosity.
+Some older workflow paths use `OCTO_PROFILE` as an intensity setting for model
+selection, phase skipping, and context verbosity. This setting is separate
+from the optional context-hook profiles above.
 
 ### What the Doctor Checks
 
-- **Current profile**: `OCTO_PROFILE` value (budget/balanced/quality, default: balanced)
-- **Profile source**: env var, legacy `OCTO_HOOK_PROFILE`, or auto-selected from intent
-- **Hook gating**: which hooks are enabled/disabled at this profile level
+- **Context profile**: `OCTOPUS_CONTEXT_PROFILE` value, default `core`
+- **Optional hook profile**: `OCTOPUS_HOOK_PROFILE` when set, otherwise the
+  context profile
+- **Legacy intensity**: `OCTO_PROFILE` when a legacy workflow reads it
+- **Hook gating**: optional context hooks only; safety and lifecycle hooks remain
+  active
 - **Model hints**: which model (sonnet/opus) is recommended for each phase
 - **Context verbosity**: compressed/standard/full
 
-### Profile Summary
+### Legacy intensity summary
 
 | Dimension | budget | balanced | quality |
 |-----------|--------|----------|---------|
-| Hooks | essential only | standard (no quality gates) | all hooks |
 | Models | Sonnet everywhere | Sonnet + Opus for synthesis | Opus for most phases |
 | Phases | Skip discover if context given | Skip re-discovery | All phases run |
 | Context | Compressed | Standard | Full inlining |
+
+### Optional context profile summary
+
+| Dimension | core | orchestration | full |
+|-----------|------|----------------|------|
+| Optional context hooks | Off | Workflow context only | All profile-managed context hooks |
+| Safety and lifecycle hooks | Active | Active | Active |
 
 ---
 
@@ -392,7 +422,7 @@ Invoke this manual skill explicitly, or run the CLI directly:
 
 | What to say / run | Action |
 |-------------------|--------|
-| `/octo:skill-doctor` | Run all 14 categories inside Claude Code |
+| `/octo:skill-doctor` | Run all 15 categories inside Claude Code |
 | `octopus doctor providers` | Check provider installation only |
 | `octopus doctor auth --verbose` | Detailed auth status |
 | `octopus doctor --json` | Machine-readable output |

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-octopus",
-  "version": "11.4.2",
+  "version": "11.5.0",
   "description": "Multi-LLM orchestration with Double Diamond workflows, provider routing, safety gates, and automation. Dispatches to Codex, Antigravity, Cursor CLI, Grok, Copilot, Qwen, Perplexity, OpenRouter, OrcaRouter, Ollama, OpenCode, and Kimi Code from a single plugin.",
   "author": {
     "name": "nyldn"
@@ -37,7 +37,7 @@
   "interface": {
     "displayName": "Claude Octopus",
     "shortDescription": "Multi-LLM orchestration \u2014 dispatch to 12 providers from one plugin.",
-    "longDescription": "Claude Octopus orchestrates twelve external AI providers (Codex, Antigravity, Cursor CLI, Grok, Copilot, Qwen, Perplexity, OpenRouter, OrcaRouter, Ollama, OpenCode, and Kimi Code) through structured Double Diamond workflows. 31 personas, 53 commands, 63 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch includes prompt-size preflight, agent summary tables, circuit breakers, cost tracking, and model routing.",
+    "longDescription": "Claude Octopus orchestrates twelve external AI providers (Codex, Antigravity, Cursor CLI, Grok, Copilot, Qwen, Perplexity, OpenRouter, OrcaRouter, Ollama, OpenCode, and Kimi Code) through structured Double Diamond workflows. 31 personas, 54 commands, 63 skills covering research, implementation, review, TDD, security audits, and more. Provider dispatch includes prompt-size preflight, agent summary tables, circuit breakers, cost tracking, and model routing.",
     "composerIcon": "./assets/octopus-icon.svg",
     "developerName": "nyldn",
     "category": "Orchestration",

--- a/.cursor-plugin/commands/octo-auto.md
+++ b/.cursor-plugin/commands/octo-auto.md
@@ -58,8 +58,9 @@ follow that command's contract in the current conversation. Do not continue to
 STEP 1 or choose a different route. This avoids two classifiers choosing
 different workflows and keeps Premium peer policy at the workflow root.
 
-The `help`, `list`, and `capabilities` requests below may be answered locally
-without invoking the runtime.
+For `help`, `list`, and `capabilities`, run the provider-free installed catalog
+with `bash "${OCTO_ROOT}/scripts/orchestrate.sh" guide list`. Do not use a
+remembered command list or initialize a workflow.
 
 ## ROUTING REFERENCE (not a second execution path)
 
@@ -73,7 +74,7 @@ If the query exceeds 500 characters, use only the first 500 characters for inten
 ### STEP 2: Meta Command Check
 
 If the query matches any of: `help`, `list`, `commands`, `what can you do`, `capabilities`, `options`, `workflows`:
-- Display the **Complete Workflow Menu** (see STEP 5c) and STOP. Do not route.
+- Show the installed catalog through `guide list` and STOP. Do not route.
 
 ### STEP 3: Analyze Intent
 

--- a/.cursor-plugin/commands/octo-doctor.md
+++ b/.cursor-plugin/commands/octo-doctor.md
@@ -49,7 +49,25 @@ if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" 
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]] && command -v octopus >/dev/null 2>&1; then
   OCTO_BIN="$(command -v octopus)"
-  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd -P)"
+  OCTO_LINK_HOPS=0
+  while [[ -L "$OCTO_BIN" ]]; do
+    OCTO_LINK_HOPS=$((OCTO_LINK_HOPS + 1))
+    if [[ "$OCTO_LINK_HOPS" -le 40 ]]; then
+      OCTO_BIN_DIR="$(cd -P "$(dirname "$OCTO_BIN")" 2>/dev/null && pwd -P)" || { OCTO_BIN=""; break; }
+      OCTO_LINK_TARGET="$(readlink "$OCTO_BIN")" || { OCTO_BIN=""; break; }
+      case "$OCTO_LINK_TARGET" in
+        /*) OCTO_BIN="$OCTO_LINK_TARGET" ;;
+        *) OCTO_BIN="$OCTO_BIN_DIR/$OCTO_LINK_TARGET" ;;
+      esac
+    else
+      OCTO_BIN=""
+      break
+    fi
+  done
+  if [[ -n "$OCTO_BIN" ]]; then
+    OCTO_BIN_DIR="$(cd -P "$(dirname "$OCTO_BIN")" 2>/dev/null && pwd -P)" || OCTO_BIN_DIR=""
+    [[ -z "$OCTO_BIN_DIR" ]] || OCTO_PLUGIN_ROOT="$(cd "$OCTO_BIN_DIR/.." 2>/dev/null && pwd -P)"
+  fi
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
   OCTO_PLUGIN_ROOT="$(

--- a/.cursor-plugin/commands/octo-doctor.md
+++ b/.cursor-plugin/commands/octo-doctor.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 
 ## Overview
 
-Run environment diagnostics across 14 check categories. Doctor 2.0 identifies
+Run environment diagnostics across 15 check categories. Doctor 2.0 identifies
 misconfigured providers, stale loaded or cached plugin versions, invalid plugin
 assembly, unwritable state, non-terminal run records, orphan process evidence,
 broken hooks, and other issues that prevent Claude Octopus from working
@@ -38,18 +38,18 @@ correctly.
 
 ### Step 1: Resolve Plugin Root and Run Full Diagnostics
 
-Use this resolver before running Octopus scripts. Do not assume
-`~/.claude-octopus/plugin` exists; Windows Git Bash installs may not support the
-stable symlink. Run this as a single Bash call.
+Use this resolver before running Octopus scripts. Prefer the active host root,
+then the stable root or the installed CLI. Do not create or replace a stable
+link while collecting diagnostics. Run this as a single Bash call.
 
 ```bash
-OCTO_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+OCTO_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-}}"
 if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
   OCTO_PLUGIN_ROOT="${HOME}/.claude-octopus/plugin"
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]] && command -v octopus >/dev/null 2>&1; then
   OCTO_BIN="$(command -v octopus)"
-  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd)"
+  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd -P)"
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
   OCTO_PLUGIN_ROOT="$(
@@ -64,18 +64,13 @@ if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" 
   echo "Claude Octopus plugin root not found. Reinstall the octo plugin, then retry doctor diagnostics."
   exit 1
 fi
-mkdir -p "${HOME}/.claude-octopus"
-_octo_stable="${HOME}/.claude-octopus/plugin"
-if [[ ! -L "$_octo_stable" ]] || [[ "$(cd "$OCTO_PLUGIN_ROOT" 2>/dev/null && pwd -P)" != "$(cd "$_octo_stable" 2>/dev/null && pwd -P)" ]]; then
-  [[ -L "$_octo_stable" || -f "$_octo_stable" ]] && rm -f "$_octo_stable" 2>/dev/null || true
-  ln -s "$OCTO_PLUGIN_ROOT" "$_octo_stable" 2>/dev/null || true
-fi
-unset _octo_stable
 export OCTO_PLUGIN_ROOT
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --verbose
 ```
 
-This runs all 14 check categories and displays a formatted report.
+This runs all 15 check categories and displays a formatted report. The
+installation category reports a missing or mismatched stable root; it does not
+repair it.
 
 ### Step 2: Filter by Category (Optional)
 
@@ -100,6 +95,7 @@ bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor conflicts
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor agents
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor recurrence
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor cache
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor installation
 ```
 
 ### Step 3: Check & Install Dependencies
@@ -159,7 +155,26 @@ Access, the Antigravity CLI item, and its Access Control settings.
 
 ### Step 5: Interactive Remediation (MANDATORY for fixable issues)
 
-After running diagnostics, if ANY fixable issues are found, you MUST use AskUserQuestion to offer fixes. Do NOT just print instructions — offer to execute them.
+After running diagnostics, if ANY fixable issues are found, you MUST use
+AskUserQuestion to offer fixes. Do not just print instructions. Offer to
+execute them.
+
+Stable-root repair is bounded and requires explicit authorization. First show
+the proposed change with:
+
+```bash
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" repair --dry-run
+```
+
+Only after the user authorizes that exact repair may you run:
+
+```bash
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" repair --apply
+```
+
+Never recreate the stable link in the resolver or as an automatic doctor
+follow-up. Cache cleanup, stale PID cleanup, login flows, package installation,
+and plugin updates also require explicit confirmation.
 
 Before each accepted repair, restate the exact target and action. Configuration
 repairs must use a validated sibling temporary file and atomic rename; if any
@@ -248,6 +263,7 @@ Offer to run the login command for the expired provider.
 | `agents` | Agent definitions, worktree isolation, CLI registration, version compatibility |
 | `recurrence` | Failure pattern detection — flags repeated quality gate failures, source hotspots, 48h trends |
 | `cache` | Cache size, freshness, and hygiene |
+| `installation` | Loaded plugin root, stable root, host-scoped install metadata, and context profile |
 
 Software dependency installation is checked separately by
 `scripts/install-deps.sh check` in Step 3, including Node.js, jq, provider CLIs,
@@ -290,41 +306,55 @@ All checks pass — no action needed.
 
 ---
 
-## Hook Profile
+## Context and intensity profiles
 
-Claude Octopus hooks can run in different profiles to balance cost and coverage.
+The installation report exposes two optional context settings:
 
-Current profile: `$OCTO_HOOK_PROFILE` (default: standard)
+- `OCTOPUS_CONTEXT_PROFILE` selects `core`, `orchestration`, or `full` context
+  behavior. The `octopus profile` command reads and writes this setting.
+- `OCTOPUS_HOOK_PROFILE` can override the optional context-hook profile with
+  `core`, `orchestration`, or `full`.
 
-Available profiles:
-- **minimal** — Only session lifecycle and cost tracking hooks (lowest overhead)
-- **standard** — All hooks except expensive review/security gates (default)
-- **strict** — All hooks enabled including quality and security gates
+These settings control optional context work only. They never disable safety or
+lifecycle hooks. A missing or invalid hook-profile registry fails closed.
 
-Override: Set `OCTO_PROFILE=budget|balanced|quality` or `OCTO_DISABLED_HOOKS=hook1,hook2` to fine-tune. Legacy `OCTO_HOOK_PROFILE` still works (minimal→budget, standard→balanced, strict→quality).
+`OCTO_PROFILE` is a separate legacy intensity setting with `budget`,
+`balanced`, and `quality` values. It is not an alias for either context
+setting, and it must not be used to claim that safety hooks are disabled.
 
 ---
 
-## Intensity Profile
+## Legacy intensity profile
 
-The doctor reports the active intensity profile — a single knob controlling hook gating, model selection, phase skipping, and context verbosity.
+Some older workflow paths use `OCTO_PROFILE` as an intensity setting for model
+selection, phase skipping, and context verbosity. This setting is separate
+from the optional context-hook profiles above.
 
 ### What the Doctor Checks
 
-- **Current profile**: `OCTO_PROFILE` value (budget/balanced/quality, default: balanced)
-- **Profile source**: env var, legacy `OCTO_HOOK_PROFILE`, or auto-selected from intent
-- **Hook gating**: which hooks are enabled/disabled at this profile level
+- **Context profile**: `OCTOPUS_CONTEXT_PROFILE` value, default `core`
+- **Optional hook profile**: `OCTOPUS_HOOK_PROFILE` when set, otherwise the
+  context profile
+- **Legacy intensity**: `OCTO_PROFILE` when a legacy workflow reads it
+- **Hook gating**: optional context hooks only; safety and lifecycle hooks remain
+  active
 - **Model hints**: which model (sonnet/opus) is recommended for each phase
 - **Context verbosity**: compressed/standard/full
 
-### Profile Summary
+### Legacy intensity summary
 
 | Dimension | budget | balanced | quality |
 |-----------|--------|----------|---------|
-| Hooks | essential only | standard (no quality gates) | all hooks |
 | Models | Sonnet everywhere | Sonnet + Opus for synthesis | Opus for most phases |
 | Phases | Skip discover if context given | Skip re-discovery | All phases run |
 | Context | Compressed | Standard | Full inlining |
+
+### Optional context profile summary
+
+| Dimension | core | orchestration | full |
+|-----------|------|----------------|------|
+| Optional context hooks | Off | Workflow context only | All profile-managed context hooks |
+| Safety and lifecycle hooks | Active | Active | Active |
 
 ---
 
@@ -379,7 +409,7 @@ Invoke this manual skill explicitly, or run the CLI directly:
 
 | What to say / run | Action |
 |-------------------|--------|
-| `/octo:skill-doctor` | Run all 14 categories inside Claude Code |
+| `/octo:skill-doctor` | Run all 15 categories inside Claude Code |
 | `octopus doctor providers` | Check provider installation only |
 | `octopus doctor auth --verbose` | Detailed auth status |
 | `octopus doctor --json` | Machine-readable output |

--- a/.cursor-plugin/commands/octo-guide.md
+++ b/.cursor-plugin/commands/octo-guide.md
@@ -1,0 +1,26 @@
+---
+description: "Find an installed Octopus command for your task without calling a provider"
+disable-model-invocation: true
+allowed-tools: Bash, Read
+---
+
+# Command guide
+
+Read the installed catalog and show a suitable next command. Do not start a
+workflow, probe providers, change settings, or install anything.
+
+Resolve the plugin root from `CODEX_PLUGIN_ROOT`, then `CLAUDE_PLUGIN_ROOT`,
+then the stable `~/.claude-octopus/plugin` link. Run:
+
+```bash
+OCTO_ROOT="${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${HOME}/.claude-octopus/plugin}}"
+bash "$OCTO_ROOT/scripts/orchestrate.sh" guide
+```
+
+For a topic, pass the user's topic as one quoted argument to `guide`. For the
+full catalog, pass `list`. Do not interpolate untrusted text into shell code.
+Recommend only commands present in the returned catalog. Show examples with a
+task, such as `/octo:auto "review the changes in this branch"`.
+
+If the installed catalog cannot be read, report that error and suggest
+`/octo:setup`. Do not invent commands from memory.

--- a/.cursor-plugin/commands/octo-guide.md
+++ b/.cursor-plugin/commands/octo-guide.md
@@ -9,11 +9,11 @@ allowed-tools: Bash, Read
 Read the installed catalog and show a suitable next command. Do not start a
 workflow, probe providers, change settings, or install anything.
 
-Resolve the plugin root from `CODEX_PLUGIN_ROOT`, then `CLAUDE_PLUGIN_ROOT`,
+Resolve the plugin root from `CLAUDE_PLUGIN_ROOT`, then `CODEX_PLUGIN_ROOT`,
 then the stable `~/.claude-octopus/plugin` link. Run:
 
 ```bash
-OCTO_ROOT="${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${HOME}/.claude-octopus/plugin}}"
+OCTO_ROOT="${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${HOME}/.claude-octopus/plugin}}"
 bash "$OCTO_ROOT/scripts/orchestrate.sh" guide
 ```
 

--- a/.cursor-plugin/commands/octo-setup.md
+++ b/.cursor-plugin/commands/octo-setup.md
@@ -42,6 +42,48 @@ fi
 export OCTO_ROOT
 ```
 
+### 1.25 Run installation health for troubleshooting
+
+When setup is being rerun to troubleshoot installation, run this safe health
+pass immediately after resolving the root. It reads the installation Doctor
+category and both host cache locations. It does not create a stable link,
+record install state, clean a cache, log in, or contact a provider. A diagnostic
+exit status is evidence to show the user, not permission to claim the check
+passed.
+
+```bash
+setup_installation_health() {
+  local doctor_json="" cache_json="" doctor_rc=0 cache_rc=0
+  if [[ ! -r "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
+    printf 'Installation health unavailable: orchestrate.sh is missing.\n'
+    return 0
+  fi
+
+  if [[ -n "${CODEX_THREAD_ID:-}${CODEX_SANDBOX:-}" ]]; then
+    doctor_json="$(env -u CLAUDE_PLUGIN_ROOT CODEX_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" doctor installation --json 2>/dev/null)" || doctor_rc=$?
+    cache_json="$(env -u CLAUDE_PLUGIN_ROOT CODEX_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" cache-check --json 2>/dev/null)" || cache_rc=$?
+  else
+    doctor_json="$(env -u CODEX_PLUGIN_ROOT CLAUDE_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" doctor installation --json 2>/dev/null)" || doctor_rc=$?
+    cache_json="$(env -u CODEX_PLUGIN_ROOT CLAUDE_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" cache-check --json 2>/dev/null)" || cache_rc=$?
+  fi
+
+  printf 'Installation health (read-only):\n'
+  if [[ -n "$doctor_json" ]]; then
+    printf '%s\n' "$doctor_json"
+  else
+    printf '%s\n' '{"error":"doctor installation returned no report"}'
+  fi
+  if [[ -n "$cache_json" ]]; then
+    printf '%s\n' "$cache_json"
+  else
+    printf '%s\n' '{"error":"cache-check returned no report"}'
+  fi
+  printf 'installation-health-exit: doctor=%s cache=%s\n' "$doctor_rc" "$cache_rc"
+}
+
+setup_installation_health
+```
+
 ### 1.5 Read resumable setup state
 
 Read the receipt without creating files. The physical plugin root and host kind
@@ -290,6 +332,22 @@ if [[ -n "$SETUP_LOCAL_FAILURE" ]]; then
   exit 1
 fi
 printf 'setup-verification:pass (no provider request)\n'
+
+# Recheck installation health at the completion boundary. This remains
+# read-only; any repair still needs a separate explicit authorization.
+if declare -F setup_installation_health >/dev/null 2>&1; then
+  setup_installation_health
+else
+  health_rc=0
+  if [[ -n "${CODEX_THREAD_ID:-}${CODEX_SANDBOX:-}" ]]; then
+    env -u CLAUDE_PLUGIN_ROOT CODEX_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" doctor installation --json || health_rc=$?
+    env -u CLAUDE_PLUGIN_ROOT CODEX_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" cache-check --json || health_rc=$?
+  else
+    env -u CODEX_PLUGIN_ROOT CLAUDE_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" doctor installation --json || health_rc=$?
+    env -u CODEX_PLUGIN_ROOT CLAUDE_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" cache-check --json || health_rc=$?
+  fi
+  printf 'installation-health-exit: %s\n' "$health_rc"
+fi
 ```
 
 Only after the user selected a completion path and this verification passed,
@@ -350,12 +408,14 @@ Finish with exactly this quick-start block:
 Next commands:
 
 ```text
-/octo:auto
+/octo:auto "describe your task"
+/octo:guide
 /octo:skill-doctor
 /octo:setup
 ```
 
-`/octo:auto` routes a task, `/octo:skill-doctor` diagnoses plugin skills inside
+`/octo:auto` routes a task, `/octo:guide` helps choose an installed command,
+and `/octo:skill-doctor` diagnoses plugin skills inside
 Claude Code, and `/octo:setup` returns here. From a shell, use `octopus doctor`
 for environment diagnostics.
 

--- a/.cursor-plugin/commands/octo-setup.md
+++ b/.cursor-plugin/commands/octo-setup.md
@@ -383,6 +383,8 @@ AskUserQuestion({
 ### Models and routing
 
 - Use `/octo:model-config` for model overrides.
+- Use `octopus profile core|orchestration|full` to control optional context
+  hooks. Explain that profiles never disable safety or lifecycle hooks.
 - Explain cost impact before changing cost mode.
 - Treat `OCTO_TIER=prototype|mvp|production` as a routing hint, not policy.
 - Never change routing, model, or tier configuration without confirmation.

--- a/.cursor-plugin/commands/octo-setup.md
+++ b/.cursor-plugin/commands/octo-setup.md
@@ -409,7 +409,6 @@ Next commands:
 
 ```text
 /octo:auto "describe your task"
-/octo:guide
 /octo:skill-doctor
 /octo:setup
 ```

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "claude-octopus",
   "displayName": "Claude Octopus",
   "description": "Multi-LLM orchestration \u2014 up to 8 providers check each other's work. Research, build, review, and ship with consensus gates.",
-  "version": "11.4.2",
+  "version": "11.5.0",
   "author": {
     "name": "nyldn"
   },

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-tentacled orchestration plugin for Factory AI Droid",
-    "version": "11.4.2"
+    "version": "11.5.0"
   },
   "plugins": [
     {
       "name": "claude-octopus",
       "source": "./",
-      "description": "v11.4.2 - Multi-AI orchestration with Double Diamond workflow. 31 personas, 53 commands, 63 skills. Run /octo:setup after install.",
-      "version": "11.4.2",
+      "description": "v11.5.0 - Multi-AI orchestration with Double Diamond workflow. 31 personas, 54 commands, 63 skills. Run /octo:setup after install.",
+      "version": "11.5.0",
       "author": {
         "name": "nyldn"
       },

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "octo",
-  "version": "11.4.2",
-  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v11.4.2. 31 expert personas, 53 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
+  "version": "11.5.0",
+  "description": "Multi-tentacled orchestrator using Double Diamond methodology. v11.5.0. 31 expert personas, 54 commands, 63 skills. Commands '/octo:*'. Run /octo:setup for guided setup. Compatible with Claude Code and Factory AI Droid.",
   "author": {
     "name": "nyldn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   instead of inferring authentication from the presence of a CLI executable.
 - Doctor and the new installation tools use a lightweight CLI path that avoids
   starting workflow state, event logs, or provider probes.
+- Unknown `octopus` CLI commands now return a usage error with exit code 2
+  instead of printing help and returning success.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Added
+
+- New local installation tools show provider readiness, validate active Claude
+  and Codex plugin caches, repair broken stable links, run offline plugin-file
+  checks, and export a redacted checkpoint for another supported host.
+- Host-scoped install metadata now records Claude and Codex separately and
+  refreshes when the loaded root, version, install scope, or context profile
+  changes.
+- Context profiles keep optional reinforcement hooks off in `core`, enable them
+  for active workflows in `orchestration`, and allow every profile-managed
+  context hook in `full`. Safety and lifecycle hooks remain active in every
+  profile.
+
+### Changed
+
+- Installation diagnostics use the shared Provider Registry readiness result
+  instead of inferring authentication from the presence of a CLI executable.
+- Doctor and the new installation tools use a lightweight CLI path that avoids
+  starting workflow state, event logs, or provider probes.
+
 ## [11.4.2] - 2026-09-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-## [Unreleased]
+## [11.5.0] - 2026-09-12
 
 ### Added
 
+- `/octo:guide` finds commands from your installed version. `/octo:auto help`
+  uses the same catalog without contacting a provider.
 - New local installation tools show provider readiness, validate active Claude
   and Codex plugin caches, repair broken stable links, run offline plugin-file
-  checks, and export a redacted checkpoint for another supported host.
+  checks, and export a filtered workflow summary for another supported host.
 - Host-scoped install metadata now records Claude and Codex separately and
   refreshes when the loaded root, version, install scope, or context profile
   changes.
@@ -21,6 +23,21 @@
   instead of inferring authentication from the presence of a CLI executable.
 - Doctor and the new installation tools use a lightweight CLI path that avoids
   starting workflow state, event logs, or provider probes.
+
+### Fixed
+
+- Cache checks inspect the active plugin even when its host cache is absent.
+  Repairs validate their target and preserve modified or unowned wrappers.
+- Installation records recover after interrupted writes and retain separate
+  Claude and Codex entries during concurrent updates.
+- Handoff exports preserve existing directory permissions and use project
+  decisions and active blockers. Exports are summaries, not resumable sessions.
+- Optional post-tool hooks receive the host session identity and cover Read,
+  WebFetch, and Grep events. Core mode still leaves these optional hooks off.
+- `octopus explain` reaches the saved-run inspector, and `sys-setup` resolves
+  to setup.
+- Package lifecycle tests use isolated state and the candidate artifact instead
+  of uninstalling the user plugin or testing the latest remote version.
 
 ## [11.4.2] - 2026-09-11
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-09-11
+last_reviewed: 2026-09-12
 ---
 
 # PRODUCT.md
@@ -41,7 +41,7 @@ Claude Octopus is a **multi-runtime orchestration plugin** with three architectu
 | **Workflow engine** (`skills/`) | Structures every task into Discover → Define → Develop → Deliver with quality gates | Stops ad-hoc "just ask Claude" from shipping low-confidence output |
 | **Consensus layer** | 75% gate: flags disagreements across providers before code is finalized | The actual blind-spot catcher — surfaces the 1-in-5 case where Claude was wrong |
 
-53 slash commands, 63 skills, and 31 specialized personas provide explicit escalation entrypoints. Installation alone activates none of them.
+54 slash commands, 63 skills, and 31 specialized personas provide explicit escalation entrypoints. Installation alone activates none of them.
 
 ## Core Value Propositions
 
@@ -77,11 +77,11 @@ Frontier AI models will remain individually overconfident for the foreseeable fu
 
 ## Evidence
 
-**Traction (as of 2026-09-11):**
+**Traction (as of 2026-09-12):**
 - GitHub stars: 4,048
 - GitHub forks: 380
 - Local CI parity: `make ci-local` runs the same smoke, unit, and integration suites as CI
-- Version: 11.4.2 (active release cadence)
+- Version: 11.5.0 (active release cadence)
 - Runtimes supported: Claude Code, Codex CLI, Command Code CLI, Cursor (MCP), Antigravity CLI
 
 **Measured Impact:**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Every AI model has blind spots. Claude Octopus supports twelve external provider
 <p align="center">
   <a href="https://claude.ai"><img src="https://img.shields.io/badge/Claude-Built_with_AI-c96442?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDJhMTAgMTAgMCAxIDAgMCAyMCAxMCAxMCAwIDAgMCAwLTIwbTAgMS44YTEuMiAxLjIgMCAwIDEgLjg1LjM1bDEuNSA0LjVhLjYuNiAwIDAgMCAuMzUuMzVsNC41IDEuNWExLjIgMS4yIDAgMCAxIDAgMi4yN2wtNC41IDEuNWEuNi42IDAgMCAwLS4zNS4zNWwtMS41IDQuNWExLjIgMS4yIDAgMCAxLTIuMjcgMGwtMS41LTQuNWEuNi42IDAgMCAwLS4zNS0uMzVsLTQuNS0xLjVhMS4yIDEuMiAwIDAgMSAwLTIuMjdsNC41LTEuNWEuNi42IDAgMCAwIC4zNS0uMzVsMS41LTQuNUExLjIgMS4yIDAgMCAxIDEyIDMuOCIvPjwvc3ZnPg==&labelColor=333" alt="Built with Claude"></a>
   <a href="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml"><img src="https://github.com/nyldn/claude-octopus/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/Version-11.4.2-blue" alt="Version 11.4.2">
+  <img src="https://img.shields.io/badge/Version-11.5.0-blue" alt="Version 11.5.0">
   <img src="https://img.shields.io/badge/Claude_Code-v2.1.14+_required-blueviolet" alt="Requires Claude Code v2.1.14+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
 </p>
@@ -26,7 +26,7 @@ Every AI model has blind spots. Claude Octopus supports twelve external provider
 
 🔄 **Choose the workflow the task needs.** Use a focused method for architecture, debugging, or TDD. Use `/octo:embrace` for Discover → Define → Develop → Deliver, with quality gates between phases.
 
-🐙 **31 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **53 commands** (slash commands you type), **63 skills** (reusable workflow modules). Explicit workflows select the experts they need; ordinary Claude requests do not activate Octopus.
+🐙 **31 specialized personas** (role-specific AI agents like security-auditor, backend-architect), **54 commands** (slash commands you type), **63 skills** (reusable workflow modules). Explicit workflows select the experts they need; ordinary Claude requests do not activate Octopus.
 
 🐙 **Works with just Claude. Adds up to twelve external provider integrations.** Zero external providers are needed to start. Add them one at a time — each becomes available when detected and runs only inside an explicit workflow.
 
@@ -55,7 +55,7 @@ workflows are not double-reviewed. Set `OCTOPUS_PREMIUM_PEER_CHECK=off` to
 disable it.
 
 <!-- BEGIN CURRENT RELEASE -->
-> 🆕 **v11.4.2 — Keep private development material out of public plugin releases.**
+> 🆕 **v11.5.0 — Find the right command, check your installation, and repair broken plugin links safely.**
 >
 > **Default roster:** Claude Opus 5 leads architecture, planning, security reasoning, and final judgment; GPT-5.6 Sol is the independent implementation/review peer; Claude Sonnet 5 is the standard Claude seat; Fable 5.1 remains an opt-in judgment escalation. Existing model pins and provider configuration still win. See [the routing strategy](docs/MODEL-ROUTING-STRATEGY.md).
 <!-- END CURRENT RELEASE -->
@@ -76,7 +76,7 @@ disable it.
 
 | Version | Best Features |
 |---------|--------------|
-| **v11.4.2** (new) | Keep private development material out of public plugin releases. |
+| **v11.5.0** (new) | Find the right command, check your installation, and repair broken plugin links safely. |
 | **v9.50** | **Claude Code 2026 compatibility layer** — routines manifest (schedule + GitHub-event automations), SubagentStop quality/cost gate, `/octo:usage` cost attribution, `worktree.bgIsolation` opt-out, Claude Agent SDK seat (introduced with Opus 4.8 and now following the current Opus 5 default), starter skills pack, `/plugin browse` manifest with projected context cost. |
 | **v9.41** | **`/octo:council`** promoted to first-class workflow — structured multi-LLM deliberation with goal modes, adversarial/red-team styles, benchmark-aware persona routing, quorum and critical-veto gates, budget preflight, and gated worktree handoff for approved implementation plans. |
 | **v9** | Up to 10 external provider integrations (Codex, Antigravity CLI, Copilot, Qwen, Ollama, Perplexity, OpenRouter, OrcaRouter, OpenCode, and Grok) alongside the Claude Code host. Structured provider debates and configurable multi-LLM councils. Explicit-only activation by default, with an optional smart router. Agent summary tables show which providers actually contributed. Provider-aware prompt preflight prevents silent oversize failures. Research breadth modes fan out light, standard, or exhaustive investigations. Setup aliases and fuzzy `/octo:*` corrections reduce command friction. Opt-in discipline gates and token compression. Two-stage review. Circuit breakers with automatic provider recovery inside active workflows. Cursor + OpenCode + Codex cross-compatibility. `bin/octopus` CLI. 182 Claude Code capability flags through v2.1.219, including Opus 5, Sonnet 5, and dynamic workflow awareness. |
@@ -162,6 +162,9 @@ dispatch remain available, but host-side command filters keep them out of
 unrelated tool calls.
 
 ### Installation health
+
+Not sure which command to use? Run `/octo:guide` or `/octo:auto help` to browse
+the commands in your installed version. Neither starts a provider workflow.
 
 Octopus records non-secret install metadata for each host. Claude Code and
 Codex keep separate entries, so switching hosts or updating one cache does not

--- a/README.md
+++ b/README.md
@@ -181,9 +181,11 @@ octopus security-audit --json  # offline checks of the installed plugin files
 octopus handoff export --json  # redacted checkpoint for another supported host
 ```
 
-`repair --apply` changes only the Octopus stable link and install metadata. It
-does not delete host caches. The security audit checks the plugin itself; use
-`/octo:security` when you want a multi-model review of your project.
+`repair --apply` changes only the Octopus-owned stable plugin root and install
+metadata. On platforms without symlink support, the stable root contains
+generated wrappers for Octopus script entry points. Repair does not delete host
+caches. The security audit checks the plugin itself; use `/octo:security` when
+you want a multi-model review of your project.
 
 The `core` context profile keeps optional context hooks off. Use
 `octopus profile orchestration` to enable context reinforcement and post-tool

--- a/README.md
+++ b/README.md
@@ -161,6 +161,35 @@ Safety guards that prevent invalid direct Codex, Qwen, or retired Gemini CLI
 dispatch remain available, but host-side command filters keep them out of
 unrelated tool calls.
 
+### Installation health
+
+Octopus records non-secret install metadata for each host. Claude Code and
+Codex keep separate entries, so switching hosts or updating one cache does not
+make the other look current. SessionStart refreshes the active host entry when
+the loaded root, version, scope, or profile changes.
+
+```bash
+octopus capabilities --json    # provider readiness and supported interfaces
+octopus doctor installation    # loaded root, stable root, and saved metadata
+octopus cache-check --json     # active, newest, stale, and stable plugin roots
+octopus repair --dry-run       # explain a broken or stale stable link
+octopus repair --apply         # repair that link and refresh install metadata
+octopus security-audit --json  # offline checks of the installed plugin files
+octopus handoff export --json  # redacted checkpoint for another supported host
+```
+
+`repair --apply` changes only the Octopus stable link and install metadata. It
+does not delete host caches. The security audit checks the plugin itself; use
+`/octo:security` when you want a multi-model review of your project.
+
+The `core` context profile keeps optional context hooks off. Use
+`octopus profile orchestration` to enable context reinforcement and post-tool
+coordination during active Octopus workflows, or `octopus profile full` to
+allow every profile-managed context hook. Profiles never disable safety or
+lifecycle hooks.
+See [installation health](docs/INSTALLATION-HEALTH.md) for exit codes and stored
+state.
+
 Claude Code **v2.1.14+** is the minimum supported runtime. Newer Claude Code releases unlock additional Octopus diagnostics and release checks automatically; the current plugin tracks 183 Claude Code capability flags through **Claude Code v2.1.219**.
 
 <details>
@@ -306,6 +335,9 @@ a loaded session that needs a reload. Run focused diagnostics at any time:
 octopus doctor config   # install path, version, manifest, Claude Code feature flags
 octopus doctor skills   # skill loading, skillOverrides, plugin zip/URL capability notes
 octopus doctor updates  # loaded/install/catalog/cache versions and auto-update state
+octopus doctor installation # loaded root, stable root, saved metadata, and profile
+octopus cache-check --json   # validate active, newest, and stale cache entries
+octopus repair --dry-run     # inspect a stable-root problem without changing it
 ```
 
 This cannot make an arbitrarily old installation self-heal: code that predates

--- a/bin/octopus
+++ b/bin/octopus
@@ -9,6 +9,8 @@
 #   octopus fleet      — Show provider fleet status
 #   octopus state-path — Show the current project's workflow state path
 #   octopus agent-summary — Show current run provider status
+#   octopus capabilities — Show local provider readiness and capabilities
+#   octopus cache-check  — Validate active and cached plugin roots
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
@@ -48,7 +50,12 @@ case "${1:-help}" in
         shift
         "$ORCHESTRATE" agent-summary "$@"
         ;;
-    help|--help|-h|*)
+    capabilities|cache-check|repair|security-audit|handoff|profile|install-state)
+        command_name="$1"
+        shift
+        "$ORCHESTRATE" "$command_name" "$@"
+        ;;
+    help|--help|-h)
         echo "octopus — Claude Octopus CLI"
         echo ""
         echo "Usage: octopus <command>"
@@ -60,6 +67,18 @@ case "${1:-help}" in
         echo "  fleet     Show provider fleet status"
         echo "  state-path  Show the current project's workflow state path"
         echo "  agent-summary  Show current run provider status"
+        echo "  capabilities  Show local provider readiness and capabilities"
+        echo "  cache-check  Validate active, stable, and cached plugin roots"
+        echo "  repair     Inspect or repair the stable plugin root"
+        echo "  security-audit  Run offline plugin security checks"
+        echo "  handoff    Export or inspect a redacted cross-host checkpoint"
+        echo "  profile    Show or set the optional-hook context profile"
+        echo "  install-state  Show or record host-scoped install metadata"
         echo "  help      Show this help"
+        ;;
+    *)
+        printf 'Unknown octopus command: %s\n' "$1" >&2
+        printf 'Run octopus help for available commands.\n' >&2
+        exit 2
         ;;
 esac

--- a/bin/octopus
+++ b/bin/octopus
@@ -50,7 +50,7 @@ case "${1:-help}" in
         shift
         "$ORCHESTRATE" agent-summary "$@"
         ;;
-    capabilities|cache-check|repair|security-audit|handoff|profile|install-state)
+    guide|explain|capabilities|cache-check|repair|security-audit|handoff|profile|install-state)
         command_name="$1"
         shift
         "$ORCHESTRATE" "$command_name" "$@"
@@ -62,6 +62,8 @@ case "${1:-help}" in
         echo ""
         echo "Commands:"
         echo "  doctor    Run diagnostics and health checks"
+        echo "  guide     Find installed commands by task or topic"
+        echo "  explain   Inspect a saved run without calling providers"
         echo "  version   Show plugin version"
         echo "  session   Show current session info"
         echo "  fleet     Show provider fleet status"

--- a/commands/auto.md
+++ b/commands/auto.md
@@ -64,8 +64,9 @@ follow that command's contract in the current conversation. Do not continue to
 STEP 1 or choose a different route. This avoids two classifiers choosing
 different workflows and keeps Premium peer policy at the workflow root.
 
-The `help`, `list`, and `capabilities` requests below may be answered locally
-without invoking the runtime.
+For `help`, `list`, and `capabilities`, run the provider-free installed catalog
+with `bash "${OCTO_ROOT}/scripts/orchestrate.sh" guide list`. Do not use a
+remembered command list or initialize a workflow.
 
 ## ROUTING REFERENCE (not a second execution path)
 
@@ -79,7 +80,7 @@ If the query exceeds 500 characters, use only the first 500 characters for inten
 ### STEP 2: Meta Command Check
 
 If the query matches any of: `help`, `list`, `commands`, `what can you do`, `capabilities`, `options`, `workflows`:
-- Display the **Complete Workflow Menu** (see STEP 5c) and STOP. Do not route.
+- Show the installed catalog through `guide list` and STOP. Do not route.
 
 ### STEP 3: Analyze Intent
 

--- a/commands/guide.md
+++ b/commands/guide.md
@@ -10,11 +10,11 @@ allowed-tools: Bash, Read
 Read the installed catalog and show a suitable next command. Do not start a
 workflow, probe providers, change settings, or install anything.
 
-Resolve the plugin root from `CODEX_PLUGIN_ROOT`, then `CLAUDE_PLUGIN_ROOT`,
+Resolve the plugin root from `CLAUDE_PLUGIN_ROOT`, then `CODEX_PLUGIN_ROOT`,
 then the stable `~/.claude-octopus/plugin` link. Run:
 
 ```bash
-OCTO_ROOT="${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${HOME}/.claude-octopus/plugin}}"
+OCTO_ROOT="${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${HOME}/.claude-octopus/plugin}}"
 bash "$OCTO_ROOT/scripts/orchestrate.sh" guide
 ```
 

--- a/commands/guide.md
+++ b/commands/guide.md
@@ -1,0 +1,27 @@
+---
+command: guide
+disable-model-invocation: true
+description: "Find an installed Octopus command for your task without calling a provider"
+allowed-tools: Bash, Read
+---
+
+# Command guide
+
+Read the installed catalog and show a suitable next command. Do not start a
+workflow, probe providers, change settings, or install anything.
+
+Resolve the plugin root from `CODEX_PLUGIN_ROOT`, then `CLAUDE_PLUGIN_ROOT`,
+then the stable `~/.claude-octopus/plugin` link. Run:
+
+```bash
+OCTO_ROOT="${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${HOME}/.claude-octopus/plugin}}"
+bash "$OCTO_ROOT/scripts/orchestrate.sh" guide
+```
+
+For a topic, pass the user's topic as one quoted argument to `guide`. For the
+full catalog, pass `list`. Do not interpolate untrusted text into shell code.
+Recommend only commands present in the returned catalog. Show examples with a
+task, such as `/octo:auto "review the changes in this branch"`.
+
+If the installed catalog cannot be read, report that error and suggest
+`/octo:setup`. Do not invent commands from memory.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -45,6 +45,48 @@ fi
 export OCTO_ROOT
 ```
 
+### 1.25 Run installation health for troubleshooting
+
+When setup is being rerun to troubleshoot installation, run this safe health
+pass immediately after resolving the root. It reads the installation Doctor
+category and both host cache locations. It does not create a stable link,
+record install state, clean a cache, log in, or contact a provider. A diagnostic
+exit status is evidence to show the user, not permission to claim the check
+passed.
+
+```bash
+setup_installation_health() {
+  local doctor_json="" cache_json="" doctor_rc=0 cache_rc=0
+  if [[ ! -r "$OCTO_ROOT/scripts/orchestrate.sh" ]]; then
+    printf 'Installation health unavailable: orchestrate.sh is missing.\n'
+    return 0
+  fi
+
+  if [[ -n "${CODEX_THREAD_ID:-}${CODEX_SANDBOX:-}" ]]; then
+    doctor_json="$(env -u CLAUDE_PLUGIN_ROOT CODEX_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" doctor installation --json 2>/dev/null)" || doctor_rc=$?
+    cache_json="$(env -u CLAUDE_PLUGIN_ROOT CODEX_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" cache-check --json 2>/dev/null)" || cache_rc=$?
+  else
+    doctor_json="$(env -u CODEX_PLUGIN_ROOT CLAUDE_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" doctor installation --json 2>/dev/null)" || doctor_rc=$?
+    cache_json="$(env -u CODEX_PLUGIN_ROOT CLAUDE_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" cache-check --json 2>/dev/null)" || cache_rc=$?
+  fi
+
+  printf 'Installation health (read-only):\n'
+  if [[ -n "$doctor_json" ]]; then
+    printf '%s\n' "$doctor_json"
+  else
+    printf '%s\n' '{"error":"doctor installation returned no report"}'
+  fi
+  if [[ -n "$cache_json" ]]; then
+    printf '%s\n' "$cache_json"
+  else
+    printf '%s\n' '{"error":"cache-check returned no report"}'
+  fi
+  printf 'installation-health-exit: doctor=%s cache=%s\n' "$doctor_rc" "$cache_rc"
+}
+
+setup_installation_health
+```
+
 ### 1.5 Read resumable setup state
 
 Read the receipt without creating files. The physical plugin root and host kind
@@ -293,6 +335,22 @@ if [[ -n "$SETUP_LOCAL_FAILURE" ]]; then
   exit 1
 fi
 printf 'setup-verification:pass (no provider request)\n'
+
+# Recheck installation health at the completion boundary. This remains
+# read-only; any repair still needs a separate explicit authorization.
+if declare -F setup_installation_health >/dev/null 2>&1; then
+  setup_installation_health
+else
+  health_rc=0
+  if [[ -n "${CODEX_THREAD_ID:-}${CODEX_SANDBOX:-}" ]]; then
+    env -u CLAUDE_PLUGIN_ROOT CODEX_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" doctor installation --json || health_rc=$?
+    env -u CLAUDE_PLUGIN_ROOT CODEX_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" cache-check --json || health_rc=$?
+  else
+    env -u CODEX_PLUGIN_ROOT CLAUDE_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" doctor installation --json || health_rc=$?
+    env -u CODEX_PLUGIN_ROOT CLAUDE_PLUGIN_ROOT="$OCTO_ROOT" bash "$OCTO_ROOT/scripts/orchestrate.sh" cache-check --json || health_rc=$?
+  fi
+  printf 'installation-health-exit: %s\n' "$health_rc"
+fi
 ```
 
 Only after the user selected a completion path and this verification passed,
@@ -353,12 +411,14 @@ Finish with exactly this quick-start block:
 Next commands:
 
 ```text
-/octo:auto
+/octo:auto "describe your task"
+/octo:guide
 /octo:skill-doctor
 /octo:setup
 ```
 
-`/octo:auto` routes a task, `/octo:skill-doctor` diagnoses plugin skills inside
+`/octo:auto` routes a task, `/octo:guide` helps choose an installed command,
+and `/octo:skill-doctor` diagnoses plugin skills inside
 Claude Code, and `/octo:setup` returns here. From a shell, use `octopus doctor`
 for environment diagnostics.
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -412,7 +412,6 @@ Next commands:
 
 ```text
 /octo:auto "describe your task"
-/octo:guide
 /octo:skill-doctor
 /octo:setup
 ```

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -386,6 +386,8 @@ AskUserQuestion({
 ### Models and routing
 
 - Use `/octo:model-config` for model overrides.
+- Use `octopus profile core|orchestration|full` to control optional context
+  hooks. Explain that profiles never disable safety or lifecycle hooks.
 - Explain cost impact before changing cost mode.
 - Treat `OCTO_TIER=prototype|mvp|production` as a routing hint, not policy.
 - Never change routing, model, or tier configuration without confirmation.

--- a/config/hook-profiles.json
+++ b/config/hook-profiles.json
@@ -1,0 +1,11 @@
+{
+  "schema": 1,
+  "profiles": {
+    "core": [],
+    "orchestration": [
+      "context-reinforcement",
+      "post-tool-dispatch"
+    ],
+    "full": ["*"]
+  }
+}

--- a/docs/COMMAND-REFERENCE.md
+++ b/docs/COMMAND-REFERENCE.md
@@ -18,6 +18,7 @@ All slash commands use the `/octo:` namespace. The smart router command is `/oct
 
 | Command | Description |
 |---------|-------------|
+| `/octo:guide` | Browse installed commands without starting a provider workflow |
 | `/octo:setup` | Check setup status and configure providers (aliases: `/octo:configure`, `/octo:config`, `/octo:init`, `/octo:wizard`, `/octo:sys-setup`) |
 | `/octo:skill-doctor` | Manually invoke fail-closed diagnostics without shadowing Claude Code's native `/doctor` |
 | `/octo:model-config` | Configure provider model selection per workflow phase |

--- a/docs/COMMAND-REFERENCE.md
+++ b/docs/COMMAND-REFERENCE.md
@@ -1,6 +1,6 @@
 # Command and Usage Reference
 
-Complete reference for all 53 Claude Octopus slash commands, CLI tools (`octopus` + `octo-compress`), plus activation rules, provider indicators, and manual-only project-lifecycle skills.
+Complete reference for all 54 Claude Octopus slash commands, CLI tools (`octopus` + `octo-compress`), plus activation rules, provider indicators, and manual-only project-lifecycle skills.
 
 ---
 
@@ -142,14 +142,15 @@ Plugin executables available as bare commands (CC v2.1.91+). Also usable via ful
 | `octopus fleet` | Show provider fleet status |
 | `octopus state-path` | Print the checkout-specific workflow `state.json` path resolved by `OCTOPUS_WORKFLOW_STATE_DIR`, `CLAUDE_PLUGIN_DATA`, `CLAUDE_OCTOPUS_WORKSPACE`, or the default host workspace |
 | `octopus agent-summary` | Show which providers ran, degraded, failed, timed out, or contributed usable output |
+| `octopus guide [topic]` | Find commands from the installed manifest without starting a workflow |
 | `octopus capabilities --json` | Show static provider readiness and registered capabilities without provider calls |
-| `octopus doctor installation` | Check the loaded root, stable root, host-scoped install state, and context profile |
+| `octopus doctor installation` | Check the loaded root, stable root, host-scoped install state, and context profile without changing them |
 | `octopus cache-check --json` | Validate active, newest, stale, and stable Claude and Codex plugin roots |
-| `octopus repair --dry-run` | Explain a stable-root repair; use `--apply` to perform it |
+| `octopus repair --dry-run` | Explain a bounded stable-root repair; use `--apply` only after explicit authorization |
 | `octopus security-audit --json` | Run offline checks against the installed plugin files |
-| `octopus handoff export --json` | Export a redacted checkpoint for another supported host |
+| `octopus handoff export --json` | Export a redacted workflow summary for inspection; it is not imported runtime state |
 | `octopus profile [core\|orchestration\|full]` | Show or set optional context-hook behavior |
-| `octopus install-state [show\|record]` | Inspect or refresh non-secret host install metadata |
+| `octopus install-state [show\|record]` | Inspect metadata or explicitly record the current host installation |
 | `octo-compress` | Pipe verbose output for token savings: `npm install 2>&1 \| octo-compress` |
 | `octo-compress json` | Force JSON array/object compression |
 | `octo-compress logs` | Force log compression (head+tail) |
@@ -241,10 +242,10 @@ Check setup status and configure AI providers.
 ```
 
 **What it does:**
-- Auto-detects installed providers (Codex CLI, Antigravity CLI, and other configured providers)
-- Shows which providers are available and their auth status
+- Reads the shared provider-readiness report
+- Runs the read-only installation health and cache checks during troubleshooting and completion
 - Provides installation instructions for missing providers
-- Verifies API keys and authentication
+- Verifies provider readiness without claiming that installation alone proves authentication
 
 **Example output:**
 ```
@@ -257,7 +258,11 @@ Providers:
 You're all set! Try: /octo:auto research OAuth patterns
 ```
 
-**Troubleshooting:** If you see "Failed to update: Plugin 'octo' not found", run `/octo:setup` for reinstall instructions, or see [issue #17](https://github.com/nyldn/claude-octopus/issues/17).
+**Troubleshooting:** If setup cannot find the plugin or a local check fails,
+rerun `/octo:setup`. Setup prints the read-only installation health report. For
+a shell-only report, run `octopus doctor installation` and
+`octopus cache-check --json`. If a stable-root repair is proposed, inspect
+`octopus repair --dry-run` and authorize `octopus repair --apply` separately.
 
 ---
 

--- a/docs/COMMAND-REFERENCE.md
+++ b/docs/COMMAND-REFERENCE.md
@@ -57,7 +57,7 @@ All slash commands use the `/octo:` namespace. The smart router command is `/oct
 | `/octo:debug` | Reproduce a symptom and verify the fix on the current host; optional `--peer-review` |
 | `/octo:tdd` | Observe failing and passing tests on the current host; optional `--peer-review` |
 
-The development branch adds the methods below. See
+Octopus includes the methods below. See
 [workflow methods](WORKFLOW-METHODS.md) for the full contracts and
 [Unreleased](../CHANGELOG.md#unreleased) for release status.
 
@@ -142,6 +142,14 @@ Plugin executables available as bare commands (CC v2.1.91+). Also usable via ful
 | `octopus fleet` | Show provider fleet status |
 | `octopus state-path` | Print the checkout-specific workflow `state.json` path resolved by `OCTOPUS_WORKFLOW_STATE_DIR`, `CLAUDE_PLUGIN_DATA`, `CLAUDE_OCTOPUS_WORKSPACE`, or the default host workspace |
 | `octopus agent-summary` | Show which providers ran, degraded, failed, timed out, or contributed usable output |
+| `octopus capabilities --json` | Show static provider readiness and registered capabilities without provider calls |
+| `octopus doctor installation` | Check the loaded root, stable root, host-scoped install state, and context profile |
+| `octopus cache-check --json` | Validate active, newest, stale, and stable Claude and Codex plugin roots |
+| `octopus repair --dry-run` | Explain a stable-root repair; use `--apply` to perform it |
+| `octopus security-audit --json` | Run offline checks against the installed plugin files |
+| `octopus handoff export --json` | Export a redacted checkpoint for another supported host |
+| `octopus profile [core\|orchestration\|full]` | Show or set optional context-hook behavior |
+| `octopus install-state [show\|record]` | Inspect or refresh non-secret host install metadata |
 | `octo-compress` | Pipe verbose output for token savings: `npm install 2>&1 \| octo-compress` |
 | `octo-compress json` | Force JSON array/object compression |
 | `octo-compress logs` | Force log compression (head+tail) |
@@ -255,7 +263,7 @@ You're all set! Try: /octo:auto research OAuth patterns
 
 ### Doctor diagnostics
 
-Run fail-closed environment diagnostics across 14 check categories.
+Run fail-closed environment diagnostics across 15 check categories.
 
 Octopus intentionally leaves `/octo:doctor` unregistered so Claude Code's
 native `/doctor` remains available. Invoke `/octo:skill-doctor` inside Claude
@@ -270,6 +278,7 @@ octopus doctor providers --live # Run a bounded live AGY catalog/model/dispatch 
 octopus doctor auth --verbose   # Detailed auth status
 octopus doctor config           # Install source/path, version, build SHA when available, and Claude Code feature flags
 octopus doctor skills           # Skill loading plus modern plugin capability notes
+octopus doctor installation     # Loaded root, stable root, install state, and profile
 octopus doctor --json           # Machine-readable Doctor 2.0 output
 ```
 
@@ -291,6 +300,7 @@ octopus doctor --json           # Machine-readable Doctor 2.0 output
 | `agents` | Agent definitions and platform projections |
 | `recurrence` | Repeated-failure and recovery evidence |
 | `cache` | Active and stale plugin-cache versions |
+| `installation` | Loaded plugin root, stable root, host-scoped install metadata, and context profile |
 
 Doctor returns `0` for passes and warnings, `1` when one or more checks fail,
 and `2` for invalid options, unknown categories, or multiple category

--- a/docs/INSTALLATION-HEALTH.md
+++ b/docs/INSTALLATION-HEALTH.md
@@ -12,7 +12,8 @@ octopus doctor installation
 This checks the plugin root loaded by the current host, the stable Octopus
 root, the saved install metadata, and the active context profile. Claude Code
 and Codex have separate saved entries because they can load different plugin
-versions.
+versions. It is read-only. A missing or mismatched stable root is reported for
+repair; Doctor does not create or replace it.
 
 Octopus stores this non-secret metadata in
 `~/.claude-octopus/install-state.json`. SessionStart refreshes the current
@@ -22,6 +23,9 @@ changed. To refresh it manually, run:
 ```bash
 octopus install-state record
 ```
+
+`install-state record` writes metadata. It is separate from the read-only
+health checks.
 
 ## Inspect provider readiness
 
@@ -52,13 +56,17 @@ Use a dry run first:
 
 ```bash
 octopus repair --dry-run
-octopus repair --apply
 ```
 
 Repair can create or replace the Octopus-owned stable link at
 `~/.claude-octopus/plugin` and refresh the current host's install metadata. It
 refuses to replace an unowned regular file or directory. It does not alter the
-Claude Code or Codex cache.
+Claude Code or Codex cache. Treat `--apply` as a write: review the dry-run
+output and authorize the exact repair first. Then, and only then, run:
+
+```bash
+octopus repair --apply
+```
 
 ## Choose a context profile
 
@@ -72,7 +80,10 @@ octopus profile full
 `core` keeps optional context hooks off. `orchestration` enables context
 reinforcement and post-tool coordination during active Octopus workflows.
 `full` allows every profile-managed context hook defined by the installed
-release. Profiles never disable safety or lifecycle hooks.
+release. `OCTOPUS_CONTEXT_PROFILE` selects this setting and
+`OCTOPUS_HOOK_PROFILE` can override the optional hook profile. These settings
+never disable safety or lifecycle hooks. `OCTO_PROFILE` is the separate legacy
+workflow-intensity setting, not a context-hook switch.
 
 ## Export a portable checkpoint
 
@@ -82,10 +93,15 @@ octopus handoff export --json
 octopus handoff show --json
 ```
 
-The export contains a small allowlisted workflow summary and strips common
+The export contains a small allowlisted workflow summary and redacts common
 credential patterns. It omits the local project path and writes with mode
-`0600` under `~/.claude-octopus/handoffs/` by default. Review any checkpoint
-before sharing it.
+`0600` under `~/.claude-octopus/handoffs/` by default. Redaction is pattern-based,
+not a guarantee that every secret is removed. An arbitrary input or output
+failure can also prevent the command from producing valid JSON. Review any
+checkpoint before sharing it.
+
+The file is a summary for inspection or manual transfer, not imported runtime
+state. `/octo:resume` resumes local state; it does not import this JSON.
 
 ## Run the local plugin audit
 
@@ -97,6 +113,15 @@ octopus security-audit --json
 This offline check validates shell syntax and plugin manifests, then reports
 high-risk shell patterns for review. It audits the installed Octopus files,
 not the user's project. Use `/octo:security` for a project security review.
+
+## Setup behavior
+
+`/octo:setup` runs the installation Doctor category and cache check as a safe,
+read-only health pass when setup is used for troubleshooting and again during
+completion verification. It reports the evidence without applying repairs,
+cleaning caches, logging in, or contacting a provider service. If the report
+calls for a change, review `octopus repair --dry-run` and authorize
+`octopus repair --apply` separately.
 
 ## Exit codes
 

--- a/docs/INSTALLATION-HEALTH.md
+++ b/docs/INSTALLATION-HEALTH.md
@@ -1,0 +1,112 @@
+# Installation health
+
+Claude Octopus can inspect its installation without contacting a model
+provider or changing a host-managed plugin cache.
+
+## Start with Doctor
+
+```bash
+octopus doctor installation
+```
+
+This checks the plugin root loaded by the current host, the stable Octopus
+root, the saved install metadata, and the active context profile. Claude Code
+and Codex have separate saved entries because they can load different plugin
+versions.
+
+Octopus stores this non-secret metadata in
+`~/.claude-octopus/install-state.json`. SessionStart refreshes the current
+host entry when the loaded root, plugin version, install scope, or profile has
+changed. To refresh it manually, run:
+
+```bash
+octopus install-state record
+```
+
+## Inspect provider readiness
+
+```bash
+octopus capabilities
+octopus capabilities --json
+```
+
+The report uses the same static readiness contract as setup and Doctor. It
+does not send prompts or make provider requests. A provider can be installed
+but `degraded` when authentication is missing or cannot be confirmed safely.
+
+## Check cached installations
+
+```bash
+octopus cache-check
+octopus cache-check --json
+```
+
+The cache check validates each Claude Code and Codex cache version it finds,
+including the active and newest entries. Invalid stale versions are warnings;
+an invalid active or newest version is a failure. The command never removes a
+cache directory.
+
+## Repair the stable root
+
+Use a dry run first:
+
+```bash
+octopus repair --dry-run
+octopus repair --apply
+```
+
+Repair can create or replace the Octopus-owned stable link at
+`~/.claude-octopus/plugin` and refresh the current host's install metadata. It
+refuses to replace an unowned regular file or directory. It does not alter the
+Claude Code or Codex cache.
+
+## Choose a context profile
+
+```bash
+octopus profile                 # show the current profile
+octopus profile core
+octopus profile orchestration
+octopus profile full
+```
+
+`core` keeps optional context hooks off. `orchestration` enables context
+reinforcement and post-tool coordination during active Octopus workflows.
+`full` allows every profile-managed context hook defined by the installed
+release. Profiles never disable safety or lifecycle hooks.
+
+## Export a portable checkpoint
+
+```bash
+octopus handoff export
+octopus handoff export --json
+octopus handoff show --json
+```
+
+The export contains a small allowlisted workflow summary and strips common
+credential patterns. It omits the local project path and writes with mode
+`0600` under `~/.claude-octopus/handoffs/` by default. Review any checkpoint
+before sharing it.
+
+## Run the local plugin audit
+
+```bash
+octopus security-audit
+octopus security-audit --json
+```
+
+This offline check validates shell syntax and plugin manifests, then reports
+high-risk shell patterns for review. It audits the installed Octopus files,
+not the user's project. Use `/octo:security` for a project security review.
+
+## Exit codes
+
+The diagnostic commands use these exit codes:
+
+| Code | Meaning |
+|---:|---|
+| `0` | Checks passed, with informational results or warnings allowed where documented |
+| `1` | A required check failed, a repair was blocked, or state could not be written |
+| `2` | Invalid command or arguments |
+
+JSON output remains valid when a check exits with code `1`, so automation can
+read the evidence before deciding what to do.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 ## Core References
 
-- [COMMAND-REFERENCE.md](./COMMAND-REFERENCE.md) — All 53 slash commands with natural-language triggers
+- [COMMAND-REFERENCE.md](./COMMAND-REFERENCE.md) — All 54 slash commands with natural-language triggers
 - [WORKFLOW-METHODS.md](./WORKFLOW-METHODS.md): Architecture, TDD, debugging, decisions, prototypes, routing previews, and resumable setup
 - [ARCHITECTURE.md](./ARCHITECTURE.md) — Provider model mapping, execution contracts, and workflow flow
 - [V10-MIGRATION.md](./V10-MIGRATION.md) — V10 compatibility, verification, and rollback guidance

--- a/hooks/context-reinforcement.sh
+++ b/hooks/context-reinforcement.sh
@@ -27,6 +27,7 @@ ACTIVATION_LIB="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}/scripts
 [[ -r "$ACTIVATION_LIB" ]] || exit 0
 # shellcheck source=../scripts/lib/hook-activation.sh
 source "$ACTIVATION_LIB" 2>/dev/null || exit 0
+octo_hook_profile_allows "context-reinforcement" || exit 0
 octo_hook_workflow_active "$INPUT" || exit 0
 
 # Build compact enforcement context only for the active, matching workflow.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -91,7 +91,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|Agent|Write|Edit",
+        "matcher": "Bash|Agent|Write|Edit|Read|WebFetch|Grep",
         "hooks": [
           {
             "type": "command",

--- a/hooks/post-tool-dispatch.sh
+++ b/hooks/post-tool-dispatch.sh
@@ -36,9 +36,6 @@ if [[ "$PROFILE_POST_TOOL" != true ]]; then
     esac
 fi
 
-SESSION="${CLAUDE_SESSION_ID:-unknown}"
-BRIDGE="/tmp/octopus-ctx-${SESSION}.json"
-
 # Read stdin once (tool output from CC hook protocol)
 STDIN_DATA=""
 if [[ ! -t 0 ]]; then
@@ -48,6 +45,13 @@ if [[ ! -t 0 ]]; then
         STDIN_DATA=$(cat 2>/dev/null || true)
     fi
 fi
+
+# Child hooks use the legacy environment name. Resolve it once from the host
+# protocol and reject path characters before constructing session-local files.
+SESSION="$(octo_hook_session_id "$STDIN_DATA" 2>/dev/null || true)"
+case "$SESSION" in ''|*[!A-Za-z0-9._-]*) exit 0 ;; esac
+export CLAUDE_SESSION_ID="$SESSION"
+BRIDGE="/tmp/octopus-ctx-${SESSION}.json"
 
 # Profiles activate bounded coordination only while this host session owns an
 # active Octopus workflow. Explicit environment opt-ins retain their existing

--- a/hooks/post-tool-dispatch.sh
+++ b/hooks/post-tool-dispatch.sh
@@ -20,17 +20,24 @@ trap _octo_hook_exit EXIT
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 HOOKS_DIR="${PLUGIN_ROOT}/hooks"
+ACTIVATION_LIB="${PLUGIN_ROOT}/scripts/lib/hook-activation.sh"
+PROFILE_POST_TOOL=false
+PROFILE_NAME=core
+if [[ -r "$ACTIVATION_LIB" ]]; then
+    # shellcheck source=../scripts/lib/hook-activation.sh
+    source "$ACTIVATION_LIB" 2>/dev/null || true
+    PROFILE_NAME="$(octo_hook_profile)"
+    octo_hook_profile_allows "post-tool-dispatch" && PROFILE_POST_TOOL=true
+fi
+if [[ "$PROFILE_POST_TOOL" != true ]]; then
+    case "${OCTOPUS_CONTEXT_AWARENESS:-off}:${OCTO_STRATEGY_ROTATION:-off}:${OCTOPUS_COMPRESS_ENABLED:-false}" in
+        on:*|*:on:*|*:*:true) ;;
+        *) exit 0 ;;
+    esac
+fi
 
-# Opinionated global behavior is disabled unless the user explicitly opts in.
-# A statusline context bridge is display state, not consent to PostToolUse
-# model-context injection.
 SESSION="${CLAUDE_SESSION_ID:-unknown}"
 BRIDGE="/tmp/octopus-ctx-${SESSION}.json"
-if [[ "${OCTOPUS_CONTEXT_AWARENESS:-off}" != "on" \
-      && "${OCTO_STRATEGY_ROTATION:-off}" != "on" \
-      && "${OCTOPUS_COMPRESS_ENABLED:-false}" != "true" ]]; then
-    exit 0
-fi
 
 # Read stdin once (tool output from CC hook protocol)
 STDIN_DATA=""
@@ -40,6 +47,26 @@ if [[ ! -t 0 ]]; then
     else
         STDIN_DATA=$(cat 2>/dev/null || true)
     fi
+fi
+
+# Profiles activate bounded coordination only while this host session owns an
+# active Octopus workflow. Explicit environment opt-ins retain their existing
+# behavior outside a workflow. Full also enables output compression unless the
+# user explicitly disabled it.
+if [[ "$PROFILE_POST_TOOL" == true ]] && octo_hook_workflow_active "$STDIN_DATA"; then
+    OCTOPUS_CONTEXT_AWARENESS="${OCTOPUS_CONTEXT_AWARENESS:-on}"
+    OCTO_STRATEGY_ROTATION="${OCTO_STRATEGY_ROTATION:-on}"
+    if [[ "$PROFILE_NAME" == full ]]; then
+        OCTOPUS_COMPRESS_ENABLED="${OCTOPUS_COMPRESS_ENABLED:-true}"
+    fi
+fi
+
+# A statusline bridge by itself is display state, not consent to model-context
+# injection.
+if [[ "${OCTOPUS_CONTEXT_AWARENESS:-off}" != "on" \
+      && "${OCTO_STRATEGY_ROTATION:-off}" != "on" \
+      && "${OCTOPUS_COMPRESS_ENABLED:-false}" != "true" ]]; then
+    exit 0
 fi
 
 # Collect additionalContext from sub-hooks

--- a/hooks/session-start-memory.sh
+++ b/hooks/session-start-memory.sh
@@ -15,6 +15,17 @@ set -euo pipefail
 _octo_hook_exit() { local c=$?; if [[ $c -ne 0 ]]; then echo "[hook:$(basename "$0")] exit $c" >&2 2>/dev/null || true; fi; return 0; }
 trap _octo_hook_exit EXIT
 
+# Refresh non-secret install metadata whenever the host, root, version, scope,
+# or context profile changes. This is best-effort and never blocks SessionStart.
+LIFECYCLE_LIB="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd -P)}/scripts/lib/lifecycle.sh"
+if [[ -r "$LIFECYCLE_LIB" ]]; then
+    # shellcheck source=../scripts/lib/lifecycle.sh
+    source "$LIFECYCLE_LIB" 2>/dev/null || true
+    if declare -f octo_lifecycle_state_valid >/dev/null 2>&1 && ! octo_lifecycle_state_valid; then
+        octo_lifecycle_record_install >/dev/null 2>&1 || true
+    fi
+fi
+
 SESSION_INPUT=""
 if [[ ! -t 0 ]]; then
     SESSION_INPUT="$(cat 2>/dev/null || true)"

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -153,11 +153,11 @@ octo_command_exists() {
 octo_alias_for() {
     local cmd="$1"
     case "$cmd" in
-        configure|config|init|install|settings|wizard|octopus-configure) echo "setup" ;;
+        configure|config|init|install|settings|wizard|octopus-configure|sys-setup) echo "setup" ;;
         ex|extr) echo "extract" ;;
         cost|usage) echo "costs" ;;
         optimize|optimise|router|smart) echo "auto" ;;
-        update|update-clis|sys-update|sys-setup) echo "doctor" ;;
+        update|update-clis|sys-update) echo "doctor" ;;
         co-research|co-discover) echo "discover" ;;
         *) return 1 ;;
     esac

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-plugins/claude-octopus",
-  "version": "11.4.2",
+  "version": "11.5.0",
   "description": "Claude Octopus - Multi-AI orchestration plugin for Claude Code. Three brains, one workflow.",
   "main": "scripts/orchestrate.sh",
   "scripts": {

--- a/scripts/cache-check.sh
+++ b/scripts/cache-check.sh
@@ -32,47 +32,28 @@ add_check() {
 CACHE_VALID_STATUS=pass
 CACHE_VALID_DETAIL="manifest and referenced paths are present"
 validate_plugin_root() {
-    local root="$1" host="$2" manifest missing=0 ref
-    CACHE_VALID_STATUS=pass
-    CACHE_VALID_DETAIL="manifest and referenced paths are present"
-    if [[ "$host" == codex ]]; then manifest="$root/.codex-plugin/plugin.json"; else manifest="$root/.claude-plugin/plugin.json"; fi
-    if [[ ! -f "$manifest" ]]; then
-        CACHE_VALID_STATUS=fail; CACHE_VALID_DETAIL="manifest is missing"; return
-    fi
-    if ! jq -e 'type == "object" and (.version | type == "string")' "$manifest" >/dev/null 2>&1; then
-        CACHE_VALID_STATUS=fail; CACHE_VALID_DETAIL="manifest is invalid JSON or lacks a version"; return
-    fi
-    if [[ ! -x "$root/scripts/orchestrate.sh" ]]; then
-        CACHE_VALID_STATUS=fail; CACHE_VALID_DETAIL="scripts/orchestrate.sh is missing or not executable"; return
-    fi
-    while IFS= read -r ref; do
-        [[ -n "$ref" ]] || continue
-        [[ -e "$root/${ref#./}" ]] || missing=$((missing + 1))
-    done < <(jq -r '[.commands?,.skills?,.agents?] | flatten | .[]? | select(type == "string")' "$manifest" 2>/dev/null || true)
-    if [[ "$missing" -gt 0 ]]; then
-        CACHE_VALID_STATUS=fail
-        CACHE_VALID_DETAIL="$missing manifest path(s) are missing"
-    fi
+    if octo_validate_install_root "$1" "$2"; then CACHE_VALID_STATUS=pass
+    else CACHE_VALID_STATUS=fail; fi
+    CACHE_VALID_DETAIL="$OCTO_ROOT_VALID_DETAIL"
 }
 
 check_host_cache() {
     local host="$1" cache_root="$2" active_root="$3" version path newest="" role status detail
     local active_real="" path_real="" active_seen=false
-    [[ -n "$active_root" && -d "$active_root" ]] && active_real="$(cd "$active_root" && pwd -P)"
+    [[ -n "$active_root" && -d "$active_root" ]] && active_real="$(cd "$active_root" 2>/dev/null && pwd -P)" || true
     if [[ ! -d "$cache_root" ]]; then
         add_check "$host" "" cache info "$cache_root" "cache directory is absent"
-        return
-    fi
-    newest="$(octo_cache_versions "$cache_root" | tail -1)"
-    if [[ -z "$newest" ]]; then
-        add_check "$host" "" cache info "$cache_root" "cache directory has no versions"
-        return
+    else
+        newest="$(octo_cache_versions "$cache_root" | tail -1)"
+        if [[ -z "$newest" ]]; then
+            add_check "$host" "" cache info "$cache_root" "cache directory has no versions"
+        fi
     fi
     while IFS= read -r version; do
         [[ -n "$version" ]] || continue
         path="$cache_root/$version"
         [[ -d "$path" ]] || continue
-        path_real="$(cd "$path" && pwd -P)"
+        path_real="$(cd "$path" 2>/dev/null && pwd -P)" || path_real=""
         role=stale
         [[ "$version" == "$newest" ]] && role=newest
         if [[ -n "$active_real" && "$path_real" == "$active_real" ]]; then role=active; active_seen=true; fi
@@ -81,7 +62,7 @@ check_host_cache() {
         if [[ "$status" == fail && "$role" == stale ]]; then status=warn; fi
         add_check "$host" "$version" "$role" "$status" "$path" "$detail"
     done < <(octo_cache_versions "$cache_root")
-    if [[ -n "$active_real" && "$active_seen" == false ]]; then
+    if [[ -n "$active_root" && "$active_seen" == false ]]; then
         validate_plugin_root "$active_root" "$host"
         add_check "$host" "$(octo_lifecycle_version "$active_root")" active "$CACHE_VALID_STATUS" \
             "$active_root" "$CACHE_VALID_DETAIL; active root is outside the host cache"
@@ -95,6 +76,9 @@ check_host_cache codex "$codex_cache" "${CODEX_PLUGIN_ROOT:-}"
 
 stable="$OCTO_LIFECYCLE_STABLE_ROOT"
 loaded_root="$(octo_lifecycle_plugin_root)"
+validate_plugin_root "$loaded_root" "$(octo_lifecycle_host)"
+add_check "$(octo_lifecycle_host)" "$(octo_lifecycle_version "$loaded_root")" loaded \
+    "$CACHE_VALID_STATUS" "$loaded_root" "$CACHE_VALID_DETAIL"
 stable_status="$(octo_lifecycle_stable_root_status "$loaded_root" 2>/dev/null || true)"
 case "$stable_status" in
     ok|shim) add_check "$(octo_lifecycle_host)" "$(octo_lifecycle_version "$stable")" stable pass "$stable" "stable root resolves to the loaded plugin" ;;

--- a/scripts/cache-check.sh
+++ b/scripts/cache-check.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Inspect active, stable, and cached plugin roots without changing them.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+OUTPUT=human
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json|json) OUTPUT=json ;;
+        --help|-h) printf 'Usage: %s [--json]\n' "$(basename "$0")"; exit 0 ;;
+        *) printf 'Unknown cache-check option: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+command -v jq >/dev/null 2>&1 || { printf 'cache-check requires jq\n' >&2; exit 1; }
+
+# shellcheck source=lib/cache-hygiene.sh
+source "$SCRIPT_DIR/lib/cache-hygiene.sh"
+# shellcheck source=lib/lifecycle.sh
+source "$SCRIPT_DIR/lib/lifecycle.sh"
+
+checks='[]'
+failures=0
+add_check() {
+    local host="$1" version="$2" role="$3" status="$4" root="$5" detail="$6"
+    checks="$(jq -cn --argjson checks "$checks" --arg host "$host" --arg version "$version" \
+        --arg role "$role" --arg status "$status" --arg root "$root" --arg detail "$detail" \
+        '$checks + [{host:$host,version:$version,role:$role,status:$status,root:$root,detail:$detail}]')"
+    [[ "$status" != fail ]] || failures=$((failures + 1))
+}
+
+CACHE_VALID_STATUS=pass
+CACHE_VALID_DETAIL="manifest and referenced paths are present"
+validate_plugin_root() {
+    local root="$1" host="$2" manifest missing=0 ref
+    CACHE_VALID_STATUS=pass
+    CACHE_VALID_DETAIL="manifest and referenced paths are present"
+    if [[ "$host" == codex ]]; then manifest="$root/.codex-plugin/plugin.json"; else manifest="$root/.claude-plugin/plugin.json"; fi
+    if [[ ! -f "$manifest" ]]; then
+        CACHE_VALID_STATUS=fail; CACHE_VALID_DETAIL="manifest is missing"; return
+    fi
+    if ! jq -e 'type == "object" and (.version | type == "string")' "$manifest" >/dev/null 2>&1; then
+        CACHE_VALID_STATUS=fail; CACHE_VALID_DETAIL="manifest is invalid JSON or lacks a version"; return
+    fi
+    if [[ ! -x "$root/scripts/orchestrate.sh" ]]; then
+        CACHE_VALID_STATUS=fail; CACHE_VALID_DETAIL="scripts/orchestrate.sh is missing or not executable"; return
+    fi
+    while IFS= read -r ref; do
+        [[ -n "$ref" ]] || continue
+        [[ -e "$root/${ref#./}" ]] || missing=$((missing + 1))
+    done < <(jq -r '[.commands?,.skills?,.agents?] | flatten | .[]? | select(type == "string")' "$manifest" 2>/dev/null || true)
+    if [[ "$missing" -gt 0 ]]; then
+        CACHE_VALID_STATUS=fail
+        CACHE_VALID_DETAIL="$missing manifest path(s) are missing"
+    fi
+}
+
+check_host_cache() {
+    local host="$1" cache_root="$2" active_root="$3" version path newest="" role status detail
+    local active_real="" path_real="" active_seen=false
+    [[ -n "$active_root" && -d "$active_root" ]] && active_real="$(cd "$active_root" && pwd -P)"
+    if [[ ! -d "$cache_root" ]]; then
+        add_check "$host" "" cache info "$cache_root" "cache directory is absent"
+        return
+    fi
+    newest="$(octo_cache_versions "$cache_root" | tail -1)"
+    if [[ -z "$newest" ]]; then
+        add_check "$host" "" cache info "$cache_root" "cache directory has no versions"
+        return
+    fi
+    while IFS= read -r version; do
+        [[ -n "$version" ]] || continue
+        path="$cache_root/$version"
+        [[ -d "$path" ]] || continue
+        path_real="$(cd "$path" && pwd -P)"
+        role=stale
+        [[ "$version" == "$newest" ]] && role=newest
+        if [[ -n "$active_real" && "$path_real" == "$active_real" ]]; then role=active; active_seen=true; fi
+        validate_plugin_root "$path" "$host"
+        status="$CACHE_VALID_STATUS"; detail="$CACHE_VALID_DETAIL"
+        if [[ "$status" == fail && "$role" == stale ]]; then status=warn; fi
+        add_check "$host" "$version" "$role" "$status" "$path" "$detail"
+    done < <(octo_cache_versions "$cache_root")
+    if [[ -n "$active_real" && "$active_seen" == false ]]; then
+        validate_plugin_root "$active_root" "$host"
+        add_check "$host" "$(octo_lifecycle_version "$active_root")" active "$CACHE_VALID_STATUS" \
+            "$active_root" "$CACHE_VALID_DETAIL; active root is outside the host cache"
+    fi
+}
+
+claude_cache="${OCTOPUS_CLAUDE_CACHE_DIR:-${HOME}/.claude/plugins/cache/nyldn-plugins/octo}"
+codex_cache="${OCTOPUS_CODEX_CACHE_DIR:-${CODEX_HOME:-${HOME}/.codex}/plugins/cache/nyldn-plugins/claude-octopus}"
+check_host_cache claude "$claude_cache" "${CLAUDE_PLUGIN_ROOT:-}"
+check_host_cache codex "$codex_cache" "${CODEX_PLUGIN_ROOT:-}"
+
+stable="$OCTO_LIFECYCLE_STABLE_ROOT"
+loaded_root="$(octo_lifecycle_plugin_root)"
+stable_status="$(octo_lifecycle_stable_root_status "$loaded_root" 2>/dev/null || true)"
+case "$stable_status" in
+    ok|shim) add_check "$(octo_lifecycle_host)" "$(octo_lifecycle_version "$stable")" stable pass "$stable" "stable root resolves to the loaded plugin" ;;
+    missing) add_check "$(octo_lifecycle_host)" "" stable info "$stable" "stable root is absent" ;;
+    *) add_check "$(octo_lifecycle_host)" "" stable fail "$stable" "stable root is $stable_status" ;;
+esac
+
+report="$(jq -cn --argjson checks "$checks" --argjson failures "$failures" \
+    '{schema:1,failures:$failures,checks:$checks}')"
+if [[ "$OUTPUT" == json ]]; then
+    printf '%s\n' "$report"
+else
+    printf 'Claude Octopus plugin cache check\n'
+    jq -r '.checks[] | "  \(.host)\t\(.version // "-")\t\(.role)\t\(.status)\t\(.detail)"' <<<"$report"
+fi
+[[ "$failures" -eq 0 ]]

--- a/scripts/capabilities.sh
+++ b/scripts/capabilities.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Local provider capability report backed by Provider Registry readiness.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+OUTPUT=human
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json|json) OUTPUT=json ;;
+        --help|-h)
+            printf 'Usage: %s [--json]\n' "$(basename "$0")"
+            exit 0
+            ;;
+        *) printf 'Unknown capabilities option: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+command -v jq >/dev/null 2>&1 || { printf 'capabilities requires jq\n' >&2; exit 1; }
+# shellcheck source=lib/lifecycle.sh
+source "$SCRIPT_DIR/lib/lifecycle.sh"
+log() { :; }
+# shellcheck source=lib/preflight.sh
+source "$SCRIPT_DIR/lib/preflight.sh"
+
+providers_json="$({
+    for provider in $(octo_provider_ids detect); do
+        readiness="$(octo_provider_readiness_result "$provider" static 2>/dev/null)"
+        organization="$(octo_provider_org "$provider" 2>/dev/null || true)"
+        command_name="$(octo_provider_command "$provider" 2>/dev/null || true)"
+        capabilities="$(octo_provider_field "$provider" capabilities 2>/dev/null || true)"
+        jq -cn --argjson readiness "$readiness" --arg id "$provider" \
+            --arg organization "$organization" --arg command "$command_name" \
+            --arg capabilities "$capabilities" \
+            '$readiness + {id:$id,organization:$organization,command:$command,
+             capabilities:($capabilities | split(",") | map(select(length > 0)))} |
+             del(.provider,.check_kind,.checked_at,.duration_ms)'
+    done
+} | jq -s '.')"
+
+report="$(jq -cn --arg host "$(octo_lifecycle_host)" \
+    --arg context_profile "$(octo_lifecycle_profile)" \
+    --arg hook_profile "$(octo_lifecycle_hook_profile)" \
+    --argjson providers "$providers_json" \
+    '{schema:1,check_kind:"static",host:$host,context_profile:$context_profile,
+      hook_profile:$hook_profile,providers:$providers}')"
+
+if [[ "$OUTPUT" == json ]]; then
+    printf '%s\n' "$report"
+    exit 0
+fi
+
+printf 'Claude Octopus capabilities\n'
+printf '  host: %s\n  context profile: %s\n  hook profile: %s\n' \
+    "$(jq -r '.host' <<<"$report")" "$(jq -r '.context_profile' <<<"$report")" \
+    "$(jq -r '.hook_profile' <<<"$report")"
+printf '%-18s %-11s %s\n' provider status capabilities
+jq -r '.providers[] | [.id,.status,(.capabilities | join(","))] | @tsv' <<<"$report" |
+    while IFS=$'\t' read -r provider status capabilities; do
+        printf '%-18s %-11s %s\n' "$provider" "$status" "$capabilities"
+    done

--- a/scripts/guide.py
+++ b/scripts/guide.py
@@ -18,11 +18,17 @@ def main():
         manifest = json.loads((root / ".claude-plugin/plugin.json").read_text())
         commands = []
         for relative in manifest["commands"]:
-            path = (root / relative).resolve()
-            path.relative_to(root)
-            header = path.read_text().split("---", 2)[1]
-            match = re.search(r"^description:\s*(.+)$", header, re.MULTILINE)
-            description = match.group(1).strip().strip("\"'") if match else ""
+            try:
+                path = (root / relative).resolve()
+                path.relative_to(root)
+                content = path.read_text().split("---", 2)
+                if len(content) != 3 or content[0].strip():
+                    raise ValueError("missing frontmatter")
+                match = re.search(r"^description:\s*(.+)$", content[1], re.MULTILINE)
+                description = match.group(1).strip().strip("\"'") if match else ""
+            except (OSError, ValueError, TypeError) as exc:
+                print(f"Skipping command {relative!r}: {exc}", file=sys.stderr)
+                continue
             commands.append({"command": f"/octo:{path.stem}", "description": description})
         topic = " ".join(args.topic).strip().lower().removeprefix("/octo:")
         if topic and topic != "list":

--- a/scripts/guide.py
+++ b/scripts/guide.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Read the installed command catalog without initializing a workflow."""
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("topic", nargs="*", help="command or topic; list shows all commands")
+    parser.add_argument("--json", action="store_true", help="print the installed catalog as JSON")
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parent.parent
+    try:
+        manifest = json.loads((root / ".claude-plugin/plugin.json").read_text())
+        commands = []
+        for relative in manifest["commands"]:
+            path = (root / relative).resolve()
+            path.relative_to(root)
+            header = path.read_text().split("---", 2)[1]
+            match = re.search(r"^description:\s*(.+)$", header, re.MULTILINE)
+            description = match.group(1).strip().strip("\"'") if match else ""
+            commands.append({"command": f"/octo:{path.stem}", "description": description})
+        topic = " ".join(args.topic).strip().lower().removeprefix("/octo:")
+        if topic and topic != "list":
+            commands = [entry for entry in commands if topic in (entry["command"] + " " + entry["description"]).lower()]
+        if args.json:
+            print(json.dumps({"version": manifest["version"], "commands": commands}))
+        else:
+            print("Claude Octopus command guide")
+            if not topic:
+                print('Start with /octo:setup, then /octo:auto "describe your task".\n')
+                primary = {"setup", "auto", "guide", "review", "debug", "security", "resume", "costs"}
+                commands = [entry for entry in commands if entry["command"].split(":")[1] in primary]
+            for entry in commands:
+                print(f'{entry["command"]:24} {entry["description"]}')
+            if not commands:
+                print("No matching installed command. Run octopus guide list.")
+            elif not topic:
+                print("\nUse /octo:guide <topic> or octopus guide list for more commands.")
+        return 0
+    except (OSError, ValueError, KeyError, TypeError, IndexError) as exc:
+        print(f"Cannot read installed command catalog: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -41,29 +41,39 @@ if [[ "$action" == show ]]; then
     exit 0
 fi
 
-[[ ! -L "$file" ]] || { printf 'refusing to replace a symlink: %s\n' "$file" >&2; exit 1; }
-session_file="${CLAUDE_PLUGIN_DATA:-${OCTOPUS_WORKSPACE:-${HOME}/.claude-octopus}}/session.json"
+[[ ! -L "$file" && ( ! -e "$file" || -f "$file" ) ]] || { printf 'output must be a regular file: %s\n' "$file" >&2; exit 1; }
+session_file="${CLAUDE_PLUGIN_DATA:-${CLAUDE_OCTOPUS_WORKSPACE:-${HOME}/.claude-octopus}}/session.json"
 session='{}'
 if [[ -f "$session_file" && ! -L "$session_file" ]]; then
     session="$(jq -c 'if type == "object" then . else {} end' "$session_file" 2>/dev/null || printf '{}')"
 fi
+state_file="$(OCTOPUS_STATE_PROJECT_ROOT="$project_root" bash "$SCRIPT_DIR/state-manager.sh" state_path)"
+project_state='{}'
+if [[ -f "$state_file" && ! -L "$state_file" ]]; then
+    project_state="$(jq -c 'if type == "object" then . else {} end' "$state_file" 2>/dev/null || printf '{}')"
+fi
+umask 077
 mkdir -p "$(dirname "$file")"
-chmod 700 "$(dirname "$file")" 2>/dev/null || true
 tmp="$(mktemp "$(dirname "$file")/.handoff.XXXXXX")"
-chmod 600 "$tmp" 2>/dev/null || true
+trap 'rm -f "$tmp"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 jq -cn --arg project_id "$(octo_lifecycle_handoff_id "$project_root")" \
     --arg project_name "$(basename "$project_root")" \
-    --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson session "$session" '
+    --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson session "$session" --argjson state "$project_state" '
     def redact:
-      tostring |
-      gsub("(?i)(api[_-]?key|token|secret|password|authorization|bearer)[[:space:]]*[:=][[:space:]]*[^[:space:],;}]+"; "[REDACTED]") |
+      if test("(?i)(api[_-]?key|token|secret|password|authorization|bearer)")
+      then "[REDACTED]" else . end |
       gsub("(sk|pk|ghp|github_pat|xai|pplx|r8)[_-][A-Za-z0-9_-]+"; "[REDACTED]");
-    {schema:1,generated_at:$generated_at,project_id:$project_id,project_name:$project_name,
-     workflow:($session.workflow // "none"),phase:($session.current_phase // $session.phase // "none"),
-     status:($session.status // "unknown"),autonomy:($session.autonomy // "supervised"),
-     completed_phases:($session.completed_phases // 0),total_phases:($session.total_phases // 4),
-     decisions:(($session.decisions // [])[:5] | map(redact)),
-     blockers:(($session.blockers // [])[:5] | map(redact)),resume_command:"/octo:resume"}
+    def summary($default): if type == "string" then redact | .[:512] else $default end;
+    def count($default): if type == "number" and . >= 0 and . == floor then . else $default end;
+    def notes: if type == "array" then [.[:5][] | select(type == "string") | redact | .[:512]] else [] end;
+    {schema:1,generated_at:$generated_at,project_id:$project_id,project_name:($project_name | redact),
+     workflow:(($state.current_workflow // $session.workflow) | summary("none")),phase:(($state.current_phase // $session.current_phase // $session.phase) | summary("none")),
+     status:($session.status | summary("unknown")),autonomy:($session.autonomy | summary("supervised")),
+     completed_phases:($session.completed_phases | count(0)),total_phases:($session.total_phases | count(4)),
+     decisions:(if ($state.decisions | type) == "array" then [$state.decisions[] | select(type == "object") | .decision] else $session.decisions end | notes),
+     blockers:(if ($state.blockers | type) == "array" then [$state.blockers[] | select(type == "object" and .status == "active") | .description] else $session.blockers end | notes)}
   ' > "$tmp" || { rm -f "$tmp"; exit 1; }
 mv -f "$tmp" "$file"
 chmod 600 "$file" 2>/dev/null || true
@@ -72,5 +82,5 @@ if [[ "$json" == true ]]; then
     cat "$file"
 else
     printf 'handoff exported: %s\n' "$file"
-    jq -r '"  workflow: \(.workflow) / \(.phase)\n  status: \(.status)\n  resume: \(.resume_command)"' "$file"
+    jq -r '"  workflow: \(.workflow) / \(.phase)\n  status: \(.status)"' "$file"
 fi

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Export a small, redacted checkpoint for another supported host.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=lib/lifecycle.sh
+source "$SCRIPT_DIR/lib/lifecycle.sh"
+
+action="export"
+output=""
+json=false
+action_seen=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        export|show)
+            [[ "$action_seen" == false ]] || { printf 'Choose one handoff action\n' >&2; exit 2; }
+            action="$1"; action_seen=true
+            ;;
+        --json) json=true ;;
+        --out)
+            [[ -n "${2:-}" ]] || { printf '%s requires a path\n' "$1" >&2; exit 2; }
+            output="$2"; shift
+            ;;
+        --help|-h)
+            printf 'Usage: %s [export|show] [--json] [--out path]\n' "$(basename "$0")"
+            exit 0
+            ;;
+        *) printf 'Unknown handoff option: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+command -v jq >/dev/null 2>&1 || { printf 'handoff requires jq\n' >&2; exit 1; }
+
+project_root="${OCTOPUS_PROJECT_DIR:-$PWD}"
+handoff_dir="${OCTOPUS_HANDOFF_DIR:-${HOME}/.claude-octopus/handoffs}"
+file="${output:-$handoff_dir/$(octo_lifecycle_handoff_id "$project_root").json}"
+
+if [[ "$action" == show ]]; then
+    [[ -f "$file" && ! -L "$file" ]] || { printf 'handoff not found: %s\n' "$file" >&2; exit 1; }
+    if [[ "$json" == true ]]; then cat "$file"; else jq . "$file"; fi
+    exit 0
+fi
+
+[[ ! -L "$file" ]] || { printf 'refusing to replace a symlink: %s\n' "$file" >&2; exit 1; }
+session_file="${CLAUDE_PLUGIN_DATA:-${OCTOPUS_WORKSPACE:-${HOME}/.claude-octopus}}/session.json"
+session='{}'
+if [[ -f "$session_file" && ! -L "$session_file" ]]; then
+    session="$(jq -c 'if type == "object" then . else {} end' "$session_file" 2>/dev/null || printf '{}')"
+fi
+mkdir -p "$(dirname "$file")"
+chmod 700 "$(dirname "$file")" 2>/dev/null || true
+tmp="$(mktemp "$(dirname "$file")/.handoff.XXXXXX")"
+chmod 600 "$tmp" 2>/dev/null || true
+jq -cn --arg project_id "$(octo_lifecycle_handoff_id "$project_root")" \
+    --arg project_name "$(basename "$project_root")" \
+    --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson session "$session" '
+    def redact:
+      tostring |
+      gsub("(?i)(api[_-]?key|token|secret|password|authorization|bearer)[[:space:]]*[:=][[:space:]]*[^[:space:],;}]+"; "[REDACTED]") |
+      gsub("(sk|pk|ghp|github_pat|xai|pplx|r8)[_-][A-Za-z0-9_-]+"; "[REDACTED]");
+    {schema:1,generated_at:$generated_at,project_id:$project_id,project_name:$project_name,
+     workflow:($session.workflow // "none"),phase:($session.current_phase // $session.phase // "none"),
+     status:($session.status // "unknown"),autonomy:($session.autonomy // "supervised"),
+     completed_phases:($session.completed_phases // 0),total_phases:($session.total_phases // 4),
+     decisions:(($session.decisions // [])[:5] | map(redact)),
+     blockers:(($session.blockers // [])[:5] | map(redact)),resume_command:"/octo:resume"}
+  ' > "$tmp" || { rm -f "$tmp"; exit 1; }
+mv -f "$tmp" "$file"
+chmod 600 "$file" 2>/dev/null || true
+
+if [[ "$json" == true ]]; then
+    cat "$file"
+else
+    printf 'handoff exported: %s\n' "$file"
+    jq -r '"  workflow: \(.workflow) / \(.phase)\n  status: \(.status)\n  resume: \(.resume_command)"' "$file"
+fi

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -45,12 +45,16 @@ fi
 session_file="${CLAUDE_PLUGIN_DATA:-${CLAUDE_OCTOPUS_WORKSPACE:-${HOME}/.claude-octopus}}/session.json"
 session='{}'
 if [[ -f "$session_file" && ! -L "$session_file" ]]; then
-    session="$(jq -c 'if type == "object" then . else {} end' "$session_file" 2>/dev/null || printf '{}')"
+    session="$(jq -c 'if type == "object" then . else {} end' "$session_file" 2>/dev/null)" || {
+        printf 'Unable to read handoff session JSON\n' >&2; exit 1;
+    }
 fi
 state_file="$(OCTOPUS_STATE_PROJECT_ROOT="$project_root" bash "$SCRIPT_DIR/state-manager.sh" state_path)"
 project_state='{}'
 if [[ -f "$state_file" && ! -L "$state_file" ]]; then
-    project_state="$(jq -c 'if type == "object" then . else {} end' "$state_file" 2>/dev/null || printf '{}')"
+    project_state="$(jq -c 'if type == "object" then . else {} end' "$state_file" 2>/dev/null)" || {
+        printf 'Unable to read handoff project state JSON\n' >&2; exit 1;
+    }
 fi
 umask 077
 mkdir -p "$(dirname "$file")"
@@ -58,11 +62,17 @@ tmp="$(mktemp "$(dirname "$file")/.handoff.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
+# Redact decoded strings before serialization. Text sanitizers can consume JSON
+# delimiters; only the completed, redacted object may reach the temporary file.
 jq -cn --arg project_id "$(octo_lifecycle_handoff_id "$project_root")" \
     --arg project_name "$(basename "$project_root")" \
     --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson session "$session" --argjson state "$project_state" '
     def redact:
-      if test("(?i)(api[_-]?key|token|secret|password|authorization|bearer)")
+      if test("(?i)(api[_-]?key|token|secret|password|authorization|bearer)") or
+         test("(AKIA|ASIA)[A-Z0-9]{16}") or
+         test("eyJ[A-Za-z0-9_-]*\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]*") or
+         test("-----BEGIN[A-Z ]*PRIVATE KEY-----") or
+         test("[A-Za-z][A-Za-z0-9+.-]*://[^\\s/@]+@")
       then "[REDACTED]" else . end |
       gsub("(sk|pk|ghp|github_pat|xai|pplx|r8)[_-][A-Za-z0-9_-]+"; "[REDACTED]");
     def summary($default): if type == "string" then redact | .[:512] else $default end;

--- a/scripts/handoff.sh
+++ b/scripts/handoff.sh
@@ -74,7 +74,7 @@ jq -cn --arg project_id "$(octo_lifecycle_handoff_id "$project_root")" \
          test("-----BEGIN[A-Z ]*PRIVATE KEY-----") or
          test("[A-Za-z][A-Za-z0-9+.-]*://[^\\s/@]+@")
       then "[REDACTED]" else . end |
-      gsub("(sk|pk|ghp|github_pat|xai|pplx|r8)[_-][A-Za-z0-9_-]+"; "[REDACTED]");
+      gsub("(sk|pk|ghp|gho|github_pat|glpat|xoxb|xoxp|xai|pplx|r8)[_-][A-Za-z0-9_-]+"; "[REDACTED]");
     def summary($default): if type == "string" then redact | .[:512] else $default end;
     def count($default): if type == "number" and . >= 0 and . == floor then . else $default end;
     def notes: if type == "array" then [.[:5][] | select(type == "string") | redact | .[:512]] else [] end;

--- a/scripts/lib/cache-hygiene.sh
+++ b/scripts/lib/cache-hygiene.sh
@@ -11,14 +11,16 @@ OCTO_CACHE_DIR="${HOME}/.claude/plugins/cache/nyldn-plugins/octo"
 
 # Versions on disk, sorted oldest → newest.
 octo_cache_versions() {
-    local cache_dir="${1:-$OCTO_CACHE_DIR}"
+    local cache_dir="${1:-$OCTO_CACHE_DIR}" path version
     [[ -d "$cache_dir" ]] || return 0
-    # -V handles semver; tolerate macOS sort which lacks -V on older systems
-    if sort -V </dev/null >/dev/null 2>&1; then
-        ls -1 "$cache_dir" 2>/dev/null | sort -V
-    else
-        ls -1 "$cache_dir" 2>/dev/null | sort
-    fi
+    # Published plugin releases use major.minor.patch. Keep unknown entries
+    # outside both the newest-version decision and automatic cleanup policy.
+    for path in "$cache_dir"/*; do
+        [[ -d "$path" && ! -L "$path" ]] || continue
+        version="${path##*/}"
+        [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+        printf '%s\n' "$version"
+    done | LC_ALL=C sort -t. -k1,1n -k2,2n -k3,3n
 }
 
 # Active version, derived from CLAUDE_PLUGIN_ROOT (set by CC at hook time).
@@ -75,7 +77,7 @@ octo_cache_format_bytes() {
 # window (defensive — should never happen, but cheap insurance).
 # Outputs one line per deletion. Non-zero exit only on filesystem error.
 octo_cache_clean() {
-    local active stale_versions deleted=0
+    local active deleted=0
     active=$(octo_cache_active_version)
     while IFS= read -r v; do
         [[ -z "$v" ]] && continue

--- a/scripts/lib/cache-hygiene.sh
+++ b/scripts/lib/cache-hygiene.sh
@@ -38,10 +38,10 @@ octo_cache_stale() {
     local keep="${OCTOPUS_CACHE_KEEP:-2}"
     [[ "$keep" =~ ^[1-9][0-9]*$ ]] || keep=2
     local total
-    total=$(octo_cache_versions | wc -l | tr -d ' ')
+    total=$(octo_cache_versions "$OCTO_CACHE_DIR" | wc -l | tr -d ' ')
     [[ "$total" -le "$keep" ]] && return 0
     local drop=$((total - keep))
-    octo_cache_versions | head -n "$drop"
+    octo_cache_versions "$OCTO_CACHE_DIR" | head -n "$drop"
 }
 
 # Total bytes used by stale versions (for user-facing reports).

--- a/scripts/lib/cache-hygiene.sh
+++ b/scripts/lib/cache-hygiene.sh
@@ -11,12 +11,13 @@ OCTO_CACHE_DIR="${HOME}/.claude/plugins/cache/nyldn-plugins/octo"
 
 # Versions on disk, sorted oldest → newest.
 octo_cache_versions() {
-    [[ -d "$OCTO_CACHE_DIR" ]] || return 0
+    local cache_dir="${1:-$OCTO_CACHE_DIR}"
+    [[ -d "$cache_dir" ]] || return 0
     # -V handles semver; tolerate macOS sort which lacks -V on older systems
     if sort -V </dev/null >/dev/null 2>&1; then
-        ls -1 "$OCTO_CACHE_DIR" 2>/dev/null | sort -V
+        ls -1 "$cache_dir" 2>/dev/null | sort -V
     else
-        ls -1 "$OCTO_CACHE_DIR" 2>/dev/null | sort
+        ls -1 "$cache_dir" 2>/dev/null | sort
     fi
 }
 

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -25,6 +25,11 @@ if ! declare -f octo_plugin_update_load >/dev/null 2>&1; then
     source "${_doctor_lib_dir}/plugin-update.sh" 2>/dev/null || true
 fi
 
+if ! declare -f octo_lifecycle_state_valid >/dev/null 2>&1; then
+    _doctor_lib_dir="${_doctor_lib_dir:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+    source "${_doctor_lib_dir}/lifecycle.sh" 2>/dev/null || true
+fi
+
 if ! declare -f _octo_bare_auth_probe >/dev/null 2>&1; then
     _doctor_lib_dir="${_doctor_lib_dir:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
     source "${_doctor_lib_dir}/providers.sh" 2>/dev/null || true
@@ -1753,6 +1758,46 @@ doctor_check_cache() {
         "Stale: ${stale_list}. Run: bash \$CLAUDE_PLUGIN_ROOT/scripts/lib/cache-hygiene.sh clean (or set OCTOPUS_AUTO_CLEAN_CACHE=1)"
 }
 
+# --- Category 15: Installation ownership and loaded-root alignment ---
+doctor_check_installation() {
+    if ! declare -f octo_lifecycle_state_valid >/dev/null 2>&1; then
+        doctor_add "install-state-library" "installation" "fail" \
+            "Installation state library is unavailable" "Reinstall Claude Octopus"
+        return
+    fi
+
+    local root stable_status
+    root="$(octo_lifecycle_plugin_root)"
+    stable_status="$(octo_lifecycle_stable_root_status "$root" 2>/dev/null || true)"
+    case "$stable_status" in
+        ok|shim)
+            doctor_add "stable-plugin-root" "installation" "pass" \
+                "Stable plugin root matches the loaded plugin" "$OCTO_LIFECYCLE_STABLE_ROOT"
+            ;;
+        missing)
+            doctor_add "stable-plugin-root" "installation" "warn" \
+                "Stable plugin root is missing" "Run: octopus repair --dry-run"
+            ;;
+        *)
+            doctor_add "stable-plugin-root" "installation" "fail" \
+                "Stable plugin root is ${stable_status}" "Run: octopus repair --dry-run"
+            ;;
+    esac
+
+    if octo_lifecycle_state_valid; then
+        doctor_add "install-state" "installation" "pass" \
+            "Install metadata matches the current host and plugin" "$OCTO_LIFECYCLE_STATE_FILE"
+    elif [[ -f "$OCTO_LIFECYCLE_STATE_FILE" ]]; then
+        doctor_add "install-state" "installation" "warn" \
+            "Install metadata is stale for the current host" "Run: octopus install-state record"
+    else
+        doctor_add "install-state" "installation" "info" \
+            "Install metadata has not been recorded for this host" "SessionStart records it automatically"
+    fi
+    doctor_add "context-profile" "installation" "pass" \
+        "Context profile: $(octo_lifecycle_profile)" "Optional hooks: $(octo_lifecycle_hook_profile)"
+}
+
 # --- Output: Human-readable ---
 doctor_output_human() {
     local verbose="${1:-false}"
@@ -1891,7 +1936,7 @@ Usage: octopus doctor [CATEGORY] [--verbose] [--json] [--live]
 
 Categories:
   providers companions auth config updates state smoke hooks scheduler
-  skills conflicts agents recurrence cache
+  skills conflicts agents recurrence cache installation
 
 Options:
   -v, --verbose  Include details for passing checks
@@ -1907,7 +1952,7 @@ do_doctor() {
     local verbose=false
     local json_output=false
     local DOCTOR_LIVE_PROBE=false
-    local categories="providers companions auth config updates state smoke hooks scheduler skills conflicts agents recurrence cache"
+    local categories="providers companions auth config updates state smoke hooks scheduler skills conflicts agents recurrence cache installation"
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do

--- a/scripts/lib/hook-activation.sh
+++ b/scripts/lib/hook-activation.sh
@@ -4,6 +4,33 @@
 [[ -n "${_OCTOPUS_HOOK_ACTIVATION_LOADED:-}" ]] && return 0
 _OCTOPUS_HOOK_ACTIVATION_LOADED=true
 
+_octopus_hook_activation_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+octo_hook_profile() {
+    local profile="${OCTOPUS_HOOK_PROFILE:-${OCTOPUS_CONTEXT_PROFILE:-}}"
+    if [[ -z "$profile" && -r "${HOME}/.claude-octopus/user-config.json" ]] && command -v jq >/dev/null 2>&1; then
+        profile="$(jq -r '.context_profile // empty' "${HOME}/.claude-octopus/user-config.json" 2>/dev/null || true)"
+    fi
+    case "$profile" in
+        orchestration|workflow) printf 'orchestration\n' ;;
+        full|all) printf 'full\n' ;;
+        *) printf 'core\n' ;;
+    esac
+}
+
+# Profiles control optional context work only. Safety and lifecycle hooks never
+# call this function, so a profile cannot disable their checks.
+octo_hook_profile_allows() {
+    local hook_id="${1:-}" profile config
+    [[ -n "$hook_id" ]] || return 1
+    profile="$(octo_hook_profile)"
+    config="${OCTOPUS_HOOK_PROFILE_CONFIG:-${_octopus_hook_activation_dir}/../../config/hook-profiles.json}"
+    [[ -r "$config" ]] || return 1
+    command -v jq >/dev/null 2>&1 || return 1
+    jq -e --arg profile "$profile" --arg hook "$hook_id" \
+        '.profiles[$profile] // [] | any(. == "*" or . == $hook)' "$config" >/dev/null 2>&1
+}
+
 octo_hook_session_id() {
     local input="${1:-}" sid=""
     sid="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"

--- a/scripts/lib/hook-activation.sh
+++ b/scripts/lib/hook-activation.sh
@@ -6,16 +6,25 @@ _OCTOPUS_HOOK_ACTIVATION_LOADED=true
 
 _octopus_hook_activation_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
-octo_hook_profile() {
-    local profile="${OCTOPUS_HOOK_PROFILE:-${OCTOPUS_CONTEXT_PROFILE:-}}"
-    if [[ -z "$profile" && -r "${HOME}/.claude-octopus/user-config.json" ]] && command -v jq >/dev/null 2>&1; then
-        profile="$(jq -r '.context_profile // empty' "${HOME}/.claude-octopus/user-config.json" 2>/dev/null || true)"
-    fi
-    case "$profile" in
+octo_normalize_context_profile() {
+    case "${1:-}" in
+        core|minimal) printf 'core\n' ;;
         orchestration|workflow) printf 'orchestration\n' ;;
         full|all) printf 'full\n' ;;
         *) printf 'core\n' ;;
     esac
+}
+
+octo_context_profile() {
+    local profile="${OCTOPUS_CONTEXT_PROFILE:-}"
+    if [[ -z "$profile" && -r "${HOME}/.claude-octopus/user-config.json" ]] && command -v jq >/dev/null 2>&1; then
+        profile="$(jq -r '.context_profile // empty' "${HOME}/.claude-octopus/user-config.json" 2>/dev/null || true)"
+    fi
+    octo_normalize_context_profile "$profile"
+}
+
+octo_hook_profile() {
+    octo_normalize_context_profile "${OCTOPUS_HOOK_PROFILE:-$(octo_context_profile)}"
 }
 
 # Profiles control optional context work only. Safety and lifecycle hooks never

--- a/scripts/lib/install-root.sh
+++ b/scripts/lib/install-root.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Read-only installation validation shared by diagnostics and repair.
+# OCTO_ROOT_VALID_DETAIL is read by callers after validation.
+# shellcheck disable=SC2034
+
+_octo_root_path_valid() {
+    local root="$1" ref="$2" kind="$3" path parent target hops=0
+    # Reject lexical escapes and control characters before resolving symlinks.
+    case "$ref" in
+        ''|/*|*\\*|*:*|..|../*|*/../*|*/..|*[[:cntrl:]]*) return 1 ;;
+    esac
+    path="$root/${ref#./}"
+    while :; do
+        parent="$(cd -P "$(dirname "$path")" 2>/dev/null && pwd -P)" || return 1
+        path="$parent/$(basename "$path")"
+        case "$path" in "$root"/*) ;; *) return 1 ;; esac
+        [[ -L "$path" ]] || break
+        hops=$((hops + 1))
+        [[ "$hops" -le 40 ]] || return 1
+        target="$(readlink "$path")" || return 1
+        case "$target" in /*) path="$target" ;; *) path="$parent/$target" ;; esac
+    done
+    case "$kind" in
+        directory)
+            [[ -d "$path" ]] || return 1
+            path="$(cd -P "$path" 2>/dev/null && pwd -P)" || return 1
+            case "$path" in "$root"|"$root"/*) return 0 ;; esac
+            return 1 ;;
+        file) [[ -f "$path" && -r "$path" ]] ;;
+        executable) [[ -f "$path" && -x "$path" && -r "$path" ]] ;;
+        *) return 1 ;;
+    esac
+}
+
+octo_validate_install_root() {
+    local root="$1" host="${2:-claude}" manifest refs kind ref
+    OCTO_ROOT_VALID_DETAIL="plugin root is missing or inaccessible"
+    root="$(cd -P "$root" 2>/dev/null && pwd -P)" || return 1
+    case "$host" in
+        codex) manifest=.codex-plugin/plugin.json ;;
+        *) manifest=.claude-plugin/plugin.json ;;
+    esac
+    OCTO_ROOT_VALID_DETAIL="manifest is missing, unreadable, or outside the plugin root"
+    _octo_root_path_valid "$root" "$manifest" file || return 1
+    OCTO_ROOT_VALID_DETAIL="manifest is invalid or has incorrectly typed references"
+    # Keep paths encoded until their types and control characters are checked.
+    refs="$(jq -esr '
+        def path: type == "string" and length > 0 and (test("[[:cntrl:]]") | not);
+        def paths: path or (type == "array" and all(.[]; path));
+        if length == 1 then .[0] else error("expected one manifest") end |
+        if type != "object" then error("manifest must be an object") else . end |
+        if (.version | path) and
+           (all([.skills?, .commands?, .agents?][]; . == null or paths)) and
+           (all([.hooks?, .mcpServers?, .lspServers?][]; . == null or type == "object" or paths)) and
+           (.interface == null or (.interface | type == "object")) and
+           (all([.interface.composerIcon?, .interface.logo?][]; . == null or path))
+        then . else error("invalid manifest fields") end |
+        [
+          (.skills? | select(. != null) | if type == "array" then .[] else . end | ["directory", .]),
+          (.commands?, .agents? | select(. != null) |
+            if type == "array" then .[] | ["file", .]
+            else [if endswith(".md") then "file" else "directory" end, .] end),
+          (.hooks?, .mcpServers?, .lspServers? | select(. != null and type != "object") |
+            if type == "array" then .[] else . end | ["file", .]),
+          (.interface.composerIcon?, .interface.logo? | select(. != null) | ["file", .])
+        ] | map(@tsv) | join("\n")
+    ' "$root/$manifest" 2>/dev/null)" || return 1
+    OCTO_ROOT_VALID_DETAIL="scripts/orchestrate.sh is missing, not executable, or outside the plugin root"
+    _octo_root_path_valid "$root" scripts/orchestrate.sh executable || return 1
+    OCTO_ROOT_VALID_DETAIL="manifest references could not be read or validated"
+    while IFS=$'\t' read -r kind ref; do
+        [[ -n "$kind" ]] || continue
+        OCTO_ROOT_VALID_DETAIL="manifest reference must be a contained $kind: $ref"
+        _octo_root_path_valid "$root" "$ref" "$kind" || return 1
+    done <<< "$refs" || return 1
+    OCTO_ROOT_VALID_DETAIL="manifest, runtime, and typed references are valid"
+}

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -4,6 +4,11 @@
 OCTO_LIFECYCLE_STATE_FILE="${OCTOPUS_INSTALL_STATE_FILE:-${HOME}/.claude-octopus/install-state.json}"
 OCTO_LIFECYCLE_STABLE_ROOT="${OCTOPUS_STABLE_PLUGIN_ROOT:-${HOME}/.claude-octopus/plugin}"
 
+# shellcheck source=scripts/lib/install-root.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/install-root.sh"
+# shellcheck source=scripts/lib/plugin-root.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/plugin-root.sh"
+
 octo_lifecycle_profile_valid() {
     case "${1:-}" in core|orchestration|full) return 0 ;; esac
     return 1
@@ -91,43 +96,83 @@ octo_lifecycle_state_valid() {
     local host expected
     host="$(octo_lifecycle_host)"
     expected="$(octo_lifecycle_snapshot)" || return 1
-    jq -e --arg host "$host" --argjson expected "$expected" '
+    jq -se --arg host "$host" --argjson expected "$expected" '
+        length == 1 and (.[0] |
         .schema == 2 and (.hosts | type == "object") and
         (.hosts[$host] | {
           host,plugin_version,plugin_root,stable_root,install_scope,context_profile,hook_profile
-        }) == $expected
+        }) == $expected)
     ' "$OCTO_LIFECYCLE_STATE_FILE" >/dev/null 2>&1
 }
 
 _octo_lifecycle_lock() {
-    local lock="$1.lock" tries=0
+    local lock="$1.lock" owner="$2" tries=0 candidate pid probe
     while ! mkdir "$lock" 2>/dev/null; do
+        [[ -d "$lock" && ! -L "$lock" ]] || return 1
+        # Removing the empty owner directory elects exactly one reclaimer.
+        # Other waiters cannot remove a newly acquired lock after losing here.
+        for candidate in "$lock/owner-$lock_host-"*; do
+            [[ -d "$candidate" && ! -L "$candidate" ]] || continue
+            pid="${candidate##*-}"
+            case "$pid" in ''|0|*[!0-9]*) continue ;; esac
+            probe="$(LC_ALL=C kill -0 "$pid" 2>&1)" && continue
+            case "$probe" in
+                *'No such process'*)
+                    if rmdir "$candidate" 2>/dev/null; then rmdir "$lock" 2>/dev/null || true; fi ;;
+            esac
+        done
         tries=$((tries + 1))
         [[ "$tries" -lt 50 ]] || return 1
         sleep 0.02 2>/dev/null || return 1
     done
+    mkdir "$lock/$owner" || { rmdir "$lock" 2>/dev/null || true; return 1; }
 }
 
-octo_lifecycle_record_install() {
+_octo_lifecycle_unlock() {
+    local lock="$1" owner="$2" tmp="$3"
+    [[ -z "$tmp" ]] || rm -f "$tmp"
+    if [[ ! -L "$lock" ]] && rmdir "$lock/$owner" 2>/dev/null; then
+        rmdir "$lock" 2>/dev/null || true
+    fi
+    return 0
+}
+
+octo_lifecycle_record_install() (
+    # A subshell confines signal and EXIT traps to this transaction.
     command -v jq >/dev/null 2>&1 || return 3
-    local expected host state_dir lock tmp current='{"schema":2,"hosts":{}}' updated rc=0
+    local expected host state_dir lock tmp="" current='{"schema":2,"hosts":{}}' updated rc=0
+    local lock_pid lock_host owner
     expected="$(octo_lifecycle_snapshot)" || return $?
     host="$(jq -r '.host' <<<"$expected")"
     case "$host" in ''|*[!A-Za-z0-9._-]*) return 2 ;; esac
     [[ -d "$(jq -r '.plugin_root' <<<"$expected")" ]] || return 4
-    [[ ! -L "$OCTO_LIFECYCLE_STATE_FILE" ]] || return 5
+    [[ ! -L "$OCTO_LIFECYCLE_STATE_FILE" && ( ! -e "$OCTO_LIFECYCLE_STATE_FILE" || -f "$OCTO_LIFECYCLE_STATE_FILE" ) ]] || return 5
     state_dir="$(dirname "$OCTO_LIFECYCLE_STATE_FILE")"
     mkdir -p "$state_dir" || return 5
-    _octo_lifecycle_lock "$OCTO_LIFECYCLE_STATE_FILE" || return 6
     lock="$OCTO_LIFECYCLE_STATE_FILE.lock"
+    # $$ identifies the caller on Bash 3.2; the exec child reports this subshell.
+    read -r lock_pid < <(exec sh -c 'echo "$PPID"') || return 6
+    lock_host="$(hostname)" || return 6
+    lock_host="${lock_host//[^A-Za-z0-9._-]/_}"
+    owner="owner-$lock_host-$lock_pid"
+    # Bash 3.2 unwinds function locals before EXIT when a signal exits the shell.
+    # These variables survive that unwind and remain confined to this subshell.
+    _octo_receipt_lock="$lock" _octo_receipt_owner="$owner" _octo_receipt_tmp=""
+    trap '_octo_lifecycle_unlock "$_octo_receipt_lock" "$_octo_receipt_owner" "$_octo_receipt_tmp"' EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    _octo_lifecycle_lock "$OCTO_LIFECYCLE_STATE_FILE" "$owner" || return 6
+    [[ ! -L "$OCTO_LIFECYCLE_STATE_FILE" && ( ! -e "$OCTO_LIFECYCLE_STATE_FILE" || -f "$OCTO_LIFECYCLE_STATE_FILE" ) ]] || return 5
 
     if [[ -f "$OCTO_LIFECYCLE_STATE_FILE" ]]; then
-        current="$(jq -c '
+        current="$(jq -sce '
+            if length == 1 then .[0] else error("expected one install state") end |
             if .schema == 2 and (.hosts | type == "object") then .
             elif .schema == 1 and (.host | type == "string") then
               {schema:2,hosts:{(.host):del(.schema,.recorded,.host)}}
-            else {schema:2,hosts:{}} end
-        ' "$OCTO_LIFECYCLE_STATE_FILE" 2>/dev/null)" || current='{"schema":2,"hosts":{}}'
+            else error("unrecognized install state") end
+        ' "$OCTO_LIFECYCLE_STATE_FILE" 2>/dev/null)" || return 5
     fi
     updated="$(jq -cn --argjson state "$current" --argjson entry "$expected" \
         --arg host "$host" --arg recorded_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -135,16 +180,17 @@ octo_lifecycle_record_install() {
          .hosts[$host] = ($entry + {recorded_at:$recorded_at})')" || rc=$?
     if [[ "$rc" -eq 0 ]]; then
         tmp="$(mktemp "$state_dir/.install-state.XXXXXX")" || rc=$?
+        _octo_receipt_tmp="$tmp"
     fi
     if [[ "$rc" -eq 0 ]]; then
         chmod 600 "$tmp" 2>/dev/null || true
-        printf '%s\n' "$updated" > "$tmp" && mv -f "$tmp" "$OCTO_LIFECYCLE_STATE_FILE" || rc=$?
+        printf '%s\n' "$updated" > "$tmp" &&
+            [[ ! -L "$OCTO_LIFECYCLE_STATE_FILE" && ( ! -e "$OCTO_LIFECYCLE_STATE_FILE" || -f "$OCTO_LIFECYCLE_STATE_FILE" ) ]] &&
+            mv -f "$tmp" "$OCTO_LIFECYCLE_STATE_FILE" || rc=$?
         [[ "$rc" -eq 0 ]] && chmod 600 "$OCTO_LIFECYCLE_STATE_FILE" 2>/dev/null || true
     fi
-    [[ -z "${tmp:-}" || "$rc" -eq 0 ]] || rm -f "$tmp" 2>/dev/null || true
-    rmdir "$lock" 2>/dev/null || true
     return "$rc"
-}
+)
 
 octo_lifecycle_state_json() {
     command -v jq >/dev/null 2>&1 || return 3
@@ -152,7 +198,10 @@ octo_lifecycle_state_json() {
     host="$(octo_lifecycle_host)"
     expected="$(octo_lifecycle_snapshot)" || return $?
     if [[ -f "$OCTO_LIFECYCLE_STATE_FILE" && ! -L "$OCTO_LIFECYCLE_STATE_FILE" ]]; then
-        recorded="$(jq -c --arg host "$host" '.hosts[$host] // null' "$OCTO_LIFECYCLE_STATE_FILE" 2>/dev/null || printf 'null')"
+        recorded="$(jq -sc --arg host "$host" '
+            if length == 1 and (.[0].hosts | type == "object")
+            then .[0].hosts[$host] // null else null end
+        ' "$OCTO_LIFECYCLE_STATE_FILE" 2>/dev/null)" || recorded=null
     fi
     octo_lifecycle_state_valid && current=true || true
     jq -cn --argjson expected "$expected" --argjson recorded "$recorded" \
@@ -162,6 +211,9 @@ octo_lifecycle_state_json() {
 
 octo_lifecycle_stable_root_status() {
     local root="${1:-$(octo_lifecycle_plugin_root)}" stable="$OCTO_LIFECYCLE_STABLE_ROOT"
+    if ! octo_validate_install_root "$root" "$(octo_lifecycle_host)"; then
+        printf 'invalid-target\n'; return 1
+    fi
     if [[ -L "$stable" ]]; then
         local stable_real="" root_real=""
         stable_real="$(cd "$stable" 2>/dev/null && pwd -P)" || true
@@ -172,22 +224,8 @@ octo_lifecycle_stable_root_status() {
     fi
     if [[ ! -e "$stable" ]]; then printf 'missing\n'; return 1; fi
     if [[ -d "$stable" && -x "$stable/scripts/orchestrate.sh" ]]; then
-        local source_script="$root/scripts/orchestrate.sh" shim_script="$stable/scripts/orchestrate.sh"
-        local quoted_source expected_exec
-        if [[ -e "$source_script" && "$source_script" -ef "$shim_script" ]]; then
-            printf 'ok\n'
-            return 0
-        fi
-        printf -v quoted_source '%q' "$source_script"
-        expected_exec="exec $quoted_source \"\$@\""
-        if grep -Fqx -- "$expected_exec" "$shim_script" 2>/dev/null; then
-            printf 'shim\n'
-            return 0
-        fi
-        if grep -Eq '^exec .+ "\$@"$' "$shim_script" 2>/dev/null; then
-            printf 'mismatch\n'
-            return 1
-        fi
+        octo_stable_shims_status "$root" "$stable"
+        return $?
     fi
     printf 'invalid\n'; return 1
 }

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Host-scoped plugin installation state. Source-safe and Bash 3.2 compatible.
+
+OCTO_LIFECYCLE_STATE_FILE="${OCTOPUS_INSTALL_STATE_FILE:-${HOME}/.claude-octopus/install-state.json}"
+OCTO_LIFECYCLE_STABLE_ROOT="${OCTOPUS_STABLE_PLUGIN_ROOT:-${HOME}/.claude-octopus/plugin}"
+
+octo_lifecycle_profile_valid() {
+    case "${1:-}" in core|orchestration|full) return 0 ;; esac
+    return 1
+}
+
+octo_lifecycle_profile() {
+    local value="${OCTOPUS_CONTEXT_PROFILE:-}"
+    if [[ -z "$value" && -r "${HOME}/.claude-octopus/user-config.json" ]] && command -v jq >/dev/null 2>&1; then
+        value="$(jq -r '.context_profile // empty' "${HOME}/.claude-octopus/user-config.json" 2>/dev/null || true)"
+    fi
+    if octo_lifecycle_profile_valid "$value"; then printf '%s\n' "$value"; else printf 'core\n'; fi
+}
+
+octo_lifecycle_hook_profile() {
+    local value="${OCTOPUS_HOOK_PROFILE:-$(octo_lifecycle_profile)}"
+    case "$value" in
+        core|minimal) printf 'core\n' ;;
+        orchestration|workflow) printf 'orchestration\n' ;;
+        full|all) printf 'full\n' ;;
+        *) printf 'core\n' ;;
+    esac
+}
+
+octo_lifecycle_host() {
+    if [[ -n "${OCTOPUS_HOST:-}" ]]; then
+        printf '%s\n' "$OCTOPUS_HOST"
+    elif [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
+        printf 'claude\n'
+    elif [[ -n "${CODEX_PLUGIN_ROOT:-}" || -n "${CODEX_HOME:-}" ]]; then
+        printf 'codex\n'
+    else
+        printf 'standalone\n'
+    fi
+}
+
+octo_lifecycle_plugin_root() {
+    local host root=""
+    host="$(octo_lifecycle_host)"
+    case "$host" in
+        claude) root="${CLAUDE_PLUGIN_ROOT:-${PLUGIN_DIR:-}}" ;;
+        codex) root="${CODEX_PLUGIN_ROOT:-${PLUGIN_DIR:-}}" ;;
+        *) root="${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-${PLUGIN_DIR:-}}}" ;;
+    esac
+    if [[ -z "$root" ]]; then
+        root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd -P)"
+    elif [[ -d "$root" ]]; then
+        root="$(cd "$root" 2>/dev/null && pwd -P)"
+    fi
+    printf '%s\n' "$root"
+}
+
+octo_lifecycle_version() {
+    local root="${1:-$(octo_lifecycle_plugin_root)}" manifest=""
+    if [[ -r "$root/.claude-plugin/plugin.json" ]]; then
+        manifest="$root/.claude-plugin/plugin.json"
+    elif [[ -r "$root/.codex-plugin/plugin.json" ]]; then
+        manifest="$root/.codex-plugin/plugin.json"
+    fi
+    if [[ -n "$manifest" ]] && command -v jq >/dev/null 2>&1; then
+        jq -r '.version // "unknown"' "$manifest" 2>/dev/null || printf 'unknown\n'
+    else
+        printf 'unknown\n'
+    fi
+}
+
+octo_lifecycle_snapshot() {
+    command -v jq >/dev/null 2>&1 || return 3
+    local host root version scope profile hooks
+    host="$(octo_lifecycle_host)"
+    root="$(octo_lifecycle_plugin_root)"
+    version="$(octo_lifecycle_version "$root")"
+    scope="${OCTOPUS_INSTALL_SCOPE:-user}"
+    profile="$(octo_lifecycle_profile)"
+    hooks="$(octo_lifecycle_hook_profile)"
+    jq -cn --arg host "$host" --arg version "$version" --arg root "$root" \
+        --arg stable "$OCTO_LIFECYCLE_STABLE_ROOT" --arg scope "$scope" \
+        --arg profile "$profile" --arg hooks "$hooks" \
+        '{host:$host,plugin_version:$version,plugin_root:$root,stable_root:$stable,
+          install_scope:$scope,context_profile:$profile,hook_profile:$hooks}'
+}
+
+octo_lifecycle_state_valid() {
+    [[ -f "$OCTO_LIFECYCLE_STATE_FILE" && ! -L "$OCTO_LIFECYCLE_STATE_FILE" ]] || return 1
+    command -v jq >/dev/null 2>&1 || return 1
+    local host expected
+    host="$(octo_lifecycle_host)"
+    expected="$(octo_lifecycle_snapshot)" || return 1
+    jq -e --arg host "$host" --argjson expected "$expected" '
+        .schema == 2 and (.hosts | type == "object") and
+        (.hosts[$host] | {
+          host,plugin_version,plugin_root,stable_root,install_scope,context_profile,hook_profile
+        }) == $expected
+    ' "$OCTO_LIFECYCLE_STATE_FILE" >/dev/null 2>&1
+}
+
+_octo_lifecycle_lock() {
+    local lock="$1.lock" tries=0
+    while ! mkdir "$lock" 2>/dev/null; do
+        tries=$((tries + 1))
+        [[ "$tries" -lt 50 ]] || return 1
+        sleep 0.02 2>/dev/null || return 1
+    done
+}
+
+octo_lifecycle_record_install() {
+    command -v jq >/dev/null 2>&1 || return 3
+    local expected host state_dir lock tmp current='{"schema":2,"hosts":{}}' updated rc=0
+    expected="$(octo_lifecycle_snapshot)" || return $?
+    host="$(jq -r '.host' <<<"$expected")"
+    case "$host" in ''|*[!A-Za-z0-9._-]*) return 2 ;; esac
+    [[ -d "$(jq -r '.plugin_root' <<<"$expected")" ]] || return 4
+    [[ ! -L "$OCTO_LIFECYCLE_STATE_FILE" ]] || return 5
+    state_dir="$(dirname "$OCTO_LIFECYCLE_STATE_FILE")"
+    mkdir -p "$state_dir" || return 5
+    _octo_lifecycle_lock "$OCTO_LIFECYCLE_STATE_FILE" || return 6
+    lock="$OCTO_LIFECYCLE_STATE_FILE.lock"
+
+    if [[ -f "$OCTO_LIFECYCLE_STATE_FILE" ]]; then
+        current="$(jq -c '
+            if .schema == 2 and (.hosts | type == "object") then .
+            elif .schema == 1 and (.host | type == "string") then
+              {schema:2,hosts:{(.host):del(.schema,.recorded,.host)}}
+            else {schema:2,hosts:{}} end
+        ' "$OCTO_LIFECYCLE_STATE_FILE" 2>/dev/null)" || current='{"schema":2,"hosts":{}}'
+    fi
+    updated="$(jq -cn --argjson state "$current" --argjson entry "$expected" \
+        --arg host "$host" --arg recorded_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '$state | .schema = 2 | .hosts = (.hosts // {}) |
+         .hosts[$host] = ($entry + {recorded_at:$recorded_at})')" || rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+        tmp="$(mktemp "$state_dir/.install-state.XXXXXX")" || rc=$?
+    fi
+    if [[ "$rc" -eq 0 ]]; then
+        chmod 600 "$tmp" 2>/dev/null || true
+        printf '%s\n' "$updated" > "$tmp" && mv -f "$tmp" "$OCTO_LIFECYCLE_STATE_FILE" || rc=$?
+        [[ "$rc" -eq 0 ]] && chmod 600 "$OCTO_LIFECYCLE_STATE_FILE" 2>/dev/null || true
+    fi
+    [[ -z "${tmp:-}" || "$rc" -eq 0 ]] || rm -f "$tmp" 2>/dev/null || true
+    rmdir "$lock" 2>/dev/null || true
+    return "$rc"
+}
+
+octo_lifecycle_state_json() {
+    command -v jq >/dev/null 2>&1 || return 3
+    local host expected recorded='null' current=false
+    host="$(octo_lifecycle_host)"
+    expected="$(octo_lifecycle_snapshot)" || return $?
+    if [[ -f "$OCTO_LIFECYCLE_STATE_FILE" && ! -L "$OCTO_LIFECYCLE_STATE_FILE" ]]; then
+        recorded="$(jq -c --arg host "$host" '.hosts[$host] // null' "$OCTO_LIFECYCLE_STATE_FILE" 2>/dev/null || printf 'null')"
+    fi
+    octo_lifecycle_state_valid && current=true || true
+    jq -cn --argjson expected "$expected" --argjson recorded "$recorded" \
+        --argjson current "$current" --arg state_file "$OCTO_LIFECYCLE_STATE_FILE" \
+        '{schema:2,current:$current,state_file:$state_file,expected:$expected,recorded:$recorded}'
+}
+
+octo_lifecycle_stable_root_status() {
+    local root="${1:-$(octo_lifecycle_plugin_root)}" stable="$OCTO_LIFECYCLE_STABLE_ROOT"
+    if [[ -L "$stable" ]]; then
+        local stable_real="" root_real=""
+        stable_real="$(cd "$stable" 2>/dev/null && pwd -P)" || true
+        root_real="$(cd "$root" 2>/dev/null && pwd -P)" || true
+        if [[ -z "$stable_real" ]]; then printf 'broken\n'; return 1; fi
+        if [[ -n "$root_real" && "$stable_real" == "$root_real" ]]; then printf 'ok\n'; return 0; fi
+        printf 'mismatch\n'; return 1
+    fi
+    if [[ ! -e "$stable" ]]; then printf 'missing\n'; return 1; fi
+    if [[ -d "$stable" && -x "$stable/scripts/orchestrate.sh" ]]; then
+        local source_script="$root/scripts/orchestrate.sh" shim_script="$stable/scripts/orchestrate.sh"
+        local quoted_source expected_exec
+        if [[ -e "$source_script" && "$source_script" -ef "$shim_script" ]]; then
+            printf 'ok\n'
+            return 0
+        fi
+        printf -v quoted_source '%q' "$source_script"
+        expected_exec="exec $quoted_source \"\$@\""
+        if grep -Fqx -- "$expected_exec" "$shim_script" 2>/dev/null; then
+            printf 'shim\n'
+            return 0
+        fi
+        if grep -Eq '^exec .+ "\$@"$' "$shim_script" 2>/dev/null; then
+            printf 'mismatch\n'
+            return 1
+        fi
+    fi
+    printf 'invalid\n'; return 1
+}
+
+octo_lifecycle_handoff_id() {
+    local project="${1:-$PWD}"
+    if command -v shasum >/dev/null 2>&1; then
+        printf '%s' "$project" | shasum -a 256 | cut -c1-16
+    elif command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$project" | sha256sum | cut -c1-16
+    else
+        printf '%s' "$project" | cksum | cut -d' ' -f1
+    fi
+}

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -8,6 +8,8 @@ OCTO_LIFECYCLE_STABLE_ROOT="${OCTOPUS_STABLE_PLUGIN_ROOT:-${HOME}/.claude-octopu
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/install-root.sh"
 # shellcheck source=scripts/lib/plugin-root.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/plugin-root.sh"
+# shellcheck source=scripts/lib/hook-activation.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/hook-activation.sh"
 
 octo_lifecycle_profile_valid() {
     case "${1:-}" in core|orchestration|full) return 0 ;; esac
@@ -15,21 +17,11 @@ octo_lifecycle_profile_valid() {
 }
 
 octo_lifecycle_profile() {
-    local value="${OCTOPUS_CONTEXT_PROFILE:-}"
-    if [[ -z "$value" && -r "${HOME}/.claude-octopus/user-config.json" ]] && command -v jq >/dev/null 2>&1; then
-        value="$(jq -r '.context_profile // empty' "${HOME}/.claude-octopus/user-config.json" 2>/dev/null || true)"
-    fi
-    if octo_lifecycle_profile_valid "$value"; then printf '%s\n' "$value"; else printf 'core\n'; fi
+    octo_context_profile
 }
 
 octo_lifecycle_hook_profile() {
-    local value="${OCTOPUS_HOOK_PROFILE:-$(octo_lifecycle_profile)}"
-    case "$value" in
-        core|minimal) printf 'core\n' ;;
-        orchestration|workflow) printf 'orchestration\n' ;;
-        full|all) printf 'full\n' ;;
-        *) printf 'core\n' ;;
-    esac
+    octo_hook_profile
 }
 
 octo_lifecycle_host() {

--- a/scripts/lib/plugin-root.sh
+++ b/scripts/lib/plugin-root.sh
@@ -59,7 +59,10 @@ octo_stable_shims_status() {
             continue
         fi
         _octo_stable_destination_safe "$stable" "$rel" || { printf 'invalid\n'; return 1; }
-        [[ -e "$dst" || -L "$dst" ]] || continue
+        if [[ ! -e "$dst" && ! -L "$dst" ]]; then
+            [[ ! -f "$src" ]] || status=mismatch
+            continue
+        fi
         target="$(octo_stable_shim_source "$dst" "$rel")" || { printf 'invalid\n'; return 1; }
         [[ "$target" == "$src" ]] || status=mismatch
     done < <(_octo_stable_script_paths)

--- a/scripts/lib/plugin-root.sh
+++ b/scripts/lib/plugin-root.sh
@@ -2,6 +2,71 @@
 # Plugin root helpers for Claude Octopus.
 # Source-safe: no main execution block.
 
+_octo_stable_script_paths() {
+    printf '%s\n' scripts/orchestrate.sh scripts/install-deps.sh \
+        scripts/helpers/check-providers.sh scripts/scheduler/octopus-scheduler.sh \
+        scripts/state-manager.sh scripts/octo-state.sh scripts/agent-registry.sh \
+        scripts/reactions.sh scripts/migrate-todos.sh scripts/claude-mem-bridge.sh
+}
+
+_octo_stable_wrapper() {
+    local quoted
+    printf -v quoted '%q' "$1"
+    printf '#!/usr/bin/env bash\nexec %s "$@"\n' "$quoted"
+}
+
+octo_stable_shim_source() {
+    local file="$1" rel="$2" first line token char decoded=""
+    [[ -f "$file" && ! -L "$file" ]] || return 1
+    { IFS= read -r first && IFS= read -r line; } < "$file" || return 1
+    [[ "$first" == '#!/usr/bin/env bash' && "$line" == 'exec '*' "$@"' ]] || return 1
+    token="${line#exec }"; token="${token% \"\$@\"}"
+    # Decode only backslash-escaped path characters. Never evaluate wrapper code.
+    while [[ -n "$token" ]]; do
+        char="${token:0:1}"; token="${token:1}"
+        if [[ "$char" == \\ ]]; then
+            [[ -n "$token" ]] || return 1
+            char="${token:0:1}"; token="${token:1}"
+        fi
+        decoded="$decoded$char"
+    done
+    case "$decoded" in /*/"$rel") ;; *) return 1 ;; esac
+    # Byte equality rejects appended code, extra lines, and altered quoting.
+    cmp -s "$file" <(_octo_stable_wrapper "$decoded") || return 1
+    printf '%s\n' "$decoded"
+}
+
+_octo_stable_destination_safe() {
+    local stable="$1" rel="$2" path="$1" part rest
+    [[ ! -L "$stable" && ( ! -e "$stable" || -d "$stable" ) ]] || return 1
+    rest="${rel%/*}"
+    while [[ -n "$rest" ]]; do
+        part="${rest%%/*}"
+        [[ "$part" != .. && -n "$part" ]] || return 1
+        path="$path/$part"
+        [[ ! -L "$path" && ( ! -e "$path" || -d "$path" ) ]] || return 1
+        if [[ "$rest" == */* ]]; then rest="${rest#*/}"; else rest=""; fi
+    done
+}
+
+octo_stable_shims_status() {
+    local root="$1" stable="$2" rel dst src target status=shim
+    [[ -x "$stable/scripts/orchestrate.sh" ]] || { printf 'invalid\n'; return 1; }
+    while IFS= read -r rel; do
+        dst="$stable/$rel"; src="$root/$rel"
+        if [[ -e "$dst" && -e "$src" && "$dst" -ef "$src" ]]; then
+            [[ "$rel" != scripts/orchestrate.sh ]] || status=ok
+            continue
+        fi
+        _octo_stable_destination_safe "$stable" "$rel" || { printf 'invalid\n'; return 1; }
+        [[ -e "$dst" || -L "$dst" ]] || continue
+        target="$(octo_stable_shim_source "$dst" "$rel")" || { printf 'invalid\n'; return 1; }
+        [[ "$target" == "$src" ]] || status=mismatch
+    done < <(_octo_stable_script_paths)
+    printf '%s\n' "$status"
+    [[ "$status" != mismatch ]]
+}
+
 octo_is_windows_git_bash() {
     local uname_s="${1:-}"
     if [[ -z "$uname_s" ]]; then
@@ -37,14 +102,18 @@ octo_write_stable_script_shim() {
     # being a symlink to src. See #521.
     [[ -e "$dst" && "$src" -ef "$dst" ]] && return 0
 
-    local quoted_src
-    printf -v quoted_src '%q' "$src"
-    mkdir -p "$(dirname "$dst")"
-    {
-        printf '%s\n' '#!/usr/bin/env bash'
-        printf 'exec %s "$@"\n' "$quoted_src"
-    } > "$dst"
-    chmod +x "$dst" 2>/dev/null || true
+    _octo_stable_destination_safe "$stable_root" "$rel_path" || return 1
+    if [[ -e "$dst" || -L "$dst" ]]; then
+        octo_stable_shim_source "$dst" "$rel_path" >/dev/null || return 1
+    fi
+    local tmp
+    mkdir -p "$(dirname "$dst")" || return 1
+    tmp="$(mktemp "$(dirname "$dst")/.octo-shim.XXXXXX")" || return 1
+    if ! { _octo_stable_wrapper "$src" > "$tmp" && chmod 755 "$tmp" && mv -f "$tmp" "$dst"; }; then
+        rm -f "$tmp"
+        return 1
+    fi
+    [[ -f "$dst" && -x "$dst" ]] && cmp -s "$dst" <(_octo_stable_wrapper "$src")
 }
 
 octo_discover_plugin_root() {
@@ -56,6 +125,8 @@ octo_discover_plugin_root() {
     # Strategy 1: CC marketplace cache (standard install path)
     local cache_base="${HOME}/.claude/plugins/cache/nyldn-plugins/octo"
     if [[ -d "$cache_base" ]]; then
+        # Preserve the existing newest-by-mtime discovery order.
+        # shellcheck disable=SC2012
         candidate="$(ls -1dt "$cache_base"/*/ 2>/dev/null | head -1)"
         candidate="${candidate%/}"
         if [[ -n "$candidate" && -f "${candidate}/scripts/orchestrate.sh" ]]; then
@@ -95,7 +166,8 @@ octo_ensure_stable_plugin_root() {
         plugin_root="$(octo_discover_plugin_root)" || true
     fi
 
-    [[ -n "$plugin_root" && -d "$plugin_root" ]] || return 1
+    [[ -n "$plugin_root" && -d "$plugin_root" && -f "$plugin_root/scripts/orchestrate.sh" && -x "$plugin_root/scripts/orchestrate.sh" ]] || return 1
+    plugin_root="$(cd "$plugin_root" && pwd -P)" || return 1
 
     mkdir -p "$(dirname "$stable_root")"
 
@@ -113,36 +185,45 @@ octo_ensure_stable_plugin_root() {
         fi
     fi
 
-    if [[ -L "$stable_root" || -f "$stable_root" ]]; then
-        rm -f "$stable_root" 2>/dev/null || true
+    if [[ -L "$stable_root" ]]; then
+        # Rename a prepared link over the old link without an unlink gap. -h on
+        # BSD and -T on GNU prevent following a destination symlink to a directory.
+        local staging
+        staging="$(mktemp -d "$(dirname "$stable_root")/.octo-link.XXXXXX")" || return 1
+        if ln -s "$plugin_root" "$staging/link" &&
+            { if [[ "$(uname -s)" == Darwin || "$(uname -s)" == *BSD ]]; then
+                mv -fh "$staging/link" "$stable_root"
+              else mv -fT "$staging/link" "$stable_root"; fi; }; then
+            rmdir "$staging"
+            [[ -x "$stable_root/scripts/orchestrate.sh" ]]
+            return $?
+        fi
+        rm -f "$staging/link"; rmdir "$staging"
+        return 1
     fi
-
-    if [[ ! -e "$stable_root" ]]; then
-        ln -s "$plugin_root" "$stable_root" 2>/dev/null || true
-    fi
-
-    if [[ -L "$stable_root" && -x "$stable_root/scripts/orchestrate.sh" ]]; then
-        return 0
-    fi
-
-    if [[ -e "$stable_root" && ! -d "$stable_root" ]]; then
-        rm -f "$stable_root" 2>/dev/null || true
+    [[ ! -e "$stable_root" || -d "$stable_root" ]] || return 1
+    if [[ ! -e "$stable_root" ]] && ln -s "$plugin_root" "$stable_root" 2>/dev/null; then
+        [[ -x "$stable_root/scripts/orchestrate.sh" ]]
+        return $?
     fi
 
     # Windows Git Bash often cannot create native symlinks without Developer
     # Mode/admin rights. Keep the stable path usable by writing tiny wrappers
     # for script entry points referenced by commands and skills.
-    mkdir -p "$stable_root"
-    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/orchestrate.sh"
-    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/install-deps.sh"
-    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/helpers/check-providers.sh"
-    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/scheduler/octopus-scheduler.sh"
-    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/state-manager.sh"
-    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/octo-state.sh"
-    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/agent-registry.sh"
-    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/reactions.sh"
-    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/migrate-todos.sh"
-    octo_write_stable_script_shim "$plugin_root" "$stable_root" "scripts/claude-mem-bridge.sh"
+    local rel src dst
+    # Preflight every destination before changing any existing wrapper.
+    while IFS= read -r rel; do
+        src="$plugin_root/$rel"; dst="$stable_root/$rel"
+        [[ -e "$src" && -e "$dst" && "$src" -ef "$dst" ]] && continue
+        _octo_stable_destination_safe "$stable_root" "$rel" || return 1
+        if [[ -e "$dst" || -L "$dst" ]]; then
+            octo_stable_shim_source "$dst" "$rel" >/dev/null || return 1
+        fi
+    done < <(_octo_stable_script_paths)
+    mkdir -p "$stable_root" || return 1
+    while IFS= read -r rel; do
+        octo_write_stable_script_shim "$plugin_root" "$stable_root" "$rel" || return 1
+    done < <(_octo_stable_script_paths)
 
     [[ -x "$stable_root/scripts/orchestrate.sh" ]]
 }

--- a/scripts/lib/usage-help.sh
+++ b/scripts/lib/usage-help.sh
@@ -32,6 +32,7 @@ _claude_octopus() {
 
     commands=(
         'auto:Smart routing - AI chooses best approach'
+        'guide:Find installed commands by task or topic without provider calls'
         'embrace:Full 4-phase Double Diamond workflow'
         'research:Phase 1 - Parallel exploration (alias: probe)'
         'probe:Phase 1 - Parallel exploration'

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -24,11 +24,18 @@ while [[ "$_octo_early_index" -lt "${#_octo_early_args[@]}" ]]; do
             break ;;
     esac
 done
-if [[ "$_octo_early_command" == "explain" ]] || \
-   [[ "$_octo_early_command" == "status" && "${_octo_early_args[$((_octo_early_index + 1))]:-}" == "--run" ]]; then
-    OCTOPUS_EARLY_ARTIFACT_READ_ONLY=true
-fi
-unset _octo_early_args _octo_early_index _octo_early_arg _octo_early_command
+case "$_octo_early_command" in
+    doctor|capabilities|cache-check|check-cache|security-audit|repair|handoff|profile|install-state)
+        OCTOPUS_EARLY_ARTIFACT_READ_ONLY=true
+        ;;
+    explain)
+        OCTOPUS_EARLY_ARTIFACT_READ_ONLY=true
+        ;;
+    status)
+        [[ "${_octo_early_args[$((_octo_early_index + 1))]:-}" == "--run" ]] && \
+            OCTOPUS_EARLY_ARTIFACT_READ_ONLY=true
+        ;;
+esac
 
 # Resolve the physical path (pwd -P) so SCRIPT_DIR points at the real install
 # directory even when the script is invoked through the ~/.claude-octopus/plugin
@@ -37,6 +44,40 @@ unset _octo_early_args _octo_early_index _octo_early_arg _octo_early_command
 # at itself (ELOOP). See #371.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Diagnostics and repair do not need the 70+ workflow libraries loaded below.
+# Dispatch them before those libraries initialize state, event logs, or probes.
+if [[ "${BASH_SOURCE[0]}" == "${0}" && "$_octo_early_index" -eq 0 ]]; then
+    _octo_early_tail=("${_octo_early_args[@]:1}")
+    case "$_octo_early_command" in
+        doctor) exec bash "${SCRIPT_DIR}/doctor.sh" "${_octo_early_tail[@]}" ;;
+        capabilities) exec bash "${SCRIPT_DIR}/capabilities.sh" "${_octo_early_tail[@]}" ;;
+        cache-check|check-cache) exec bash "${SCRIPT_DIR}/cache-check.sh" "${_octo_early_tail[@]}" ;;
+        security-audit) exec bash "${SCRIPT_DIR}/security-audit.sh" "${_octo_early_tail[@]}" ;;
+        repair) exec bash "${SCRIPT_DIR}/repair.sh" "${_octo_early_tail[@]}" ;;
+        handoff) exec bash "${SCRIPT_DIR}/handoff.sh" "${_octo_early_tail[@]}" ;;
+        profile) exec bash "${SCRIPT_DIR}/profile.sh" "${_octo_early_tail[@]}" ;;
+        install-state)
+            # shellcheck source=lib/lifecycle.sh
+            source "${SCRIPT_DIR}/lib/lifecycle.sh"
+            case "${_octo_early_tail[0]:-show}" in
+                record)
+                    [[ "${#_octo_early_tail[@]}" -eq 1 ]] || { printf 'Usage: %s install-state [show|record]\n' "$(basename "$0")" >&2; exit 2; }
+                    octo_lifecycle_record_install
+                    printf 'Install state recorded at %s\n' "$OCTO_LIFECYCLE_STATE_FILE"
+                    ;;
+                show|status|--json)
+                    [[ "${#_octo_early_tail[@]}" -le 1 ]] || { printf 'Usage: %s install-state [show|record]\n' "$(basename "$0")" >&2; exit 2; }
+                    octo_lifecycle_state_json
+                    ;;
+                *) printf 'Unknown install-state action: %s\n' "${_octo_early_tail[0]}" >&2; exit 2 ;;
+            esac
+            exit 0
+            ;;
+    esac
+    unset _octo_early_tail
+fi
+unset _octo_early_args _octo_early_index _octo_early_arg _octo_early_command
 source "${SCRIPT_DIR}/lib/plugin-root.sh" 2>/dev/null || true
 
 # Self-heal: ensure the stable symlink exists for LLM Bash tool access.
@@ -135,6 +176,7 @@ source "${SCRIPT_DIR}/agent-teams-bridge.sh"
 source "${SCRIPT_DIR}/lib/common.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/utils.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/state-root.sh"
+source "${SCRIPT_DIR}/lib/lifecycle.sh"
 source "${SCRIPT_DIR}/lib/session-id.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/similarity.sh" 2>/dev/null || true
 source "${SCRIPT_DIR}/lib/models.sh" 2>/dev/null || true
@@ -2266,7 +2308,7 @@ init_ci_mode
 validate_autonomy_mode || exit $?
 
 # Artifact-only run inspection must not invoke even provider version probes.
-OCTOPUS_ARTIFACT_READ_ONLY=false
+OCTOPUS_ARTIFACT_READ_ONLY="$OCTOPUS_EARLY_ARTIFACT_READ_ONLY"
 if [[ "${1:-}" == "explain" ]] || \
    [[ "${1:-}" == "status" && "${2:-}" == "--run" ]]; then
     OCTOPUS_ARTIFACT_READ_ONLY=true
@@ -2844,6 +2886,41 @@ case "$COMMAND" in
         ;;
     doctor)
         do_doctor "$@"
+        ;;
+    capabilities)
+        bash "${SCRIPT_DIR}/capabilities.sh" "$@"
+        ;;
+    cache-check|check-cache)
+        bash "${SCRIPT_DIR}/cache-check.sh" "$@"
+        ;;
+    security-audit)
+        bash "${SCRIPT_DIR}/security-audit.sh" "$@"
+        ;;
+    repair)
+        bash "${SCRIPT_DIR}/repair.sh" "$@"
+        ;;
+    handoff)
+        bash "${SCRIPT_DIR}/handoff.sh" "$@"
+        ;;
+    profile)
+        bash "${SCRIPT_DIR}/profile.sh" "$@"
+        ;;
+    install-state)
+        case "${1:-show}" in
+            record)
+                [[ $# -eq 1 ]] || { printf 'Usage: %s install-state [show|record]\n' "$(basename "$0")" >&2; exit 2; }
+                octo_lifecycle_record_install
+                printf 'Install state recorded at %s\n' "$OCTO_LIFECYCLE_STATE_FILE"
+                ;;
+            show|status|--json)
+                [[ $# -le 1 ]] || { printf 'Usage: %s install-state [show|record]\n' "$(basename "$0")" >&2; exit 2; }
+                octo_lifecycle_state_json
+                ;;
+            *)
+                printf 'Unknown install-state action: %s\n' "$1" >&2
+                exit 2
+                ;;
+        esac
         ;;
     update-plugin)
         octo_plugin_update_run "$PLUGIN_DIR" "$OCTOPUS_HOST"

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -25,7 +25,7 @@ while [[ "$_octo_early_index" -lt "${#_octo_early_args[@]}" ]]; do
     esac
 done
 case "$_octo_early_command" in
-    doctor|capabilities|cache-check|check-cache|security-audit|repair|handoff|profile|install-state)
+    guide|doctor|capabilities|cache-check|check-cache|security-audit|repair|handoff|profile|install-state)
         OCTOPUS_EARLY_ARTIFACT_READ_ONLY=true
         ;;
     explain)
@@ -50,6 +50,15 @@ PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
 if [[ "${BASH_SOURCE[0]}" == "${0}" && "$_octo_early_index" -eq 0 ]]; then
     _octo_early_tail=("${_octo_early_args[@]:1}")
     case "$_octo_early_command" in
+        guide) exec python3 "${SCRIPT_DIR}/guide.py" "${_octo_early_tail[@]}" ;;
+        auto)
+            if [[ "${#_octo_early_tail[@]}" -eq 1 ]]; then
+                case "${_octo_early_tail[0]}" in
+                    help|list|commands|capabilities|options|workflows)
+                        exec python3 "${SCRIPT_DIR}/guide.py" list ;;
+                esac
+            fi
+            ;;
         doctor) exec bash "${SCRIPT_DIR}/doctor.sh" "${_octo_early_tail[@]}" ;;
         capabilities) exec bash "${SCRIPT_DIR}/capabilities.sh" "${_octo_early_tail[@]}" ;;
         cache-check|check-cache) exec bash "${SCRIPT_DIR}/cache-check.sh" "${_octo_early_tail[@]}" ;;
@@ -2886,6 +2895,9 @@ case "$COMMAND" in
         ;;
     doctor)
         do_doctor "$@"
+        ;;
+    guide)
+        python3 "${SCRIPT_DIR}/guide.py" "$@"
         ;;
     capabilities)
         bash "${SCRIPT_DIR}/capabilities.sh" "$@"

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Show or persist the lightweight context profile.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=lib/lifecycle.sh
+source "$SCRIPT_DIR/lib/lifecycle.sh"
+# shellcheck source=lib/user-config.sh
+source "$SCRIPT_DIR/lib/user-config.sh"
+
+case "${1:-show}" in
+    show|status)
+        [[ $# -le 1 ]] || { printf 'Usage: %s [show|core|orchestration|full]\n' "$(basename "$0")" >&2; exit 2; }
+        octo_lifecycle_profile
+        ;;
+    core|orchestration|full)
+        [[ $# -eq 1 ]] || { printf 'Usage: %s [show|core|orchestration|full]\n' "$(basename "$0")" >&2; exit 2; }
+        octo_config_write context_profile "\"$1\""
+        persisted="$(octo_config_read context_profile "")"
+        if [[ "$persisted" != "$1" ]]; then
+            printf 'Unable to persist context profile: %s\n' "$1" >&2
+            exit 1
+        fi
+        printf 'context profile: %s\n' "$1"
+        ;;
+    --help|-h)
+        printf 'Usage: %s [show|core|orchestration|full]\n' "$(basename "$0")"
+        ;;
+    *)
+        printf 'Unknown profile: %s\n' "$1" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/repair.sh
+++ b/scripts/repair.sh
@@ -70,6 +70,6 @@ if [[ "$OUTPUT" == json ]]; then
     printf '%s\n' "$report"
 else
     printf 'Claude Octopus repair (%s)\n' "$mode"
-    jq -r '"  plugin root: \(.plugin_root)\n  stable root: \(.stable_root)\n  status: \(.status)\n  action: \(.action)"' <<<"$report"
+    jq -r '"  plugin root: \(.plugin_root)\n  stable root: \(.stable_root)\n  status: \(.status)\n  action: \(.action)\n  result: \(.result)"' <<<"$report"
 fi
 [[ "$result" == ready ]]

--- a/scripts/repair.sh
+++ b/scripts/repair.sh
@@ -43,6 +43,7 @@ case "$status" in
     missing) action="create stable plugin root" ;;
     broken) action="replace broken stable plugin link" ;;
     mismatch) action="replace stale stable plugin link" ;;
+    invalid-target) action="manual review required: plugin target failed validation"; result=blocked ;;
     invalid) action="manual review required: stable path is not an Octopus link or shim"; result=blocked ;;
     *) action="manual review required: plugin root is unavailable"; result=blocked ;;
 esac

--- a/scripts/repair.sh
+++ b/scripts/repair.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Conservative repair for the Octopus-owned stable plugin root.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+APPLY=false
+OUTPUT=human
+mode_seen=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --apply)
+            [[ -z "$mode_seen" || "$mode_seen" == apply ]] || { printf 'Choose either --apply or --dry-run\n' >&2; exit 2; }
+            APPLY=true; mode_seen=apply
+            ;;
+        --dry-run)
+            [[ -z "$mode_seen" || "$mode_seen" == dry-run ]] || { printf 'Choose either --apply or --dry-run\n' >&2; exit 2; }
+            APPLY=false; mode_seen=dry-run
+            ;;
+        --json) OUTPUT=json ;;
+        --help|-h)
+            printf 'Usage: %s [--dry-run|--apply] [--json]\n' "$(basename "$0")"
+            exit 0
+            ;;
+        *) printf 'Unknown repair option: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+command -v jq >/dev/null 2>&1 || { printf 'repair requires jq\n' >&2; exit 1; }
+# shellcheck source=lib/lifecycle.sh
+source "$SCRIPT_DIR/lib/lifecycle.sh"
+# shellcheck source=lib/plugin-root.sh
+source "$SCRIPT_DIR/lib/plugin-root.sh"
+
+root="$(octo_lifecycle_plugin_root)"
+stable="$OCTO_LIFECYCLE_STABLE_ROOT"
+status="$(octo_lifecycle_stable_root_status "$root" 2>/dev/null || true)"
+action=none
+result=ready
+
+case "$status" in
+    ok|shim) ;;
+    missing) action="create stable plugin root" ;;
+    broken) action="replace broken stable plugin link" ;;
+    mismatch) action="replace stale stable plugin link" ;;
+    invalid) action="manual review required: stable path is not an Octopus link or shim"; result=blocked ;;
+    *) action="manual review required: plugin root is unavailable"; result=blocked ;;
+esac
+
+if [[ "$APPLY" == true && "$result" == ready && "$status" != ok && "$status" != shim ]]; then
+    if octo_ensure_stable_plugin_root "$root" "$stable" >/dev/null 2>&1; then
+        status="$(octo_lifecycle_stable_root_status "$root" 2>/dev/null || true)"
+        case "$status" in ok|shim) ;; *) result=failed ;; esac
+    else
+        result=failed
+    fi
+fi
+if [[ "$APPLY" == true && "$result" == ready ]]; then
+    octo_lifecycle_record_install >/dev/null 2>&1 || result=state-write-failed
+fi
+
+mode=dry-run
+[[ "$APPLY" == true ]] && mode=apply
+report="$(jq -cn --arg mode "$mode" --arg root "$root" --arg stable "$stable" \
+    --arg status "$status" --arg action "$action" --arg result "$result" \
+    '{schema:1,mode:$mode,plugin_root:$root,stable_root:$stable,status:$status,
+      action:$action,result:$result}')"
+if [[ "$OUTPUT" == json ]]; then
+    printf '%s\n' "$report"
+else
+    printf 'Claude Octopus repair (%s)\n' "$mode"
+    jq -r '"  plugin root: \(.plugin_root)\n  stable root: \(.stable_root)\n  status: \(.status)\n  action: \(.action)"' <<<"$report"
+fi
+[[ "$result" == ready ]]

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -43,7 +43,11 @@ fi
 
 manifest_failures=0
 manifest_count=0
-for manifest in "$ROOT_DIR/.claude-plugin/plugin.json" "$ROOT_DIR/.codex-plugin/plugin.json"; do
+for manifest in \
+    "$ROOT_DIR/.claude-plugin/plugin.json" \
+    "$ROOT_DIR/.codex-plugin/plugin.json" \
+    "$ROOT_DIR/.cursor-plugin/plugin.json" \
+    "$ROOT_DIR/.factory-plugin/plugin.json"; do
     [[ -e "$manifest" ]] || continue
     manifest_count=$((manifest_count + 1))
     jq -e 'type == "object" and (.name | type == "string") and (.version | type == "string")' \

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Offline, non-destructive checks for the installed plugin files.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DIR="${OCTOPUS_SECURITY_AUDIT_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd -P)}"
+OUTPUT=human
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json|json) OUTPUT=json ;;
+        --help|-h) printf 'Usage: %s [--json]\n' "$(basename "$0")"; exit 0 ;;
+        *) printf 'Unknown security-audit option: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+command -v jq >/dev/null 2>&1 || { printf 'security-audit requires jq\n' >&2; exit 1; }
+
+checks='[]'
+failures=0
+add_check() {
+    local name="$1" status="$2" detail="$3"
+    checks="$(jq -cn --argjson checks "$checks" --arg name "$name" --arg status "$status" \
+        --arg detail "$detail" '$checks + [{name:$name,status:$status,detail:$detail}]')"
+    [[ "$status" != fail ]] || failures=$((failures + 1))
+}
+
+syntax_failures=0
+while IFS= read -r -d '' file; do
+    bash -n "$file" >/dev/null 2>&1 || syntax_failures=$((syntax_failures + 1))
+done < <(find "$ROOT_DIR/hooks" "$ROOT_DIR/scripts" -type f -name '*.sh' -print0 2>/dev/null)
+if [[ "$syntax_failures" -eq 0 ]]; then
+    add_check shell-syntax pass "all hook and script shell files parse"
+else
+    add_check shell-syntax fail "$syntax_failures shell file(s) failed bash -n"
+fi
+
+if [[ -f "$ROOT_DIR/hooks/hooks.json" ]] && jq -e 'type == "object" and (.hooks | type == "object")' \
+      "$ROOT_DIR/hooks/hooks.json" >/dev/null 2>&1; then
+    add_check hooks-manifest pass "hook manifest is valid JSON"
+else
+    add_check hooks-manifest fail "hook manifest is missing, invalid, or lacks a hooks object"
+fi
+
+manifest_failures=0
+manifest_count=0
+for manifest in "$ROOT_DIR/.claude-plugin/plugin.json" "$ROOT_DIR/.codex-plugin/plugin.json"; do
+    [[ -e "$manifest" ]] || continue
+    manifest_count=$((manifest_count + 1))
+    jq -e 'type == "object" and (.name | type == "string") and (.version | type == "string")' \
+        "$manifest" >/dev/null 2>&1 || manifest_failures=$((manifest_failures + 1))
+done
+if [[ "$manifest_failures" -gt 0 ]]; then
+    add_check plugin-manifests fail "$manifest_failures plugin manifest(s) are invalid"
+elif [[ "$manifest_count" -gt 0 ]]; then
+    add_check plugin-manifests pass "$manifest_count plugin manifest(s) are valid"
+else
+    add_check plugin-manifests warn "no plugin manifests were present in the selected root"
+fi
+
+if command -v rg >/dev/null 2>&1; then
+    risk_patterns="$(rg -n --hidden --glob '*.sh' --glob '!tests/**' \
+        '(^|[[:space:]])eval[[:space:]]|curl[^|]*\|[[:space:]]*(bash|sh)|chmod[[:space:]]+777' \
+        "$ROOT_DIR/hooks" "$ROOT_DIR/scripts" 2>/dev/null || true)"
+    if [[ -n "$risk_patterns" ]]; then
+        add_check shell-risk-patterns warn "reviewable high-risk shell patterns found"
+    else
+        add_check shell-risk-patterns pass "no high-risk shell patterns found"
+    fi
+
+    host_paths="$(rg -n --hidden --glob '*.sh' --glob '!tests/**' \
+        --glob '!security-audit.sh' --glob '!validate-no-hardcoded-paths.sh' \
+        '(/Users/[^/$[:space:]]+|/home/[^/$[:space:]]+|[A-Za-z]:\\\\Users\\\\[^%$[:space:]]+)' \
+        "$ROOT_DIR/hooks" "$ROOT_DIR/scripts" 2>/dev/null || true)"
+    if [[ -n "$host_paths" ]]; then
+        add_check host-specific-paths warn "host-specific absolute paths found"
+    else
+        add_check host-specific-paths pass "no host-specific absolute paths found"
+    fi
+else
+    add_check shell-risk-patterns warn "ripgrep is unavailable; shell risk scan was skipped"
+    add_check host-specific-paths warn "ripgrep is unavailable; host path scan was skipped"
+fi
+
+report="$(jq -cn --argjson checks "$checks" --argjson failures "$failures" \
+    '{schema:1,failures:$failures,checks:$checks}')"
+if [[ "$OUTPUT" == json ]]; then
+    printf '%s\n' "$report"
+else
+    printf 'Claude Octopus local security audit\n'
+    jq -r '.checks[] | "  \(.status)\t\(.name)\t\(.detail)"' <<<"$report"
+fi
+[[ "$failures" -eq 0 ]]

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -69,7 +69,7 @@ if command -v rg >/dev/null 2>&1; then
 
     host_paths="$(rg -n --hidden --glob '*.sh' --glob '!tests/**' \
         --glob '!security-audit.sh' --glob '!validate-no-hardcoded-paths.sh' \
-        '(/Users/[^/$[:space:]]+|/home/[^/$[:space:]]+|[A-Za-z]:\\\\Users\\\\[^%$[:space:]]+)' \
+        '([/]Users[/][^/$[:space:]]+|[/]home[/][^/$[:space:]]+|[A-Za-z]:\\\\Users\\\\[^%$[:space:]]+)' \
         "$ROOT_DIR/hooks" "$ROOT_DIR/scripts" 2>/dev/null || true)"
     if [[ -n "$host_paths" ]]; then
         add_check host-specific-paths warn "host-specific absolute paths found"

--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -14,7 +14,7 @@ disable-model-invocation: true
 
 ## Overview
 
-Run environment diagnostics across 14 check categories. Doctor 2.0 identifies
+Run environment diagnostics across 15 check categories. Doctor 2.0 identifies
 misconfigured providers, stale loaded or cached plugin versions, invalid plugin
 assembly, unwritable state, non-terminal run records, orphan process evidence,
 broken hooks, and other issues that prevent Claude Octopus from working
@@ -42,18 +42,18 @@ correctly.
 
 ### Step 1: Resolve Plugin Root and Run Full Diagnostics
 
-Use this resolver before running Octopus scripts. Do not assume
-`~/.claude-octopus/plugin` exists; Windows Git Bash installs may not support the
-stable symlink. Run this as a single Bash call.
+Use this resolver before running Octopus scripts. Prefer the active host root,
+then the stable root or the installed CLI. Do not create or replace a stable
+link while collecting diagnostics. Run this as a single Bash call.
 
 ```bash
-OCTO_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+OCTO_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-}}"
 if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
   OCTO_PLUGIN_ROOT="${HOME}/.claude-octopus/plugin"
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]] && command -v octopus >/dev/null 2>&1; then
   OCTO_BIN="$(command -v octopus)"
-  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd)"
+  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd -P)"
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
   OCTO_PLUGIN_ROOT="$(
@@ -68,18 +68,13 @@ if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" 
   echo "Claude Octopus plugin root not found. Reinstall the octo plugin, then retry doctor diagnostics."
   exit 1
 fi
-mkdir -p "${HOME}/.claude-octopus"
-_octo_stable="${HOME}/.claude-octopus/plugin"
-if [[ ! -L "$_octo_stable" ]] || [[ "$(cd "$OCTO_PLUGIN_ROOT" 2>/dev/null && pwd -P)" != "$(cd "$_octo_stable" 2>/dev/null && pwd -P)" ]]; then
-  [[ -L "$_octo_stable" || -f "$_octo_stable" ]] && rm -f "$_octo_stable" 2>/dev/null || true
-  ln -s "$OCTO_PLUGIN_ROOT" "$_octo_stable" 2>/dev/null || true
-fi
-unset _octo_stable
 export OCTO_PLUGIN_ROOT
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor --verbose
 ```
 
-This runs all 14 check categories and displays a formatted report.
+This runs all 15 check categories and displays a formatted report. The
+installation category reports a missing or mismatched stable root; it does not
+repair it.
 
 ### Step 2: Filter by Category (Optional)
 
@@ -104,6 +99,7 @@ bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor conflicts
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor agents
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor recurrence
 bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor cache
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" doctor installation
 ```
 
 ### Step 3: Check & Install Dependencies
@@ -163,7 +159,26 @@ Access, the Antigravity CLI item, and its Access Control settings.
 
 ### Step 5: Interactive Remediation (MANDATORY for fixable issues)
 
-After running diagnostics, if ANY fixable issues are found, you MUST use AskUserQuestion to offer fixes. Do NOT just print instructions — offer to execute them.
+After running diagnostics, if ANY fixable issues are found, you MUST use
+AskUserQuestion to offer fixes. Do not just print instructions. Offer to
+execute them.
+
+Stable-root repair is bounded and requires explicit authorization. First show
+the proposed change with:
+
+```bash
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" repair --dry-run
+```
+
+Only after the user authorizes that exact repair may you run:
+
+```bash
+bash "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" repair --apply
+```
+
+Never recreate the stable link in the resolver or as an automatic doctor
+follow-up. Cache cleanup, stale PID cleanup, login flows, package installation,
+and plugin updates also require explicit confirmation.
 
 Before each accepted repair, restate the exact target and action. Configuration
 repairs must use a validated sibling temporary file and atomic rename; if any
@@ -251,6 +266,7 @@ Offer to run the login command for the expired provider.
 | `agents` | Agent definitions, worktree isolation, CLI registration, version compatibility |
 | `recurrence` | Failure pattern detection — flags repeated quality gate failures, source hotspots, 48h trends |
 | `cache` | Cache size, freshness, and hygiene |
+| `installation` | Loaded plugin root, stable root, host-scoped install metadata, and context profile |
 
 Software dependency installation is checked separately by
 `scripts/install-deps.sh check` in Step 3, including Node.js, jq, provider CLIs,
@@ -290,40 +306,54 @@ All checks pass — no action needed.
 | All checks pass, user still has issues | Suggest `/octo:debug` for deeper investigation |
 
 
-## Hook Profile
+## Context and intensity profiles
 
-Claude Octopus hooks can run in different profiles to balance cost and coverage.
+The installation report exposes two optional context settings:
 
-Current profile: `$OCTO_HOOK_PROFILE` (default: standard)
+- `OCTOPUS_CONTEXT_PROFILE` selects `core`, `orchestration`, or `full` context
+  behavior. The `octopus profile` command reads and writes this setting.
+- `OCTOPUS_HOOK_PROFILE` can override the optional context-hook profile with
+  `core`, `orchestration`, or `full`.
 
-Available profiles:
-- **minimal** — Only session lifecycle and cost tracking hooks (lowest overhead)
-- **standard** — All hooks except expensive review/security gates (default)
-- **strict** — All hooks enabled including quality and security gates
+These settings control optional context work only. They never disable safety or
+lifecycle hooks. A missing or invalid hook-profile registry fails closed.
 
-Override: Set `OCTO_PROFILE=budget|balanced|quality` or `OCTO_DISABLED_HOOKS=hook1,hook2` to fine-tune. Legacy `OCTO_HOOK_PROFILE` still works (minimal→budget, standard→balanced, strict→quality).
+`OCTO_PROFILE` is a separate legacy intensity setting with `budget`,
+`balanced`, and `quality` values. It is not an alias for either context
+setting, and it must not be used to claim that safety hooks are disabled.
 
 
-## Intensity Profile
+## Legacy intensity profile
 
-The doctor reports the active intensity profile — a single knob controlling hook gating, model selection, phase skipping, and context verbosity.
+Some older workflow paths use `OCTO_PROFILE` as an intensity setting for model
+selection, phase skipping, and context verbosity. This setting is separate
+from the optional context-hook profiles above.
 
 ### What the Doctor Checks
 
-- **Current profile**: `OCTO_PROFILE` value (budget/balanced/quality, default: balanced)
-- **Profile source**: env var, legacy `OCTO_HOOK_PROFILE`, or auto-selected from intent
-- **Hook gating**: which hooks are enabled/disabled at this profile level
+- **Context profile**: `OCTOPUS_CONTEXT_PROFILE` value, default `core`
+- **Optional hook profile**: `OCTOPUS_HOOK_PROFILE` when set, otherwise the
+  context profile
+- **Legacy intensity**: `OCTO_PROFILE` when a legacy workflow reads it
+- **Hook gating**: optional context hooks only; safety and lifecycle hooks remain
+  active
 - **Model hints**: which model (sonnet/opus) is recommended for each phase
 - **Context verbosity**: compressed/standard/full
 
-### Profile Summary
+### Legacy intensity summary
 
 | Dimension | budget | balanced | quality |
 |-----------|--------|----------|---------|
-| Hooks | essential only | standard (no quality gates) | all hooks |
 | Models | Sonnet everywhere | Sonnet + Opus for synthesis | Opus for most phases |
 | Phases | Skip discover if context given | Skip re-discovery | All phases run |
 | Context | Compressed | Standard | Full inlining |
+
+### Optional context profile summary
+
+| Dimension | core | orchestration | full |
+|-----------|------|----------------|------|
+| Optional context hooks | Off | Workflow context only | All profile-managed context hooks |
+| Safety and lifecycle hooks | Active | Active | Active |
 
 
 ## Project Tier Hint
@@ -374,7 +404,7 @@ Invoke this manual skill explicitly, or run the CLI directly:
 
 | What to say / run | Action |
 |-------------------|--------|
-| `/octo:skill-doctor` | Run all 14 categories inside Claude Code |
+| `/octo:skill-doctor` | Run all 15 categories inside Claude Code |
 | `octopus doctor providers` | Check provider installation only |
 | `octopus doctor auth --verbose` | Detailed auth status |
 | `octopus doctor --json` | Machine-readable output |

--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -53,7 +53,25 @@ if [[ -z "$OCTO_PLUGIN_ROOT" || ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" 
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]] && command -v octopus >/dev/null 2>&1; then
   OCTO_BIN="$(command -v octopus)"
-  OCTO_PLUGIN_ROOT="$(cd "$(dirname "$OCTO_BIN")/.." && pwd -P)"
+  OCTO_LINK_HOPS=0
+  while [[ -L "$OCTO_BIN" ]]; do
+    OCTO_LINK_HOPS=$((OCTO_LINK_HOPS + 1))
+    if [[ "$OCTO_LINK_HOPS" -le 40 ]]; then
+      OCTO_BIN_DIR="$(cd -P "$(dirname "$OCTO_BIN")" 2>/dev/null && pwd -P)" || { OCTO_BIN=""; break; }
+      OCTO_LINK_TARGET="$(readlink "$OCTO_BIN")" || { OCTO_BIN=""; break; }
+      case "$OCTO_LINK_TARGET" in
+        /*) OCTO_BIN="$OCTO_LINK_TARGET" ;;
+        *) OCTO_BIN="$OCTO_BIN_DIR/$OCTO_LINK_TARGET" ;;
+      esac
+    else
+      OCTO_BIN=""
+      break
+    fi
+  done
+  if [[ -n "$OCTO_BIN" ]]; then
+    OCTO_BIN_DIR="$(cd -P "$(dirname "$OCTO_BIN")" 2>/dev/null && pwd -P)" || OCTO_BIN_DIR=""
+    [[ -z "$OCTO_BIN_DIR" ]] || OCTO_PLUGIN_ROOT="$(cd "$OCTO_BIN_DIR/.." 2>/dev/null && pwd -P)"
+  fi
 fi
 if [[ ! -x "$OCTO_PLUGIN_ROOT/scripts/orchestrate.sh" ]]; then
   OCTO_PLUGIN_ROOT="$(

--- a/tests/changed-scope.tsv
+++ b/tests/changed-scope.tsv
@@ -8,6 +8,19 @@ scripts/lib/model-resolver.sh	tests/unit/test-resolve-model.sh tests/unit/test-a
 scripts/lib/preflight.sh	tests/unit/test-agy-provider.sh tests/unit/test-provider-availability-parity.sh tests/unit/test-provider-banner-auth.sh tests/unit/test-provider-registry*.sh tests/test-version-check.sh
 scripts/lib/run-contract.sh	tests/unit/test-run-contract-v10.sh tests/unit/test-agent-sync-run-contract.sh tests/unit/test-spawn-run-contract.sh tests/unit/test-v10-cancellation-recovery.sh tests/unit/test-run-observability-v10.sh
 scripts/lib/doctor.sh	tests/unit/test-doctor-v10.sh tests/unit/test-agy-provider.sh tests/unit/test-windows-doctor-compat.sh
+scripts/lib/lifecycle.sh	tests/unit/test-install-readiness.sh tests/unit/test-doctor-v10.sh
+scripts/lib/hook-activation.sh	tests/unit/test-install-readiness.sh tests/unit/test-explicit-activation.sh tests/unit/test-post-tool-dispatch.sh
+scripts/lib/cache-hygiene.sh	tests/unit/test-cache-hygiene.sh tests/unit/test-install-readiness.sh
+scripts/capabilities.sh	tests/unit/test-install-readiness.sh tests/unit/test-provider-readiness-contract.sh
+scripts/cache-check.sh	tests/unit/test-install-readiness.sh tests/unit/test-cache-hygiene.sh
+scripts/repair.sh	tests/unit/test-install-readiness.sh tests/unit/test-ensure-plugin-root.sh tests/unit/test-plugin-root-shim.sh
+scripts/security-audit.sh	tests/unit/test-install-readiness.sh
+scripts/handoff.sh	tests/unit/test-install-readiness.sh tests/unit/test-handoff.sh
+scripts/profile.sh	tests/unit/test-install-readiness.sh
+hooks/context-reinforcement.sh	tests/unit/test-install-readiness.sh tests/unit/test-explicit-activation.sh
+hooks/post-tool-dispatch.sh	tests/unit/test-install-readiness.sh tests/unit/test-post-tool-dispatch.sh
+hooks/session-start-memory.sh	tests/unit/test-install-readiness.sh tests/unit/test-setup-state.sh
+bin/octopus	tests/unit/test-install-readiness.sh tests/smoke/test-packaging-integrity.sh
 scripts/helpers/check-providers.sh	tests/unit/test-provider-readiness-contract.sh tests/unit/test-provider-contract-audit.sh tests/unit/test-provider-auth-validity.sh tests/unit/test-provider-availability-parity.sh tests/unit/test-provider-health-probe.sh tests/unit/test-agy-provider.sh
 scripts/helpers/audit-provider-contracts.sh	tests/unit/test-provider-contract-audit.sh
 scripts/helpers/preflight.sh	tests/unit/test-provider-readiness-contract.sh tests/smoke/test-preflight-json.sh tests/unit/test-agy-provider.sh

--- a/tests/changed-scope.tsv
+++ b/tests/changed-scope.tsv
@@ -9,6 +9,13 @@ scripts/lib/preflight.sh	tests/unit/test-agy-provider.sh tests/unit/test-provide
 scripts/lib/run-contract.sh	tests/unit/test-run-contract-v10.sh tests/unit/test-agent-sync-run-contract.sh tests/unit/test-spawn-run-contract.sh tests/unit/test-v10-cancellation-recovery.sh tests/unit/test-run-observability-v10.sh
 scripts/lib/doctor.sh	tests/unit/test-doctor-v10.sh tests/unit/test-agy-provider.sh tests/unit/test-windows-doctor-compat.sh
 scripts/lib/lifecycle.sh	tests/unit/test-install-readiness.sh tests/unit/test-doctor-v10.sh
+scripts/lib/install-root.sh	tests/unit/test-install-root-safety.sh tests/unit/test-install-readiness.sh
+scripts/lib/lifecycle.sh	tests/unit/test-install-root-safety.sh
+scripts/lib/plugin-root.sh	tests/unit/test-install-root-safety.sh
+scripts/cache-check.sh	tests/unit/test-install-root-safety.sh
+scripts/repair.sh	tests/unit/test-install-root-safety.sh
+scripts/guide.py	tests/unit/test-command-discovery.sh tests/smoke/test-packaging-integrity.sh
+bin/octopus	tests/unit/test-command-discovery.sh
 scripts/lib/hook-activation.sh	tests/unit/test-install-readiness.sh tests/unit/test-explicit-activation.sh tests/unit/test-post-tool-dispatch.sh
 scripts/lib/cache-hygiene.sh	tests/unit/test-cache-hygiene.sh tests/unit/test-install-readiness.sh
 scripts/capabilities.sh	tests/unit/test-install-readiness.sh tests/unit/test-provider-readiness-contract.sh

--- a/tests/integration/test-plugin-lifecycle.sh
+++ b/tests/integration/test-plugin-lifecycle.sh
@@ -1,361 +1,225 @@
 #!/bin/bash
-# tests/integration/test-plugin-lifecycle.sh
-# Tests plugin installation, verification, and uninstallation
+# Hermetic lifecycle checks for the current plugin candidate.
+# Native Claude CLI installation is opt-in and still uses an isolated host home.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+SCRIPT_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
+
+# shellcheck source=tests/helpers/test-framework.sh
 source "$SCRIPT_DIR/../helpers/test-framework.sh"
 
-test_suite "Plugin Lifecycle"
+test_suite "Plugin lifecycle isolation"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+candidate_command() (
+    local home="$1"
+    local host="$2"
+    local root="$3"
+    shift 3
+    cd "$home" || return 1
 
-#==============================================================================
-# Setup and Cleanup
-#==============================================================================
+    case "$host" in
+        claude)
+            env -i HOME="$home" CLAUDE_CONFIG_DIR="$home/.claude" \
+                TMPDIR="$home/tmp" PATH="$PATH" \
+                OCTOPUS_HOST=claude CLAUDE_PLUGIN_ROOT="$root" \
+                OCTOPUS_INSTALL_SCOPE=user "$PROJECT_ROOT/bin/octopus" "$@"
+            ;;
+        codex)
+            env -i HOME="$home" CLAUDE_CONFIG_DIR="$home/.claude" TMPDIR="$home/tmp" \
+                CODEX_HOME="$home/.codex" PATH="$PATH" OCTOPUS_HOST=codex \
+                CODEX_PLUGIN_ROOT="$root" OCTOPUS_INSTALL_SCOPE=user \
+                "$PROJECT_ROOT/bin/octopus" "$@"
+            ;;
+        *)
+            printf 'Unsupported test host: %s\n' "$host" >&2
+            return 2
+            ;;
+    esac
+)
 
-setup_test_env() {
-    # Save original state if plugin is installed
-    ORIGINAL_STATE=$(claude plugin list 2>/dev/null | grep -c "octo" || echo "0")
-
-    # Ensure clean state for testing
-    if [[ "$ORIGINAL_STATE" != "0" ]]; then
-        echo -e "${YELLOW}  → Uninstalling existing plugin for clean test...${NC}"
-        claude plugin uninstall octo --scope user 2>/dev/null || true
-        rm -rf ~/.claude/plugins/cache/nyldn-plugins/octo 2>/dev/null || true
-    fi
-}
-
-restore_original_state() {
-    if [[ "$ORIGINAL_STATE" != "0" ]]; then
-        echo -e "${YELLOW}  → Restoring original plugin state...${NC}"
-        claude plugin marketplace add https://github.com/nyldn/claude-octopus 2>/dev/null || true
-        claude plugin install octo@nyldn-plugins --scope user 2>/dev/null || true
-    fi
-}
-
-#==============================================================================
-# Test: Claude CLI Available
-#==============================================================================
-
-test_claude_cli_available() {
-    test_case "Claude CLI is available"
-
-    if ! command -v claude &>/dev/null; then
-        test_skip "Claude CLI not found in PATH"
-        return 0
-    fi
-
-    test_pass
-}
-
-#==============================================================================
-# Test: Add Marketplace
-#==============================================================================
-
-test_add_marketplace() {
-    test_case "Add nyldn/claude-octopus marketplace"
-
-    if ! command -v claude &>/dev/null; then
-        test_skip "Claude CLI not available"
-        return 0
-    fi
-
-    # Add marketplace
-    local output=$(claude plugin marketplace add https://github.com/nyldn/claude-octopus 2>&1)
-    local exit_code=$?
-
-    # Check if marketplace was added or already exists
-    if [[ $exit_code -eq 0 ]] || echo "$output" | grep -qi "already exists\|already added"; then
-        test_pass
-    else
-        test_fail "Failed to add marketplace: $output"
-    fi
-}
-
-#==============================================================================
-# Test: Install Plugin
-#==============================================================================
-
-test_install_plugin() {
-    test_case "Install octo@nyldn-plugins"
-
-    if ! command -v claude &>/dev/null; then
-        test_skip "Claude CLI not available"
-        return 0
-    fi
-
-    # Install plugin
-    local output=$(claude plugin install octo@nyldn-plugins --scope user 2>&1)
-    local exit_code=$?
-
-    if [[ $exit_code -ne 0 ]]; then
-        test_fail "Installation failed: $output"
-        return 1
-    fi
-
-    # Wait briefly for installation to complete
-    sleep 2
-
-    test_pass
-}
-
-#==============================================================================
-# Test: Verify Plugin Installed
-#==============================================================================
-
-test_verify_installed() {
-    test_case "Verify plugin appears in list"
-
-    if ! command -v claude &>/dev/null; then
-        test_skip "Claude CLI not available"
-        return 0
-    fi
-
-    local output=$(claude plugin list 2>&1)
-
-    if echo "$output" | grep -q "octo"; then
-        test_pass
-    else
-        test_fail "Plugin not found in list: $output"
-    fi
-}
-
-#==============================================================================
-# Test: Verify Plugin Files Exist
-#==============================================================================
-
-test_verify_files_exist() {
-    test_case "Verify plugin files were installed"
-
-    if ! command -v claude &>/dev/null; then
-        test_skip "Claude CLI not available"
-        return 0
-    fi
-
-    # Check for plugin files in cache directory
-    local cache_dir="$HOME/.claude/plugins/cache/nyldn-plugins/octo"
-
-    if [[ ! -d "$cache_dir" ]]; then
-        test_fail "Plugin cache directory not found: $cache_dir"
-        return 1
-    fi
-
-    # Find the version directory (e.g., 4.9.4)
-    local version_dir=$(find "$cache_dir" -maxdepth 1 -type d ! -name "octo" -exec basename {} \; | head -1)
-
-    if [[ -z "$version_dir" ]]; then
-        test_fail "No version directory found in $cache_dir"
-        return 1
-    fi
-
-    local plugin_dir="$cache_dir/$version_dir"
-
-    # Check for critical plugin files
-    local required_files=(
-        ".claude-plugin/plugin.json"
-        ".claude-plugin/marketplace.json"
-        "scripts/orchestrate.sh"
+isolated_claude() {
+    local home="$1"
+    shift
+    (
+        cd "$home" || return 1
+        env -i HOME="$home" CLAUDE_CONFIG_DIR="$home/.claude" \
+            TMPDIR="$home/tmp" PATH="$PATH" \
+            DISABLE_TELEMETRY=1 CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+            claude "$@"
     )
+}
 
-    for file in "${required_files[@]}"; do
-        if [[ ! -f "$plugin_dir/$file" ]]; then
-            test_fail "Required file missing: $file (looked in $plugin_dir)"
-            return 1
+test_legacy_safety_regression() {
+    test_case "lifecycle suite cannot target a real host or remote marketplace"
+    local unsafe=""
+    local legacy_home_delete="rm -""rf ~/"
+    local legacy_remote="https""://"
+    local legacy_status="local output=\$""(claude"
+    local match
+    for match in "$legacy_home_delete" "$legacy_remote" "$legacy_status"; do
+        if grep -Fn -- "$match" "$SCRIPT_PATH" >/dev/null 2>&1; then
+            unsafe="${unsafe}${unsafe:+; }$match"
         fi
     done
-
-    test_pass
-}
-
-#==============================================================================
-# Test: Verify Plugin Configuration
-#==============================================================================
-
-test_verify_plugin_config() {
-    test_case "Verify plugin.json is valid"
-
-    if ! command -v claude &>/dev/null; then
-        test_skip "Claude CLI not available"
-        return 0
-    fi
-
-    local cache_dir="$HOME/.claude/plugins/cache/nyldn-plugins/octo"
-    local version_dir=$(find "$cache_dir" -maxdepth 1 -type d ! -name "octo" -exec basename {} \; | head -1)
-
-    if [[ -z "$version_dir" ]]; then
-        test_fail "No version directory found"
-        return 1
-    fi
-
-    local plugin_json="$cache_dir/$version_dir/.claude-plugin/plugin.json"
-
-    if [[ ! -f "$plugin_json" ]]; then
-        test_fail "plugin.json not found at $plugin_json"
-        return 1
-    fi
-
-    # Verify JSON is valid and contains expected fields
-    if ! command -v jq &>/dev/null; then
-        test_skip "jq not available for JSON validation"
-        return 0
-    fi
-
-    local name=$(jq -r '.name' "$plugin_json" 2>/dev/null)
-    local skills=$(jq -r '.skills | length' "$plugin_json" 2>/dev/null)
-
-    if [[ "$name" != "octo" ]]; then
-        test_fail "Plugin name mismatch: expected 'octo', got '$name'"
-        return 1
-    fi
-
-    if [[ "$skills" -lt 1 ]]; then
-        test_fail "No skills defined in plugin.json"
-        return 1
-    fi
-
-    test_pass
-}
-
-#==============================================================================
-# Test: Update Plugin
-#==============================================================================
-
-test_update_plugin() {
-    test_case "Update plugin to latest version"
-
-    if ! command -v claude &>/dev/null; then
-        test_skip "Claude CLI not available"
-        return 0
-    fi
-
-    # Update plugin
-    local output=$(claude plugin update octo --scope user 2>&1)
-    local exit_code=$?
-
-    # Update may say "already up to date" which is fine
-    if [[ $exit_code -eq 0 ]] || echo "$output" | grep -qi "up to date\|already at latest"; then
+    if [[ -z "$unsafe" ]] && grep -Fq 'CLAUDE_CONFIG_DIR=' "$SCRIPT_PATH"; then
         test_pass
     else
-        test_fail "Update failed: $output"
+        test_fail "unsafe lifecycle pattern found: ${unsafe:-missing CLAUDE_CONFIG_DIR isolation}"
     fi
 }
 
-#==============================================================================
-# Test: Uninstall Plugin
-#==============================================================================
+test_claude_failure_status_is_preserved() {
+    test_case "Claude command failures retain their original status"
+    local stub_bin="$TEST_TMP_DIR/status-bin"
+    local home="$TEST_TMP_DIR/status-home"
+    local output rc=0
+    mkdir -p "$stub_bin" "$home/.claude" "$home/tmp"
+    {
+        printf '%s\n' '#!/bin/bash'
+        printf '%s\n' 'printf "stub failure\\n" >&2'
+        printf '%s\n' 'exit 23'
+    } > "$stub_bin/claude"
+    chmod +x "$stub_bin/claude"
 
-test_uninstall_plugin() {
-    test_case "Uninstall octo plugin"
-
-    if ! command -v claude &>/dev/null; then
-        test_skip "Claude CLI not available"
-        return 0
+    if output="$(PATH="$stub_bin:$PATH" isolated_claude "$home" plugin list 2>&1)"; then
+        rc=0
+    else
+        rc=$?
     fi
-
-    # Uninstall plugin
-    local output=$(claude plugin uninstall octo --scope user 2>&1)
-    local exit_code=$?
-
-    if [[ $exit_code -ne 0 ]]; then
-        test_fail "Uninstallation failed: $output"
-        return 1
-    fi
-
-    # Wait briefly for uninstallation to complete
-    sleep 1
-
-    test_pass
-}
-
-#==============================================================================
-# Test: Verify Plugin Removed
-#==============================================================================
-
-test_verify_removed() {
-    test_case "Verify plugin no longer in list"
-
-    if ! command -v claude &>/dev/null; then
-        test_skip "Claude CLI not available"
-        return 0
-    fi
-
-    local output=$(claude plugin list 2>&1)
-
-    # Plugin should not appear in list (or should show as not installed)
-    if echo "$output" | grep -q "octo.*enabled"; then
-        test_fail "Plugin still appears as enabled: $output"
-        return 1
-    fi
-
-    test_pass
-}
-
-#==============================================================================
-# Test: Reinstall After Uninstall
-#==============================================================================
-
-test_reinstall() {
-    test_case "Reinstall plugin after uninstall"
-
-    if ! command -v claude &>/dev/null; then
-        test_skip "Claude CLI not available"
-        return 0
-    fi
-
-    # Reinstall
-    local output=$(claude plugin install octo@nyldn-plugins --scope user 2>&1)
-    local exit_code=$?
-
-    if [[ $exit_code -ne 0 ]]; then
-        test_fail "Reinstallation failed: $output"
-        return 1
-    fi
-
-    # Wait briefly
-    sleep 2
-
-    # Verify it's back
-    local list_output=$(claude plugin list 2>&1)
-    if echo "$list_output" | grep -q "octo"; then
+    if [[ "$rc" -eq 23 && "$output" == "stub failure" ]]; then
         test_pass
     else
-        test_fail "Plugin not found after reinstall"
+        test_fail "Claude failure was swallowed (exit=$rc output=${output:-<empty>})"
     fi
 }
 
-#==============================================================================
-# Run All Tests
-#==============================================================================
+test_candidate_lifecycle_is_hermetic() {
+    test_case "candidate health commands preserve isolated host and user state"
+    local home="$TEST_TMP_DIR/candidate-home"
+    local state="$home/.claude-octopus/install-state.json"
+    local sentinel="$home/.claude-octopus/results/user-result.txt"
+    local before after repair_json missing_rc=0 failures=0
+    mkdir -p "$(dirname "$sentinel")" "$home/.claude" "$home/.codex" "$home/tmp"
+    printf '%s\n' 'keep-user-result' > "$sentinel"
 
-main() {
-    echo -e "${YELLOW}Setting up test environment...${NC}"
-    setup_test_env
+    candidate_command "$home" claude "$PROJECT_ROOT" install-state record \
+        > "$TEST_TMP_DIR/claude-record.log" 2>&1 || failures=$((failures + 1))
+    candidate_command "$home" codex "$PROJECT_ROOT" install-state record \
+        > "$TEST_TMP_DIR/codex-record.log" 2>&1 || failures=$((failures + 1))
+    candidate_command "$home" claude "$PROJECT_ROOT" install-state record \
+        > "$TEST_TMP_DIR/claude-rerecord.log" 2>&1 || failures=$((failures + 1))
 
-    # Run test sequence
-    test_claude_cli_available || exit 1
-    test_add_marketplace
-    test_install_plugin
-    test_verify_installed
-    test_verify_files_exist
-    test_verify_plugin_config
-    test_update_plugin
-    test_uninstall_plugin
-    test_verify_removed
-    test_reinstall
-    test_uninstall_plugin  # Clean up after test
+    before="$(cksum "$state" 2>/dev/null || true)"
+    if candidate_command "$home" claude "$home/missing-candidate" install-state record \
+        > "$TEST_TMP_DIR/missing-root.log" 2>&1; then
+        missing_rc=0
+    else
+        missing_rc=$?
+    fi
+    after="$(cksum "$state" 2>/dev/null || true)"
 
-    echo -e "\n${YELLOW}Restoring original state...${NC}"
-    restore_original_state
+    repair_json="$(candidate_command "$home" claude "$PROJECT_ROOT" \
+        repair --dry-run --json 2>/dev/null || true)"
 
-    test_summary
+    if [[ "$failures" -eq 0 && "$missing_rc" -ne 0 && "$before" == "$after" ]] &&
+       [[ ! -e "$home/.claude-octopus/plugin" ]] &&
+       [[ "$(cat "$sentinel" 2>/dev/null || true)" == "keep-user-result" ]] &&
+       jq -e --arg root "$PROJECT_ROOT" '
+           .schema == 2 and (.hosts | keys | sort) == ["claude","codex"] and
+           .hosts.claude.plugin_root == $root and
+           .hosts.codex.plugin_root == $root
+       ' "$state" >/dev/null 2>&1 &&
+       jq -e '.mode == "dry-run" and .status == "missing" and .result == "ready"' \
+           <<<"$repair_json" >/dev/null 2>&1; then
+        test_pass
+    else
+        test_fail "candidate lifecycle isolation failed (commands=$failures missing-exit=$missing_rc)"
+    fi
 }
 
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    main "$@"
-fi
+run_native_claude_acceptance() {
+    test_case "opt-in Claude lifecycle installs the local candidate"
+    if [[ "${OCTOPUS_RUN_CLAUDE_LIFECYCLE_ACCEPTANCE:-0}" != "1" ]]; then
+        test_skip "set OCTOPUS_RUN_CLAUDE_LIFECYCLE_ACCEPTANCE=1 to run isolated native acceptance"
+        return 0
+    fi
+    if ! command -v claude >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+        test_skip "Claude CLI and jq are required for native acceptance"
+        return 0
+    fi
+
+    local home="$TEST_TMP_DIR/native-home"
+    local marketplace="$TEST_TMP_DIR/local-marketplace"
+    local sentinel="$home/.claude-octopus/results/user-result.txt"
+    local candidate_version output rc=0 failures=0
+    mkdir -p "$home/.claude" "$home/tmp" "$(dirname "$sentinel")" \
+        "$marketplace/.claude-plugin" "$marketplace/plugins"
+    printf '%s\n' 'keep-user-result' > "$sentinel"
+    ln -s "$PROJECT_ROOT" "$marketplace/plugins/candidate"
+    candidate_version="$(jq -r '.version' "$PROJECT_ROOT/.claude-plugin/plugin.json")"
+    jq -n --arg version "$candidate_version" '{
+        name:"octopus-candidate",
+        owner:{name:"acceptance"},
+        plugins:[{name:"octo",source:"./plugins/candidate",version:$version}]
+    }' > "$marketplace/.claude-plugin/marketplace.json"
+
+    if output="$(isolated_claude "$home" plugin marketplace add "$marketplace" 2>&1)"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    [[ "$rc" -eq 0 ]] || { printf '%s\n' "$output" >&2; failures=$((failures + 1)); }
+
+    if output="$(isolated_claude "$home" plugin install octo@octopus-candidate --scope user 2>&1)"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    [[ "$rc" -eq 0 ]] || { printf '%s\n' "$output" >&2; failures=$((failures + 1)); }
+
+    if output="$(isolated_claude "$home" plugin list 2>&1)"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    [[ "$rc" -eq 0 && "$output" == *"octo"* ]] || failures=$((failures + 1))
+
+    if output="$(isolated_claude "$home" plugin update octo --scope user 2>&1)"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    [[ "$rc" -eq 0 ]] || { printf '%s\n' "$output" >&2; failures=$((failures + 1)); }
+
+    if output="$(isolated_claude "$home" plugin uninstall octo --scope user 2>&1)"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    [[ "$rc" -eq 0 ]] || { printf '%s\n' "$output" >&2; failures=$((failures + 1)); }
+
+    if output="$(isolated_claude "$home" plugin list 2>&1)"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    [[ "$rc" -eq 0 && "$output" != *"octo@octopus-candidate"* ]] || \
+        failures=$((failures + 1))
+
+    if [[ "$failures" -eq 0 ]] &&
+       [[ "$(cat "$sentinel" 2>/dev/null || true)" == "keep-user-result" ]]; then
+        test_pass
+    else
+        test_fail "isolated native lifecycle had $failures failure(s) or changed user data"
+    fi
+}
+
+test_legacy_safety_regression
+test_claude_failure_status_is_preserved
+test_candidate_lifecycle_is_hermetic
+run_native_claude_acceptance
+
+test_summary

--- a/tests/smoke/test-packaging-integrity.sh
+++ b/tests/smoke/test-packaging-integrity.sh
@@ -21,10 +21,175 @@ trap cleanup_packaging_fixture EXIT INT TERM
 
 ORCHESTRATE="$PROJECT_ROOT/scripts/orchestrate.sh"
 
+packaged_health_command() (
+    local package_root="$1"
+    local home="$2"
+    local host="$3"
+    local active_root="$4"
+    shift 4
+    cd "$home" || return 1
+
+    case "$host" in
+        claude)
+            env -i HOME="$home" CLAUDE_CONFIG_DIR="$home/.claude" \
+                TMPDIR="$home/tmp" PATH="$PATH" \
+                OCTOPUS_HOST=claude CLAUDE_PLUGIN_ROOT="$active_root" \
+                OCTOPUS_INSTALL_SCOPE=user "$package_root/bin/octopus" "$@"
+            ;;
+        codex)
+            env -i HOME="$home" CLAUDE_CONFIG_DIR="$home/.claude" TMPDIR="$home/tmp" \
+                CODEX_HOME="$home/.codex" PATH="$PATH" OCTOPUS_HOST=codex \
+                CODEX_PLUGIN_ROOT="$active_root" OCTOPUS_INSTALL_SCOPE=user \
+                "$package_root/bin/octopus" "$@"
+            ;;
+        *) return 2 ;;
+    esac
+)
+
+packaged_home_snapshot() {
+    local home="$1"
+    {
+        find "$home" -mindepth 1 -print 2>/dev/null
+        find "$home" -mindepth 1 -exec ls -ldn {} \; 2>/dev/null
+        find "$home" -type f -exec cksum {} \; 2>/dev/null
+        find "$home" -type l -exec readlink {} \; 2>/dev/null
+    } | LC_ALL=C sort | cksum
+}
+
+validate_extracted_lifecycle_contract() {
+    local package_root="$1"
+    local active_root
+    local home="$PACKAGING_FIXTURE_DIR/health-home"
+    local state="$home/.claude-octopus/install-state.json"
+    local sentinel="$home/.claude-octopus/results/user-result.txt"
+    local missing_root="$home/missing-active-root"
+    local expected_version version show_json doctor_json missing_doctor_json repair_json
+    local before after before_dry after_dry before_records after_records rc=0
+
+    active_root="$(cd "$package_root" && pwd -P)" || return 1
+    mkdir -p "$(dirname "$sentinel")" "$home/.claude" "$home/.codex" "$home/tmp" || return 1
+    printf '%s\n' 'keep-user-result' > "$sentinel"
+    expected_version="$(jq -r '.version' "$package_root/.claude-plugin/plugin.json")"
+    if version="$(packaged_health_command "$package_root" "$home" claude \
+        "$active_root" version 2>&1)"; then
+        :
+    else
+        printf 'packaged version command failed\n'
+        return 1
+    fi
+    if [[ "$version" != "$expected_version" ]]; then
+        printf 'packaged version mismatch: expected %s, got %s\n' "$expected_version" "$version"
+        return 1
+    fi
+
+    packaged_health_command "$package_root" "$home" claude "$active_root" \
+        install-state record >/dev/null 2>&1 || return 1
+    packaged_health_command "$package_root" "$home" codex "$active_root" \
+        install-state record >/dev/null 2>&1 || return 1
+    before_records="$(jq -c '.hosts | with_entries(.value |= del(.recorded_at))' "$state")"
+    packaged_health_command "$package_root" "$home" claude "$active_root" \
+        install-state record >/dev/null 2>&1 || return 1
+    packaged_health_command "$package_root" "$home" codex "$active_root" \
+        install-state record >/dev/null 2>&1 || return 1
+    after_records="$(jq -c '.hosts | with_entries(.value |= del(.recorded_at))' "$state")"
+
+    if [[ "$before_records" != "$after_records" ]] ||
+       ! jq -e --arg root "$active_root" --arg version "$expected_version" '
+        .schema == 2 and (.hosts | keys | sort) == ["claude","codex"] and
+        .hosts.claude.plugin_root == $root and
+        .hosts.codex.plugin_root == $root and
+        .hosts.claude.plugin_version == $version and
+        .hosts.codex.plugin_version == $version and
+        .hosts.claude.install_scope == "user" and
+        .hosts.codex.install_scope == "user"
+    ' "$state" >/dev/null 2>&1; then
+        printf 'repeated recording did not preserve exactly one record for each host\n'
+        return 1
+    fi
+    if show_json="$(packaged_health_command "$package_root" "$home" codex \
+        "$active_root" install-state show 2>/dev/null)"; then
+        :
+    else
+        printf 'packaged install-state show failed\n'
+        return 1
+    fi
+    if ! jq -e '.current == true and .recorded.host == "codex"' \
+        <<<"$show_json" >/dev/null 2>&1; then
+        printf 'repeated host record is not current\n'
+        return 1
+    fi
+
+    if doctor_json="$(packaged_health_command "$package_root" "$home" claude \
+        "$active_root" doctor installation --json 2>/dev/null)"; then
+        :
+    else
+        printf 'packaged installation doctor failed for the candidate\n'
+        return 1
+    fi
+    if ! jq -e '
+        any(.results[]; .name == "install-state" and .status == "pass") and
+        any(.results[]; .name == "stable-plugin-root" and .status == "warn")
+    ' <<<"$doctor_json" >/dev/null 2>&1; then
+        printf 'packaged installation doctor omitted lifecycle evidence\n'
+        return 1
+    fi
+
+    before="$(cksum "$state")"
+    if packaged_health_command "$package_root" "$home" claude "$missing_root" \
+        install-state record >/dev/null 2>&1; then
+        printf 'missing active root was recorded\n'
+        return 1
+    else
+        rc=$?
+    fi
+    after="$(cksum "$state")"
+    if [[ "$rc" -eq 0 || "$before" != "$after" ]]; then
+        printf 'missing active root changed the saved host records\n'
+        return 1
+    fi
+    rc=0
+    if missing_doctor_json="$(packaged_health_command "$package_root" "$home" claude \
+        "$missing_root" doctor installation --json 2>/dev/null)"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [[ "$rc" -eq 0 ]] || ! jq -e '
+        any(.results[]; .category == "installation" and .status == "fail")
+    ' <<<"$missing_doctor_json" >/dev/null 2>&1; then
+        printf 'installation doctor did not reject a missing active root\n'
+        return 1
+    fi
+
+    before_dry="$(packaged_home_snapshot "$home")"
+    if repair_json="$(packaged_health_command "$package_root" "$home" claude \
+        "$active_root" repair --dry-run --json 2>/dev/null)"; then
+        :
+    else
+        printf 'packaged repair dry-run failed\n'
+        return 1
+    fi
+    after_dry="$(packaged_home_snapshot "$home")"
+    if [[ "$before_dry" != "$after_dry" || -e "$home/.claude-octopus/plugin" ]] ||
+       ! jq -e '.mode == "dry-run" and .status == "missing" and .result == "ready"' \
+           <<<"$repair_json" >/dev/null 2>&1; then
+        printf 'repair dry-run changed isolated host state\n'
+        return 1
+    fi
+    if [[ "$(cat "$sentinel" 2>/dev/null || true)" != "keep-user-result" ]]; then
+        printf 'lifecycle health commands changed user data\n'
+        return 1
+    fi
+}
+
 test_public_publication_boundary() {
     test_case "public checkout excludes private development material"
     local output
-    if output=$(bash "$PROJECT_ROOT/scripts/validate-no-hardcoded-paths.sh" 2>&1); then
+    local boundary_home="$TEST_TMP_DIR/public-boundary-home"
+    mkdir -p "$boundary_home/npm-cache" "$boundary_home/tmp"
+    if output=$(env -i HOME="$boundary_home" TMPDIR="$boundary_home/tmp" PATH="$PATH" \
+        NPM_CONFIG_CACHE="$boundary_home/npm-cache" NPM_CONFIG_USERCONFIG=/dev/null \
+        bash "$PROJECT_ROOT/scripts/validate-no-hardcoded-paths.sh" 2>&1); then
         test_pass
     else
         test_fail "public publication boundary failed: $output"
@@ -178,8 +343,13 @@ test_extracted_archive_contract() {
     fi
     npm_error="$PACKAGING_FIXTURE_DIR/npm-pack.stderr"
     extract_dir="$PACKAGING_FIXTURE_DIR/extracted"
-    mkdir -p "$extract_dir"
-    if ! pack_json=$(cd "$PROJECT_ROOT" && npm pack --ignore-scripts --json --pack-destination "$PACKAGING_FIXTURE_DIR" 2>"$npm_error"); then
+    mkdir -p "$extract_dir" "$PACKAGING_FIXTURE_DIR/npm-home" "$PACKAGING_FIXTURE_DIR/npm-cache"
+    if ! pack_json=$(cd "$PROJECT_ROOT" && env -i \
+        HOME="$PACKAGING_FIXTURE_DIR/npm-home" PATH="$PATH" \
+        TMPDIR="$PACKAGING_FIXTURE_DIR/npm-home" \
+        NPM_CONFIG_CACHE="$PACKAGING_FIXTURE_DIR/npm-cache" NPM_CONFIG_USERCONFIG=/dev/null \
+        npm pack --ignore-scripts --json --pack-destination "$PACKAGING_FIXTURE_DIR" \
+        2>"$npm_error"); then
         result="$(tr '\n' ' ' < "$npm_error")"
         cleanup_packaging_fixture
         test_fail "npm pack failed: ${result:-no diagnostics}"
@@ -278,11 +448,18 @@ PYTEST
     else
         status=$?
     fi
+    if [[ "$status" -eq 0 ]]; then
+        if result="$(validate_extracted_lifecycle_contract "$package_root")"; then
+            status=0
+        else
+            status=$?
+        fi
+    fi
     cleanup_packaging_fixture
     if [[ "$status" -eq 0 ]]; then
         test_pass
     else
-        test_fail "extracted archive is incomplete: $result"
+        test_fail "extracted archive contract failed: ${result:-no diagnostics}"
         return 1
     fi
 }

--- a/tests/unit/fixtures/env-var-effects.tsv
+++ b/tests/unit/fixtures/env-var-effects.tsv
@@ -7,6 +7,8 @@
 # OCTOPUS_COMMANDCODE_PERMISSION_MODE) and no test noticed.
 #
 # Format: <VAR><TAB><kind><TAB><detail>
+OCTOPUS_CONTEXT_PROFILE	covered-by	test-install-readiness.sh
+OCTOPUS_HOOK_PROFILE	covered-by	test-install-readiness.sh
 #   covered-by  <test file>  a suite that exercises this variable's effect
 #   skip        <reason>     real variable, assertion impractical — reason required
 #   placeholder <note>       not a variable; a template fragment in docs

--- a/tests/unit/test-audit-followup.sh
+++ b/tests/unit/test-audit-followup.sh
@@ -170,17 +170,6 @@ if [[ "$first_input" == 100 && -z "$_PARSED_INPUT_TOKENS" && "$_PARSED_CACHE_WRI
     test_pass
 else test_fail "cache token suffix overwrote uncached input"; fi
 
-test_case "packaging archive fixture uses suite-owned cleanup and preserves npm diagnostics"
-packaging_test="$PROJECT_ROOT/tests/smoke/test-packaging-integrity.sh"
-if grep -Fq 'for required_tool in npm jq tar python3' "$packaging_test" &&
-   grep -Fq 'PACKAGING_FIXTURE_DIR="$TEST_TMP_DIR/' "$packaging_test" &&
-   grep -Fq 'npm pack --ignore-scripts --json --pack-destination "$PACKAGING_FIXTURE_DIR" 2>"$npm_error"' "$packaging_test" &&
-   grep -Fq 'trap cleanup_packaging_fixture EXIT INT TERM' "$packaging_test"; then
-    test_pass
-else
-    test_fail "packaging fixture prerequisites, diagnostics, or cleanup are not explicit"
-fi
-
 test_case "Codex safety contract is a framework suite with a separate Python test module"
 safety_wrapper="$PROJECT_ROOT/tests/unit/test-codex-safety-contract.sh"
 safety_python="$PROJECT_ROOT/tests/unit/codex_safety_contract_test.py"

--- a/tests/unit/test-cache-hygiene.sh
+++ b/tests/unit/test-cache-hygiene.sh
@@ -149,4 +149,11 @@ test_clean_skips_active
 test_clean_removes_stale
 test_format_bytes
 
+test_case "cache ordering is numeric and ignores files and non-release directories"
+cache="$TEST_TMP_DIR/version-order"
+mkdir -p "$cache/11.9.0" "$cache/11.10.0" "$cache/11.4.2" "$cache/zz-not-a-version"
+touch "$cache/99.0.0"
+out="$(bash -c 'source "$1"; octo_cache_versions "$2"' _ "$LIB" "$cache" | tr '\n' ',')"
+if [[ "$out" == "11.4.2,11.9.0,11.10.0," ]]; then test_pass; else test_fail "incorrect version catalog: $out"; fi
+
 test_summary

--- a/tests/unit/test-command-discovery.sh
+++ b/tests/unit/test-command-discovery.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+test_suite "Installed command discovery"
+
+test_case "guide lists only commands declared by the installed manifest"
+output="$(HOME="$TEST_TMP_DIR" "$PROJECT_ROOT/bin/octopus" guide --json 2>/dev/null || true)"
+if jq -e --slurpfile manifest "$PROJECT_ROOT/.claude-plugin/plugin.json" '
+    .commands | length == ($manifest[0].commands | length)' <<<"$output" >/dev/null 2>&1 &&
+    [[ ! -d "$TEST_TMP_DIR/.claude-octopus" ]]; then test_pass; else test_fail "guide missing, incomplete, or initialized state"; fi
+
+test_case "automatic help uses the same provider-free catalog"
+auto_output="$(HOME="$TEST_TMP_DIR" "$PROJECT_ROOT/scripts/orchestrate.sh" auto help 2>/dev/null || true)"
+if [[ "$auto_output" == *"/octo:setup"* && "$auto_output" == *"/octo:auto"* && ! -d "$TEST_TMP_DIR/.claude-octopus" ]]; then
+    test_pass
+else test_fail "auto help did not return the installed catalog without workflow state"; fi
+
+test_case "public explain command reaches its runtime parser"
+output="$(HOME="$TEST_TMP_DIR" "$PROJECT_ROOT/bin/octopus" explain --help 2>&1 || true)"
+if [[ "$output" != *"Unknown octopus command"* && "$output" == *"explain"* ]]; then test_pass; else test_fail "explain is not dispatched"; fi
+
+test_case "legacy setup alias reaches setup"
+output="$(HOME="$TEST_TMP_DIR" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$PROJECT_ROOT/hooks/user-prompt-submit.sh" <<< '{"prompt":"/octo:sys-setup"}' 2>/dev/null || true)"
+if [[ "$output" == *"Alias resolved: /octo:sys-setup -> /octo:setup"* ]]; then test_pass; else test_fail "sys-setup does not resolve to setup"; fi
+test_summary

--- a/tests/unit/test-command-discovery.sh
+++ b/tests/unit/test-command-discovery.sh
@@ -24,4 +24,48 @@ if [[ "$output" != *"Unknown octopus command"* && "$output" == *"explain"* ]]; t
 test_case "legacy setup alias reaches setup"
 output="$(HOME="$TEST_TMP_DIR" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" bash "$PROJECT_ROOT/hooks/user-prompt-submit.sh" <<< '{"prompt":"/octo:sys-setup"}' 2>/dev/null || true)"
 if [[ "$output" == *"Alias resolved: /octo:sys-setup -> /octo:setup"* ]]; then test_pass; else test_fail "sys-setup does not resolve to setup"; fi
+test_case "guide preserves readable entries when one command is damaged"
+if python3 - "$PROJECT_ROOT" "$TEST_TMP_DIR" <<'PY'
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+root = Path(sys.argv[2]) / "guide-fixture"
+(root / "scripts").mkdir(parents=True)
+(root / ".claude-plugin").mkdir()
+(root / "commands").mkdir()
+shutil.copyfile(Path(sys.argv[1]) / "scripts/guide.py", root / "scripts/guide.py")
+(root / ".claude-plugin/plugin.json").write_text(json.dumps({"version": "test", "commands": ["commands/good.md", "commands/bad.md"]}))
+(root / "commands/good.md").write_text('---\ndescription: "Valid entry"\n---\n')
+(root / "commands/bad.md").write_text("Missing frontmatter\n")
+result = subprocess.run([sys.executable, str(root / "scripts/guide.py"), "--json"], capture_output=True, text=True)
+assert result.returncode == 0, result.stderr
+assert json.loads(result.stdout)["commands"] == [{"command": "/octo:good", "description": "Valid entry"}]
+assert "bad.md" in result.stderr, result.stderr
+PY
+then test_pass; else test_fail "one damaged entry disabled the guide"; fi
+
+test_case "guide and doctor choose the same root when both hosts are set"
+if python3 - "$PROJECT_ROOT" <<'PY'
+from pathlib import Path
+import os
+import re
+import subprocess
+import sys
+root = Path(sys.argv[1])
+resolved = []
+for relative in ("commands/guide.md", "skills/skill-doctor/SKILL.md"):
+    match = re.search(r'^OCTO_(?:PLUGIN_)?ROOT=(.+)$', (root / relative).read_text(), re.MULTILINE)
+    assert match, relative
+    result = subprocess.run(["bash", "-c", 'selected=' + match.group(1) + '; printf "%s" "$selected"'], env={**os.environ, "CLAUDE_PLUGIN_ROOT": "/claude", "CODEX_PLUGIN_ROOT": "/codex"}, capture_output=True, text=True, check=True)
+    resolved.append(result.stdout)
+assert resolved == ["/claude", "/claude"], resolved
+PY
+then test_pass; else test_fail "host root precedence differs"; fi
+
+test_case "unknown CLI commands return a usage error"
+rc=0
+output="$(HOME="$TEST_TMP_DIR" "$PROJECT_ROOT/bin/octopus" not-a-command 2>&1)" || rc=$?
+if [[ "$rc" == 2 && "$output" == *"Unknown octopus command"* ]]; then test_pass; else test_fail "unknown command did not return exit 2"; fi
 test_summary

--- a/tests/unit/test-install-readiness.sh
+++ b/tests/unit/test-install-readiness.sh
@@ -17,6 +17,19 @@ SECURITY_AUDIT="$PROJECT_ROOT/scripts/security-audit.sh"
 PROFILE="$PROJECT_ROOT/scripts/profile.sh"
 HANDOFF="$PROJECT_ROOT/scripts/handoff.sh"
 
+portable_file_mode() {
+    local path="$1" value=""
+    if value="$(stat -f '%Lp' "$path" 2>/dev/null)"; then
+        printf '%s\n' "$value"
+        return 0
+    fi
+    if value="$(stat -c '%a' "$path" 2>/dev/null)"; then
+        printf '%s\n' "$value"
+        return 0
+    fi
+    return 1
+}
+
 test_case "lifecycle state keeps Claude and Codex records separate"
 home="$TEST_TMP_DIR/lifecycle-home"
 state="$home/.claude-octopus/install-state.json"
@@ -162,6 +175,19 @@ else
     test_fail "repair changed or accepted an unowned regular file (exit=$blocked_rc)"
 fi
 
+test_case "repair human output explains install-state write failures"
+repair_state_rc=0
+repair_state_output="$(HOME="$repair_home" \
+    OCTOPUS_STABLE_PLUGIN_ROOT="$repair_home/.claude-octopus/plugin" \
+    OCTOPUS_INSTALL_STATE_FILE="/dev/null/install-state.json" \
+    CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$REPAIR" --apply 2>/dev/null)" || repair_state_rc=$?
+if [[ "$repair_state_rc" -ne 0 ]] &&
+   grep -Fq 'result: state-write-failed' <<<"$repair_state_output"; then
+    test_pass
+else
+    test_fail "repair hid the state-write-failed result (exit=$repair_state_rc)"
+fi
+
 test_case "capabilities render shared readiness states, not guessed auth booleans"
 cap_home="$TEST_TMP_DIR/capabilities-home"
 cap_bin="$TEST_TMP_DIR/capabilities-bin"
@@ -254,6 +280,30 @@ else
     test_fail "invalid hook manifest did not fail the audit (exit=$audit_rc)"
 fi
 
+test_case "security audit rejects malformed present Cursor and Factory manifests"
+adapter_audit_failures=0
+for adapter_manifest in .cursor-plugin/plugin.json .factory-plugin/plugin.json; do
+    adapter_root="$TEST_TMP_DIR/audit-${adapter_manifest%%/*}"
+    mkdir -p "$adapter_root/hooks" "$adapter_root/scripts" \
+        "$adapter_root/$(dirname "$adapter_manifest")"
+    printf '%s\n' '{"hooks":{}}' > "$adapter_root/hooks/hooks.json"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$adapter_root/scripts/ok.sh"
+    printf '%s\n' '{invalid' > "$adapter_root/$adapter_manifest"
+    adapter_rc=0
+    OCTOPUS_SECURITY_AUDIT_ROOT="$adapter_root" "$SECURITY_AUDIT" --json \
+        > "$adapter_root/audit.json" 2>/dev/null || adapter_rc=$?
+    if [[ "$adapter_rc" -eq 0 ]] ||
+       ! jq -e '.checks[] | select(.name == "plugin-manifests" and .status == "fail")' \
+           "$adapter_root/audit.json" >/dev/null 2>&1; then
+        adapter_audit_failures=$((adapter_audit_failures + 1))
+    fi
+done
+if [[ "$adapter_audit_failures" -eq 0 ]]; then
+    test_pass
+else
+    test_fail "$adapter_audit_failures adapter manifest audit(s) accepted malformed JSON"
+fi
+
 test_case "cache check validates the active cache rather than only the newest directory"
 cache_home="$TEST_TMP_DIR/cache-home"
 claude_cache="$cache_home/.claude/plugins/cache/nyldn-plugins/octo"
@@ -279,15 +329,33 @@ else
     test_fail "active invalid cache was not reported (exit=$cache_rc)"
 fi
 
+test_case "portable mode lookup discards output from a failed stat probe"
+stat_bin="$TEST_TMP_DIR/stat-bin"
+mkdir -p "$stat_bin"
+# shellcheck disable=SC2016 # Keep parameter expansion inside the generated fixture.
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'if [[ "$1" == -f ]]; then printf "filesystem details\\n"; exit 1; fi' \
+    'if [[ "$1" == -c ]]; then printf "600\\n"; exit 0; fi' \
+    'exit 2' > "$stat_bin/stat"
+chmod +x "$stat_bin/stat"
+mode="$(PATH="$stat_bin:$PATH" portable_file_mode "$TEST_TMP_DIR/unused")"
+if [[ "$mode" == "600" ]]; then
+    test_pass
+else
+    test_fail "failed stat probe polluted fallback mode: $mode"
+fi
+
 test_case "portable handoff export is structured, private, and redacted"
 handoff_home="$TEST_TMP_DIR/handoff-home"
 mkdir -p "$handoff_home/data"
 printf '%s\n' '{"workflow":"develop","current_phase":"build","status":"running","decisions":["OPENAI_API_KEY=do-not-export"]}' \
     > "$handoff_home/data/session.json"
+handoff_file="$TEST_TMP_DIR/portable-handoff.json"
 handoff_json="$(HOME="$handoff_home" CLAUDE_PLUGIN_DATA="$handoff_home/data" \
-    OCTOPUS_PROJECT_DIR="$PROJECT_ROOT" "$HANDOFF" export --json 2>/dev/null || true)"
-handoff_file="$handoff_home/.claude-octopus/handoffs/$(printf '%s' "$PROJECT_ROOT" | shasum -a 256 | cut -c1-16).json"
-mode="$(stat -f '%Lp' "$handoff_file" 2>/dev/null || stat -c '%a' "$handoff_file" 2>/dev/null || true)"
+    OCTOPUS_PROJECT_DIR="$PROJECT_ROOT" "$HANDOFF" export --json --out "$handoff_file" \
+    2>/dev/null || true)"
+mode="$(portable_file_mode "$handoff_file" || true)"
 if jq -e '.workflow == "develop" and .phase == "build" and
           (tostring | contains("do-not-export") | not)' <<<"$handoff_json" >/dev/null 2>&1 &&
    [[ "$mode" == "600" ]]; then
@@ -296,13 +364,23 @@ else
     test_fail "portable handoff was missing, unredacted, or not private"
 fi
 
+test_case "handoff project ID follows the lifecycle producer contract"
+expected_handoff_id="$(bash -c 'source "$1"; octo_lifecycle_handoff_id "$2"' \
+    _ "$LIFECYCLE_LIB" "$PROJECT_ROOT")"
+if jq -e --arg expected "$expected_handoff_id" '.project_id == $expected' \
+      <<<"$handoff_json" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "handoff project ID diverged from octo_lifecycle_handoff_id"
+fi
+
 test_case "handoff preserves existing output directory permissions"
 handoff_out="$TEST_TMP_DIR/shared-output"
 mkdir -p "$handoff_out"
 chmod 755 "$handoff_out"
 HOME="$handoff_home" CLAUDE_PLUGIN_DATA="$handoff_home/data" \
     "$HANDOFF" export --out "$handoff_out/checkpoint.json" >/dev/null 2>&1
-mode="$(stat -f '%Lp' "$handoff_out" 2>/dev/null || stat -c '%a' "$handoff_out")"
+mode="$(portable_file_mode "$handoff_out")"
 if [[ "$mode" == 755 ]]; then test_pass; else test_fail "changed existing directory permissions to $mode"; fi
 
 test_case "handoff rejects a directory as the output file"

--- a/tests/unit/test-install-readiness.sh
+++ b/tests/unit/test-install-readiness.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# Focused contract coverage for install readiness and lightweight hook profiles.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+# shellcheck source=tests/helpers/test-framework.sh
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Install readiness and lightweight profiles"
+
+LIFECYCLE_LIB="$PROJECT_ROOT/scripts/lib/lifecycle.sh"
+CAPABILITIES="$PROJECT_ROOT/scripts/capabilities.sh"
+CACHE_CHECK="$PROJECT_ROOT/scripts/cache-check.sh"
+REPAIR="$PROJECT_ROOT/scripts/repair.sh"
+SECURITY_AUDIT="$PROJECT_ROOT/scripts/security-audit.sh"
+PROFILE="$PROJECT_ROOT/scripts/profile.sh"
+HANDOFF="$PROJECT_ROOT/scripts/handoff.sh"
+
+test_case "lifecycle state keeps Claude and Codex records separate"
+home="$TEST_TMP_DIR/lifecycle-home"
+state="$home/.claude-octopus/install-state.json"
+mkdir -p "$home"
+if HOME="$home" OCTOPUS_INSTALL_STATE_FILE="$state" bash -c '
+    set -euo pipefail
+    source "$1"
+    OCTOPUS_HOST=claude CLAUDE_PLUGIN_ROOT="$2" OCTOPUS_INSTALL_SCOPE=user \
+        octo_lifecycle_record_install
+    OCTOPUS_HOST=codex CODEX_PLUGIN_ROOT="$2" OCTOPUS_INSTALL_SCOPE=project \
+        octo_lifecycle_record_install
+' _ "$LIFECYCLE_LIB" "$PROJECT_ROOT" 2>/dev/null &&
+   jq -e '.schema == 2 and .hosts.claude.install_scope == "user" and
+          .hosts.codex.install_scope == "project"' "$state" >/dev/null; then
+    test_pass
+else
+    test_fail "host-scoped lifecycle state was not preserved"
+fi
+
+test_case "lifecycle state becomes stale when the loaded root changes"
+root_a="$TEST_TMP_DIR/root-a"
+root_b="$TEST_TMP_DIR/root-b"
+mkdir -p "$root_a/.claude-plugin" "$root_b/.claude-plugin"
+printf '%s\n' '{"version":"1.0.0"}' > "$root_a/.claude-plugin/plugin.json"
+printf '%s\n' '{"version":"1.0.0"}' > "$root_b/.claude-plugin/plugin.json"
+stale_result="$(HOME="$home" OCTOPUS_INSTALL_STATE_FILE="$state" OCTOPUS_HOST=claude \
+    CLAUDE_PLUGIN_ROOT="$root_b" bash -c 'source "$1"; if octo_lifecycle_state_valid; then echo valid; else echo stale; fi' \
+    _ "$LIFECYCLE_LIB" 2>/dev/null || true)"
+if [[ "$stale_result" == "stale" ]]; then test_pass; else test_fail "changed root remained valid: $stale_result"; fi
+
+test_case "lifecycle state detects version, scope, and profile changes"
+fresh_home="$TEST_TMP_DIR/freshness-home"
+fresh_root="$TEST_TMP_DIR/freshness-root"
+fresh_state="$fresh_home/.claude-octopus/install-state.json"
+mkdir -p "$fresh_home" "$fresh_root/.claude-plugin"
+printf '%s\n' '{"version":"1.0.0"}' > "$fresh_root/.claude-plugin/plugin.json"
+freshness_failures=0
+HOME="$fresh_home" OCTOPUS_INSTALL_STATE_FILE="$fresh_state" OCTOPUS_HOST=claude \
+    CLAUDE_PLUGIN_ROOT="$fresh_root" OCTOPUS_INSTALL_SCOPE=user OCTOPUS_CONTEXT_PROFILE=core \
+    bash -c 'source "$1"; octo_lifecycle_record_install' _ "$LIFECYCLE_LIB" 2>/dev/null || \
+    freshness_failures=$((freshness_failures + 1))
+printf '%s\n' '{"version":"2.0.0"}' > "$fresh_root/.claude-plugin/plugin.json"
+HOME="$fresh_home" OCTOPUS_INSTALL_STATE_FILE="$fresh_state" OCTOPUS_HOST=claude \
+    CLAUDE_PLUGIN_ROOT="$fresh_root" OCTOPUS_INSTALL_SCOPE=user OCTOPUS_CONTEXT_PROFILE=core \
+    bash -c 'source "$1"; ! octo_lifecycle_state_valid' _ "$LIFECYCLE_LIB" 2>/dev/null || \
+    freshness_failures=$((freshness_failures + 1))
+printf '%s\n' '{"version":"1.0.0"}' > "$fresh_root/.claude-plugin/plugin.json"
+HOME="$fresh_home" OCTOPUS_INSTALL_STATE_FILE="$fresh_state" OCTOPUS_HOST=claude \
+    CLAUDE_PLUGIN_ROOT="$fresh_root" OCTOPUS_INSTALL_SCOPE=project OCTOPUS_CONTEXT_PROFILE=core \
+    bash -c 'source "$1"; ! octo_lifecycle_state_valid' _ "$LIFECYCLE_LIB" 2>/dev/null || \
+    freshness_failures=$((freshness_failures + 1))
+HOME="$fresh_home" OCTOPUS_INSTALL_STATE_FILE="$fresh_state" OCTOPUS_HOST=claude \
+    CLAUDE_PLUGIN_ROOT="$fresh_root" OCTOPUS_INSTALL_SCOPE=user OCTOPUS_CONTEXT_PROFILE=orchestration \
+    bash -c 'source "$1"; ! octo_lifecycle_state_valid' _ "$LIFECYCLE_LIB" 2>/dev/null || \
+    freshness_failures=$((freshness_failures + 1))
+if [[ "$freshness_failures" -eq 0 ]]; then test_pass; else test_fail "$freshness_failures freshness checks failed"; fi
+
+test_case "SessionStart refreshes stale install metadata without blocking"
+mkdir -p "$home/.claude-octopus"
+printf '%s\n' '{}' > "$home/.claude-octopus/.setup-complete"
+printf '%s\n' '{"schema":2,"hosts":{"claude":{"plugin_root":"/stale"}}}' > "$state"
+HOME="$home" OCTOPUS_INSTALL_STATE_FILE="$state" OCTOPUS_HOST=claude \
+    CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" OCTOPUS_CONTEXT_PROFILE=core \
+    bash "$PROJECT_ROOT/hooks/session-start-memory.sh" <<< '{"session_id":"readiness-session"}' >/dev/null 2>&1 || true
+if jq -e --arg root "$PROJECT_ROOT" '.hosts.claude.plugin_root == $root' "$state" >/dev/null; then
+    test_pass
+else
+    test_fail "SessionStart left stale install metadata"
+fi
+
+test_case "repair dry-run reports a broken stable link without changing it"
+repair_home="$TEST_TMP_DIR/repair-home"
+mkdir -p "$repair_home/.claude-octopus"
+ln -s "$repair_home/missing-version" "$repair_home/.claude-octopus/plugin"
+before="$(readlink "$repair_home/.claude-octopus/plugin")"
+repair_json="$(HOME="$repair_home" OCTOPUS_STABLE_PLUGIN_ROOT="$repair_home/.claude-octopus/plugin" \
+    CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$REPAIR" --dry-run --json 2>/dev/null || true)"
+after="$(readlink "$repair_home/.claude-octopus/plugin")"
+if [[ "$before" == "$after" ]] && [[ "$(jq -r '.status' <<<"$repair_json" 2>/dev/null)" == "broken" ]]; then
+    test_pass
+else
+    test_fail "dry-run mutated or misclassified the broken link"
+fi
+
+test_case "repair apply replaces a broken stable link through the shared root helper"
+if HOME="$repair_home" OCTOPUS_STABLE_PLUGIN_ROOT="$repair_home/.claude-octopus/plugin" \
+      OCTOPUS_INSTALL_STATE_FILE="$repair_home/.claude-octopus/install-state.json" \
+      CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$REPAIR" --apply --json >/dev/null 2>&1 &&
+   [[ "$(cd "$repair_home/.claude-octopus/plugin" && pwd -P)" == "$PROJECT_ROOT" ]]; then
+    test_pass
+else
+    test_fail "broken stable link was not repaired"
+fi
+
+test_case "repair apply replaces a self-referential stable link"
+self_home="$TEST_TMP_DIR/self-link-home"
+mkdir -p "$self_home/.claude-octopus"
+ln -s "$self_home/.claude-octopus/plugin" "$self_home/.claude-octopus/plugin"
+if HOME="$self_home" OCTOPUS_STABLE_PLUGIN_ROOT="$self_home/.claude-octopus/plugin" \
+      OCTOPUS_INSTALL_STATE_FILE="$self_home/.claude-octopus/install-state.json" \
+      CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$REPAIR" --apply --json >/dev/null 2>&1 &&
+   [[ "$(cd "$self_home/.claude-octopus/plugin" && pwd -P)" == "$PROJECT_ROOT" ]]; then
+    test_pass
+else
+    test_fail "self-referential stable link was not repaired"
+fi
+
+test_case "repair detects and refreshes a stale script shim"
+shim_home="$TEST_TMP_DIR/stale-shim-home"
+shim_old="$TEST_TMP_DIR/stale-shim-old"
+shim_root="$shim_home/.claude-octopus/plugin"
+mkdir -p "$shim_root/scripts" "$shim_old/scripts"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$shim_old/scripts/orchestrate.sh"
+printf -v shim_old_quoted '%q' "$shim_old/scripts/orchestrate.sh"
+printf '%s\n' '#!/usr/bin/env bash' "exec $shim_old_quoted \"\$@\"" > "$shim_root/scripts/orchestrate.sh"
+chmod +x "$shim_old/scripts/orchestrate.sh" "$shim_root/scripts/orchestrate.sh"
+shim_dry_json="$(HOME="$shim_home" OCTOPUS_STABLE_PLUGIN_ROOT="$shim_root" \
+    CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$REPAIR" --dry-run --json 2>/dev/null || true)"
+shim_apply_json="$(HOME="$shim_home" OCTOPUS_STABLE_PLUGIN_ROOT="$shim_root" \
+    OCTOPUS_INSTALL_STATE_FILE="$shim_home/.claude-octopus/install-state.json" \
+    CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$REPAIR" --apply --json 2>/dev/null || true)"
+if [[ "$(jq -r '.status' <<<"$shim_dry_json" 2>/dev/null)" == "mismatch" ]] &&
+   [[ "$(jq -r '.status' <<<"$shim_apply_json" 2>/dev/null)" == "shim" ]] &&
+   grep -F "$PROJECT_ROOT/scripts/orchestrate.sh" "$shim_root/scripts/orchestrate.sh" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "stale script shim was not detected and refreshed"
+fi
+
+test_case "repair refuses an unowned regular file without changing it"
+blocked_home="$TEST_TMP_DIR/blocked-repair-home"
+mkdir -p "$blocked_home/.claude-octopus"
+printf '%s\n' 'keep this file' > "$blocked_home/.claude-octopus/plugin"
+blocked_rc=0
+HOME="$blocked_home" OCTOPUS_STABLE_PLUGIN_ROOT="$blocked_home/.claude-octopus/plugin" \
+    CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" "$REPAIR" --apply --json \
+    > "$TEST_TMP_DIR/blocked-repair.json" 2>/dev/null || blocked_rc=$?
+if [[ "$blocked_rc" -ne 0 ]] && [[ "$(cat "$blocked_home/.claude-octopus/plugin")" == "keep this file" ]] &&
+   jq -e '.result == "blocked" and .status == "invalid"' \
+      "$TEST_TMP_DIR/blocked-repair.json" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "repair changed or accepted an unowned regular file (exit=$blocked_rc)"
+fi
+
+test_case "capabilities render shared readiness states, not guessed auth booleans"
+cap_home="$TEST_TMP_DIR/capabilities-home"
+cap_bin="$TEST_TMP_DIR/capabilities-bin"
+mkdir -p "$cap_home" "$cap_bin"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$cap_bin/qwen"
+chmod +x "$cap_bin/qwen"
+cap_json="$(HOME="$cap_home" PATH="$cap_bin:$PATH" QWEN_API_KEY='' \
+    "$CAPABILITIES" --json 2>/dev/null || true)"
+if jq -e '.providers[] | select(.id == "qwen") |
+          .status == "degraded" and .reason_code == "auth-missing" and
+          (has("auth_ready") | not)' <<<"$cap_json" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "capability output bypassed provider readiness: ${cap_json:-<empty>}"
+fi
+
+test_case "core profile suppresses optional context reinforcement in a real hook run"
+hook_home="$TEST_TMP_DIR/hook-home"
+mkdir -p "$hook_home/.claude-octopus"
+printf '%s\n' '{"host_session_id":"hook-session","status":"active","current_phase":"develop"}' \
+    > "$hook_home/.claude-octopus/session.json"
+core_output="$(printf '%s' '{"session_id":"hook-session"}' | HOME="$hook_home" \
+    CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" OCTOPUS_CONTEXT_PROFILE=core \
+    bash "$PROJECT_ROOT/hooks/context-reinforcement.sh" 2>/dev/null || true)"
+workflow_output="$(printf '%s' '{"session_id":"hook-session"}' | HOME="$hook_home" \
+    CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" OCTOPUS_CONTEXT_PROFILE=orchestration \
+    bash "$PROJECT_ROOT/hooks/context-reinforcement.sh" 2>/dev/null || true)"
+if [[ -z "$core_output" ]] && jq -e '.hookSpecificOutput.hookEventName == "SessionStart"' \
+      <<<"$workflow_output" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "profile did not gate real hook execution"
+fi
+
+test_case "orchestration profile activates post-tool coordination only for an active workflow"
+post_session="profile-post-tool-$$"
+post_state="/tmp/octopus-failures-${post_session}.json"
+rm -f "$post_state"
+post_input="$(jq -cn --arg session "$post_session" \
+    '{session_id:$session,tool_name:"Bash",exit_code:1,result:"error: fixture failure"}')"
+printf '%s\n' "$post_input" | HOME="$hook_home" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+    CLAUDE_SESSION_ID="$post_session" OCTOPUS_CONTEXT_PROFILE=core \
+    bash "$PROJECT_ROOT/hooks/post-tool-dispatch.sh" >/dev/null 2>&1 || true
+core_created=false
+[[ -e "$post_state" ]] && core_created=true
+printf '%s\n' "$(jq -cn --arg session "$post_session" \
+    '{host_session_id:$session,status:"active",current_phase:"develop"}')" \
+    > "$hook_home/.claude-octopus/session.json"
+printf '%s\n' "$post_input" | HOME="$hook_home" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+    CLAUDE_SESSION_ID="$post_session" OCTOPUS_CONTEXT_PROFILE=orchestration \
+    bash "$PROJECT_ROOT/hooks/post-tool-dispatch.sh" >/dev/null 2>&1 || true
+if [[ "$core_created" == false ]] &&
+   jq -e '.bash.consecutive == 1' "$post_state" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "profile did not control real post-tool coordination"
+fi
+rm -f "$post_state"
+
+test_case "profile-managed hooks fail closed when their registry is unavailable"
+missing_profile_config="$TEST_TMP_DIR/missing-hook-profiles.json"
+profile_gate_rc=0
+HOME="$hook_home" OCTOPUS_CONTEXT_PROFILE=full \
+    OCTOPUS_HOOK_PROFILE_CONFIG="$missing_profile_config" \
+    bash -c 'source "$1"; octo_hook_profile_allows context-reinforcement' \
+    _ "$PROJECT_ROOT/scripts/lib/hook-activation.sh" >/dev/null 2>&1 || profile_gate_rc=$?
+if [[ "$profile_gate_rc" -ne 0 ]]; then
+    test_pass
+else
+    test_fail "full profile bypassed the missing registry"
+fi
+
+test_case "profile reports failure when its setting cannot be persisted"
+profile_rc=0
+HOME=/dev/null "$PROFILE" orchestration >/dev/null 2>&1 || profile_rc=$?
+if [[ "$profile_rc" -ne 0 ]]; then test_pass; else test_fail "profile claimed an impossible write succeeded"; fi
+
+test_case "security audit exits nonzero when the hook manifest fails"
+audit_root="$TEST_TMP_DIR/audit-root"
+mkdir -p "$audit_root/hooks" "$audit_root/scripts"
+printf '%s\n' '{invalid' > "$audit_root/hooks/hooks.json"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$audit_root/scripts/ok.sh"
+audit_rc=0
+OCTOPUS_SECURITY_AUDIT_ROOT="$audit_root" "$SECURITY_AUDIT" --json \
+    > "$TEST_TMP_DIR/audit.json" 2>/dev/null || audit_rc=$?
+if [[ "$audit_rc" -ne 0 ]] && jq -e '.checks[] | select(.name == "hooks-manifest" and .status == "fail")' \
+      "$TEST_TMP_DIR/audit.json" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "invalid hook manifest did not fail the audit (exit=$audit_rc)"
+fi
+
+test_case "cache check validates the active cache rather than only the newest directory"
+cache_home="$TEST_TMP_DIR/cache-home"
+claude_cache="$cache_home/.claude/plugins/cache/nyldn-plugins/octo"
+codex_cache="$cache_home/.codex/plugins/cache/nyldn-plugins/claude-octopus"
+mkdir -p "$claude_cache/1.0.0/.claude-plugin" "$claude_cache/2.0.0/.claude-plugin" "$codex_cache"
+printf '%s\n' '{invalid' > "$claude_cache/1.0.0/.claude-plugin/plugin.json"
+printf '%s\n' '{"version":"2.0.0","commands":[],"skills":[]}' > "$claude_cache/2.0.0/.claude-plugin/plugin.json"
+mkdir -p "$claude_cache/2.0.0/scripts"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$claude_cache/2.0.0/scripts/orchestrate.sh"
+chmod +x "$claude_cache/2.0.0/scripts/orchestrate.sh"
+cache_rc=0
+HOME="$cache_home" CLAUDE_PLUGIN_ROOT="$claude_cache/1.0.0" \
+    OCTOPUS_STABLE_PLUGIN_ROOT="$cache_home/.claude-octopus/plugin" \
+    "$CACHE_CHECK" --json > "$TEST_TMP_DIR/cache.json" 2>/dev/null || cache_rc=$?
+if [[ "$cache_rc" -ne 0 ]] && jq -e '
+      any(.checks[]; .host == "claude" and .version == "1.0.0" and
+          .role == "active" and .status == "fail") and
+      any(.checks[]; .host == "claude" and .version == "2.0.0" and
+          .role == "newest" and .status == "pass")' \
+      "$TEST_TMP_DIR/cache.json" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "active invalid cache was not reported (exit=$cache_rc)"
+fi
+
+test_case "portable handoff export is structured, private, and redacted"
+handoff_home="$TEST_TMP_DIR/handoff-home"
+mkdir -p "$handoff_home/data"
+printf '%s\n' '{"workflow":"develop","current_phase":"build","status":"running","decisions":["OPENAI_API_KEY=do-not-export"]}' \
+    > "$handoff_home/data/session.json"
+handoff_json="$(HOME="$handoff_home" CLAUDE_PLUGIN_DATA="$handoff_home/data" \
+    OCTOPUS_PROJECT_DIR="$PROJECT_ROOT" "$HANDOFF" export --json 2>/dev/null || true)"
+handoff_file="$handoff_home/.claude-octopus/handoffs/$(printf '%s' "$PROJECT_ROOT" | shasum -a 256 | cut -c1-16).json"
+mode="$(stat -f '%Lp' "$handoff_file" 2>/dev/null || stat -c '%a' "$handoff_file" 2>/dev/null || true)"
+if jq -e '.workflow == "develop" and .phase == "build" and
+          (tostring | contains("do-not-export") | not)' <<<"$handoff_json" >/dev/null 2>&1 &&
+   [[ "$mode" == "600" ]]; then
+    test_pass
+else
+    test_fail "portable handoff was missing, unredacted, or not private"
+fi
+
+test_case "new diagnostic CLIs reject unknown arguments"
+cli_failures=0
+for cli in "$CAPABILITIES" "$CACHE_CHECK" "$REPAIR" "$SECURITY_AUDIT" "$PROFILE" "$HANDOFF"; do
+    rc=0
+    "$cli" --not-a-real-option >/dev/null 2>&1 || rc=$?
+    [[ "$rc" -eq 2 ]] || cli_failures=$((cli_failures + 1))
+done
+rc=0
+"$PROJECT_ROOT/scripts/orchestrate.sh" install-state nonsense >/dev/null 2>&1 || rc=$?
+[[ "$rc" -eq 2 ]] || cli_failures=$((cli_failures + 1))
+if [[ "$cli_failures" -eq 0 ]]; then test_pass; else test_fail "$cli_failures CLI(s) accepted invalid arguments"; fi
+
+test_case "orchestrator exposes diagnostics without generic workflow initialization"
+orchestrator_home="$TEST_TMP_DIR/orchestrator-home"
+mkdir -p "$orchestrator_home"
+orchestrator_json="$(HOME="$orchestrator_home" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+    "$PROJECT_ROOT/scripts/orchestrate.sh" capabilities --json 2>/dev/null || true)"
+doctor_json="$(HOME="$orchestrator_home" CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT" \
+    "$PROJECT_ROOT/scripts/orchestrate.sh" doctor installation --json 2>/dev/null || true)"
+if jq -e '.providers | type == "array"' <<<"$orchestrator_json" >/dev/null 2>&1 &&
+   jq -e '.results[] | select(.category == "installation")' <<<"$doctor_json" >/dev/null 2>&1 &&
+   [[ ! -d "$orchestrator_home/.claude-octopus/results" ]]; then
+    test_pass
+else
+    test_fail "diagnostic dispatch was missing or initialized workflow state"
+fi
+
+test_case "installed octopus CLI exposes the readiness commands and rejects unknown commands"
+bin_failures=0
+for command in capabilities cache-check repair security-audit handoff profile; do
+    bin_help="$("$PROJECT_ROOT/bin/octopus" "$command" --help 2>/dev/null || true)"
+    [[ "$bin_help" == *"Usage:"* && "$bin_help" == *"$command"* ]] || bin_failures=$((bin_failures + 1))
+done
+bin_unknown_rc=0
+"$PROJECT_ROOT/bin/octopus" definitely-not-a-command >/dev/null 2>&1 || bin_unknown_rc=$?
+if [[ "$bin_failures" -eq 0 && "$bin_unknown_rc" -eq 2 ]]; then
+    test_pass
+else
+    test_fail "CLI dispatch failures=$bin_failures unknown-exit=$bin_unknown_rc"
+fi
+
+test_summary

--- a/tests/unit/test-install-readiness.sh
+++ b/tests/unit/test-install-readiness.sh
@@ -296,6 +296,50 @@ else
     test_fail "portable handoff was missing, unredacted, or not private"
 fi
 
+test_case "handoff preserves existing output directory permissions"
+handoff_out="$TEST_TMP_DIR/shared-output"
+mkdir -p "$handoff_out"
+chmod 755 "$handoff_out"
+HOME="$handoff_home" CLAUDE_PLUGIN_DATA="$handoff_home/data" \
+    "$HANDOFF" export --out "$handoff_out/checkpoint.json" >/dev/null 2>&1
+mode="$(stat -f '%Lp' "$handoff_out" 2>/dev/null || stat -c '%a' "$handoff_out")"
+if [[ "$mode" == 755 ]]; then test_pass; else test_fail "changed existing directory permissions to $mode"; fi
+
+test_case "handoff rejects a directory as the output file"
+handoff_rc=0
+HOME="$handoff_home" "$HANDOFF" export --out "$handoff_out" >/dev/null 2>&1 || handoff_rc=$?
+if [[ "$handoff_rc" -ne 0 ]]; then test_pass; else test_fail "directory destination was accepted"; fi
+
+test_case "handoff validates summary field types and redacts every exported string"
+printf '%s\n' '{"workflow":{"token":"private-value"},"status":"token=private-status","decisions":"unexpected","blockers":[{"token":"private-object"}]}' \
+    > "$handoff_home/data/session.json"
+handoff_json="$(HOME="$handoff_home" CLAUDE_PLUGIN_DATA="$handoff_home/data" \
+    "$HANDOFF" export --json 2>/dev/null || true)"
+if jq -e '.workflow == "none" and .decisions == [] and .blockers == [] and
+    (tostring | contains("private-") | not)' <<<"$handoff_json" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "invalid or sensitive summary fields escaped the export schema"
+fi
+
+test_case "handoff uses canonical project decisions and suppresses secret-bearing notes"
+project_state="$TEST_TMP_DIR/project-state"
+mkdir -p "$project_state"
+printf '%s\n' '{"current_workflow":"develop","current_phase":"deliver","decisions":[{"decision":"Keep SQLite","rationale":"Fits the workload"},{"decision":"AWS_SECRET_ACCESS_KEY=private-aws"},{"decision":"{\"password\":\"private-pass word\"}"}],"blockers":[{"description":"Need design approval","status":"active"},{"description":"Already resolved","status":"resolved"}]}' > "$project_state/state.json"
+handoff_json="$(HOME="$handoff_home" CLAUDE_PLUGIN_DATA="$handoff_home/data" OCTOPUS_WORKFLOW_STATE_DIR="$project_state" \
+    "$HANDOFF" export --json 2>/dev/null || true)"
+if jq -e '.workflow == "develop" and .phase == "deliver" and
+    (.decisions | index("Keep SQLite")) != null and .blockers == ["Need design approval"] and
+    (has("resume_command") | not) and (tostring | contains("private-") | not)' <<<"$handoff_json" >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "handoff missed canonical state or exported sensitive notes"
+fi
+
+test_case "explicit hook profile overrides the context profile"
+profile_name="$(OCTOPUS_CONTEXT_PROFILE=core OCTOPUS_HOOK_PROFILE=full bash -c 'source "$1"; octo_hook_profile' _ "$PROJECT_ROOT/scripts/lib/hook-activation.sh")"
+if [[ "$profile_name" == full ]]; then test_pass; else test_fail "explicit hook profile did not win"; fi
+
 test_case "new diagnostic CLIs reject unknown arguments"
 cli_failures=0
 for cli in "$CAPABILITIES" "$CACHE_CHECK" "$REPAIR" "$SECURITY_AUDIT" "$PROFILE" "$HANDOFF"; do

--- a/tests/unit/test-install-root-safety.sh
+++ b/tests/unit/test-install-root-safety.sh
@@ -6,12 +6,14 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 TEST_BASH="${TEST_BASH:-/bin/bash}"
-work="$(mktemp -d "${TMPDIR:-/tmp}/octo-install-safety.XXXXXX")"
-trap 'rm -rf "$work"' EXIT
-passed=0 failed=0
+# shellcheck source=tests/helpers/test-framework.sh
+source "$PROJECT_ROOT/tests/helpers/test-framework.sh"
+test_suite "Installation root safety and handoff redaction"
+work="$TEST_TMP_DIR/install-safety"
+mkdir -p "$work"
 check() {
-    if "$@"; then passed=$((passed + 1)); printf 'PASS %s\n' "$*"
-    else failed=$((failed + 1)); printf 'FAIL %s\n' "$*"; fi
+    test_case "$*"
+    if "$@"; then test_pass; else test_fail "$*"; fi
 }
 fixture() {
     mkdir -p "$1/.claude-plugin" "$1/.codex-plugin" "$1/scripts" "$1/skills" "$1/commands" "$1/assets"
@@ -153,6 +155,125 @@ repair_owned() {
 check repair_owned shim
 check repair_owned link
 
+missing_wrapper() {
+    local stable="$work/missing-wrapper" rc=0
+    wrapper "$(cd "$work/good" && pwd -P)/scripts/orchestrate.sh" "$stable/scripts/orchestrate.sh"
+    run_cli repair "$work/good" "$stable" claude --dry-run --json || return 1
+    jq -e '.status=="mismatch"' "$work/result.json" >/dev/null || return 1
+    [[ ! -e "$stable/scripts/install-deps.sh" ]] || return 1
+    run_cli repair "$work/good" "$stable" claude --apply --json || rc=$?
+    [[ "$rc" == 0 && -x "$stable/scripts/install-deps.sh" ]] &&
+        "$stable/scripts/install-deps.sh" &&
+        jq -e '.result=="ready" and .status=="shim"' "$work/result.json" >/dev/null
+}
+check missing_wrapper
+
+profile_parity() {
+    local origin="$1" value="$2" expected="$3" override="${4:-}" hooks="${5:-$3}"
+    local profile_home="$work/profile-$origin-$value-$override" context="$2"
+    mkdir -p "$profile_home/.claude-octopus"
+    if [[ "$origin" == config ]]; then
+        jq -cn --arg value "$value" '{context_profile:$value}' > "$profile_home/.claude-octopus/user-config.json"
+        context=""
+    fi
+    env "HOME=$profile_home" "OCTOPUS_CONTEXT_PROFILE=$context" "OCTOPUS_HOOK_PROFILE=$override" \
+        "OCTOPUS_HOST=claude" "CLAUDE_PLUGIN_ROOT=$work/good" \
+        "OCTOPUS_INSTALL_STATE_FILE=$profile_home/receipt.json" \
+        "$TEST_BASH" -c '
+        source "$1/scripts/lib/lifecycle.sh"
+        source "$1/scripts/lib/hook-activation.sh"
+        [[ "$(octo_lifecycle_profile)" == "$2" && "$(octo_hook_profile)" == "$3" &&
+           "$(octo_lifecycle_hook_profile)" == "$3" ]] || exit 1
+        octo_lifecycle_record_install && octo_lifecycle_state_valid || exit 1
+        jq -e --arg context "$2" --arg hooks "$3" \
+            ".hosts.claude | .context_profile==\$context and .hook_profile==\$hooks" "$OCTO_LIFECYCLE_STATE_FILE" >/dev/null
+    ' _ "$PROJECT_ROOT" "$expected" "$hooks"
+}
+for origin in env config; do
+    for pair in core:core minimal:core orchestration:orchestration workflow:orchestration full:full all:full invalid:core; do
+        check profile_parity "$origin" "${pair%:*}" "${pair#*:}"
+    done
+    check profile_parity "$origin" workflow orchestration all full
+    check profile_parity "$origin" all full minimal core
+done
+
+handoff_redaction() {
+    local kind="$1" source_kind="$2" sample handoff_home="$work/handoff-$1-$2"
+    local state session out safe=$'Keep "SQLite"\nUse https://localhost/db and C:\\data'
+    state="$handoff_home/state"; session="$handoff_home/data"; out="$handoff_home/out"
+    mkdir -p "$state" "$session" "$out" "$handoff_home/bin"
+    case "$kind" in
+        aws) sample='AKIA0123456789ABCDEF' ;;
+        aws-session) sample='ASIA0123456789ABCDEF' ;;
+        jwt) sample='eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzeW50aGV0aWMifQ.c3ludGhldGlj' ;;
+        jwt-empty-object) sample='eyJhbGciOiJIUzI1NiJ9.e30.c3ludGhldGlj' ;;
+        pem) sample=$'-----BEGIN RSA PRIVATE KEY-----\nU1lOVEhFVElDLUtFWS1EQVRB\n-----END RSA PRIVATE KEY-----' ;;
+        pem-partial) sample=$'-----BEGIN OPENSSH PRIVATE KEY-----\nU1lOVEhFVElDLUtFWS1EQVRB' ;;
+        postgres) sample='postgres://fixture:synthetic-value@localhost/db' ;;
+        postgresql) sample='postgresql://fixture:synthetic-value@localhost/db' ;;
+        mysql) sample='mysql://fixture:synthetic-value@localhost/db' ;;
+        mongodb) sample='mongodb+srv://fixture:synthetic-value@localhost/db' ;;
+        redis) sample='rediss://fixture:synthetic-value@localhost/0' ;;
+        https) sample='https://fixture:synthetic%2Fvalue@localhost/' ;;
+    esac
+    if [[ "$source_kind" == session ]]; then
+        jq -cn --arg value "$sample" --arg safe "$safe" '{workflow:$value,current_phase:$value,status:$value,autonomy:$value,
+            decisions:[$value,$safe],blockers:[$value]}' > "$session/session.json"
+    else
+        jq -cn --arg value "$sample" --arg safe "$safe" '{current_workflow:$value,current_phase:$value,
+            decisions:[{decision:$value},{decision:$safe}],blockers:[{description:$value,status:"active"}]}' > "$state/state.json"
+    fi
+    # Inspect the staged export before publication, including JSON delimiters.
+    cat > "$handoff_home/bin/mv" <<'EOF'
+#!/bin/bash
+if ! "$REAL_JQ" -e --arg value "$SYNTHETIC_VALUE" \
+    'type=="object" and ([.. | strings] | all(contains($value) | not))' "$2" >/dev/null; then exit 99; fi
+exec /bin/mv "$@"
+EOF
+    chmod +x "$handoff_home/bin/mv"
+    env "HOME=$handoff_home" "CLAUDE_PLUGIN_DATA=$session" "OCTOPUS_WORKFLOW_STATE_DIR=$state" \
+        "OCTOPUS_PROJECT_DIR=$handoff_home/project-AKIA0123456789ABCDEF" "PATH=$handoff_home/bin:$PATH" \
+        "REAL_JQ=$(command -v jq)" "SYNTHETIC_VALUE=$sample" \
+        "$TEST_BASH" "$PROJECT_ROOT/scripts/handoff.sh" export --json --out "$out/export.json" \
+        > "$handoff_home/stdout" 2> "$handoff_home/stderr" || return 1
+    cmp -s "$out/export.json" "$handoff_home/stdout" &&
+        jq -e --arg value "$sample" --arg safe "$safe" --arg source "$source_kind" '
+            .schema==1 and .workflow=="[REDACTED]" and .phase=="[REDACTED]" and
+            .project_name=="[REDACTED]" and .decisions==["[REDACTED]",$safe] and .blockers==["[REDACTED]"] and
+            .status==(if $source=="session" then "[REDACTED]" else "unknown" end) and
+            .autonomy==(if $source=="session" then "[REDACTED]" else "supervised" end) and
+            ([.. | strings] | all(contains($value) | not))' "$out/export.json" >/dev/null
+}
+for kind in aws aws-session jwt jwt-empty-object pem pem-partial postgres postgresql mysql mongodb redis https; do
+    for source_kind in session state; do check handoff_redaction "$kind" "$source_kind"; done
+done
+
+handoff_failure() {
+    local kind="$1" root="$work/handoff-failure-$1" rc=0
+    mkdir -p "$root/data" "$root/state" "$root/out" "$root/bin"
+    printf '{"keep":"existing export"}\n' > "$root/out/export.json"
+    cp "$root/out/export.json" "$root/before"
+    case "$kind" in
+        session) printf '{invalid' > "$root/data/session.json" ;;
+        state) printf '{invalid' > "$root/state/state.json" ;;
+        sanitizer)
+            cat > "$root/bin/jq" <<'EOF'
+#!/bin/bash
+for arg in "$@"; do [[ "$arg" != project_id ]] || exit 42; done
+exec "$REAL_JQ" "$@"
+EOF
+            chmod +x "$root/bin/jq"
+            ;;
+    esac
+    env "HOME=$root" "CLAUDE_PLUGIN_DATA=$root/data" "OCTOPUS_WORKFLOW_STATE_DIR=$root/state" \
+        "OCTOPUS_PROJECT_DIR=$root/project" "REAL_JQ=$(command -v jq)" "PATH=$root/bin:$PATH" \
+        "$TEST_BASH" "$PROJECT_ROOT/scripts/handoff.sh" export --json --out "$root/out/export.json" \
+        > "$root/stdout" 2> "$root/stderr" || rc=$?
+    [[ "$rc" != 0 && ! -s "$root/stdout" && "$(ls -A "$root/out")" == export.json ]] &&
+        cmp -s "$root/before" "$root/out/export.json"
+}
+for kind in session state sanitizer; do check handoff_failure "$kind"; done
+
 record() {
     env "HOME=$work/home" "OCTOPUS_INSTALL_STATE_FILE=$1" "OCTOPUS_HOST=$2" \
         "CLAUDE_PLUGIN_ROOT=$work/good" "CODEX_PLUGIN_ROOT=$work/good" \
@@ -245,10 +366,6 @@ concurrent_records() {
 }
 check concurrent_records
 reference_input_failure() {
-    if [[ "$(uname -s)" != Darwin ]] || ! command -v sandbox-exec >/dev/null 2>&1; then
-        printf 'SKIP native Bash temporary-file denial requires macOS\n'
-        return 0
-    fi
     local root="$work/no-temp-root"
     fixture "$root"
     sandbox-exec -p '(version 1)(allow default)(deny file-write*)(allow file-write* (literal "/dev/null"))' /bin/bash -c '
@@ -256,6 +373,14 @@ reference_input_failure() {
         if octo_validate_install_root "$2" claude; then exit 1; fi
     ' _ "$PROJECT_ROOT/scripts/lib/install-root.sh" "$root" 2>/dev/null
 }
-check reference_input_failure
-printf '%s passed, %s failed\n' "$passed" "$failed"
-[[ "$failed" == 0 ]]
+test_case "reference_input_failure"
+if [[ "$(uname -s)" != Darwin ]] || ! command -v sandbox-exec >/dev/null 2>&1; then
+    test_skip "Native Bash temporary-file denial requires macOS sandbox-exec"
+elif ! sandbox-exec -p '(version 1)(allow default)' /usr/bin/true 2>/dev/null; then
+    test_skip "macOS sandbox-exec cannot start in this environment"
+elif reference_input_failure; then
+    test_pass
+else
+    test_fail "Native Bash temporary-file denial was not rejected"
+fi
+test_summary

--- a/tests/unit/test-install-root-safety.sh
+++ b/tests/unit/test-install-root-safety.sh
@@ -205,6 +205,10 @@ handoff_redaction() {
     case "$kind" in
         aws) sample='AKIA0123456789ABCDEF' ;;
         aws-session) sample='ASIA0123456789ABCDEF' ;;
+        github-oauth) sample='gho_synthetic0123456789abcdefghijklmnopqrstuvwxyz' ;;
+        gitlab) sample='glpat-synthetic0123456789abcdef' ;;
+        slack-bot) sample='xoxb'; sample="${sample}-000000000000-000000000000-syntheticexample" ;;
+        slack-user) sample='xoxp'; sample="${sample}-000000000000-000000000000-syntheticexample" ;;
         jwt) sample='eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzeW50aGV0aWMifQ.c3ludGhldGlj' ;;
         jwt-empty-object) sample='eyJhbGciOiJIUzI1NiJ9.e30.c3ludGhldGlj' ;;
         pem) sample=$'-----BEGIN RSA PRIVATE KEY-----\nU1lOVEhFVElDLUtFWS1EQVRB\n-----END RSA PRIVATE KEY-----' ;;
@@ -244,7 +248,7 @@ EOF
             .autonomy==(if $source=="session" then "[REDACTED]" else "supervised" end) and
             ([.. | strings] | all(contains($value) | not))' "$out/export.json" >/dev/null
 }
-for kind in aws aws-session jwt jwt-empty-object pem pem-partial postgres postgresql mysql mongodb redis https; do
+for kind in aws aws-session github-oauth gitlab slack-bot slack-user jwt jwt-empty-object pem pem-partial postgres postgresql mysql mongodb redis https; do
     for source_kind in session state; do check handoff_redaction "$kind" "$source_kind"; done
 done
 

--- a/tests/unit/test-install-root-safety.sh
+++ b/tests/unit/test-install-root-safety.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Installation safety acceptance checks on disposable files and real processes.
+# Child shell snippets intentionally expand their own variables.
+# shellcheck disable=SC2016
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+TEST_BASH="${TEST_BASH:-/bin/bash}"
+work="$(mktemp -d "${TMPDIR:-/tmp}/octo-install-safety.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+passed=0 failed=0
+check() {
+    if "$@"; then passed=$((passed + 1)); printf 'PASS %s\n' "$*"
+    else failed=$((failed + 1)); printf 'FAIL %s\n' "$*"; fi
+}
+fixture() {
+    mkdir -p "$1/.claude-plugin" "$1/.codex-plugin" "$1/scripts" "$1/skills" "$1/commands" "$1/assets"
+    printf '%s\n' '#!/usr/bin/env bash' 'printf "fixture runtime\\n"' > "$1/scripts/orchestrate.sh"
+    chmod +x "$1/scripts/orchestrate.sh"
+    printf 'command\n' > "$1/commands/test.md"
+    printf '<svg/>\n' > "$1/assets/icon.svg"
+    printf '%s\n' '{"version":"1.0.0","skills":"./skills","commands":["./commands/test.md"]}' > "$1/.claude-plugin/plugin.json"
+    printf '%s\n' '{"version":"1.0.0","skills":"./skills","interface":{"composerIcon":"./assets/icon.svg"}}' > "$1/.codex-plugin/plugin.json"
+}
+run_cli() {
+    local command="$1" root="$2" stable="$3" host="${4:-claude}"
+    shift 4
+    env -u CLAUDE_PLUGIN_ROOT -u CODEX_PLUGIN_ROOT -u CODEX_HOME \
+        "HOME=$work/home" "OCTOPUS_HOST=$host" \
+        "OCTOPUS_STABLE_PLUGIN_ROOT=$stable" "OCTOPUS_INSTALL_STATE_FILE=$work/state.json" \
+        "OCTOPUS_CLAUDE_CACHE_DIR=$work/claude-cache" "OCTOPUS_CODEX_CACHE_DIR=$work/codex-cache" \
+        "$(if [[ "$host" == codex ]]; then printf CODEX; else printf CLAUDE; fi)_PLUGIN_ROOT=$root" \
+        "$TEST_BASH" "$PROJECT_ROOT/scripts/$command.sh" "$@" > "$work/result.json" 2> "$work/diagnostic.txt"
+}
+active_check() {
+    local kind="$1" host="$2" rc=0
+    local root="$work/$kind-$host"
+    case "$kind" in
+        absent) ;;
+        invalid) mkdir -p "$root" ;;
+        valid) fixture "$root" ;;
+    esac
+    run_cli cache-check "$root" "$work/no-stable" "$host" --json || rc=$?
+    if [[ "$kind" == valid ]]; then
+        [[ "$rc" == 0 ]] && jq -e --arg host "$host" '.checks[] | select(.host==$host and .role=="active" and .status=="pass")' "$work/result.json" >/dev/null
+    else
+        [[ "$rc" != 0 ]] && jq -e --arg host "$host" '.failures>0 and any(.checks[]; .host==$host and .role=="active" and .status=="fail")' "$work/result.json" >/dev/null
+    fi
+}
+for cache in absent empty; do
+    [[ "$cache" == absent ]] || mkdir -p "$work/claude-cache" "$work/codex-cache"
+    for host in claude codex; do
+        for kind in absent invalid valid; do check active_check "$kind" "$host"; done
+    done
+done
+
+manifest_check() {
+    local problem="$1" host=claude root="$work/manifest-$1" rc=0 manifest
+    fixture "$root"
+    case "$problem" in icon-*) host=codex ;; esac
+    manifest="$root/.$host-plugin/plugin.json"
+    case "$problem" in
+        skill-file) rmdir "$root/skills"; printf data > "$root/skills" ;;
+        command-directory) rm "$root/commands/test.md"; mkdir "$root/commands/test.md" ;;
+        traversal) jq '.skills="../outside"' "$manifest" > "$work/edit.json"; mv "$work/edit.json" "$manifest" ;;
+        absolute) jq --arg path "$work/outside" '.skills=$path' "$manifest" > "$work/edit.json"; mv "$work/edit.json" "$manifest" ;;
+        symlink) rmdir "$root/skills"; ln -s "$work/outside" "$root/skills" ;;
+        wrong-type) jq '.skills=42' "$manifest" > "$work/edit.json"; mv "$work/edit.json" "$manifest" ;;
+        empty-version) jq '.version=""' "$manifest" > "$work/edit.json"; mv "$work/edit.json" "$manifest" ;;
+        json-stream) cat "$manifest" > "$work/edit.json"; cat "$work/edit.json" >> "$manifest" ;;
+        runtime-directory) rm "$root/scripts/orchestrate.sh"; mkdir "$root/scripts/orchestrate.sh" ;;
+        runtime-symlink) rm "$root/scripts/orchestrate.sh"; ln -s "$work/good/scripts/orchestrate.sh" "$root/scripts/orchestrate.sh" ;;
+        icon-missing) rm "$root/assets/icon.svg" ;;
+        icon-directory) rm "$root/assets/icon.svg"; mkdir "$root/assets/icon.svg" ;;
+        icon-symlink) rm "$root/assets/icon.svg"; ln -s "$work/good/assets/icon.svg" "$root/assets/icon.svg" ;;
+        icon-wrong-type) jq '.interface.composerIcon=[]' "$manifest" > "$work/edit.json"; mv "$work/edit.json" "$manifest" ;;
+    esac
+    mkdir -p "$work/$host-cache"
+    ln -s "$root" "$work/$host-cache/1.0.0"
+    run_cli cache-check "$root" "$work/no-stable" "$host" --json || rc=$?
+    rm "$work/$host-cache/1.0.0"
+    [[ "$rc" != 0 ]] && jq -e '.checks[] | select(.role=="active" and .status=="fail")' "$work/result.json" >/dev/null
+}
+fixture "$work/good"
+mkdir "$work/outside"
+for problem in skill-file command-directory traversal absolute symlink wrong-type empty-version json-stream runtime-directory runtime-symlink icon-missing icon-directory icon-symlink icon-wrong-type; do
+    check manifest_check "$problem"
+done
+
+repair_invalid() {
+    local mode="$1" rc=0 root="$work/bad-target-$1"
+    fixture "$root"
+    printf '{invalid\n' > "$root/.claude-plugin/plugin.json"
+    printf keep > "$root/user-data"
+    run_cli repair "$root" "$root" claude "$mode" --json || rc=$?
+    [[ "$rc" != 0 && "$(cat "$root/user-data")" == keep ]] &&
+        [[ ! -e "$work/state.json" ]] && jq -e '.result=="blocked"' "$work/result.json" >/dev/null
+}
+check repair_invalid --dry-run
+check repair_invalid --apply
+
+unreadable_root() {
+    local command="$1" root="$work/claude-cache/3.0.0" rc=0 valid=0
+    fixture "$root"
+    chmod 000 "$root"
+    run_cli "$command" "$root" "$work/no-stable" claude --json || rc=$?
+    chmod 700 "$root"
+    if [[ "$command" == repair ]]; then
+        [[ "$rc" != 0 ]] && jq -e '.result=="blocked"' "$work/result.json" >/dev/null || valid=1
+    else
+        [[ "$rc" != 0 ]] && jq -e '.failures>0' "$work/result.json" >/dev/null || valid=1
+    fi
+    rm -rf "$root"
+    return "$valid"
+}
+check unreadable_root cache-check
+check unreadable_root repair
+
+wrapper() {
+    local quoted
+    mkdir -p "$(dirname "$2")"
+    printf -v quoted '%q' "$1"
+    printf '#!/usr/bin/env bash\nexec %s "$@"\n' "$quoted" > "$2"
+    chmod +x "$2"
+}
+shim_preserved() {
+    local kind="$1" stable="$work/shim-$1" rc=0
+    wrapper "$work/old/scripts/orchestrate.sh" "$stable/scripts/orchestrate.sh"
+    case "$kind" in
+        appended) printf 'printf user-customization\n' >> "$stable/scripts/orchestrate.sh" ;;
+        blank-line) printf '\n' >> "$stable/scripts/orchestrate.sh" ;;
+        secondary) printf 'user script\n' > "$stable/scripts/install-deps.sh" ;;
+        symlink) mv "$stable/scripts" "$work/external-scripts"; ln -s "$work/external-scripts" "$stable/scripts" ;;
+    esac
+    cp "$stable/scripts/orchestrate.sh" "$work/before"
+    run_cli repair "$work/good" "$stable" claude --apply --json || rc=$?
+    [[ "$rc" != 0 ]] && cmp -s "$work/before" "$stable/scripts/orchestrate.sh" &&
+        jq -e '.result=="blocked"' "$work/result.json" >/dev/null &&
+        { [[ "$kind" != secondary ]] || [[ "$(cat "$stable/scripts/install-deps.sh")" == 'user script' ]]; }
+}
+printf '#!/usr/bin/env bash\nexit 0\n' > "$work/good/scripts/install-deps.sh"
+chmod +x "$work/good/scripts/install-deps.sh"
+for kind in appended blank-line secondary symlink; do check shim_preserved "$kind"; done
+
+repair_owned() {
+    local kind="$1" stable="$work/owned-$1"
+    if [[ "$kind" == shim ]]; then wrapper "$work/old with space/scripts/orchestrate.sh" "$stable/scripts/orchestrate.sh"
+    else ln -s "$work/missing" "$stable"; fi
+    run_cli repair "$work/good" "$stable" claude --apply --json &&
+        jq -e '.result=="ready"' "$work/result.json" >/dev/null &&
+        [[ "$("$stable/scripts/orchestrate.sh")" == 'fixture runtime' ]]
+}
+check repair_owned shim
+check repair_owned link
+
+record() {
+    env "HOME=$work/home" "OCTOPUS_INSTALL_STATE_FILE=$1" "OCTOPUS_HOST=$2" \
+        "CLAUDE_PLUGIN_ROOT=$work/good" "CODEX_PLUGIN_ROOT=$work/good" \
+        "$TEST_BASH" -c 'source "$1"; octo_lifecycle_record_install' _ "$PROJECT_ROOT/scripts/lib/lifecycle.sh"
+}
+receipt_directory() {
+    local state="$work/directory-state" rc=0 intact=0
+    mkdir "$state"
+    printf keep > "$state/user-data"
+    record "$state" claude || rc=$?
+    # A broken writer may chmod the directory; restore fixture access for cleanup.
+    chmod 700 "$state"
+    [[ "$rc" != 0 && "$(ls -A "$state")" == user-data && "$(cat "$state/user-data")" == keep ]] || intact=1
+    return "$intact"
+}
+check receipt_directory
+
+receipt_preserved() {
+    local kind="$1" state="$work/receipt-$1.json" rc=0
+    case "$kind" in malformed) printf '{user-data\n' > "$state" ;; unknown) printf '{"user_data":"keep"}\n' > "$state" ;; esac
+    cp "$state" "$state.before"
+    record "$state" claude || rc=$?
+    [[ "$rc" != 0 ]] && cmp -s "$state.before" "$state"
+}
+check receipt_preserved malformed
+check receipt_preserved unknown
+
+receipt_cleanup() {
+    local state="$work/cleanup.json"
+    record "$state" claude && [[ ! -e "$state.lock" ]]
+}
+check receipt_cleanup
+
+receipt_diagnostic() {
+    local state="$work/diagnostic-state.json" rc=0
+    printf '%s\n' '{"schema":2,"hosts":{}}' '{"schema":2,"hosts":{}}' > "$state"
+    env "HOME=$work/home" "OCTOPUS_INSTALL_STATE_FILE=$state" "OCTOPUS_HOST=claude" \
+        "CLAUDE_PLUGIN_ROOT=$work/good" "$TEST_BASH" -c \
+        'source "$1"; octo_lifecycle_state_json' _ "$PROJECT_ROOT/scripts/lib/lifecycle.sh" > "$work/state-diagnostic.json" 2>/dev/null || rc=$?
+    [[ "$rc" == 0 ]] && jq -e '.current==false and .recorded==null' "$work/state-diagnostic.json" >/dev/null
+}
+check receipt_diagnostic
+
+interrupted_writer() {
+    local signal="$1" state="$work/interrupted-$1.json" pid launcher rc=0 i
+    env "HOME=$work/home" "OCTOPUS_INSTALL_STATE_FILE=$state" "CLAUDE_PLUGIN_ROOT=$work/good" \
+        "OCTOPUS_HOST=claude" "$TEST_BASH" -c '
+        source "$1"
+        marker="$2"
+        eval "$(declare -f _octo_lifecycle_lock | sed "1s/_octo_lifecycle_lock/_original_lock/")"
+        _octo_lifecycle_lock() {
+            _original_lock "$@" || return
+            sh -c '\''echo "$PPID"'\'' > "$marker"
+            while [[ ! -f "$marker.release" ]]; do sleep 0.02; done
+        }
+        octo_lifecycle_record_install
+    ' _ "$PROJECT_ROOT/scripts/lib/lifecycle.sh" "$state.ready" > "$state.log" 2>&1 &
+    launcher=$!
+    for ((i=0; i<250; i++)); do [[ -s "$state.ready" ]] && break; sleep 0.02; done
+    if [[ ! -s "$state.ready" ]]; then kill "$launcher" 2>/dev/null || true; wait "$launcher" 2>/dev/null || true; return 1; fi
+    pid="$(cat "$state.ready")"
+    if [[ "$signal" == LIVE ]]; then
+        record "$state" codex >/dev/null 2>&1 || rc=$?
+        [[ "$rc" != 0 && -d "$state.lock" ]] || rc=0
+        touch "$state.ready.release"
+        wait "$launcher" || return 1
+        [[ "$rc" != 0 ]] || return 1
+    else
+        kill "-$signal" "$pid"
+        wait "$launcher" 2>/dev/null || true
+        if [[ "$signal" == TERM && -e "$state.lock" ]]; then return 1; fi
+    fi
+    record "$state" claude && record "$state" codex &&
+        jq -e '.hosts.claude.host=="claude" and .hosts.codex.host=="codex"' "$state" >/dev/null
+}
+check interrupted_writer TERM
+check interrupted_writer KILL
+check interrupted_writer LIVE
+
+concurrent_records() {
+    local i state="$work/concurrent.json" first second
+    for ((i=0; i<5; i++)); do
+        rm -f "$state"
+        record "$state" claude & first=$!
+        record "$state" codex & second=$!
+        wait "$first" || return 1
+        wait "$second" || return 1
+        jq -e '.hosts | has("claude") and has("codex")' "$state" >/dev/null || return 1
+    done
+}
+check concurrent_records
+reference_input_failure() {
+    if [[ "$(uname -s)" != Darwin ]] || ! command -v sandbox-exec >/dev/null 2>&1; then
+        printf 'SKIP native Bash temporary-file denial requires macOS\n'
+        return 0
+    fi
+    local root="$work/no-temp-root"
+    fixture "$root"
+    sandbox-exec -p '(version 1)(allow default)(deny file-write*)(allow file-write* (literal "/dev/null"))' /bin/bash -c '
+        source "$1"
+        if octo_validate_install_root "$2" claude; then exit 1; fi
+    ' _ "$PROJECT_ROOT/scripts/lib/install-root.sh" "$root" 2>/dev/null
+}
+check reference_input_failure
+printf '%s passed, %s failed\n' "$passed" "$failed"
+[[ "$failed" == 0 ]]

--- a/tests/unit/test-installation-health-docs.sh
+++ b/tests/unit/test-installation-health-docs.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../helpers/test-framework.sh"
+
+test_suite "Installation health documentation contracts"
+
+DOCTOR_SKILL="$PROJECT_ROOT/.claude/skills/skill-doctor/SKILL.md"
+SETUP_COMMAND="$PROJECT_ROOT/commands/setup.md"
+HEALTH_DOC="$PROJECT_ROOT/docs/INSTALLATION-HEALTH.md"
+REFERENCE_DOC="$PROJECT_ROOT/docs/COMMAND-REFERENCE.md"
+
+test_case "setup activates read-only installation health"
+if grep -Fq 'setup_installation_health' "$SETUP_COMMAND" &&
+   grep -Fq 'doctor installation --json' "$SETUP_COMMAND" &&
+   grep -Fq 'cache-check --json' "$SETUP_COMMAND" &&
+   [[ "$(grep -Fc 'setup_installation_health' "$SETUP_COMMAND")" -ge 3 ]]; then
+    test_pass
+else
+    test_fail "setup does not run the installation and cache checks at troubleshooting and completion boundaries"
+fi
+
+test_case "doctor resolves both host roots without mutating the stable root"
+resolver_block="$(awk '
+  /^```bash$/ && !found {found=1; capture=1; next}
+  capture && /^```$/ {exit}
+  capture {print}
+' "$DOCTOR_SKILL")"
+if grep -Fq 'CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-}' "$DOCTOR_SKILL" &&
+   grep -Fq 'doctor installation' "$DOCTOR_SKILL" &&
+   grep -Fq 'repair --dry-run' "$DOCTOR_SKILL" &&
+   grep -Fq 'repair --apply' "$DOCTOR_SKILL" &&
+   ! grep -Eq '(^|[[:space:]])(mkdir|rm|ln)[[:space:]]' <<<"$resolver_block"; then
+    test_pass
+else
+    test_fail "doctor resolver lacks Codex support, installation coverage, or repair authorization guidance"
+fi
+
+test_case "docs separate optional profiles and preserve safety hooks"
+if grep -Fq 'OCTOPUS_CONTEXT_PROFILE' "$HEALTH_DOC" &&
+   grep -Fq 'OCTOPUS_HOOK_PROFILE' "$HEALTH_DOC" &&
+   grep -Fq 'OCTO_PROFILE' "$HEALTH_DOC" &&
+   grep -Fq 'never disable safety or lifecycle hooks' "$HEALTH_DOC"; then
+    test_pass
+else
+    test_fail "profile documentation conflates context settings with legacy intensity or safety behavior"
+fi
+
+test_case "handoff documentation states its limits"
+if grep -Fq 'not imported runtime' "$HEALTH_DOC" &&
+   grep -Fq '/octo:resume' "$HEALTH_DOC" &&
+   grep -Fq 'not a guarantee that every secret is removed' "$HEALTH_DOC" &&
+   grep -Fq 'repair --dry-run' "$REFERENCE_DOC"; then
+    test_pass
+else
+    test_fail "handoff or bounded repair behavior is overstated"
+fi
+
+test_summary

--- a/tests/unit/test-installation-health-docs.sh
+++ b/tests/unit/test-installation-health-docs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016 # Tests inspect and execute literal shell snippets.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -38,6 +39,63 @@ else
     test_fail "doctor resolver lacks Codex support, installation coverage, or repair authorization guidance"
 fi
 
+test_case "doctor resolves an npm-style octopus executable symlink"
+doctor_fixture="$TEST_TMP_DIR/doctor-cli-symlink"
+doctor_root="$doctor_fixture/prefix/lib/node_modules/claude-octopus"
+doctor_bin="$doctor_fixture/prefix/bin"
+doctor_log="$doctor_fixture/doctor.log"
+doctor_resolver="$doctor_fixture/resolver.sh"
+mkdir -p "$doctor_root/bin" "$doctor_root/scripts" "$doctor_bin" "$doctor_fixture/home"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$doctor_root/bin/octopus"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\\n" "$*" > "$DOCTOR_CALL_LOG"' \
+    > "$doctor_root/scripts/orchestrate.sh"
+chmod +x "$doctor_root/bin/octopus" "$doctor_root/scripts/orchestrate.sh"
+ln -s ../lib/node_modules/claude-octopus/bin/octopus "$doctor_bin/octopus"
+printf '%s\n' "$resolver_block" > "$doctor_resolver"
+doctor_resolver_rc=0
+env -u CLAUDE_PLUGIN_ROOT -u CODEX_PLUGIN_ROOT -u OCTO_PLUGIN_ROOT \
+    HOME="$doctor_fixture/home" PATH="$doctor_bin:/usr/bin:/bin" \
+    DOCTOR_CALL_LOG="$doctor_log" bash "$doctor_resolver" >/dev/null 2>&1 || \
+    doctor_resolver_rc=$?
+if [[ "$doctor_resolver_rc" -eq 0 ]] &&
+   [[ "$(cat "$doctor_log" 2>/dev/null || true)" == "doctor --verbose" ]] &&
+   grep -Fq 'OCTO_LINK_HOPS' "$doctor_resolver" &&
+   grep -Fq '[[ "$OCTO_LINK_HOPS" -le 40 ]]' "$doctor_resolver" &&
+   [[ ! -e "$doctor_fixture/home/.claude-octopus/plugin" ]]; then
+    test_pass
+else
+    test_fail "doctor did not resolve the linked CLI safely (exit=$doctor_resolver_rc)"
+fi
+
+test_case "doctor stops executable symlink cycles after 40 hops"
+cycle_fixture="$TEST_TMP_DIR/doctor-cli-cycle"
+cycle_bin="$cycle_fixture/bin"
+cycle_log="$cycle_fixture/readlink.log"
+cycle_resolver="$cycle_fixture/resolver.sh"
+real_readlink="$(command -v readlink)"
+mkdir -p "$cycle_bin" "$cycle_fixture/home"
+ln -s octopus "$cycle_bin/octopus"
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf x >> "$READLINK_CALL_LOG"' \
+    'count="$(wc -c < "$READLINK_CALL_LOG")"' \
+    '[[ "$count" -le 45 ]] || exit 1' \
+    'exec "$REAL_READLINK" "$@"' > "$cycle_bin/readlink"
+chmod +x "$cycle_bin/readlink"
+printf '%s\n' "$resolver_block" > "$cycle_resolver"
+cycle_rc=0
+env -u CLAUDE_PLUGIN_ROOT -u CODEX_PLUGIN_ROOT -u OCTO_PLUGIN_ROOT \
+    HOME="$cycle_fixture/home" PATH="$cycle_bin:/usr/bin:/bin" \
+    READLINK_CALL_LOG="$cycle_log" REAL_READLINK="$real_readlink" \
+    bash -c 'octopus() { :; }; cd "$1"; source "$2"' \
+    _ "$cycle_bin" "$cycle_resolver" >/dev/null 2>&1 || cycle_rc=$?
+cycle_hops="$(wc -c < "$cycle_log" | tr -d '[:space:]')"
+if [[ "$cycle_rc" -ne 0 ]] && [[ "$cycle_hops" == 40 ]]; then
+    test_pass
+else
+    test_fail "doctor followed a symlink cycle $cycle_hops times (exit=$cycle_rc)"
+fi
+
 test_case "docs separate optional profiles and preserve safety hooks"
 if grep -Fq 'OCTOPUS_CONTEXT_PROFILE' "$HEALTH_DOC" &&
    grep -Fq 'OCTOPUS_HOOK_PROFILE' "$HEALTH_DOC" &&
@@ -56,6 +114,15 @@ if grep -Fq 'not imported runtime' "$HEALTH_DOC" &&
     test_pass
 else
     test_fail "handoff or bounded repair behavior is overstated"
+fi
+
+test_case "command and repair prose cover guide and wrapper-based stable roots"
+if grep -Fq '| `/octo:guide` | Browse installed commands without starting a provider workflow |' \
+      "$REFERENCE_DOC" &&
+   grep -Fq 'generated wrappers for Octopus script entry points' "$PROJECT_ROOT/README.md"; then
+    test_pass
+else
+    test_fail "guide or wrapper-based repair ownership is missing from public documentation"
 fi
 
 test_summary

--- a/tests/unit/test-mandatory-compliance.sh
+++ b/tests/unit/test-mandatory-compliance.sh
@@ -16,7 +16,7 @@ fail() { test_case "$1"; test_fail "${2:-$1}"; }
 # ── Commands that call orchestrate.sh MUST have MANDATORY COMPLIANCE ─────────
 # Exceptions: utility commands that don't run multi-LLM workflows
 
-EXEMPT_COMMANDS="octo-auto octo-careful octo-costs octo-dev octo-doctor octo-freeze octo-guard octo-history octo-km octo-model-config octo-setup octo-unfreeze"
+EXEMPT_COMMANDS="octo-auto octo-careful octo-costs octo-dev octo-doctor octo-freeze octo-guard octo-guide octo-history octo-km octo-model-config octo-setup octo-unfreeze"
 
 for f in "$PROJECT_ROOT"/.cursor-plugin/commands/octo-*.md; do
     name=$(basename "$f" .md)

--- a/tests/unit/test-post-tool-dispatch.sh
+++ b/tests/unit/test-post-tool-dispatch.sh
@@ -82,4 +82,19 @@ else
     test_fail "statusline state activated PostToolUse context: ${output:-<empty>}"
 fi
 
+test_case "installed dispatcher subscribes to the tools it compresses"
+if jq -e '.hooks.PostToolUse[] | select(any(.hooks[]; .command | endswith("/post-tool-dispatch.sh"))) |
+    .matcher | split("|") | index("Read") != null and index("WebFetch") != null and index("Grep") != null' \
+    "$PROJECT_ROOT/hooks/hooks.json" >/dev/null; then test_pass; else test_fail "manifest omits supported tools"; fi
+
+test_case "dispatcher passes protocol session identity to child hooks"
+fixture="$TEST_TMP_DIR/dispatch-root"
+mkdir -p "$fixture/hooks" "$fixture/scripts/lib"
+cp "$PROJECT_ROOT/scripts/lib/hook-activation.sh" "$fixture/scripts/lib/"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "%s" "${CLAUDE_SESSION_ID:-missing}" > "$SESSION_CAPTURE"' > "$fixture/hooks/strategy-rotation.sh"
+capture="$TEST_TMP_DIR/session-id"
+env -u CLAUDE_SESSION_ID -u CLAUDE_CODE_SESSION_ID CLAUDE_PLUGIN_ROOT="$fixture" \
+    OCTO_STRATEGY_ROTATION=on SESSION_CAPTURE="$capture" bash "$HOOK" <<< '{"session_id":"protocol-session"}'
+if [[ "$(cat "$capture")" == protocol-session ]]; then test_pass; else test_fail "child lost protocol session identity"; fi
+
 test_summary

--- a/tests/unit/test-provider-reliability.sh
+++ b/tests/unit/test-provider-reliability.sh
@@ -187,7 +187,7 @@ fi
 
 # ── No attribution references ─────────────────────────────────────────────────
 
-if grep -qi 'gsd-2\|ecc\|strategic-audit\|Rust agent runtime' "$ROUTER" 2>/dev/null; then
+if grep -qi 'gsd-2\|strategic-audit\|Rust agent runtime' "$ROUTER" 2>/dev/null; then
     fail "No attribution references" "found prohibited reference"
 else
     pass "No attribution references"

--- a/tests/unit/test-scope-drift-research.sh
+++ b/tests/unit/test-scope-drift-research.sh
@@ -77,13 +77,13 @@ fi
 
 # ── No attribution ────────────────────────────────────────────────────────────
 
-if grep -qi 'gstack\|ecc\|gsd-2\|strategic-audit' "$DELIVER" 2>/dev/null; then
+if grep -qi 'gstack\|gsd-2\|strategic-audit' "$DELIVER" 2>/dev/null; then
     fail "Deliver has no attribution" "found reference"
 else
     pass "Deliver has no attribution"
 fi
 
-if grep -qi 'ecc\|strategic-audit\|autoresearch' "$RESEARCH" 2>/dev/null; then
+if grep -qi 'strategic-audit\|autoresearch' "$RESEARCH" 2>/dev/null; then
     fail "Research has no attribution" "found reference"
 else
     pass "Research has no attribution"


### PR DESCRIPTION
## Changes

Add installation health checks and an installed-command guide for v11.5.0. Setup and Doctor expose the checks directly. Repairs validate their targets and preserve modified files. Host receipts recover from interrupted writes, and handoff summaries use canonical project decisions and blockers.

Fix command aliases and public CLI dispatch, align optional hooks with supported events and host session identity, and validate the extracted package in isolated homes. The lifecycle suite no longer uninstalls the user's plugin.

## Verification

Focused filesystem, interruption, concurrency, command discovery, hook dispatch, setup, documentation, and handoff checks passed. The packaged candidate passed strict Claude validation, native Claude install/update/uninstall in an isolated home, and Codex 0.154.0 installation in an isolated home. Full local and hosted test results are recorded with this pull request.

Model routing and existing consent defaults are unchanged. Existing required license notices are preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/octo:guide` to find commands by task or topic without provider calls.
  * Added installation health, cache-check, capabilities, security-audit, handoff export, profile, and repair tools.
  * Added `core`, `orchestration`, and `full` context profiles for optional hooks.
  * Added authorized dry-run/apply workflows for repairing installation links.
  * Expanded post-tool support to Read, WebFetch, and Grep actions.
  * Added clear usage errors for unknown CLI commands.

* **Documentation**
  * Updated command references and troubleshooting guidance for 54 commands and installation health workflows.

* **Release**
  * Updated the release to version 11.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->